### PR TITLE
Remove outdated url pattern match support for static file hosting

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -277,19 +277,7 @@ class HomeAssistantHTTP:
                 """Serve file from disk."""
                 return web.FileResponse(path)
 
-        # aiohttp supports regex matching for variables. Using that as temp
-        # to work around cache busting MD5.
-        # Turns something like /static/dev-panel.html into
-        # /static/{filename:dev-panel(-[a-z0-9]{32}|)\.html}
-        base, ext = os.path.splitext(url_path)
-        if ext:
-            base, file = base.rsplit('/', 1)
-            regex = r"{}(-[a-z0-9]{{32}}|){}".format(file, ext)
-            url_pattern = "{}/{{filename:{}}}".format(base, regex)
-        else:
-            url_pattern = url_path
-
-        self.app.router.add_route('GET', url_pattern, serve_file)
+        self.app.router.add_route('GET', url_path, serve_file)
 
     async def start(self):
         """Start the aiohttp server."""


### PR DESCRIPTION
## Description:

request review from @balloob 

I think that logic is outdated, need balloob's confirmation

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

