### PR TITLE
Upgrade python-anthemav to v1.1.9

### DIFF
--- a/homeassistant/components/media_player/anthemav.py
+++ b/homeassistant/components/media_player/anthemav.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['anthemav==1.1.8']
+REQUIREMENTS = ['anthemav==1.1.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -154,7 +154,7 @@ amcrest==1.2.3
 anel_pwrctrl-homeassistant==0.0.1.dev2
 
 # homeassistant.components.media_player.anthemav
-anthemav==1.1.8
+anthemav==1.1.9
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.13


### PR DESCRIPTION
## Description:

Version bump of underlying `python-anthemav` library to 1.1.9.  This fixes a syntax error in Python 3.7 where `async` has become a reserved word.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
