### PR TITLE
Remove constraint from regex

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -26,6 +26,3 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
-
-# The 2019.02.19 failed to be imported, breaking our builds
-regex==2019.02.07

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -158,9 +158,6 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
-
-# The 2019.02.19 failed to be imported, breaking our builds
-regex==2019.02.07
 """
 
 


### PR DESCRIPTION
## Description:
This has been fixed and is no longer needed. https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
