### PR TITLE
Nissanleaf

### DIFF
--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -462,7 +462,6 @@ class LeafEntity(Entity):
             'last_attempt': self.car.last_check,
             'updated_on': self.car.last_battery_response,
             'update_in_progress': self.car.request_in_progress,
-            'location_updated_on': self.car.last_location_response,
             'vin': self.car.leaf.vin,
         }
 

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import logging
 import sys
 import time
-import urllib
 
 import voluptuous as vol
 

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -115,11 +115,6 @@ def setup(hass, config):
             # homeassistant to be slow to start
             sess = pycarwings2.Session(username, password, region)
             leaf = sess.get_leaf()
-        except(RuntimeError, urllib.error.HTTPError):
-            _LOGGER.error(
-                "Unable to connect to Nissan Connect with "
-                "username and password")
-            return False
         except KeyError:
             _LOGGER.error(
                 "Unable to fetch car details..."

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -403,7 +403,7 @@ class LeafDataStore:
             for attempt in range(MAX_RESPONSE_ATTEMPTS):
                 if attempt > 0:
                     _LOGGER.debug("Climate data not in yet (%s) (%s). "
-                                  "Waiting (%s) seconds.", self.leaf.vin,
+                                  "Waiting (%s) seconds", self.leaf.vin,
                                   attempt, PYCARWINGS2_SLEEP)
                     await asyncio.sleep(PYCARWINGS2_SLEEP)
 

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -98,10 +98,8 @@ async def async_setup(hass, config):
             data_store = hass.data[DATA_LEAF][vin]
             async_track_point_in_utc_time(
                 hass, data_store.async_update_data, utcnow())
-            return True
-
-        _LOGGER.debug("Vin %s not recognised for update", vin)
-        return False
+        else:
+            _LOGGER.debug("Vin %s not recognised for update", vin)
 
     async def async_setup_leaf(car_config):
         """Set up a car."""

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect, dispatcher_send)
+    async_dispatcher_connect, async_dispatcher_send)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
@@ -303,7 +303,7 @@ class LeafDataStore:
                 self.data[DATA_PLUGGED_IN] = (
                     server_response.is_connected
                 )
-                dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
+                async_dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
                 self.last_battery_response = utcnow()
 
         # Climate response only updated if battery data updated first.
@@ -334,7 +334,7 @@ class LeafDataStore:
                 _LOGGER.error("Error fetching location info")
 
         self.request_in_progress = False
-        dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
+        async_dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
 
     @staticmethod
     def _extract_start_date(battery_info):
@@ -433,7 +433,7 @@ class LeafDataStore:
 
         if climate_result is not None:
             _LOGGER.debug("Climate result: %s", climate_result.__dict__)
-            dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
+            async_dispatcher_send(self.hass, SIGNAL_UPDATE_LEAF)
             return climate_result.is_hvac_running == toggle
 
         _LOGGER.debug("Climate result not returned by Nissan servers")

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -493,4 +493,4 @@ class LeafEntity(Entity):
     @callback
     def _update_callback(self):
         """Update the state."""
-        self.schedule_update_ha_state(True)
+        self.async_schedule_update_ha_state(True)

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import (
-    dispatcher_connect, dispatcher_send)
+    async_dispatcher_connect, dispatcher_send)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
@@ -465,10 +465,10 @@ class LeafEntity(Entity):
             'vin': self.car.leaf.vin,
         }
 
-    def added_to_hass(self):
+    async def async_added_to_hass(self):
         """Register callbacks."""
         self.log_registration()
