### PR TITLE
Add friendly name to devices in the device registry

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -50,13 +50,13 @@ async def websocket_update_device(hass, connection, msg):
     """Handle update area websocket command."""
     registry = await async_get_registry(hass)
 
-    entry = registry.async_update_device(
-        msg['device_id'],
-        area_id=msg['area_id'],
-        name_by_user=msg['name_by_user'])
+    msg.pop('type')
+    msg_id = msg.pop('id')
+
+    entry = registry.async_update_device(**msg)
 
     connection.send_message(websocket_api.result_message(
-        msg['id'], _entry_dict(entry)
+        msg_id, _entry_dict(entry)
     ))
 
 

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -19,7 +19,7 @@ SCHEMA_WS_UPDATE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_UPDATE,
     vol.Required('device_id'): str,
     vol.Optional('area_id'): vol.Any(str, None),
-    vol.Optional('friendly_name'): vol.Any(str, None),
+    vol.Optional('name_by_user'): vol.Any(str, None),
 })
 
 
@@ -53,7 +53,7 @@ async def websocket_update_device(hass, connection, msg):
     entry = registry.async_update_device(
         msg['device_id'],
         area_id=msg['area_id'],
-        friendly_name=msg['friendly_name'])
+        name_by_user=msg['name_by_user'])
 
     connection.send_message(websocket_api.result_message(
         msg['id'], _entry_dict(entry)
@@ -73,5 +73,5 @@ def _entry_dict(entry):
         'id': entry.id,
         'hub_device_id': entry.hub_device_id,
         'area_id': entry.area_id,
-        'friendly_name': entry.friendly_name,
+        'name_by_user': entry.name_by_user,
     }

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -19,6 +19,7 @@ SCHEMA_WS_UPDATE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_UPDATE,
     vol.Required('device_id'): str,
     vol.Optional('area_id'): vol.Any(str, None),
+    vol.Optional('friendly_name'): vol.Any(str, None),
 })
 
 
@@ -50,7 +51,9 @@ async def websocket_update_device(hass, connection, msg):
     registry = await async_get_registry(hass)
 
     entry = registry.async_update_device(
-        msg['device_id'], area_id=msg['area_id'])
+        msg['device_id'],
+        area_id=msg['area_id'],
+        friendly_name=msg['friendly_name'])
 
     connection.send_message(websocket_api.result_message(
         msg['id'], _entry_dict(entry)
@@ -70,4 +73,5 @@ def _entry_dict(entry):
         'id': entry.id,
         'hub_device_id': entry.hub_device_id,
         'area_id': entry.area_id,
+        'friendly_name': entry.friendly_name,
     }

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -37,6 +37,7 @@ class DeviceEntry:
     sw_version = attr.ib(type=str, default=None)
     hub_device_id = attr.ib(type=str, default=None)
     area_id = attr.ib(type=str, default=None)
+    friendly_name = attr.ib(type=str, default=None)
     id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
 
 
@@ -124,9 +125,11 @@ class DeviceRegistry:
         )
 
     @callback
-    def async_update_device(self, device_id, *, area_id=_UNDEF):
+    def async_update_device(
+            self, device_id, *, area_id=_UNDEF, friendly_name=_UNDEF):
         """Update properties of a device."""
-        return self._async_update_device(device_id, area_id=area_id)
+        return self._async_update_device(
+            device_id, area_id=area_id, friendly_name=friendly_name)
 
     @callback
     def _async_update_device(self, device_id, *, add_config_entry_id=_UNDEF,
@@ -138,7 +141,8 @@ class DeviceRegistry:
                              name=_UNDEF,
                              sw_version=_UNDEF,
                              hub_device_id=_UNDEF,
-                             area_id=_UNDEF):
+                             area_id=_UNDEF,
+                             friendly_name=_UNDEF):
         """Update device attributes."""
         old = self.devices[device_id]
 
@@ -179,6 +183,10 @@ class DeviceRegistry:
         if (area_id is not _UNDEF and area_id != old.area_id):
             changes['area_id'] = area_id
 
+        if (friendly_name is not _UNDEF and
+                friendly_name != old.friendly_name):
+            changes['friendly_name'] = friendly_name
+
         if not changes:
             return old
 
