### PR TITLE
Adds serial port detection for Z Wave USB Z Sticks

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -42,7 +42,7 @@ from .discovery_schemas import DISCOVERY_SCHEMAS
 from .util import (check_node_schema, check_value_schema, node_name,
                    check_has_unique_id, is_node_parsed)
 
-REQUIREMENTS = ['pydispatcher==2.0.5', 'homeassistant-pyozw==0.1.2']
+REQUIREMENTS = ['pydispatcher==2.0.5', 'homeassistant-pyozw==0.1.2', 'pyserial==3.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -42,7 +42,11 @@ from .discovery_schemas import DISCOVERY_SCHEMAS
 from .util import (check_node_schema, check_value_schema, node_name,
                    check_has_unique_id, is_node_parsed)
 
-REQUIREMENTS = ['pydispatcher==2.0.5', 'homeassistant-pyozw==0.1.2', 'pyserial==3.4']
+REQUIREMENTS = [
+    'pydispatcher==2.0.5', 
+    'homeassistant-pyozw==0.1.2', 
+    'pyserial==3.4'
+]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zwave/config_flow.py
+++ b/homeassistant/components/zwave/config_flow.py
@@ -29,7 +29,7 @@ def _get_z_stick():
                 else:
                     return vendor + ' : ' + port.device
 
-                
+
 @config_entries.HANDLERS.register(DOMAIN)
 class ZwaveFlowHandler(config_entries.ConfigFlow):
     """Handle a Z-Wave config flow."""

--- a/homeassistant/components/zwave/config_flow.py
+++ b/homeassistant/components/zwave/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure Z-Wave."""
 from collections import OrderedDict
 import logging
+import sys
 
 import voluptuous as vol
 


### PR DESCRIPTION
## Description:
adds serial port detection for the USB Z Wave sticks

I currently only have the Vendor ID for the Aeon Labs Gen5 Z Stick. others will need to be added for the detection to work for those brands.

There is a constant called VENDOR_IDS in homeassistant/components/zwave/config_flow.py this is where other Z Sticks would need to be added.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
