### PR TITLE
Do not warn for internally loaded components

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -83,7 +83,7 @@ def get_platform(hass,  # type: HomeAssistant
     """
     # If the platform has a component, we will limit the platform loading path
     # to be the same source (custom/built-in).
-    component = get_component(hass, platform_name)
+    component = _load_file(hass, platform_name, LOOKUP_PATHS)
 
     # Until we have moved all platforms under their component/own folder, it
     # can be that the component is None.
@@ -181,7 +181,7 @@ def _load_file(hass,  # type: HomeAssistant
 
             cache[comp_or_platform] = module
 
-            if index == 0:
+            if module.__name__.startswith(PACKAGE_CUSTOM_COMPONENTS):
                 _LOGGER.warning(
                     'You are using a custom component for %s which has not '
                     'been tested by Home Assistant. This component might '


### PR DESCRIPTION
## Description:
In #21070 I made a mistake by using the externally facing `get_component` inside `get_platform`, causing a warning to be printed for errors that were expected.

This fixes it. It also fixes the custom component warning.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
