### PR TITLE
Solaredge new sensors

### DIFF
--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -40,13 +40,8 @@ SENSOR_TYPES = {
     'energy_today': ['lastDayData', "Energy today",
                      ENERGY_WATT_HOUR, 'mdi:solar-power'],
     'current_power': ['currentPower', "Current Power",
-                      POWER_WATT, 'mdi:solar-power']
-}
-
-# Supported details sensor types:
-# Key: ['name', unit, icon]
-DETAILS_SENSOR_TYPES = {
-    'site_details': ['Site details', None, None]
+                      POWER_WATT, 'mdi:solar-power'],
+    'site_details': [None, 'Site details', None, None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -54,7 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SITE_ID): cv.string,
     vol.Optional(CONF_NAME, default='SolarEdge'): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['current_power']):
-    vol.All(cv.ensure_list, [vol.In(OVERVIEW_SENSOR_TYPES), vol.In(DETAILS_SENSOR_TYPES)])
+    vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)])
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -111,10 +106,10 @@ class SolarEdgeSensorFactory:
 
     def create_sensor(self, sensor_key):
         """Create and return a sensor based on the sensor_key"""
-        if sensor_key in OVERVIEW_SENSOR_TYPES.keys():
+        if sensor_key in ['life_time_data', 'last_year_data', 'last_month_data', 'last_day_data', 'current_power']:
             return SolarEdgeOverviewSensor(self.platform_name, sensor_key, 
                     self.overview_data_service)
-        elif sensor_key in DETAILS_SENSOR_TYPES.keys():
+        elif sensor_key == 'site_details':
             return SolarEdgeDetailsSensor(self.platform_name, sensor_key,
                     self.details_data_service)
 
@@ -158,9 +153,9 @@ class SolarEdgeOverviewSensor(SolarEdgeSensor):
         """Initialize the overview sensor."""
         super().__init__(platform_name, sensor_key, data_service)
 
-        self._json_key = OVERVIEW_SENSOR_TYPES[self.sensor_key][0]
-        self._unit_of_measurement = OVERVIEW_SENSOR_TYPES[self.sensor_key][2]
-        self._icon = OVERVIEW_SENSOR_TYPES[self.sensor_key][3]
+        self._json_key = SENSOR_TYPES[self.sensor_key][0]
+        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
+        self._icon = SENSOR_TYPES[self.sensor_key][3]
 
     def update(self):
         """Get the latest data from the sensor and update the state."""
@@ -177,8 +172,8 @@ class SolarEdgeDetailsSensor(SolarEdgeSensor):
        
         self._attributes = {}
 
-        self._unit_of_measurement = DETAILS_SENSOR_TYPES[self.sensor_key][1]
-        self._icon = DETAILS_SENSOR_TYPES[self.sensor_key][2]
+        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
+        self._icon = SENSOR_TYPES[self.sensor_key][3]
 
     @property
     def state_attributes(self):

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -95,34 +95,41 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class SolarEdgeSensorFactory:
-    """Factory which creates sensors based on the sensor_key"""
+    """Factory which creates sensors based on the sensor_key."""
 
     def __init__(self, platform_name, site_id, api):
-        """Initialize the factory"""
+        """Initialize the factory."""
         self.platform_name = platform_name
-        
+
         self.overview_data_service = SolarEdgeOverviewDataService(api, site_id)
         self.details_data_service = SolarEdgeDetailsDataService(api, site_id)
 
     def create_sensor(self, sensor_key):
-        """Create and return a sensor based on the sensor_key"""
-        if sensor_key in ['life_time_data', 'last_year_data', 'last_month_data', 'last_day_data', 'current_power']:
-            return SolarEdgeOverviewSensor(self.platform_name, sensor_key, 
-                    self.overview_data_service)
-        elif sensor_key == 'site_details':
-            return SolarEdgeDetailsSensor(self.platform_name, sensor_key,
-                    self.details_data_service)
+        """Create and return a sensor based on the sensor_key."""
+        sensor = None
+
+        if sensor_key == 'site_details':
+            sensor = SolarEdgeDetailsSensor(self.platform_name, sensor_key,
+                                            self.details_data_service)
+        else:
+            sensor = SolarEdgeOverviewSensor(self.platform_name, sensor_key,
+                                             self.overview_data_service)
+        return sensor
 
 
 class SolarEdgeSensor(Entity):
-    """Abstract class for a solaredge sensor"""
+    """Abstract class for a solaredge sensor."""
 
     def __init__(self, platform_name, sensor_key, data_service):
+        """Initialize the sensor."""
         self.platform_name = platform_name
         self.sensor_key = sensor_key
         self.data_service = data_service
-        
+
         self._state = None
+
+        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
+        self._icon = SENSOR_TYPES[self.sensor_key][3]
 
     @property
     def name(self):
@@ -154,8 +161,6 @@ class SolarEdgeOverviewSensor(SolarEdgeSensor):
         super().__init__(platform_name, sensor_key, data_service)
 
         self._json_key = SENSOR_TYPES[self.sensor_key][0]
-        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
-        self._icon = SENSOR_TYPES[self.sensor_key][3]
 
     def update(self):
         """Get the latest data from the sensor and update the state."""
@@ -169,19 +174,16 @@ class SolarEdgeDetailsSensor(SolarEdgeSensor):
     def __init__(self, platform_name, sensor_key, data_service):
         """Initialize the details sensor."""
         super().__init__(platform_name, sensor_key, data_service)
