### PR TITLE
Fix initialization and add "pending" status of Satel integra

### DIFF
--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['satel_integra==0.2.0']
+REQUIREMENTS = ['satel_integra==0.3.0']
 
 DEFAULT_ALARM_NAME = 'satel_integra'
 DEFAULT_PORT = 7094
@@ -104,33 +104,37 @@ async def async_setup(hass, config):
                             {CONF_ZONES: zones, CONF_OUTPUTS: outputs}, config)
         )
 
-    await asyncio.wait([task_control_panel, task_zones], loop=hass.loop)
-
+#    _LOGGER.debug("Before waiting for task_control_panel")
+        
+#    await asyncio.wait([task_control_panel, task_zones], loop=hass.loop)
+    
+#    _LOGGER.debug("After waiting for task_control_panel")
+        
     @callback
     def alarm_status_update_callback(status):
         """Send status update received from alarm to home assistant."""
         _LOGGER.debug("Alarm status callback, status: %s", status)
         hass_alarm_status = STATE_ALARM_DISARMED
 
-        if status == AlarmState.ARMED_MODE0:
-            hass_alarm_status = STATE_ALARM_ARMED_AWAY
+        # if status == AlarmState.ARMED_MODE0:
+        #     hass_alarm_status = STATE_ALARM_ARMED_AWAY
 
-        elif status in [
-                AlarmState.ARMED_MODE0,
-                AlarmState.ARMED_MODE1,
-                AlarmState.ARMED_MODE2,
-                AlarmState.ARMED_MODE3
-        ]:
-            hass_alarm_status = STATE_ALARM_ARMED_HOME
+        # elif status in [
+        #         AlarmState.ARMED_MODE0,
+        #         AlarmState.ARMED_MODE1,
+        #         AlarmState.ARMED_MODE2,
+        #         AlarmState.ARMED_MODE3
+        # ]:
+        #     hass_alarm_status = STATE_ALARM_ARMED_HOME
 
-        elif status in [AlarmState.TRIGGERED, AlarmState.TRIGGERED_FIRE]:
-            hass_alarm_status = STATE_ALARM_TRIGGERED
+        # elif status in [AlarmState.TRIGGERED, AlarmState.TRIGGERED_FIRE]:
+        #     hass_alarm_status = STATE_ALARM_TRIGGERED
 
-        elif status == AlarmState.DISARMED:
-            hass_alarm_status = STATE_ALARM_DISARMED
+        # elif status == AlarmState.DISARMED:
+        #     hass_alarm_status = STATE_ALARM_DISARMED
 
-        _LOGGER.debug("Sending hass_alarm_status: %s...", hass_alarm_status)
-        async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE, hass_alarm_status)
+        _LOGGER.debug("Sending request to update state, currently: %s...", controller.status)
+        async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE, None)
 
     @callback
     def zones_update_callback(status):

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['satel_integra==0.3.0']
+REQUIREMENTS = ['satel_integra==0.3.2']
 
 DEFAULT_ALARM_NAME = 'satel_integra'
 DEFAULT_PORT = 7094
@@ -96,20 +96,20 @@ async def async_setup(hass, config):
                   conf,
                   conf.get(CONF_ARM_HOME_MODE))
 
