### PR TITLE
Add legacy PLATFORM_SCHEMA config validation

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -192,7 +192,7 @@ async def async_from_config_dict(config: Dict[str, Any],
             '\n\n'.join(msg), "Config Warning", "config_warning"
         )
 
-    # TEMP: warn users for invalid slugs
+    # TEMP: warn users of invalid extra keys
     # Remove after 0.92
     if cv.INVALID_EXTRA_KEYS_FOUND:
         msg = []

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -192,6 +192,23 @@ async def async_from_config_dict(config: Dict[str, Any],
             '\n\n'.join(msg), "Config Warning", "config_warning"
         )
 
+    # TEMP: warn users for invalid slugs
+    # Remove after 0.92
+    if cv.INVALID_EXTRA_KEYS_FOUND:
+        msg = []
+        msg.append(
+            "Your configuration contains extra keys "
+            "that the platform does not support (but were silently "
+            "accepted before 0.88). Please find and remove the following."
+            "This will become a breaking change."
+        )
+        msg.append('\n'.join('- {}'.format(it)
+                             for it in cv.INVALID_EXTRA_KEYS_FOUND))
+
+        hass.components.persistent_notification.async_create(
+            '\n\n'.join(msg), "Config Warning", "config_warning"
+        )
+
     return hass
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -25,8 +25,6 @@ from homeassistant.helpers import template as template_helper
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 
-_LOGGER = logging.getLogger(__name__)
-
 # pylint: disable=invalid-name
 
 TIME_PERIOD_ERROR = "offset {} should be format 'HH:MM' or 'HH:MM:SS'"
@@ -36,6 +34,7 @@ OLD_ENTITY_ID_VALIDATION = r"^(\w+)\.(\w+)$"
 # persistent notification. Rare temporary exception to use a global.
 INVALID_SLUGS_FOUND = {}
 INVALID_ENTITY_IDS_FOUND = {}
+INVALID_EXTRA_KEYS_FOUND = []
 
 
 # Home Assistant types
@@ -661,14 +660,17 @@ class HASchema(vol.Schema):
                               if err.error_message == 'extra keys not allowed']
             if extra_key_errs:
                 msg = "Your configuration contains extra keys " \
-                      "that the platform does not support. The keys "
-                msg += ', '.join('[{}]'.format(err.path[-1]) for err in
-                                 extra_key_errs)
-                msg += ' are 42.'
+                      "that the platform does not support.\n" \
+                      "Please remove "
+                submsg = ', '.join('[{}]'.format(err.path[-1]) for err in
+                                   extra_key_errs)
+                submsg += '. '
                 if hasattr(data, '__config_file__'):
-                    msg += " (See {}, line {}). ".format(data.__config_file__,
-                                                         data.__line__)
-                _LOGGER.warning(msg)
+                    submsg += " (See {}, line {}). ".format(
+                        data.__config_file__, data.__line__)
+                msg += submsg
+                logging.getLogger(__name__).warning(msg)
+                INVALID_EXTRA_KEYS_FOUND.append(submsg)
             else:
                 # This should not happen (all errors should be extra key
                 # errors). Let's raise the original error anyway.

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -636,7 +636,9 @@ def key_dependency(key, dependency):
 # Schemas
 class HASchema(vol.Schema):
     """Schema class that allows us to mark PREVENT_EXTRA errors as warnings."""
+
     def __call__(self, data):
+        """Override __call__ to mark PREVENT_EXTRA as warning."""
         try:
             return super().__call__(data)
         except vol.Invalid as orig_err:
@@ -645,6 +647,7 @@ class HASchema(vol.Schema):
 
             # orig_error is of type vol.MultipleInvalid (see super __call__)
             assert isinstance(orig_err, vol.MultipleInvalid)
+            # pylint: disable=no-member
             # If it fails with PREVENT_EXTRA, try with ALLOW_EXTRA
             self.extra = vol.ALLOW_EXTRA
             # In case it still fails the following will raise
@@ -675,7 +678,7 @@ class HASchema(vol.Schema):
             return validated
 
     def extend(self, schema, required=None, extra=None):
-        """Extend this schema and convert it to HASchema if necessary"""
+        """Extend this schema and convert it to HASchema if necessary."""
         ret = super().extend(schema, required=required, extra=extra)
         if extra is not None:
             return ret

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -90,7 +90,7 @@ class TestSetup:
                 }
             })
 
-    def test_validate_platform_config(self):
+    def test_validate_platform_config(self, caplog):
         """Test validating platform configuration."""
         platform_schema = PLATFORM_SCHEMA.extend({
             'hello': str,
@@ -109,7 +109,7 @@ class TestSetup:
             MockPlatform('whatever',
                          platform_schema=platform_schema))
 
-        with assert_setup_component(0):
+        with assert_setup_component(1):
             assert setup.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {
                     'platform': 'whatever',
@@ -117,11 +117,12 @@ class TestSetup:
                     'invalid': 'extra',
                 }
             })
