### PR TITLE
Enhance SmartThings component subscription

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -44,7 +44,7 @@ async def async_migrate_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     A config entry created under a previous version must go through the
     integration setup again so we can properly retrieve the needed data
-    elements.  Force this by removing the entry and triggering a new flow.
+    elements. Force this by removing the entry and triggering a new flow.
     """
     from pysmartthings import SmartThings
 
@@ -124,6 +124,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
         # Setup device broker
         broker = DeviceBroker(hass, entry, token, smart_app, devices)
+        broker.connect()
         hass.data[DOMAIN][DATA_BROKERS][entry.entry_id] = broker
 
     except ClientResponseError as ex:
@@ -181,7 +182,6 @@ class DeviceBroker:
         self._regenerate_token_remove = None
         self._assignments = self._assign_capabilities(devices)
         self.devices = {device.device_id: device for device in devices}
-        self._connect()
 
     def _assign_capabilities(self, devices: Iterable):
         """Assign platforms to capabilities."""
@@ -204,7 +204,7 @@ class DeviceBroker:
             assignments[device.device_id] = slots
         return assignments
 
-    def _connect(self):
+    def connect(self):
         """Connect handlers/listeners for device/lifecycle events."""
         # Setup interval to regenerate the refresh token on a periodic basis.
         # Tokens expire in 30 days and once expired, cannot be recovered.

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -27,7 +27,7 @@ from .smartapp import (
     setup_smartapp, setup_smartapp_endpoint, smartapp_sync_subscriptions,
     validate_installed_app)
 
-REQUIREMENTS = ['pysmartapp==0.3.0', 'pysmartthings==0.6.2']
+REQUIREMENTS = ['pysmartapp==0.3.0', 'pysmartthings==0.6.3']
 DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)
@@ -206,11 +206,13 @@ class DeviceBroker:
 
     def _connect(self):
         """Connect handlers/listeners for device/lifecycle events."""
-        # Setup timer to regenerate the refresh token on a periodic basis.
+        # Setup interval to regenerate the refresh token on a periodic basis.
         # Tokens expire in 30 days and once expired, cannot be recovered.
-        async def regenerate_refresh_token():
+        async def regenerate_refresh_token(now):
             """Generate a new refresh token and update the config entry."""
-            await self._token.refresh()
+            await self._token.refresh(
+                self._entry.data[CONF_OAUTH_CLIENT_ID],
+                self._entry.data[CONF_OAUTH_CLIENT_SECRET])
             self._entry.data[CONF_REFRESH_TOKEN] = self._token.refresh_token
             self._hass.config_entries.async_update_entry(self._entry)
             _LOGGER.debug('Regenerated refresh token for installed app: %s',

--- a/homeassistant/components/smartthings/config_flow.py
+++ b/homeassistant/components/smartthings/config_flow.py
@@ -9,7 +9,8 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
-    CONF_APP_ID, CONF_INSTALLED_APP_ID, CONF_LOCATION_ID, DOMAIN,
+    APP_OAUTH_CLIENT_NAME, APP_OAUTH_SCOPES, CONF_APP_ID, CONF_INSTALLED_APPS,
+    CONF_LOCATION_ID, CONF_OAUTH_CLIENT_ID, CONF_OAUTH_CLIENT_SECRET, DOMAIN,
     VAL_UID_MATCHER)
 from .smartapp import (
     create_app, find_app, setup_smartapp, setup_smartapp_endpoint, update_app)
@@ -35,7 +36,7 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
         b) Config entries setup for all installations
     """
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
     def __init__(self):
@@ -43,6 +44,8 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
         self.access_token = None
         self.app_id = None
         self.api = None
+        self.oauth_client_secret = None
+        self.oauth_client_id = None
 
     async def async_step_import(self, user_input=None):
         """Occurs when a previously entry setup fails and is re-initiated."""
@@ -50,7 +53,7 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input=None):
         """Get access token and validate it."""
-        from pysmartthings import APIResponseError, SmartThings
+        from pysmartthings import APIResponseError, AppOAuth, SmartThings
 
         errors = {}
         if not self.hass.config.api.base_url.lower().startswith('https://'):
@@ -83,10 +86,18 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
             if app:
                 await app.refresh()  # load all attributes
                 await update_app(self.hass, app)
+                # Get oauth settings by regenerating it
+                app_oauth = AppOAuth(app.app_id)
+                app_oauth.client_name = APP_OAUTH_CLIENT_NAME
+                app_oauth.scope.extend(APP_OAUTH_SCOPES)
+                client = await self.api.generate_app_oauth(app_oauth)
             else:
-                app = await create_app(self.hass, self.api)
+                app, client = await create_app(self.hass, self.api)
             setup_smartapp(self.hass, app)
             self.app_id = app.app_id
+            self.oauth_client_secret = client.client_secret
+            self.oauth_client_id = client.client_id
+
         except APIResponseError as ex:
             if ex.is_target_error():
                 errors['base'] = 'webhook_error'
@@ -113,16 +124,12 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_wait_install(self, user_input=None):
         """Wait for SmartApp installation."""
-        from pysmartthings import InstalledAppStatus
-
         errors = {}
         if user_input is None:
             return self._show_step_wait_install(errors)
 
         # Find installed apps that were authorized
-        installed_apps = [app for app in await self.api.installed_apps(
-            installed_app_status=InstalledAppStatus.AUTHORIZED)
-                          if app.app_id == self.app_id]
+        installed_apps = self.hass.data[DOMAIN][CONF_INSTALLED_APPS]
         if not installed_apps:
             errors['base'] = 'app_not_installed'
             return self._show_step_wait_install(errors)
@@ -130,24 +137,26 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
         # User may have installed the SmartApp in more than one SmartThings
         # location. Config flows are created for the additional installations
         for installed_app in installed_apps[1:]:
+            installed_app[CONF_APP_ID] = self.app_id
+            installed_app[CONF_ACCESS_TOKEN] = self.access_token
+            installed_app[CONF_OAUTH_CLIENT_ID] = self.oauth_client_id
+            installed_app[CONF_OAUTH_CLIENT_SECRET] = self.oauth_client_secret
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
                     DOMAIN, context={'source': 'install'},
-                    data={
-                        CONF_APP_ID: installed_app.app_id,
-                        CONF_INSTALLED_APP_ID: installed_app.installed_app_id,
-                        CONF_LOCATION_ID: installed_app.location_id,
-                        CONF_ACCESS_TOKEN: self.access_token
-                    }))
+                    data=installed_app))
 
         # return entity for the first one.
         installed_app = installed_apps[0]
-        return await self.async_step_install({
-            CONF_APP_ID: installed_app.app_id,
-            CONF_INSTALLED_APP_ID: installed_app.installed_app_id,
-            CONF_LOCATION_ID: installed_app.location_id,
-            CONF_ACCESS_TOKEN: self.access_token
-        })
+        installed_app[CONF_APP_ID] = self.app_id
+        installed_app[CONF_ACCESS_TOKEN] = self.access_token
+        installed_app[CONF_OAUTH_CLIENT_ID] = self.oauth_client_id
+        installed_app[CONF_OAUTH_CLIENT_SECRET] = self.oauth_client_secret
+
+        # Clear out the saved data.
+        self.hass.data[DOMAIN][CONF_INSTALLED_APPS].clear()
+
+        return await self.async_step_install(installed_app)
 
     def _show_step_user(self, errors):
         return self.async_show_form(

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -1,14 +1,19 @@
 """Constants used by the SmartThings component and platforms."""
 import re
 
+APP_OAUTH_CLIENT_NAME = "Home Assistant"
 APP_OAUTH_SCOPES = [
     'r:devices:*'
 ]
 APP_NAME_PREFIX = 'homeassistant.'
 CONF_APP_ID = 'app_id'
 CONF_INSTALLED_APP_ID = 'installed_app_id'
+CONF_INSTALLED_APPS = 'installed_apps'
 CONF_INSTANCE_ID = 'instance_id'
 CONF_LOCATION_ID = 'location_id'
+CONF_OAUTH_CLIENT_ID = 'client_id'
+CONF_OAUTH_CLIENT_SECRET = 'client_secret'
+CONF_REFRESH_TOKEN = 'refresh_token'
 DATA_MANAGER = 'manager'
 DATA_BROKERS = 'brokers'
 DOMAIN = 'smartthings'

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -1,4 +1,5 @@
 """Constants used by the SmartThings component and platforms."""
+from datetime import timedelta
 import re
 
 APP_OAUTH_CLIENT_NAME = "Home Assistant"
@@ -34,6 +35,7 @@ SUPPORTED_PLATFORMS = [
     'binary_sensor',
     'sensor'
 ]
+TOKEN_REFRESH_INTERVAL = timedelta(days=14)
 VAL_UID = "^(?:([0-9a-fA-F]{32})|([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]" \
           "{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))$"
 VAL_UID_MATCHER = re.compile(VAL_UID)

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -290,7 +290,7 @@ async def smartapp_update(hass: HomeAssistantType, req, resp, app):
     """
     Handle when a SmartApp is updated (reconfigured) by the user.
 
-    Store the refresh token and reload the config entry.
+    Store the refresh token in the config entry.
     """
     # Update refresh token in config entry
     entry = next((entry for entry in hass.config_entries.async_entries(DOMAIN)
@@ -300,9 +300,6 @@ async def smartapp_update(hass: HomeAssistantType, req, resp, app):
     if entry:
         entry.data[CONF_REFRESH_TOKEN] = req.refresh_token
         hass.config_entries.async_update_entry(entry)
-        # Reload it
-        await entry.async_unload(hass)
-        await entry.async_setup(hass)
 
     _LOGGER.debug("SmartApp '%s' under parent app '%s' was updated",
                   req.installed_app_id, app.app_id)

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -193,13 +193,12 @@ async def setup_smartapp_endpoint(hass: HomeAssistantType):
 
 async def smartapp_sync_subscriptions(
         hass: HomeAssistantType, auth_token: str, location_id: str,
-        installed_app_id: str, *, skip_delete=False):
+        installed_app_id: str, devices):
     """Synchronize subscriptions of an installed up."""
     from pysmartthings import (
         CAPABILITIES, SmartThings, SourceType, Subscription)
 
     api = SmartThings(async_get_clientsession(hass), auth_token)
-    devices = await api.devices(location_ids=[location_id])
 
     # Build set of capabilities and prune unsupported ones
     capabilities = set()
@@ -207,9 +206,8 @@ async def smartapp_sync_subscriptions(
         capabilities.update(device.capabilities)
     capabilities.intersection_update(CAPABILITIES)
 
-    # Remove all (except for installs)
-    if not skip_delete:
-        await api.delete_subscriptions(installed_app_id)
+    # Remove all existing
+    await api.delete_subscriptions(installed_app_id)
 
     # Create for each capability
     async def create_subscription(target):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1252,7 +1252,7 @@ pysma==0.3.1
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.2
+pysmartthings==0.6.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -223,7 +223,7 @@ pyqwikswitch==0.8
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.2
+pysmartthings==0.6.3
 
 # homeassistant.components.sonos
 pysonos==0.0.6

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -28,7 +28,7 @@ async def setup_platform(hass, platform: str, *devices):
     """Set up the SmartThings platform and prerequisites."""
     hass.config.components.add(DOMAIN)
     broker = DeviceBroker(hass, devices, '')
-    config_entry = ConfigEntry("1", DOMAIN, "Test", {},
+    config_entry = ConfigEntry(2, DOMAIN, "Test", {},
                                SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
     hass.data[DOMAIN] = {
         DATA_BROKERS: {
@@ -240,7 +240,7 @@ def config_entry_fixture(hass, installed_app, location):
         CONF_OAUTH_CLIENT_ID: str(uuid4()),
         CONF_OAUTH_CLIENT_SECRET: str(uuid4())
     }
-    return ConfigEntry("1", DOMAIN, location.name, data, SOURCE_USER,
+    return ConfigEntry(2, DOMAIN, location.name, data, SOURCE_USER,
                        CONN_CLASS_CLOUD_PUSH)
 
 

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -4,8 +4,8 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from pysmartthings import (
-    CLASSIFICATION_AUTOMATION, AppEntity, AppSettings, DeviceEntity,
-    InstalledApp, Location)
+    CLASSIFICATION_AUTOMATION, AppEntity, AppOAuthClient, AppSettings,
+    DeviceEntity, InstalledApp, Location)
 from pysmartthings.api import Api
 import pytest
 
@@ -13,8 +13,9 @@ from homeassistant.components import webhook
 from homeassistant.components.smartthings import DeviceBroker
 from homeassistant.components.smartthings.const import (
     APP_NAME_PREFIX, CONF_APP_ID, CONF_INSTALLED_APP_ID, CONF_INSTANCE_ID,
-    CONF_LOCATION_ID, DATA_BROKERS, DOMAIN, SETTINGS_INSTANCE_ID, STORAGE_KEY,
-    STORAGE_VERSION)
+    CONF_LOCATION_ID, CONF_OAUTH_CLIENT_ID, CONF_OAUTH_CLIENT_SECRET,
+    CONF_REFRESH_TOKEN, DATA_BROKERS, DOMAIN, SETTINGS_INSTANCE_ID,
+    STORAGE_KEY, STORAGE_VERSION)
 from homeassistant.config_entries import (
     CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_WEBHOOK_ID
@@ -96,6 +97,15 @@ def app_fixture(hass, config_file):
     app.settings = Mock()
     app.settings.return_value = mock_coro(return_value=settings)
     return app
+
+
+@pytest.fixture(name="app_oauth_client")
+def app_oauth_client_fixture():
+    """Fixture for a single app's oauth."""
+    return AppOAuthClient({
+        'oauthClientId': str(uuid4()),
+        'oauthClientSecret': str(uuid4())
+    })
 
 
 @pytest.fixture(name='app_settings')
@@ -225,7 +235,10 @@ def config_entry_fixture(hass, installed_app, location):
         CONF_ACCESS_TOKEN: str(uuid4()),
         CONF_INSTALLED_APP_ID: installed_app.installed_app_id,
         CONF_APP_ID: installed_app.app_id,
-        CONF_LOCATION_ID: location.location_id
+        CONF_LOCATION_ID: location.location_id,
+        CONF_REFRESH_TOKEN: str(uuid4()),
+        CONF_OAUTH_CLIENT_ID: str(uuid4()),
+        CONF_OAUTH_CLIENT_SECRET: str(uuid4())
     }
     return ConfigEntry("1", DOMAIN, location.name, data, SOURCE_USER,
                        CONN_CLASS_CLOUD_PUSH)

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from pysmartthings import (
     CLASSIFICATION_AUTOMATION, AppEntity, AppOAuthClient, AppSettings,
-    DeviceEntity, InstalledApp, Location)
+    DeviceEntity, InstalledApp, Location, Subscription)
 from pysmartthings.api import Api
 import pytest
 
@@ -244,6 +244,16 @@ def config_entry_fixture(hass, installed_app, location):
     }
     return ConfigEntry(2, DOMAIN, location.name, data, SOURCE_USER,
                        CONN_CLASS_CLOUD_PUSH)
+
+
+@pytest.fixture(name="subscription_factory")
+def subscription_factory_fixture():
+    """Fixture for creating mock subscriptions."""
+    def _factory(capability):
+        sub = Subscription()
+        sub.capability = capability
+        return sub
+    return _factory
 
 
 @pytest.fixture(name="device_factory")

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -27,9 +27,11 @@ from tests.common import mock_coro
 async def setup_platform(hass, platform: str, *devices):
     """Set up the SmartThings platform and prerequisites."""
     hass.config.components.add(DOMAIN)
-    broker = DeviceBroker(hass, devices, '')
-    config_entry = ConfigEntry(2, DOMAIN, "Test", {},
+    config_entry = ConfigEntry(2, DOMAIN, "Test",
+                               {CONF_INSTALLED_APP_ID:  str(uuid4())},
                                SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
+    broker = DeviceBroker(hass, config_entry, Mock(), Mock(), devices)
+
     hass.data[DOMAIN] = {
         DATA_BROKERS: {
             config_entry.entry_id: broker

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -6,31 +6,15 @@ real HTTP calls are not initiated during testing.
 """
 from pysmartthings import ATTRIBUTES, CAPABILITIES, Attribute, Capability
 
-from homeassistant.components.binary_sensor import DEVICE_CLASSES
-from homeassistant.components.smartthings import DeviceBroker, binary_sensor
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASSES, DOMAIN as BINARY_SENSOR_DOMAIN)
+from homeassistant.components.smartthings import binary_sensor
 from homeassistant.components.smartthings.const import (
-    DATA_BROKERS, DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
-from homeassistant.config_entries import (
-    CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
+    DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-
-async def _setup_platform(hass, *devices):
-    """Set up the SmartThings binary_sensor platform and prerequisites."""
-    hass.config.components.add(DOMAIN)
-    broker = DeviceBroker(hass, devices, '')
-    config_entry = ConfigEntry("1", DOMAIN, "Test", {},
-                               SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
-    hass.data[DOMAIN] = {
-        DATA_BROKERS: {
-            config_entry.entry_id: broker
-        }
-    }
-    await hass.config_entries.async_forward_entry_setup(
-        config_entry, 'binary_sensor')
-    await hass.async_block_till_done()
-    return config_entry
+from .conftest import setup_platform
 
 
 async def test_mapping_integrity():
@@ -56,7 +40,7 @@ async def test_entity_state(hass, device_factory):
     """Tests the state attributes properly match the light types."""
     device = device_factory('Motion Sensor 1', [Capability.motion_sensor],
                             {Attribute.motion: 'inactive'})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, BINARY_SENSOR_DOMAIN, device)
     state = hass.states.get('binary_sensor.motion_sensor_1_motion')
     assert state.state == 'off'
     assert state.attributes[ATTR_FRIENDLY_NAME] ==\
@@ -71,7 +55,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
     device_registry = await hass.helpers.device_registry.async_get_registry()
     # Act
-    await _setup_platform(hass, device)
+    await setup_platform(hass, BINARY_SENSOR_DOMAIN, device)
     # Assert
     entry = entity_registry.async_get('binary_sensor.motion_sensor_1_motion')
     assert entry
@@ -89,7 +73,7 @@ async def test_update_from_signal(hass, device_factory):
     # Arrange
     device = device_factory('Motion Sensor 1', [Capability.motion_sensor],
                             {Attribute.motion: 'inactive'})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, BINARY_SENSOR_DOMAIN, device)
     device.status.apply_attribute_update(
         'main', Capability.motion_sensor, Attribute.motion, 'active')
     # Act
@@ -107,7 +91,7 @@ async def test_unload_config_entry(hass, device_factory):
     # Arrange
     device = device_factory('Motion Sensor 1', [Capability.motion_sensor],
                             {Attribute.motion: 'inactive'})
-    config_entry = await _setup_platform(hass, device)
+    config_entry = await setup_platform(hass, BINARY_SENSOR_DOMAIN, device)
     # Act
     await hass.config_entries.async_forward_entry_unload(
         config_entry, 'binary_sensor')

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -7,31 +7,15 @@ real HTTP calls are not initiated during testing.
 from pysmartthings import Attribute, Capability
 
 from homeassistant.components.fan import (
-    ATTR_SPEED, ATTR_SPEED_LIST, SPEED_HIGH, SPEED_LOW, SPEED_MEDIUM,
-    SPEED_OFF, SUPPORT_SET_SPEED)
-from homeassistant.components.smartthings import DeviceBroker, fan
+    ATTR_SPEED, ATTR_SPEED_LIST, DOMAIN as FAN_DOMAIN, SPEED_HIGH, SPEED_LOW,
+    SPEED_MEDIUM, SPEED_OFF, SUPPORT_SET_SPEED)
+from homeassistant.components.smartthings import fan
 from homeassistant.components.smartthings.const import (
-    DATA_BROKERS, DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
-from homeassistant.config_entries import (
-    CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
+    DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-
-async def _setup_platform(hass, *devices):
-    """Set up the SmartThings fan platform and prerequisites."""
-    hass.config.components.add(DOMAIN)
-    broker = DeviceBroker(hass, devices, '')
-    config_entry = ConfigEntry("1", DOMAIN, "Test", {},
-                               SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
-    hass.data[DOMAIN] = {
-        DATA_BROKERS: {
-            config_entry.entry_id: broker
-        }
-    }
-    await hass.config_entries.async_forward_entry_setup(config_entry, 'fan')
-    await hass.async_block_till_done()
-    return config_entry
+from .conftest import setup_platform
 
 
 async def test_async_setup_platform():
@@ -45,7 +29,7 @@ async def test_entity_state(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'on', Attribute.fan_speed: 2})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, FAN_DOMAIN, device)
 
     # Dimmer 1
     state = hass.states.get('fan.fan_1')
@@ -63,11 +47,10 @@ async def test_entity_and_device_attributes(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'on', Attribute.fan_speed: 2})
-    await _setup_platform(hass, device)
+    # Act
+    await setup_platform(hass, FAN_DOMAIN, device)
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
     device_registry = await hass.helpers.device_registry.async_get_registry()
-    # Act
-    await _setup_platform(hass, device)
     # Assert
     entry = entity_registry.async_get("fan.fan_1")
     assert entry
@@ -88,7 +71,7 @@ async def test_turn_off(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'on', Attribute.fan_speed: 2})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, FAN_DOMAIN, device)
     # Act
     await hass.services.async_call(
         'fan', 'turn_off', {'entity_id': 'fan.fan_1'},
@@ -106,7 +89,7 @@ async def test_turn_on(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'off', Attribute.fan_speed: 0})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, FAN_DOMAIN, device)
     # Act
     await hass.services.async_call(
         'fan', 'turn_on', {ATTR_ENTITY_ID: "fan.fan_1"},
@@ -124,7 +107,7 @@ async def test_turn_on_with_speed(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'off', Attribute.fan_speed: 0})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, FAN_DOMAIN, device)
     # Act
     await hass.services.async_call(
         'fan', 'turn_on',
@@ -145,7 +128,7 @@ async def test_set_speed(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'off', Attribute.fan_speed: 0})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, FAN_DOMAIN, device)
     # Act
     await hass.services.async_call(
         'fan', 'set_speed',
@@ -166,7 +149,7 @@ async def test_update_from_signal(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'off', Attribute.fan_speed: 0})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, FAN_DOMAIN, device)
     await device.switch_on(True)
     # Act
     async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE,
@@ -185,7 +168,7 @@ async def test_unload_config_entry(hass, device_factory):
         "Fan 1",
         capabilities=[Capability.switch, Capability.fan_speed],
         status={Attribute.switch: 'off', Attribute.fan_speed: 0})
-    config_entry = await _setup_platform(hass, device)
+    config_entry = await setup_platform(hass, FAN_DOMAIN, device)
     # Act
     await hass.config_entries.async_forward_entry_unload(
         config_entry, 'fan')

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -185,7 +185,7 @@ async def test_broker_regenerates_token(
             hass, config_entry, token, Mock(), [])
 
     assert stored_action
-    await stored_action()  # pylint:disable=not-callable
+    await stored_action(None)  # pylint:disable=not-callable
     assert token.refresh.call_count == 1
     assert config_entry.data[CONF_REFRESH_TOKEN] == token.refresh_token
 

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -151,6 +151,7 @@ async def test_unload_entry(hass, config_entry):
     smart_app.connect_event.return_value = connect_disconnect
     broker = smartthings.DeviceBroker(
         hass, config_entry, Mock(), smart_app, [])
+    broker.connect()
     hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id] = broker
 
     with patch.object(hass.config_entries, 'async_forward_entry_unload',
@@ -181,8 +182,9 @@ async def test_broker_regenerates_token(
     with patch('homeassistant.components.smartthings'
                '.async_track_time_interval',
                new=async_track_time_interval):
-        smartthings.DeviceBroker(
+        broker = smartthings.DeviceBroker(
             hass, config_entry, token, Mock(), [])
+        broker.connect()
 
     assert stored_action
     await stored_action(None)  # pylint:disable=not-callable
@@ -212,6 +214,7 @@ async def test_event_handler_dispatches_updated_devices(
 
     broker = smartthings.DeviceBroker(
         hass, config_entry, Mock(), Mock(), devices)
+    broker.connect()
 
     # pylint:disable=protected-access
     await broker._event_handler(request, None, None)
@@ -235,6 +238,7 @@ async def test_event_handler_ignores_other_installed_app(
     async_dispatcher_connect(hass, SIGNAL_SMARTTHINGS_UPDATE, signal)
     broker = smartthings.DeviceBroker(
         hass, config_entry, Mock(), Mock(), [device])
+    broker.connect()
 
     # pylint:disable=protected-access
     await broker._event_handler(request, None, None)
@@ -267,6 +271,7 @@ async def test_event_handler_fires_button_events(
     hass.bus.async_listen(EVENT_BUTTON, handler)
     broker = smartthings.DeviceBroker(
         hass, config_entry, Mock(), Mock(), [device])
+    broker.connect()
 
     # pylint:disable=protected-access
     await broker._event_handler(request, None, None)

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -120,7 +120,7 @@ async def test_unauthorized_installed_app_raises_not_ready(
 
 async def test_config_entry_loads_platforms(
         hass, config_entry, app, installed_app,
-        device, smartthings_mock):
+        device, smartthings_mock, subscription_factory):
     """Test config entry loads properly and proxies to platforms."""
     setattr(hass.config_entries, '_entries', [config_entry])
 
@@ -133,8 +133,9 @@ async def test_config_entry_loads_platforms(
     mock_token.access_token.return_value = str(uuid4())
     mock_token.refresh_token.return_value = str(uuid4())
     api.generate_tokens.return_value = mock_coro(return_value=mock_token)
-    api.delete_subscriptions.return_value = mock_coro()
-    api.create_subscription.side_effect = lambda *args, **kwargs: mock_coro()
+    subscriptions = [subscription_factory(capability)
+                     for capability in device.capabilities]
+    api.subscriptions.return_value = mock_coro(return_value=subscriptions)
 
     with patch.object(hass.config_entries, 'async_forward_entry_setup',
                       return_value=mock_coro()) as forward_mock:

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -8,8 +8,8 @@ import pytest
 
 from homeassistant.components import smartthings
 from homeassistant.components.smartthings.const import (
-    DATA_BROKERS, DOMAIN, EVENT_BUTTON, SIGNAL_SMARTTHINGS_UPDATE,
-    SUPPORTED_PLATFORMS)
+    CONF_INSTALLED_APP_ID, CONF_REFRESH_TOKEN, DATA_BROKERS, DOMAIN,
+    EVENT_BUTTON, SIGNAL_SMARTTHINGS_UPDATE, SUPPORTED_PLATFORMS)
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -146,8 +146,11 @@ async def test_config_entry_loads_platforms(
 
 async def test_unload_entry(hass, config_entry):
     """Test entries are unloaded correctly."""
-    broker = Mock()
-    broker.event_handler_disconnect = Mock()
+    connect_disconnect = Mock()
+    smart_app = Mock()
+    smart_app.connect_event.return_value = connect_disconnect
+    broker = smartthings.DeviceBroker(
+        hass, config_entry, Mock(), smart_app, [])
     hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id] = broker
 
     with patch.object(hass.config_entries, 'async_forward_entry_unload',
@@ -155,15 +158,40 @@ async def test_unload_entry(hass, config_entry):
                           return_value=True
                       )) as forward_mock:
         assert await smartthings.async_unload_entry(hass, config_entry)
-        assert broker.event_handler_disconnect.call_count == 1
+
+        assert connect_disconnect.call_count == 1
         assert config_entry.entry_id not in hass.data[DOMAIN][DATA_BROKERS]
         # Assert platforms unloaded
         await hass.async_block_till_done()
         assert forward_mock.call_count == len(SUPPORTED_PLATFORMS)
 
 
+async def test_broker_regenerates_token(
+        hass, config_entry):
+    """Test the device broker regenerates the refresh token."""
+    token = Mock()
+    token.refresh_token = str(uuid4())
+    token.refresh.return_value = mock_coro()
+    stored_action = None
+
+    def async_track_time_interval(hass, action, interval):
+        nonlocal stored_action
+        stored_action = action
+
+    with patch('homeassistant.components.smartthings'
+               '.async_track_time_interval',
+               new=async_track_time_interval):
+        smartthings.DeviceBroker(
+            hass, config_entry, token, Mock(), [])
+
+    assert stored_action
+    await stored_action()  # pylint:disable=not-callable
+    assert token.refresh.call_count == 1
+    assert config_entry.data[CONF_REFRESH_TOKEN] == token.refresh_token
+
+
 async def test_event_handler_dispatches_updated_devices(
-        hass, device_factory, event_request_factory):
+        hass, config_entry, device_factory, event_request_factory):
     """Test the event handler dispatches updated devices."""
     devices = [
         device_factory('Bedroom 1 Switch', ['switch']),
@@ -173,6 +201,7 @@ async def test_event_handler_dispatches_updated_devices(
     device_ids = [devices[0].device_id, devices[1].device_id,
                   devices[2].device_id]
     request = event_request_factory(device_ids)
+    config_entry.data[CONF_INSTALLED_APP_ID] = request.installed_app_id
     called = False
 
     def signal(ids):
@@ -180,10 +209,12 @@ async def test_event_handler_dispatches_updated_devices(
         called = True
         assert device_ids == ids
     async_dispatcher_connect(hass, SIGNAL_SMARTTHINGS_UPDATE, signal)
-    broker = smartthings.DeviceBroker(
-        hass, devices, request.installed_app_id)
 
-    await broker.event_handler(request, None, None)
+    broker = smartthings.DeviceBroker(
+        hass, config_entry, Mock(), Mock(), devices)
+
+    # pylint:disable=protected-access
+    await broker._event_handler(request, None, None)
     await hass.async_block_till_done()
 
     assert called
@@ -192,7 +223,7 @@ async def test_event_handler_dispatches_updated_devices(
 
 
 async def test_event_handler_ignores_other_installed_app(
-        hass, device_factory, event_request_factory):
+        hass, config_entry, device_factory, event_request_factory):
     """Test the event handler dispatches updated devices."""
     device = device_factory('Bedroom 1 Switch', ['switch'])
     request = event_request_factory([device.device_id])
@@ -202,21 +233,25 @@ async def test_event_handler_ignores_other_installed_app(
         nonlocal called
         called = True
     async_dispatcher_connect(hass, SIGNAL_SMARTTHINGS_UPDATE, signal)
-    broker = smartthings.DeviceBroker(hass, [device], str(uuid4()))
+    broker = smartthings.DeviceBroker(
+        hass, config_entry, Mock(), Mock(), [device])
 
-    await broker.event_handler(request, None, None)
+    # pylint:disable=protected-access
+    await broker._event_handler(request, None, None)
     await hass.async_block_till_done()
 
     assert not called
 
 
 async def test_event_handler_fires_button_events(
-        hass, device_factory, event_factory, event_request_factory):
+        hass, config_entry, device_factory, event_factory,
+        event_request_factory):
     """Test the event handler fires button events."""
     device = device_factory('Button 1', ['button'])
     event = event_factory(device.device_id, capability='button',
                           attribute='button', value='pushed')
     request = event_request_factory(events=[event])
+    config_entry.data[CONF_INSTALLED_APP_ID] = request.installed_app_id
     called = False
 
     def handler(evt):
@@ -231,8 +266,10 @@ async def test_event_handler_fires_button_events(
         }
     hass.bus.async_listen(EVENT_BUTTON, handler)
     broker = smartthings.DeviceBroker(
-        hass, [device], request.installed_app_id)
-    await broker.event_handler(request, None, None)
+        hass, config_entry, Mock(), Mock(), [device])
+
+    # pylint:disable=protected-access
+    await broker._event_handler(request, None, None)
     await hass.async_block_till_done()
 
     assert called

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -108,7 +108,14 @@ async def test_config_entry_loads_platforms(
     api = smartthings_mock.return_value
     api.app.return_value = mock_coro(return_value=app)
     api.installed_app.return_value = mock_coro(return_value=installed_app)
-    api.devices.return_value = mock_coro(return_value=[device])
+    api.devices.side_effect = \
+        lambda *args, **kwargs: mock_coro(return_value=[device])
+    mock_token = Mock()
+    mock_token.access_token.return_value = str(uuid4())
+    mock_token.refresh_token.return_value = str(uuid4())
+    api.generate_tokens.return_value = mock_coro(return_value=mock_token)
+    api.delete_subscriptions.return_value = mock_coro()
+    api.create_subscription.side_effect = lambda *args, **kwargs: mock_coro()
 
     with patch.object(hass.config_entries, 'async_forward_entry_setup',
                       return_value=mock_coro()) as forward_mock:

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -9,14 +9,15 @@ import pytest
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, ATTR_TRANSITION,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_TRANSITION)
-from homeassistant.components.smartthings import DeviceBroker, light
+    DOMAIN as LIGHT_DOMAIN, SUPPORT_BRIGHTNESS, SUPPORT_COLOR,
+    SUPPORT_COLOR_TEMP, SUPPORT_TRANSITION)
+from homeassistant.components.smartthings import light
 from homeassistant.components.smartthings.const import (
-    DATA_BROKERS, DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
-from homeassistant.config_entries import (
-    CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
+    DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .conftest import setup_platform
 
 
 @pytest.fixture(name="light_devices")
@@ -44,22 +45,6 @@ def light_devices_fixture(device_factory):
     ]
 
 
-async def _setup_platform(hass, *devices):
-    """Set up the SmartThings light platform and prerequisites."""
-    hass.config.components.add(DOMAIN)
-    broker = DeviceBroker(hass, devices, '')
-    config_entry = ConfigEntry("1", DOMAIN, "Test", {},
-                               SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
-    hass.data[DOMAIN] = {
-        DATA_BROKERS: {
-            config_entry.entry_id: broker
-        }
-    }
-    await hass.config_entries.async_forward_entry_setup(config_entry, 'light')
-    await hass.async_block_till_done()
-    return config_entry
-
-
 async def test_async_setup_platform():
     """Test setup platform does nothing (it uses config entries)."""
     await light.async_setup_platform(None, None, None)
@@ -67,7 +52,7 @@ async def test_async_setup_platform():
 
 async def test_entity_state(hass, light_devices):
     """Tests the state attributes properly match the light types."""
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
 
     # Dimmer 1
     state = hass.states.get('light.dimmer_1')
@@ -101,7 +86,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
     device_registry = await hass.helpers.device_registry.async_get_registry()
     # Act
-    await _setup_platform(hass, device)
+    await setup_platform(hass, LIGHT_DOMAIN, device)
     # Assert
     entry = entity_registry.async_get("light.light_1")
     assert entry
@@ -118,7 +103,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
 async def test_turn_off(hass, light_devices):
     """Test the light turns of successfully."""
     # Arrange
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
     # Act
     await hass.services.async_call(
         'light', 'turn_off', {'entity_id': 'light.color_dimmer_2'},
@@ -132,7 +117,7 @@ async def test_turn_off(hass, light_devices):
 async def test_turn_off_with_transition(hass, light_devices):
     """Test the light turns of successfully with transition."""
     # Arrange
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
     # Act
     await hass.services.async_call(
         'light', 'turn_off',
@@ -147,7 +132,7 @@ async def test_turn_off_with_transition(hass, light_devices):
 async def test_turn_on(hass, light_devices):
     """Test the light turns of successfully."""
     # Arrange
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
     # Act
     await hass.services.async_call(
         'light', 'turn_on', {ATTR_ENTITY_ID: "light.color_dimmer_1"},
@@ -161,7 +146,7 @@ async def test_turn_on(hass, light_devices):
 async def test_turn_on_with_brightness(hass, light_devices):
     """Test the light turns on to the specified brightness."""
     # Arrange
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
     # Act
     await hass.services.async_call(
         'light', 'turn_on',
@@ -185,7 +170,7 @@ async def test_turn_on_with_minimal_brightness(hass, light_devices):
     set the level to zero, which turns off the lights in SmartThings.
     """
     # Arrange
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
     # Act
     await hass.services.async_call(
         'light', 'turn_on',
@@ -203,7 +188,7 @@ async def test_turn_on_with_minimal_brightness(hass, light_devices):
 async def test_turn_on_with_color(hass, light_devices):
     """Test the light turns on with color."""
     # Arrange
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
     # Act
     await hass.services.async_call(
         'light', 'turn_on',
@@ -220,7 +205,7 @@ async def test_turn_on_with_color(hass, light_devices):
 async def test_turn_on_with_color_temp(hass, light_devices):
     """Test the light turns on with color temp."""
     # Arrange
-    await _setup_platform(hass, *light_devices)
+    await setup_platform(hass, LIGHT_DOMAIN, *light_devices)
     # Act
     await hass.services.async_call(
         'light', 'turn_on',
@@ -244,7 +229,7 @@ async def test_update_from_signal(hass, device_factory):
         status={Attribute.switch: 'off', Attribute.level: 100,
                 Attribute.hue: 76.0, Attribute.saturation: 55.0,
                 Attribute.color_temperature: 4500})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, LIGHT_DOMAIN, device)
     await device.switch_on(True)
     # Act
     async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE,
@@ -266,7 +251,7 @@ async def test_unload_config_entry(hass, device_factory):
         status={Attribute.switch: 'off', Attribute.level: 100,
                 Attribute.hue: 76.0, Attribute.saturation: 55.0,
                 Attribute.color_temperature: 4500})
-    config_entry = await _setup_platform(hass, device)
+    config_entry = await setup_platform(hass, LIGHT_DOMAIN, device)
     # Act
     await hass.config_entries.async_forward_entry_unload(
         config_entry, 'light')

--- a/tests/components/smartthings/test_smartapp.py
+++ b/tests/components/smartthings/test_smartapp.py
@@ -5,7 +5,9 @@ from uuid import uuid4
 from pysmartthings import AppEntity, Capability
 
 from homeassistant.components.smartthings import smartapp
-from homeassistant.components.smartthings.const import DATA_MANAGER, DOMAIN
+from homeassistant.components.smartthings.const import (
+    CONF_INSTALLED_APP_ID, CONF_INSTALLED_APPS, CONF_LOCATION_ID,
+    CONF_REFRESH_TOKEN, DATA_MANAGER, DOMAIN)
 
 from tests.common import mock_coro
 
@@ -35,31 +37,26 @@ async def test_update_app_updated_needed(hass, app):
     assert mock_app.classifications == app.classifications
 
 
-async def test_smartapp_install_abort_if_no_other(
+async def test_smartapp_install_store_if_no_other(
         hass, smartthings_mock, device_factory):
     """Test aborts if no other app was configured already."""
     # Arrange
-    api = smartthings_mock.return_value
-    api.create_subscription.return_value = mock_coro()
     app = Mock()
     app.app_id = uuid4()
     request = Mock()
-    request.installed_app_id = uuid4()
-    request.auth_token = uuid4()
-    request.location_id = uuid4()
-    devices = [
-        device_factory('', [Capability.battery, 'ping']),
-        device_factory('', [Capability.switch, Capability.switch_level]),
-        device_factory('', [Capability.switch])
-    ]
-    api.devices = Mock()
-    api.devices.return_value = mock_coro(return_value=devices)
+    request.installed_app_id = str(uuid4())
+    request.auth_token = str(uuid4())
+    request.location_id = str(uuid4())
+    request.refresh_token = str(uuid4())
     # Act
     await smartapp.smartapp_install(hass, request, None, app)
     # Assert
     entries = hass.config_entries.async_entries('smartthings')
     assert not entries
-    assert api.create_subscription.call_count == 3
+    data = hass.data[DOMAIN][CONF_INSTALLED_APPS][0]
+    assert data[CONF_REFRESH_TOKEN] == request.refresh_token
+    assert data[CONF_LOCATION_ID] == request.location_id
+    assert data[CONF_INSTALLED_APP_ID] == request.installed_app_id
 
 
 async def test_smartapp_install_creates_flow(
@@ -68,12 +65,12 @@ async def test_smartapp_install_creates_flow(
     # Arrange
     setattr(hass.config_entries, '_entries', [config_entry])
     api = smartthings_mock.return_value
-    api.create_subscription.return_value = mock_coro()
     app = Mock()
     app.app_id = config_entry.data['app_id']
     request = Mock()
     request.installed_app_id = str(uuid4())
     request.auth_token = str(uuid4())
+    request.refresh_token = str(uuid4())
     request.location_id = location.location_id
     devices = [
         device_factory('', [Capability.battery, 'ping']),
@@ -88,42 +85,45 @@ async def test_smartapp_install_creates_flow(
     await hass.async_block_till_done()
     entries = hass.config_entries.async_entries('smartthings')
     assert len(entries) == 2
-    assert api.create_subscription.call_count == 3
     assert entries[1].data['app_id'] == app.app_id
     assert entries[1].data['installed_app_id'] == request.installed_app_id
     assert entries[1].data['location_id'] == request.location_id
     assert entries[1].data['access_token'] == \
         config_entry.data['access_token']
+    assert entries[1].data['refresh_token'] == request.refresh_token
+    assert entries[1].data['client_secret'] == \
+        config_entry.data['client_secret']
+    assert entries[1].data['client_id'] == config_entry.data['client_id']
     assert entries[1].title == location.name
 
 
-async def test_smartapp_update_syncs_subs(
-        hass, smartthings_mock, config_entry, location, device_factory):
-    """Test update synchronizes subscriptions."""
+async def test_smartapp_update_reloads_entry(
+        hass, smartthings_mock, location, device_factory):
+    """Test update reloads the entry."""
     # Arrange
-    setattr(hass.config_entries, '_entries', [config_entry])
+    entry = Mock()
+    entry.async_unload.return_value = mock_coro()
+    entry.async_setup.return_value = mock_coro()
+    entry.data = {
+        'installed_app_id': str(uuid4()),
+        'app_id': str(uuid4())
+    }
+    entry.domain = DOMAIN
+
+    setattr(hass.config_entries, '_entries', [entry])
     app = Mock()
-    app.app_id = config_entry.data['app_id']
-    api = smartthings_mock.return_value
-    api.delete_subscriptions = Mock()
-    api.delete_subscriptions.return_value = mock_coro()
-    api.create_subscription.return_value = mock_coro()
+    app.app_id = entry.data['app_id']
     request = Mock()
-    request.installed_app_id = str(uuid4())
+    request.installed_app_id = entry.data['installed_app_id']
     request.auth_token = str(uuid4())
+    request.refresh_token = str(uuid4())
     request.location_id = location.location_id
-    devices = [
-        device_factory('', [Capability.battery, 'ping']),
-        device_factory('', [Capability.switch, Capability.switch_level]),
-        device_factory('', [Capability.switch])
-    ]
-    api.devices = Mock()
-    api.devices.return_value = mock_coro(return_value=devices)
+
     # Act
     await smartapp.smartapp_update(hass, request, None, app)
     # Assert
-    assert api.create_subscription.call_count == 3
-    assert api.delete_subscriptions.call_count == 1
+    assert entry.async_unload.call_count == 1
+    assert entry.async_setup.call_count == 1
 
 
 async def test_smartapp_uninstall(hass, config_entry):

--- a/tests/components/smartthings/test_smartapp.py
+++ b/tests/components/smartthings/test_smartapp.py
@@ -97,13 +97,11 @@ async def test_smartapp_install_creates_flow(
     assert entries[1].title == location.name
 
 
-async def test_smartapp_update_reloads_entry(
+async def test_smartapp_update_saves_token(
         hass, smartthings_mock, location, device_factory):
-    """Test update reloads the entry."""
+    """Test update saves token."""
     # Arrange
     entry = Mock()
-    entry.async_unload.return_value = mock_coro()
-    entry.async_setup.return_value = mock_coro()
     entry.data = {
         'installed_app_id': str(uuid4()),
         'app_id': str(uuid4())
@@ -122,8 +120,7 @@ async def test_smartapp_update_reloads_entry(
     # Act
     await smartapp.smartapp_update(hass, request, None, app)
     # Assert
-    assert entry.async_unload.call_count == 1
-    assert entry.async_setup.call_count == 1
+    assert entry.data[CONF_REFRESH_TOKEN] == request.refresh_token
 
 
 async def test_smartapp_uninstall(hass, config_entry):


### PR DESCRIPTION
## Description:
This change eliminates the need to manually re-authorize the Home Assistant SmartApp when the devices change or when new platforms are introduced and optimizes when subscriptions are created/deleted to eliminate unnecessary API calls.

**BREAKING CHANGE:** Existing SmartThings integrations will be removed, including the SmartApp/Automation from the SmartThings app.  Home Assistant will prompt you to configure the integration again or it can be invoked from the integrations page.  The configuration process is the same as before.  To prepare, have your personal access token and a mobile device with the SmartThings Classic App handy. This will not affect the naming of devices or entities and is a one-time inconvenience.

The implementation switches over to the SmartApp access token to synchronize subscriptions during setup of the config entry, which cannot be done using the personal access token. 
- SmartApp access tokens are short-lived (5min ttl) and are obtained using a refresh token (30-day ttl) and app client id/secrets.  
- The refresh token is regenerated every 14 days to ensure it does not expire
- The config entry version bumped to v2 to accommodate the storage of 3 new attributes `client_id`, `client_secret` and `refresh_token`.
- A direct conversion from config entry v1 is not possible and those entries will be removed and a new config-flow started for the user to setup the integration again.
- While this is a larger set of changes, unit tests have been added/updated, maintaining the high test coverage for this component (>99%).  Additionally, manual testing has also been performed.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