-    task_control_panel = hass.async_create_task(
+    hass.async_create_task(
         async_load_platform(hass, 'alarm_control_panel', DOMAIN, conf, config))
 
-    task_zones = hass.async_create_task(
+    hass.async_create_task(
         async_load_platform(hass, 'binary_sensor', DOMAIN,
                             {CONF_ZONES: zones, CONF_OUTPUTS: outputs}, config)
         )
 
 #    _LOGGER.debug("Before waiting for task_control_panel")
-        
+
 #    await asyncio.wait([task_control_panel, task_zones], loop=hass.loop)
-    
+
 #    _LOGGER.debug("After waiting for task_control_panel")
-        
+
     @callback
     def alarm_status_update_callback():
         """Send status update received from alarm to home assistant."""

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -104,7 +104,6 @@ async def async_setup(hass, config):
     @callback
     def alarm_status_update_callback():
         """Send status update received from alarm to home assistant."""
-
         _LOGGER.debug("Sending request to update panel state")
         async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE, None)
 

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -1,14 +1,11 @@
 """Support for Satel Integra devices."""
-import asyncio
 import logging
 
 
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import (
-    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
-    STATE_ALARM_TRIGGERED, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import (EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -76,7 +73,7 @@ async def async_setup(hass, config):
     port = conf.get(CONF_DEVICE_PORT)
     partition = conf.get(CONF_DEVICE_PARTITION)
 
-    from satel_integra.satel_integra import AsyncSatel, AlarmState
+    from satel_integra.satel_integra import AsyncSatel
 
     controller = AsyncSatel(host, port, hass.loop, zones, outputs, partition)
 
@@ -103,12 +100,6 @@ async def async_setup(hass, config):
         async_load_platform(hass, 'binary_sensor', DOMAIN,
                             {CONF_ZONES: zones, CONF_OUTPUTS: outputs}, config)
         )
-
-#    _LOGGER.debug("Before waiting for task_control_panel")
-
-#    await asyncio.wait([task_control_panel, task_zones], loop=hass.loop)
-
-#    _LOGGER.debug("After waiting for task_control_panel")
 
     @callback
     def alarm_status_update_callback():

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -111,10 +111,10 @@ async def async_setup(hass, config):
 #    _LOGGER.debug("After waiting for task_control_panel")
         
     @callback
-    def alarm_status_update_callback(status):
+    def alarm_status_update_callback():
         """Send status update received from alarm to home assistant."""
-        _LOGGER.debug("Alarm status callback, status: %s", status)
-        hass_alarm_status = STATE_ALARM_DISARMED
+        _LOGGER.debug("Alarm status callback")
+        # hass_alarm_status = STATE_ALARM_DISARMED
 
         # if status == AlarmState.ARMED_MODE0:
         #     hass_alarm_status = STATE_ALARM_ARMED_AWAY
@@ -133,7 +133,7 @@ async def async_setup(hass, config):
         # elif status == AlarmState.DISARMED:
         #     hass_alarm_status = STATE_ALARM_DISARMED
 
-        _LOGGER.debug("Sending request to update state, currently: %s...", controller.status)
+        _LOGGER.debug("Sending request to update panel state")
         async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE, None)
 
     @callback

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -1,11 +1,10 @@
 """Support for Satel Integra devices."""
 import logging
 
-
 import voluptuous as vol
 
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
-from homeassistant.const import (EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -105,7 +104,7 @@ async def async_setup(hass, config):
     def alarm_status_update_callback():
         """Send status update received from alarm to home assistant."""
         _LOGGER.debug("Sending request to update panel state")
-        async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE, None)
+        async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE)
 
     @callback
     def zones_update_callback(status):

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -113,25 +113,6 @@ async def async_setup(hass, config):
     @callback
     def alarm_status_update_callback():
         """Send status update received from alarm to home assistant."""
-        _LOGGER.debug("Alarm status callback")
-        # hass_alarm_status = STATE_ALARM_DISARMED
-
-        # if status == AlarmState.ARMED_MODE0:
-        #     hass_alarm_status = STATE_ALARM_ARMED_AWAY
-
-        # elif status in [
-        #         AlarmState.ARMED_MODE0,
-        #         AlarmState.ARMED_MODE1,
-        #         AlarmState.ARMED_MODE2,
-        #         AlarmState.ARMED_MODE3
-        # ]:
-        #     hass_alarm_status = STATE_ALARM_ARMED_HOME
-
-        # elif status in [AlarmState.TRIGGERED, AlarmState.TRIGGERED_FIRE]:
-        #     hass_alarm_status = STATE_ALARM_TRIGGERED
-
-        # elif status == AlarmState.DISARMED:
-        #     hass_alarm_status = STATE_ALARM_DISARMED
 
         _LOGGER.debug("Sending request to update panel state")
         async_dispatcher_send(hass, SIGNAL_PANEL_MESSAGE, None)

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -51,9 +51,7 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
             self.hass, SIGNAL_PANEL_MESSAGE, self._update_alarm_status)
 
     def _read_alarm_state(self):
-        """Read current status of the alarm device and
-           translate it into HA alarm status"""
-
+        """Read current status of the alarm and translate it into HA status"""
         from satel_integra.satel_integra import AlarmState
 
         # Default - disarmed:
