### PR TITLE
Fix log entries were not ordered based on last occurrence

### DIFF
--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -93,7 +93,7 @@ class LogEntry:
 
     def __init__(self, record, stack, source):
         """Initialize a log entry."""
-        self.timestamp = record.created
+        self.first_occured = self.timestamp = record.created
         self.level = record.levelname
         self.message = record.getMessage()
         if record.exc_info:
@@ -130,9 +130,13 @@ class DedupStore(OrderedDict):
         key = str(entry.hash())
 
         if key in self:
-            entry.count = self[key].count + 1
+            # Update stored entry
+            self[key].count += 1
+            self[key].timestamp = entry.timestamp
 
-        self[key] = entry
+            self.move_to_end(key)
+        else:
+            self[key] = entry
 
         if len(self) > self.maxlen:
             # Removes the first record which should also be the oldest

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -152,6 +152,11 @@ async def test_dedup_logs(hass, hass_client):
     assert log[1]["count"] == 2
     assert_log(log[1], '', 'error message 2', 'ERROR')
 
+    _LOGGER.error('error message 2')
+    log = await get_error_log(hass, hass_client, 2)
+    assert_log(log[0], '', 'error message 2', 'ERROR')
+    assert log[0]["timestamp"] > log[0]["first_occured"]
+
 
 async def test_clear_logs(hass, hass_client):
     """Test that the log can be cleared via a service call."""


### PR DESCRIPTION
## Description:

Reported by @gerard33 on discord #beta

"I have seen in 0.88.0b2 that the order of the log entries is not updated based on the time as shown here https://imgur.com/a/59G0GG7
The 1st and 2nd log entry arer at 7:13PM and the 3rd and 4th at 10:05PM (these are repetitive messages which are shown each 30 minutes). I would have expected these 3rd and 4th lines as first entries in the log based on the timestamp."

**Related issue (if applicable):** fixes #20493 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
system_log:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23