### PR TITLE
Add Wake over Lan support for Panasonic Viera

### DIFF
--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -59,20 +59,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         else:
             uuid = None
         remote = RemoteControl(host, port)
-        add_entities([PanasonicVieraTVDevice(mac, name, remote, uuid)])
+        add_entities([PanasonicVieraTVDevice(mac, name, remote, host, uuid)])
         return True
 
     host = config.get(CONF_HOST)
     remote = RemoteControl(host, port)
 
-    add_entities([PanasonicVieraTVDevice(mac, name, remote)])
+    add_entities([PanasonicVieraTVDevice(mac, name, remote, host)])
     return True
 
 
 class PanasonicVieraTVDevice(MediaPlayerDevice):
     """Representation of a Panasonic Viera TV."""
 
-    def __init__(self, mac, name, remote, uuid=None):
+    def __init__(self, mac, name, remote, host, uuid=None):
         """Initialize the Panasonic device."""
         import wakeonlan
         # Save a reference to the imported class
@@ -84,6 +84,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         self._playing = True
         self._state = None
         self._remote = remote
+        self._host = host
         self._volume = 0
 
     @property
@@ -140,7 +141,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
     def turn_on(self):
         """Turn on the media player."""
         if self._mac:
-            self._wol.send_magic_packet(self._mac)
+            self._wol.send_magic_packet(self._mac, ip_address=self._host)
             self._state = STATE_ON
 
     def turn_off(self):


### PR DESCRIPTION


## Description:
Pass a ip address of device to WOL. Without it will not work on my TV.

`Tox` didn't pass. Tried `pylint homeassistant/components/media_player/panasonic_v                             iera.py` and it say:
`panasonic_viera.py:45:4: E0611: No name 'RemoteControl' in module 'pana                             sonic_viera' (no-name-in-module)` and this part I didn't touch.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: panasonic_viera
    host: "10.0.1.108"
    mac: "20:C6:EB:AB:8B:20"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
