### PR TITLE
Fix an Ambient PWS exception when location info is missing

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -339,8 +339,10 @@ class AmbientStation:
 
                 self.stations[station['macAddress']] = {
                     ATTR_LAST_DATA: station['lastData'],
-                    ATTR_LOCATION: station['info']['location'],
-                    ATTR_NAME: station['info']['name'],
+                    ATTR_LOCATION: station.get('info', {}).get('location'),
+                    ATTR_NAME:
+                        station.get('info', {}).get(
+                            'name', station['macAddress']),
                 }
 
             for component in ('binary_sensor', 'sensor'):


### PR DESCRIPTION
## Description:

A user pointed out to me that if an Ambient customer doesn't specify a device name or location name, those fields are removed from the socket response. Currently, that'll throw an unhandled exception. This PR fixes it by defaulting to using the MAC address if no name is provided.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
