### PR TITLE
Add /secure path to host static files need authentication to access

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -236,6 +236,12 @@ async def async_setup(hass, config):
     if os.path.isdir(local):
         hass.http.register_static_path("/local", local, not is_dev)
 
+    secure = hass.config.path('www_secure')
+    if os.path.isdir(secure):
+        # we do not want browser cache files under secure folder
+        hass.http.register_static_path("/secure", secure, False,
+                                       requires_auth=True)
+
     index_view = IndexView(repo_path, js_version)
     hass.http.register_view(index_view)
     hass.http.register_view(AuthorizeView(repo_path, js_version))

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -265,7 +265,7 @@ class HomeAssistantHTTP:
             if requires_auth:
                 resource = SecureStaticResource
                 if cache_headers:
-                    _LOGGER.warning('cache_headers is ignored on % since'
+                    _LOGGER.warning('cache_headers is ignored on %s since'
                                     ' requires_auth=True', path)
             elif cache_headers:
                 resource = CachingStaticResource

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -265,8 +265,8 @@ class HomeAssistantHTTP:
             if requires_auth:
                 resource = SecureStaticResource
                 if cache_headers:
-                    _LOGGER.warning('cache_headers is ignored on {} since'
-                                    ' requires_auth=True'.format(path))
+                    _LOGGER.warning('cache_headers is ignored on % since'
+                                    ' requires_auth=True', path)
             elif cache_headers:
                 resource = CachingStaticResource
             else:

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -1,13 +1,23 @@
 """Static file handling for HTTP component."""
+import logging
 from pathlib import Path
 
 from aiohttp import hdrs
 from aiohttp.web import FileResponse
-from aiohttp.web_exceptions import HTTPNotFound, HTTPForbidden
+from aiohttp.web_exceptions import (
+    HTTPForbidden,
+    HTTPNotFound,
+    HTTPUnauthorized,
+)
 from aiohttp.web_urldispatcher import StaticResource
+
+from .const import KEY_AUTHENTICATED, KEY_REAL_IP
+from .ban import process_success_login
 
 CACHE_TIME = 31 * 86400  # = 1 month
 CACHE_HEADERS = {hdrs.CACHE_CONTROL: "public, max-age={}".format(CACHE_TIME)}
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # https://github.com/PyCQA/astroid/issues/633
@@ -16,6 +26,7 @@ class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
 
     async def _handle(self, request):
+        """Handle HTTP request."""
         rel_url = request.match_info['filename']
         try:
             filename = Path(rel_url)
@@ -42,3 +53,20 @@ class CachingStaticResource(StaticResource):
             return FileResponse(
                 filepath, chunk_size=self._chunk_size, headers=CACHE_HEADERS)
         raise HTTPNotFound
+
+
+class SecureStaticResource(StaticResource):
+    """Static Resource handler that will require authorize."""
+
+    async def _handle(self, request):
+        """Handle HTTP request."""
+        authenticated = request.get(KEY_AUTHENTICATED, False)
+        if authenticated:
+            await process_success_login(request)
+        else:
+            raise HTTPUnauthorized()
+
+        _LOGGER.info('Serving %s to %s (auth: %s)',
+                     request.path, request.get(KEY_REAL_IP), authenticated)
+
+        return await super()._handle(request)

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -133,6 +133,3 @@ async def test_register_static_path(hass, hass_client, aiohttp_client):
         with pytest.raises(ValueError):
             hass.http.register_static_path(
                 '/invalid', secure_dir + '/not-exist', False, True)
-
-
-

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -10,14 +10,12 @@ from homeassistant.setup import async_setup_component
 async def test_register_static_path(hass, hass_client, aiohttp_client):
     """Test register a dir to host static resources."""
     assert await async_setup_component(hass, 'http', {'http': {}}) is True
-    # same hack as the one in http.start()
-    # prevent freeze of http app in order to register test path
+    # use the same hack as the one used in http.start()
+    # prevent freeze of http app in order to register static path
     hass.http.app._router.freeze = lambda: None
     client = await hass_client()
 
     with TemporaryDirectory() as tmp_dir:
-        # real_path = os.path.realpath(tmp_dir)
-
         # test default setting is cache-able and no auth need
         default_dir = os.path.join(tmp_dir, 'default')
         os.mkdir(default_dir)

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -73,7 +73,7 @@ async def test_register_static_path(hass, hass_client, aiohttp_client):
         assert await resp.text() == 'no-cache'
 
         # test single file register with cache control
-        test_file_path = os.path.join(no_cache_dir, 'cache.me')
+        test_file_path = os.path.join(no_cache_dir, 'cache.txt')
         with open(test_file_path, 'w') as tmp_file:
             tmp_file.write('cached')
 
@@ -82,14 +82,14 @@ async def test_register_static_path(hass, hass_client, aiohttp_client):
         resp = await client.get('cache.me')
         assert resp.status == 200
         assert resp.headers['Cache-Control'] == 'public, max-age=2678400'
-        assert resp.headers['Content-Type'] == 'text/troff'
+        assert resp.headers['Content-Type'] == 'text/plain'
         assert await resp.text() == 'cached'
 
         # this file still can be access from no-cache url
-        resp = await client.get('no-cache/cache.me')
+        resp = await client.get('no-cache/cache.txt')
         assert resp.status == 200
         assert 'Cache-Control' not in resp.headers
-        assert resp.headers['Content-Type'] == 'text/troff'
+        assert resp.headers['Content-Type'] == 'text/plain'
         assert await resp.text() == 'cached'
 
         # test secure feature

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -1,0 +1,138 @@
+"""Tests for hosting static resource."""
+import os
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from homeassistant.setup import async_setup_component
+
+
+async def test_register_static_path(hass, hass_client, aiohttp_client):
+    """Test register a dir to host static resources."""
+    assert await async_setup_component(hass, 'http', {'http': {}}) is True
+    # same hack as the one in http.start()
+    # prevent freeze of http app in order to register test path
+    hass.http.app._router.freeze = lambda: None
+    client = await hass_client()
+
+    with TemporaryDirectory() as tmp_dir:
+        # real_path = os.path.realpath(tmp_dir)
+
+        # test default setting is cache-able and no auth need
+        default_dir = os.path.join(tmp_dir, 'default')
+        os.mkdir(default_dir)
+
+        test_file_path = os.path.join(default_dir, 'test.jpg')
+        with open(test_file_path, 'w') as tmp_file:
+            tmp_file.write('test')
+
+        hass.http.register_static_path('/default', default_dir)
+
+        # no auth
+        resp = await client.get('default/test.jpg',
+                                headers={'Authorization': ''})
+        assert resp.status == 200
+        assert resp.headers['Cache-Control'] == 'public, max-age=2678400'
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+        assert await resp.text() == 'test'
+
+        # test dynamic content prefer not be cached
+        no_cache_dir = os.path.join(tmp_dir, 'no-cache')
+        os.mkdir(no_cache_dir)
+
+        test_file_path = os.path.join(no_cache_dir, 'dynamic.mp3')
+        with open(test_file_path, 'w') as tmp_file:
+            tmp_file.write('no-cache')
+
+        hass.http.register_static_path('/no-cache', no_cache_dir, False)
+
+        resp = await client.get('no-cache/dynamic.mp3')
+        assert resp.status == 200
+        assert 'Cache-Control' not in resp.headers
+        assert resp.headers['Content-Type'] == 'audio/mpeg'
+        assert await resp.text() == 'no-cache'
+
+        # test single file register with no cache control
+        test_file_path = os.path.join(default_dir, 'dynamic.mp4')
+        with open(test_file_path, 'w') as tmp_file:
+            tmp_file.write('no-cache')
+
+        hass.http.register_static_path('/nc/d.m', test_file_path, False)
+
+        resp = await client.get('nc/d.m')
+        assert resp.status == 200
+        assert 'Cache-Control' not in resp.headers
+        assert resp.headers['Content-Type'] == 'video/mp4'
+        assert await resp.text() == 'no-cache'
+
+        # this file still can be access from cached url
+        resp = await client.get('default/dynamic.mp4')
+        assert resp.status == 200
+        assert resp.headers['Cache-Control'] == 'public, max-age=2678400'
+        assert resp.headers['Content-Type'] == 'video/mp4'
+        assert await resp.text() == 'no-cache'
+
+        # test single file register with cache control
+        test_file_path = os.path.join(no_cache_dir, 'cache.me')
+        with open(test_file_path, 'w') as tmp_file:
+            tmp_file.write('cached')
+
+        hass.http.register_static_path('/cache.me', test_file_path, True)
+
+        resp = await client.get('cache.me')
+        assert resp.status == 200
+        assert resp.headers['Cache-Control'] == 'public, max-age=2678400'
+        assert resp.headers['Content-Type'] == 'text/troff'
+        assert await resp.text() == 'cached'
+
+        # this file still can be access from no-cache url
+        resp = await client.get('no-cache/cache.me')
+        assert resp.status == 200
+        assert 'Cache-Control' not in resp.headers
+        assert resp.headers['Content-Type'] == 'text/troff'
+        assert await resp.text() == 'cached'
+
+        # test secure feature
+        secure_dir = os.path.join(tmp_dir, 'secure')
+        os.mkdir(secure_dir)
+
+        test_file_path = os.path.join(secure_dir, 'pass.html')
+        with open(test_file_path, 'w') as tmp_file:
+            tmp_file.write('<html>pass</html>')
+
+        hass.http.register_static_path('/secure', secure_dir, True,
+                                       requires_auth=True)
+
+        resp = await client.get('secure/pass.html')
+        assert resp.status == 200
+        # secure file is not cache-able, cache-headers parameter is ignored
+        assert 'Cache-Control' not in resp.headers
+        assert resp.headers['Content-Type'] == 'text/html'
+        assert await resp.text() == '<html>pass</html>'
+
+        # negative test: no auth
+        resp = await client.get('secure/pass.html',
+                                headers={'Authorization': ''})
+        assert resp.status == 401
+        resp = await client.get('secure/',
+                                headers={'Authorization': ''})
+        assert resp.status == 401
+
+        # negative test
+        resp = await client.get('default/')
+        assert resp.status == 403   # not allow list dir
+        resp = await client.get('not-valid-path/')
+        assert resp.status == 404   # path not found
+        resp = await client.get('default/not-valid-file')
+        assert resp.status == 404   # file not found
+
+        # negative register test
+        with pytest.raises(ValueError):
+            hass.http.register_static_path(
+                '/invalid', secure_dir + '/pass.html', False, True)
+        with pytest.raises(ValueError):
+            hass.http.register_static_path(
+                '/invalid', secure_dir + '/not-exist', False, True)
+
+
+

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -15,16 +15,17 @@ async def test_register_static_path(hass, hass_client, aiohttp_client):
     hass.http.app._router.freeze = lambda: None
     client = await hass_client()
 
+    # we are using same test file to save I/O
     with TemporaryDirectory() as tmp_dir:
         # test default setting is cache-able and no auth need
-        default_dir = os.path.join(tmp_dir, 'default')
-        os.mkdir(default_dir)
+        test_dir = os.path.join(tmp_dir, 'static_test')
+        os.mkdir(test_dir)
 
-        test_file_path = os.path.join(default_dir, 'test.jpg')
+        test_file_path = os.path.join(test_dir, 'test.jpg')
         with open(test_file_path, 'w') as tmp_file:
             tmp_file.write('test')
 
-        hass.http.register_static_path('/default', default_dir)
+        hass.http.register_static_path('/default', test_dir)
 
         # no auth
         resp = await client.get('default/test.jpg',
@@ -35,81 +36,59 @@ async def test_register_static_path(hass, hass_client, aiohttp_client):
         assert await resp.text() == 'test'
 
         # test dynamic content prefer not be cached
-        no_cache_dir = os.path.join(tmp_dir, 'no-cache')
-        os.mkdir(no_cache_dir)
+        hass.http.register_static_path('/no-cache', test_dir, False)
 
-        test_file_path = os.path.join(no_cache_dir, 'dynamic.mp3')
-        with open(test_file_path, 'w') as tmp_file:
-            tmp_file.write('no-cache')
-
-        hass.http.register_static_path('/no-cache', no_cache_dir, False)
-
-        resp = await client.get('no-cache/dynamic.mp3')
+        resp = await client.get('no-cache/test.jpg')
         assert resp.status == 200
         assert 'Cache-Control' not in resp.headers
-        assert resp.headers['Content-Type'] == 'audio/mpeg'
-        assert await resp.text() == 'no-cache'
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+        assert await resp.text() == 'test'
 
         # test single file register with no cache control
-        test_file_path = os.path.join(default_dir, 'dynamic.mp4')
-        with open(test_file_path, 'w') as tmp_file:
-            tmp_file.write('no-cache')
-
         hass.http.register_static_path('/nc/d.m', test_file_path, False)
 
         resp = await client.get('nc/d.m')
         assert resp.status == 200
         assert 'Cache-Control' not in resp.headers
-        assert resp.headers['Content-Type'] == 'video/mp4'
-        assert await resp.text() == 'no-cache'
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+        assert await resp.text() == 'test'
 
         # this file still can be access from cached url
-        resp = await client.get('default/dynamic.mp4')
+        resp = await client.get('default/test.jpg')
         assert resp.status == 200
         assert resp.headers['Cache-Control'] == 'public, max-age=2678400'
-        assert resp.headers['Content-Type'] == 'video/mp4'
-        assert await resp.text() == 'no-cache'
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+        assert await resp.text() == 'test'
 
         # test single file register with cache control
-        test_file_path = os.path.join(no_cache_dir, 'cache.txt')
-        with open(test_file_path, 'w') as tmp_file:
-            tmp_file.write('cached')
-
         hass.http.register_static_path('/cache.me', test_file_path, True)
 
         resp = await client.get('cache.me')
         assert resp.status == 200
         assert resp.headers['Cache-Control'] == 'public, max-age=2678400'
-        assert resp.headers['Content-Type'] == 'text/plain'
-        assert await resp.text() == 'cached'
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+        assert await resp.text() == 'test'
 
         # this file still can be access from no-cache url
-        resp = await client.get('no-cache/cache.txt')
+        resp = await client.get('no-cache/test.jpg')
         assert resp.status == 200
         assert 'Cache-Control' not in resp.headers
-        assert resp.headers['Content-Type'] == 'text/plain'
-        assert await resp.text() == 'cached'
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+        assert await resp.text() == 'test'
 
         # test secure feature
-        secure_dir = os.path.join(tmp_dir, 'secure')
-        os.mkdir(secure_dir)
-
-        test_file_path = os.path.join(secure_dir, 'pass.html')
-        with open(test_file_path, 'w') as tmp_file:
-            tmp_file.write('<html>pass</html>')
-
-        hass.http.register_static_path('/secure', secure_dir, True,
+        hass.http.register_static_path('/secure', test_dir, True,
                                        requires_auth=True)
 
-        resp = await client.get('secure/pass.html')
+        resp = await client.get('secure/test.jpg')
         assert resp.status == 200
         # secure file is not cache-able, cache-headers parameter is ignored
         assert 'Cache-Control' not in resp.headers
-        assert resp.headers['Content-Type'] == 'text/html'
-        assert await resp.text() == '<html>pass</html>'
+        assert resp.headers['Content-Type'] == 'image/jpeg'
+        assert await resp.text() == 'test'
 
         # negative test: no auth
-        resp = await client.get('secure/pass.html',
+        resp = await client.get('secure/test.jpg',
                                 headers={'Authorization': ''})
         assert resp.status == 401
         resp = await client.get('secure/',
@@ -127,7 +106,7 @@ async def test_register_static_path(hass, hass_client, aiohttp_client):
         # negative register test
         with pytest.raises(ValueError):
             hass.http.register_static_path(
-                '/invalid', secure_dir + '/pass.html', False, True)
+                '/invalid', test_dir + '/pass.html', False, True)
         with pytest.raises(ValueError):
             hass.http.register_static_path(
-                '/invalid', secure_dir + '/not-exist', False, True)
+                '/invalid', test_dir + '/not-exist', False, True)


### PR DESCRIPTION
## Description:

Add `/secure` path to host static files need authentication to access.

All files stored in `[config_folder]/www_secure` can be access via `[base_url]/secure` with appropriate authentication 

**Related issue (if applicable):** fixes #18607, fixes #19748

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8602

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
