### PR TITLE
Add device tracker entity component

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -105,6 +105,8 @@ SERVICE_SEE_PAYLOAD_SCHEMA = vol.Schema(vol.All(
         ATTR_MAC: cv.string,
         ATTR_DEV_ID: cv.string,
         ATTR_HOST_NAME: cv.string,
+        ATTR_LATITUDE: cv.latitude,
+        ATTR_LONGITUDE: cv.longitude,
         ATTR_LOCATION_NAME: cv.string,
         ATTR_GPS: cv.gps,
         ATTR_GPS_ACCURACY: cv.positive_int,

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -199,7 +199,8 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
                 # This is needed during transition phase to EntityComponent.
                 # Remove when all device_tracker platforms have been converted
                 # to EntityPlatforms.
-                async def placeholder_setup_platform():
+                async def placeholder_setup_platform(
+                        hass, config, async_add_entities, discovery_info=None):
                     """Define placeholder for async_setup_platform."""
                     pass
                 platform.async_setup_platform = placeholder_setup_platform

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -85,6 +85,10 @@ NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(None, vol.Schema({
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
     vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
 }))
+
+# track_new_devices will be legacy and deprecated in EntityPlatform platforms.
+# new_device_defaults will also be legacy and deprecated.
+
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
     vol.Optional(CONF_TRACK_NEW): cv.boolean,
@@ -363,6 +367,10 @@ class DeviceTracker:
                 self.hass.config.path(YAML_DEVICES), dev_id, device)
         )
 
+    # The config file, known_devices.yaml is legacy and deprecated.
+    # It will be removed when all platforms have been converted to
+    # EntityPlatform.
+
     async def async_update_config(self, path, dev_id, device):
         """Add device to YAML configuration file.
 
@@ -372,6 +380,10 @@ class DeviceTracker:
             await self.hass.async_add_executor_job(
                 update_config, self.hass.config.path(YAML_DEVICES),
                 dev_id, device)
+
+    # The default group for device tracker entities is legacy and deprecated.
+    # It will be removed when all platforms have been converted to
+    # EntityPlatform.
 
     @callback
     def async_setup_group(self):
@@ -389,6 +401,9 @@ class DeviceTracker:
                     ATTR_VISIBLE: False,
                     ATTR_NAME: GROUP_NAME_ALL_DEVICES,
                     ATTR_ENTITIES: entity_ids}))
+
+    # Think about what to do to support update of stale device
+    # and consider home.
 
     @callback
     def async_update_stale(self, now: dt_util.dt.datetime):
@@ -863,6 +878,8 @@ def update_config(path: str, dev_id: str, device: Device):
         out.write('\n')
         out.write(dump(device))
 
+# Gravatar option is legacy and deprecated and will be removed when all
+# platforms have been converted to EntityPlatform.
 
 def get_gravatar_for_email(email: str):
     """Return an 80px Gravatar for the given email address.

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -736,9 +736,7 @@ class DeviceTrackerEntity(Entity):
     @property
     def unique_id(self):
         """Return a unique ID for the device."""
-        if self.mac_address is not None:
-            return self.mac_address
-        return None
+        return self.mac_address
 
     def seen(self, **kwargs):
         """Mark the device as seen."""

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -250,12 +250,19 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
         # to EntityPlatform.
         entity_ids = hass.helpers.service.extract_entity_ids(call)
         data.pop(ATTR_ENTITY_ID, None)
+        entity_comp_data = dict(data)
+        if ATTR_GPS in entity_comp_data:
+            latitude, longitude = entity_comp_data[ATTR_GPS]
+            latitude = entity_comp_data.get(ATTR_LATITUDE, latitude)
+            longitude = entity_comp_data.get(ATTR_LONGITUDE, longitude)
+            entity_comp_data[ATTR_LATITUDE] = latitude
+            entity_comp_data[ATTR_LONGITUDE] = longitude
         entities = [
             entity for entity in component.entities
             if entity.entity_id in entity_ids]
         tasks = []
         for entity in entities:
