### PR TITLE
Add config entry support to person tracker

### DIFF
--- a/homeassistant/components/person/.translations/en.json
+++ b/homeassistant/components/person/.translations/en.json
@@ -1,0 +1,9 @@
+{
+    "config": {
+        "title": "Person tracker",
+        "abort": {
+            "already_configured": "Person component is already configured through configuration.yaml",
+            "only_one_entry": "Person component can only have one entry"
+        }
+    }
+}

--- a/homeassistant/components/person/strings.json
+++ b/homeassistant/components/person/strings.json
@@ -1,0 +1,9 @@
+{
+    "config": {
+        "title": "Person tracker",
+        "abort": {
+            "already_configured": "Person component is already configured through configuration.yaml",
+            "only_one_entry": "Person component can only have one entry"
+        }
+    }
+}

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -164,6 +164,7 @@ FLOWS = [
     'nest',
     'openuv',
     'owntracks',
+    'person',
     'point',
     'ps4',
     'rainmachine',

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -2,10 +2,12 @@
 from typing import Dict, Any, Tuple, Optional
 
 import homeassistant.core
+from homeassistant.config_entries import ConfigEntry
 
 # pylint: disable=invalid-name
 
 GPSType = Tuple[float, float]
+ConfigEntryType = ConfigEntry
 ConfigType = Dict[str, Any]
 HomeAssistantType = homeassistant.core.HomeAssistant
 ServiceDataType = Dict[str, Any]


### PR DESCRIPTION
## Description:
Configuration.yaml will always override person config entry.
I don't think we should support unload here.


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.