### PR TITLE
Add new SmartHab light and cover platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -539,6 +539,7 @@ omit =
     homeassistant/components/slack/notify.py
     homeassistant/components/sma/sensor.py
     homeassistant/components/smappee/*
+    homeassistant/components/smarthab/*
     homeassistant/components/smtp/notify.py
     homeassistant/components/snapcast/media_player.py
     homeassistant/components/snmp/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -205,6 +205,7 @@ homeassistant/components/shiftr/* @fabaff
 homeassistant/components/shodan/* @fabaff
 homeassistant/components/simplisafe/* @bachya
 homeassistant/components/sma/* @kellerza
+homeassistant/components/smarthab/* @outadoc
 homeassistant/components/smartthings/* @andrewsayre
 homeassistant/components/smtp/* @fabaff
 homeassistant/components/sonos/* @amelchio

--- a/homeassistant/components/smarthab/__init__.py
+++ b/homeassistant/components/smarthab/__init__.py
@@ -1,0 +1,75 @@
+"""
+Support for SmartHab device integration.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/smarthab/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.helpers.discovery import load_platform
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.const import (
+    CONF_EMAIL, CONF_PASSWORD, CONF_URL)
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN = 'smarthab'
+DATA_HUB = 'hub'
+
+REQUIREMENTS = ['smarthab==0.19']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_EMAIL): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_URL): cv.string
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config) -> bool:
+    """Set up the SmartHab platform."""
+    import pysmarthab
+
+    sh_conf = config.get(DOMAIN)
+
+    # Assign configuration variables
+    username = sh_conf.get(CONF_EMAIL)
+    password = sh_conf.get(CONF_PASSWORD)
+    base_url = sh_conf.get(CONF_URL)
+
+    # Verify that configuration exists
+    if username is None or password is None:
+        _LOGGER.error(
+            "SmartHab username or password is empty, please check your"
+            " configuration")
+        return False
+
+    if base_url is None:
+        base_url = pysmarthab.SmartHab.DEFAULT_BASE_API_URL
+
+    # Setup connection with SmartHab API
+    hub = pysmarthab.SmartHab(base_url=base_url)
+
+    try:
+        hub.login(username, password)
+    except pysmarthab.RequestFailedException as ex:
+        raise PlatformNotReady(ex)
+
+    # Verify that passed in configuration works
+    if not hub.is_logged_in():
+        _LOGGER.error("Could not authenticate with SmartHab API")
+        raise PlatformNotReady
+
+    # Pass hub object to child platforms
+    hass.data[DOMAIN] = {
+        DATA_HUB: hub
+    }
+
+    load_platform(hass, 'light', DOMAIN, None, config)
+    load_platform(hass, 'cover', DOMAIN, None, config)
+
+    return True

--- a/homeassistant/components/smarthab/__init__.py
+++ b/homeassistant/components/smarthab/__init__.py
@@ -16,8 +16,6 @@ import homeassistant.helpers.config_validation as cv
 DOMAIN = 'smarthab'
 DATA_HUB = 'hub'
 
-REQUIREMENTS = ['smarthab==0.20']
-
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({
@@ -46,16 +44,12 @@ def setup(hass, config) -> bool:
     except pysmarthab.RequestFailedException as ex:
         _LOGGER.error("Error while trying to reach SmartHab API.")
         _LOGGER.debug(ex, exc_info=True)
-        raise HomeAssistantError(
-            "Error while trying to reach SmartHab. Please check service and"
-            " network status, and try again later.")
+        return False
 
     # Verify that passed in configuration works
     if not hub.is_logged_in():
         _LOGGER.error("Could not authenticate with SmartHab API")
-        raise HomeAssistantError(
-            "Could not authenticate with SmartHab. Please check your"
-            " credentials.")
+        return False
 
     # Pass hub object to child platforms
     hass.data[DOMAIN] = {

--- a/homeassistant/components/smarthab/__init__.py
+++ b/homeassistant/components/smarthab/__init__.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 DOMAIN = 'smarthab'
 DATA_HUB = 'hub'
 
-REQUIREMENTS = ['smarthab==0.19']
+REQUIREMENTS = ['smarthab==0.20']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/smarthab/__init__.py
+++ b/homeassistant/components/smarthab/__init__.py
@@ -9,7 +9,6 @@ import logging
 import voluptuous as vol
 
 from homeassistant.helpers.discovery import load_platform
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/smarthab/cover.py
+++ b/homeassistant/components/smarthab/cover.py
@@ -14,8 +14,6 @@ from homeassistant.components.cover import (
 )
 from . import DOMAIN, DATA_HUB
 
-DEPENDENCIES = ['smarthab']
-
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/smarthab/cover.py
+++ b/homeassistant/components/smarthab/cover.py
@@ -1,0 +1,102 @@
+"""
+Support for SmartHab device integration.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/smarthab/
+"""
+import logging
+from datetime import timedelta
+from requests.exceptions import Timeout
+
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_SET_POSITION,
+    ATTR_POSITION
+)
+from . import DOMAIN, DATA_HUB
+
+DEPENDENCIES = ['smarthab']
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=60)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the SmartHab roller shutters platform."""
+    import pysmarthab
+
+    hub = hass.data[DOMAIN][DATA_HUB]
+    devices = hub.get_device_list()
+
+    _LOGGER.debug("Found a total of %s devices", str(len(devices)))
+
+    entities = (SmartHabCover(cover)
+                for cover in devices if isinstance(cover, pysmarthab.Shutter))
+
+    add_entities(entities, True)
+
+
+class SmartHabCover(CoverDevice):
+    """Representation a cover."""
+
+    def __init__(self, cover):
+        """Initialize a SmartHabCover."""
+        self._cover = cover
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._cover.device_id
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this light."""
+        return self._cover.label
+
+    @property
+    def current_cover_position(self) -> int:
+        """Return current position of cover.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        return self._cover.state
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
+
+        if self.current_cover_position is not None:
+            supported_features |= SUPPORT_SET_POSITION
+
+        return supported_features
+
+    @property
+    def is_closed(self) -> bool:
+        """Return if the cover is closed or not."""
+        return self._cover.state == 0
+
+    @property
+    def device_class(self) -> str:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return 'window'
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self._cover.open()
+
+    def close_cover(self, **kwargs):
+        """Close cover."""
+        self._cover.close()
+
+    def set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        self._cover.state = kwargs[ATTR_POSITION]
+
+    def update(self):
+        """Fetch new state data for this cover."""
+        try:
+            self._cover.update()
+        except Timeout:
+            _LOGGER.error("Reached timeout while updating cover %s from API",
+                          self.entity_id)

--- a/homeassistant/components/smarthab/light.py
+++ b/homeassistant/components/smarthab/light.py
@@ -11,8 +11,6 @@ from requests.exceptions import Timeout
 from homeassistant.components.light import Light
 from . import DOMAIN, DATA_HUB
 
-DEPENDENCIES = ['smarthab']
-
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/smarthab/light.py
+++ b/homeassistant/components/smarthab/light.py
@@ -1,0 +1,72 @@
+"""
+Support for SmartHab device integration.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/smarthab/
+"""
+import logging
+from datetime import timedelta
+from requests.exceptions import Timeout
+
+from homeassistant.components.light import Light
+from . import DOMAIN, DATA_HUB
+
+DEPENDENCIES = ['smarthab']
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=60)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the SmartHab lights platform."""
+    import pysmarthab
+
+    hub = hass.data[DOMAIN][DATA_HUB]
+    devices = hub.get_device_list()
+
+    _LOGGER.debug("Found a total of %s devices", str(len(devices)))
+
+    entities = (SmartHabLight(light)
+                for light in devices if isinstance(light, pysmarthab.Light))
+
+    add_entities(entities, True)
+
+
+class SmartHabLight(Light):
+    """Representation of a SmartHab Light."""
+
+    def __init__(self, light):
+        """Initialize a SmartHabLight."""
+        self._light = light
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._light.device_id
+
+    @property
+    def name(self) -> str:
+        """Return the display name of this light."""
+        return self._light.label
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if light is on."""
+        return self._light.state
+
+    def turn_on(self, **kwargs):
+        """Instruct the light to turn on."""
+        self._light.turn_on()
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._light.turn_off()
+
+    def update(self):
+        """Fetch new state data for this light."""
+        try:
+            self._light.update()
+        except Timeout:
+            _LOGGER.error("Reached timeout while updating light %s from API",
+                          self.entity_id)

--- a/homeassistant/components/smarthab/manifest.json
+++ b/homeassistant/components/smarthab/manifest.json
@@ -3,7 +3,7 @@
   "name": "SmartHab",
   "documentation": "https://www.home-assistant.io/components/smarthab",
   "requirements": [
-    "smarthab==0.19"
+    "smarthab==0.20"
   ],
   "dependencies": [],
   "codeowners": ["@outadoc"]

--- a/homeassistant/components/smarthab/manifest.json
+++ b/homeassistant/components/smarthab/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "smarthab",
+  "name": "SmartHab",
+  "documentation": "https://www.home-assistant.io/components/smarthab",
+  "requirements": [
+    "smarthab==0.19"
+  ],
+  "dependencies": [],
+  "codeowners": ["@outadoc"]
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1618,7 +1618,7 @@ slixmpp==1.4.2
 smappy==0.2.16
 
 # homeassistant.components.smarthab
-smarthab==0.19
+smarthab==0.20
 
 # homeassistant.components.bh1750
 # homeassistant.components.bme280

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1617,6 +1617,9 @@ slixmpp==1.4.2
 # homeassistant.components.smappee
 smappy==0.2.16
 
+# homeassistant.components.smarthab
+smarthab==0.19
+
 # homeassistant.components.bh1750
 # homeassistant.components.bme280
 # homeassistant.components.bme680


### PR DESCRIPTION
## Description:
This PR adds SmartHab integration into Home Assistant. Current support includes both `light` and `cover` components.

SmartHab is a French company that provides a proprietary app-based home automation platform in some new buildings, including mine. You can learn a bit more on their website: https://www.smarthab.fr

To do:
- [x] Wait for SmartHab to use a proper domain name for their API
- [x] Wait for SmartHab to secure their API and finally use HTTPS
- [x] See if I encounter any issues while eating my own dogfood

Future improvements:
- Add thermostat support (either that or a Migo component)

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8647

## Example entry for `configuration.yaml`:
```yaml
smarthab:
  email: john.doe@example.com
  password: '123456'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_