### PR TITLE
Update rova component with suffix for house number

### DIFF
--- a/homeassistant/components/sensor/rova.py
+++ b/homeassistant/components/sensor/rova.py
@@ -38,7 +38,7 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ZIP_CODE): cv.string,
     vol.Required(CONF_HOUSE_NUMBER): cv.string,
-    vol.Optional(CONF_HOUSE_NUMBER_SUFFIX): cv.string,
+    vol.Optional(CONF_HOUSE_NUMBER_SUFFIX, default=''): cv.string,
     vol.Optional(CONF_NAME, default='Rova'): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['bio']):
     vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)])
@@ -54,7 +54,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     zip_code = config[CONF_ZIP_CODE]
     house_number = config[CONF_HOUSE_NUMBER]
-    house_number_suffix = config.get(CONF_HOUSE_NUMBER_SUFFIX, '')
+    house_number_suffix = config[CONF_HOUSE_NUMBER_SUFFIX]
     platform_name = config[CONF_NAME]
 
     # Create new Rova object to  retrieve data

--- a/homeassistant/components/sensor/rova.py
+++ b/homeassistant/components/sensor/rova.py
@@ -17,11 +17,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['rova==0.0.2']
+REQUIREMENTS = ['rova==0.1.0']
 
 # Config for rova requests.
 CONF_ZIP_CODE = 'zip_code'
 CONF_HOUSE_NUMBER = 'house_number'
+CONF_HOUSE_NUMBER_SUFFIX = 'house_number_suffix'
 
 UPDATE_DELAY = timedelta(hours=12)
 SCAN_INTERVAL = timedelta(hours=12)
@@ -37,6 +38,7 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ZIP_CODE): cv.string,
     vol.Required(CONF_HOUSE_NUMBER): cv.string,
+    vol.Optional(CONF_HOUSE_NUMBER_SUFFIX): cv.string,
     vol.Optional(CONF_NAME, default='Rova'): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=['bio']):
     vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)])
@@ -52,10 +54,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     zip_code = config[CONF_ZIP_CODE]
     house_number = config[CONF_HOUSE_NUMBER]
+    house_number_suffix = config.get(CONF_HOUSE_NUMBER_SUFFIX, '')
     platform_name = config[CONF_NAME]
 
     # Create new Rova object to  retrieve data
-    api = Rova(zip_code, house_number)
+    api = Rova(zip_code, house_number, house_number_suffix)
 
     try:
         if not api.is_rova_area():

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1502,7 +1502,7 @@ rocketchat-API==0.6.1
 roombapy==1.3.1
 
 # homeassistant.components.sensor.rova
-rova==0.0.2
+rova==0.1.0
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.7


### PR DESCRIPTION
Add house_number_suffix to configuration

## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8624

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rova
    zip_code: ZIP_CODE
    house_number: HOUSE_NUMBER
    house_number_suffix: HOUSE_NUMBER_SUFFIX
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
