### PR TITLE
Adds 2 logging decorators that log function/method calls

### DIFF
--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -219,7 +219,6 @@ def log_it_with_return(
 
         return result
 
-
     return update_wrapper(wrapper, func)
 
 


### PR DESCRIPTION

OK so you will have to excuse my "noobness" I am not sure how the whole PR process goes with Home Assistant. If I have done something wrong please let me know. or If I have missed something please let me know that as well. 

## Description:
I added 2 additional convenience logging wrappers. one will log a function/method call. and the other logs the function/method call as well as the returned data.

I wrote this code to easily follow a data path. And with the complexities of Home Assistant I thought it may be useful if added to the core code. this way everyone will be able to use it if creating a custom component. It is my "go to" debugging tool.

The "cherry on top"
I have thee decorators pulling the logger to log to from the actual module that the function/method resides in. This way if a specific part of Home Assistant is set in the configuration.yaml file to log differently this is going to follow that same pattern

The second "cherry"
These decorators also supports logging the path to functions nested inside of other functions or functions nested inside of a method.

I only have it logging the path to the function/method down to the module level. this is because hass already outputs the path leading to the module.
I also set it up to remove the path information for the internal thread calls

test code
```python
import time

@log_it
def test_function(arg1):
    @log_it
    def test_function2(arg2):
        @log_it
        def test_function3(arg3):
            return arg3

        test_function3('test3')
        return arg2

    test_function2('test2')
    return arg1


class TestClass(object):

    @log_it
    def test_method(self, arg1):
        @log_it
        def test_function2(arg2):
            @log_it
            def test_function3(arg3):
                return arg3

            test_function3('test3')
            return arg2

        test_function2('test2')
        return arg1


test_class = TestClass()
print('FUNCTION @log_it')
time.sleep(0.1)
test_function('test1')
time.sleep(0.1)
print('')
print('METHOD @log_it')
time.sleep(0.1)
test_class.test_method('test1')
time.sleep(0.1)
print('\n\n')


@log_it_with_return
def test_function(arg1):
    @log_it_with_return
    def test_function2(arg2):
        @log_it_with_return
        def test_function3(arg3):
            return arg3

        test_function3('test3')
        return arg2

    test_function2('test2')
    return arg1


class TestClass(object):

    @log_it_with_return
    def test_method(self, arg1):
        @log_it_with_return
        def test_function2(arg2):
            @log_it_with_return
            def test_function3(arg3):
                return arg3

            test_function3('test3')
            return arg2

        test_function2('test2')
        return arg1

test_class = TestClass()
print('FUNCTION @log_it_with_return')
time.sleep(0.1)
test_function('test1')
time.sleep(0.1)
print('')
print('METHOD @log_it_with_return')
time.sleep(0.1)
test_class.test_method('test1')
```

the time.sleep is because of how PyCharm handles writes to it's console window.  it is not needed in normal code use.

output is
```
FUNCTION @log_it
DEBUG:__main__:test_function(arg1='test1')
DEBUG:__main__:test_function.test_function2(arg2='test2')
DEBUG:__main__:test_function.test_function2.test_function3(arg3='test3')

METHOD @log_it
DEBUG:__main__:TestClass.test_method(arg1='test1')
DEBUG:__main__:TestClass.test_method.test_function2(arg2='test2')
DEBUG:__main__:TestClass.test_method.test_function2.test_function3(arg3='test3')



FUNCTION @log_it_with_return
DEBUG:__main__:test_function(arg1='test1')
DEBUG:__main__:test_function.test_function2(arg2='test2')
DEBUG:__main__:test_function.test_function2.test_function3(arg3='test3')
DEBUG:__main__:test_function.test_function2.test_function3 => 'test3'
DEBUG:__main__:test_function.test_function2 => 'test2'
DEBUG:__main__:test_function => 'test1'

METHOD @log_it_with_return
DEBUG:__main__:TestClass.test_method(arg1='test1')
DEBUG:__main__:TestClass.test_method.test_function2(arg2='test2')
DEBUG:__main__:TestClass.test_method.test_function2.test_function3(arg3='test3')
DEBUG:__main__:TestClass.test_method.test_function2.test_function3 => 'test3'
DEBUG:__main__:TestClass.test_method.test_function2 => 'test2'
DEBUG:__main__:TestClass.test_method => 'test1'
```

example of use in Home Assistant

```
2019-02-16 10:41:09 DEBUG (SyncWorker_2) [homeassistant.components.media_player.samsungtv] setup_platform(hass=<homeassistant.core.HomeAssistant object at 0x0000000003F03E48>, config=OrderedDict([('platform', 'samsungtv')]), add_entities=<bound method EntityPlatform._schedule_add_entities of <homeassistant.helpers.entity_platform.EntityPlatform object at 0x000000000731D358>>, _=None)
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
I am not sure exactly what is meant by this.

## Example entry for `configuration.yaml` (if applicable):
```yaml
logger:
  default: debug
  logs:
    components.media_player.samsungtv: debug
    samsungctl: debug
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
