### PR TITLE
Add conf_key check for LCN platform load

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -184,10 +184,10 @@ async def async_setup(hass, config):
     for component, conf_key in (('cover', CONF_COVERS),
                                 ('light', CONF_LIGHTS),
                                 ('switch', CONF_SWITCHES)):
-        hass.async_create_task(
-            async_load_platform(hass, component, DOMAIN,
-                                config[DOMAIN][conf_key], config))
-
+        if conf_key in config[DOMAIN]:
+            hass.async_create_task(
+                async_load_platform(hass, component, DOMAIN,
+                                    config[DOMAIN][conf_key], config))
     return True
 
 


### PR DESCRIPTION
## Description:
Depending on the configuration, platforms for the LCN component are loaded on demand. This implements the missing configuration key-check just before the corresponding platform is loaded.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
