### PR TITLE
Fixing buienradar sensor config key error

### DIFF
--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -137,6 +137,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                   'Latitude and longitude must exist together'): cv.longitude,
     vol.Optional(CONF_TIMEFRAME, default=60):
         vol.All(vol.Coerce(int), vol.Range(min=5, max=120)),
+    vol.Optional(CONF_NAME, default='br'): cv.string,
 })
 
 
@@ -161,7 +162,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     dev = []
     for sensor_type in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(BrSensor(sensor_type, config.get(CONF_NAME, 'br'),
+        dev.append(BrSensor(sensor_type, config.get(CONF_NAME),
                             coordinates))
     async_add_entities(dev)
 


### PR DESCRIPTION
## Description:
Fixing warning about unsupported config key 'name' in Buienradar sensor, whilst it was actually supported (but just not validated).

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `sensors.yaml`:
```yaml
### This will set the sensor name to sensor.volkel_[monitored_condition], 
### i.e. sensor.volkel_temperature
- platform: buienradar
  name: 'volkel'
  monitored_conditions:
    - stationname
    - condition
    - temperature

### This will set the sensor name to the default 'br': 
### sensor.br_[monitored_condition], i.e. sensor.br_temperature
- platform: buienradar
  monitored_conditions:
    - stationname
    - condition
    - temperature
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
