### PR TITLE
Make sure that device trackers is always a list during creation

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -176,7 +176,7 @@ class PersonManager:
             CONF_ID: uuid.uuid4().hex,
             CONF_NAME: name,
             CONF_USER_ID: user_id,
-            CONF_DEVICE_TRACKERS: device_trackers,
+            CONF_DEVICE_TRACKERS: device_trackers or [],
         }
         self.storage_data[person[CONF_ID]] = person
         self._async_schedule_save()


### PR DESCRIPTION
## Description:
We accidentally would set device trackers to `None`, causing an exception when we would update the state of a person.

reported by @dmulcahey 

```
2019-02-18 15:49:23 ERROR (MainThread) [homeassistant.core] Error doing job: Exception in callback EventBus.async_listen_once.<locals>.onetime_listener(<Event homeassistant_start[L]>) at /Users/davidmulcahey/development/home-assistant/homeassistant/core.py:614
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/davidmulcahey/development/home-assistant/homeassistant/core.py", line 626, in onetime_listener
    self._hass.async_run_job(listener, event)
  File "/Users/davidmulcahey/development/home-assistant/homeassistant/core.py", line 333, in async_run_job
    target(*args)
  File "/Users/davidmulcahey/development/home-assistant/homeassistant/components/person/__init__.py", line 342, in person_start_hass
    self.person_updated()
  File "/Users/davidmulcahey/development/home-assistant/homeassistant/components/person/__init__.py", line 363, in person_updated
    self._update_state()
  File "/Users/davidmulcahey/development/home-assistant/homeassistant/components/person/__init__.py", line 374, in _update_state
    for entity_id in self._config.get(CONF_DEVICE_TRACKERS, []):
TypeError: 'NoneType' object is not iterable
```