### PR TITLE
Fix ZHA bugs

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -126,9 +126,11 @@ class LevelControlChannel(ZigbeeChannel):
 class BasicChannel(ZigbeeChannel):
     """Channel to interact with the basic cluster."""
 
+    UNKNOWN = 0
     BATTERY = 3
+
     POWER_SOURCES = {
-        0: 'Unknown',
+        UNKNOWN: 'Unknown',
         1: 'Mains (single phase)',
         2: 'Mains (3 phase)',
         BATTERY: 'Battery',

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -146,11 +146,11 @@ class ZHADevice:
                 self._available_signal,
                 False
             )
-            async_dispatcher_send(
-                self.hass,
-                "{}_{}".format(self._available_signal, 'entity'),
-                True
-            )
+        async_dispatcher_send(
+            self.hass,
+            "{}_{}".format(self._available_signal, 'entity'),
+            available
+        )
         self._available = available
 
     @property

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -478,6 +478,8 @@ def establish_device_mappings():
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'switch',
         zcl.clusters.measurement.RelativeHumidity: 'sensor',
+        # this works for now but if we hit conflicts we can break it out to
+        # a different dict that is keyed by manufacturer
         SMARTTHINGS_HUMIDITY_CLUSTER: 'sensor',
         zcl.clusters.measurement.TemperatureMeasurement: 'sensor',
         zcl.clusters.measurement.PressureMeasurement: 'sensor',


### PR DESCRIPTION
this should fix 2 reported issues from .88 release: 

fixes #21243 - we won't flood the network with requests if we can't determine power profiles
fixes #21245 - added manufacturer specific cluster support back in but in a more generic way