### PR TITLE
Bumped py-synology to 0.3.0 and added support for turning on and off.

### DIFF
--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -135,7 +135,7 @@ class SynologyCamera(Camera):
         self.is_streaming = self._camera.is_enabled
         self.home_mode = self._surveillance.get_home_mode_status()
         self.hass.states.set('camera.synology_home_mode',
-        self._surveillance.get_home_mode_status())
+            self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -11,9 +11,9 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
-    CONF_URL, CONF_WHITELIST, CONF_VERIFY_SSL, CONF_TIMEOUT)
+    CONF_URL, CONF_WHITELIST, CONF_VERIFY_SSL, CONF_TIMEOUT, STATE_HOME)
 from homeassistant.components.camera import (
-    Camera, PLATFORM_SCHEMA)
+    Camera, PLATFORM_SCHEMA, DOMAIN)
 from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_web,
     async_get_clientsession)
@@ -58,6 +58,18 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     cameras = surveillance.get_all_cameras()
 
+    """Register a service to be able to enable home mode."""
+    def handle_enable_home_mode(call):
+        surveillance.set_home_mode(True)
+
+    hass.services.async_register(DOMAIN, 'enable_home_mode', handle_enable_home_mode)
+
+    """Register a service to be able to disable home mode."""
+    def handle_disable_home_mode(call):
+        surveillance.set_home_mode(False)
+
+    hass.services.async_register(DOMAIN, 'disable_home_mode', handle_disable_home_mode)
+
     # add cameras
     devices = []
     for camera in cameras:
@@ -80,6 +92,7 @@ class SynologyCamera(Camera):
         self._camera = self._surveillance.get_camera(camera_id)
         self._motion_setting = self._surveillance.get_motion_setting(camera_id)
         self.is_streaming = self._camera.is_enabled
+        self.home_mode = self._surveillance.get_home_mode_status()
 
     def camera_image(self):
         """Return bytes of camera image."""
@@ -115,6 +128,7 @@ class SynologyCamera(Camera):
         self._motion_setting = self._surveillance.get_motion_setting(
             self._camera.camera_id)
         self.is_streaming = self._camera.is_enabled
