### PR TITLE
Allow custom_effect to be absent from Flux configuration

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -166,9 +166,13 @@ class FluxLight(Light):
         self._ipaddr = device['ipaddr']
         self._protocol = device[CONF_PROTOCOL]
         self._mode = device[ATTR_MODE]
-        self._custom_effect = device[CONF_CUSTOM_EFFECT]
         self._bulb = None
         self._error_reported = False
+
+        if CONF_CUSTOM_EFFECT in device:
+            self._custom_effect = device[CONF_CUSTOM_EFFECT]
+        else:
+            self._custom_effect = {}
 
     def _connect(self):
         """Connect to Flux light."""

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -151,6 +151,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device['name'] = '{} {}'.format(device['id'], ipaddr)
         device[ATTR_MODE] = MODE_RGBW
         device[CONF_PROTOCOL] = None
+        device[CONF_CUSTOM_EFFECT] = None
         light = FluxLight(device)
         lights.append(light)
 
@@ -166,13 +167,9 @@ class FluxLight(Light):
         self._ipaddr = device['ipaddr']
         self._protocol = device[CONF_PROTOCOL]
         self._mode = device[ATTR_MODE]
+        self._custom_effect = device[CONF_CUSTOM_EFFECT]
         self._bulb = None
         self._error_reported = False
-
-        if CONF_CUSTOM_EFFECT in device:
-            self._custom_effect = device[CONF_CUSTOM_EFFECT]
-        else:
-            self._custom_effect = {}
 
     def _connect(self):
         """Connect to Flux light."""


### PR DESCRIPTION
## Description:

Fixing issue that raised key error if custom_effect was not included in configuration.

**Related issue (if applicable):** fixes #21281

flux_led not working in HA 0.88.0 #21281


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: flux_led
    automatic_add: True
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