-       
-        self._attributes = {}
 
-        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
-        self._icon = SENSOR_TYPES[self.sensor_key][3]
+        self._attributes = {}
 
     @property
     def state_attributes(self):
         """Return the state attributes."""
         return self._attributes
-    
+
     def update(self):
-        """Get the latest details and update state and attributes"""
+        """Get the latest details and update state and attributes."""
         self.data_service.update()
         self._state = self.data_service.data
         self._attributes = self.data_service.attributes
@@ -194,9 +196,10 @@ class SolarEdgeDataService:
         """Initialize the data object."""
         self.api = api
         self.site_id = site_id
-        
+
         self.data = {}
         self.attributes = {}
+
 
 class SolarEdgeOverviewDataService(SolarEdgeDataService):
     """Get and update the latest overview data."""
@@ -219,7 +222,8 @@ class SolarEdgeOverviewDataService(SolarEdgeDataService):
         self.data = {}
 
         for key, value in overview.items():
-            if key in ['lifeTimeData', 'lastYearData', 'lastMonthData', 'lastDayData']:
+            if key in ['lifeTimeData', 'lastYearData',
+                       'lastMonthData', 'lastDayData']:
                 data = value['energy']
             elif key in ['currentPower']:
                 data = value['power']
@@ -254,10 +258,11 @@ class SolarEdgeDetailsDataService(SolarEdgeDataService):
         for key, value in details.items():
             if key in ['primaryModule']:
                 self.attributes.update(value)
-            elif key in ['peakPower', 'type', 'name', 'lastUpdateTime', 'installationDate']:
+            elif key in ['peakPower', 'type', 'name', 'lastUpdateTime',
+                         'installationDate']:
                 self.attributes[key] = value
             elif key == 'status':
                 self.data = value
 
-        _LOGGER.debug("Updated SolarEdge details data and attributes: %s, %s", self.data, self.attributes)
-
+        _LOGGER.debug("Updated SolarEdge details data and attributes: %s, %s",
+                      self.data, self.attributes)

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -10,6 +10,7 @@ import logging
 
 import voluptuous as vol
 
+from requests.exceptions import HTTPError, ConnectTimeout
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_API_KEY, CONF_MONITORED_CONDITIONS, CONF_NAME, POWER_WATT,
@@ -17,7 +18,6 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-from requests.exceptions import HTTPError, ConnectTimeout
 
 REQUIREMENTS = ['solaredge==0.0.2']
 
