### PR TITLE
Adding enigma2 media player

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -154,6 +154,7 @@ omit =
     homeassistant/components/elkm1/*
     homeassistant/components/emoncms_history/*
     homeassistant/components/emulated_hue/upnp.py
+    homeassistant/components/enigma2/media_player.py
     homeassistant/components/enocean/*
     homeassistant/components/envisalink/*
     homeassistant/components/esphome/__init__.py
@@ -280,7 +281,6 @@ omit =
     homeassistant/components/media_player/dlna_dmr.py
     homeassistant/components/media_player/dunehd.py
     homeassistant/components/media_player/emby.py
-    homeassistant/components/media_player/enigma2.py
     homeassistant/components/media_player/epson.py
     homeassistant/components/media_player/frontier_silicon.py
     homeassistant/components/media_player/gpmdp.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -280,6 +280,7 @@ omit =
     homeassistant/components/media_player/dlna_dmr.py
     homeassistant/components/media_player/dunehd.py
     homeassistant/components/media_player/emby.py
+    homeassistant/components/media_player/enigma2.py
     homeassistant/components/media_player/epson.py
     homeassistant/components/media_player/frontier_silicon.py
     homeassistant/components/media_player/gpmdp.py

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -31,6 +31,7 @@ SERVICE_AXIS = 'axis'
 SERVICE_DAIKIN = 'daikin'
 SERVICE_DECONZ = 'deconz'
 SERVICE_DLNA_DMR = 'dlna_dmr'
+SERVICE_ENIGMA2 = 'enigma2'
 SERVICE_FREEBOX = 'freebox'
 SERVICE_HASS_IOS_APP = 'hass_ios'
 SERVICE_HASSIO = 'hassio'
@@ -68,6 +69,7 @@ SERVICE_HANDLERS = {
     SERVICE_HASSIO: ('hassio', None),
     SERVICE_AXIS: ('axis', None),
     SERVICE_APPLE_TV: ('apple_tv', None),
+    SERVICE_ENIGMA2: ('enigma2', None),
     SERVICE_ROKU: ('roku', None),
     SERVICE_WINK: ('wink', None),
     SERVICE_XIAOMI_GW: ('xiaomi_aqara', None),

--- a/homeassistant/components/enigma2/__init__.py
+++ b/homeassistant/components/enigma2/__init__.py
@@ -8,7 +8,6 @@ DOMAIN = 'enigma2'
 
 def setup(hass, config):
     """Set up the Enigma2 platform."""
-
     def device_discovered(service, info):
         """Handle when an Enigma2 device has been discovered."""
         load_platform(hass, 'media_player', DOMAIN, info, config)

--- a/homeassistant/components/enigma2/__init__.py
+++ b/homeassistant/components/enigma2/__init__.py
@@ -1,0 +1,20 @@
+"""Support for Enigma2 devices."""
+from homeassistant.components.discovery import SERVICE_ENIGMA2
+from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers import discovery
+
+DOMAIN = 'enigma2'
+
+DEPENDENCIES = ['http']
+
+
+def setup(hass, config):
+    """Set up the Enigma2 platform."""
+    def device_discovered(service, info):
+        """Handle when an Enigma2 device has been discovered."""
+        load_platform(hass, 'media_player', DOMAIN, info, config)
+
+    discovery.listen(
+        hass, SERVICE_ENIGMA2, device_discovered)
+
+    return True

--- a/homeassistant/components/enigma2/__init__.py
+++ b/homeassistant/components/enigma2/__init__.py
@@ -5,11 +5,10 @@ from homeassistant.helpers import discovery
 
 DOMAIN = 'enigma2'
 
-DEPENDENCIES = ['http']
-
 
 def setup(hass, config):
     """Set up the Enigma2 platform."""
+
     def device_discovered(service, info):
         """Handle when an Enigma2 device has been discovered."""
         load_platform(hass, 'media_player', DOMAIN, info, config)

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -33,10 +33,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up of an enigma2 media player."""
-    name = config[CONF_NAME]
+    if discovery_info:
+        discovered_config = {
+            'name': DEFAULT_NAME,
+            'port': DEFAULT_PORT,
+            'host': discovery_info['host'],
+            'timeout': DEFAULT_TIMEOUT,
+        }
+        add_devices([Enigma2Device(discovery_info['hostname'],
+                                   discovered_config)], True)
+        return
 
     # Generate a configuration for the Enigma2 library
     remote_config = {
@@ -47,7 +55,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         'timeout': DEFAULT_TIMEOUT,
     }
 
-    add_devices([Enigma2Device(name, remote_config)], True)
+    add_devices([Enigma2Device(config[CONF_NAME], remote_config)], True)
 
 
 class Enigma2Device(MediaPlayerDevice):

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['openwebifpy==1.2.4']
+REQUIREMENTS = ['openwebifpy==1.2.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -1,9 +1,4 @@
-"""
-Support for Enigma2 media players.
-
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/media_player.enigma2/
-"""
+"""Support for Enigma2 media players."""
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_OFF, STATE_ON, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['openwebifpy==1.0.9']
+REQUIREMENTS = ['openwebifpy==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['openwebifpy==1.2.3']
+REQUIREMENTS = ['openwebifpy==1.2.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['openwebifpy==1.1.7']
+REQUIREMENTS = ['openwebifpy==1.1.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['openwebifpy==1.1.8']
+REQUIREMENTS = ['openwebifpy==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,9 +23,12 @@ ATTR_MEDIA_DESCRIPTION = 'media_description'
 ATTR_MEDIA_END_TIME = 'media_end_time'
 ATTR_MEDIA_START_TIME = 'media_start_time'
 
+CONF_PREFER_PICON = "prefer_picon"
+
 DEFAULT_NAME = 'Enigma2 Media Player'
 DEFAULT_PORT = 80
 DEFAULT_SSL = False
+DEFAULT_PREFER_PICON = False
 DEFAULT_USERNAME = 'root'
 DEFAULT_PASSWORD = 'dreambox'
 
@@ -41,6 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_PREFER_PICON, default=DEFAULT_PREFER_PICON): cv.boolean,
 })
 
 
@@ -56,6 +60,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             CONF_USERNAME: DEFAULT_USERNAME,
             CONF_PASSWORD: DEFAULT_PASSWORD,
             CONF_SSL: DEFAULT_SSL,
+            CONF_PREFER_PICON: DEFAULT_PREFER_PICON,
         }
         add_devices([Enigma2Device(discovery_info['hostname'],
                                    discovered_config)], True)
@@ -77,7 +82,8 @@ class Enigma2Device(MediaPlayerDevice):
                                        port=config[CONF_PORT],
                                        username=config[CONF_USERNAME],
                                        password=config[CONF_PASSWORD],
-                                       is_https=config[CONF_SSL])
+                                       is_https=config[CONF_SSL],
+                                       prefer_picon=config[CONF_PREFER_PICON])
 
         self.volume = 10
         self.current_service_channel_name = None

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['openwebifpy==1.1.5']
+REQUIREMENTS = ['openwebifpy==1.1.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -85,13 +85,11 @@ class Enigma2Device(MediaPlayerDevice):
 
     def turn_off(self):
         """Turn off media player."""
-        if self.state == STATE_ON:
-            self.e2_box.toggle_standby()
+        self.e2_box.toggle_standby()
 
     def turn_on(self):
         """Turn the media player on."""
-        if self.state == STATE_OFF:
-            self.e2_box.toggle_standby()
+        self.e2_box.toggle_standby()
 
     @property
     def media_title(self):
@@ -133,17 +131,14 @@ class Enigma2Device(MediaPlayerDevice):
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         self.e2_box.set_volume(int(volume * 100))
-        self.volume = volume * 100
 
     def volume_up(self):
         """Volume up the media player."""
-        self.volume += 5
-        self.e2_box.set_volume(self.volume)
+        self.e2_box.set_volume(self.volume + 5)
 
     def volume_down(self):
         """Volume down media player."""
-        self.volume -= 5
-        self.e2_box.set_volume(self.volume)
+        self.e2_box.set_volume(self.volume - 5)
 
     @property
     def volume_level(self):
@@ -172,8 +167,7 @@ class Enigma2Device(MediaPlayerDevice):
 
     def mute_volume(self, mute):
         """Mute or unmute."""
-        if self.muted != mute:
-            self.e2_box.mute_volume()
+        self.e2_box.mute_volume()
 
     def update(self):
         """Update state of the media_player."""
@@ -181,16 +175,16 @@ class Enigma2Device(MediaPlayerDevice):
 
         if self.e2_box.is_box_in_standby():
             self._state = STATE_OFF
-        else:
-            self._state = STATE_ON
-            self.current_service_channel_name = \
-                status_info['currservice_station']
-            pname = status_info['currservice_name']
-            self.current_programme_name = pname if pname != "N/A" else ""
-            self.current_service_ref = status_info['currservice_serviceref']
-            self.muted = status_info['muted']
-            self.volume = status_info['volume']
-            self.picon_url = \
-                self.e2_box.get_current_playing_picon_url(
-                    channel_name=self.current_service_channel_name,
-                    currservice_serviceref=self.current_service_ref)
+            return
+        self._state = STATE_ON
+        self.current_service_channel_name = \
+            status_info['currservice_station']
+        pname = status_info['currservice_name']
+        self.current_programme_name = pname if pname != "N/A" else ""
+        self.current_service_ref = status_info['currservice_serviceref']
+        self.muted = status_info['muted']
+        self.volume = status_info['volume']
+        self.picon_url = \
+            self.e2_box.get_current_playing_picon_url(
+                channel_name=self.current_service_channel_name,
+                currservice_serviceref=self.current_service_ref)

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -183,11 +183,10 @@ class Enigma2Device(MediaPlayerDevice):
         """Mute or unmute."""
         self.e2_box.mute_volume()
 
-    # GET - Current channel - Current Channel Name
     @property
     def source(self):
         """Return the current input source."""
-        return "1"
+        return self.current_service_channel_name
 
     @property
     def source_list(self):

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -23,12 +23,12 @@ ATTR_MEDIA_DESCRIPTION = 'media_description'
 ATTR_MEDIA_END_TIME = 'media_end_time'
 ATTR_MEDIA_START_TIME = 'media_start_time'
 
-CONF_PREFER_PICON = "prefer_picon"
+CONF_USE_CHANNEL_ICON = "use_channel_icon"
 
 DEFAULT_NAME = 'Enigma2 Media Player'
 DEFAULT_PORT = 80
 DEFAULT_SSL = False
-DEFAULT_PREFER_PICON = False
+DEFAULT_USE_CHANNEL_ICON = False
 DEFAULT_USERNAME = 'root'
 DEFAULT_PASSWORD = 'dreambox'
 
@@ -44,7 +44,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-    vol.Optional(CONF_PREFER_PICON, default=DEFAULT_PREFER_PICON): cv.boolean,
+    vol.Optional(CONF_USE_CHANNEL_ICON,
+                 default=DEFAULT_USE_CHANNEL_ICON): cv.boolean,
 })
 
 
@@ -60,7 +61,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             CONF_USERNAME: DEFAULT_USERNAME,
             CONF_PASSWORD: DEFAULT_PASSWORD,
             CONF_SSL: DEFAULT_SSL,
-            CONF_PREFER_PICON: DEFAULT_PREFER_PICON,
+            CONF_USE_CHANNEL_ICON: DEFAULT_USE_CHANNEL_ICON,
         }
         add_devices([Enigma2Device(discovery_info['hostname'],
                                    discovered_config)], True)
@@ -82,7 +83,8 @@ class Enigma2Device(MediaPlayerDevice):
                                        username=config[CONF_USERNAME],
                                        password=config[CONF_PASSWORD],
                                        is_https=config[CONF_SSL],
-                                       prefer_picon=config[CONF_PREFER_PICON])
+                                       prefer_picon=config[
+                                           CONF_USE_CHANNEL_ICON])
 
     @property
     def name(self):
@@ -150,11 +152,11 @@ class Enigma2Device(MediaPlayerDevice):
 
     def volume_up(self):
         """Volume up the media player."""
-        self.e2_box.set_volume(self.e2_box.volume + 5)
+        self.e2_box.set_volume(int(self.e2_box.volume * 100) + 5)
 
     def volume_down(self):
         """Volume down media player."""
-        self.e2_box.set_volume(self.e2_box.volume - 5)
+        self.e2_box.set_volume(int(self.e2_box.volume * 100) - 5)
 
     @property
     def volume_level(self):

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -46,8 +46,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             CONF_NAME: DEFAULT_NAME,
             CONF_PORT: DEFAULT_PORT,
             CONF_HOST: discovery_info['host'],
-            CONF_USERNAME: None,
-            CONF_PASSWORD: None,
+            CONF_USERNAME: DEFAULT_USERNAME,
+            CONF_PASSWORD: DEFAULT_PASSWORD,
             CONF_SSL: DEFAULT_SSL,
         }
         add_devices([Enigma2Device(discovery_info['hostname'],

--- a/homeassistant/components/media_player/enigma2.py
+++ b/homeassistant/components/media_player/enigma2.py
@@ -40,7 +40,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Enigma2 TV platform."""
     name = config[CONF_NAME]
 
     # Generate a configuration for the Enigma2 library

--- a/homeassistant/components/media_player/enigma2.py
+++ b/homeassistant/components/media_player/enigma2.py
@@ -40,7 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
-"""Set up of an enigma2 media player."""
+    """Set up of an enigma2 media player."""
     name = config[CONF_NAME]
 
     # Generate a configuration for the Enigma2 library

--- a/homeassistant/components/media_player/enigma2.py
+++ b/homeassistant/components/media_player/enigma2.py
@@ -1,0 +1,200 @@
+"""
+Support for Enigma2 based media players.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.enigma2/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import MediaPlayerDevice
+from homeassistant.helpers.config_validation import (PLATFORM_SCHEMA)
+from homeassistant.components.media_player.const import (
+    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, SUPPORT_TURN_ON,
+    SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
+    MEDIA_TYPE_TVSHOW)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['openwebif.py==0.9']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Enigma2 Media Player'
+DEFAULT_PORT = 80
+DEFAULT_TIMEOUT = 0
+
+SUPPORTED_ENIGMA2 = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
+                          SUPPORT_TURN_OFF | SUPPORT_NEXT_TRACK | \
+                          SUPPORT_PREVIOUS_TRACK | SUPPORT_TURN_ON | SUPPORT_PAUSE
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup the Enigma2 TV platform."""
+    name = config[CONF_NAME]
+
+    # Generate a configuration for the Enigma2 library
+    remote_config = {
+        'name': 'HomeAssistant',
+        'description': config[CONF_NAME],
+        'port': config[CONF_PORT],
+        'host': config[CONF_HOST],
+        'timeout': DEFAULT_TIMEOUT,
+    }
+
+    add_devices([Enigma2Device(name, remote_config)], True)
+
+
+class Enigma2Device(MediaPlayerDevice):
+    """Representation of an Enigma2 box."""
+
+    def __init__(self, name, config):
+        """Initialize the Enigma2 device."""
+        import openwebif.api
+        self._state = None
+        self._name = name
+        self.e2_box = openwebif.api.CreateDevice(config['host'],
+                                                 port=config['port'])
+
+        self.volume = 20
+        self.current_service_channel_name = None
+        self.current_programme_name = None
+        self.current_service_ref = None
+        self.muted = False
+        self.picon_url = None
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Flag of media commands that are supported."""
+        return SUPPORTED_ENIGMA2
+
+    def turn_off(self):
+        """Turn off media player."""
+        if self.state == STATE_ON:
+            self.e2_box.toggle_standby()
+
+    def turn_on(self):
+        """Turn the media player on."""
+        if self.state == STATE_OFF:
+            self.e2_box.toggle_standby()
+
+    @property
+    def media_title(self):
+        """Title of current playing media."""
+        if self.current_service_ref.startswith('1:0:0'):
+            return "[Recording Playback] - {}".format(
+                self.current_programme_name)
+        if self.current_service_channel_name:
+            return "{} - {}".format(self.current_programme_name,
+                                    self.current_service_channel_name)
+
+        return self.current_programme_name
+
+    @property
+    def media_channel(self):
+        """Channel of current playing media."""
+        return self.current_service_channel_name
+
+    @property
+    def media_content_id(self):
+        """Service Ref of current playing media."""
+        return self.current_service_ref
+
+    @property
+    def media_content_type(self):
+        """Type of video currently playing."""
+        return MEDIA_TYPE_TVSHOW
+
+    @property
+    def is_volume_muted(self):
+        """Boolean if volume is currently muted."""
+        return self.muted
+
+    @property
+    def media_image_url(self):
+        """Picon url for the channel."""
+        return self.picon_url
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        self.e2_box.set_volume(int(volume * 100))
+        self.volume = volume * 100
+
+    def volume_up(self):
+        """Volume up the media player."""
+        self.volume += 5
+        self.e2_box.set_volume(self.volume)
+
+    def volume_down(self):
+        """Volume down media player."""
+        self.volume -= 5
+        self.e2_box.set_volume(self.volume)
+
+    @property
+    def volume_level(self):
+        """Volume level of the media player (0..1)."""
+        return self.volume / 100
+
+    def media_play_pause(self):
+        """Pause media on media player."""
+        self.e2_box.toggle_play_pause()
+
+    def media_play(self):
+        """Play media."""
+        self.e2_box.toggle_play_pause()
+
+    def media_pause(self):
+        """Pause the media player."""
+        self.e2_box.toggle_play_pause()
+
+    def media_next_track(self):
+        """Send next track command."""
+        self.e2_box.set_channel_up()
+
+    def media_previous_track(self):
+        """Send next track command."""
+        self.e2_box.set_channel_down()
+
+    def mute_volume(self, mute):
+        """Mute or unmute."""
+        if self.muted != mute:
+            self.e2_box.mute_volume()
+
+    def update(self):
+        """Update state of the media_player."""
+        status_info = self.e2_box.refresh_status_info()
+
+        if self.e2_box.is_box_in_standby():
+            self._state = STATE_OFF
+        else:
+            self._state = STATE_ON
+            self.current_service_channel_name = \
+                status_info['currservice_station']
+            pname = status_info['currservice_name']
+            self.current_programme_name = pname if pname != "N/A" else ""
+            self.current_service_ref = status_info['currservice_serviceref']
+            self.muted = status_info['muted']
+            self.volume = status_info['volume']
+            self.picon_url = \
+                self.e2_box.get_current_playing_picon_url(
+                    channel_name=self.current_service_channel_name,
+                    currservice_serviceref=self.current_service_ref)

--- a/homeassistant/components/media_player/enigma2.py
+++ b/homeassistant/components/media_player/enigma2.py
@@ -40,6 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
+"""Set up of an enigma2 media player."""
     name = config[CONF_NAME]
 
     # Generate a configuration for the Enigma2 library

--- a/homeassistant/components/media_player/enigma2.py
+++ b/homeassistant/components/media_player/enigma2.py
@@ -15,7 +15,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     MEDIA_TYPE_TVSHOW)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT)
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['openwebif.py==0.9']
@@ -28,7 +28,8 @@ DEFAULT_TIMEOUT = 0
 
 SUPPORTED_ENIGMA2 = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
                           SUPPORT_TURN_OFF | SUPPORT_NEXT_TRACK | \
-                          SUPPORT_PREVIOUS_TRACK | SUPPORT_TURN_ON | SUPPORT_PAUSE
+                          SUPPORT_PREVIOUS_TRACK | \
+                          SUPPORT_TURN_ON | SUPPORT_PAUSE
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,

--- a/homeassistant/components/media_player/enigma2.py
+++ b/homeassistant/components/media_player/enigma2.py
@@ -1,5 +1,5 @@
 """
-Support for Enigma2 based media players.
+Support for Enigma2 media players.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.enigma2/

--- a/homeassistant/components/media_player/enigma2.py
+++ b/homeassistant/components/media_player/enigma2.py
@@ -66,7 +66,7 @@ class Enigma2Device(MediaPlayerDevice):
         self.e2_box = openwebif.api.CreateDevice(config['host'],
                                                  port=config['port'])
 
-        self.volume = 20
+        self.volume = 10
         self.current_service_channel_name = None
         self.current_programme_name = None
         self.current_service_ref = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.1.8
+openwebifpy==1.2.0
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.1.7
+openwebifpy==1.1.8
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.2.0
+openwebifpy==1.2.3
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.2.6
+openwebifpy==1.2.7
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebif.py==0.9
+openwebifpy==1.0.4
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.2.3
+openwebifpy==1.2.4
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -776,6 +776,9 @@ openhomedevice==0.4.2
 # homeassistant.components.air_quality.opensensemap
 opensensemap-api==0.1.5
 
+# homeassistant.components.enigma2.media_player
+openwebif.py==0.9
+
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -776,9 +776,6 @@ openhomedevice==0.4.2
 # homeassistant.components.air_quality.opensensemap
 opensensemap-api==0.1.5
 
-# homeassistant.components.media_player.enigma2
-openwebif.py==0.9
-
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.0.4
+openwebifpy==1.0.9
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -776,6 +776,9 @@ openhomedevice==0.4.2
 # homeassistant.components.air_quality.opensensemap
 opensensemap-api==0.1.5
 
+# homeassistant.components.media_player.enigma2
+openwebif.py==0.9
+
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.2.4
+openwebifpy==1.2.6
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.1.5
+openwebifpy==1.1.7
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.0.9
+openwebifpy==1.1.0
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -777,7 +777,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.5
 
 # homeassistant.components.enigma2.media_player
-openwebifpy==1.1.0
+openwebifpy==1.1.5
 
 # homeassistant.components.device_tracker.luci
 openwrt-luci-rpc==1.0.5


### PR DESCRIPTION
## Description:

This PR adds support for Enigma2 based set top box receivers. Examples include devices from Vu (Duo, Duo2, Uno, etc) and lots of manufacturers who support the open sourced images based on Enigma2, such as OpenVix and Black Hole.

At present, the platform supports:

1. Power standby/wake toggle (on/off)
2. Select next/prev channel
3. Volume set
4. Mute/unmute
5. Query current program info such as:
	- TV station active, 
    - Programme Name & Description
    - Picon (channel icon) for the station
6. Auto-discover of enigma2 boxes (via netdisco - Pull request in [netdisco](https://github.com/home-assistant/netdisco):** home-assistant/netdisco#241 )

## How does it work?

![Home Assistant Enigma2 Architecture](http://finbarrbrady.com/img/posts/enigma2-hass.png)
)

**note: Component should be worded 'Platform' in the diagram**

This PR contains a **media_player** platform named `enigma2` for Home Assistant, which allows basic control of the unit and the TV via my 3rd party pip module, called [openwebifpy](https://github.com/fbradyirl/openwebifpy). 

![e2v2](https://user-images.githubusercontent.com/254309/53898565-39922e00-4030-11e9-80e9-fe2cec01b5e0.gif)

More details and example automations can be [found here](http://finbarrbrady.com/2017-02-19-automate-your-tv/).

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8776

## Discovery
**Pull request in [netdisco](https://github.com/home-assistant/netdisco):** home-assistant/netdisco#241


## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
media_player:
  - platform: enigma2
    host: 192.168.1.12
    name: Vu Duo2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23