### PR TITLE
Add base_url  in telegram bot for reverse proxy user(api.telegram.org)

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -52,6 +52,7 @@ ATTR_USERNAME = 'username'
 CONF_ALLOWED_CHAT_IDS = 'allowed_chat_ids'
 CONF_PROXY_URL = 'proxy_url'
 CONF_PROXY_PARAMS = 'proxy_params'
+CONF_BASE_URL = 'base_url'
 
 DOMAIN = 'telegram_bot'
 
@@ -302,13 +303,14 @@ def initialize_bot(p_config):
     api_key = p_config.get(CONF_API_KEY)
     proxy_url = p_config.get(CONF_PROXY_URL)
     proxy_params = p_config.get(CONF_PROXY_PARAMS)
+    base_url = p_config.get(CONF_BASE_URL)
 
     if proxy_url is not None:
         request = Request(con_pool_size=8, proxy_url=proxy_url,
                           urllib3_proxy_kwargs=proxy_params)
     else:
         request = Request(con_pool_size=8)
-    return Bot(token=api_key, request=request)
+    return Bot(token=api_key, base_url = base_url,  request=request)
 
 
 class TelegramNotificationService:


### PR DESCRIPTION
Add reverser proxy for telegram api
just add base_url config 

# Example configuration.yaml entry
```
telegram_bot:
  - platform: polling
    api_key: YOUR_API_KEY
    base_url: TG.YOUR_DOMAIN.COM/bot
    allowed_chat_ids:
      - 12345
      - 67890
```