### PR TITLE
Add SmartThings Cover platform and add cover device classes

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -35,10 +35,19 @@ ENTITY_ID_ALL_COVERS = group.ENTITY_ID_FORMAT.format('all_covers')
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
+DEVICE_CLASS_CURTAIN = 'curtain'
+DEVICE_CLASS_DAMPER = 'damper'
+DEVICE_CLASS_DOOR = 'door'
+DEVICE_CLASS_GARAGE = 'garage'
+DEVICE_CLASS_SHADE = 'shade'
+DEVICE_CLASS_WINDOW = 'window'
 DEVICE_CLASSES = [
-    'damper',
-    'garage',        # Garage door control
-    'window',        # Window control
+    DEVICE_CLASS_CURTAIN,   # Curtain control (covering window, wall, etc..)
+    DEVICE_CLASS_DAMPER,
+    DEVICE_CLASS_DOOR,      # Generic door control
+    DEVICE_CLASS_GARAGE,    # Garage door control
+    DEVICE_CLASS_SHADE,     # Shade control (covering window, wall, etc..)
+    DEVICE_CLASS_WINDOW,    # Window control
 ]
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -35,18 +35,25 @@ ENTITY_ID_ALL_COVERS = group.ENTITY_ID_FORMAT.format('all_covers')
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
+DEVICE_CLASS_AWNING = 'awning'
+DEVICE_CLASS_BLIND = 'blind'
 DEVICE_CLASS_CURTAIN = 'curtain'
 DEVICE_CLASS_DAMPER = 'damper'
 DEVICE_CLASS_DOOR = 'door'
 DEVICE_CLASS_GARAGE = 'garage'
 DEVICE_CLASS_SHADE = 'shade'
+DEVICE_CLASS_SHUTTER = 'shutter'
 DEVICE_CLASS_WINDOW = 'window'
+
 DEVICE_CLASSES = [
-    DEVICE_CLASS_CURTAIN,   # Curtain control (covering window, wall, etc..)
-    DEVICE_CLASS_DAMPER,
+    DEVICE_CLASS_AWNING,    # Awning over a over window, patio, tec..
+    DEVICE_CLASS_BLIND,     # Window blinds
+    DEVICE_CLASS_CURTAIN,   # Curtain covering a window, wall, etc..
+    DEVICE_CLASS_DAMPER,    # Vent damper, digital window tint/film, etc...
     DEVICE_CLASS_DOOR,      # Generic door control
     DEVICE_CLASS_GARAGE,    # Garage door control
     DEVICE_CLASS_SHADE,     # Shade control (covering window, wall, etc..)
+    DEVICE_CLASS_SHUTTER,   # Shutter covering a window, door, etc...
     DEVICE_CLASS_WINDOW,    # Window control
 ]
 

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -35,6 +35,7 @@ ENTITY_ID_ALL_COVERS = group.ENTITY_ID_FORMAT.format('all_covers')
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
+# Refer to the cover dev docs for device class descriptions
 DEVICE_CLASS_AWNING = 'awning'
 DEVICE_CLASS_BLIND = 'blind'
 DEVICE_CLASS_CURTAIN = 'curtain'
@@ -44,19 +45,17 @@ DEVICE_CLASS_GARAGE = 'garage'
 DEVICE_CLASS_SHADE = 'shade'
 DEVICE_CLASS_SHUTTER = 'shutter'
 DEVICE_CLASS_WINDOW = 'window'
