### PR TITLE
Netatmo, address comments from #20755

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -1,6 +1,5 @@
 """Support for the Netatmo devices."""
 import logging
-import json
 from datetime import timedelta
 from urllib.error import HTTPError
 

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -18,6 +18,9 @@ DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)
 
+DATA_PERSONS = 'netatmo_persons'
+DATA_WEBHOOK_URL = 'netatmo_webhook_url'
+
 CONF_SECRET_KEY = 'secret_key'
 CONF_WEBHOOKS = 'webhooks'
 
@@ -28,7 +31,6 @@ SERVICE_DROPWEBHOOK = 'dropwebhook'
 
 NETATMO_AUTH = None
 NETATMO_WEBHOOK_URL = None
-NETATMO_PERSONS = {}
 
 DEFAULT_PERSON = 'Unknown'
 DEFAULT_DISCOVERY = True
@@ -85,7 +87,8 @@ def setup(hass, config):
     """Set up the Netatmo devices."""
     import pyatmo
 
-    global NETATMO_AUTH, NETATMO_WEBHOOK_URL
+    global NETATMO_AUTH
+    hass.data[DATA_PERSONS] = {}
     try:
         NETATMO_AUTH = pyatmo.ClientAuth(
             config[DOMAIN][CONF_API_KEY], config[DOMAIN][CONF_SECRET_KEY],
@@ -103,11 +106,12 @@ def setup(hass, config):
 
     if config[DOMAIN][CONF_WEBHOOKS]:
         webhook_id = hass.components.webhook.async_generate_id()
-        NETATMO_WEBHOOK_URL = hass.components.webhook.async_generate_url(
-            webhook_id)
+        hass.data[
+            DATA_WEBHOOK_URL] = hass.components.webhook.async_generate_url(
+                webhook_id)
         hass.components.webhook.async_register(
             DOMAIN, 'Netatmo', webhook_id, handle_webhook)
-        NETATMO_AUTH.addwebhook(NETATMO_WEBHOOK_URL)
+        NETATMO_AUTH.addwebhook(hass.data[DATA_WEBHOOK_URL])
         hass.bus.listen_once(
             EVENT_HOMEASSISTANT_STOP, dropwebhook)
 
@@ -115,7 +119,7 @@ def setup(hass, config):
         """Service to (re)add webhooks during runtime."""
         url = service.data.get(CONF_URL)
         if url is None:
-            url = NETATMO_WEBHOOK_URL
+            url = hass.data[DATA_WEBHOOK_URL]
         _LOGGER.info("Adding webhook for URL: %s", url)
         NETATMO_AUTH.addwebhook(url)
 
@@ -142,9 +146,8 @@ def dropwebhook(hass):
 
 async def handle_webhook(hass, webhook_id, request):
     """Handle webhook callback."""
-    body = await request.text()
     try:
-        data = json.loads(body) if body else {}
+        data = await request.json()
     except ValueError:
         return None
 
@@ -158,7 +161,7 @@ async def handle_webhook(hass, webhook_id, request):
     if data.get(ATTR_EVENT_TYPE) == EVENT_PERSON:
         for person in data[ATTR_PERSONS]:
             published_data[ATTR_ID] = person.get(ATTR_ID)
-            published_data[ATTR_NAME] = NETATMO_PERSONS.get(
+            published_data[ATTR_NAME] = hass.data[DATA_PERSONS].get(
                 published_data[ATTR_ID], DEFAULT_PERSON)
             published_data[ATTR_IS_KNOWN] = person.get(ATTR_IS_KNOWN)
             published_data[ATTR_FACE_URL] = person.get(ATTR_FACE_URL)
@@ -186,8 +189,9 @@ async def handle_webhook(hass, webhook_id, request):
 class CameraData:
     """Get the latest data from Netatmo."""
 
-    def __init__(self, auth, home=None):
+    def __init__(self, hass, auth, home=None):
         """Initialize the data object."""
+        self._hass = hass
         self.auth = auth
         self.camera_data = None
         self.camera_names = []
@@ -227,9 +231,9 @@ class CameraData:
 
     def get_persons(self):
         """Gather person data for webhooks."""
-        global NETATMO_PERSONS
         for person_id, person_data in self.camera_data.persons.items():
-            NETATMO_PERSONS[person_id] = person_data.get(ATTR_PSEUDO)
+            self._hass.data[DATA_PERSONS][person_id] = person_data.get(
+                ATTR_PSEUDO)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -62,7 +62,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     import pyatmo
     try:
-        data = CameraData(netatmo.NETATMO_AUTH, home)
+        data = CameraData(hass, netatmo.NETATMO_AUTH, home)
         if not data.get_camera_names():
             return None
     except pyatmo.NoDevice:

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -31,7 +31,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     verify_ssl = config.get(CONF_VERIFY_SSL, True)
     import pyatmo
     try:
-        data = CameraData(netatmo.NETATMO_AUTH, home)
+        data = CameraData(hass, netatmo.NETATMO_AUTH, home)
         for camera_name in data.get_camera_names():
             camera_type = data.get_camera_type(camera=camera_name, home=home)
             if CONF_CAMERAS in config:


### PR DESCRIPTION
## Description:
Address comments from @MartinHjelmare in PR #20755 .
I got rid of the `global NETATMO_PERSONS`. I can't remove the `NETATMO_AUTH` because the climate component also uses that, and I don't have such a device. Thus I can't verify if it will keep working.

What I did __not__ change yet is the comment regarding the usage of `hass.components.webhook.async_generate_id` and `hass.components.webhook.async_generate_url` within the sync `setup_platform`. I didn't find any other component where I could steal that from, and I don't know enough about async to know what the correct solution should be. IMHO there should actually a sync-safe variant for other sync-components to use.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
