### PR TITLE
Implementing freedaily mode for Openweathermap

### DIFF
--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTRIBUTION = 'Data provided by OpenWeatherMap'
 
-FORECAST_MODE = ['hourly', 'daily']
+FORECAST_MODE = ['hourly', 'daily', 'freedaily']
 
 DEFAULT_NAME = 'OpenWeatherMap'
 
@@ -152,7 +152,12 @@ class OpenWeatherMapWeather(WeatherEntity):
                 return None
             return round(rain_value + snow_value, 1)
 
-        for entry in self.forecast_data.get_weathers():
+        if self._mode == 'freedaily':
+            weather = self.forecast_data.get_weathers()[::8]
+        else:
+            weather = self.forecast_data.get_weathers()
+
+        for entry in weather:
             if self._mode == 'daily':
                 data.append({
                     ATTR_FORECAST_TIME:


### PR DESCRIPTION
adressing #15105 and add a freedaily mode for a 5 day forecast with free API key

## Description:
work based on this comment: https://github.com/home-assistant/home-assistant/issues/15105#issuecomment-466381364

**Related issue (if applicable):** fixes #15105 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
- [ ] updating documentation: [todo](https://github.com/home-assistant/home-assistant.io/blob/current/source/_components/weather.openweathermap.markdown)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
