### PR TITLE
Add config for trusted networks auth provider

### DIFF
--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -3,16 +3,15 @@
 It shows list of users if access from trusted network.
 Abort login flow if not access from trusted network.
 """
-from ipaddress import ip_address, ip_network, IPv4Address, IPv6Address, \
-    IPv4Network, IPv6Network
+from ipaddress import ip_network, IPv4Address, IPv6Address, IPv4Network,\
+    IPv6Network
 from typing import Any, Dict, List, Optional, Union, cast
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
-import homeassistant.helpers.config_validation as cv
-
 from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
 from ..models import Credentials, UserMeta
 

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -91,7 +91,7 @@ class TrustedNetworksAuthProvider(AuthProvider):
         raise NotImplementedError
 
     @callback
-    def async_validate_access(self, ip: IPAddress) -> None:
+    def async_validate_access(self, ip_addr: IPAddress) -> None:
         """Make sure the access from trusted networks.
 
         Raise InvalidAuthError if not.
@@ -100,7 +100,7 @@ class TrustedNetworksAuthProvider(AuthProvider):
         if not self.trusted_networks:
             raise InvalidAuthError('trusted_networks is not configured')
 
-        if not any(ip in trusted_network for trusted_network
+        if not any(ip_addr in trusted_network for trusted_network
                    in self.trusted_networks):
             raise InvalidAuthError('Not in trusted_networks')
 
@@ -109,12 +109,12 @@ class TrustedNetworksLoginFlow(LoginFlow):
     """Handler for the login flow."""
 
     def __init__(self, auth_provider: TrustedNetworksAuthProvider,
-                 ip: IPAddress, available_users: Dict[str, Optional[str]]) \
-            -> None:
+                 ip_addr: IPAddress,
+                 available_users: Dict[str, Optional[str]]) -> None:
         """Initialize the login flow."""
         super().__init__(auth_provider)
         self._available_users = available_users
-        self._ip_address = ip
+        self._ip_address = ip_addr
 
     async def async_step_init(
             self, user_input: Optional[Dict[str, str]] = None) \

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -3,8 +3,9 @@
 It shows list of users if access from trusted network.
 Abort login flow if not access from trusted network.
 """
-from ipaddress import ip_address, ip_network
-from typing import Any, Dict, List, Optional, cast
+from ipaddress import ip_address, ip_network, IPv4Address, IPv6Address, \
+    IPv4Network, IPv6Network
+from typing import Any, Dict, List, Optional, Union, cast
 
 import voluptuous as vol
 
@@ -14,6 +15,9 @@ import homeassistant.helpers.config_validation as cv
 
 from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
 from ..models import Credentials, UserMeta
+
+IPAddress = Union[IPv4Address, IPv6Address]
+IPNetwork = Union[IPv4Network, IPv6Network]
 
 CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend({
     vol.Required('trusted_networks'): vol.All(cv.ensure_list, [ip_network])
@@ -38,9 +42,9 @@ class TrustedNetworksAuthProvider(AuthProvider):
     DEFAULT_TITLE = 'Trusted Networks'
 
     @property
-    def trusted_networks(self) -> List[ip_network]:
+    def trusted_networks(self) -> List[IPNetwork]:
         """Return trusted networks."""
-        return self.config['trusted_networks']
+        return cast(List[IPNetwork], self.config['trusted_networks'])
 
     @property
     def support_mfa(self) -> bool:
@@ -56,7 +60,7 @@ class TrustedNetworksAuthProvider(AuthProvider):
                            if not user.system_generated and user.is_active}
 
         return TrustedNetworksLoginFlow(
-            self, context.get('ip_address'), available_users)
+            self, cast(IPAddress, context.get('ip_address')), available_users)
 
     async def async_get_or_create_credentials(
             self, flow_result: Dict[str, str]) -> Credentials:
@@ -87,7 +91,7 @@ class TrustedNetworksAuthProvider(AuthProvider):
         raise NotImplementedError
 
     @callback
-    def async_validate_access(self, ip: ip_address) -> None:
+    def async_validate_access(self, ip: IPAddress) -> None:
         """Make sure the access from trusted networks.
 
         Raise InvalidAuthError if not.