-        dispatcher_connect(
+        async_dispatcher_connect(
             self.car.hass, SIGNAL_UPDATE_LEAF, self._update_callback)
 
     @callback

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -221,8 +221,8 @@ class LeafDataStore:
         if (self.last_battery_response is not None and
                 self.data[DATA_CHARGING] is False and
                 self.data[DATA_BATTERY] <= RESTRICTED_BATTERY):
-            _LOGGER.info("Low battery so restricting refresh frequency (%s)",
-                         self.leaf.nickname)
+            _LOGGER.debug("Low battery so restricting refresh frequency (%s)",
+                          self.leaf.nickname)
             interval = RESTRICTED_INTERVAL
         else:
             intervals = [base_interval]
@@ -344,18 +344,19 @@ class LeafDataStore:
                 _LOGGER.info("No start date from servers. Aborting")
                 return None
 
-            _LOGGER.info("Start server date=%s", start_date)
+            _LOGGER.debug("Start server date=%s", start_date)
 
             # Request battery update from the car
-            _LOGGER.info("Requesting battery update, %s", self.leaf.vin)
+            _LOGGER.debug("Requesting battery update, %s", self.leaf.vin)
             request = await self.hass.async_add_job(self.leaf.request_update)
             if not request:
                 _LOGGER.error("Battery update request failed")
                 return None
 
             for attempt in range(MAX_RESPONSE_ATTEMPTS):
-                _LOGGER.info("Waiting %s seconds for battery update (%s) (%s)",
-                             PYCARWINGS2_SLEEP, self.leaf.vin, attempt)
+                _LOGGER.debug(
+                    "Waiting %s seconds for battery update (%s) (%s)",
+                    PYCARWINGS2_SLEEP, self.leaf.vin, attempt)
                 await asyncio.sleep(PYCARWINGS2_SLEEP)
 
                 # Note leaf.get_status_from_update is always returning 0, so
@@ -365,12 +366,13 @@ class LeafDataStore:
                 )
 
                 latest_date = self._extract_start_date(server_info)
-                _LOGGER.info("Latest server date=%s", latest_date)
+                _LOGGER.debug("Latest server date=%s", latest_date)
                 if latest_date is not None and latest_date != start_date:
                     return server_info
 
-            _LOGGER.info("%s attempts exceeded return latest data from server",
-                         MAX_RESPONSE_ATTEMPTS)
+            _LOGGER.debug(
+                "%s attempts exceeded return latest data from server",
+                MAX_RESPONSE_ATTEMPTS)
             return server_info
         except CarwingsError:
             _LOGGER.error("An error occurred getting battery status.")
@@ -394,15 +396,15 @@ class LeafDataStore:
         """Set climate control mode via Nissan servers."""
         climate_result = None
         if toggle:
-            _LOGGER.info("Requesting climate turn on for %s", self.leaf.vin)
+            _LOGGER.debug("Requesting climate turn on for %s", self.leaf.vin)
             request = await self.hass.async_add_job(
                 self.leaf.start_climate_control
             )
             for attempt in range(MAX_RESPONSE_ATTEMPTS):
                 if attempt > 0:
