### PR TITLE
0.88.1

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -263,7 +263,8 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            hass.data[DOMAIN][DATA_CONFIG].get(CONF_MONITORED_CONDITIONS, []))
+            hass.data[DOMAIN].get(DATA_CONFIG, {}).get(
+                CONF_MONITORED_CONDITIONS, []))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketError as err:

--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -77,14 +77,15 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_MODE_MUSIC, default=False): cv.boolean,
     vol.Optional(CONF_SAVE_ON_CHANGE, default=False): cv.boolean,
     vol.Optional(CONF_MODEL): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
     vol.Optional(CONF_CUSTOM_EFFECTS): [{
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_FLOW_PARAMS): YEELIGHT_FLOW_TRANSITION_SCHEMA
     }]
 })
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA}, })
 
 SUPPORT_YEELIGHT = (SUPPORT_BRIGHTNESS |
                     SUPPORT_TRANSITION |

--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -47,6 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_INCLUDE_NON_CLIENTS, default=False): cv.boolean,
     vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
     vol.Optional(CONF_USE_CUSTOM_ENTITY_IDS, default=False): cv.boolean,
+    vol.Optional(CONF_SHOW_ALL_CONTROLS, default=False): cv.boolean,
     vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True): cv.boolean,
     vol.Optional(CONF_CLIENT_REMOVE_INTERVAL, default=timedelta(seconds=600)):
         vol.All(cv.time_period, cv.positive_timedelta),

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -42,6 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_MAC): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
 })
 

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -35,6 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_SERVER): cv.string,
+    vol.Required(CONF_SENDERS): [cv.string],
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_FOLDER, default='INBOX'): cv.string,

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -126,9 +126,11 @@ class LevelControlChannel(ZigbeeChannel):
 class BasicChannel(ZigbeeChannel):
     """Channel to interact with the basic cluster."""
 
+    UNKNOWN = 0
     BATTERY = 3
+
     POWER_SOURCES = {
-        0: 'Unknown',
+        UNKNOWN: 'Unknown',
         1: 'Mains (single phase)',
         2: 'Mains (3 phase)',
         BATTERY: 'Battery',

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -146,11 +146,11 @@ class ZHADevice:
                 self._available_signal,
                 False
             )
-            async_dispatcher_send(
-                self.hass,
-                "{}_{}".format(self._available_signal, 'entity'),
-                True
-            )
+        async_dispatcher_send(
+            self.hass,
+            "{}_{}".format(self._available_signal, 'entity'),
+            available
+        )
         self._available = available
 
     @property

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -36,6 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {}
 BINARY_SENSOR_TYPES = {}
+SMARTTHINGS_HUMIDITY_CLUSTER = 64581
 EntityReference = collections.namedtuple(
     'EntityReference', 'reference_id zha_device cluster_channels device_info')
 
@@ -174,7 +175,8 @@ class ZHAGateway:
             # available and we already loaded fresh state above
             zha_device.update_available(True)
         elif not zha_device.available and zha_device.power_source is not None\
