### PR TITLE
Fix for latest Harmony firmware version 4.15.250

### DIFF
--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['aioharmony==0.1.5']
+REQUIREMENTS = ['aioharmony==0.1.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -111,7 +111,7 @@ aiofreepybox==0.0.6
 aioftp==0.12.0
 
 # homeassistant.components.harmony.remote
-aioharmony==0.1.5
+aioharmony==0.1.8
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

Update aioharmony version to 0.1.8 to support latest HUB firmware (4.15.250). 
Breaking change, with this version the older HUB firmware versions are not supported anymore.

**Related issue (if applicable):** fixes #21191

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
