### PR TITLE
Allow google home component device tracker to be optional

### DIFF
--- a/homeassistant/components/googlehome/__init__.py
+++ b/homeassistant/components/googlehome/__init__.py
@@ -20,6 +20,7 @@ NAME = 'GoogleHome'
 CONF_DEVICE_TYPES = 'device_types'
 CONF_RSSI_THRESHOLD = 'rssi_threshold'
 CONF_TRACK_ALARMS = 'track_alarms'
+CONF_TRACK_DEVICES = 'track_devices'
 
 DEVICE_TYPES = [1, 2, 3]
 DEFAULT_RSSI_THRESHOLD = -70
@@ -31,6 +32,7 @@ DEVICE_CONFIG = vol.Schema({
     vol.Optional(CONF_RSSI_THRESHOLD, default=DEFAULT_RSSI_THRESHOLD):
         vol.Coerce(int),
     vol.Optional(CONF_TRACK_ALARMS, default=False): cv.boolean,
+    vol.Optional(CONF_TRACK_DEVICES, default=True): cv.boolean,
 })
 
 
@@ -48,9 +50,10 @@ async def async_setup(hass, config):
 
     for device in config[DOMAIN][CONF_DEVICES]:
         hass.data[DOMAIN][device['host']] = {}
-        hass.async_create_task(
-            discovery.async_load_platform(
-                hass, 'device_tracker', DOMAIN, device, config))
+        if device[CONF_TRACK_DEVICES]:
+            hass.async_create_task(
+                discovery.async_load_platform(
+                    hass, 'device_tracker', DOMAIN, device, config))
 
         if device[CONF_TRACK_ALARMS]:
             hass.async_create_task(


### PR DESCRIPTION
## Description:

Allow users to disable the device tracker so they can only use alarms and timers if they decide to do so.  Can also be useful if several google homes are in close proximity of each other so they can decide which to use.

This is a non-breaking change as the default behavior has not been changed.  Just a setting to disable it was added.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8701
## Example entry for `configuration.yaml` (if applicable):
```yaml
googlehome:
  devices:
    - host: 192.168.1.2
      track_devices: False
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
