### PR TITLE
Mark water_heater as significant domain

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
-SIGNIFICANT_DOMAINS = ('thermostat', 'climate')
+SIGNIFICANT_DOMAINS = ('thermostat', 'climate', 'water_heater')
 IGNORE_DOMAINS = ('zone', 'scene',)
 
 


### PR DESCRIPTION
## Description:
water_heater have same temperature behavior as climate, and should be marked as significant

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