@@ -208,7 +216,8 @@ class DeviceRegistry:
                     # Introduced in 0.79
                     hub_device_id=device.get('hub_device_id'),
                     # Introduced in 0.87
-                    area_id=device.get('area_id')
+                    area_id=device.get('area_id'),
+                    friendly_name=device.get('friendly_name')
                 )
 
         self.devices = devices
@@ -234,7 +243,8 @@ class DeviceRegistry:
                 'sw_version': entry.sw_version,
                 'id': entry.id,
                 'hub_device_id': entry.hub_device_id,
-                'area_id': entry.area_id
+                'area_id': entry.area_id,
+                'friendly_name': entry.friendly_name
             } for entry in self.devices.values()
         ]
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -37,7 +37,7 @@ class DeviceEntry:
     sw_version = attr.ib(type=str, default=None)
     hub_device_id = attr.ib(type=str, default=None)
     area_id = attr.ib(type=str, default=None)
-    friendly_name = attr.ib(type=str, default=None)
+    name_by_user = attr.ib(type=str, default=None)
     id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
 
 
@@ -126,10 +126,10 @@ class DeviceRegistry:
 
     @callback
     def async_update_device(
-            self, device_id, *, area_id=_UNDEF, friendly_name=_UNDEF):
+            self, device_id, *, area_id=_UNDEF, name_by_user=_UNDEF):
         """Update properties of a device."""
         return self._async_update_device(
-            device_id, area_id=area_id, friendly_name=friendly_name)
+            device_id, area_id=area_id, name_by_user=name_by_user)
 
     @callback
     def _async_update_device(self, device_id, *, add_config_entry_id=_UNDEF,
@@ -142,7 +142,7 @@ class DeviceRegistry:
                              sw_version=_UNDEF,
                              hub_device_id=_UNDEF,
                              area_id=_UNDEF,
-                             friendly_name=_UNDEF):
+                             name_by_user=_UNDEF):
         """Update device attributes."""
         old = self.devices[device_id]
 
@@ -183,9 +183,9 @@ class DeviceRegistry:
         if (area_id is not _UNDEF and area_id != old.area_id):
             changes['area_id'] = area_id
 
-        if (friendly_name is not _UNDEF and
-                friendly_name != old.friendly_name):
-            changes['friendly_name'] = friendly_name
+        if (name_by_user is not _UNDEF and
+                name_by_user != old.name_by_user):
+            changes['name_by_user'] = name_by_user
 
         if not changes:
             return old
@@ -217,7 +217,7 @@ class DeviceRegistry:
                     hub_device_id=device.get('hub_device_id'),
                     # Introduced in 0.87
                     area_id=device.get('area_id'),
-                    friendly_name=device.get('friendly_name')
+                    name_by_user=device.get('name_by_user')
                 )
 
         self.devices = devices
@@ -244,7 +244,7 @@ class DeviceRegistry:
                 'id': entry.id,
                 'hub_device_id': entry.hub_device_id,
                 'area_id': entry.area_id,
-                'friendly_name': entry.friendly_name
+                'name_by_user': entry.name_by_user
             } for entry in self.devices.values()
         ]
 

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -49,6 +49,7 @@ async def test_list_devices(hass, client, registry):
             'sw_version': None,
             'hub_device_id': None,
             'area_id': None,
+            'friendly_name': None,
         },
         {
             'config_entries': ['1234'],
@@ -59,6 +60,7 @@ async def test_list_devices(hass, client, registry):
             'sw_version': None,
             'hub_device_id': dev1,
             'area_id': None,
+            'friendly_name': None,
         }
     ]
 
@@ -72,11 +74,13 @@ async def test_update_device(hass, client, registry):
         manufacturer='manufacturer', model='model')
 
     assert not device.area_id
+    assert not device.friendly_name
 
     await client.send_json({
         'id': 1,
         'device_id': device.id,
         'area_id': '12345A',
+        'friendly_name': 'Test Friendly Name',
         'type': 'config/device_registry/update',
     })
 
@@ -84,4 +88,5 @@ async def test_update_device(hass, client, registry):
 
     assert msg['result']['id'] == device.id
     assert msg['result']['area_id'] == '12345A'