@@ -118,7 +116,6 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command.fclea"""
-
         if not code:
             _LOGGER.debug("Code was null")
             return
@@ -136,16 +133,14 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-
-        _LOGGER.debug("Arm away: %s", code)
+        _LOGGER.debug("Arming away...")
 
         if code:
             await self.hass.data[DATA_SATEL].arm(code)
 
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
-
-        _LOGGER.debug("Arm home: %s", code)
+        _LOGGER.debug("Arming home")
 
         if code:
             await self.hass.data[DATA_SATEL].arm(

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -51,7 +51,7 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
             self.hass, SIGNAL_PANEL_MESSAGE, self._update_alarm_status)
 
     def _read_alarm_state(self):
-        """Read current status of the alarm and translate it into HA status"""
+        """Read current status of the alarm and translate it into HA status."""
         from satel_integra.satel_integra import AlarmState
 
         # Default - disarmed:
@@ -115,7 +115,7 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
         return self._state
 
     async def async_alarm_disarm(self, code=None):
-        """Send disarm command.fclea"""
+        """Send disarm command."""
         if not code:
             _LOGGER.debug("Code was null")
             return

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -3,12 +3,12 @@ import logging
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.satel_integra import (
-    CONF_ARM_HOME_MODE, DATA_SATEL, SIGNAL_PANEL_MESSAGE)
+    CONF_ARM_HOME_MODE, CONF_DEVICE_PARTITION, DATA_SATEL, SIGNAL_PANEL_MESSAGE)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
-    STATE_ALARM_TRIGGERED)
+    STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,18 +22,19 @@ async def async_setup_platform(
         return
 
     device = SatelIntegraAlarmPanel(
-        "Alarm Panel", discovery_info.get(CONF_ARM_HOME_MODE))
+        "Alarm Panel", discovery_info.get(CONF_ARM_HOME_MODE),discovery_info.get(CONF_DEVICE_PARTITION) )
     async_add_entities([device])
 
 
 class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
     """Representation of an AlarmDecoder-based alarm panel."""
 
-    def __init__(self, name, arm_home_mode):
+    def __init__(self, name, arm_home_mode, partition_id):
         """Initialize the alarm panel."""
         self._name = name
         self._state = None
         self._arm_home_mode = arm_home_mode
+        self._partition_id = partition_id
         _LOGGER.info("Creating AlarmPanel")
 
     async def async_added_to_hass(self):
@@ -45,35 +46,57 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     def _read_alarm_state(self):
         """Read current status of the alarm device and translate it into HA alarm status"""       
-        hass_alarm_status = STATE_ALARM_DISARMED
-
+        
         from satel_integra.satel_integra import AlarmState
         
-        status = self.hass.data[DATA_SATEL].status 
+        # Default - disarmed:
+        hass_alarm_status = STATE_ALARM_DISARMED
 
-        if status == AlarmState.ARMED_MODE0:
-            hass_alarm_status = STATE_ALARM_ARMED_AWAY
+        # Hardcoded for now, maybe in the future will make it into configuration variable:
+        
+        satel_controller = self.hass.data[DATA_SATEL]
+        if not satel_controller.connected:
+            return STATE_UNKNOWN
+        
+        state_map = {
+                AlarmState.TRIGGERED : STATE_ALARM_TRIGGERED,
+                AlarmState.TRIGGERED_FIRE : STATE_ALARM_TRIGGERED,
+                AlarmState.ARMED_MODE0 : STATE_ALARM_ARMED_AWAY, 
+                AlarmState.ARMED_MODE1 : STATE_ALARM_ARMED_HOME,
+                AlarmState.ARMED_MODE2 : STATE_ALARM_ARMED_HOME,
+                AlarmState.ARMED_MODE3 : STATE_ALARM_ARMED_HOME,
+        }
 
-        elif status in [
-                AlarmState.ARMED_MODE0,
-                AlarmState.ARMED_MODE1,
-                AlarmState.ARMED_MODE2,
-                AlarmState.ARMED_MODE3
-        ]:
-            hass_alarm_status = STATE_ALARM_ARMED_HOME
+        for satel_state, ha_state in state_map.items():
+            if satel_state in satel_controller.partition_states and self._partition_id in satel_controller.partition_states[satel_state]:
+                    hass_alarm_status = ha_state
+                    break
+        
+        # status = self.hass.data[DATA_SATEL].status 
 
-        elif status in [AlarmState.TRIGGERED, AlarmState.TRIGGERED_FIRE]:
-            hass_alarm_status = STATE_ALARM_TRIGGERED
+        # if status == AlarmState.ARMED_MODE0:
+        #     hass_alarm_status = STATE_ALARM_ARMED_AWAY
 
-        elif status == AlarmState.DISARMED:
-            hass_alarm_status = STATE_ALARM_DISARMED
+        # elif status in [
+        #         AlarmState.ARMED_MODE0,
+        #         AlarmState.ARMED_MODE1,
+        #         AlarmState.ARMED_MODE2,
+        #         AlarmState.ARMED_MODE3
+        # ]:
+        #     hass_alarm_status = STATE_ALARM_ARMED_HOME
+
+        # elif status in [AlarmState.TRIGGERED, AlarmState.TRIGGERED_FIRE]:
+        #     hass_alarm_status = STATE_ALARM_TRIGGERED
+
+        # elif status == AlarmState.DISARMED:
+        #     hass_alarm_status = STATE_ALARM_DISARMED
         return hass_alarm_status
         
     @callback
-    def _update_alarm_status(self, message = None):
+    def _update_alarm_status(self, message=None):
         """Handle received messages."""
         state = self._read_alarm_state()
-        _LOGGER.info("Got status update, current status: %s", message)
+        _LOGGER.info("Got status update, current status: %s", state)
         if state != self._state:
             self._state = state
             self.async_schedule_update_ha_state()

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -45,13 +45,14 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
 
     async def async_added_to_hass(self):
         """Update alarm status and register callbacks for future updates."""
-        _LOGGER.info("Starts listening for panel messages: async_dispatcher_connect")
+        _LOGGER.debug("Starts listening for panel messages")
         self._update_alarm_status()
         async_dispatcher_connect(
             self.hass, SIGNAL_PANEL_MESSAGE, self._update_alarm_status)
 
     def _read_alarm_state(self):
-        """Read current status of the alarm device and translate it into HA alarm status"""
+        """Read current status of the alarm device and
+           translate it into HA alarm status"""
 
         from satel_integra.satel_integra import AlarmState
 
@@ -63,21 +64,22 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
             return STATE_UNKNOWN
         # Warning: order is important here:
         state_map = {
-            AlarmState.TRIGGERED : STATE_ALARM_TRIGGERED,
-            AlarmState.TRIGGERED_FIRE : STATE_ALARM_TRIGGERED,
-            AlarmState.ARMED_MODE3 : STATE_ALARM_ARMED_HOME,
-            AlarmState.ARMED_MODE2 : STATE_ALARM_ARMED_HOME,
-            AlarmState.ARMED_MODE1 : STATE_ALARM_ARMED_HOME,
-            AlarmState.ARMED_MODE0 : STATE_ALARM_ARMED_AWAY,
-            AlarmState.EXIT_COUNTDOWN_OVER_10 : STATE_ALARM_PENDING,
-            AlarmState.EXIT_COUNTDOWN_UNDER_10 : STATE_ALARM_PENDING,
+            AlarmState.TRIGGERED: STATE_ALARM_TRIGGERED,
+            AlarmState.TRIGGERED_FIRE: STATE_ALARM_TRIGGERED,
+            AlarmState.ARMED_MODE3: STATE_ALARM_ARMED_HOME,
+            AlarmState.ARMED_MODE2: STATE_ALARM_ARMED_HOME,
+            AlarmState.ARMED_MODE1: STATE_ALARM_ARMED_HOME,
+            AlarmState.ARMED_MODE0: STATE_ALARM_ARMED_AWAY,
+            AlarmState.EXIT_COUNTDOWN_OVER_10: STATE_ALARM_PENDING,
+            AlarmState.EXIT_COUNTDOWN_UNDER_10: STATE_ALARM_PENDING,
         }
         _LOGGER.debug("State map of Satel: %s",
                       satel_controller.partition_states)
 
         for satel_state, ha_state in state_map.items():
             if satel_state in satel_controller.partition_states and\
-               self._partition_id in satel_controller.partition_states[satel_state]:
+               self._partition_id in\
+                    satel_controller.partition_states[satel_state]:
                 hass_alarm_status = ha_state
                 break
 
@@ -131,8 +133,6 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
             # Wait 1s before clearing the alarm
             await asyncio.sleep(1)
             await self.hass.data[DATA_SATEL].clear_alarm(code)
-
-
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -42,7 +42,6 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
         self._state = None
         self._arm_home_mode = arm_home_mode
         self._partition_id = partition_id
-        _LOGGER.debug("Creating AlarmPanel")
 
     async def async_added_to_hass(self):
         """Update alarm status and register callbacks for future updates."""

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -61,12 +61,14 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
     async def async_added_to_hass(self):
         """Register callbacks."""
         if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
-            if self._device_number in self.hass.data[DATA_SATEL].violated_outputs:
+            if self._device_number in\
+                self.hass.data[DATA_SATEL].violated_outputs:
                 self._state = 1
             else:
                 self._state = 0
         else:
-            if self._device_number in self.hass.data[DATA_SATEL].violated_zones:
+            if self._device_number in\
+                self.hass.data[DATA_SATEL].violated_zones:
                 self._state = 1
             else:
                 self._state = 0

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -2,15 +2,16 @@
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.satel_integra import (DATA_SATEL,
-                                                    CONF_ZONES,
-                                                    CONF_OUTPUTS,
-                                                    CONF_ZONE_NAME,
-                                                    CONF_ZONE_TYPE,
-                                                    SIGNAL_ZONES_UPDATED,
-                                                    SIGNAL_OUTPUTS_UPDATED)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import (DATA_SATEL,
+               CONF_ZONES,
+               CONF_OUTPUTS,
+               CONF_ZONE_NAME,
+               CONF_ZONE_TYPE,
+               SIGNAL_ZONES_UPDATED,
+               SIGNAL_OUTPUTS_UPDATED)
 
 DEPENDENCIES = ['satel_integra']
 
@@ -62,12 +63,12 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
             if self._device_number in self.hass.data[DATA_SATEL].violated_outputs:
                 self._state = 1
-            else: 
+            else:
                 self._state = 0
         else:
             if self._device_number in self.hass.data[DATA_SATEL].violated_zones:
                 self._state = 1
-            else: 
+            else:
                 self._state = 0
         async_dispatcher_connect(
             self.hass, self._react_to_signal, self._devices_updated)

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -63,7 +63,7 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
             if self._device_number in\
                self.hass.data[DATA_SATEL].violated_outputs:
-                    self._state = 1
+                self._state = 1
             else:
                 self._state = 0
         else:

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -5,13 +5,9 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from . import (DATA_SATEL,
-               CONF_ZONES,
-               CONF_OUTPUTS,
-               CONF_ZONE_NAME,
-               CONF_ZONE_TYPE,
-               SIGNAL_ZONES_UPDATED,
-               SIGNAL_OUTPUTS_UPDATED)
+from . import (
+    CONF_OUTPUTS, CONF_ZONE_NAME, CONF_ZONE_TYPE, CONF_ZONES, DATA_SATEL,
+    SIGNAL_OUTPUTS_UPDATED, SIGNAL_ZONES_UPDATED)
 
 DEPENDENCIES = ['satel_integra']
 

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -2,7 +2,8 @@
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.satel_integra import (CONF_ZONES,
+from homeassistant.components.satel_integra import (DATA_SATEL,
+                                                    CONF_ZONES,
                                                     CONF_OUTPUTS,
                                                     CONF_ZONE_NAME,
                                                     CONF_ZONE_TYPE,
@@ -58,6 +59,16 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
+        if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
+            if self._device_number in self.hass.data[DATA_SATEL].violated_outputs:
+                self._state = 1
+            else: 
+                self._state = 0
+        else:
+            if self._device_number in self.hass.data[DATA_SATEL].violated_zones:
+                self._state = 1
+            else: 
+                self._state = 0
         async_dispatcher_connect(
             self.hass, self._react_to_signal, self._devices_updated)
 

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -62,13 +62,13 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         """Register callbacks."""
         if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
             if self._device_number in\
-                self.hass.data[DATA_SATEL].violated_outputs:
-                self._state = 1
+               self.hass.data[DATA_SATEL].violated_outputs:
+                    self._state = 1
             else:
                 self._state = 0
         else:
             if self._device_number in\
-                self.hass.data[DATA_SATEL].violated_zones:
+               self.hass.data[DATA_SATEL].violated_zones:
                 self._state = 1
             else:
                 self._state = 0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1531,7 +1531,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.satel_integra
-satel_integra==0.2.0
+satel_integra==0.3.2
 
 # homeassistant.components.sensor.deutsche_bahn
 schiene==0.22


### PR DESCRIPTION
## Description:

Fix for issue that set the alarm into "uknown" state during initialization which prevented it from working. 

**Related issue (if applicable):** fixes #19329

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
No changes to the configuration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ X Tests have been added to verify that the new code works.
