### PR TITLE
Handle GA Disconnect intent

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -229,8 +229,7 @@ async def _process(hass, config, message):
 
     if result is None:
         return None
-    else:
-        return {'requestId': request_id, 'payload': result}
+    return {'requestId': request_id, 'payload': result}
 
 
 @HANDLERS.register('action.devices.SYNC')

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -187,7 +187,7 @@ async def async_handle_message(hass, config, message):
     """Handle incoming API messages."""
     response = await _process(hass, config, message)
 
-    if 'errorCode' in response['payload']:
+    if response and 'errorCode' in response['payload']:
         _LOGGER.error('Error handling message %s: %s',
                       message, response['payload'])
 
@@ -215,7 +215,6 @@ async def _process(hass, config, message):
 
     try:
         result = await handler(hass, config, inputs[0].get('payload'))
-        return {'requestId': request_id, 'payload': result}
     except SmartHomeError as err:
         return {
             'requestId': request_id,
@@ -227,6 +226,11 @@ async def _process(hass, config, message):
             'requestId': request_id,
             'payload': {'errorCode': ERR_UNKNOWN_ERROR}
         }
+
+    if result is None:
+        return None
+    else:
+        return {'requestId': request_id, 'payload': result}
 
 
 @HANDLERS.register('action.devices.SYNC')
@@ -335,6 +339,15 @@ async def handle_devices_execute(hass, config, payload):
         })
 
     return {'commands': final_results}
+
+
+@HANDLERS.register('action.devices.DISCONNECT')
+async def async_devices_disconnect(hass, config, payload):
+    """Handle action.devices.DISCONNECT request.
+
+    https://developers.google.com/actions/smarthome/create#actiondevicesdisconnect
+    """
+    return None
 
 
 def turned_off_response(message):

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -316,3 +316,15 @@ async def test_empty_name_doesnt_sync(hass):
             'devices': []
         }
     }
+
+
+async def test_query_disconnect(hass):
+    """Test a disconnect message."""
+    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
+        'inputs': [
+            {'intent': 'action.devices.DISCONNECT'}
+        ],
+        'requestId': REQ_ID
+    })
+
+    assert result is None


### PR DESCRIPTION
## Description:
Implement the GA disconnect intent https://developers.google.com/actions/smarthome/create#actiondevicesdisconnect

Implementation does nothing as we don't support report state yet. By not having it implemented, it was raising an exception.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