@@ -105,7 +109,7 @@ class TrustedNetworksLoginFlow(LoginFlow):
     """Handler for the login flow."""
 
     def __init__(self, auth_provider: TrustedNetworksAuthProvider,
-                 ip: ip_address, available_users: Dict[str, Optional[str]]) \
+                 ip: IPAddress, available_users: Dict[str, Optional[str]]) \
             -> None:
         """Initialize the login flow."""
         super().__init__(auth_provider)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -86,13 +86,12 @@ async def async_from_config_dict(config: Dict[str, Any],
                              log_no_color)
 
     core_config = config.get(core.DOMAIN, {})
-    has_api_password = bool((config.get('http') or {}).get('api_password'))
-    has_trusted_networks = bool((config.get('http') or {})
-                                .get('trusted_networks'))
+    has_api_password = bool(config.get('http', {}).get('api_password'))
+    trusted_networks = config.get('http', {}).get('trusted_networks')
 
     try:
         await conf_util.async_process_ha_core_config(
-            hass, core_config, has_api_password, has_trusted_networks)
+            hass, core_config, has_api_password, trusted_networks)
     except vol.Invalid as config_err:
         conf_util.async_log_exception(
             config_err, 'homeassistant', core_config, hass)

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -54,7 +54,7 @@ NO_LOGIN_ATTEMPT_THRESHOLD = -1
 
 
 def trusted_networks_deprecated(value):
