### PR TITLE
Return time based attributes as datetime in Unifi module

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -43,6 +43,8 @@ AVAILABLE_ATTRS = [
     'uptime', 'user_id', 'usergroup_id', 'vlan'
 ]
 
+TIMESTAMP_ATTRS = ['first_seen', 'last_seen', 'latest_assoc_time']
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_SITE_ID, default='default'): cv.string,
@@ -149,7 +151,12 @@ class UnifiScanner(DeviceScanner):
         attributes = {}
         for variable in self._monitored_conditions:
             if variable in client:
-                attributes[variable] = client[variable]
+                if variable in TIMESTAMP_ATTRS:
+                    attributes[variable] = dt_util.utc_from_timestamp(
+                        float(client[variable])
+                    )
+                else:
+                    attributes[variable] = client[variable]
 
         _LOGGER.debug("Device mac %s attributes %s", device, attributes)
         return attributes

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -2,7 +2,7 @@
 from unittest import mock
 from pyunifi.controller import APIError
 import homeassistant.util.dt as dt_util
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 
 import pytest
@@ -241,7 +241,8 @@ def test_monitored_conditions():
          'hostname': 'foobar',
          'essid': 'barnet',
          'signal': -60,
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
+         'last_seen': dt_util.as_timestamp(dt_util.utcnow()),
+         'latest_assoc_time': 946684800.0},
         {'mac': '234',
          'name': 'Nice Name',
          'essid': 'barnet',
@@ -254,9 +255,14 @@ def test_monitored_conditions():
     ]
     ctrl.get_clients.return_value = fake_clients
     scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
-                                 ['essid', 'signal'])
-    assert scanner.get_extra_attributes('123') == {'essid': 'barnet',
-                                                   'signal': -60}
-    assert scanner.get_extra_attributes('234') == {'essid': 'barnet',
-                                                   'signal': -42}
+                                 ['essid', 'signal','latest_assoc_time'])
+    assert scanner.get_extra_attributes('123') == {
+        'essid': 'barnet',
+        'signal': -60,
+        'latest_assoc_time': datetime(2000, 1, 1, 0, 0, tzinfo=dt_util.UTC)
+    }
+    assert scanner.get_extra_attributes('234') == {
+        'essid': 'barnet',
+        'signal': -42
+    }
     assert scanner.get_extra_attributes('456') == {'essid': 'barnet'}

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -1,13 +1,13 @@
 """The tests for the Unifi WAP device tracker platform."""
 from unittest import mock
-from pyunifi.controller import APIError
-import homeassistant.util.dt as dt_util
 from datetime import datetime, timedelta
+from pyunifi.controller import APIError
 
 
 import pytest
 import voluptuous as vol
 
+import homeassistant.util.dt as dt_util
 from homeassistant.components.device_tracker import DOMAIN, unifi as unifi
 from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
                                  CONF_PLATFORM, CONF_VERIFY_SSL,
@@ -255,7 +255,7 @@ def test_monitored_conditions():
     ]
     ctrl.get_clients.return_value = fake_clients
     scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
-                                 ['essid', 'signal','latest_assoc_time'])
+                                 ['essid', 'signal', 'latest_assoc_time'])
     assert scanner.get_extra_attributes('123') == {
         'essid': 'barnet',
         'signal': -60,


### PR DESCRIPTION
## Description: Updates the Unifi module to return time based attributes in datetime format.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