-            tasks.append(entity.async_seen(**data))
+            tasks.append(entity.async_seen(**entity_comp_data))
         if tasks:
             await asyncio.wait(tasks)
         else:

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -114,10 +114,10 @@ SERVICE_SEE_PAYLOAD_SCHEMA = vol.Schema(vol.All(
         ATTR_ATTRIBUTES: dict,
         ATTR_SOURCE_TYPE: vol.In(SOURCE_TYPES),
         ATTR_CONSIDER_HOME: cv.time_period,
+        ATTR_ENTITY_ID: cv.entity_ids,
         # Temp workaround for iOS app introduced in 0.65
         vol.Optional('battery_status'): str,
         vol.Optional('hostname'): str,
-        vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     }))
 
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -249,7 +249,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
         # Handle service call for EntityPlatform platforms.
         # Replace this service handler when all platforms have been converted
         # to EntityPlatform.
-        entity_ids = hass.helpers.service.extract_entity_ids(call)
+        entity_ids = await hass.helpers.service.async_extract_entity_ids(call)
         data.pop(ATTR_ENTITY_ID, None)
         entity_comp_data = dict(data)
         if ATTR_GPS in entity_comp_data:

--- a/homeassistant/components/geofency/__init__.py
+++ b/homeassistant/components/geofency/__init__.py
@@ -33,6 +33,7 @@ ATTR_DEVICE = 'device'
 ATTR_ENTRY = 'entry'
 
 BEACON_DEV_PREFIX = 'beacon'
+DATA_KEY = '{}.{}'.format(DOMAIN, DEVICE_TRACKER)
 
 LOCATION_ENTRY = '1'
 LOCATION_EXIT = '0'
@@ -106,8 +107,14 @@ def _set_location(hass, data, location_name):
     device = _device_name(data)
 
     async_dispatcher_send(
-        hass, TRACKER_UPDATE, device,
-        (data[ATTR_LATITUDE], data[ATTR_LONGITUDE]), location_name, data)
+        hass,
+        TRACKER_UPDATE,
+        device,
+        data[ATTR_LATITUDE],
+        data[ATTR_LONGITUDE],
+        location_name,
+        data
+    )
 
     return web.Response(
         text="Setting location for {}".format(device), status=HTTP_OK)
@@ -127,6 +134,7 @@ async def async_setup_entry(hass, entry):
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
+    hass.data[DATA_KEY]()
 
     await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
     return True

--- a/homeassistant/components/geofency/device_tracker.py
+++ b/homeassistant/components/geofency/device_tracker.py
@@ -2,34 +2,110 @@
 import logging
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN)
+    ATTR_ATTRIBUTES, ATTR_LOCATION_NAME, SOURCE_TYPE_GPS, DeviceTrackerEntity)
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import DOMAIN as GEOFENCY_DOMAIN, TRACKER_UPDATE
+from . import DATA_KEY, TRACKER_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_KEY = '{}.{}'.format(GEOFENCY_DOMAIN, DEVICE_TRACKER_DOMAIN)
+GEOFENCY_ENTITIES = 'geofency_entities'
 
 
-async def async_setup_entry(hass, entry, async_see):
-    """Configure a dispatcher connection based on a config entry."""
-    async def _set_location(device, gps, location_name, attributes):
-        """Fire HA event to set location."""
-        await async_see(
-            dev_id=device,
-            gps=gps,
-            location_name=location_name,
-            attributes=attributes
-        )
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Geofency from config entry."""
+    entities = hass.data.setdefault(GEOFENCY_ENTITIES, {})
+
+    async def async_see(
+            device, latitude, longitude, location_name, attributes):
+        """Notify the device tracker entities that you see a device."""
+        entity = entities.get(device)
+
+        if entity:
+            await entity.async_seen(
+                latitude=latitude, longitude=longitude,
+                location_name=location_name, attributes=attributes)
+            return
+
+        # If no device can be found, create it
+        entity = GeofencyEntity(
+            device, latitude, longitude, location_name, attributes)
+        entities[device] = entity
+        async_add_entities([entity])
 
     hass.data[DATA_KEY] = async_dispatcher_connect(
-        hass, TRACKER_UPDATE, _set_location
+        hass, TRACKER_UPDATE, async_see
     )
     return True
 
 
-async def async_unload_entry(hass, entry):
-    """Unload the config entry and remove the dispatcher connection."""
-    hass.data[DATA_KEY]()
-    return True
+class GeofencyEntity(DeviceTrackerEntity):
+    """Represent a tracked device."""
+
+    def __init__(self, device, latitude, longitude, location_name, attributes):
+        """Set up Geofency entity."""
+        self._attributes = attributes
+        self._name = device
+        self._location_name = location_name
+        self._latitude = latitude
+        self._longitude = longitude
+        self._connected_seen = None
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific attributes."""
+        return self._attributes
+
+    @property
+    def latitude(self):
+        """Return latitude value of the device."""
+        return self._latitude
+
+    @property
+    def location_name(self):
+        """Return a location name for the current location of the device."""
+        return self._location_name
+
+    @property
+    def longitude(self):
+        """Return longitude value of the device."""
+        return self._longitude
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return SOURCE_TYPE_GPS
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self._connected_seen = self._async_seen
+
+    async def async_will_remove_from_hass(self):
+        """Clean up after entity before removal."""
+        self.hass.data[GEOFENCY_ENTITIES].pop(self._name)
+
+    async def async_seen(self, **kwargs):
+        """Mark the device as seen."""
+        if self._connected_seen is None:
+            return
+        await self._connected_seen(**kwargs)
+
+    async def _async_seen(self, **kwargs):
+        """Mark the device as seen."""
+        self._attributes.update(kwargs.get(ATTR_ATTRIBUTES, {}))
+        self._location_name = kwargs.get(ATTR_LOCATION_NAME)
+        self._latitude = kwargs.get(ATTR_LATITUDE)
+        self._longitude = kwargs.get(ATTR_LONGITUDE)
+
+        await self.async_update_ha_state()