@@ -70,7 +70,6 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Create the SolarEdge Monitoring API sensor."""
     import solaredge
-    from requests.exceptions import HTTPError, ConnectTimeout
 
     api_key = config[CONF_API_KEY]
     site_id = config[CONF_SITE_ID]
@@ -278,7 +277,6 @@ class SolarEdgeOverviewDataService(SolarEdgeDataService):
     @Throttle(OVERVIEW_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-
         try:
             data = self.api.get_overview(self.site_id)
             overview = data['overview']
@@ -310,7 +308,6 @@ class SolarEdgeDetailsDataService(SolarEdgeDataService):
     @Throttle(DETAILS_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-
         try:
             data = self.api.get_details(self.site_id)
             details = data['details']
@@ -343,7 +340,6 @@ class SolarEdgeInventoryDataService(SolarEdgeDataService):
     @Throttle(INVENTORY_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-
         try:
             data = self.api.get_inventory(self.site_id)
             inventory = data['Inventory']
@@ -377,7 +373,6 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
     @Throttle(POWER_FLOW_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-
         try:
             data = self.api.get_current_power_flow(self.site_id)
             power_flow = data['siteCurrentPowerFlow']

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+from requests.exceptions import HTTPError, ConnectTimeout
 
 REQUIREMENTS = ['solaredge==0.0.2']
 
@@ -202,7 +203,7 @@ class SolarEdgeDetailsSensor(SolarEdgeSensor):
         self._attributes = {}
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
 
@@ -225,7 +226,7 @@ class SolarEdgeInventorySensor(SolarEdgeSensor):
         self._attributes = {}
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
 
@@ -248,7 +249,7 @@ class SolarEdgePowerFlowSensor(SolarEdgeSensor):
         self._attributes = {}
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
 
@@ -278,7 +279,6 @@ class SolarEdgeOverviewDataService(SolarEdgeDataService):
     @Throttle(OVERVIEW_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-        from requests.exceptions import HTTPError, ConnectTimeout
 
         try:
             data = self.api.get_overview(self.site_id)
@@ -311,7 +311,6 @@ class SolarEdgeDetailsDataService(SolarEdgeDataService):
     @Throttle(DETAILS_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-        from requests.exceptions import HTTPError, ConnectTimeout
 
         try:
             data = self.api.get_details(self.site_id)
@@ -345,7 +344,6 @@ class SolarEdgeInventoryDataService(SolarEdgeDataService):
     @Throttle(INVENTORY_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-        from requests.exceptions import HTTPError, ConnectTimeout
 
         try:
             data = self.api.get_inventory(self.site_id)
@@ -380,7 +378,6 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
     @Throttle(POWER_FLOW_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
-        from requests.exceptions import HTTPError, ConnectTimeout
 
         try:
             data = self.api.get_current_power_flow(self.site_id)
@@ -423,7 +420,6 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
                 self.data[key] *= -1 if charge else 1
                 self.attributes[key]['flow'] = ('charge' if charge
                                                 else 'discharge')
-                pass
 
         _LOGGER.debug("Updated SolarEdge power flow: %s, %s",
                       self.data, self.attributes)

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -79,19 +79,32 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.error("Could not retrieve details from SolarEdge API")
         return
 
-    # Create solaredge data service which will retrieve and update the data.
-    data = SolarEdgeData(api, site_id)
+    # Create sensor factory that will create sensors based on sensor_key.
+    sensor_factory = SolarEdgeSensorFactory(platform_name, site_id, api)
 
     # Create a new sensor for each sensor type.
     entities = []
     for sensor_key in config[CONF_MONITORED_CONDITIONS]:
-        sensor = SolarEdgeSensor(platform_name, sensor_key, data)
+        sensor = sensor_factory.create_sensor(sensor_key)
         entities.append(sensor)
 
     add_entities(entities, True)
 
 
-class SolarEdgeSensor(Entity):
+class SolarEdgeSensorFactory:
+
+    def __init__(self, platform_name, site_id, api):
+        self.platform_name = platform_name
+        
+        self.overview_data_service = SolarEdgeOverviewDataService(api, site_id)
+
+    def create_sensor(self, sensor_key):
+        if sensor_key in SENSOR_TYPES.keys():
+            return SolarEdgeOverviewSensor(self.platform_name, sensor_key, 
+                    self.overview_data_service)
+
+
+class SolarEdgeOverviewSensor(Entity):
     """Representation of an SolarEdge Monitoring API sensor."""
 
     def __init__(self, platform_name, sensor_key, data):
@@ -131,7 +144,7 @@ class SolarEdgeSensor(Entity):
         self._state = self.data.data[self._json_key]
 
 
-class SolarEdgeData:
+class SolarEdgeOverviewDataService:
     """Get and update the latest data."""
 
     def __init__(self, api, site_id):

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -146,7 +146,6 @@ class SolarEdgeSensor(Entity):
 
     def __init__(self, platform_name, sensor_key, data_service):
         """Initialize the sensor."""
-        self.entity_id = '{}.{}'.format(platform_name, sensor_key).lower()
         self.platform_name = platform_name
         self.sensor_key = sensor_key
         self.data_service = data_service

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -23,10 +23,12 @@ REQUIREMENTS = ['solaredge==0.0.2']
 # Config for solaredge monitoring api requests.
 CONF_SITE_ID = "site_id"
 
-UPDATE_DELAY = timedelta(minutes=10)
+OVERVIEW_UPDATE_DELAY = timedelta(minutes=10)
+DETAILS_UPDATE_DELAY = timedelta(hours=12)
+
 SCAN_INTERVAL = timedelta(minutes=10)
 
-# Supported sensor types:
+# Supported overview sensor types:
 # Key: ['json_key', 'name', unit, icon]
 SENSOR_TYPES = {
     'lifetime_energy': ['lifeTimeData', "Lifetime energy",
@@ -41,12 +43,29 @@ SENSOR_TYPES = {
                       POWER_WATT, 'mdi:solar-power']
 }
 
+# Supported details sensor types:
+# Key: ['json_key', 'name', unit, icon]
+DETAILS_SENSOR_TYPES = {
+    'id': ['id', 'Id', None, None],
+    'name': ['name', 'Name', None, None],
+    'account_id': ['accountId', "Account Id", None, None],
+    'status': ['status', 'Status', None, None],
+    'peak_power': ['peakPower', "Peak power", None, None],
+    'last_update_time': ['lastUpdateTime', "Last update time", None, None],
+    'installation_date': ['installationDate', "Installation date", None, None],
+    'pto_date': ['ptoDate', "Permission to operate date", None, None],
+    'notes': ['notes', 'Notes', None, None],
+    'type': ['type', 'Type', None, None],
+    'location': ['location', 'Location', None, None],
+    'primary_module': ['primaryModule', "Primary module", None, None]
+}
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_SITE_ID): cv.string,
     vol.Optional(CONF_NAME, default='SolarEdge'): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['current_power']):
-    vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)])
+    vol.All(cv.ensure_list, [vol.In(OVERVIEW_SENSOR_TYPES)])
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,30 +111,33 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class SolarEdgeSensorFactory:
+    """Factory which creates sensors based on the sensor_key"""
 
     def __init__(self, platform_name, site_id, api):
+        """Initialize the factory"""
         self.platform_name = platform_name
         
         self.overview_data_service = SolarEdgeOverviewDataService(api, site_id)
+        self.details_data_service = SolarEdgeDetailsDataService(api, site_id)
 
     def create_sensor(self, sensor_key):
-        if sensor_key in SENSOR_TYPES.keys():
+        """Create and return a sensor based on the sensor_key"""
+        if sensor_key in OVERVIEW_SENSOR_TYPES.keys():
             return SolarEdgeOverviewSensor(self.platform_name, sensor_key, 
                     self.overview_data_service)
+        elif sensor_key in DETAILS_SENSOR_TYPES.keys():
+            return SolarEdgeDetailsSensor(self.platform_name, sensor_key,
+                    self.details_data_service)
 
 
-class SolarEdgeOverviewSensor(Entity):
-    """Representation of an SolarEdge Monitoring API sensor."""
+class SolarEdgeSensor(Entity):
+    """Abstract class for a solaredge sensor"""
 
-    def __init__(self, platform_name, sensor_key, data):
-        """Initialize the sensor."""
+    def __init__(self, platform_name, sensor_key, data_service):
         self.platform_name = platform_name
         self.sensor_key = sensor_key
-        self.data = data
+        self.data_service = data_service
         self._state = None
-
-        self._json_key = SENSOR_TYPES[self.sensor_key][0]
-        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
 
     @property
     def name(self):
@@ -131,7 +153,7 @@ class SolarEdgeOverviewSensor(Entity):
     @property
     def icon(self):
         """Return the sensor icon."""
-        return SENSOR_TYPES[self.sensor_key][3]
+        return self._icon
 
     @property
     def state(self):
@@ -140,11 +162,36 @@ class SolarEdgeOverviewSensor(Entity):
 
     def update(self):
         """Get the latest data from the sensor and update the state."""
-        self.data.update()
-        self._state = self.data.data[self._json_key]
+        self.data_service.update()
+        self._state = self.data_service.data[self._json_key]
 
 
-class SolarEdgeOverviewDataService:
+
+class SolarEdgeOverviewSensor(SolarEdgeSensor):
+    """Representation of an SolarEdge Monitoring API overview sensor."""
+
+    def __init__(self, platform_name, sensor_key, data_service):
+        """Initialize the overview sensor."""
+        super().__init__(platform_name, sensor_key, data_service)
+
+        self._json_key = OVERVIEW_SENSOR_TYPES[self.sensor_key][0]
+        self._unit_of_measurement = OVERVIEW_SENSOR_TYPES[self.sensor_key][2]
+        self._icon = OVERVIEW_SENSOR_TYPES[self.sensor_key][3]
+
+
+class SolarEdgeDetailsSensor(SolarEdgeSensor):
+    """Representation of an SolarEdge Monitoring API details sensor."""
+
+    def __init__(self, platform_name, sensor_key, data):
+        """Initialize the details sensor."""
+        super().__init__(platform_name, sensor_key, data_service)
+        
+        self._json_key = DETAILS_SENSOR_TYPES[self.sensor_key][0]
+        self._unit_of_measurement = DETAILS_SENSOR_TYPES[self.sensor_key][2]
+        self._icon = DETAILS_SENSOR_TYPES[self.sensor_key][3]
+
+
+class SolarEdgeDataService:
     """Get and update the latest data."""
 
     def __init__(self, api, site_id):
@@ -154,7 +201,11 @@ class SolarEdgeOverviewDataService:
         
         self.data = {}
 
-    @Throttle(UPDATE_DELAY)
+
+class SolarEdgeOverviewDataService(SolarEdgeDataService):
+    """Get and update the latest overview data."""
+
+    @Throttle(OVERVIEW_UPDATE_DELAY)
     def update(self):
         """Update the data from the SolarEdge Monitoring API."""
         from requests.exceptions import HTTPError, ConnectTimeout
@@ -172,9 +223,42 @@ class SolarEdgeOverviewDataService:
         self.data = {}
 
         for key, value in overview.items():
+            if key in ['lifeTimeData', 'lastYearData', 'lastMonthData', 'lastDayData']:
+                data = value['energy']
+            elif key in ['currentPower']:
+                data = value['power']
+            else:
+                data = value
+            self.data[key] = data
+
+        _LOGGER.debug("Updated SolarEdge overview data: %s", self.data)
+
+
+class SolarEdgeDetailsDataService(SolarEdgeDataService):
+    """Get and update the latest details data."""
+
+    @Throttle(DETAILS_UPDATE_DELAY)
+    def update(self):
+        """Update the data from the SolarEdge Monitoring API."""
+        from requests.exceptions import HTTPError, ConnectTimeout
+
+        try:
+            data = self.api.get_details(self.site_id)
+            details = data['details']
+        except KeyError:
+            _LOGGER.error("Missing details data, skipping update")
+            return
+        except (ConnectTimeout, HTTPError):
+            _LOGGER.error("Could not retrieve data, skipping update")
+            return
+
+        self.data = {}
+
+        for key, value in details.items():
             if 'energy' in value:
                 self.data[key] = value['energy']
             elif 'power' in value:
                 self.data[key] = value['power']
 
-        _LOGGER.debug("Updated SolarEdge overview data: %s", self.data)
+        _LOGGER.debug("Updated SolarEdge details data: %s", self.data)
+

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -5,8 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.solaredge/
 """
 