-                and zha_device.power_source != BasicChannel.BATTERY:
+                and zha_device.power_source != BasicChannel.BATTERY\
+                and zha_device.power_source != BasicChannel.UNKNOWN:
             # the device is currently marked unavailable and it isn't a battery
             # powered device so we should be able to update it now
             _LOGGER.debug(
@@ -380,7 +382,10 @@ async def _handle_single_cluster_match(hass, zha_device, cluster, device_key,
     """Dispatch a single cluster match to a HA component."""
     component = None  # sub_component = None
     for cluster_type, candidate_component in device_classes.items():
-        if isinstance(cluster, cluster_type):
+        if isinstance(cluster_type, int):
+            if cluster.cluster_id == cluster_type:
+                component = candidate_component
+        elif isinstance(cluster, cluster_type):
             component = candidate_component
             break
 
@@ -473,6 +478,9 @@ def establish_device_mappings():
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'switch',
         zcl.clusters.measurement.RelativeHumidity: 'sensor',
+        # this works for now but if we hit conflicts we can break it out to
+        # a different dict that is keyed by manufacturer
+        SMARTTHINGS_HUMIDITY_CLUSTER: 'sensor',
         zcl.clusters.measurement.TemperatureMeasurement: 'sensor',
         zcl.clusters.measurement.PressureMeasurement: 'sensor',
         zcl.clusters.measurement.IlluminanceMeasurement: 'sensor',
@@ -489,6 +497,7 @@ def establish_device_mappings():
 
     SENSOR_TYPES.update({
         zcl.clusters.measurement.RelativeHumidity.cluster_id: HUMIDITY,
+        SMARTTHINGS_HUMIDITY_CLUSTER: HUMIDITY,
         zcl.clusters.measurement.TemperatureMeasurement.cluster_id:
         TEMPERATURE,
         zcl.clusters.measurement.PressureMeasurement.cluster_id: PRESSURE,

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -29,9 +29,12 @@ set_zigbee_cluster_attribute:
   description: >- 
     Set attribute value for the specified cluster on the specified entity. 
   fields:
-    entity_id:
-      description: Entity id
-      example: "binary_sensor.centralite_3130_00e8fb4e_1"
+    ieee:
+      description: IEEE address for the device
+      example: "00:0d:6f:00:05:7d:2d:34"
+    endpoint_id:
+      description: Endpoint id for the cluster
+      example: 1
     cluster_id:
       description: ZCL cluster to retrieve attributes for
       example: 6
@@ -52,9 +55,12 @@ issue_zigbee_cluster_command:
   description: >- 
     Issue command on the specified cluster on the specified entity. 
   fields:
-    entity_id:
-      description: Entity id
-      example: "binary_sensor.centralite_3130_00e8fb4e_1"
+    ieee:
+      description: IEEE address for the device
+      example: "00:0d:6f:00:05:7d:2d:34"
+    endpoint_id:
+      description: Endpoint id for the cluster
+      example: 1
     cluster_id:
       description: ZCL cluster to retrieve attributes for
       example: 6

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 88
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)


### PR DESCRIPTION
- Fix ZHA bugs ([@dmulcahey] - [#21246]) ([zha docs])
- Add missing configuration option to plex ([@elupus] - [#21264]) ([media_player.plex docs])
- Add missing configation option ([@elupus] - [#21265]) ([sensor.imap_email_content docs])
- Add SamsungTV Mac validation ([@balloob] - [#21268]) ([media_player.samsungtv docs])
- update services.yaml ([@dmulcahey] - [#21276])
- Fix unhandled exception in Ambient PWS config entry ([@bachya] - [#21278]) ([ambient_station docs])
- Fix yeelight config validation ([@balloob] - [#21295]) ([light.yeelight docs])

[#21246]: https://github.com/home-assistant/home-assistant/pull/21246
[#21264]: https://github.com/home-assistant/home-assistant/pull/21264
[#21265]: https://github.com/home-assistant/home-assistant/pull/21265
[#21268]: https://github.com/home-assistant/home-assistant/pull/21268
[#21276]: https://github.com/home-assistant/home-assistant/pull/21276
[#21278]: https://github.com/home-assistant/home-assistant/pull/21278
[#21295]: https://github.com/home-assistant/home-assistant/pull/21295
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@dmulcahey]: https://github.com/dmulcahey
[@elupus]: https://github.com/elupus
[ambient_station docs]: https://www.home-assistant.io/components/ambient_station/
[light.yeelight docs]: https://www.home-assistant.io/components/light.yeelight/
[media_player.plex docs]: https://www.home-assistant.io/components/media_player.plex/
[media_player.samsungtv docs]: https://www.home-assistant.io/components/media_player.samsungtv/
[sensor.imap_email_content docs]: https://www.home-assistant.io/components/sensor.imap_email_content/
[zha docs]: https://www.home-assistant.io/components/zha/