### PR TITLE
HomematicIP Cloud fix cover position property

### DIFF
--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -39,7 +39,7 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
     @property
     def current_cover_position(self):
         """Return current position of cover."""
-        return int(self._device.shutterLevel * 100)
+        return int((1 - self._device.shutterLevel) * 100)
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""


### PR DESCRIPTION
## Description:
Fix cover position property

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23