### PR TITLE
Fix battery_level error - HomeKit

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -122,6 +122,8 @@ class HomeAccessory(Accessory):
         """
         battery_level = convert_to_float(
             new_state.attributes.get(ATTR_BATTERY_LEVEL))
+        if battery_level is None:
+            return
         self._char_battery.set_value(battery_level)
         self._char_low_battery.set_value(battery_level < 20)
         _LOGGER.debug('%s: Updated battery level to %d', self.entity_id,

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -100,7 +100,7 @@ async def test_home_accessory(hass, hk_driver):
     assert serv.get_characteristic(CHAR_MODEL).value == 'Test Model'
 
 
-async def test_battery_service(hass, hk_driver):
+async def test_battery_service(hass, hk_driver, caplog):
     """Test battery service."""
     entity_id = 'homekit.accessory'
     hass.states.async_set(entity_id, None, {ATTR_BATTERY_LEVEL: 50})
@@ -123,6 +123,13 @@ async def test_battery_service(hass, hk_driver):
     assert acc._char_battery.value == 15
     assert acc._char_low_battery.value == 1
     assert acc._char_charging.value == 2
+
+    hass.states.async_set(entity_id, None, {ATTR_BATTERY_LEVEL: 'error'})
+    await hass.async_block_till_done()
+    assert acc._char_battery.value == 15
+    assert acc._char_low_battery.value == 1
+    assert acc._char_charging.value == 2
+    assert 'ERROR' not in caplog.text
 
     # Test charging
     hass.states.async_set(entity_id, None, {


### PR DESCRIPTION
## Description:
Ignore battery level update in HomeKit if the value is not float convertible.

**Related issue (if applicable):** fixes #19701


## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

----
Reported by: @maxandersen 