### PR TITLE
Check for attribute existence for HS220 support

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -222,12 +222,11 @@ class TPLinkSmartBulb(Light):
 
         if self.smartbulb.is_dimmable:
             self._supported_features += SUPPORT_BRIGHTNESS
-        if hasattr(self.smartbulb, 'is_variable_color_temp') \
-                and self.smartbulb.is_variable_color_temp:
+        if getattr(self.smartbulb, 'is_variable_color_temp', False):
             self._supported_features += SUPPORT_COLOR_TEMP
             self._min_mireds = kelvin_to_mired(
                 self.smartbulb.valid_temperature_range[1])
             self._max_mireds = kelvin_to_mired(
                 self.smartbulb.valid_temperature_range[0])
-        if hasattr(self.smartbulb, 'is_color') and self.smartbulb.is_color:
+        if getattr(self.smartbulb, 'is_color', False):
             self._supported_features += SUPPORT_COLOR

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -222,11 +222,12 @@ class TPLinkSmartBulb(Light):
 
         if self.smartbulb.is_dimmable:
             self._supported_features += SUPPORT_BRIGHTNESS
-        if self.smartbulb.is_variable_color_temp:
+        if hasattr(self.smartbulb, 'is_variable_color_temp') \
+                and self.smartbulb.is_variable_color_temp:
             self._supported_features += SUPPORT_COLOR_TEMP
             self._min_mireds = kelvin_to_mired(
                 self.smartbulb.valid_temperature_range[1])
             self._max_mireds = kelvin_to_mired(
                 self.smartbulb.valid_temperature_range[0])
-        if self.smartbulb.is_color:
+        if hasattr(self.smartbulb, 'is_color') and self.smartbulb.is_color:
             self._supported_features += SUPPORT_COLOR


### PR DESCRIPTION
## Description:
The HS220 acts as a smartplug and does not currently contain `is_color` nor `is_variable_color_temp` attributes, causing this to crash on those devices.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