--- a/homeassistant/components/geofency/device_tracker.py
+++ b/homeassistant/components/geofency/device_tracker.py
@@ -93,6 +93,7 @@ class GeofencyEntity(DeviceTrackerEntity):
 
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""
+        self._connected_seen = None
         self.hass.data[GEOFENCY_ENTITIES].pop(self._name)
 
     async def async_seen(self, **kwargs):

--- a/homeassistant/components/gpslogger/__init__.py
+++ b/homeassistant/components/gpslogger/__init__.py
@@ -25,6 +25,7 @@ ATTR_DIRECTION = 'direction'
 ATTR_PROVIDER = 'provider'
 ATTR_SPEED = 'speed'
 
+DATA_KEY = '{}.{}'.format(DOMAIN, DEVICE_TRACKER)
 DEFAULT_ACCURACY = 200
 DEFAULT_BATTERY = -1
 
@@ -74,9 +75,15 @@ async def handle_webhook(hass, webhook_id, request):
     device = data[ATTR_DEVICE]
 
     async_dispatcher_send(
-        hass, TRACKER_UPDATE, device,
-        (data[ATTR_LATITUDE], data[ATTR_LONGITUDE]),
-        data[ATTR_BATTERY], data[ATTR_ACCURACY], attrs)
+        hass,
+        TRACKER_UPDATE,
+        device,
+        data[ATTR_LATITUDE],
+        data[ATTR_LONGITUDE],
+        data[ATTR_BATTERY],
+        data[ATTR_ACCURACY],
+        attrs
+    )
 
     return web.Response(
         text='Setting location for {}'.format(device),
@@ -98,6 +105,7 @@ async def async_setup_entry(hass, entry):
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
+    hass.data[DATA_KEY]()
 
     await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
     return True

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -102,6 +102,7 @@ class GPSLoggerEntity(DeviceTrackerEntity):
 
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""
+        self._connected_seen = None
         self.hass.data[GPSLOGGER_ENTITIES].pop(self._name)
 
     async def async_seen(self, **kwargs):

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -2,36 +2,120 @@
 import logging
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN)
+    ATTR_ATTRIBUTES, ATTR_BATTERY, DEFAULT_GPS_ACCURACY, SOURCE_TYPE_GPS,
+    DeviceTrackerEntity)
+from homeassistant.const import (
+    ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.typing import HomeAssistantType
 
-from . import DOMAIN as GPSLOGGER_DOMAIN, TRACKER_UPDATE
+from . import DATA_KEY, TRACKER_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_KEY = '{}.{}'.format(GPSLOGGER_DOMAIN, DEVICE_TRACKER_DOMAIN)
+GPSLOGGER_ENTITIES = 'gpslogger_entities'
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry, async_see):
-    """Configure a dispatcher connection based on a config entry."""
-    async def _set_location(device, gps_location, battery, accuracy, attrs):
-        """Fire HA event to set location."""
-        await async_see(
-            dev_id=device,
-            gps=gps_location,
-            battery=battery,
-            gps_accuracy=accuracy,
-            attributes=attrs
-        )
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up gpslogger from config entry."""
+    entities = hass.data.setdefault(GPSLOGGER_ENTITIES, {})
+
+    async def async_see(
+            device, latitude, longitude, battery, accuracy, attributes):
+        """Notify the device tracker entities that you see a device."""
+        entity = entities.get(device)
+
+        if entity:
+            await entity.async_seen(
+                latitude=latitude, longitude=longitude,
+                battery=battery, accuracy=accuracy, attributes=attributes)
+            return
+
+        # If no device can be found, create it
+        entity = GPSLoggerEntity(
+            device, latitude, longitude, battery, accuracy, attributes)
+        entities[device] = entity
+        async_add_entities([entity])
 
     hass.data[DATA_KEY] = async_dispatcher_connect(
-        hass, TRACKER_UPDATE, _set_location
+        hass, TRACKER_UPDATE, async_see
     )
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry):
-    """Unload the config entry and remove the dispatcher connection."""
-    hass.data[DATA_KEY]()
-    return True
+class GPSLoggerEntity(DeviceTrackerEntity):
+    """Represent a tracked device."""
+
+    def __init__(
+            self, device, latitude, longitude, battery, accuracy, attributes):
+        """Set up Geofency entity."""
+        self._accuracy = accuracy
+        self._attributes = attributes
+        self._name = device
+        self._battery = battery
+        self._latitude = latitude
+        self._longitude = longitude
+        self._connected_seen = None
+
+    @property
+    def battery(self):
+        """Return battery value of the device."""
+        return self._battery
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific attributes."""
+        return self._attributes
+
+    @property
+    def gps_accuracy(self):
+        """Return the gps accuracy of the device."""
+        return self._accuracy
+
+    @property
+    def latitude(self):
+        """Return latitude value of the device."""
+        return self._latitude
+
+    @property
+    def longitude(self):
+        """Return longitude value of the device."""
+        return self._longitude
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return SOURCE_TYPE_GPS
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self._connected_seen = self._async_seen
+
+    async def async_will_remove_from_hass(self):
+        """Clean up after entity before removal."""
+        self.hass.data[GPSLOGGER_ENTITIES].pop(self._name)
+
+    async def async_seen(self, **kwargs):
+        """Mark the device as seen."""
+        if self._connected_seen is None:
+            return
+        await self._connected_seen(**kwargs)
+
+    async def _async_seen(self, **kwargs):
+        """Mark the device as seen."""
+        self._attributes.update(kwargs.get(ATTR_ATTRIBUTES, {}))
+        self._battery = kwargs.get(ATTR_BATTERY)
+        self._latitude = kwargs.get(ATTR_LATITUDE)
+        self._longitude = kwargs.get(ATTR_LONGITUDE)
+        self._accuracy = kwargs.get(ATTR_GPS_ACCURACY, DEFAULT_GPS_ACCURACY)
+
+        await self.async_update_ha_state()