-import requests
-
 from datetime import timedelta
 import logging
 
@@ -385,11 +383,7 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
         from requests.exceptions import HTTPError, ConnectTimeout
 
         try:
-            # data = self.api.get_current_power_flow(self.site_idl
-            r = requests.get('http://localhost/currentPowerFlow/2')
-            r.raise_for_status()
-            data = r.json()
-
+            data = self.api.get_current_power_flow(self.site_id)
             power_flow = data['siteCurrentPowerFlow']
         except KeyError:
             _LOGGER.error("Missing power flow data, skipping update")
@@ -400,6 +394,10 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
 
         power_from = []
         power_to = []
+        
+        if not 'connections' in power_flow:
+            _LOGGER.error("Missing connections in power flow data")
+            return
 
         for connection in power_flow['connections']:
             power_from.append(connection['from'].lower())

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -42,10 +42,12 @@ SENSOR_TYPES = {
                      ENERGY_WATT_HOUR, 'mdi:solar-power'],
     'current_power': ['currentPower', "Current Power", POWER_WATT,
                       'mdi:solar-power'],
-    'site_details': [None, 'Site details', None,
-                     None],
-    'inverter_details': ['inverters', 'Inverter', None,
-                         None]
+    'site_details': [None, 'Site details', None, None],
+    'inventory_meters': ['meters', 'Meters', None, None],
+    'inventory_sensors': ['sensors', 'Sensors', None, None],
+    'inventory_gateways': ['gateways', 'Gateways', None, None],
+    'inventory_batteries': ['batteries', 'Batteries', None, None],
+    'inventory_inverters': ['inverters', 'Inverters', None, None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -117,7 +119,7 @@ class SolarEdgeSensorFactory:
         if sensor_key == 'site_details':
             sensor = SolarEdgeDetailsSensor(self.platform_name, sensor_key,
                                             self.details_data_service)
-        elif sensor_key == 'inverter_details':
+        elif sensor_key.startswith('inventory'):
             sensor = SolarEdgeInventorySensor(self.platform_name, sensor_key,
                                               self.inventory_data_service)
         else:
@@ -322,9 +324,8 @@ class SolarEdgeInventoryDataService(SolarEdgeDataService):
         self.attributes = {}
 
         for key, value in inventory.items():
-            if key == 'inverters' and value:
-                self.data[key] = value[0]['name']
-                self.attributes[key] = value[0]
+            self.data[key] = len(value)
+            self.attributes[key] = {key: value}
 
         _LOGGER.debug("Updated SolarEdge inventory: %s, %s",
                       self.data, self.attributes)

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -80,7 +80,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
 
     # Create solaredge data service which will retrieve and update the data.
-    data = SolarEdgeData(hass, api, site_id)
+    data = SolarEdgeData(api, site_id)
 
     # Create a new sensor for each sensor type.
     entities = []
@@ -134,12 +134,12 @@ class SolarEdgeSensor(Entity):
 class SolarEdgeData:
     """Get and update the latest data."""
 
-    def __init__(self, hass, api, site_id):
+    def __init__(self, api, site_id):
         """Initialize the data object."""
-        self.hass = hass
         self.api = api
-        self.data = {}
         self.site_id = site_id
+        
+        self.data = {}
 
     @Throttle(UPDATE_DELAY)
     def update(self):

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -62,7 +62,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SITE_ID): cv.string,
     vol.Optional(CONF_NAME, default='SolarEdge'): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['current_power']):
