### PR TITLE
Fix hue retry crash

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -101,11 +101,11 @@ async def async_setup_entry(hass, entry):
         allow_groups = config[CONF_ALLOW_HUE_GROUPS]
 
     bridge = HueBridge(hass, entry, allow_unreachable, allow_groups)
-    hass.data[DOMAIN][host] = bridge
 
     if not await bridge.async_setup():
         return False
 
+    hass.data[DOMAIN][host] = bridge
     config = bridge.api.config
     device_registry = await dr.async_get_registry(hass)
     device_registry.async_get_or_create(

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -23,6 +23,8 @@ CONF_BRIDGES = "bridges"
 CONF_ALLOW_UNREACHABLE = 'allow_unreachable'
 DEFAULT_ALLOW_UNREACHABLE = False
 
+DATA_CONFIGS = 'hue_configs'
+
 PHUE_CONFIG_FILE = 'phue.conf'
 
 CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
@@ -54,6 +56,7 @@ async def async_setup(hass, config):
         conf = {}
 
     hass.data[DOMAIN] = {}
+    hass.data[DATA_CONFIGS] = {}
     configured = configured_hosts(hass)
 
     # User has configured bridges
@@ -66,7 +69,7 @@ async def async_setup(hass, config):
         host = bridge_conf[CONF_HOST]
 
         # Store config in hass.data so the config entry can find it
-        hass.data[DOMAIN][host] = bridge_conf
+        hass.data[DATA_CONFIGS][host] = bridge_conf
 
         # If configured, the bridge will be set up during config entry phase
         if host in configured:
@@ -91,7 +94,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, entry):
     """Set up a bridge from a config entry."""
     host = entry.data['host']
-    config = hass.data[DOMAIN].get(host)
+    config = hass.data[DATA_CONFIGS].get(host)
 
     if config is None:
         allow_unreachable = DEFAULT_ALLOW_UNREACHABLE

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -39,7 +39,7 @@ async def test_setup_defined_hosts_known_auth(hass):
     assert len(mock_config_entries.flow.mock_calls) == 0
 
     # Config stored for domain.
-    assert hass.data[hue.DOMAIN] == {
+    assert hass.data[hue.DATA_CONFIGS] == {
         '0.0.0.0': {
             hue.CONF_HOST: '0.0.0.0',
             hue.CONF_FILENAME: 'bla.conf',
@@ -73,7 +73,7 @@ async def test_setup_defined_hosts_no_known_auth(hass):
     }
 
     # Config stored for domain.
-    assert hass.data[hue.DOMAIN] == {
+    assert hass.data[hue.DATA_CONFIGS] == {
         '0.0.0.0': {
             hue.CONF_HOST: '0.0.0.0',
             hue.CONF_FILENAME: 'bla.conf',


### PR DESCRIPTION
## Description:
If Hue would need to retry connection, subsequent tries would crash because we were using `hass.data[DOMAIN]` for both config and bridge. Also, if unloading and setting up same host again, the YAML config would be lost.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