+        self.home_mode = self._surveillance.get_home_mode_status()
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -62,16 +62,16 @@ async def async_setup_platform(hass, config, async_add_entities,
     def handle_enable_home_mode(call):
         surveillance.set_home_mode(True)
 
-    hass.services.async_register(DOMAIN, 
-                                 'enable_home_mode', 
+    hass.services.async_register(DOMAIN,
+                                 'enable_home_mode',
                                  handle_enable_home_mode)
 
     """Register a service to be able to disable home mode."""
     def handle_disable_home_mode(call):
         surveillance.set_home_mode(False)
 
-    hass.services.async_register(DOMAIN, 
-                                 'disable_home_mode', 
+    hass.services.async_register(DOMAIN,
+                                 'disable_home_mode',
                                  handle_disable_home_mode)
 
     # add cameras

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -111,12 +111,20 @@ class SynologyCamera(Camera):
 
         return await async_aiohttp_proxy_web(self.hass, request, stream_coro)
 
+
     @property
     def name(self):
         """Return the name of this device."""
         return self._camera.name
 
     @property
+
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'home_mode': self.home_mode
+        }
+    
     def is_recording(self):
         """Return true if the device is recording."""
         return self._camera.is_recording

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -136,7 +136,8 @@ class SynologyCamera(Camera):
         self._motion_setting = self._surveillance.get_motion_setting(
             self._camera.camera_id)
         self.is_streaming = self._camera.is_enabled
-        self.hass.states.set('camera.synology_home_mode', self._surveillance.get_home_mode_status())
+        self.hass.states.set('camera.synology_home_mode', 
+                              self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -135,7 +135,7 @@ class SynologyCamera(Camera):
         self.is_streaming = self._camera.is_enabled
         self.home_mode = self._surveillance.get_home_mode_status()
         self.hass.states.set('camera.synology_home_mode',
-            self._surveillance.get_home_mode_status())
+                self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -96,6 +96,7 @@ class SynologyCamera(Camera):
         self._camera = self._surveillance.get_camera(camera_id)
         self._motion_setting = self._surveillance.get_motion_setting(camera_id)
         self.is_streaming = self._camera.is_enabled
+        self.home_mode = self._surveillance.get_home_mode_status()
 
     def camera_image(self):
         """Return bytes of camera image."""
@@ -117,10 +118,6 @@ class SynologyCamera(Camera):
         return self._camera.name
 
     @property
-    def home_mode(self):
-        """Return true if the device is recording."""
-        return self.home_mode
-
     def is_recording(self):
         """Return true if the device is recording."""
         return self._camera.is_recording
@@ -136,8 +133,9 @@ class SynologyCamera(Camera):
         self._motion_setting = self._surveillance.get_motion_setting(
             self._camera.camera_id)
         self.is_streaming = self._camera.is_enabled
+        self.home_mode = self._surveillance.get_home_mode_status()
         self.hass.states.set('camera.synology_home_mode',
-            self._surveillance.get_home_mode_status())
+        self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['py-synology==0.2.0']
+REQUIREMENTS = ['py-synology==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,3 +128,11 @@ class SynologyCamera(Camera):
     def disable_motion_detection(self):
         """Disable motion detection in camera."""
         self._surveillance.disable_motion_detection(self._camera_id)
+
+    def turn_off(self):
+        """Turn off camera."""
+        self._surveillance.disable_camera(self._camera_id)
+
+    def turn_on(self):
+        """Turn on camera."""
+        self._surveillance.enable_camera(self._camera_id)

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -123,7 +123,7 @@ class SynologyCamera(Camera):
         return {
             'home_mode': self.home_mode
         }
-        
+
     def is_recording(self):
         """Return true if the device is recording."""
         return self._camera.is_recording

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -136,8 +136,8 @@ class SynologyCamera(Camera):
         self._motion_setting = self._surveillance.get_motion_setting(
             self._camera.camera_id)
         self.is_streaming = self._camera.is_enabled
-        self.hass.states.set('camera.synology_home_mode', 
-                              self._surveillance.get_home_mode_status())
+        self.hass.states.set('camera.synology_home_mode',
+        self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
-    CONF_URL, CONF_WHITELIST, CONF_VERIFY_SSL, CONF_TIMEOUT, STATE_HOME)
+    CONF_URL, CONF_WHITELIST, CONF_VERIFY_SSL, CONF_TIMEOUT)
 from homeassistant.components.camera import (
     Camera, PLATFORM_SCHEMA, DOMAIN)
 from homeassistant.helpers.aiohttp_client import (

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -118,13 +118,12 @@ class SynologyCamera(Camera):
         return self._camera.name
 
     @property
-
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
             'home_mode': self.home_mode
         }
-    
+        
     def is_recording(self):
         """Return true if the device is recording."""
         return self._camera.is_recording

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -62,13 +62,17 @@ async def async_setup_platform(hass, config, async_add_entities,
     def handle_enable_home_mode(call):
         surveillance.set_home_mode(True)
 
-    hass.services.async_register(DOMAIN, 'enable_home_mode', handle_enable_home_mode)
+    hass.services.async_register(DOMAIN, 
+                                 'enable_home_mode', 
+                                 handle_enable_home_mode)
 
     """Register a service to be able to disable home mode."""
     def handle_disable_home_mode(call):
         surveillance.set_home_mode(False)
 
-    hass.services.async_register(DOMAIN, 'disable_home_mode', handle_disable_home_mode)
+    hass.services.async_register(DOMAIN, 
+                                 'disable_home_mode', 
+                                 handle_disable_home_mode)
 
     # add cameras
     devices = []

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -96,7 +96,6 @@ class SynologyCamera(Camera):
         self._camera = self._surveillance.get_camera(camera_id)
         self._motion_setting = self._surveillance.get_motion_setting(camera_id)
         self.is_streaming = self._camera.is_enabled
-        self.home_mode = self._surveillance.get_home_mode_status()
 
     def camera_image(self):
         """Return bytes of camera image."""
@@ -118,11 +117,9 @@ class SynologyCamera(Camera):
         return self._camera.name
 
     @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return {
-            'home_mode': self.home_mode
-        }
+    def home_mode(self):
+        """Return true if the device is recording."""
+        return self.home_mode
 
     def is_recording(self):
         """Return true if the device is recording."""
@@ -139,7 +136,7 @@ class SynologyCamera(Camera):
         self._motion_setting = self._surveillance.get_motion_setting(
             self._camera.camera_id)
         self.is_streaming = self._camera.is_enabled
-        self.home_mode = self._surveillance.get_home_mode_status()
+        self.hass.states.set('camera.synology_home_mode', self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -135,7 +135,7 @@ class SynologyCamera(Camera):
         self.is_streaming = self._camera.is_enabled
         self.home_mode = self._surveillance.get_home_mode_status()
         self.hass.states.set('camera.synology_home_mode',
-                    self._surveillance.get_home_mode_status())
+                             self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -135,7 +135,7 @@ class SynologyCamera(Camera):
         self.is_streaming = self._camera.is_enabled
         self.home_mode = self._surveillance.get_home_mode_status()
         self.hass.states.set('camera.synology_home_mode',
-                self._surveillance.get_home_mode_status())
+                    self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/homeassistant/components/camera/synology.py
+++ b/homeassistant/components/camera/synology.py
@@ -137,7 +137,7 @@ class SynologyCamera(Camera):
             self._camera.camera_id)
         self.is_streaming = self._camera.is_enabled
         self.hass.states.set('camera.synology_home_mode',
-        self._surveillance.get_home_mode_status())
+            self._surveillance.get_home_mode_status())
 
     @property
     def motion_detection_enabled(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -884,7 +884,7 @@ py-cpuinfo==4.0.0
 py-melissa-climate==2.0.0
 
 # homeassistant.components.camera.synology
-py-synology==0.2.0
+py-synology==0.3.0
 
 # homeassistant.components.sensor.seventeentrack
 py17track==2.1.1


### PR DESCRIPTION
## Description:

I noticed two services did not work with the synology components, physically turn a camera on and off - pushed the code to the py-synology and services. The py-synology needs to be 0.3.0 to use the new services.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

Fixes the component not supporting on/off camera

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

