### PR TITLE
Bump Synology SRM dependency to version 0.0.6

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,6 +68,7 @@ homeassistant/components/device_tracker/quantum_gateway.py @cisasteelersfan
 homeassistant/components/device_tracker/tile.py @bachya
 homeassistant/components/device_tracker/traccar.py @ludeeus
 homeassistant/components/device_tracker/bt_smarthub.py @jxwolstenholme
+homeassistant/components/device_tracker/synology_srm.py @aerialls
 homeassistant/components/history_graph/* @andrey-git
 homeassistant/components/influx/* @fabaff
 homeassistant/components/light/lifx_legacy.py @amelchio

--- a/homeassistant/components/device_tracker/synology_srm.py
+++ b/homeassistant/components/device_tracker/synology_srm.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
     CONF_PORT, CONF_SSL, CONF_VERIFY_SSL)
 
-REQUIREMENTS = ['synology-srm==0.0.4']
+REQUIREMENTS = ['synology-srm==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1635,7 +1635,7 @@ suds-py3==1.3.3.0
 swisshydrodata==0.0.3
 
 # homeassistant.components.device_tracker.synology_srm
-synology-srm==0.0.4
+synology-srm==0.0.6
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.14


### PR DESCRIPTION
## Description

Add better error messages for the Synology SRM dependency.


**Related issue (if applicable):** fixes #20922

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
