### PR TITLE
Bump firetv to 1.0.8

### DIFF
--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -159,6 +159,8 @@ class FireTVDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the player."""
+        if not self._available:
+            return None
         return self._state
 
     @property
@@ -169,16 +171,22 @@ class FireTVDevice(MediaPlayerDevice):
     @property
     def app_id(self):
         """Return the current app."""
+        if not self._available:
+            return None
         return self._current_app
 
     @property
     def source(self):
         """Return the current app."""
+        if not self._available:
+            return None
         return self._current_app
 
     @property
     def source_list(self):
         """Return a list of running apps."""
+        if not self._available:
+            return None
         return self._running_apps
 
     @adb_decorator(override_available=True)
@@ -186,9 +194,6 @@ class FireTVDevice(MediaPlayerDevice):
         """Update the device state and, if necessary, re-connect."""
         # Check if device is disconnected.
         if not self._available:
-            self._running_apps = None
-            self._current_app = None
-
             # Try to connect
             self._available = self.firetv.connect()
 

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/media_player.firetv/
 """
 import functools
 import logging
-import threading
 import voluptuous as vol
 
 from homeassistant.components.media_player import (

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -128,9 +128,6 @@ class FireTVDevice(MediaPlayerDevice):
         self._get_source = get_source
         self._get_sources = get_sources
 
-        # whether or not the ADB connection is currently in use
-        self.adb_lock = threading.Lock()
-
         # ADB exceptions to catch
         self.exceptions = (
             AttributeError, BrokenPipeError, TypeError, ValueError,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -417,7 +417,7 @@ fiblary3==0.1.7
 fints==1.0.1
 
 # homeassistant.components.media_player.firetv
-firetv==1.0.7
+firetv==1.0.8
 
 # homeassistant.components.sensor.fitbit
 fitbit==0.3.0


### PR DESCRIPTION
## Description:

This is pull request 1 of 3 that I have planned for the Fire TV component. 

1. **Bump the version of the `firetv` package.**
2. Allow for using an ADB server to send ADB commands, in addition to the current method (the Python implementation of ADB). 
3. Register a `media_player.firetv_adb_cmd` service. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
