### PR TITLE
Bump thermoworks_smoke version to get new pyrebase version

### DIFF
--- a/homeassistant/components/sensor/thermoworks_smoke.py
+++ b/homeassistant/components/sensor/thermoworks_smoke.py
@@ -17,7 +17,7 @@ from homeassistant.const import TEMP_FAHRENHEIT, CONF_EMAIL, CONF_PASSWORD,\
     CONF_MONITORED_CONDITIONS, CONF_EXCLUDE, ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['thermoworks_smoke==0.1.7', 'stringcase==1.2.0']
+REQUIREMENTS = ['thermoworks_smoke==0.1.8', 'stringcase==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1659,7 +1659,7 @@ temperusb==1.5.3
 teslajsonpy==0.0.23
 
 # homeassistant.components.sensor.thermoworks_smoke
-thermoworks_smoke==0.1.7
+thermoworks_smoke==0.1.8
 
 # homeassistant.components.thingspeak
 thingspeak==0.4.1


### PR DESCRIPTION
## Description:
Something must have changed on firebase that exposed an issue with double escaping quotes. I fixed the issue in Pyrebase and updated the dependencies in thermoworks_smoke.

**Related issue (if applicable):** fixes n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
