### PR TITLE
Add connection quality related attributes to HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -9,8 +9,8 @@ import homeassistant.helpers.config_validation as cv
 
 from .config_flow import configured_haps
 from .const import (
-    CONF_ACCESSPOINT, CONF_AUTHTOKEN, DOMAIN, HMIPC_AUTHTOKEN, HMIPC_HAPID,
-    HMIPC_NAME)
+    CONF_ACCESSPOINT, CONF_AUTHTOKEN, CONF_SHOW_EXTRA_ATTR, DOMAIN,
+    HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_SHOW_EXTRA_ATTR)
 from .device import HomematicipGenericDevice  # noqa: F401
 from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
@@ -23,6 +23,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_NAME, default=''): vol.Any(cv.string),
         vol.Required(CONF_ACCESSPOINT): cv.string,
         vol.Required(CONF_AUTHTOKEN): cv.string,
+        vol.Optional(CONF_SHOW_EXTRA_ATTR, default=False): cv.boolean,
     })]),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -41,6 +42,7 @@ async def async_setup(hass, config):
                     HMIPC_HAPID: conf[CONF_ACCESSPOINT],
                     HMIPC_AUTHTOKEN: conf[CONF_AUTHTOKEN],
                     HMIPC_NAME: conf[CONF_NAME],
+                    HMIPC_SHOW_EXTRA_ATTR: conf[CONF_SHOW_EXTRA_ATTR],
                 }
             ))
 

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant.core import callback
 
 from .const import (
     _LOGGER, DOMAIN as HMIPC_DOMAIN, HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME,
-    HMIPC_PIN)
+    HMIPC_PIN, HMIPC_SHOW_EXTRA_ATTR)
 from .hap import HomematicipAuth
 
 
@@ -84,6 +84,7 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
         hapid = import_info[HMIPC_HAPID]
         authtoken = import_info[HMIPC_AUTHTOKEN]
         name = import_info[HMIPC_NAME]
+        show_extra_attr = import_info[HMIPC_SHOW_EXTRA_ATTR]
 
         hapid = hapid.replace('-', '').upper()
         if hapid in configured_haps(self.hass):
@@ -97,5 +98,6 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
                 HMIPC_AUTHTOKEN: authtoken,
                 HMIPC_HAPID: hapid,
                 HMIPC_NAME: name,
+                HMIPC_SHOW_EXTRA_ATTR: show_extra_attr,
             }
         )