-    """Warn user trusted_networks config is deprecated"""
+    """Warn user trusted_networks config is deprecated."""
     _LOGGER.warning(
         "Configuring trusted_networks via the http component has been"
         " deprecated. Use the trusted networks auth provider instead."

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -52,6 +52,17 @@ DEFAULT_SERVER_HOST = '0.0.0.0'
 DEFAULT_DEVELOPMENT = '0'
 NO_LOGIN_ATTEMPT_THRESHOLD = -1
 
+
+def trusted_networks_deprecated(value):
+    """Warn user trusted_networks config is deprecated"""
+    _LOGGER.warning(
+        "Configuring trusted_networks via the http component has been"
+        " deprecated. Use the trusted networks auth provider instead."
+        " For instructions, see https://www.home-assistant.io/docs/"
+        "authentication/providers/#trusted-networks")
+    return value
+
+
 HTTP_SCHEMA = vol.Schema({
     vol.Optional(CONF_API_PASSWORD): cv.string,
     vol.Optional(CONF_SERVER_HOST, default=DEFAULT_SERVER_HOST): cv.string,
@@ -66,7 +77,7 @@ HTTP_SCHEMA = vol.Schema({
     vol.Inclusive(CONF_TRUSTED_PROXIES, 'proxy'):
         vol.All(cv.ensure_list, [ip_network]),
     vol.Optional(CONF_TRUSTED_NETWORKS, default=[]):
-        vol.All(cv.ensure_list, [ip_network]),
+        vol.All(cv.ensure_list, [ip_network], trusted_networks_deprecated),
     vol.Optional(CONF_LOGIN_ATTEMPTS_THRESHOLD,
                  default=NO_LOGIN_ATTEMPT_THRESHOLD):
         vol.Any(cv.positive_int, NO_LOGIN_ATTEMPT_THRESHOLD),

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -429,7 +429,7 @@ def _format_config_error(ex: vol.Invalid, domain: str, config: Dict) -> str:
 async def async_process_ha_core_config(
         hass: HomeAssistant, config: Dict,
         has_api_password: bool = False,
-        has_trusted_networks: bool = False) -> None:
+        trusted_networks: Optional[Any] = None) -> None:
     """Process the [homeassistant] section from the configuration.
 
     This method is a coroutine.
@@ -446,8 +446,11 @@ async def async_process_ha_core_config(
             ]
             if has_api_password:
                 auth_conf.append({'type': 'legacy_api_password'})
-            if has_trusted_networks:
-                auth_conf.append({'type': 'trusted_networks'})
+            if trusted_networks:
+                auth_conf.append({
+                    'type': 'trusted_networks',
+                    'trusted_networks': trusted_networks,
+                })
 
         mfa_conf = config.get(CONF_AUTH_MFA_MODULES, [
             {'type': 'totp', 'id': 'totp', 'name': 'Authenticator app'},

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -444,17 +444,24 @@ async def async_process_ha_core_config(
             auth_conf = [
                 {'type': 'homeassistant'}
             ]
+            _LOGGER.info('A Homeassistant auth provider is automatic'
+                         ' configured')
             if has_api_password:
                 auth_conf.append({'type': 'legacy_api_password'})
+                _LOGGER.info('A Legacy API Password auth provider is automatic'
+                             ' configured using http.api_password config')
             if trusted_networks:
                 auth_conf.append({
                     'type': 'trusted_networks',
                     'trusted_networks': trusted_networks,
                 })
+                _LOGGER.info('A Trusted Networks auth provider is automatic'
+                             ' configured using http.trusted_networks config')
 
         mfa_conf = config.get(CONF_AUTH_MFA_MODULES, [
             {'type': 'totp', 'id': 'totp', 'name': 'Authenticator app'},
         ])
+        _LOGGER.info('A Authenticator app MFA module is automatic configured')
 
         setattr(hass, 'auth', await auth.auth_manager_from_config(
             hass,

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -444,8 +444,6 @@ async def async_process_ha_core_config(
             auth_conf = [
                 {'type': 'homeassistant'}
             ]
-            _LOGGER.info('A Homeassistant auth provider is automatic'
-                         ' configured')
             if has_api_password:
                 auth_conf.append({'type': 'legacy_api_password'})
                 _LOGGER.info('A Legacy API Password auth provider is automatic'
@@ -455,8 +453,6 @@ async def async_process_ha_core_config(
                     'type': 'trusted_networks',
                     'trusted_networks': trusted_networks,
                 })
-                _LOGGER.info('A Trusted Networks auth provider is automatic'
-                             ' configured using http.trusted_networks config')
 
         mfa_conf = config.get(CONF_AUTH_MFA_MODULES, [
             {'type': 'totp', 'id': 'totp', 'name': 'Authenticator app'},

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -446,8 +446,6 @@ async def async_process_ha_core_config(
             ]
             if has_api_password:
                 auth_conf.append({'type': 'legacy_api_password'})
-                _LOGGER.info('A Legacy API Password auth provider is automatic'
-                             ' configured using http.api_password config')
             if trusted_networks:
                 auth_conf.append({
                     'type': 'trusted_networks',
@@ -457,7 +455,6 @@ async def async_process_ha_core_config(
         mfa_conf = config.get(CONF_AUTH_MFA_MODULES, [
             {'type': 'totp', 'id': 'totp', 'name': 'Authenticator app'},
         ])
-        _LOGGER.info('A Authenticator app MFA module is automatic configured')
 
         setattr(hass, 'auth', await auth.auth_manager_from_config(
             hass,

--- a/tests/auth/providers/test_trusted_networks.py
+++ b/tests/auth/providers/test_trusted_networks.py
@@ -1,4 +1,5 @@
 """Test the Trusted Networks auth provider."""
+from ipaddress import ip_network, ip_address
 from unittest.mock import Mock
 
 import pytest
@@ -18,9 +19,17 @@ def store(hass):
 @pytest.fixture
 def provider(hass, store):
     """Mock provider."""
-    return tn_auth.TrustedNetworksAuthProvider(hass, store, {
-        'type': 'trusted_networks'
-    })
+    return tn_auth.TrustedNetworksAuthProvider(
+        hass, store, tn_auth.CONFIG_SCHEMA({
+            'type': 'trusted_networks',
+            'trusted_networks': [
+                '192.168.0.1',
+                '192.168.128.0/24',
+                '::1',
+                'fd00::/8'
+            ]
+        })
+    )
 
 
 @pytest.fixture
@@ -56,14 +65,17 @@ async def test_trusted_networks_credentials(manager, provider):
 
 async def test_validate_access(provider):
     """Test validate access from trusted networks."""
-    with pytest.raises(tn_auth.InvalidAuthError):
-        provider.async_validate_access('192.168.0.1')
+    provider.async_validate_access(ip_address('192.168.0.1'))
+    provider.async_validate_access(ip_address('192.168.128.10'))
+    provider.async_validate_access(ip_address('::1'))
+    provider.async_validate_access(ip_address('fd01:db8::ff00:42:8329'))
 
-    provider.hass.http = Mock(trusted_networks=['192.168.0.1'])
-    provider.async_validate_access('192.168.0.1')
-
     with pytest.raises(tn_auth.InvalidAuthError):
-        provider.async_validate_access('127.0.0.1')
+        provider.async_validate_access(ip_address('192.168.0.2'))
+    with pytest.raises(tn_auth.InvalidAuthError):
+        provider.async_validate_access(ip_address('127.0.0.1'))
+    with pytest.raises(tn_auth.InvalidAuthError):
+        provider.async_validate_access(ip_address('2001:db8::ff00:42:8329'))
 
 
 async def test_login_flow(manager, provider):
@@ -71,22 +83,16 @@ async def test_login_flow(manager, provider):
     owner = await manager.async_create_user("test-owner")
     user = await manager.async_create_user("test-user")
 
-    # trusted network didn't loaded
-    flow = await provider.async_login_flow({'ip_address': '127.0.0.1'})
-    step = await flow.async_step_init()
-    assert step['type'] == 'abort'
-    assert step['reason'] == 'not_whitelisted'
-
-    provider.hass.http = Mock(trusted_networks=['192.168.0.1'])
-
     # not from trusted network
-    flow = await provider.async_login_flow({'ip_address': '127.0.0.1'})
+    flow = await provider.async_login_flow(
+        {'ip_address': ip_address('127.0.0.1')})
     step = await flow.async_step_init()
     assert step['type'] == 'abort'
     assert step['reason'] == 'not_whitelisted'
 
     # from trusted network, list users
-    flow = await provider.async_login_flow({'ip_address': '192.168.0.1'})
+    flow = await provider.async_login_flow(
+        {'ip_address': ip_address('192.168.0.1')})
     step = await flow.async_step_init()
     assert step['step_id'] == 'init'
 

--- a/tests/auth/providers/test_trusted_networks.py
+++ b/tests/auth/providers/test_trusted_networks.py
@@ -1,6 +1,5 @@
 """Test the Trusted Networks auth provider."""
-from ipaddress import ip_network, ip_address
-from unittest.mock import Mock
+from ipaddress import ip_address
 
 import pytest
 import voluptuous as vol

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import os
 import unittest
 import unittest.mock as mock
 from collections import OrderedDict
+from ipaddress import ip_network
 
 import asynctest
 import pytest
@@ -891,12 +892,14 @@ async def test_auth_provider_config_default_trusted_networks(hass):
     }
     if hasattr(hass, 'auth'):
         del hass.auth
-    await config_util.async_process_ha_core_config(hass, core_config,
-                                                   has_trusted_networks=True)
+    await config_util.async_process_ha_core_config(
+        hass, core_config, trusted_networks=['192.168.0.1'])
 
     assert len(hass.auth.auth_providers) == 2
     assert hass.auth.auth_providers[0].type == 'homeassistant'
     assert hass.auth.auth_providers[1].type == 'trusted_networks'
+    assert hass.auth.auth_providers[1].trusted_networks[0] == ip_network(
+        '192.168.0.1')
 
 
 async def test_disallowed_auth_provider_config(hass):


### PR DESCRIPTION
## Description:

Add config for trusted networks auth provider. 

**Breaking changes**
It is a breaking changes for user who manual configured trusted network auth provider. An invalid config error will be thrown and HA won't be able to fully started.

It is NOT a breaking changes for user who didn't manual configured trusted network auth provider.

If trusted_networks configured in http component, and no auth_provider configured in core config, http.trusted_networks value will be used for default loaded trusted network auth provider.

**Related issue (if applicable):** fixes #16149

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8605

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  auth_providers:
   - type: trusted_networks
     trusted_networks:
      - 127.0.0.1
      - ::1
      - 192.168.0.0/24
      - fd00::/8
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
