### PR TITLE
Add support for multiple devices for PS4 component

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.3.4']
+REQUIREMENTS = ['pyps4-homeassistant==0.4.0']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.3.3']
+REQUIREMENTS = ['pyps4-homeassistant==0.3.4']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.3.0']
+REQUIREMENTS = ['pyps4-homeassistant==0.3.3']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.4.4']
+REQUIREMENTS = ['pyps4-homeassistant==0.4.6']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.4.0']
+REQUIREMENTS = ['pyps4-homeassistant==0.4.4']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.4.7']
+REQUIREMENTS = ['pyps4-homeassistant==0.4.8']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.4.6']
+REQUIREMENTS = ['pyps4-homeassistant==0.4.7']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.ps4.const import DOMAIN  # noqa: pylint: disable=u
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.3.3']
+REQUIREMENTS = ['pyps4-homeassistant==0.3.0']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -38,8 +38,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
     async def async_step_user(self, user_input=None):
         """Handle a user config flow."""
         # Skip Creds Step if a device is configured.
-        self.entry = self.hass.config_entries.async_entries(DOMAIN)
-        if self.entry:
+        if self.hass.config_entries.async_entries(DOMAIN):
             return await self.async_step_link()
 
         # Check if able to bind to ports: UDP 987, TCP 997.
@@ -80,9 +79,9 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             device['host-ip'] for device in devices]
 
         # If entry exists check that devices found aren't configured.
-        if self.entry:
+        if self.hass.config_entries.async_entries(DOMAIN):
             # Should be only 1 entry max.
-            _entry = self.entry[0]
+            _entry = self.hass.config_entries.async_entries(DOMAIN)[0]
             conf_devices = _entry.data['devices']
             for c_device in conf_devices:
                 if c_device['host'] in device_list:

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -37,10 +37,6 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input=None):
         """Handle a user config flow."""
-        # Skip Creds Step if a device is configured.
-        if self.hass.config_entries.async_entries(DOMAIN):
-            return await self.async_step_link()
-
         # Check if able to bind to ports: UDP 987, TCP 997.
         ports = PORT_MSG.keys()
         failed = await self.hass.async_add_executor_job(
@@ -48,6 +44,9 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
         if failed in ports:
             reason = PORT_MSG[failed]
             return self.async_abort(reason=reason)
+        # Skip Creds Step if a device is configured.
+        if self.hass.config_entries.async_entries(DOMAIN):
+            return await self.async_step_link()
         return await self.async_step_creds()
 
     async def async_step_creds(self, user_input=None):

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -37,10 +37,9 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input=None):
         """Handle a user config flow."""
-        # Skip Creds Step if a device is configured.
-        self.entry = self.hass.config_entries.async_entries(DOMAIN)
-        if self.entry:
-            return await self.async_step_link()
+        # Abort if device is configured.
+        if self.hass.config_entries.async_entries(DOMAIN):
+            return self.async_abort(reason='devices_configured')
 
         # Check if able to bind to ports: UDP 987, TCP 997.
         ports = PORT_MSG.keys()
@@ -79,19 +78,6 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
         device_list = [
             device['host-ip'] for device in devices]
 
-        # If entry exists check that devices found aren't configured.
-        if self.entry:
-            # Should be only 1 entry max.
-            _entry = self.entry[0]
-            conf_devices = _entry.data['devices']
-            for c_device in conf_devices:
-                if c_device['host'] in device_list:
-                    # Remove configured device from search list.
-                    device_list.remove(c_device['host'])
-            # If list is empty then all devices are configured.
-            if not device_list:
-                return self.async_abort(reason='devices_configured')
-
         # Login to PS4 with user data.
         if user_input is not None:
             self.region = user_input[CONF_REGION]
@@ -112,15 +98,6 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
                     CONF_NAME: self.name,
                     CONF_REGION: self.region
                 }
-
-                if self.entry:
-                    conf_devices.append(device)
-                    await self.hass.config_entries.async_remove(
-                        _entry.entry_id)
-                    return self.async_create_entry(
-                        title='PlayStation 4',
-                        data=_entry.data,
-                    )
 
                 # Create entry.
                 return self.async_create_entry(

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -37,9 +37,10 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input=None):
         """Handle a user config flow."""