--- a/homeassistant/components/homematicip_cloud/const.py
+++ b/homeassistant/components/homematicip_cloud/const.py
@@ -17,8 +17,10 @@ COMPONENTS = [
 
 CONF_ACCESSPOINT = 'accesspoint'
 CONF_AUTHTOKEN = 'authtoken'
+CONF_SHOW_EXTRA_ATTR = 'show_extra_attributes'
 
 HMIPC_NAME = 'name'
 HMIPC_HAPID = 'hapid'
 HMIPC_AUTHTOKEN = 'authtoken'
 HMIPC_PIN = 'pin'
+HMIPC_SHOW_EXTRA_ATTR = 'show_extra_attributes'

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -91,6 +91,4 @@ class HomematicipGenericDevice(Entity):
             if hasattr(self._device, 'rssiPeerValue') and \
                     self._device.rssiPeerValue:
                 attr.update({ATTR_PEER_RSSI: self._device.rssiPeerValue})
-            if hasattr(self._device, 'dutyCycle') and self._device.dutyCycle:
-                attr.update({ATTR_DUTY_CYCLE: True})
         return attr

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -84,12 +84,13 @@ class HomematicipGenericDevice(Entity):
             attr.update({ATTR_LOW_BATTERY: self._device.lowBat})
         if hasattr(self._device, 'sabotage') and self._device.sabotage:
             attr.update({ATTR_SABOTAGE: self._device.sabotage})
-        if hasattr(self._device, 'rssiDeviceValue') and \
-                self._device.rssiDeviceValue:
-            attr.update({ATTR_DEVICE_RSSI: self._device.rssiDeviceValue})
-        if hasattr(self._device, 'rssiPeerValue') and \
-                self._device.rssiPeerValue:
-            attr.update({ATTR_PEER_RSSI: self._device.rssiPeerValue})
-        if hasattr(self._device, 'dutyCycle') and self._device.dutyCycle:
-            attr.update({ATTR_DUTY_CYCLE: True})
+        if self._home.show_extra_attr:
+            if hasattr(self._device, 'rssiDeviceValue') and \
+                    self._device.rssiDeviceValue:
+                attr.update({ATTR_DEVICE_RSSI: self._device.rssiDeviceValue})
+            if hasattr(self._device, 'rssiPeerValue') and \
+                    self._device.rssiPeerValue:
+                attr.update({ATTR_PEER_RSSI: self._device.rssiPeerValue})
+            if hasattr(self._device, 'dutyCycle') and self._device.dutyCycle:
+                attr.update({ATTR_DUTY_CYCLE: True})
         return attr

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -90,8 +90,6 @@ class HomematicipGenericDevice(Entity):
         if hasattr(self._device, 'rssiPeerValue') and \
                 self._device.rssiPeerValue:
             attr.update({ATTR_PEER_RSSI: self._device.rssiPeerValue})
-        if hasattr(self._device, 'unreach') and self._device.unreach:
-            attr.update({ATTR_UNREACHABLE: self._device.unreach})
         if hasattr(self._device, 'dutyCycle') and self._device.dutyCycle:
             attr.update({ATTR_DUTY_CYCLE: True})
         return attr

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -17,6 +17,7 @@ ATTR_HOME_NAME = 'home_name'
 ATTR_LOW_BATTERY = 'low_battery'
 ATTR_MODEL_TYPE = 'model_type'
 ATTR_OPERATION_LOCK = 'operation_lock'
+ATTR_PEER_RSSI = 'peer_rssi'
 ATTR_SABOTAGE = 'sabotage'
 ATTR_STATUS_UPDATE = 'status_update'
 ATTR_UNREACHABLE = 'unreachable'
@@ -83,4 +84,14 @@ class HomematicipGenericDevice(Entity):
             attr.update({ATTR_LOW_BATTERY: self._device.lowBat})
         if hasattr(self._device, 'sabotage') and self._device.sabotage:
             attr.update({ATTR_SABOTAGE: self._device.sabotage})
+        if hasattr(self._device, 'rssiDeviceValue') and \
+                self._device.rssiDeviceValue:
+            attr.update({ATTR_DEVICE_RSSI: self._device.rssiDeviceValue})
+        if hasattr(self._device, 'rssiPeerValue') and \
+                self._device.rssiPeerValue:
+            attr.update({ATTR_PEER_RSSI: self._device.rssiPeerValue})
+        if hasattr(self._device, 'unreach') and self._device.unreach:
+            attr.update({ATTR_UNREACHABLE: self._device.unreach})
+        if hasattr(self._device, 'dutyCycle') and self._device.dutyCycle:
+            attr.update({ATTR_DUTY_CYCLE: True})
         return attr

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -7,7 +7,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
-    COMPONENTS, HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN)
+    COMPONENTS, HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN,
+    HMIPC_SHOW_EXTRA_ATTR)
 from .errors import HmipcConnectionError
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,7 +93,8 @@ class HomematicipHAP:
                 self.hass,
                 self.config_entry.data.get(HMIPC_HAPID),
                 self.config_entry.data.get(HMIPC_AUTHTOKEN),
-                self.config_entry.data.get(HMIPC_NAME)
+                self.config_entry.data.get(HMIPC_NAME),
+                self.config_entry.data.get(HMIPC_SHOW_EXTRA_ATTR)
             )
         except HmipcConnectionError:
             raise ConfigEntryNotReady
@@ -204,7 +206,7 @@ class HomematicipHAP:
                 self.config_entry, component)
         return True
 
-    async def get_hap(self, hass, hapid, authtoken, name):
+    async def get_hap(self, hass, hapid, authtoken, name, show_extra_attr):
         """Create a HomematicIP access point object."""
         from homematicip.aio.home import AsyncHome
         from homematicip.base.base_connection import HmipConnectionError
@@ -214,6 +216,7 @@ class HomematicipHAP:
         home.name = name
         home.label = 'Access Point'
         home.modelType = 'HmIP-HAP'
+        home.show_extra_attr = show_extra_attr
 
         home.set_auth_token(authtoken)
         try:

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -167,13 +167,11 @@ class HomematicipNotificationLight(HomematicipGenericDevice, Light):
     def device_state_attributes(self):
         """Return the state attributes of the generic device."""
         attr = super().device_state_attributes
-
-        if self._home.show_extra_attr:
-            if self.is_on:
-                attr.update({
-                    ATTR_COLOR_NAME:
-                        self._channel.simpleRGBColorState
-                })
+        if self.is_on:
+            attr.update({
+                ATTR_COLOR_NAME:
+                    self._channel.simpleRGBColorState
+            })
         return attr
 
     @property

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -167,11 +167,13 @@ class HomematicipNotificationLight(HomematicipGenericDevice, Light):
     def device_state_attributes(self):
         """Return the state attributes of the generic device."""
         attr = super().device_state_attributes
