### PR TITLE
Add traccar scan_interval configuration option

### DIFF
--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -40,8 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=8082): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): 
-            cv.time_period,
+    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
 })
 
 

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -32,6 +32,7 @@ ATTR_SPEED = 'speed'
 ATTR_TRACKER = 'tracker'
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = DEFAULT_SCAN_INTERVAL
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
@@ -40,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=8082): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
 })
 
 
@@ -52,7 +52,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
 
     api = API(hass.loop, session, config[CONF_USERNAME], config[CONF_PASSWORD],
               config[CONF_HOST], config[CONF_PORT], config[CONF_SSL])
-    scanner = TraccarScanner(api, hass, async_see, config[CONF_SCAN_INTERVAL])
+    scanner = TraccarScanner(api, hass, async_see, config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL))
     return await scanner.async_init()
 
 

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -52,7 +52,8 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
 
     api = API(hass.loop, session, config[CONF_USERNAME], config[CONF_PASSWORD],
               config[CONF_HOST], config[CONF_PORT], config[CONF_SSL])
-    scanner = TraccarScanner(api, hass, async_see, config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL))
+    scanner = TraccarScanner(
+        api, hass, async_see, config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL))
     return await scanner.async_init()
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8618

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: traccar
    host: hostname
    port: 8072
    ssl: true
    username: admin
    password: password
    scan_interval: 00:00:05
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
