### PR TITLE
Fix track_change error in utility_meter

### DIFF
--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -90,9 +90,9 @@ class UtilityMeterSensor(RestoreEntity):
     @callback
     def async_reading(self, entity, old_state, new_state):
         """Handle the sensor state changes."""
-        if any([old_state is None, new_state is None]) or\
-            any([old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE],
-                 new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]]):
+        if old_state is None or new_state is None or\
+                old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE] or\
+                new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]:
             return
 
         if self._unit_of_measurement is None and\

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -90,9 +90,9 @@ class UtilityMeterSensor(RestoreEntity):
     @callback
     def async_reading(self, entity, old_state, new_state):
         """Handle the sensor state changes."""
-        if any([old_state is None,
-                old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE],
-                new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]]):
+        if any([old_state is None, new_state is None]) or\
+            any([old_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE],
+                 new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]]):
             return
 
         if self._unit_of_measurement is None and\


### PR DESCRIPTION
## Description:

Python any() checks ALL member elements, this commit makes sure we return as soon as one of the states is None.

**Related issue (if applicable):** fixes #21122 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
utility_meter:
  daily_energy:
    source: sensor.aeotec_hem_kwh
    cycle: daily
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23