### PR TITLE
Remove the google travel time update service

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -4,21 +4,21 @@ Support for Google travel time sensors.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.google_travel_time/
 """
+import logging
 from datetime import datetime
 from datetime import timedelta
-import logging
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import DOMAIN, PLATFORM_SCHEMA
-from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_API_KEY, CONF_NAME, EVENT_HOMEASSISTANT_START, ATTR_LATITUDE,
     ATTR_LONGITUDE, CONF_MODE)
-from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
-import homeassistant.util.dt as dt_util
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
 REQUIREMENTS = ['googlemaps==2.5.1']
 
@@ -83,18 +83,16 @@ def convert_time_to_utc(timestr):
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the Google travel time platform."""
     def run_setup(event):
-        """Delay the setup until Home Assistant is fully initialized.
+        """
+        Delay the setup until Home Assistant is fully initialized.
 
         This allows any entities to be created already
         """
+        hass.data.setdefault(DATA_KEY, [])
         options = config.get(CONF_OPTIONS)
 
         if options.get('units') is None:
             options['units'] = hass.config.units.name
-        if DATA_KEY not in hass.data:
-            hass.data[DATA_KEY] = []
-            hass.services.register(
-                DOMAIN, 'google_travel_sensor_update', update)
 
         travel_mode = config.get(CONF_TRAVEL_MODE)
         mode = options.get(CONF_MODE)
@@ -119,14 +117,6 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
         if sensor.valid_api_connection:
             add_entities_callback([sensor])
-
-    def update(service):
-        """Update service for manual updates."""
-        entity_id = service.data.get('entity_id')
-        for sensor in hass.data[DATA_KEY]:
-            if sensor.entity_id == entity_id:
-                sensor.update(no_throttle=True)
-                sensor.schedule_update_ha_state()
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)


### PR DESCRIPTION
## Description:
Per [home-assistant/architecture#131](https://github.com/home-assistant/architecture/issues/131), sensor platforms should not be registering services. google_travel_time is one of several that does and this should be cleaned up. This sensor has a service call which is used to manually update the sensor with the latest travel time.

Since there is now a service `homeassistant.update` that takes in one or more entity ids, the update service in this platform is redundant and now removed.

**Breaking Change:** The google_travel_time platform no longer has an `update` service, use `homeassistant.update` with the appropriate entity_id(s) instead.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8749

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