-    vol.All(cv.ensure_list, [vol.In(OVERVIEW_SENSOR_TYPES)])
+    vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)])
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -147,20 +147,21 @@ class SolarEdgeSensor(Entity):
 
     def __init__(self, platform_name, sensor_key, data_service):
         """Initialize the sensor."""
+        self.entity_id = '{}.{}'.format(platform_name, sensor_key).lower()
         self.platform_name = platform_name
         self.sensor_key = sensor_key
         self.data_service = data_service
 
         self._state = None
 
-        self._unit_of_measurement = OVERVIEW_SENSOR_TYPES[self.sensor_key][2]
-        self._icon = OVERVIEW_SENSOR_TYPES[self.sensor_key][3]
+        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
+        self._icon = SENSOR_TYPES[self.sensor_key][3]
 
     @property
     def name(self):
         """Return the name."""
         return "{} ({})".format(self.platform_name,
-                                OVERVIEW_SENSOR_TYPES[self.sensor_key][1])
+                                SENSOR_TYPES[self.sensor_key][1])
 
     @property
     def unit_of_measurement(self):
@@ -185,7 +186,7 @@ class SolarEdgeOverviewSensor(SolarEdgeSensor):
         """Initialize the overview sensor."""
         super().__init__(platform_name, sensor_key, data_service)
 
-        self._json_key = OVERVIEW_SENSOR_TYPES[self.sensor_key][0]
+        self._json_key = SENSOR_TYPES[self.sensor_key][0]
 
     def update(self):
         """Get the latest data from the sensor and update the state."""
@@ -221,7 +222,7 @@ class SolarEdgeInventorySensor(SolarEdgeSensor):
         """Initialize the inventory sensor."""
         super().__init__(platform_name, sensor_key, data_service)
 
-        self._json_key = OVERVIEW_SENSOR_TYPES[self.sensor_key][0]
+        self._json_key = SENSOR_TYPES[self.sensor_key][0]
 
         self._attributes = {}
 
@@ -244,7 +245,7 @@ class SolarEdgePowerFlowSensor(SolarEdgeSensor):
         """Initialize the power flow sensor."""
         super().__init__(platform_name, sensor_key, data_service)
 
-        self._json_key = OVERVIEW_SENSOR_TYPES[self.sensor_key][0]
+        self._json_key = SENSOR_TYPES[self.sensor_key][0]
 
         self._attributes = {}
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -135,9 +135,9 @@ class SolarEdgeSensorFactory:
 
     def create_sensor(self, sensor_key):
         """Create and return a sensor based on the sensor_key."""
-        service = self.services[sensor_key]
+        sensor_class, service = self.services[sensor_key]
 
-        return service[0](self.platform_name, sensor_key, service[1])
+        return sensor_class(self.platform_name, sensor_key, service)
 
 
 class SolarEdgeSensor(Entity):
@@ -326,7 +326,7 @@ class SolarEdgeDetailsDataService(SolarEdgeDataService):
             _LOGGER.error("Could not retrieve data, skipping update")
             return
 
-        self.data = {}
+        self.data = None
         self.attributes = {}
 
         for key, value in details.items():
@@ -379,7 +379,7 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
         """Initialize the power flow data service."""
         super().__init__(api, site_id)
 