-        # Abort if device is configured.
-        if self.hass.config_entries.async_entries(DOMAIN):
-            return self.async_abort(reason='devices_configured')
+        # Skip Creds Step if a device is configured.
+        self.entry = self.hass.config_entries.async_entries(DOMAIN)
+        if self.entry:
+            return await self.async_step_link()
 
         # Check if able to bind to ports: UDP 987, TCP 997.
         ports = PORT_MSG.keys()
@@ -78,6 +79,19 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
         device_list = [
             device['host-ip'] for device in devices]
 
+        # If entry exists check that devices found aren't configured.
+        if self.entry:
+            # Should be only 1 entry max.
+            _entry = self.entry[0]
+            conf_devices = _entry.data['devices']
+            for c_device in conf_devices:
+                if c_device['host'] in device_list:
+                    # Remove configured device from search list.
+                    device_list.remove(c_device['host'])
+            # If list is empty then all devices are configured.
+            if not device_list:
+                return self.async_abort(reason='devices_configured')
+
         # Login to PS4 with user data.
         if user_input is not None:
             self.region = user_input[CONF_REGION]
@@ -98,6 +112,15 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
                     CONF_NAME: self.name,
                     CONF_REGION: self.region
                 }
+
+                if self.entry:
+                    conf_devices.append(device)
+                    await self.hass.config_entries.async_remove(
+                        _entry.entry_id)
+                    return self.async_create_entry(
+                        title='PlayStation 4',
+                        data=_entry.data,
+                    )
 
                 # Create entry.
                 return self.async_create_entry(

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -79,13 +79,15 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
         # If entry exists check that devices found aren't configured.
         if self.hass.config_entries.async_entries(DOMAIN):
-            # Should be only 1 entry max.
-            _entry = self.hass.config_entries.async_entries(DOMAIN)[0]
-            conf_devices = _entry.data['devices']
-            for c_device in conf_devices:
-                if c_device['host'] in device_list:
-                    # Remove configured device from search list.
-                    device_list.remove(c_device['host'])
+            _entries = []
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                _entries.append(entry)
+            for _entry in _entries:
+                conf_devices = _entry.data['devices']
+                for c_device in conf_devices:
+                    if c_device['host'] in device_list:
+                        # Remove configured device from search list.
+                        device_list.remove(c_device['host'])
             # If list is empty then all devices are configured.
             if not device_list:
                 return self.async_abort(reason='devices_configured')
@@ -110,18 +112,6 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
                     CONF_NAME: self.name,
                     CONF_REGION: self.region
                 }
-
-                if self.hass.config_entries.async_entries(DOMAIN):
-                    # Add new device to previous entry data
-                    _entry.data['devices'].append(device)
-                    # Delete previous entry
-                    await self.hass.config_entries.async_remove(
-                        _entry.entry_id)
-                    # Create new entry from previous, with new device
-                    return self.async_create_entry(
-                        title='PlayStation 4',
-                        data=_entry.data,
-                    )
 
                 # Create entry.
                 return self.async_create_entry(

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -112,7 +112,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
                     CONF_REGION: self.region
                 }
 
-                if self.entry:
+                if self.hass.config_entries.async_entries(DOMAIN):
                     conf_devices.append(device)
                     await self.hass.config_entries.async_remove(
                         _entry.entry_id)

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -113,9 +113,12 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
                 }
 
                 if self.hass.config_entries.async_entries(DOMAIN):
-                    conf_devices.append(device)
+                    # Add new device to previous entry data
+                    _entry.data['devices'].append(device)
+                    # Delete previous entry
                     await self.hass.config_entries.async_remove(
                         _entry.entry_id)
+                    # Create new entry from previous, with new device
                     return self.async_create_entry(
                         title='PlayStation 4',
                         data=_entry.data,

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -79,11 +79,8 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
         # If entry exists check that devices found aren't configured.
         if self.hass.config_entries.async_entries(DOMAIN):
-            _entries = []
             for entry in self.hass.config_entries.async_entries(DOMAIN):
-                _entries.append(entry)
-            for _entry in _entries:
-                conf_devices = _entry.data['devices']
+                conf_devices = entry.data['devices']
                 for c_device in conf_devices:
                     if c_device['host'] in device_list:
                         # Remove configured device from search list.

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -162,7 +162,7 @@ class PS4Device(MediaPlayerDevice):
                     self._ps4.keep_alive = True
                 else:
                     self._ps4.keep_alive = False
-                if self._power_on is True:
+                if self._power_on:
                     # Auto Login after Turn On.
                     self._ps4.open()
                     self._power_on = False

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -279,7 +279,7 @@ class PS4Device(MediaPlayerDevice):
             'sw_version': sw_version
         }
         self._unique_id = status['host-id']
