### PR TITLE
Upgrade voluptuous-serialize to 2.1.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -14,7 +14,7 @@ pyyaml>=3.13,<4
 requests==2.21.0
 ruamel.yaml==0.15.88
 voluptuous==0.11.5
-voluptuous-serialize==2.0.0
+voluptuous-serialize==2.1.0
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,7 +15,7 @@ pyyaml>=3.13,<4
 requests==2.21.0
 ruamel.yaml==0.15.88
 voluptuous==0.11.5
-voluptuous-serialize==2.0.0
+voluptuous-serialize==2.1.0
 
 # homeassistant.components.nuimo_controller
 --only-binary=all nuimo==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ REQUIRES = [
     'requests==2.21.0',
     'ruamel.yaml==0.15.88',
     'voluptuous==0.11.5',
-    'voluptuous-serialize==2.0.0',
+    'voluptuous-serialize==2.1.0',
 ]
 
 MIN_PY_VERSION = '.'.join(map(str, hass_const.REQUIRED_PYTHON_VER))


### PR DESCRIPTION
## Description:
Changelog: https://github.com/balloob/voluptuous-serialize/releases/tag/2.1.0

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
