### PR TITLE
Check against unlinked user

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -134,22 +134,26 @@ class PersonManager:
 
             entities.append(Person(person_conf, False))
 
+        # To make sure IDs don't overlap between config/storage
+        seen_persons = set(self.config_data)
+
         for person_conf in storage_data.values():
             person_id = person_conf[CONF_ID]
             user_id = person_conf[CONF_USER_ID]
 
-            if user_id in self.config_data:
+            if person_id in seen_persons:
                 _LOGGER.error(
                     "Skipping adding person from storage with same ID as"
                     " configuration.yaml entry: %s", person_id)
                 continue
 
-            if user_id in seen_users:
+            if user_id is not None and user_id in seen_users:
                 _LOGGER.error(
                     "Duplicate user_id %s detected for person %s",
                     user_id, person_id)
                 continue
 
+            # To make sure all users have just 1 person linked.
             seen_users.add(user_id)
 
             entities.append(Person(person_conf, True))

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -287,6 +287,35 @@ async def test_load_person_storage(hass, hass_admin_user, storage_setup):
     assert state.attributes.get(ATTR_USER_ID) == hass_admin_user.id
 
 
+async def test_load_person_storage_two_nonlinked(hass, hass_storage):
+    """Test loading two users with both not having a user linked."""
+    hass_storage[DOMAIN] = {
+        'key': DOMAIN,
+        'version': 1,
+        'data': {
+            'persons': [
+                {
+                    'id': '1234',
+                    'name': 'tracked person 1',
+                    'user_id': None,
+                    'device_trackers': []
+                },
+                {
+                    'id': '5678',
+                    'name': 'tracked person 2',
+                    'user_id': None,
+                    'device_trackers': []
+                },
+            ]
+        }
+    }
+    await async_setup_component(hass, DOMAIN, {})
+
+    assert len(hass.states.async_entity_ids('person')) == 2
+    assert hass.states.get('person.tracked_person_1') is not None
+    assert hass.states.get('person.tracked_person_2') is not None
+
+
 async def test_ws_list(hass, hass_ws_client, storage_setup):
     """Test listing via WS."""
     manager = hass.data[DOMAIN]


### PR DESCRIPTION
## Description:
Fix allowing creation of 2 persons in storage, both not linked to a user and then restarting Home Assistant.

**Related issue (if applicable):** fixes @arsaboo issue via #beta on Discord