-        self.unit = ''
+        self.unit = None
 
     @Throttle(POWER_FLOW_UPDATE_DELAY)
     def update(self):

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -394,8 +394,8 @@ class SolarEdgePowerFlowDataService(SolarEdgeDataService):
 
         power_from = []
         power_to = []
-        
-        if not 'connections' in power_flow:
+
+        if 'connections' not in power_flow:
             _LOGGER.error("Missing connections in power flow data")
             return
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -44,20 +44,9 @@ SENSOR_TYPES = {
 }
 
 # Supported details sensor types:
-# Key: ['json_key', 'name', unit, icon]
+# Key: ['name', unit, icon]
 DETAILS_SENSOR_TYPES = {
-    'id': ['id', 'Id', None, None],
-    'name': ['name', 'Name', None, None],
-    'account_id': ['accountId', "Account Id", None, None],
-    'status': ['status', 'Status', None, None],
-    'peak_power': ['peakPower', "Peak power", None, None],
-    'last_update_time': ['lastUpdateTime', "Last update time", None, None],
-    'installation_date': ['installationDate', "Installation date", None, None],
-    'pto_date': ['ptoDate', "Permission to operate date", None, None],
-    'notes': ['notes', 'Notes', None, None],
-    'type': ['type', 'Type', None, None],
-    'location': ['location', 'Location', None, None],
-    'primary_module': ['primaryModule', "Primary module", None, None]
+    'site_details': ['Site details', None, None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -65,7 +54,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SITE_ID): cv.string,
     vol.Optional(CONF_NAME, default='SolarEdge'): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['current_power']):
-    vol.All(cv.ensure_list, [vol.In(OVERVIEW_SENSOR_TYPES)])
+    vol.All(cv.ensure_list, [vol.In(OVERVIEW_SENSOR_TYPES), vol.In(DETAILS_SENSOR_TYPES)])
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -137,6 +126,7 @@ class SolarEdgeSensor(Entity):
         self.platform_name = platform_name
         self.sensor_key = sensor_key
         self.data_service = data_service
+        
         self._state = None
 
     @property
@@ -160,12 +150,6 @@ class SolarEdgeSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
-    def update(self):
-        """Get the latest data from the sensor and update the state."""
-        self.data_service.update()
-        self._state = self.data_service.data[self._json_key]
-
-
 
 class SolarEdgeOverviewSensor(SolarEdgeSensor):
     """Representation of an SolarEdge Monitoring API overview sensor."""
@@ -178,17 +162,34 @@ class SolarEdgeOverviewSensor(SolarEdgeSensor):
         self._unit_of_measurement = OVERVIEW_SENSOR_TYPES[self.sensor_key][2]
         self._icon = OVERVIEW_SENSOR_TYPES[self.sensor_key][3]
 
+    def update(self):
+        """Get the latest data from the sensor and update the state."""
+        self.data_service.update()
+        self._state = self.data_service.data[self._json_key]
+
 
 class SolarEdgeDetailsSensor(SolarEdgeSensor):
     """Representation of an SolarEdge Monitoring API details sensor."""
 
-    def __init__(self, platform_name, sensor_key, data):
+    def __init__(self, platform_name, sensor_key, data_service):
         """Initialize the details sensor."""
         super().__init__(platform_name, sensor_key, data_service)
-        
-        self._json_key = DETAILS_SENSOR_TYPES[self.sensor_key][0]
-        self._unit_of_measurement = DETAILS_SENSOR_TYPES[self.sensor_key][2]
-        self._icon = DETAILS_SENSOR_TYPES[self.sensor_key][3]
+       
+        self._attributes = {}
+
+        self._unit_of_measurement = DETAILS_SENSOR_TYPES[self.sensor_key][1]
+        self._icon = DETAILS_SENSOR_TYPES[self.sensor_key][2]
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+    
+    def update(self):
+        """Get the latest details and update state and attributes"""
+        self.data_service.update()
+        self._state = self.data_service.data
+        self._attributes = self.data_service.attributes
 
 
 class SolarEdgeDataService:
@@ -200,7 +201,7 @@ class SolarEdgeDataService:
         self.site_id = site_id
         
         self.data = {}
-
+        self.attributes = {}
 
 class SolarEdgeOverviewDataService(SolarEdgeDataService):
     """Get and update the latest overview data."""
@@ -253,12 +254,15 @@ class SolarEdgeDetailsDataService(SolarEdgeDataService):
             return
 
         self.data = {}
+        self.attributes = {}
 
         for key, value in details.items():
-            if 'energy' in value:
-                self.data[key] = value['energy']
-            elif 'power' in value:
-                self.data[key] = value['power']
+            if key in ['primaryModule']:
+                self.attributes.update(value)
+            elif key in ['peakPower', 'type', 'name', 'lastUpdateTime', 'installationDate']:
+                self.attributes[key] = value
+            elif key == 'status':
+                self.data = value
 
-        _LOGGER.debug("Updated SolarEdge details data: %s", self.data)
+        _LOGGER.debug("Updated SolarEdge details data and attributes: %s, %s", self.data, self.attributes)
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -43,11 +43,11 @@ SENSOR_TYPES = {
     'current_power': ['currentPower', "Current Power", POWER_WATT,
                       'mdi:solar-power'],
     'site_details': [None, 'Site details', None, None],
-    'inventory_meters': ['meters', 'Meters', None, None],
-    'inventory_sensors': ['sensors', 'Sensors', None, None],
-    'inventory_gateways': ['gateways', 'Gateways', None, None],
-    'inventory_batteries': ['batteries', 'Batteries', None, None],
-    'inventory_inverters': ['inverters', 'Inverters', None, None]
+    'meters': ['meters', 'Meters', None, None],
+    'sensors': ['sensors', 'Sensors', None, None],
+    'gateways': ['gateways', 'Gateways', None, None],
+    'batteries': ['batteries', 'Batteries', None, None],
+    'inverters': ['inverters', 'Inverters', None, None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -55,7 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SITE_ID): cv.string,
     vol.Optional(CONF_NAME, default='SolarEdge'): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['current_power']):