--- a/homeassistant/components/locative/__init__.py
+++ b/homeassistant/components/locative/__init__.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'locative'
+
+DATA_KEY = '{}.{}'.format(DOMAIN, DEVICE_TRACKER)
 TRACKER_UPDATE = '{}_tracker_update'.format(DOMAIN)
 
 
@@ -65,14 +67,14 @@ async def handle_webhook(hass, webhook_id, request):
     device = data[ATTR_DEVICE_ID]
     location_name = data.get(ATTR_ID, data[ATTR_TRIGGER]).lower()
     direction = data[ATTR_TRIGGER]
-    gps_location = (data[ATTR_LATITUDE], data[ATTR_LONGITUDE])
 
     if direction == 'enter':
         async_dispatcher_send(
             hass,
             TRACKER_UPDATE,
             device,
-            gps_location,
+            data[ATTR_LATITUDE],
+            data[ATTR_LONGITUDE],
             location_name
         )
         return web.Response(
@@ -90,7 +92,8 @@ async def handle_webhook(hass, webhook_id, request):
                 hass,
                 TRACKER_UPDATE,
                 device,
-                gps_location,
+                data[ATTR_LATITUDE],
+                data[ATTR_LONGITUDE],
                 location_name
             )
             return web.Response(
@@ -139,6 +142,8 @@ async def async_setup_entry(hass, entry):
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
+    hass.data[DATA_KEY]()
+
     await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
     return True
 

--- a/homeassistant/components/locative/device_tracker.py
+++ b/homeassistant/components/locative/device_tracker.py
@@ -85,6 +85,7 @@ class LocativeEntity(DeviceTrackerEntity):
 
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""
+        self._connected_seen = None
         self.hass.data[LOCATIVE_ENTITIES].pop(self._name)
 
     async def async_seen(self, **kwargs):

--- a/homeassistant/components/locative/device_tracker.py
+++ b/homeassistant/components/locative/device_tracker.py
@@ -2,34 +2,101 @@
 import logging
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN)
+    ATTR_LOCATION_NAME, SOURCE_TYPE_GPS, DeviceTrackerEntity)
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util import slugify
 