-                    _LOGGER.info("Climate data not in yet (%s) (%s). "
-                                 "Waiting (%s) seconds.", self.leaf.vin,
-                                 attempt, PYCARWINGS2_SLEEP)
+                    _LOGGER.debug("Climate data not in yet (%s) (%s). "
+                                  "Waiting (%s) seconds.", self.leaf.vin,
+                                  attempt, PYCARWINGS2_SLEEP)
                     await asyncio.sleep(PYCARWINGS2_SLEEP)
 
                 climate_result = await self.hass.async_add_job(
@@ -413,7 +415,7 @@ class LeafDataStore:
                     break
 
         else:
-            _LOGGER.info("Requesting climate turn off for %s", self.leaf.vin)
+            _LOGGER.debug("Requesting climate turn off for %s", self.leaf.vin)
             request = await self.hass.async_add_job(
                 self.leaf.stop_climate_control
             )

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -176,10 +176,10 @@ def setup(hass, config):
     for car in config[DOMAIN]:
         setup_leaf(car)
 
-    hass.services.async_register(
+    hass.services.register(
         DOMAIN, SERVICE_UPDATE_LEAF,
         async_handle_update, schema=UPDATE_LEAF_SCHEMA)
-    hass.services.async_register(
+    hass.services.register(
         DOMAIN, SERVICE_START_CHARGE_LEAF,
         async_handle_start_charge, schema=START_CHARGE_LEAF_SCHEMA)
 

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -141,7 +141,7 @@ async def async_setup(hass, config):
             " as the drive train battery won't connect."
             " Don't set the intervals too low.")
 
-        data_store = LeafDataStore(leaf, hass, car_config)
+        data_store = LeafDataStore(hass, leaf, car_config)
         hass.data[DATA_LEAF][leaf.vin] = data_store
 
         for component in LEAF_COMPONENTS:
@@ -165,13 +165,13 @@ async def async_setup(hass, config):
 class LeafDataStore:
     """Nissan Leaf Data Store."""
 
-    def __init__(self, leaf, hass, car_config):
+    def __init__(self, hass, leaf, car_config):
         """Initialise the data store."""
+        self.hass = hass
         self.leaf = leaf
         self.car_config = car_config
         self.nissan_connect = car_config[CONF_NCONNECT]
         self.force_miles = car_config[CONF_FORCE_MILES]
-        self.hass = hass
         self.data = {}
         self.data[DATA_CLIMATE] = False
         self.data[DATA_BATTERY] = 0

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -97,8 +97,7 @@ async def async_setup(hass, config):
 
         if vin in hass.data[DATA_LEAF]:
             data_store = hass.data[DATA_LEAF][vin]
-            async_track_point_in_utc_time(
-                hass, data_store.async_update_data, utcnow())
+            await data_store.async_update_data(utcnow())
         else:
             _LOGGER.debug("Vin %s not recognised for update", vin)
 

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -8,6 +8,7 @@ import urllib
 import voluptuous as vol
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import (
@@ -509,6 +510,7 @@ class LeafEntity(Entity):
         async_dispatcher_connect(
             self.car.hass, SIGNAL_UPDATE_LEAF, self._update_callback)
 
+    @callback
     def _update_callback(self):
         """Update the state."""
         self.schedule_update_ha_state(True)

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -92,7 +92,7 @@ def setup(hass, config):
     async def async_handle_update(service):
         # It would be better if this was changed to use nickname, or
         # an entity name rather than a vin.
-        vin = service.data.get(ATTR_VIN, '')
+        vin = service.data[ATTR_VIN]
 
         if vin in hass.data[DATA_LEAF]:
             data_store = hass.data[DATA_LEAF][vin]

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -226,20 +226,14 @@ class LeafDataStore:
             interval = RESTRICTED_INTERVAL
         else:
             intervals = [base_interval]
-            _LOGGER.debug("Could use base interval=%s", base_interval)
 
             if self.data[DATA_CHARGING]:
                 intervals.append(charging_interval)
-                _LOGGER.debug("Could use charging interval=%s",
-                              charging_interval)
 
             if self.data[DATA_CLIMATE]:
                 intervals.append(climate_interval)
-                _LOGGER.debug(
-                    "Could use climate interval=%s", climate_interval)
 
             interval = min(intervals)
-            _LOGGER.debug("Resulting interval=%s", interval)
 
         return utcnow() + interval
 
@@ -308,12 +302,10 @@ class LeafDataStore:
                     _LOGGER.debug("Empty Location Response Received")
                     self.data[DATA_LOCATION] = None
                 else:
-                    _LOGGER.debug("Got location data for Leaf")
-                    self.data[DATA_LOCATION] = location_response
-                    self.last_location_response = utcnow()
-
                     _LOGGER.debug("Location Response: %s",
                                   location_response.__dict__)
+                    self.data[DATA_LOCATION] = location_response
+                    self.last_location_response = utcnow()
             except CarwingsError:
                 _LOGGER.error("Error fetching location info")
 

--- a/homeassistant/components/nissan_leaf/binary_sensor.py
+++ b/homeassistant/components/nissan_leaf/binary_sensor.py
@@ -12,10 +12,10 @@ DEPENDENCIES = ['nissan_leaf']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up of a Nissan Leaf binary sensor."""
     devices = []
-    for key, value in hass.data[DATA_LEAF].items():
+    for vin, datastore in hass.data[DATA_LEAF].items():
         _LOGGER.debug(
-            "binary_sensor setup_platform, key=%s, value=%s", key, value)
-        devices.append(LeafPluggedInSensor(value))
+            "binary_sensor setup_platform, vin=%s, datastore=%s", vin, datastore)
+        devices.append(LeafPluggedInSensor(datastore))
 
     add_devices(devices, True)
 

--- a/homeassistant/components/nissan_leaf/binary_sensor.py
+++ b/homeassistant/components/nissan_leaf/binary_sensor.py
@@ -10,7 +10,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['nissan_leaf']
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up of a Nissan Leaf binary sensor."""
     devices = []
     for vin, datastore in hass.data[DATA_LEAF].items():
@@ -19,7 +19,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             vin, datastore)
         devices.append(LeafPluggedInSensor(datastore))
 
-    add_devices(devices, True)
+    add_entities(devices, True)
 
 
 class LeafPluggedInSensor(LeafEntity, BinarySensorDevice):

--- a/homeassistant/components/nissan_leaf/binary_sensor.py
+++ b/homeassistant/components/nissan_leaf/binary_sensor.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.nissan_leaf import (
-    DATA_LEAF, DATA_PLUGGED_IN, LeafEntity)
+    DATA_CHARGING, DATA_LEAF, DATA_PLUGGED_IN, LeafEntity)
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,6 +18,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             "binary_sensor setup_platform, vin=%s, datastore=%s",
             vin, datastore)
         devices.append(LeafPluggedInSensor(datastore))