-    vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)])
+    vol.All(cv.ensure_list, [vol.In(OVERVIEW_SENSOR_TYPES)])
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,7 +119,8 @@ class SolarEdgeSensorFactory:
         if sensor_key == 'site_details':
             sensor = SolarEdgeDetailsSensor(self.platform_name, sensor_key,
                                             self.details_data_service)
-        elif sensor_key.startswith('inventory'):
+        elif sensor_key in ['meters', 'sensors', 'gateways',
+                            'batteries', 'inverters']:
             sensor = SolarEdgeInventorySensor(self.platform_name, sensor_key,
                                               self.inventory_data_service)
         else:
@@ -139,14 +140,14 @@ class SolarEdgeSensor(Entity):
 
         self._state = None
 
-        self._unit_of_measurement = SENSOR_TYPES[self.sensor_key][2]
-        self._icon = SENSOR_TYPES[self.sensor_key][3]
+        self._unit_of_measurement = OVERVIEW_SENSOR_TYPES[self.sensor_key][2]
+        self._icon = OVERVIEW_SENSOR_TYPES[self.sensor_key][3]
 
     @property
     def name(self):
         """Return the name."""
         return "{} ({})".format(self.platform_name,
-                                SENSOR_TYPES[self.sensor_key][1])
+                                OVERVIEW_SENSOR_TYPES[self.sensor_key][1])
 
     @property
     def unit_of_measurement(self):
@@ -171,7 +172,7 @@ class SolarEdgeOverviewSensor(SolarEdgeSensor):
         """Initialize the overview sensor."""
         super().__init__(platform_name, sensor_key, data_service)
 
-        self._json_key = SENSOR_TYPES[self.sensor_key][0]
+        self._json_key = OVERVIEW_SENSOR_TYPES[self.sensor_key][0]
 
     def update(self):
         """Get the latest data from the sensor and update the state."""
@@ -207,7 +208,7 @@ class SolarEdgeInventorySensor(SolarEdgeSensor):
         """Initialize the inventory sensor."""
         super().__init__(platform_name, sensor_key, data_service)
 
-        self._json_key = SENSOR_TYPES[self.sensor_key][0]
+        self._json_key = OVERVIEW_SENSOR_TYPES[self.sensor_key][0]
 
         self._attributes = {}
 

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -25,6 +25,7 @@ CONF_SITE_ID = "site_id"
 
 OVERVIEW_UPDATE_DELAY = timedelta(minutes=10)
 DETAILS_UPDATE_DELAY = timedelta(hours=12)
+INVENTORY_UPDATE_DELAY = timedelta(hours=12)
 
 SCAN_INTERVAL = timedelta(minutes=10)
 
@@ -41,7 +42,10 @@ SENSOR_TYPES = {
                      ENERGY_WATT_HOUR, 'mdi:solar-power'],
     'current_power': ['currentPower', "Current Power",
                       POWER_WATT, 'mdi:solar-power'],
