### PR TITLE
 Add traccar monitored_conditions option

### DIFF
--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -13,7 +13,7 @@ from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL,
     CONF_PASSWORD, CONF_USERNAME, ATTR_BATTERY_LEVEL,
-    CONF_SCAN_INTERVAL)
+    CONF_SCAN_INTERVAL, CONF_MONITORED_CONDITIONS)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
@@ -54,12 +54,12 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
 
     api = API(hass.loop, session, config[CONF_USERNAME], config[CONF_PASSWORD],
               config[CONF_HOST], config[CONF_PORT], config[CONF_SSL])
-    
+
     scanner = TraccarScanner(
         api, hass, async_see,
         config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
         config.get(CONF_MONITORED_CONDITIONS, []))
-    
+
     return await scanner.async_init()
 
 

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import slugify
 
 
-REQUIREMENTS = ['pytraccar==0.2.1']
+REQUIREMENTS = ['pytraccar==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +41,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=8082): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+                 default=[]): vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -52,16 +54,21 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
 
     api = API(hass.loop, session, config[CONF_USERNAME], config[CONF_PASSWORD],
               config[CONF_HOST], config[CONF_PORT], config[CONF_SSL])
+    
     scanner = TraccarScanner(
-        api, hass, async_see, config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL))
+        api, hass, async_see,
+        config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
+        config.get(CONF_MONITORED_CONDITIONS, []))
+    
     return await scanner.async_init()
 
 
 class TraccarScanner:
     """Define an object to retrieve Traccar data."""
 
-    def __init__(self, api, hass, async_see, scan_interval):
+    def __init__(self, api, hass, async_see, scan_interval, custom_attributes):
         """Initialize."""
+        self._custom_attributes = custom_attributes
         self._scan_interval = scan_interval
         self._async_see = async_see
         self._api = api
@@ -81,7 +88,7 @@ class TraccarScanner:
     async def _async_update(self, now=None):
         """Update info from Traccar."""
         _LOGGER.debug('Updating device data.')
-        await self._api.get_device_info()
+        await self._api.get_device_info(self._custom_attributes)
         for devicename in self._api.device_info:
             device = self._api.device_info[devicename]
             attr = {}
@@ -98,6 +105,11 @@ class TraccarScanner:
                 attr[ATTR_BATTERY_LEVEL] = device['battery']
             if device.get('motion') is not None:
                 attr[ATTR_MOTION] = device['motion']
+            for custom_attr in self._custom_attributes:
+                if device.get(custom_attr) is not None:
+                    attr[custom_attr] = device[custom_attr]
+                else:
+                    attr[custom_attr] = ''
             await self._async_see(
                 dev_id=slugify(device['device_id']),
                 gps=(device.get('latitude'), device.get('longitude')),

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -58,7 +58,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     scanner = TraccarScanner(
         api, hass, async_see,
         config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
-        config.get(CONF_MONITORED_CONDITIONS))
+        config[CONF_MONITORED_CONDITIONS])
 
     return await scanner.async_init()
 

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -108,8 +108,6 @@ class TraccarScanner:
             for custom_attr in self._custom_attributes:
                 if device.get(custom_attr) is not None:
                     attr[custom_attr] = device[custom_attr]
-                else:
-                    attr[custom_attr] = ''
             await self._async_see(
                 dev_id=slugify(device['device_id']),
                 gps=(device.get('latitude'), device.get('longitude')),

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -58,7 +58,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     scanner = TraccarScanner(
         api, hass, async_see,
         config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
-        config.get(CONF_MONITORED_CONDITIONS, []))
+        config.get(CONF_MONITORED_CONDITIONS))
 
     return await scanner.async_init()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1400,7 +1400,7 @@ pytile==2.0.5
 pytouchline==0.7
 
 # homeassistant.components.device_tracker.traccar
-pytraccar==0.2.1
+pytraccar==0.3.0
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
## Description:

User defined additional parameters to track from the traccar platform

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8618

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: traccar
    host: hostname
    port: 8072
    ssl: true
    username: admin
    password: password
    scan_interval: 00:00:02
    monitored_conditions: ['alarm', 'foo', 'bar']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
