### PR TITLE
Allow Namecheap to accept several hosts

### DIFF
--- a/homeassistant/components/namecheapdns/__init__.py
+++ b/homeassistant/components/namecheapdns/__init__.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'namecheapdns'
 
-CONF_HOSTS = CONF_HOST + 's' #FIXME Put in homeassistant.const ?
+CONF_HOSTS = CONF_HOST + 's'  #FIXME Put in homeassistant.const ?
 
 INTERVAL = timedelta(minutes=5)
 
@@ -27,7 +27,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_DOMAIN): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_HOST, default='@'): cv.deprecated(replacement_key=CONF_HOSTS),
+        vol.Optional(CONF_HOST, default='@'): 
+        cv.deprecated(replacement_key=CONF_HOSTS),
         vol.Optional(CONF_HOSTS): cv.ensure_list,
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -41,13 +42,13 @@ async def async_setup(hass, config):
     password = config[DOMAIN][CONF_PASSWORD]
 
     session = async_get_clientsession(hass)
-    
+
     if not hosts and _host is not None:
-        hosts = [_host];
-    
+        hosts = [_host]
+
     result = False
-    
-    for host in hosts :
+
+    for host in hosts:
         result |= await _update_namecheapdns(session, host, domain, password)
 
         if not result:

--- a/homeassistant/components/namecheapdns/__init__.py
+++ b/homeassistant/components/namecheapdns/__init__.py
@@ -5,7 +5,8 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_HOST, CONF_HOSTS, CONF_PASSWORD, CONF_DOMAIN
+from homeassistant.const import (CONF_HOST, CONF_HOSTS, 
+                                 CONF_PASSWORD, CONF_DOMAIN)
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -33,9 +34,10 @@ CONFIG_SCHEMA = vol.Schema({
         CONF_HOST,
         replacement_key=CONF_HOSTS,
         invalidation_version="0.91",
-        default = [DEFAULT_HOST]),
+        default=[DEFAULT_HOST]),
     _ensure_list('hosts')
 }, extra=vol.ALLOW_EXTRA)
+
 
 def _ensure_list(key: str):
     def validator(config: {}):

--- a/homeassistant/components/namecheapdns/__init__.py
+++ b/homeassistant/components/namecheapdns/__init__.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_DOMAIN): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_HOST, default='@'): 
+        vol.Optional(CONF_HOST, default='@'):
         cv.deprecated(replacement_key=CONF_HOSTS),
         vol.Optional(CONF_HOSTS): cv.ensure_list,
     })

--- a/homeassistant/components/namecheapdns/__init__.py
+++ b/homeassistant/components/namecheapdns/__init__.py
@@ -47,15 +47,11 @@ def _ensure_list(key: str):
 
 async def async_setup(hass, config):
     """Initialize the namecheap DNS component."""
-    _host = config[DOMAIN][CONF_HOST]
     hosts = config[DOMAIN][CONF_HOSTS]
     domain = config[DOMAIN][CONF_DOMAIN]
     password = config[DOMAIN][CONF_PASSWORD]
 
     session = async_get_clientsession(hass)
-
-    if not hosts and _host is not None:
-        hosts = [_host]
 
     result = False
 

--- a/homeassistant/components/namecheapdns/__init__.py
+++ b/homeassistant/components/namecheapdns/__init__.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (CONF_HOST, CONF_HOSTS, 
+from homeassistant.const import (CONF_HOST, CONF_HOSTS,
                                  CONF_PASSWORD, CONF_DOMAIN)
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -33,8 +33,7 @@ CONFIG_SCHEMA = vol.Schema({
     cv.deprecated(
         CONF_HOST,
         replacement_key=CONF_HOSTS,
-        invalidation_version="0.91",
-        default=[DEFAULT_HOST]),
+        invalidation_version='0.91'),
     _ensure_list('hosts')
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/namecheapdns/__init__.py
+++ b/homeassistant/components/namecheapdns/__init__.py
@@ -15,37 +15,49 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'namecheapdns'
 
+CONF_HOSTS = CONF_HOST + 's' #FIXME Put in homeassistant.const ?
+
 INTERVAL = timedelta(minutes=5)
 
 UPDATE_URL = 'https://dynamicdns.park-your-domain.com/update'
+
+DEFAULT_HOST = '@'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_DOMAIN): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_HOST, default='@'): cv.string,
+        vol.Optional(CONF_HOST, default='@'): cv.deprecated(replacement_key=CONF_HOSTS),
+        vol.Optional(CONF_HOSTS): cv.ensure_list,
     })
 }, extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):
     """Initialize the namecheap DNS component."""
-    host = config[DOMAIN][CONF_HOST]
+    _host = config[DOMAIN][CONF_HOST]
+    hosts = config[DOMAIN][CONF_HOSTS]
     domain = config[DOMAIN][CONF_DOMAIN]
     password = config[DOMAIN][CONF_PASSWORD]
 
     session = async_get_clientsession(hass)