-        
+
     async def async_will_remove_from_hass(self):
         """Remove Entity from Hass."""
         self.hass.data[PS4_DATA].devices.remove(self)

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -159,6 +159,8 @@ class PS4Device(MediaPlayerDevice):
                     # Enable keep alive feature for PS4 Connection.
                     # Only 1 device is supported, Since have to use port 997.
                     self._ps4.keep_alive = True
+                else:
+                    self._ps4.keep_alive = False
                 if self._power_on is True:
                     # Auto Login after Turn On.
                     self._ps4.open()
@@ -277,6 +279,10 @@ class PS4Device(MediaPlayerDevice):
             'sw_version': sw_version
         }
         self._unique_id = status['host-id']
+        
+    async def async_will_remove_from_hass(self):
+        """Remove Entity from Hass."""
+        self.hass.data[PS4_DATA].devices.remove(self)
 
     @property
     def device_info(self):

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -156,10 +156,9 @@ class PS4Device(MediaPlayerDevice):
             if status.get('status') == 'Ok':
                 # Check if only 1 device in Hass.
                 if len(self.hass.data[PS4_DATA].devices) == 1:
-                    """Enable keep alive feature for PS4 Connection.
-                     Only 1 device is supported,
-                     since can only use a single port, 997."""
-                    self._ps4._keep_alive = True
+                    # Enable keep alive feature for PS4 Connection.
+                    # Only 1 device is supported, Since have to use port 997.
+                    self._ps4.keep_alive = True
                 if self._power_on is True:
                     # Auto Login after Turn On.
                     self._ps4.open()

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -133,6 +133,7 @@ class PS4Device(MediaPlayerDevice):
         self._retry = 0
         self._info = None
         self._unique_id = None
+        self._power_on = False
 
     async def async_added_to_hass(self):
         """Subscribe PS4 events."""
@@ -153,6 +154,16 @@ class PS4Device(MediaPlayerDevice):
         if status is not None:
             self._retry = 0
             if status.get('status') == 'Ok':
+                # Check if only 1 device in Hass.
+                if len(self.hass.data[PS4_DATA].devices) == 1:
+                    """Enable keep alive feature for PS4 Connection.
+                     Only 1 device is supported,
+                     since can only use a single port, 997."""
+                    self._ps4._keep_alive = True
+                if self._power_on is True:
+                    # Auto Login after Turn On.
+                    self._ps4.open()
+                    self._power_on = False
                 title_id = status.get('running-app-titleid')
                 name = status.get('running-app-name')
                 if title_id and name is not None:
