### PR TITLE
Fix person update on create

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -337,12 +337,18 @@ class Person(RestoreEntity):
         if state:
             self._parse_source_state(state)
 
-        @callback
-        def person_start_hass(now):
+        if self.hass.is_running:
+            # Update person now if hass is already running.
             self.person_updated()
+        else:
+            # Wait for hass start to not have race between person
+            # and device trackers finishing setup.
+            @callback
+            def person_start_hass(now):
+                self.person_updated()
 
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, person_start_hass)
+            self.hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_START, person_start_hass)
 
     @callback
     def person_updated(self):

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -101,6 +101,7 @@ async def test_valid_invalid_user_ids(hass, hass_admin_user):
 
 async def test_setup_tracker(hass, hass_admin_user):
     """Test set up person with one device tracker."""
+    hass.state = CoreState.not_running
     user_id = hass_admin_user.id
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
@@ -148,6 +149,7 @@ async def test_setup_tracker(hass, hass_admin_user):
 
 async def test_setup_two_trackers(hass, hass_admin_user):
     """Test set up person with two device trackers."""
+    hass.state = CoreState.not_running
     user_id = hass_admin_user.id
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
@@ -191,6 +193,7 @@ async def test_setup_two_trackers(hass, hass_admin_user):
 
 async def test_ignore_unavailable_states(hass, hass_admin_user):
     """Test set up person with two device trackers, one unavailable."""
+    hass.state = CoreState.not_running
     user_id = hass_admin_user.id
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
@@ -234,7 +237,7 @@ async def test_restore_home_state(hass, hass_admin_user):
         ATTR_SOURCE: DEVICE_TRACKER, ATTR_USER_ID: user_id}
     state = State('person.tracked_person', 'home', attrs)
     mock_restore_cache(hass, (state, ))
-    hass.state = CoreState.starting
+    hass.state = CoreState.not_running
     mock_component(hass, 'recorder')
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -266,6 +266,21 @@ async def test_duplicate_ids(hass, hass_admin_user):
     assert hass.states.get('person.test_user_2') is None
 
 
+async def test_create_person_during_run(hass):
+    """Test that person is updated if created while hass is running."""
+    config = {DOMAIN: {}}
+    assert await async_setup_component(hass, DOMAIN, config)
+    hass.states.async_set(DEVICE_TRACKER, 'home')
+    await hass.async_block_till_done()
+
+    await hass.components.person.async_create_person(
+        'tracked person', device_trackers=[DEVICE_TRACKER])
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == 'home'
+
+
 async def test_load_person_storage(hass, hass_admin_user, storage_setup):
     """Test set up person from storage."""
     state = hass.states.get('person.tracked_person')


### PR DESCRIPTION
## Description:
If home assistant is already running after start, a person that is created should be updated, and not wait for home assistant start to be updated.

**Related issue (if applicable):**
fixes #21334 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.