### PR TITLE
Fix webhook update for Point

### DIFF
--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -25,7 +25,7 @@ from .const import (
     CONF_WEBHOOK_URL, DOMAIN, EVENT_RECEIVED, POINT_DISCOVERY_NEW,
     SCAN_INTERVAL, SIGNAL_UPDATE_ENTITY, SIGNAL_WEBHOOK)
 
-REQUIREMENTS = ['pypoint==1.0.7']
+REQUIREMENTS = ['pypoint==1.0.8']
 DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/point/binary_sensor.py
+++ b/homeassistant/components/point/binary_sensor.py
@@ -91,7 +91,8 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorDevice):
         if self.device.webhook != webhook:
             return
         _type = data.get('event', {}).get('type')
-        if _type not in self._events:
+        _device_id = data.get('event', {}).get('device_id')
+        if _type not in self._events or _device_id != self.device.device_id:
             return
         _LOGGER.debug("Recieved webhook: %s", _type)
         if _type == self._events[0]:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1196,7 +1196,7 @@ pypck==0.5.9
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.0.7
+pypoint==1.0.8
 
 # homeassistant.components.sensor.pollen
 pypollencom==2.2.2


### PR DESCRIPTION
## Description:

The pypoint library had an issue with webhook-id, this fixes that and ensures that the right device is updated.

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