+    assert msg['result']['friendly_name'] == 'Test Friendly Name'
     assert len(registry.devices) == 1

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -49,7 +49,7 @@ async def test_list_devices(hass, client, registry):
             'sw_version': None,
             'hub_device_id': None,
             'area_id': None,
-            'friendly_name': None,
+            'name_by_user': None,
         },
         {
             'config_entries': ['1234'],
@@ -60,7 +60,7 @@ async def test_list_devices(hass, client, registry):
             'sw_version': None,
             'hub_device_id': dev1,
             'area_id': None,
-            'friendly_name': None,
+            'name_by_user': None,
         }
     ]
 
@@ -74,13 +74,13 @@ async def test_update_device(hass, client, registry):
         manufacturer='manufacturer', model='model')
 
     assert not device.area_id
-    assert not device.friendly_name
+    assert not device.name_by_user
 
     await client.send_json({
         'id': 1,
         'device_id': device.id,
         'area_id': '12345A',
-        'friendly_name': 'Test Friendly Name',
+        'name_by_user': 'Test Friendly Name',
         'type': 'config/device_registry/update',
     })
 
@@ -88,5 +88,5 @@ async def test_update_device(hass, client, registry):
 
     assert msg['result']['id'] == device.id
     assert msg['result']['area_id'] == '12345A'
-    assert msg['result']['friendly_name'] == 'Test Friendly Name'
+    assert msg['result']['name_by_user'] == 'Test Friendly Name'
     assert len(registry.devices) == 1

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -134,7 +134,7 @@ async def test_loading_from_storage(hass, hass_storage):
                     'name': 'name',
                     'sw_version': 'version',
                     'area_id': '12345A',
-                    'friendly_name': 'Test Friendly Name'
+                    'name_by_user': 'Test Friendly Name'
                 }
             ]
         }
@@ -149,7 +149,7 @@ async def test_loading_from_storage(hass, hass_storage):
         manufacturer='manufacturer', model='model')
     assert entry.id == 'abcdefghijklm'
     assert entry.area_id == '12345A'
-    assert entry.friendly_name == 'Test Friendly Name'
+    assert entry.name_by_user == 'Test Friendly Name'
     assert isinstance(entry.config_entries, set)
 
 
@@ -362,11 +362,11 @@ async def test_update(registry):
         })
 
     assert not entry.area_id
-    assert not entry.friendly_name
+    assert not entry.name_by_user
 
     updated_entry = registry.async_update_device(
-        entry.id, area_id='12345A', friendly_name='Test Friendly Name')
+        entry.id, area_id='12345A', name_by_user='Test Friendly Name')
 
     assert updated_entry != entry
     assert updated_entry.area_id == '12345A'
-    assert updated_entry.friendly_name == 'Test Friendly Name'
+    assert updated_entry.name_by_user == 'Test Friendly Name'

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -133,7 +133,8 @@ async def test_loading_from_storage(hass, hass_storage):
                     'model': 'model',
                     'name': 'name',
                     'sw_version': 'version',
-                    'area_id': '12345A'
+                    'area_id': '12345A',
+                    'friendly_name': 'Test Friendly Name'
                 }
             ]
         }
@@ -148,6 +149,7 @@ async def test_loading_from_storage(hass, hass_storage):
         manufacturer='manufacturer', model='model')
     assert entry.id == 'abcdefghijklm'
     assert entry.area_id == '12345A'
+    assert entry.friendly_name == 'Test Friendly Name'
     assert isinstance(entry.config_entries, set)
 
 
@@ -360,8 +362,11 @@ async def test_update(registry):
         })
 
     assert not entry.area_id
+    assert not entry.friendly_name
 
-    updated_entry = registry.async_update_device(entry.id, area_id='12345A')
+    updated_entry = registry.async_update_device(
+        entry.id, area_id='12345A', friendly_name='Test Friendly Name')
 
     assert updated_entry != entry
     assert updated_entry.area_id == '12345A'
+    assert updated_entry.friendly_name == 'Test Friendly Name'


### PR DESCRIPTION
This adds the ability to set a friendly name on devices in the device registry. Currently it can only be set through the API. This will be used to allow custom names so that #21242 can be corrected. 