+        devices.append(LeafChargingSensor(datastore))
 
     add_entities(devices, True)
 
@@ -41,3 +42,24 @@ class LeafPluggedInSensor(LeafEntity, BinarySensorDevice):
         if self.car.data[DATA_PLUGGED_IN]:
             return 'mdi:power-plug'
         return 'mdi:power-plug-off'
+
+
+class LeafChargingSensor(LeafEntity, BinarySensorDevice):
+    """Charging Sensor class."""
+
+    @property
+    def name(self):
+        """Sensor name."""
+        return "{} {}".format(self.car.leaf.nickname, "Charging Status")
+
+    @property
+    def is_on(self):
+        """Return true if charging."""
+        return self.car.data[DATA_CHARGING]
+
+    @property
+    def icon(self):
+        """Icon handling."""
+        if self.car.data[DATA_CHARGING]:
+            return 'mdi:flash'
+        return 'mdi:flash-off'

--- a/homeassistant/components/nissan_leaf/binary_sensor.py
+++ b/homeassistant/components/nissan_leaf/binary_sensor.py
@@ -12,11 +12,12 @@ DEPENDENCIES = ['nissan_leaf']
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up of a Nissan Leaf binary sensor."""
+    if discovery_info is None:
+        return
+
     devices = []
     for vin, datastore in hass.data[DATA_LEAF].items():
-        _LOGGER.debug(
-            "binary_sensor setup_platform, vin=%s, datastore=%s",
-            vin, datastore)
+        _LOGGER.debug("Adding binary_sensors for vin=%s", vin)
         devices.append(LeafPluggedInSensor(datastore))
         devices.append(LeafChargingSensor(datastore))
 

--- a/homeassistant/components/nissan_leaf/binary_sensor.py
+++ b/homeassistant/components/nissan_leaf/binary_sensor.py
@@ -11,9 +11,6 @@ DEPENDENCIES = ['nissan_leaf']
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up of a Nissan Leaf binary sensor."""
-    _LOGGER.debug(
-        "binary_sensor setup_platform, discovery_info=%s", discovery_info)
-
     devices = []
     for key, value in hass.data[DATA_LEAF].items():
         _LOGGER.debug(

--- a/homeassistant/components/nissan_leaf/binary_sensor.py
+++ b/homeassistant/components/nissan_leaf/binary_sensor.py
@@ -3,6 +3,7 @@ import logging
 
 from homeassistant.components.nissan_leaf import (
     DATA_LEAF, DATA_PLUGGED_IN, LeafEntity)
+from homeassistant.components.binary_sensor import BinarySensorDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,13 +15,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     devices = []
     for vin, datastore in hass.data[DATA_LEAF].items():
         _LOGGER.debug(
-            "binary_sensor setup_platform, vin=%s, datastore=%s", vin, datastore)
+            "binary_sensor setup_platform, vin=%s, datastore=%s",
+            vin, datastore)
         devices.append(LeafPluggedInSensor(datastore))
 
     add_devices(devices, True)
 
 
