### PR TITLE
Set uvloop version consistent with hass.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY requirements_all.txt requirements_all.txt
 # Uninstall enum34 because some dependencies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython tensorflow
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop==0.11.3 cchardet cython tensorflow
 
 # Copy source
 COPY . .

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -29,7 +29,7 @@ COPY requirements_all.txt requirements_all.txt
 # Uninstall enum34 because some dependencies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop==0.11.3 cchardet cython
 
 # BEGIN: Development additions
 


### PR DESCRIPTION
## Description:
This sets the uvloop version in Docker containers to 0.11.3, which is the
same version that hass.io uses.

uvloop might be causing issues with some Docker containers on some host
systems.

**Related issue (if applicable):** fixes #20829 