+    
+    if not hosts and _host is not None:
+        hosts = [_host];
+    
+    result = False
+    
+    for host in hosts :
+        result |= await _update_namecheapdns(session, host, domain, password)
 
-    result = await _update_namecheapdns(session, host, domain, password)
+        if not result:
+            return False
 
-    if not result:
-        return False
+        async def update_domain_interval(now):
+            """Update the namecheap DNS entry."""
+            await _update_namecheapdns(session, host, domain, password)
 
-    async def update_domain_interval(now):
-        """Update the namecheap DNS entry."""
-        await _update_namecheapdns(session, host, domain, password)
-
-    async_track_time_interval(hass, update_domain_interval, INTERVAL)
+        async_track_time_interval(hass, update_domain_interval, INTERVAL)
 
     return result
 

--- a/tests/components/namecheapdns/test_init.py
+++ b/tests/components/namecheapdns/test_init.py
@@ -78,6 +78,7 @@ def test_setup_fails_if_update_fails_deprecated(hass, aioclient_mock):
     assert not result
     assert aioclient_mock.call_count == 1
 
+
 @pytest.fixture
 def setup_namecheapdns(hass, aioclient_mock):
     """Fixture that sets up NamecheapDNS."""

--- a/tests/components/namecheapdns/test_init.py
+++ b/tests/components/namecheapdns/test_init.py
@@ -11,12 +11,13 @@ from homeassistant.util.dt import utcnow
 from tests.common import async_fire_time_changed
 
 HOST = 'test'
+HOSTS = ['test1', 'test2']
 DOMAIN = 'bla'
 PASSWORD = 'abcdefgh'
 
 
 @pytest.fixture
-def setup_namecheapdns(hass, aioclient_mock):
+def setup_namecheapdns_deprecated(hass, aioclient_mock):
     """Fixture that sets up NamecheapDNS."""
     aioclient_mock.get(namecheapdns.UPDATE_URL, params={
         'host': HOST,
@@ -35,7 +36,7 @@ def setup_namecheapdns(hass, aioclient_mock):
 
 
 @asyncio.coroutine
-def test_setup(hass, aioclient_mock):
+def test_setup_deprecated(hass, aioclient_mock):
     """Test setup works if update passes."""
     aioclient_mock.get(namecheapdns.UPDATE_URL, params={
         'host': HOST,
@@ -56,6 +57,68 @@ def test_setup(hass, aioclient_mock):
     async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
     yield from hass.async_block_till_done()
     assert aioclient_mock.call_count == 2
+
+
+@asyncio.coroutine
+def test_setup_fails_if_update_fails_deprecated(hass, aioclient_mock):
+    """Test setup fails if first update fails."""
+    aioclient_mock.get(namecheapdns.UPDATE_URL, params={
+        'host': HOST,
+        'domain': DOMAIN,
+        'password': PASSWORD,
+    }, text='<interface-response><ErrCount>1</ErrCount></interface-response>')
+
+    result = yield from async_setup_component(hass, namecheapdns.DOMAIN, {
+        'namecheapdns': {
+            'host': HOST,
+            'domain': DOMAIN,
+            'password': PASSWORD,
+        }
+    })
+    assert not result
+    assert aioclient_mock.call_count == 1
+
+@pytest.fixture
+def setup_namecheapdns(hass, aioclient_mock):
+    """Fixture that sets up NamecheapDNS."""
+    aioclient_mock.get(namecheapdns.UPDATE_URL, params={
+        'hosts': HOSTS,
+        'domain': DOMAIN,
+        'password': PASSWORD,
+    }, text='<interface-response><ErrCount>0</ErrCount></interface-response>')
+
+    hass.loop.run_until_complete(async_setup_component(
+        hass, namecheapdns.DOMAIN, {
+            'namecheapdns': {
+                'hosts': HOSTS,
+                'domain': DOMAIN,
+                'password': PASSWORD,
+            }
+        }))
+
+
+@asyncio.coroutine
+def test_setup(hass, aioclient_mock):
+    """Test setup works if update passes."""
+    aioclient_mock.get(namecheapdns.UPDATE_URL, params={
+        'hosts': HOSTS,
+        'domain': DOMAIN,
+        'password': PASSWORD
+    }, text='<interface-response><ErrCount>0</ErrCount></interface-response>')
+
+    result = yield from async_setup_component(hass, namecheapdns.DOMAIN, {
+        'namecheapdns': {
+            'hosts': HOSTS,
+            'domain': DOMAIN,
+            'password': PASSWORD,
+        }
+    })
+    assert result
+    assert aioclient_mock.call_count == 2
+
+    async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
+    yield from hass.async_block_till_done()
+    assert aioclient_mock.call_count == 4
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Simple change to allow Namecheap to handle several hosts. BREAKING CHANGE.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
namecheapdns:
  domain: example.com
  hosts:
     - subdomain1
     - subdomain2
  password: !secret namecheap
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