-class LeafPluggedInSensor(LeafEntity):
+class LeafPluggedInSensor(LeafEntity, BinarySensorDevice):
     """Plugged In Sensor class."""
 
     @property
@@ -29,7 +31,7 @@ class LeafPluggedInSensor(LeafEntity):
         return "{} {}".format(self.car.leaf.nickname, "Plug Status")
 
     @property
-    def state(self):
+    def is_on(self):
         """Return true if plugged in."""
         return self.car.data[DATA_PLUGGED_IN]
 

--- a/homeassistant/components/nissan_leaf/device_tracker.py
+++ b/homeassistant/components/nissan_leaf/device_tracker.py
@@ -15,6 +15,9 @@ ICON_CAR = "mdi:car"
 
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Nissan Leaf tracker."""
+    if discovery_info is None:
+        return False
+
     def see_vehicle():
         """Handle the reporting of the vehicle position."""
         for vin, datastore in hass.data[DATA_LEAF].items():

--- a/homeassistant/components/nissan_leaf/device_tracker.py
+++ b/homeassistant/components/nissan_leaf/device_tracker.py
@@ -39,3 +39,5 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 icon=ICON_CAR)
 
     dispatcher_connect(hass, SIGNAL_UPDATE_LEAF, see_vehicle)
+
+    return True

--- a/homeassistant/components/nissan_leaf/device_tracker.py
+++ b/homeassistant/components/nissan_leaf/device_tracker.py
@@ -22,7 +22,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
             dev_id = 'nissan_leaf_{}'.format(slugify(host_name))
             if not value.data[DATA_LOCATION]:
                 _LOGGER.debug("No position found for vehicle %s", key)
-                return False
+                return
             _LOGGER.debug("Updating device_tracker for %s with position %s",
                           value.leaf.nickname,
                           value.data[DATA_LOCATION].__dict__)
@@ -39,5 +39,3 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 icon=ICON_CAR)
 
     dispatcher_connect(hass, SIGNAL_UPDATE_LEAF, see_vehicle)
-
-    return True

--- a/homeassistant/components/nissan_leaf/device_tracker.py
+++ b/homeassistant/components/nissan_leaf/device_tracker.py
@@ -15,9 +15,6 @@ ICON_CAR = "mdi:car"
 
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Nissan Leaf tracker."""
-    _LOGGER.debug("Setting up Scanner (device_tracker) for Nissan Leaf, "
-                  "discovery_info=%s", discovery_info)
-
     def see_vehicle():
         """Handle the reporting of the vehicle position."""
         for key, value in hass.data[DATA_LEAF].items():

--- a/homeassistant/components/nissan_leaf/device_tracker.py
+++ b/homeassistant/components/nissan_leaf/device_tracker.py
@@ -17,23 +17,23 @@ def setup_scanner(hass, config, see, discovery_info=None):
     """Set up the Nissan Leaf tracker."""
     def see_vehicle():
         """Handle the reporting of the vehicle position."""
-        for key, value in hass.data[DATA_LEAF].items():
-            host_name = value.leaf.nickname
+        for vin, datastore in hass.data[DATA_LEAF].items():
+            host_name = datastore.leaf.nickname
             dev_id = 'nissan_leaf_{}'.format(slugify(host_name))