-
 DEVICE_CLASSES = [
-    DEVICE_CLASS_AWNING,    # Awning over a over window, patio, tec..
-    DEVICE_CLASS_BLIND,     # Window blinds
-    DEVICE_CLASS_CURTAIN,   # Curtain covering a window, wall, etc..
-    DEVICE_CLASS_DAMPER,    # Vent damper, digital window tint/film, etc...
-    DEVICE_CLASS_DOOR,      # Generic door control
-    DEVICE_CLASS_GARAGE,    # Garage door control
-    DEVICE_CLASS_SHADE,     # Shade control (covering window, wall, etc..)
-    DEVICE_CLASS_SHUTTER,   # Shutter covering a window, door, etc...
-    DEVICE_CLASS_WINDOW,    # Window control
+    DEVICE_CLASS_AWNING,
+    DEVICE_CLASS_BLIND,
+    DEVICE_CLASS_CURTAIN,
+    DEVICE_CLASS_DAMPER,
+    DEVICE_CLASS_DOOR,
+    DEVICE_CLASS_GARAGE,
+    DEVICE_CLASS_SHADE,
+    DEVICE_CLASS_SHUTTER,
+    DEVICE_CLASS_WINDOW
 ]
-
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 
 SUPPORT_OPEN = 1

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -25,12 +25,13 @@ SETTINGS_INSTANCE_ID = "hassInstanceId"
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
 # Ordered 'specific to least-specific platform' in order for capabilities
