### PR TITLE
Prevent partial custom component overlays

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -15,7 +15,7 @@ import importlib
 import logging
 import sys
 from types import ModuleType
-from typing import Optional, Set, TYPE_CHECKING, Callable, Any, TypeVar  # noqa pylint: disable=unused-import
+from typing import Optional, Set, TYPE_CHECKING, Callable, Any, TypeVar, List  # noqa pylint: disable=unused-import
 
 from homeassistant.const import PLATFORM_FORMAT
 
@@ -34,8 +34,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 DATA_KEY = 'components'
-PATH_CUSTOM_COMPONENTS = 'custom_components'
-PACKAGE_COMPONENTS = 'homeassistant.components'
+PACKAGE_CUSTOM_COMPONENTS = 'custom_components'
+PACKAGE_BUILTIN = 'homeassistant.components'
+LOOKUP_PATHS = [PACKAGE_CUSTOM_COMPONENTS, PACKAGE_BUILTIN]
 
 
 class LoaderError(Exception):
@@ -76,23 +77,43 @@ def get_platform(hass,  # type: HomeAssistant
                  domain: str, platform_name: str) -> Optional[ModuleType]:
     """Try to load specified platform.
 
+    Example invocation: get_platform(hass, 'light', 'hue')
+
     Async friendly.
     """
-    platform = _load_file(hass, PLATFORM_FORMAT.format(
-        domain=domain, platform=platform_name))
+    # If the platform has a component, we will limit the platform loading path
+    # to be the same source (custom/built-in).
+    component = get_component(hass, platform_name)
+
+    # Until we have moved all platforms under their component/own folder, it
+    # can be that the component is None.
+    if component is not None:
+        base_paths = [component.__name__.rsplit('.', 1)[0]]
+    else:
+        base_paths = LOOKUP_PATHS
+
+    platform = _load_file(
+        hass, PLATFORM_FORMAT.format(domain=domain, platform=platform_name),
+        base_paths)
 
     if platform is not None:
         return platform
 
     # Legacy platform check: light/hue.py
-    platform = _load_file(hass, PLATFORM_FORMAT.format(
-        domain=platform_name, platform=domain))
+    platform = _load_file(
+        hass, PLATFORM_FORMAT.format(domain=platform_name, platform=domain),
+        base_paths)
 
     if platform is None:
-        _LOGGER.error("Unable to find platform %s", platform_name)
+        if component is None:
+            extra = ""
+        else:
+            extra = " Search path was limited to path of component: {}".format(
+                base_paths[0])
+        _LOGGER.error("Unable to find platform %s.%s", platform_name, extra)
         return None
 
-    if platform.__name__.startswith(PATH_CUSTOM_COMPONENTS):
+    if platform.__name__.startswith(PACKAGE_CUSTOM_COMPONENTS):
         _LOGGER.warning(
             "Integrations need to be in their own folder. Change %s/%s.py to "
             "%s/%s.py. This will stop working soon.",
@@ -107,7 +128,7 @@ def get_component(hass,  # type: HomeAssistant
 
     Async friendly.
     """
-    comp = _load_file(hass, comp_or_platform)
+    comp = _load_file(hass, comp_or_platform, LOOKUP_PATHS)
 
     if comp is None:
         _LOGGER.error("Unable to find component %s", comp_or_platform)
@@ -116,7 +137,8 @@ def get_component(hass,  # type: HomeAssistant
 
 
 def _load_file(hass,  # type: HomeAssistant
-               comp_or_platform: str) -> Optional[ModuleType]:
+               comp_or_platform: str,
+               base_paths: List[str]) -> Optional[ModuleType]:
     """Try to load specified file.
 
     Looks in config dir first, then built-in components.
@@ -138,11 +160,8 @@ def _load_file(hass,  # type: HomeAssistant
             sys.path.insert(0, hass.config.config_dir)
         cache = hass.data[DATA_KEY] = {}
 
-    # First check custom, then built-in
-    potential_paths = ['custom_components.{}'.format(comp_or_platform),
-                       'homeassistant.components.{}'.format(comp_or_platform)]
-
-    for index, path in enumerate(potential_paths):
+    for index, path in enumerate('{}.{}'.format(base, comp_or_platform)
+                                 for base in base_paths):
         try:
             module = importlib.import_module(path)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -453,6 +453,7 @@ class MockModule:
                  platform_schema_base=None, async_setup=None,
                  async_setup_entry=None, async_unload_entry=None):
         """Initialize the mock module."""
+        self.__name__ = 'homeassistant.components.{}'.format(domain)
         self.DOMAIN = domain
         self.DEPENDENCIES = dependencies or []
         self.REQUIREMENTS = requirements or []

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -135,3 +135,10 @@ async def test_get_platform(hass, caplog):
     legacy_platform = loader.get_platform(hass, 'switch', 'test')
     assert legacy_platform.__name__ == 'custom_components.switch.test'
     assert 'Integrations need to be in their own folder.' in caplog.text
+
+
+async def test_get_platform_enforces_component_path(hass, caplog):
+    """Test that existence of a component limits lookup path of platforms."""
+    assert loader.get_platform(hass, 'comp_path_test', 'hue') is None
+    assert ('Search path was limited to path of component: '
+            'homeassistant.components') in caplog.text

--- a/tests/testing_config/custom_components/hue/comp_path_test.py
+++ b/tests/testing_config/custom_components/hue/comp_path_test.py
@@ -1,0 +1,1 @@
+"""Custom platform for a built-in component, should not be allowed."""


### PR DESCRIPTION
## Description:
This will force platforms to be resolved based off the component path, if it exists.

Today, if you want, you can override the Hue light platform, but not the other parts of the Hue integration. If a future update evolves the Hue component, removing or changing internal methods that the custom platform relied upon, the custom platform will start failing (like [this report](https://github.com/home-assistant/home-assistant/issues/17943#issuecomment-462014778)).

To avoid this, we're going to no longer allow custom components to be partial overlays (just a platform). Instead, if you want to override a built-in platform, you will need to override the whole component.

This is enforced by first resolving the platform as a component, and if it exists, limiting the lookup path to the component path.

Example: if I look up the `hue` component, and it is provided by a custom component, then all platform lookups will also be looked up in the custom component dir. The same works the other way around, if a user would only try to override `hue/light.py` but not `hue/__init__.py`, the custom platform will be ignored.

**Breaking change:** Custom platforms that override a built-in platform that has a component, should now also include the component in the `custom_components/` folder. So if you want to override `hue/light.py` with a custom version, you will also need to provide/copy over `hue/__init__.py`.

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/141

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
