### PR TITLE
Refactor http CachingStaticResource

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -16,13 +16,12 @@ import homeassistant.util as hass_util
 from homeassistant.util import ssl as ssl_util
 from homeassistant.util.logging import HideSensitiveDataFilter
 
-# Import as alias
 from .auth import setup_auth
 from .ban import setup_bans
 from .const import KEY_AUTHENTICATED, KEY_REAL_IP  # noqa
 from .cors import setup_cors
 from .real_ip import setup_real_ip
-from .static import CachingFileResponse, CachingStaticResource
+from .static import CACHE_HEADERS, CachingStaticResource
 from .view import HomeAssistantView  # noqa
 
 REQUIREMENTS = ['aiohttp_cors==0.7.0']
@@ -272,7 +271,7 @@ class HomeAssistantHTTP:
         if cache_headers:
             async def serve_file(request):
                 """Serve file from disk."""
-                return CachingFileResponse(path)
+                return web.FileResponse(path, headers=CACHE_HEADERS)
         else:
             async def serve_file(request):
                 """Serve file from disk."""

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -10,6 +10,8 @@ CACHE_TIME = 31 * 86400  # = 1 month
 CACHE_HEADERS = {hdrs.CACHE_CONTROL: "public, max-age={}".format(CACHE_TIME)}
 
 
+# https://github.com/PyCQA/astroid/issues/633
+# pylint: disable=duplicate-bases
 class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
 
@@ -28,8 +30,6 @@ class CachingStaticResource(StaticResource):
         except (ValueError, FileNotFoundError) as error:
             # relatively safe
             raise HTTPNotFound() from error
-        except HTTPForbidden:
-            raise
         except Exception as error:
             # perm error or other kind!
             request.app.logger.exception(error)
@@ -38,8 +38,7 @@ class CachingStaticResource(StaticResource):
         # on opening a dir, load its contents if allowed
         if filepath.is_dir():
             return await super()._handle(request)
-        elif filepath.is_file():
+        if filepath.is_file():
             return FileResponse(
                 filepath, chunk_size=self._chunk_size, headers=CACHE_HEADERS)
-        else:
-            raise HTTPNotFound
+        raise HTTPNotFound

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -1,5 +1,4 @@
 """Static file handling for HTTP component."""
-#pylint: skip-file
 from pathlib import Path
 
 from aiohttp import hdrs

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -1,4 +1,5 @@
 """Static file handling for HTTP component."""
+#pylint: skip-file
 from pathlib import Path
 
 from aiohttp import hdrs
@@ -10,7 +11,6 @@ CACHE_TIME = 31 * 86400  # = 1 month
 CACHE_HEADERS = {hdrs.CACHE_CONTROL: "public, max-age={}".format(CACHE_TIME)}
 
 
-# pylint: disable=E0241
 class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
 

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -5,6 +5,9 @@ from aiohttp.web_exceptions import HTTPNotFound
 from aiohttp.web_urldispatcher import StaticResource
 from yarl import URL
 
+CACHE_TIME = 31 * 86400  # = 1 month
+CACHE_HEADERS = {hdrs.CACHE_CONTROL: "public, max-age={}".format(CACHE_TIME)}
+
 
 class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
@@ -27,27 +30,6 @@ class CachingStaticResource(StaticResource):
         if filepath.is_dir():
             return await super()._handle(request)
         if filepath.is_file():
-            return CachingFileResponse(filepath, chunk_size=self._chunk_size)
+            return FileResponse(
+                filepath, chunk_size=self._chunk_size, headers=CACHE_HEADERS)
         raise HTTPNotFound
-
-
-# pylint: disable=too-many-ancestors
-class CachingFileResponse(FileResponse):
-    """FileSender class that caches output if not in dev mode."""
-
-    def __init__(self, *args, **kwargs):
-        """Initialize the hass file sender."""
-        super().__init__(*args, **kwargs)
-
-        orig_sendfile = self._sendfile
-
-        async def sendfile(request, fobj, count):
-            """Sendfile that includes a cache header."""
-            cache_time = 31 * 86400  # = 1 month
-            self.headers[hdrs.CACHE_CONTROL] = "public, max-age={}".format(
-                cache_time)
-
-            await orig_sendfile(request, fobj, count)
-
-        # Overwriting like this because __init__ can change implementation.
-        self._sendfile = sendfile

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -10,6 +10,7 @@ CACHE_TIME = 31 * 86400  # = 1 month
 CACHE_HEADERS = {hdrs.CACHE_CONTROL: "public, max-age={}".format(CACHE_TIME)}
 
 
+# pylint: disable=E0241
 class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
 


### PR DESCRIPTION
## Description:

Simplify http.CachingStaticResource implementation, and catch up the changes in aiohttp.
No need define CachingFileResponse

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

