### PR TITLE
Update luci device tracker

### DIFF
--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -66,7 +66,7 @@ class LuciDeviceScanner(DeviceScanner):
         """
         Get extra attributes of a device.
 
-        Some known extra attributes that may be returned in the dict
+        Some known extra attributes that may be returned in the device tuple
         include Mac Address (mac), Network Device (dev), Ip Address
         (ip), reachable status (reachable), Associated router
         (host), Hostname if known (hostname) among others.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -776,7 +776,7 @@ openhomedevice==0.4.2
 opensensemap-api==0.1.4
 
 # homeassistant.components.device_tracker.luci
-openwrt-luci-rpc==0.3.0
+openwrt-luci-rpc==1.0.5
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
## Description:

* bump pip module version.
* moved named tuple into the module.
* pass SSL bool into the object init.
* support get_extra_attributes

![screenshot 2019-02-22 at 15 41 52](https://user-images.githubusercontent.com/254309/53253443-3060a300-36b9-11e9-9d06-ae8f32e5701a.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23