### PR TITLE
Fix plex race condition

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -172,12 +172,15 @@ def setup_plexserver(
 
         # add devices with a session and no client (ex. PlexConnect Apple TV's)
         if config.get(CONF_INCLUDE_NON_CLIENTS):
-            for machine_identifier, (session, player) in plex_sessions.items():
+            # To avoid errors when plex sessions created during iteration
+            sessions = list(plex_sessions.items())
+            for machine_identifier, (session, player) in sessions:
                 if machine_identifier in available_client_ids:
                     # Avoid using session if already added as a device.
                     _LOGGER.debug("Skipping session, device exists: %s",
                                   machine_identifier)
                     continue
+
                 if (machine_identifier not in plex_clients
                         and machine_identifier is not None):
                     new_client = PlexClient(


### PR DESCRIPTION
If the updater is running at the same time, this can result in this dict changing size during iteration, which Python does not like. Then you get an error like this

```
Feb 20 22:59:44 myhost hass[29573]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/media_player/plex.py", line 178, in update_devices
Feb 20 22:59:44 myhost hass[29573]:     for machine_identifier, (session, player) in plex_sessions.items():
Feb 20 22:59:44 myhost hass[29573]: RuntimeError: dictionary changed size during iteration
```