-        if self.is_on:
-            attr.update({
-                ATTR_COLOR_NAME:
-                    self._channel.simpleRGBColorState
-            })
+
+        if self._home.show_extra_attr:
+            if self.is_on:
+                attr.update({
+                    ATTR_COLOR_NAME:
+                        self._channel.simpleRGBColorState
+                })
         return attr
 
     @property

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -122,7 +122,8 @@ async def test_import_config(hass):
     result = await flow.async_step_import({
         hmipc.HMIPC_HAPID: 'ABC123',
         hmipc.HMIPC_AUTHTOKEN: '123',
-        hmipc.HMIPC_NAME: 'hmip'
+        hmipc.HMIPC_NAME: 'hmip',
+        hmipc.HMIPC_SHOW_EXTRA_ATTR: False
     })
 
     assert result['type'] == 'create_entry'
@@ -130,7 +131,8 @@ async def test_import_config(hass):
     assert result['data'] == {
         hmipc.HMIPC_HAPID: 'ABC123',
         hmipc.HMIPC_AUTHTOKEN: '123',
-        hmipc.HMIPC_NAME: 'hmip'
+        hmipc.HMIPC_NAME: 'hmip',
+        hmipc.HMIPC_SHOW_EXTRA_ATTR: False
     }
 
 
@@ -146,7 +148,8 @@ async def test_import_existing_config(hass):
     result = await flow.async_step_import({
         hmipc.HMIPC_HAPID: 'ABC123',
         hmipc.HMIPC_AUTHTOKEN: '123',
-        hmipc.HMIPC_NAME: 'hmip'
+        hmipc.HMIPC_NAME: 'hmip',
+        hmipc.HMIPC_SHOW_EXTRA_ATTR: True
     })
 
     assert result['type'] == 'abort'

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -17,6 +17,7 @@ async def test_config_with_accesspoint_passed_to_config_entry(hass):
                 hmipc.CONF_ACCESSPOINT: 'ABC123',
                 hmipc.CONF_AUTHTOKEN: '123',
                 hmipc.CONF_NAME: 'name',
+                hmipc.CONF_SHOW_EXTRA_ATTR: False
             }
         }) is True
 
@@ -33,6 +34,7 @@ async def test_config_already_registered_not_passed_to_config_entry(hass):
                 hmipc.CONF_ACCESSPOINT: 'ABC123',
                 hmipc.CONF_AUTHTOKEN: '123',
                 hmipc.CONF_NAME: 'name',
+                hmipc.CONF_SHOW_EXTRA_ATTR: False
             }
         }) is True
 
@@ -46,6 +48,7 @@ async def test_setup_entry_successful(hass):
         hmipc.HMIPC_HAPID: 'ABC123',
         hmipc.HMIPC_AUTHTOKEN: '123',
         hmipc.HMIPC_NAME: 'hmip',
+        hmipc.HMIPC_SHOW_EXTRA_ATTR: False
     })
     entry.add_to_hass(hass)
     with patch.object(hmipc, 'HomematicipHAP') as mock_hap:
@@ -55,6 +58,7 @@ async def test_setup_entry_successful(hass):
                 hmipc.CONF_ACCESSPOINT: 'ABC123',
                 hmipc.CONF_AUTHTOKEN: '123',
                 hmipc.CONF_NAME: 'hmip',
+                hmipc.CONF_SHOW_EXTRA_ATTR: False
             }
         }) is True
 
@@ -71,6 +75,7 @@ async def test_setup_defined_accesspoint(hass):
                 hmipc.CONF_ACCESSPOINT: 'ABC123',
                 hmipc.CONF_AUTHTOKEN: '123',
                 hmipc.CONF_NAME: 'hmip',
+                hmipc.CONF_SHOW_EXTRA_ATTR: True
             }
         }) is True
 
@@ -79,6 +84,7 @@ async def test_setup_defined_accesspoint(hass):
         hmipc.HMIPC_HAPID: 'ABC123',
         hmipc.HMIPC_AUTHTOKEN: '123',
         hmipc.HMIPC_NAME: 'hmip',
+        hmipc.HMIPC_SHOW_EXTRA_ATTR: True
     }
 
 


### PR DESCRIPTION
## Description:
This PR adds extra attributes to Homematic IP devices to determine connection quality, and helps to identify issues with it.

To keep the device as clean as possible these extra attributes are only available if parameter `show_extra_attributes` is set to `true `in config.

## Example entry for `configuration.yaml` (if applicable):
```yaml
homematicip_cloud:
  - accesspoint: IDENTIFIER
    authtoken: AUTHTOKEN
  - name: Location2
    accesspoint: IDENTIFIER2
    authtoken: AUTHTOKEN2
    show_extra_attributes: true
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io/pull/8651)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
