### PR TITLE
Bump pyHik library to 0.2.2, improve connections, add sensors

### DIFF
--- a/homeassistant/components/binary_sensor/hikvision.py
+++ b/homeassistant/components/binary_sensor/hikvision.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_SSL, EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_START,
     ATTR_LAST_TRIP_TIME, CONF_CUSTOMIZE)
 
-REQUIREMENTS = ['pyhik==0.1.9']
+REQUIREMENTS = ['pyhik==0.2.2']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_IGNORED = 'ignored'
@@ -51,6 +51,8 @@ DEVICE_CLASS_MAP = {
     'Unattended Baggage': 'motion',
     'Attended Baggage': 'motion',
     'Recording Failure': None,
+    'Exiting Region': 'motion',
+    'Entering Region': 'motion',
 }
 
 CUSTOMIZE_SCHEMA = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1053,7 +1053,7 @@ pygtt==1.1.2
 pyhaversion==2.0.3
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.9
+pyhik==0.2.2
 
 # homeassistant.components.hive
 pyhiveapi==0.2.17


### PR DESCRIPTION
## Description:
Increase pyHik library version to 0.2.2 to improve handling of dropped camera connections and add region entering and exiting sensor types.

**Related issue (if applicable):** 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