+            assert caplog.text.count('Your configuration contains extra keys') == 1
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
 
-        with assert_setup_component(1):
+        with assert_setup_component(2):
             assert setup.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {
                     'platform': 'whatever',
@@ -132,6 +133,7 @@ class TestSetup:
                     'invalid': True
                 }
             })
+            assert caplog.text.count('Your configuration contains extra keys') == 2
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
@@ -183,7 +185,7 @@ class TestSetup:
             assert 'platform_conf' in self.hass.config.components
             assert not config['platform_conf']  # empty
 
-    def test_validate_platform_config_2(self):
+    def test_validate_platform_config_2(self, caplog):
         """Test component PLATFORM_SCHEMA_BASE prio over PLATFORM_SCHEMA."""
         platform_schema = PLATFORM_SCHEMA.extend({
             'hello': str,
@@ -204,7 +206,7 @@ class TestSetup:
             MockPlatform('whatever',
                          platform_schema=platform_schema))
 
-        with assert_setup_component(0):
+        with assert_setup_component(1):
             assert setup.setup_component(self.hass, 'platform_conf', {
                 # fail: no extra keys allowed in platform schema
                 'platform_conf': {
@@ -213,6 +215,7 @@ class TestSetup:
                     'invalid': 'extra',
                 }
             })
+            assert caplog.text.count('Your configuration contains extra keys') == 1
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
@@ -234,7 +237,7 @@ class TestSetup:
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
 
-    def test_validate_platform_config_3(self):
+    def test_validate_platform_config_3(self, caplog):
         """Test fallback to component PLATFORM_SCHEMA."""
         component_schema = PLATFORM_SCHEMA_BASE.extend({
             'hello': str,
@@ -255,15 +258,15 @@ class TestSetup:
             MockPlatform('whatever',
                          platform_schema=platform_schema))
 
-        with assert_setup_component(0):
+        with assert_setup_component(1):
             assert setup.setup_component(self.hass, 'platform_conf', {
                 'platform_conf': {
-                    # fail: no extra keys allowed
                     'platform': 'whatever',
                     'hello': 'world',
                     'invalid': 'extra',
                 }
             })
+            assert caplog.text.count('Your configuration contains extra keys') == 1
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -117,7 +117,8 @@ class TestSetup:
                     'invalid': 'extra',
                 }
             })
-            assert caplog.text.count('Your configuration contains extra keys') == 1
+            assert caplog.text.count('Your configuration contains '
+                                     'extra keys') == 1
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
@@ -133,7 +134,8 @@ class TestSetup:
                     'invalid': True
                 }
             })
-            assert caplog.text.count('Your configuration contains extra keys') == 2
+            assert caplog.text.count('Your configuration contains '
+                                     'extra keys') == 2
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
@@ -215,7 +217,8 @@ class TestSetup:
                     'invalid': 'extra',
                 }
             })
-            assert caplog.text.count('Your configuration contains extra keys') == 1
+            assert caplog.text.count('Your configuration contains '
+                                     'extra keys') == 1
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')
@@ -266,7 +269,8 @@ class TestSetup:
                     'invalid': 'extra',
                 }
             })
-            assert caplog.text.count('Your configuration contains extra keys') == 1
+            assert caplog.text.count('Your configuration contains '
+                                     'extra keys') == 1
 
         self.hass.data.pop(setup.DATA_SETUP)
         self.hass.config.components.remove('platform_conf')


### PR DESCRIPTION
## Description:

PLATFORM_SCHEMA is now using `PREVENT_EXTRA` instead of `ALLOW_EXTRA`. This will probably create a whole bunch of erroneous issues in the issue tracker

This PR adds a hacky legacy schema class that behaves like `ALLOW_EXTRA` but prints warnings when `PREVENT_EXTRA` fails. 

Unfortunately in the voluptuous system the error path is bubbled _up_, so we do not know the exact path in the config where the warning is. So the error message uses the custom YAML loader's magic variables to at least show in which file to look.

Todo:
- [ ] Find descriptive error Message
- [ ] Clean up code a bit

See chat in #beta discord channel.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
- platform: template
  abc: hi
  sensors:
    sunrise:
      value_template: "{{ state_attr('sun.sun', 'next_rising') }}"
```

Message:
```
WARNING (MainThread) [homeassistant.helpers.config_validation] Your configuration contains extra keys that the platform does not support. The keys [abc] are 42. (See ./home-assistant/config/configuration.yaml, line 34). 
```

## Checklist:
  - [] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