-# to be drawn-down and represented by the appropriate platform.
+# to be drawn-down and represented by the most appropriate platform.
 SUPPORTED_PLATFORMS = [
     'climate',
     'fan',
     'light',
     'lock',
+    'cover',
     'switch',
     'binary_sensor',
     'sensor'

--- a/homeassistant/components/smartthings/cover.py
+++ b/homeassistant/components/smartthings/cover.py
@@ -1,0 +1,108 @@
+"""Support for covers through the SmartThings cloud API."""
+from typing import Optional, Sequence
+
+from homeassistant.components.cover import (
+    DEVICE_CLASS_DOOR, DEVICE_CLASS_GARAGE, DEVICE_CLASS_SHADE,
+    DOMAIN as COVER_DOMAIN, STATE_CLOSED, STATE_CLOSING, STATE_OPEN,
+    STATE_OPENING, SUPPORT_CLOSE, SUPPORT_OPEN, CoverDevice)
+
+from . import SmartThingsEntity
+from .const import DATA_BROKERS, DOMAIN
+
+DEPENDENCIES = ['smartthings']
+
+VALUE_TO_STATE = {
+    'closed': STATE_CLOSED,
+    'closing': STATE_CLOSING,
+    'open': STATE_OPEN,
+    'opening': STATE_OPENING,
+    'partially open': STATE_OPEN,
+    'unknown': None
+}
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Add covers for a config entry."""
+    broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
+    async_add_entities(
+        [SmartThingsCover(device) for device in broker.devices.values()
+         if broker.any_assigned(device.device_id, COVER_DOMAIN)], True)
+
+
+def get_capabilities(capabilities: Sequence[str]) -> Optional[Sequence[str]]:
+    """Return all capabilities supported if minimum required are present."""
+    from pysmartthings import Capability
+
+    supported = [
+        Capability.door_control,
+        Capability.garage_door_control,
+        Capability.window_shade
+    ]
+    # Must have one of the supported
+    if any(capability in capabilities
+           for capability in supported):
+        return supported
+    return None
+
+
+class SmartThingsCover(SmartThingsEntity, CoverDevice):
+    """Define a SmartThings cover."""
+
+    def __init__(self, device):
+        """Initialize the cover class."""
+        super().__init__(device)
+        self._device_class = None
+        self._state = None
+
+    async def async_close_cover(self, **kwargs):
+        """Close cover."""
+        # Same command for all 3 supported capabilities
+        await self._device.close(set_status=True)
+        # State is set optimistically in the commands above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_schedule_update_ha_state(True)
+
+    async def async_open_cover(self, **kwargs):
+        """Open the cover."""
+        # Same for all capability types
+        await self._device.open(set_status=True)
+        # State is set optimistically in the commands above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_schedule_update_ha_state(True)
+
+    async def async_update(self):
+        """Update the attrs of the cover."""
+        from pysmartthings import Capability
+
+        value = None
+        if Capability.door_control in self._device.capabilities:
+            self._device_class = DEVICE_CLASS_DOOR
+            value = self._device.status.door
+        elif Capability.window_shade in self._device.capabilities:
+            self._device_class = DEVICE_CLASS_SHADE
+            value = self._device.status.window_shade
+        elif Capability.garage_door_control in self._device.capabilities:
+            self._device_class = DEVICE_CLASS_GARAGE
+            value = self._device.status.door
+        self._state = VALUE_TO_STATE.get(value)
+
+    @property
+    def device_class(self):
+        """Define this cover as a garage door."""
+        return self._device_class
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE
+
+    @property
+    def state(self) -> str:
+        """Get the state of the cover."""
+        return self._state

--- a/homeassistant/components/smartthings/cover.py
+++ b/homeassistant/components/smartthings/cover.py
@@ -2,9 +2,11 @@
 from typing import Optional, Sequence
 
 from homeassistant.components.cover import (
-    DEVICE_CLASS_DOOR, DEVICE_CLASS_GARAGE, DEVICE_CLASS_SHADE,
+    ATTR_POSITION, DEVICE_CLASS_DOOR, DEVICE_CLASS_GARAGE, DEVICE_CLASS_SHADE,
     DOMAIN as COVER_DOMAIN, STATE_CLOSED, STATE_CLOSING, STATE_OPEN,
-    STATE_OPENING, SUPPORT_CLOSE, SUPPORT_OPEN, CoverDevice)
+    STATE_OPENING, SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION,
+    CoverDevice)
+from homeassistant.const import ATTR_BATTERY_LEVEL
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
@@ -39,14 +41,19 @@ def get_capabilities(capabilities: Sequence[str]) -> Optional[Sequence[str]]:
     """Return all capabilities supported if minimum required are present."""
     from pysmartthings import Capability
 
-    supported = [
+    min_required = [
         Capability.door_control,
         Capability.garage_door_control,
         Capability.window_shade
     ]
-    # Must have one of the supported
+    supported = min_required.copy()
+    supported.extend([
+        Capability.battery,
+        Capability.switch_level
+    ])
+    # Must have one of the min_required
     if any(capability in capabilities
-           for capability in supported):
+           for capability in min_required):
         return supported
     return None
 
@@ -56,9 +63,15 @@ class SmartThingsCover(SmartThingsEntity, CoverDevice):
 
     def __init__(self, device):
         """Initialize the cover class."""
+        from pysmartthings import Capability
+
         super().__init__(device)
         self._device_class = None
         self._state = None
+        self._state_attrs = None
+        self._supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
+        if Capability.switch_level in device.capabilities:
+            self._supported_features |= SUPPORT_SET_POSITION
 
     async def async_close_cover(self, **kwargs):
         """Close cover."""
@@ -76,9 +89,18 @@ class SmartThingsCover(SmartThingsEntity, CoverDevice):
         # the entity state ahead of receiving the confirming push updates
         self.async_schedule_update_ha_state(True)
 
+    async def async_set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        position = kwargs.get(ATTR_POSITION)
+        if not self._supported_features & SUPPORT_SET_POSITION \
+                or not position:
+            return
+        # Do not set_status=True as device will report progress.
+        await self._device.set_level(position, 0)
+
     async def async_update(self):
         """Update the attrs of the cover."""
-        from pysmartthings import Capability
+        from pysmartthings import Attribute, Capability
 
         value = None
         if Capability.door_control in self._device.capabilities:
@@ -90,7 +112,18 @@ class SmartThingsCover(SmartThingsEntity, CoverDevice):
         elif Capability.garage_door_control in self._device.capabilities:
             self._device_class = DEVICE_CLASS_GARAGE
             value = self._device.status.door
+
         self._state = VALUE_TO_STATE.get(value)
+
+        self._state_attrs = {}
+        battery = self._device.status.attributes[Attribute.battery].value
+        if battery is not None:
+            self._state_attrs[ATTR_BATTERY_LEVEL] = battery
+
+    @property
+    def current_cover_position(self):
+        """Return current position of cover."""
+        return self._device.status.level
 
     @property
     def device_class(self):
@@ -98,9 +131,14 @@ class SmartThingsCover(SmartThingsEntity, CoverDevice):
         return self._device_class
 
     @property
+    def device_state_attributes(self):
+        """Get additional state attributes."""
+        return self._state_attrs
+
+    @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE
+        return self._supported_features
 
     @property
     def state(self) -> str:

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -43,8 +43,6 @@ CAPABILITY_TO_SENSORS = {
         Map('dishwasherJobState', "Dishwasher Job State", None, None),
         Map('completionTime', "Dishwasher Completion Time", None,
             DEVICE_CLASS_TIMESTAMP)],
-    'doorControl': [
-        Map('door', "Door", None, None)],
     'dryerMode': [
         Map('dryerMode', "Dryer Mode", None, None)],
     'dryerOperatingState': [
@@ -62,8 +60,6 @@ CAPABILITY_TO_SENSORS = {
             'Equivalent Carbon Dioxide Measurement', 'ppm', None)],
     'formaldehydeMeasurement': [
         Map('formaldehydeLevel', 'Formaldehyde Measurement', 'ppm', None)],
-    'garageDoorControl': [
-        Map('door', 'Garage Door', None, None)],
     'illuminanceMeasurement': [
         Map('illuminance', "Illuminance", 'lux', DEVICE_CLASS_ILLUMINANCE)],
     'infraredLevel': [
@@ -143,9 +139,7 @@ CAPABILITY_TO_SENSORS = {
         Map('machineState', "Washer Machine State", None, None),
         Map('washerJobState', "Washer Job State", None, None),
         Map('completionTime', "Washer Completion Time", None,
-            DEVICE_CLASS_TIMESTAMP)],
-    'windowShade': [
-        Map('windowShade', 'Window Shade', None, None)]
+            DEVICE_CLASS_TIMESTAMP)]
 }
 
 UNITS = {

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -9,7 +9,7 @@ from pysmartthings import Attribute, Capability
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION, ATTR_POSITION, DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER, SERVICE_SET_COVER_POSITION,
-    STATE_CLOSING, STATE_OPENING)
+    STATE_CLOSING, STATE_OPEN, STATE_OPENING)
 from homeassistant.components.smartthings import cover
 from homeassistant.components.smartthings.const import (
     DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
@@ -153,7 +153,8 @@ async def test_update_from_signal(hass, device_factory):
     device = device_factory('Garage', [Capability.garage_door_control],
                             {Attribute.door: 'opening'})
     await setup_platform(hass, COVER_DOMAIN, device)
-    await device.lock(True)
+    device.status.update_attribute_value(Attribute.door, 'open')
+    assert hass.states.get('cover.garage').state == STATE_OPENING
     # Act
     async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE,
                           [device.device_id])
@@ -161,7 +162,7 @@ async def test_update_from_signal(hass, device_factory):
     await hass.async_block_till_done()
     state = hass.states.get('cover.garage')
     assert state is not None
-    assert state.state == STATE_OPENING
+    assert state.state == STATE_OPEN
 
 
 async def test_unload_config_entry(hass, device_factory):


### PR DESCRIPTION
## Description:
Adds SmartThings Cover platform that represents SmartThings devices that have open/close related capabilities.  Highlights:
- Supports open/close for doors, garage doors, and window shades.
- Cover position is supported for device that implement the `switchLevel` capability.  
- Battery level is reported as a state attribute if the `battery` capability is implemented by the device.
- Cover entities are automatically created if supported by the device.
- Adds 6 new device classes to the Cover platform per home-assistant/architecture#153 (`curtain`, `door`, `shade`, `shutter`, `blind`, and `awning`)

**BREAKING CHANGE:**  With the addition of the SmartThings Cover platform, the SmartThings Sensor platform will no longer represent `Door`, `Garage Door` and `Window Share` attributes.  Additionally, if the cover device reports battery status, the value will be present as a state attribute (`battery_level`) and not a discrete sensor.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#8625

**Pull request in [developers.home-assistant](https://github.com/home-assistant/developers.home-assistant) with dev documentation:** home-assistant/developers.home-assistant#187

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.