-from . import DOMAIN as LOCATIVE_DOMAIN, TRACKER_UPDATE
+from . import DATA_KEY, TRACKER_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_KEY = '{}.{}'.format(LOCATIVE_DOMAIN, DEVICE_TRACKER_DOMAIN)
+LOCATIVE_ENTITIES = 'locative_entities'
 
 
-async def async_setup_entry(hass, entry, async_see):
-    """Configure a dispatcher connection based on a config entry."""
-    async def _set_location(device, gps_location, location_name):
-        """Fire HA event to set location."""
-        await async_see(
-            dev_id=slugify(device),
-            gps=gps_location,
-            location_name=location_name
-        )
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Locative from config entry."""
+    entities = hass.data.setdefault(LOCATIVE_ENTITIES, {})
+
+    async def async_see(device, latitude, longitude, location_name):
+        """Notify the device tracker entities that you see a device."""
+        entity = entities.get(device)
+
+        if entity:
+            await entity.async_seen(
+                latitude=latitude, longitude=longitude,
+                location_name=location_name)
+            return
+
+        # If no device can be found, create it
+        entity = LocativeEntity(device, latitude, longitude, location_name)
+        entities[device] = entity
+        async_add_entities([entity])
 
     hass.data[DATA_KEY] = async_dispatcher_connect(
-        hass, TRACKER_UPDATE, _set_location
+        hass, TRACKER_UPDATE, async_see
     )
     return True
 
 
-async def async_unload_entry(hass, entry):
-    """Unload the config entry and remove the dispatcher connection."""
-    hass.data[DATA_KEY]()
-    return True
+class LocativeEntity(DeviceTrackerEntity):
+    """Represent a tracked device."""
+
+    def __init__(self, device, latitude, longitude, location_name):
+        """Set up Locative entity."""
+        self._name = device
+        self._location_name = location_name
+        self._latitude = latitude
+        self._longitude = longitude
+        self._connected_seen = None
+
+    @property
+    def latitude(self):
+        """Return latitude value of the device."""
+        return self._latitude
+
+    @property
+    def location_name(self):
+        """Return a location name for the current location of the device."""
+        return self._location_name
+
+    @property
+    def longitude(self):
+        """Return longitude value of the device."""
+        return self._longitude
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return SOURCE_TYPE_GPS
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self._connected_seen = self._async_seen
+
+    async def async_will_remove_from_hass(self):
+        """Clean up after entity before removal."""
+        self.hass.data[LOCATIVE_ENTITIES].pop(self._name)
+
+    async def async_seen(self, **kwargs):
+        """Mark the device as seen."""
+        if self._connected_seen is None:
+            return
+        await self._connected_seen(**kwargs)
+
+    async def _async_seen(self, **kwargs):
+        """Mark the device as seen."""
+        self._location_name = kwargs.get(ATTR_LOCATION_NAME)
+        self._latitude = kwargs.get(ATTR_LATITUDE)
+        self._longitude = kwargs.get(ATTR_LONGITUDE)
+
+        await self.async_update_ha_state()

--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import mqtt
-from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_WEBHOOK_ID
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.setup import async_when_setup
@@ -211,10 +211,11 @@ class OwnTracksContext:
 
         if device_tracker_state is not None:
             acc = device_tracker_state.attributes.get("gps_accuracy")
-            lat = device_tracker_state.attributes.get("latitude")
-            lon = device_tracker_state.attributes.get("longitude")
+            lat = device_tracker_state.attributes.get(ATTR_LATITUDE)
+            lon = device_tracker_state.attributes.get(ATTR_LONGITUDE)
             kwargs['gps_accuracy'] = acc
-            kwargs['gps'] = (lat, lon)
+            kwargs[ATTR_LATITUDE] = lat
+            kwargs[ATTR_LONGITUDE] = lon
 
         # the battery state applies to the tracking device, not the beacon
         # kwargs location is the beacon's configured lat/lon

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -112,6 +112,7 @@ class OwnTracksEntity(DeviceTrackerEntity):
 
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""
+        self._connected_seen = None
         self.hass.data[OWNTRACKS_ENTITIES].pop(self._dev_id)
 
     async def async_seen(self, **kwargs):

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -285,9 +285,6 @@ async def test_beacon_enter_and_exit_car(hass, geofency_client, webhook_id):
     assert STATE_HOME == state_name
 
 
-@pytest.mark.xfail(
-    reason='The device_tracker component does not support unloading yet.'
-)
 async def test_load_unload_entry(hass, geofency_client, webhook_id):
     """Test that the appropriate dispatch signals are added and removed."""
     url = '/api/webhook/{}'.format(webhook_id)

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -173,9 +173,6 @@ async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
     assert state.attributes['activity'] == 'running'
 
 
-@pytest.mark.xfail(
-    reason='The device_tracker component does not support unloading yet.'
-)
 async def test_load_unload_entry(hass, gpslogger_client, webhook_id):
     """Test that the appropriate dispatch signals are added and removed."""
     url = '/api/webhook/{}'.format(webhook_id)

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -242,9 +242,6 @@ async def test_exit_first(hass, locative_client, webhook_id):
     assert state.state == 'not_home'
 
 
-@pytest.mark.xfail(
-    reason='The device_tracker component does not support unloading yet.'
-)
 async def test_load_unload_entry(hass, locative_client, webhook_id):
     """Test that the appropriate dispatch signals are added and removed."""
     url = '/api/webhook/{}'.format(webhook_id)

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -5,7 +5,7 @@ from asynctest import patch
 import pytest
 
 from homeassistant.components import owntracks
-from homeassistant.const import STATE_NOT_HOME
+from homeassistant.const import STATE_NOT_HOME, STATE_UNKNOWN
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -847,24 +847,24 @@ async def test_event_beacon_unknown_zone_no_location(hass, context):
     # that will be tracked at my current location. Except
     # in this case my Device hasn't had a location message
     # yet so it's in an odd state where it has state.state
-    # None and no GPS coords to set the beacon to.
-    hass.states.async_set(DEVICE_TRACKER_STATE, None)
+    # unknown and no GPS coords to set the beacon to.
+    hass.states.async_set(DEVICE_TRACKER_STATE, STATE_UNKNOWN)
 
     message = build_message(
         {'desc': "unknown"},
         REGION_BEACON_ENTER_MESSAGE)
     await send_message(hass, EVENT_TOPIC, message)
 
-    # My current state is None because I haven't seen a
+    # My current state is unknown because I haven't seen a
     # location message or a GPS or Region # Beacon event
-    # message. None is the state the test harness set for
+    # message. unknown is the state the test harness set for
     # the Device during test case setup.
-    assert_location_state(hass, 'None')
+    assert_location_state(hass, STATE_UNKNOWN)
 
-    # home is the state of a Device constructed through
+    # unknown is the state of a Device constructed through
     # the normal code path on it's first observation with
     # the conditions I pass along.
-    assert_mobile_tracker_state(hass, 'home', 'unknown')
+    assert_mobile_tracker_state(hass, STATE_UNKNOWN, 'unknown')
 
 
 async def test_event_beacon_unknown_zone(hass, context):


### PR DESCRIPTION
## Description:
This PR is a draft PR which tracks the progress to lay the groundwork for device tracker component as EntityComponent and convert the first (necessary) device tracker platforms to EntityPlatforms.

See https://github.com/home-assistant/architecture/issues/151 for background. In that issue I've detailed questions I would like help with answering if we think this PR is going in the right direction.

- Test clean ups will be cherry picked and merged separately after which this PR will be rebased.
- Aim is to keep the diff as small as possible but still show enough of the idea to get feedback.
- All platforms that use config entries have to be converted in this first PR to not break, unfortunately.

## Todo:
  - [x] Cherry pick remaining clean up tests.
  - [ ] Update or add tests for new device tracker component features.
    - [ ] Add a test that sets up both a legacy platform and an EntityPlatform device tracker platform and test that both platforms report state correctly while active at the same time.
    - [ ] Add a test that sets up both a legacy platform and an EntityPlatform device tracker platform and test that both platforms handle service calls to the see service correctly, while active at the same time.
  - [ ] Optionally add filter for entities to avoid adding many not needed entities to state machine.


**Related issue (if applicable):**
closes https://github.com/home-assistant/architecture/issues/151
closes https://github.com/home-assistant/architecture/issues/71

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**
TBD

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.