-    'site_details': [None, 'Site details', None, None]
+    'site_details': [None, 'Site details', None, 
+                     None],
+    'inverter_details': ['inverters', 'Inverter', None, 
+                          None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -103,6 +107,7 @@ class SolarEdgeSensorFactory:
 
         self.overview_data_service = SolarEdgeOverviewDataService(api, site_id)
         self.details_data_service = SolarEdgeDetailsDataService(api, site_id)
+        self.inventory_data_service = SolarEdgeInventoryDataService(api, site_id)
 
     def create_sensor(self, sensor_key):
         """Create and return a sensor based on the sensor_key."""
@@ -111,6 +116,9 @@ class SolarEdgeSensorFactory:
         if sensor_key == 'site_details':
             sensor = SolarEdgeDetailsSensor(self.platform_name, sensor_key,
                                             self.details_data_service)
+        elif sensor_key == 'inverter_details':
+            sensor = SolarEdgeInventorySensor(self.platform_name, sensor_key,
+                                              self.inventory_data_service)
         else:
             sensor = SolarEdgeOverviewSensor(self.platform_name, sensor_key,
                                              self.overview_data_service)
@@ -187,6 +195,29 @@ class SolarEdgeDetailsSensor(SolarEdgeSensor):
         self.data_service.update()
         self._state = self.data_service.data
         self._attributes = self.data_service.attributes
+
+
+class SolarEdgeInventorySensor(SolarEdgeSensor):
+    """Representation of an SolarEdge Monitoring API inventory sensor."""
+
+    def __init__(self, platform_name, sensor_key, data_service):
+        """Initialize the inventory sensor."""
+        super().__init__(platform_name, sensor_key, data_service)
+
+        self._json_key = SENSOR_TYPES[self.sensor_key][0]
+
+        self._attributes = {}
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    def update(self):
+        """Get the latest inventory data and update state and attributes."""
+        self.data_service.update()
+        self._state = self.data_service.data[self._json_key]
+        self._attributes = self.data_service.attributes[self._json_key]
 
 
 class SolarEdgeDataService:
@@ -266,3 +297,34 @@ class SolarEdgeDetailsDataService(SolarEdgeDataService):
 
         _LOGGER.debug("Updated SolarEdge details data and attributes: %s, %s",
                       self.data, self.attributes)
+
+
+class SolarEdgeInventoryDataService(SolarEdgeDataService):
+    """Get and update the latest inventory data."""
+
+    @Throttle(INVENTORY_UPDATE_DELAY)
+    def update(self):
+        """Update the data from the SolarEdge Monitoring API."""
+        from requests.exceptions import HTTPError, ConnectTimeout
+
+        try:
+            data = self.api.get_inventory(self.site_id)
+            inventory = data['Inventory']
+        except KeyError:
+            _LOGGER.error("Missing inventory data, skipping update")
+            return
+        except (ConnectTimeout, HTTPError):
+            _LOGGER.error("Could not retrieve data, skipping update")
+            return
+
+        self.data = {}
+        self.attributes = {}
+
+        for key, value in inventory.items():
+            if key == 'inverters' and len(value) > 0:
+                self.data[key] = value[0]['name']
+                self.attributes[key] = value[0]
+
+        _LOGGER.debug("Updated SolarEdge inventory data and attributes: %s, %s",
+                      self.data, self.attributes)
+

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -40,12 +40,12 @@ SENSOR_TYPES = {
                           ENERGY_WATT_HOUR, 'mdi:solar-power'],
     'energy_today': ['lastDayData', "Energy today",
                      ENERGY_WATT_HOUR, 'mdi:solar-power'],
-    'current_power': ['currentPower', "Current Power",
-                      POWER_WATT, 'mdi:solar-power'],
-    'site_details': [None, 'Site details', None, 
+    'current_power': ['currentPower', "Current Power", POWER_WATT,
+                      'mdi:solar-power'],
+    'site_details': [None, 'Site details', None,
                      None],
-    'inverter_details': ['inverters', 'Inverter', None, 
-                          None]
+    'inverter_details': ['inverters', 'Inverter', None,
+                         None]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -107,7 +107,8 @@ class SolarEdgeSensorFactory:
 
         self.overview_data_service = SolarEdgeOverviewDataService(api, site_id)
         self.details_data_service = SolarEdgeDetailsDataService(api, site_id)
-        self.inventory_data_service = SolarEdgeInventoryDataService(api, site_id)
+        self.inventory_data_service = SolarEdgeInventoryDataService(api,
+                                                                    site_id)
 
     def create_sensor(self, sensor_key):
         """Create and return a sensor based on the sensor_key."""
@@ -262,7 +263,7 @@ class SolarEdgeOverviewDataService(SolarEdgeDataService):
                 data = value
             self.data[key] = data
 
-        _LOGGER.debug("Updated SolarEdge overview data: %s", self.data)
+        _LOGGER.debug("Updated SolarEdge overview: %s", self.data)
 
 
 class SolarEdgeDetailsDataService(SolarEdgeDataService):
@@ -295,7 +296,7 @@ class SolarEdgeDetailsDataService(SolarEdgeDataService):
             elif key == 'status':
                 self.data = value
 
-        _LOGGER.debug("Updated SolarEdge details data and attributes: %s, %s",
+        _LOGGER.debug("Updated SolarEdge details: %s, %s",
                       self.data, self.attributes)
 
 
@@ -321,10 +322,9 @@ class SolarEdgeInventoryDataService(SolarEdgeDataService):
         self.attributes = {}
 
         for key, value in inventory.items():
-            if key == 'inverters' and len(value) > 0:
+            if key == 'inverters' and value:
                 self.data[key] = value[0]['name']
                 self.attributes[key] = value[0]
 
-        _LOGGER.debug("Updated SolarEdge inventory data and attributes: %s, %s",
+        _LOGGER.debug("Updated SolarEdge inventory: %s, %s",
                       self.data, self.attributes)
-

--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -100,7 +100,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     entities = []
     for sensor_key in config[CONF_MONITORED_CONDITIONS]:
         sensor = sensor_factory.create_sensor(sensor_key)
-        entities.append(sensor)
+        if sensor is not None:
+            entities.append(sensor)
 
     add_entities(entities, True)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1616,7 +1616,6 @@ socialbladeclient==0.2
 
 # homeassistant.components.solaredge.sensor
 solaredge==0.0.2
-stringcase==1.2.0
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.5.2
@@ -1649,6 +1648,7 @@ statsd==3.2.1
 # homeassistant.components.steam_online.sensor
 steamodd==4.21
 
+# homeassistant.components.solaredge.sensor
 # homeassistant.components.thermoworks_smoke.sensor
 stringcase==1.2.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1616,6 +1616,7 @@ socialbladeclient==0.2
 
 # homeassistant.components.solaredge.sensor
 solaredge==0.0.2
+stringcase==1.2.0
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.5.2


### PR DESCRIPTION
## Description:

Adding additional monitored_conditions to the SolarEdge platform.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8213

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
 - platform: solaredge
    api_key: YOUR_API_KEY
    site_id: YOUR_SITE_ID
    monitored_conditions:
      - current_power
      - energy_today
      - energy_this_month
      - energy_this_year
      - lifetime_energy
      # new conditions
      - site_details
      - inverters
      - meters
      - sensors
      - gateways
      - batteries
      - power_consumption
      - solar_power
      - grid_power
      - storage_power
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54