### PR TITLE
Philips Hue: Add bridge update prompt

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -14,7 +14,7 @@ from .bridge import HueBridge
 # Loading the config flow file will register the flow
 from .config_flow import configured_hosts
 
-REQUIREMENTS = ['aiohue==1.9.0']
+REQUIREMENTS = ['aiohue==1.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -121,10 +121,16 @@ async def async_setup_entry(hass, entry):
         },
         manufacturer='Signify',
         name=config.name,
-        # Not yet exposed as properties in aiohue
-        model=config.raw['modelid'],
-        sw_version=config.raw['swversion'],
+        model=config.modelid,
+        sw_version=config.swversion,
     )
+
+    if config.swupdatebridgestate == "readytoinstall":
+        err = (
+            "Please check for software updates of the bridge "
+            "in the Philips Hue App."
+        )
+        _LOGGER.warning(err)
 
     return True
 

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -125,7 +125,7 @@ async def async_setup_entry(hass, entry):
         sw_version=config.swversion,
     )
 
-    if config.swupdatebridgestate == "readytoinstall":
+    if config.swupdate2_bridge_state == "readytoinstall":
         err = (
             "Please check for software updates of the bridge "
             "in the Philips Hue App."

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -227,7 +227,7 @@ class HueLight(Light):
             _LOGGER.debug("Color gamut of %s: %s", self.name, str(self.gamut))
             if self.light.swupdatestate == "readytoinstall":
                 err = (
-                    "Please check for software updates of the %s"
+                    "Please check for software updates of the %s "
                     "bulb in the Philips Hue App."
                 )
                 _LOGGER.warning(err, self.name)

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -227,8 +227,8 @@ class HueLight(Light):
             _LOGGER.debug("Color gamut of %s: %s", self.name, str(self.gamut))
             if self.light.swupdatestate == "readytoinstall":
                 err = (
-                    "Please check for software updates of the bridge "
-                    "and/or the bulb: %s, in the Philips Hue App."
+                    "Please check for software updates of the %s"
+                    "bulb in the Philips Hue App."
                 )
                 _LOGGER.warning(err, self.name)
             if self.gamut:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -118,7 +118,7 @@ aioharmony==0.1.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.0
+aiohue==1.9.1
 
 # homeassistant.components.sensor.iliad_italy
 aioiliad==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -41,7 +41,7 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.0
+aiohue==1.9.1
 
 # homeassistant.components.unifi
 aiounifi==4

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -97,10 +97,8 @@ async def test_config_passed_to_config_entry(hass):
         mock_bridge.return_value.api.config = Mock(
             mac='mock-mac',
             bridgeid='mock-bridgeid',
-            raw={
-                'modelid': 'mock-modelid',
-                'swversion': 'mock-swversion',
-            }
+            modelid='mock-modelid',
+            swversion='mock-swversion'
         )
         # Can't set name via kwargs
         mock_bridge.return_value.api.config.name = 'mock-name'


### PR DESCRIPTION
## Description:
An logger warning will be issued in homeassistant when their is an update available for the Hue Bridge.

This code depends on a PR in the aiohue library: https://github.com/balloob/aiohue/pull/16

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
