### PR TITLE
Improve tolerance of SmartThings Climate platform

### DIFF
--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -1,8 +1,10 @@
 """Support for climate devices through the SmartThings cloud API."""
 import asyncio
-from typing import Optional, Sequence
+import logging
+from typing import Iterable, Optional, Sequence
 
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN, ClimateDevice)
 from homeassistant.components.climate.const import (
     ATTR_OPERATION_MODE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     STATE_AUTO, STATE_COOL, STATE_ECO, STATE_HEAT, SUPPORT_FAN_MODE,
@@ -38,6 +40,8 @@ UNIT_MAP = {
     'F': TEMP_FAHRENHEIT
 }
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -50,7 +54,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
     async_add_entities(
         [SmartThingsThermostat(device) for device in broker.devices.values()
-         if broker.any_assigned(device.device_id, 'climate')])
+         if broker.any_assigned(device.device_id, CLIMATE_DOMAIN)], True)
 
 
 def get_capabilities(capabilities: Sequence[str]) -> Optional[Sequence[str]]:
@@ -90,6 +94,8 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
         """Init the class."""
         super().__init__(device)
         self._supported_features = self._determine_features()
+        self._current_operation = None
+        self._operation_list = None
 
     def _determine_features(self):
         from pysmartthings import Capability
@@ -127,6 +133,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
         if operation_state:
             mode = STATE_TO_MODE[operation_state]
             await self._device.set_thermostat_mode(mode, set_status=True)
+            await self.async_update()
 
         # Heat/cool setpoint
         heating_setpoint = None
@@ -151,6 +158,24 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
         # the entity state ahead of receiving the confirming push updates
         self.async_schedule_update_ha_state(True)
 
+    async def async_update(self):
+        """Update the attributes of the climate device."""
+        thermostat_mode = self._device.status.thermostat_mode
+        self._current_operation = MODE_TO_STATE.get(thermostat_mode)
+        if self._current_operation is None:
+            _LOGGER.debug('Device %s (%s) returned an invalid'
+                          'thermostat_mode: %s', self._device.label,
+                          self._device.device_id, thermostat_mode)
+
+        operation_mode_list = self._device.status.supported_thermostat_modes
+        if isinstance(operation_mode_list, Iterable):
+            self._operation_list = {MODE_TO_STATE.get(mode) for mode
+                                    in operation_mode_list}
+        else:
+            _LOGGER.debug('Device %s (%s) returned an invalid'
+                          'operation_mode_list: %s', self._device.label,
+                          self._device.device_id, operation_mode_list)
+
     @property
     def current_fan_mode(self):
         """Return the fan setting."""
@@ -164,7 +189,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
     @property
     def current_operation(self):
         """Return current operation ie. heat, cool, idle."""
-        return MODE_TO_STATE[self._device.status.thermostat_mode]
+        return self._current_operation
 
     @property
     def current_temperature(self):
@@ -187,8 +212,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
     @property
     def operation_list(self):
         """Return the list of available operation modes."""
-        return {MODE_TO_STATE[mode] for mode in
-                self._device.status.supported_thermostat_modes}
+        return self._operation_list
 
     @property
     def supported_features(self):

--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -164,17 +164,26 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
         self._current_operation = MODE_TO_STATE.get(thermostat_mode)
         if self._current_operation is None:
             _LOGGER.debug('Device %s (%s) returned an invalid'
-                          'thermostat_mode: %s', self._device.label,
+                          'thermostat mode: %s', self._device.label,
                           self._device.device_id, thermostat_mode)
 
-        operation_mode_list = self._device.status.supported_thermostat_modes
-        if isinstance(operation_mode_list, Iterable):
-            self._operation_list = {MODE_TO_STATE.get(mode) for mode
-                                    in operation_mode_list}
+        supported_modes = self._device.status.supported_thermostat_modes
+        if isinstance(supported_modes, Iterable):
+            operations = set()
+            for mode in supported_modes:
+                state = MODE_TO_STATE.get(mode)
+                if state is not None:
+                    operations.add(state)
+                else:
+                    _LOGGER.debug('Device %s (%s) returned an invalid '
+                                  'supported thermostat mode: %s',
+                                  self._device.label, self._device.device_id,
+                                  mode)
+            self._operation_list = operations
         else:
-            _LOGGER.debug('Device %s (%s) returned an invalid'
-                          'operation_mode_list: %s', self._device.label,
-                          self._device.device_id, operation_mode_list)
+            _LOGGER.debug('Device %s (%s) returned invalid supported '
+                          'thermostat modes: %s', self._device.label,
+                          self._device.device_id, supported_modes)
 
     @property
     def current_fan_mode(self):

--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -95,7 +95,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
         super().__init__(device)
         self._supported_features = self._determine_features()
         self._current_operation = None
-        self._operation_list = None
+        self._operations = None
 
     def _determine_features(self):
         from pysmartthings import Capability
@@ -179,7 +179,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
                                   'supported thermostat mode: %s',
                                   self._device.label, self._device.device_id,
                                   mode)
-            self._operation_list = operations
+            self._operations = operations
         else:
             _LOGGER.debug('Device %s (%s) returned invalid supported '
                           'thermostat modes: %s', self._device.label,
@@ -221,7 +221,7 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
     @property
     def operation_list(self):
         """Return the list of available operation modes."""
-        return self._operation_list
+        return self._operations
 
     @property
     def supported_features(self):

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -107,9 +107,9 @@ def buggy_thermostat_fixture(device_factory):
             Capability.thermostat_heating_setpoint,
             Capability.thermostat_mode],
         status={
+            Attribute.thermostat_mode: 'heating',
             Attribute.cooling_setpoint: 74,
-            Attribute.heating_setpoint: 68,
-            Attribute.thermostat_fan_mode: 'on'}
+            Attribute.heating_setpoint: 68}
     )
     device.status.attributes[Attribute.temperature] = Status(70, 'F', None)
     return device
@@ -183,6 +183,16 @@ async def test_buggy_thermostat_entity_state(hass, buggy_thermostat):
     assert ATTR_OPERATION_LIST not in state.attributes
     assert state.attributes[ATTR_TEMPERATURE] is None
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 21.1  # celsius
+
+
+async def test_buggy_thermostat_invalid_mode(hass, buggy_thermostat):
+    """Tests when an invalid operation mode is included."""
+    buggy_thermostat.status.update_attribute_value(
+        Attribute.supported_thermostat_modes,
+        ['heat', 'emergency heat', 'other'])
+    await setup_platform(hass, CLIMATE_DOMAIN, buggy_thermostat)
+    state = hass.states.get('climate.buggy_thermostat')
+    assert state.attributes[ATTR_OPERATION_LIST] == {'heat'}
 
 
 async def test_set_fan_mode(hass, thermostat):


### PR DESCRIPTION
## Description:
This change improves the tolerance in the SmartThings climate platform for custom device type handlers that do not properly implement the thermostat capability.  This will allow the entities to load, but have partial functionality, compared to logging an error today, providing a better user experience until the root cause of the buggy device type handlers can be resolved.

**Related issue (if applicable):** fixes #21298 


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added and updated to verify that the new code works.