@@ -346,15 +357,16 @@ class PS4Device(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn on the media player."""
+        self._power_on = True
         self._ps4.wakeup()
 
     def media_pause(self):
         """Send keypress ps to return to menu."""
-        self._ps4.remote_control('ps')
+        self.send_remote_control('ps')
 
     def media_stop(self):
         """Send keypress ps to return to menu."""
-        self._ps4.remote_control('ps')
+        self.send_remote_control('ps')
 
     def select_source(self, source):
         """Select input source."""
@@ -369,4 +381,8 @@ class PS4Device(MediaPlayerDevice):
 
     def send_command(self, command):
         """Send Button Command."""
+        self.send_remote_control(command)
+
+    def send_remote_control(self, command):
+        """Send RC command."""
         self._ps4.remote_control(command)

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -145,6 +145,7 @@ class PS4Device(MediaPlayerDevice):
         try:
             status = self._ps4.get_status()
             if self._info is None:
+                # Add entity to registry
                 self.get_device_info(status)
                 self._games = self.load_games()
                 if self._games is not None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ pypoint==1.1.1
 pypollencom==2.2.2
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.4
+pyps4-homeassistant==0.4.6
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ pypoint==1.1.1
 pypollencom==2.2.2
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.3.0
+pyps4-homeassistant==0.3.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ pypoint==1.1.1
 pypollencom==2.2.2
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.7
+pyps4-homeassistant==0.4.8
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ pypoint==1.1.1
 pypollencom==2.2.2
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.0
+pyps4-homeassistant==0.4.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ pypoint==1.1.1
 pypollencom==2.2.2
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.6
+pyps4-homeassistant==0.4.7
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ pypoint==1.1.1
 pypollencom==2.2.2
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.3.4
+pyps4-homeassistant==0.4.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -214,7 +214,7 @@ pyopenuv==1.0.4
 pyotp==2.2.6
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.7
+pyps4-homeassistant==0.4.8
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -214,7 +214,7 @@ pyopenuv==1.0.4
 pyotp==2.2.6
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.4
+pyps4-homeassistant==0.4.6
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -214,7 +214,7 @@ pyopenuv==1.0.4
 pyotp==2.2.6
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.0
+pyps4-homeassistant==0.4.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -214,7 +214,7 @@ pyopenuv==1.0.4
 pyotp==2.2.6
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.3.0
+pyps4-homeassistant==0.3.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -214,7 +214,7 @@ pyopenuv==1.0.4
 pyotp==2.2.6
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.4.6
+pyps4-homeassistant==0.4.7
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -214,7 +214,7 @@ pyopenuv==1.0.4
 pyotp==2.2.6
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.3.4
+pyps4-homeassistant==0.4.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -94,7 +94,8 @@ async def test_multiple_flow_implementation(hass):
     with patch('pyps4_homeassistant.Helper.get_creds',
                return_value=MOCK_CREDS), \
             patch('pyps4_homeassistant.Helper.has_devices',
-                  return_value=[{'host-ip': MOCK_HOST}]):
+                  return_value=[{'host-ip': MOCK_HOST},
+                                {'host-ip': MOCK_HOST_ADDITIONAL}]):
         result = await flow.async_step_creds({})
         assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
         assert result['step_id'] == 'link'

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -103,7 +103,8 @@ async def test_multiple_flow_implementation(hass):
     with patch('pyps4_homeassistant.Helper.link',
                return_value=(True, True)), \
             patch('pyps4_homeassistant.Helper.has_devices',
-                  return_value=[{'host-ip': MOCK_HOST}]):
+                  return_value=[{'host-ip': MOCK_HOST},
+                                {'host-ip': MOCK_HOST_ADDITIONAL}]):
         result = await flow.async_step_link(MOCK_CONFIG)
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result['data'][CONF_TOKEN] == MOCK_CREDS
@@ -123,6 +124,8 @@ async def test_multiple_flow_implementation(hass):
         result = await flow.async_step_user()
         assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
         assert result['step_id'] == 'link'
+
+        await hass.async_block_till_done()
 
     # Step Link
     with patch('pyps4_homeassistant.Helper.has_devices',

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -52,6 +52,7 @@ async def test_full_flow_implementation(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
+    hass.config_entries = manager
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -100,6 +101,7 @@ async def test_multiple_flow_implementation(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
+    hass.config_entries = manager
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -224,6 +226,7 @@ async def test_additional_device(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
+    hass.config_entries = manager
 
     # Mock existing entry.
     entry = MockConfigEntry(domain=ps4.DOMAIN, data=MOCK_DATA)

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -118,15 +118,17 @@ async def test_multiple_flow_implementation(hass):
     mock_data = {
         CONF_TOKEN: result['data'][CONF_TOKEN],
         'devices': result['data']['devices']}
+
     # User Step Started, results in Step Link:
     MockConfigEntry(domain=ps4.DOMAIN, data=mock_data).add_to_hass(hass)
     with patch('pyps4_homeassistant.Helper.port_bind',
-               return_value=None):
+               return_value=None), \
+            patch('pyps4_homeassistant.Helper.has_devices',
+                  return_value=[{'host-ip': MOCK_HOST},
+                                {'host-ip': MOCK_HOST_ADDITIONAL}]):
         result = await flow.async_step_user()
         assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
         assert result['step_id'] == 'link'
-
-        await hass.async_block_till_done()
 
     # Step Link
     with patch('pyps4_homeassistant.Helper.has_devices',

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -50,12 +50,10 @@ async def test_full_flow_implementation(hass):
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
 
-    """Init config manager."""
+    # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    manager._entries = []
+    manager._entries = []  # noqa: pylint: disable=protected-access
     hass.config_entries = manager
-    # Check if there are no entries.
-    assert len(manager.async_entries()) == 0
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -102,12 +100,10 @@ async def test_multiple_flow_implementation(hass):
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
 
-    """Init config manager."""
+    # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    manager._entries = []
+    manager._entries = []   # noqa: pylint: disable=protected-access
     hass.config_entries = manager
-    # Check if there are no entries.
-    assert len(manager.async_entries()) == 0
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -230,9 +226,9 @@ async def test_additional_device(hass):
     flow.hass = hass
     flow.creds = MOCK_CREDS
 
-    """Init config manager."""
+    # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    manager._entries = []
+    manager._entries = []  # noqa: pylint: disable=protected-access
     hass.config_entries = manager
 
     # Mock existing entry.

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -1,7 +1,7 @@
 """Define tests for the PlayStation 4 config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import data_entry_flow
 from homeassistant.components import ps4
 from homeassistant.components.ps4.const import (
     DEFAULT_NAME, DEFAULT_REGION)
@@ -49,7 +49,7 @@ async def test_full_flow_implementation(hass):
     """Test registering an implementation and flow works."""
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
-    manager = flow.hass.config_entries()
+    manager = hass.config_entries
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -95,7 +95,7 @@ async def test_multiple_flow_implementation(hass):
     """Test multiple device flows."""
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
-    manager = flow.hass.config_entries()
+    manager = hass.config_entries
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -217,7 +217,7 @@ async def test_additional_device(hass):
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
     flow.creds = MOCK_CREDS
-    manager = flow.hass.config_entries()
+    manager = hass.config_entries
 
     # Mock existing entry.
     entry = MockConfigEntry(domain=ps4.DOMAIN, data=MOCK_DATA)

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -49,10 +49,7 @@ async def test_full_flow_implementation(hass):
     """Test registering an implementation and flow works."""
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
-
-    # Init config manager.
-    manager = config_entries.ConfigEntries(hass, {})
-    hass.config_entries = manager
+    manager = flow.hass.config_entries()
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -98,10 +95,7 @@ async def test_multiple_flow_implementation(hass):
     """Test multiple device flows."""
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
-
-    # Init config manager.
-    manager = config_entries.ConfigEntries(hass, {})
-    hass.config_entries = manager
+    manager = flow.hass.config_entries()
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -223,10 +217,7 @@ async def test_additional_device(hass):
     flow = ps4.PlayStation4FlowHandler()
     flow.hass = hass
     flow.creds = MOCK_CREDS
-
-    # Init config manager.
-    manager = config_entries.ConfigEntries(hass, {})
-    hass.config_entries = manager
+    manager = flow.hass.config_entries()
 
     # Mock existing entry.
     entry = MockConfigEntry(domain=ps4.DOMAIN, data=MOCK_DATA)

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -126,7 +126,7 @@ async def test_multiple_flow_implementation(hass):
     assert result['data']['devices'] == [MOCK_DEVICE]
     assert result['title'] == MOCK_TITLE
 
-        await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # Add entry using result data.
     mock_data = {
@@ -161,7 +161,7 @@ async def test_multiple_flow_implementation(hass):
         result = await flow.async_step_link(user_input=MOCK_CONFIG_ADDITIONAL)
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['data'][CONF_TOKEN] == MOCK_CREDS
-        assert len(result['data']['devices']) == 1
+    assert len(result['data']['devices']) == 1
     assert result['title'] == MOCK_TITLE
 
     mock_data = {
@@ -233,7 +233,7 @@ async def test_additional_device(hass):
         result = await flow.async_step_link(user_input=MOCK_CONFIG_ADDITIONAL)
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['data'][CONF_TOKEN] == MOCK_CREDS
-        assert len(result['data']['devices']) == 1
+    assert len(result['data']['devices']) == 1
     assert result['title'] == MOCK_TITLE
 
     # Add New Entry

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -52,7 +52,6 @@ async def test_full_flow_implementation(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    manager._entries = []  # noqa: pylint: disable=protected-access
     hass.config_entries = manager
 
     # User Step Started, results in Step Creds
@@ -102,7 +101,6 @@ async def test_multiple_flow_implementation(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    manager._entries = []   # noqa: pylint: disable=protected-access
     hass.config_entries = manager
 
     # User Step Started, results in Step Creds
@@ -228,7 +226,6 @@ async def test_additional_device(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    manager._entries = []  # noqa: pylint: disable=protected-access
     hass.config_entries = manager
 
     # Mock existing entry.

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -55,8 +55,8 @@ async def test_full_flow_implementation(hass):
     with patch('pyps4_homeassistant.Helper.port_bind',
                return_value=None):
         result = await flow.async_step_user()
-        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert result['step_id'] == 'creds'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'creds'
 
     # Step Creds results with form in Step Link.
     with patch('pyps4_homeassistant.Helper.get_creds',
@@ -64,8 +64,8 @@ async def test_full_flow_implementation(hass):
             patch('pyps4_homeassistant.Helper.has_devices',
                   return_value=[{'host-ip': MOCK_HOST}]):
         result = await flow.async_step_creds({})
-        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert result['step_id'] == 'link'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'link'
 
     # User Input results in created entry.
     with patch('pyps4_homeassistant.Helper.link',
@@ -73,10 +73,10 @@ async def test_full_flow_implementation(hass):
             patch('pyps4_homeassistant.Helper.has_devices',
                   return_value=[{'host-ip': MOCK_HOST}]):
         result = await flow.async_step_link(MOCK_CONFIG)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result['data'][CONF_TOKEN] == MOCK_CREDS
-        assert result['data']['devices'] == [MOCK_DEVICE]
-        assert result['title'] == MOCK_TITLE
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['data'][CONF_TOKEN] == MOCK_CREDS
+    assert result['data']['devices'] == [MOCK_DEVICE]
+    assert result['title'] == MOCK_TITLE
 
     # Add entry using result data.
     mock_data = {
@@ -101,8 +101,8 @@ async def test_multiple_flow_implementation(hass):
     with patch('pyps4_homeassistant.Helper.port_bind',
                return_value=None):
         result = await flow.async_step_user()
-        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert result['step_id'] == 'creds'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'creds'
 
     # Step Creds results with form in Step Link.
     with patch('pyps4_homeassistant.Helper.get_creds',
@@ -111,8 +111,8 @@ async def test_multiple_flow_implementation(hass):
                   return_value=[{'host-ip': MOCK_HOST},
                                 {'host-ip': MOCK_HOST_ADDITIONAL}]):
         result = await flow.async_step_creds({})
-        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert result['step_id'] == 'link'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'link'
 
     # User Input results in created entry.
     with patch('pyps4_homeassistant.Helper.link',
@@ -121,10 +121,10 @@ async def test_multiple_flow_implementation(hass):
                   return_value=[{'host-ip': MOCK_HOST},
                                 {'host-ip': MOCK_HOST_ADDITIONAL}]):
         result = await flow.async_step_link(MOCK_CONFIG)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result['data'][CONF_TOKEN] == MOCK_CREDS
-        assert result['data']['devices'] == [MOCK_DEVICE]
-        assert result['title'] == MOCK_TITLE
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['data'][CONF_TOKEN] == MOCK_CREDS
+    assert result['data']['devices'] == [MOCK_DEVICE]
+    assert result['title'] == MOCK_TITLE
 
         await hass.async_block_till_done()
 
@@ -149,8 +149,8 @@ async def test_multiple_flow_implementation(hass):
                   return_value=[{'host-ip': MOCK_HOST},
                                 {'host-ip': MOCK_HOST_ADDITIONAL}]):
         result = await flow.async_step_user()
-        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert result['step_id'] == 'link'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'link'
 
     # Step Link
     with patch('pyps4_homeassistant.Helper.has_devices',
@@ -159,10 +159,10 @@ async def test_multiple_flow_implementation(hass):
             patch('pyps4_homeassistant.Helper.link',
                   return_value=(True, True)):
         result = await flow.async_step_link(user_input=MOCK_CONFIG_ADDITIONAL)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result['data'][CONF_TOKEN] == MOCK_CREDS
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['data'][CONF_TOKEN] == MOCK_CREDS
         assert len(result['data']['devices']) == 1
-        assert result['title'] == MOCK_TITLE
+    assert result['title'] == MOCK_TITLE
 
     mock_data = {
         CONF_TOKEN: result['data'][CONF_TOKEN],
@@ -188,15 +188,15 @@ async def test_port_bind_abort(hass):
                return_value=MOCK_UDP_PORT):
         reason = 'port_987_bind_error'
         result = await flow.async_step_user(user_input=None)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result['reason'] == reason
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result['reason'] == reason
 
     with patch('pyps4_homeassistant.Helper.port_bind',
                return_value=MOCK_TCP_PORT):
         reason = 'port_997_bind_error'
         result = await flow.async_step_user(user_input=None)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result['reason'] == reason
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result['reason'] == reason
 
 
 async def test_duplicate_abort(hass):
@@ -208,8 +208,8 @@ async def test_duplicate_abort(hass):
     with patch('pyps4_homeassistant.Helper.has_devices',
                return_value=[{'host-ip': MOCK_HOST}]):
         result = await flow.async_step_link(user_input=None)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result['reason'] == 'devices_configured'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result['reason'] == 'devices_configured'
 
 
 async def test_additional_device(hass):
@@ -231,10 +231,10 @@ async def test_additional_device(hass):
             patch('pyps4_homeassistant.Helper.link',
                   return_value=(True, True)):
         result = await flow.async_step_link(user_input=MOCK_CONFIG_ADDITIONAL)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result['data'][CONF_TOKEN] == MOCK_CREDS
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['data'][CONF_TOKEN] == MOCK_CREDS
         assert len(result['data']['devices']) == 1
-        assert result['title'] == MOCK_TITLE
+    assert result['title'] == MOCK_TITLE
 
     # Add New Entry
     entry = MockConfigEntry(domain=ps4.DOMAIN, data=MOCK_DATA)
@@ -251,8 +251,8 @@ async def test_no_devices_found_abort(hass):
 
     with patch('pyps4_homeassistant.Helper.has_devices', return_value=None):
         result = await flow.async_step_link(MOCK_CONFIG)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result['reason'] == 'no_devices_found'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result['reason'] == 'no_devices_found'
 
 
 async def test_credential_abort(hass):
@@ -262,8 +262,8 @@ async def test_credential_abort(hass):
 
     with patch('pyps4_homeassistant.Helper.get_creds', return_value=None):
         result = await flow.async_step_creds({})
-        assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result['reason'] == 'credential_error'
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result['reason'] == 'credential_error'
 
 
 async def test_invalid_pin_error(hass):
@@ -276,9 +276,9 @@ async def test_invalid_pin_error(hass):
             patch('pyps4_homeassistant.Helper.has_devices',
                   return_value=[{'host-ip': MOCK_HOST}]):
         result = await flow.async_step_link(MOCK_CONFIG)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert result['step_id'] == 'link'
-        assert result['errors'] == {'base': 'login_failed'}
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'link'
+    assert result['errors'] == {'base': 'login_failed'}
 
 
 async def test_device_connection_error(hass):
@@ -291,6 +291,6 @@ async def test_device_connection_error(hass):
             patch('pyps4_homeassistant.Helper.has_devices',
                   return_value=[{'host-ip': MOCK_HOST}]):
         result = await flow.async_step_link(MOCK_CONFIG)
-        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert result['step_id'] == 'link'
-        assert result['errors'] == {'base': 'not_ready'}
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'link'
+    assert result['errors'] == {'base': 'not_ready'}

--- a/tests/components/ps4/test_config_flow.py
+++ b/tests/components/ps4/test_config_flow.py
@@ -52,7 +52,6 @@ async def test_full_flow_implementation(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    hass.config_entries = manager
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -101,7 +100,6 @@ async def test_multiple_flow_implementation(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    hass.config_entries = manager
 
     # User Step Started, results in Step Creds
     with patch('pyps4_homeassistant.Helper.port_bind',
@@ -226,7 +224,6 @@ async def test_additional_device(hass):
 
     # Init config manager.
     manager = config_entries.ConfigEntries(hass, {})
-    hass.config_entries = manager
 
     # Mock existing entry.
     entry = MockConfigEntry(domain=ps4.DOMAIN, data=MOCK_DATA)


### PR DESCRIPTION
## Description:
Added support for the use of multiple PS4 devices. Additional devices can be added by starting the ps4 config flow again.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8679

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
