### PR TITLE
Fix SmartThings Translation Error

### DIFF
--- a/homeassistant/components/smartthings/.translations/en.json
+++ b/homeassistant/components/smartthings/.translations/en.json
@@ -8,7 +8,7 @@
             "token_forbidden": "The token does not have the required OAuth scopes.",
             "token_invalid_format": "The token must be in the UID/GUID format",
             "token_unauthorized": "The token is invalid or no longer authorized.",
-            "webhook_error": "SmartThings could not validate the endpoint configured in `base_url`. Please review the [component requirements]({component_url})."
+            "webhook_error": "SmartThings could not validate the endpoint configured in `base_url`. Please review the component requirements."
         },
         "step": {
             "user": {

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -22,7 +22,7 @@
         "app_setup_error": "Unable to setup the SmartApp.  Please try again.",
         "app_not_installed": "Please ensure you have installed and authorized the Home Assistant SmartApp and try again.",
         "base_url_not_https": "The `base_url` for the `http` component must be configured and start with `https://`.",
-        "webhook_error": "SmartThings could not validate the endpoint configured in `base_url`. Please review the [component requirements]({component_url})."
+        "webhook_error": "SmartThings could not validate the endpoint configured in `base_url`. Please review the component requirements."
     }
   }
 }


### PR DESCRIPTION
## Description:
Removes the token from a new error message added to the translation file, as tokens in error messages are not currently supported.

Introduced by #21085 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.