-            if not value.data[DATA_LOCATION]:
-                _LOGGER.debug("No position found for vehicle %s", key)
+            if not datastore.data[DATA_LOCATION]:
+                _LOGGER.debug("No position found for vehicle %s", vin)
                 return
             _LOGGER.debug("Updating device_tracker for %s with position %s",
-                          value.leaf.nickname,
-                          value.data[DATA_LOCATION].__dict__)
+                          datastore.leaf.nickname,
+                          datastore.data[DATA_LOCATION].__dict__)
             attrs = {
-                'updated_on': value.last_location_response,
+                'updated_on': datastore.last_location_response,
             }
             see(dev_id=dev_id,
                 host_name=host_name,
                 gps=(
-                    value.data[DATA_LOCATION].latitude,
-                    value.data[DATA_LOCATION].longitude
+                    datastore.data[DATA_LOCATION].latitude,
+                    datastore.data[DATA_LOCATION].longitude
                 ),
                 attributes=attrs,
                 icon=ICON_CAR)

--- a/homeassistant/components/nissan_leaf/sensor.py
+++ b/homeassistant/components/nissan_leaf/sensor.py
@@ -18,9 +18,6 @@ ICON_RANGE = 'mdi:speedometer'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Sensors setup."""
-    _LOGGER.debug("setup_platform nissan_leaf sensors, discovery_info=%s",
-                  discovery_info)
-
     devices = []
     for key, value in hass.data[DATA_LEAF].items():
         _LOGGER.debug("adding sensor for item key=%s, value=%s", key, value)

--- a/homeassistant/components/nissan_leaf/sensor.py
+++ b/homeassistant/components/nissan_leaf/sensor.py
@@ -18,10 +18,12 @@ ICON_RANGE = 'mdi:speedometer'
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Sensors setup."""
+    if discovery_info is None:
+        return
+
     devices = []
     for vin, datastore in hass.data[DATA_LEAF].items():
-        _LOGGER.debug(
-            "Adding sensor for item vin=%s, datastore=%s", vin, datastore)
+        _LOGGER.debug("Adding sensors for vin=%s", vin)
         devices.append(LeafBatterySensor(datastore))
         devices.append(LeafRangeSensor(datastore, True))
         devices.append(LeafRangeSensor(datastore, False))

--- a/homeassistant/components/nissan_leaf/sensor.py
+++ b/homeassistant/components/nissan_leaf/sensor.py
@@ -19,11 +19,12 @@ ICON_RANGE = 'mdi:speedometer'
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Sensors setup."""
     devices = []
-    for key, value in hass.data[DATA_LEAF].items():
-        _LOGGER.debug("adding sensor for item key=%s, value=%s", key, value)
-        devices.append(LeafBatterySensor(value))
-        devices.append(LeafRangeSensor(value, True))
-        devices.append(LeafRangeSensor(value, False))
+    for vin, datastore in hass.data[DATA_LEAF].items():
+        _LOGGER.debug(
+            "Adding sensor for item vin=%s, datastore=%s", vin, datastore)
+        devices.append(LeafBatterySensor(datastore))
+        devices.append(LeafRangeSensor(datastore, True))
+        devices.append(LeafRangeSensor(datastore, False))
 
     add_devices(devices, True)
 

--- a/homeassistant/components/nissan_leaf/services.yaml
+++ b/homeassistant/components/nissan_leaf/services.yaml
@@ -1,5 +1,14 @@
 # Describes the format for available services for nissan_leaf
 
+start_charge:
+  description: >
+    Start the vehicle charging. It must be plugged in first!
+  fields:
+    vin:
+      description: >
+        The vehicle identification number (VIN) of the vehicle, 17 characters
+      example: WBANXXXXXX1234567
+
 update:
   description: >
     Fetch the last state of the vehicle of all your accounts, requesting

--- a/homeassistant/components/nissan_leaf/services.yaml
+++ b/homeassistant/components/nissan_leaf/services.yaml
@@ -1,0 +1,12 @@
+# Describes the format for available services for nissan_leaf
+
+update:
+  description: >
+    Fetch the last state of the vehicle of all your accounts, requesting
+    an update from of the state from the car if possible.
+  fields:
+    vin:
+      description: >
+        The vehicle identification number (VIN) of the vehicle, 17 characters
+      example: WBANXXXXXX1234567
+

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -37,7 +37,7 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
     @property
     def device_state_attributes(self):
         """Return climate control attributes."""
-        attrs = super(LeafClimateSwitch, self).device_state_attributes
+        attrs = super().device_state_attributes
         attrs["updated_on"] = self.car.last_climate_response
         return attrs
 

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -12,9 +12,13 @@ DEPENDENCIES = ['nissan_leaf']
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Nissan Leaf switch platform setup."""
+    if discovery_info is None:
+        return
+
     devices = []
