### PR TITLE
Add the velbus sync clock service

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -66,7 +66,8 @@ async def async_setup(hass, config):
         controller.sync_clock()
 
     controller.scan(callback)
-    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock, schema=vol.Schema({}))
+    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock,
+            schema=vol.Schema({}))
 
     return True
 

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -62,11 +62,11 @@ async def async_setup(hass, config):
         load_platform(hass, 'sensor', DOMAIN,
                       discovery_info['sensor'], config)
 
-    def syn_clock(self):
+    def syn_clock(self, service=None):
         controller.sync_clock()
 
     controller.scan(callback)
-    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock)
+    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock, schema=vol.Schema({}))
 
     return True
 

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -65,7 +65,6 @@ async def async_setup(hass, config):
     def syn_clock(self):
         controller.sync_clock()
 
-
     controller.scan(callback)
     hass.services.async_register(DOMAIN, 'sync_clock', syn_clock)
 

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -66,8 +66,9 @@ async def async_setup(hass, config):
         controller.sync_clock()
 
     controller.scan(callback)
-    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock,
-            schema=vol.Schema({}))
+    hass.services.async_register(
+        DOMAIN, 'sync_clock', syn_clock,
+        schema=vol.Schema({}))
 
     return True
 

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -61,12 +61,13 @@ async def async_setup(hass, config):
                       discovery_info['binary_sensor'], config)
         load_platform(hass, 'sensor', DOMAIN,
                       discovery_info['sensor'], config)
+
     def syn_clock(self):
-        controller.sync_clock();
+        controller.sync_clock()
 
 
     controller.scan(callback)
-    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock )
+    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock)
 
     return True
 

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_PORT
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-velbus==2.0.21']
+REQUIREMENTS = ['python-velbus==2.0.22']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,8 +61,12 @@ async def async_setup(hass, config):
                       discovery_info['binary_sensor'], config)
         load_platform(hass, 'sensor', DOMAIN,
                       discovery_info['sensor'], config)
+    def syn_clock(self):
+        controller.sync_clock();
+
 
     controller.scan(callback)
+    hass.services.async_register(DOMAIN, 'sync_clock', syn_clock )
 
     return True
 

--- a/homeassistant/components/velbus/services.yaml
+++ b/homeassistant/components/velbus/services.yaml
@@ -1,0 +1,2 @@
+sync_clock:
+  description: Sync the velbus modules clock to the HASS clock, this is the same as the 'sync clock' from VelbusLink

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1385,7 +1385,7 @@ python-telegram-bot==11.1.0
 python-twitch-client==0.6.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.21
+python-velbus==2.0.22
 
 # homeassistant.components.media_player.vlc
 python-vlc==1.1.2


### PR DESCRIPTION
## Description:

This adds a new service to the velbus component. When calling this service it will do a 'sync clock' action from VelbusLink. It will synchronize the modules time with the system time of HA.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
