### PR TITLE
Filter outlier fixes (handle step-changes correctly)

### DIFF
--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -405,9 +405,9 @@ class OutlierFilter(Filter):
 
     def _filter_state(self, new_state):
         """Implement the outlier filter."""
+        median = statistics.median([s.state for s in self.states])
         if (len(self.states) == self.states.maxlen and
-                abs(new_state.state -
-                    statistics.median([s.state for s in self.states])) >
+                abs(new_state.state - median) >
                 self._radius):
 
             self._stats_internal['erasures'] += 1
@@ -415,7 +415,7 @@ class OutlierFilter(Filter):
             _LOGGER.debug("Outlier nr. %s in %s: %s",
                           self._stats_internal['erasures'],
                           self._entity, new_state)
-            return self.states[-1]
+            new_state.state = median
         return new_state
 
 

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -313,6 +313,7 @@ class Filter:
         self._entity = entity
         self._skip_processing = False
         self._window_size = window_size
+        self._store_raw = False
 
     @property
     def window_size(self):
@@ -333,11 +334,11 @@ class Filter:
         """Implement filter."""
         raise NotImplementedError()
 
-    def filter_state(self, new_state, store_raw=False):
+    def filter_state(self, new_state):
         """Implement a common interface for filters."""
         filtered = self._filter_state(FilterState(new_state))
         filtered.set_precision(self.precision)
-        if store_raw:
+        if self._store_raw:
             self.states.append(copy(FilterState(new_state)))
         else:
             self.states.append(copy(filtered))
@@ -405,9 +406,7 @@ class OutlierFilter(Filter):
         super().__init__(FILTER_NAME_OUTLIER, window_size, precision, entity)
         self._radius = radius
         self._stats_internal = Counter()
-
-    def filter_state(self, new_state, store_raw=True):
-        return super().filter_state(new_state, store_raw)
+        self._store_raw = True
 
     def _filter_state(self, new_state):
         """Implement the outlier filter."""

--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -411,7 +411,7 @@ class OutlierFilter(Filter):
     def _filter_state(self, new_state):
         """Implement the outlier filter."""
         median = statistics.median([s.state for s in self.states]) \
-            if len(self.states) > 0 else 0
+            if self.states else 0
         if (len(self.states) == self.states.maxlen and
                 abs(new_state.state - median) >
                 self._radius):

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -111,8 +111,13 @@ class TestFilterSensor(unittest.TestCase):
         assert 21 == filtered.state
 
     def test_outlier_step(self):
-        """Test if outlier filter handles long-running
-        step-changes correctly."""
+        """
+        Test step-change handling in outlier.
+
+        Test if outlier filter handles long-running step-changes correctly.
+        It should converge to no longer filter once just over half the
+        window_size is occupied by the new post step-change values.
+        """
         filt = OutlierFilter(window_size=3,
                              precision=2,
                              entity=None,

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -108,6 +108,16 @@ class TestFilterSensor(unittest.TestCase):
                              radius=4.0)
         for state in self.values:
             filtered = filt.filter_state(state)
+        assert 21 == filtered.state
+
+    def test_outlier_step(self):
+        """Test if outlier filter handles long-running step-changes correctly."""
+        filt = OutlierFilter(window_size=3,
+                             precision=2,
+                             entity=None,
+                             radius=1.0)
+        for state in self.values[:-1]:
+            filtered = filt.filter_state(state)
         assert 22 == filtered.state
 
     def test_initial_outlier(self):

--- a/tests/components/sensor/test_filter.py
+++ b/tests/components/sensor/test_filter.py
@@ -111,12 +111,14 @@ class TestFilterSensor(unittest.TestCase):
         assert 21 == filtered.state
 
     def test_outlier_step(self):
-        """Test if outlier filter handles long-running step-changes correctly."""
+        """Test if outlier filter handles long-running
+        step-changes correctly."""
         filt = OutlierFilter(window_size=3,
                              precision=2,
                              entity=None,
-                             radius=1.0)
-        for state in self.values[:-1]:
+                             radius=1.1)
+        self.values[-1].state = 22
+        for state in self.values:
             filtered = filt.filter_state(state)
         assert 22 == filtered.state
 
@@ -129,7 +131,7 @@ class TestFilterSensor(unittest.TestCase):
         out = ha.State('sensor.test_monitored', 4000)
         for state in [out]+self.values:
             filtered = filt.filter_state(state)
-        assert 22 == filtered.state
+        assert 21 == filtered.state
 
     def test_lowpass(self):
         """Test if lowpass filter works."""


### PR DESCRIPTION
## Description:
As currently implemented, the outlier filter has two issues:
* Documentation at https://www.home-assistant.io/components/sensor.filter/#outlier implies that the outlier filter returns the median of the windowed values in the case of outliers, when in fact it returns the **last** sensor value.
* Outlier filter doesn't handle step-changes in the source sensor correctly, because it operates on filtered values and gets "stuck" indefinitely in the event of a step-change until the value returns to the original window.

This came up because I was attempting to filter "glitches" for a power monitoring input, *without* also filtering legitimate periods where the device has turned off for more than a single reading or two
![14964562-2de2-497c-8a18-be7f5294849d png](https://user-images.githubusercontent.com/246440/53266557-f500ad00-3695-11e9-8bf2-827ea4fb2bad.jpg)

Filter behaviour post-fix below. Before fixing, the filtered output would "ride" over the legitimate power-off periods, cutting off the zero-watt periods, regardless of how short the window_size was:
![70fccc1f-388d-468a-8268-97e9c1a91459 png](https://user-images.githubusercontent.com/246440/53266661-5a549e00-3696-11e9-96c7-af70c3b5be27.jpg)

This PR adjusts the return of the outlier filter to actually provide the median as documented, and corrects the indefinite step-change degenerate case by allowing the outlier filter to store raw values in its `self.states`

Accomplishing this required adding an optional override to `filter_state()` to allow specific filter types to store the raw values instead of the filtered values - some filters other than outlier expect to act on a rolling log of filtered states (at least as currently implemented) but an outlier filter that correctly catches "outliers" (based on the window size) without also capturing step-changes exceeding the radius requires this.

Apologies in advance if I'm not following the submission procedure correctly as this is my first PR.

## Entry for `configuration.yaml` (tested against hass instance using the below sensor):
```yaml
  - platform: filter
    name: ac_power_filtered
    entity_id: sensor.ac_power
    filters:
      - filter: outlier
        window_size: 3
        radius: 600
        precision: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
Tests pass locally when run against pytest for the sensor filters source file manually, but I can't get the full tox suite to run correctly in my dev environment (Windows). Hopefully somebody can assist by running the full test suite against this to double-check there are no issues, but it should be ok as the scope of changes was only in filter.py.
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
