### PR TITLE
Fix Homematic IP Cloud configuration

### DIFF
--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -39,8 +39,7 @@ class HomematicipAuth:
         from homematicip.base.base_connection import HmipConnectionError
 
         try:
-            await self.auth.isRequestAcknowledged()
-            return True
+            return await self.auth.isRequestAcknowledged()
         except HmipConnectionError:
             return False
 

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -44,7 +44,7 @@ async def test_auth_auth_check_and_register(hass):
     hap = hmipc.HomematicipAuth(hass, config)
     hap.auth = Mock()
     with patch.object(hap.auth, 'isRequestAcknowledged',
-                      return_value=mock_coro()), \
+                      return_value=mock_coro(True)), \
             patch.object(hap.auth, 'requestAuthToken',
                          return_value=mock_coro('ABC')), \
             patch.object(hap.auth, 'confirmAuthToken',


### PR DESCRIPTION
## Description:

Currently, configuration of Homematic IP access points through the web interface is broken. Supplying correct information results in "Could not connect to HMIP server". The HMIP-Cloud authentication mechanism relies on the user pressing a button on their AP to pair the connecting device. Home Assistant's check whether that button was pressed is not working due to an upstream change:

`homematicip.aio.auth.isRequestAcknowledged` returns false if the request failed in stead of raising an error.

See coreGreenberet/homematicip-rest-api@0b61954f6accf773a32cf91772b0a5b1bb7ef4ac



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


Closes: #20428