### PR TITLE
Add ADB server functionality to Fire TV

### DIFF
--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -72,7 +72,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     host = '{0}:{1}'.format(config[CONF_HOST], config[CONF_PORT])
 
     if CONF_ADB_SERVER_IP not in config:
-        # "python-adb"
+        # Use "python-adb" (Python ADB implementation)
         if CONF_ADBKEY in config:
             ftv = FireTV(host, config[CONF_ADBKEY])
             adb_log = " using adbkey='{0}'".format(config[CONF_ADBKEY])
@@ -80,7 +80,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             ftv = FireTV(host)
             adb_log = ""
     else:
-        # "pure-python-adb"
+        # Use "pure-python-adb" (communicate with ADB server)
         ftv = FireTV(host, adb_server_ip=config[CONF_ADB_SERVER_IP],
                      adb_server_port=config[CONF_ADB_SERVER_PORT])
         adb_log = " using ADB server at {0}:{1}".format(
@@ -134,7 +134,7 @@ class FireTVDevice(MediaPlayerDevice):
 
         # ADB exceptions to catch
         if not self.firetv.adb_server_ip:
-            # "python-adb"
+            # Using "python-adb" (Python ADB implementation)
             from adb.adb_protocol import (InvalidChecksumError,
                                           InvalidCommandError,
                                           InvalidResponseError)
@@ -145,7 +145,7 @@ class FireTVDevice(MediaPlayerDevice):
                                InvalidCommandError, InvalidResponseError,
                                TcpTimeoutException)
         else:
-            # "pure-python-adb"
+            # Using "pure-python-adb" (communicate with ADB server)
             self.exceptions = (ConnectionResetError,)
 
         self._state = None

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -103,7 +103,7 @@ def adb_decorator(override_available=False):
     def _adb_decorator(func):
         """Wait if previous ADB commands haven't finished."""
         @functools.wraps(func)
-        def __adb_decorator(self, *args, **kwargs):
+        def _adb_exception_catcher(self, *args, **kwargs):
             # If the device is unavailable, don't do anything
             if not self.available and not override_available:
                 return None
@@ -117,7 +117,7 @@ def adb_decorator(override_available=False):
                 self._available = False  # pylint: disable=protected-access
                 return None
 
-        return __adb_decorator
+        return _adb_exception_catcher
 
     return _adb_decorator
 

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -159,6 +159,8 @@ class FireTVDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the player."""
+        if not self._available:
+            return None
         return self._state
 
     @property
@@ -169,16 +171,22 @@ class FireTVDevice(MediaPlayerDevice):
     @property
     def app_id(self):
         """Return the current app."""
+        if not self._available:
+            return None
         return self._current_app
 
     @property
     def source(self):
         """Return the current app."""
+        if not self._available:
+            return None
         return self._current_app
 
     @property
     def source_list(self):
         """Return a list of running apps."""
+        if not self._available:
+            return None
         return self._running_apps
 
     @adb_decorator(override_available=True)
@@ -186,9 +194,6 @@ class FireTVDevice(MediaPlayerDevice):
         """Update the device state and, if necessary, re-connect."""
         # Check if device is disconnected.
         if not self._available:
-            self._running_apps = None
-            self._current_app = None
-
             # Try to connect
             self._available = self.firetv.connect()
 

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/media_player.firetv/
 """
 import functools
 import logging
-import threading
 import voluptuous as vol
 
 from homeassistant.components.media_player import (

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -128,9 +128,6 @@ class FireTVDevice(MediaPlayerDevice):
         self._get_source = get_source
         self._get_sources = get_sources
 
-        # whether or not the ADB connection is currently in use
-        self.adb_lock = threading.Lock()
-
         # ADB exceptions to catch
         self.exceptions = (
             AttributeError, BrokenPipeError, TypeError, ValueError,

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -171,8 +171,6 @@ class FireTVDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the player."""
-        if not self._available:
-            return None
         return self._state
 
     @property
@@ -183,22 +181,16 @@ class FireTVDevice(MediaPlayerDevice):
     @property
     def app_id(self):
         """Return the current app."""
-        if not self._available:
-            return None
         return self._current_app
 
     @property
     def source(self):
         """Return the current app."""
-        if not self._available:
-            return None
         return self._current_app
 
     @property
     def source_list(self):
         """Return a list of running apps."""
-        if not self._available:
-            return None
         return self._running_apps
 
     @adb_decorator(override_available=True)

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     STATE_PLAYING, STATE_STANDBY)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['firetv==1.0.8']
+REQUIREMENTS = ['firetv==1.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -417,7 +417,7 @@ fiblary3==0.1.7
 fints==1.0.1
 
 # homeassistant.components.media_player.firetv
-firetv==1.0.8
+firetv==1.0.9
 
 # homeassistant.components.sensor.fitbit
 fitbit==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -417,7 +417,7 @@ fiblary3==0.1.7
 fints==1.0.1
 
 # homeassistant.components.media_player.firetv
-firetv==1.0.7
+firetv==1.0.8
 
 # homeassistant.components.sensor.fitbit
 fitbit==0.3.0


### PR DESCRIPTION
## Description:

Allow for using an ADB server instance, such as the [Hass.io ADB addon](https://github.com/hassio-addons/addon-adb), with the Fire TV component. 

This is a **breaking change**, as it removes the `get_source` configuration option. 

This includes the changes in https://github.com/home-assistant/home-assistant/pull/21131. 

**Related issue (if applicable):** 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8641

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: firetv
    name: Fire TV
    host: 192.168.0.123
    adb_server_ip: 127.0.0.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23