-    for value in hass.data[DATA_LEAF].values():
-        devices.append(LeafClimateSwitch(value))
+    for vin, datastore in hass.data[DATA_LEAF].items():
+        _LOGGER.debug("Adding switch for vin=%s", vin)
+        devices.append(LeafClimateSwitch(datastore))
 
     add_devices(devices, True)
 

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -62,9 +62,9 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
     # @MartinHjelmare would like removed - think provides nice UI feedback
     # for switch.
     # Think VolvoOnCall component hase different icons for the switches.
-    @property
-    def icon(self):
-        """Climate control icon."""
-        if self.car.data[DATA_CLIMATE]:
-            return 'mdi:fan'
-        return 'mdi:fan-off'
+#    @property
+#    def icon(self):
+#        """Climate control icon."""
+#        if self.car.data[DATA_CLIMATE]:
+#            return 'mdi:fan'
+#        return 'mdi:fan-off'

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.nissan_leaf import (
-    DATA_CHARGING, DATA_CLIMATE, DATA_LEAF, LeafEntity)
+    DATA_CLIMATE, DATA_LEAF, LeafEntity)
 from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -14,7 +14,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Nissan Leaf switch platform setup."""
     devices = []
     for value in hass.data[DATA_LEAF].values():
-        devices.append(LeafChargeSwitch(value))
         devices.append(LeafClimateSwitch(value))
 
     add_devices(devices, True)
@@ -65,35 +64,3 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
         if self.car.data[DATA_CLIMATE]:
             return 'mdi:fan'
         return 'mdi:fan-off'
-
-
-class LeafChargeSwitch(LeafEntity, ToggleEntity):
-    """Nissan Leaf Charging On switch."""
-
-    @property
-    def name(self):
-        """Switch name."""
-        return "{} {}".format(self.car.leaf.nickname, "Charging Status")
-
-    @property
-    def is_on(self):
-        """Return true if charging."""
-        return self.car.data[DATA_CHARGING]
-
-    async def async_turn_on(self, **kwargs):
-        """Start car charging."""
-        if await self.car.async_start_charging():
-            self.car.data[DATA_CHARGING] = True
-
-    # @MartinHjelmare says should be removed if we don't support it.
-    #                 Maybe it should be a scene?
-    # Unsure if better to provide as a sensor for the state, and a service to
-    # start a charge, e.g.
-    # - service: nissan_leaf.start_charging
-    #   data:
-    #     vin: XXXXXXXXXX
-    def turn_off(self, **kwargs):
-        """Nissan API doesn't allow stopping of charge remotely."""
-        _LOGGER.info(
-            "Cannot turn off Leaf charging."
-            " Nissan API does not support stopping charge remotely")

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -12,9 +12,6 @@ DEPENDENCIES = ['nissan_leaf']
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Nissan Leaf switch platform setup."""
-    _LOGGER.debug(
-        "In switch setup platform, discovery_info=%s", discovery_info)
-
     devices = []
     for value in hass.data[DATA_LEAF].values():
         devices.append(LeafChargeSwitch(value))

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -56,6 +56,9 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
         if await self.car.async_set_climate(False):
             self.car.data[DATA_CLIMATE] = False
 
+    # @MartinHjelmare would like removed - think provides nice UI feedback 
+    # for switch.
+    # Think VolvoOnCall component hase different icons for the switches.
     @property
     def icon(self):
         """Climate control icon."""
@@ -72,6 +75,9 @@ class LeafChargeSwitch(LeafEntity, ToggleEntity):
         """Switch name."""
         return "{} {}".format(self.car.leaf.nickname, "Charging Status")
 
+    # @MartinHjelmare would like removed - think provides nice UI feedback
+    # for switch
+    # Think VolvoOnCall component hase different icons for the switches.
     @property
     def icon(self):
         """Charging switch icon."""
@@ -89,6 +95,13 @@ class LeafChargeSwitch(LeafEntity, ToggleEntity):
         if await self.car.async_start_charging():
             self.car.data[DATA_CHARGING] = True
 
+    # @MartinHjelmare says should be removed if we don't support it.
+    #                 Maybe it should be a scene?
+    # Unsure if better to provide as a sensor for the state, and a service to
+    # start a charge, e.g.
+    # - service: nissan_leaf.start_charging
+    #   data:
+    #     vin: XXXXXXXXXX
     def turn_off(self, **kwargs):
         """Nissan API doesn't allow stopping of charge remotely."""
         _LOGGER.info(

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -56,7 +56,7 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
         if await self.car.async_set_climate(False):
             self.car.data[DATA_CLIMATE] = False
 
-    # @MartinHjelmare would like removed - think provides nice UI feedback 
+    # @MartinHjelmare would like removed - think provides nice UI feedback
     # for switch.
     # Think VolvoOnCall component hase different icons for the switches.
     @property

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -75,16 +75,6 @@ class LeafChargeSwitch(LeafEntity, ToggleEntity):
         """Switch name."""
         return "{} {}".format(self.car.leaf.nickname, "Charging Status")
 
-    # @MartinHjelmare would like removed - think provides nice UI feedback
-    # for switch
-    # Think VolvoOnCall component hase different icons for the switches.
-    @property
-    def icon(self):
-        """Charging switch icon."""
-        if self.car.data[DATA_CHARGING]:
-            return 'mdi:flash'
-        return 'mdi:flash-off'
-
     @property
     def is_on(self):
         """Return true if charging."""

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -58,13 +58,3 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
         """Turn off climate control."""
         if await self.car.async_set_climate(False):
             self.car.data[DATA_CLIMATE] = False
-
-    # @MartinHjelmare would like removed - think provides nice UI feedback
-    # for switch.
-    # Think VolvoOnCall component hase different icons for the switches.
-#    @property
-#    def icon(self):
-#        """Climate control icon."""
-#        if self.car.data[DATA_CLIMATE]:
-#            return 'mdi:fan'
-#        return 'mdi:fan-off'


### PR DESCRIPTION
## Description:

Follow-up to pull request https://github.com/home-assistant/home-assistant/pull/19786 for Nissan Leaf integration to try to fix issues identified by @MartinHjelmare.

Improvements remaining to be made (at least!):
* ~~how to implement start charging.  Switch (status quo), scene + sensor, or service + sensor.~~
* ~~icons~~
* ~~remove time.sleep(x)~~

**Pull request for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation has already been merged: https://github.com/home-assistant/home-assistant.io/pull/8073 but needs to be updated to include new service.

## Example entry for `configuration.yaml`:
```yaml
nissan_leaf:
  username: "username"
  password: "password"
  region: 'NE'     # Indicates Europe, must be changed for other regions
  nissan_connect: true  # Set to false for early Leafs 24kWh that don't report location
  update_interval: 
    hours: 1
  update_interval_charging: 
    minutes: 15
  update_interval_climate: 
    minutes: 5
  force_miles: true
```

Two new services exposed:

```yaml
- service: nissan_leaf.update
  data:
    vin: XXXXXXXXXX

- service: nissan_leaf.start_charge
  data:
    vin: XXXXXXXXXX
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
