### PR TITLE
Add target_temp_high/low and current_temperature

### DIFF
--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -39,8 +39,6 @@ STATE_GAS = 'gas'
 SUPPORT_TARGET_TEMPERATURE = 1
 SUPPORT_OPERATION_MODE = 2
 SUPPORT_AWAY_MODE = 4
-SUPPORT_TARGET_TEMPERATURE_HIGH = 8
-SUPPORT_TARGET_TEMPERATURE_LOW = 16
 
 ATTR_MAX_TEMP = 'max_temp'
 ATTR_MIN_TEMP = 'min_temp'
@@ -149,6 +147,12 @@ class WaterHeaterDevice(Entity):
             ATTR_TEMPERATURE: show_temp(
                 self.hass, self.target_temperature, self.temperature_unit,
                 self.precision),
+            ATTR_TARGET_TEMP_HIGH: show_temp(
+                self.hass, self.target_temperature_high, self.temperature_unit,
+                self.precision),
+            ATTR_TARGET_TEMP_LOW: show_temp(
+                self.hass, self.target_temperature_low, self.temperature_unit,
+                self.precision),
         }
 
         supported_features = self.supported_features
@@ -161,16 +165,6 @@ class WaterHeaterDevice(Entity):
         if supported_features & SUPPORT_AWAY_MODE:
             is_away = self.is_away_mode_on
             data[ATTR_AWAY_MODE] = STATE_ON if is_away else STATE_OFF
-
-        if supported_features & SUPPORT_TARGET_TEMPERATURE_HIGH:
-            data[ATTR_TARGET_TEMP_HIGH] = show_temp(
-                self.hass, self.target_temperature_high, self.temperature_unit,
-                self.precision)
-
-        if supported_features & SUPPORT_TARGET_TEMPERATURE_LOW:
-            data[ATTR_TARGET_TEMP_LOW] = show_temp(
-                self.hass, self.target_temperature_low, self.temperature_unit,
-                self.precision)
 
         return data
 

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -39,12 +39,17 @@ STATE_GAS = 'gas'
 SUPPORT_TARGET_TEMPERATURE = 1
 SUPPORT_OPERATION_MODE = 2
 SUPPORT_AWAY_MODE = 4
+SUPPORT_TARGET_TEMPERATURE_HIGH = 8
+SUPPORT_TARGET_TEMPERATURE_LOW = 16
 
 ATTR_MAX_TEMP = 'max_temp'
 ATTR_MIN_TEMP = 'min_temp'
 ATTR_AWAY_MODE = 'away_mode'
 ATTR_OPERATION_MODE = 'operation_mode'
 ATTR_OPERATION_LIST = 'operation_list'
+ATTR_TARGET_TEMP_HIGH = 'target_temp_high'
+ATTR_TARGET_TEMP_LOW = 'target_temp_low'
+ATTR_CURRENT_TEMPERATURE = 'current_temperature'
 
 CONVERTIBLE_ATTRIBUTE = [
     ATTR_TEMPERATURE,
@@ -132,6 +137,9 @@ class WaterHeaterDevice(Entity):
     def state_attributes(self):
         """Return the optional state attributes."""
         data = {
+            ATTR_CURRENT_TEMPERATURE: show_temp(
+                self.hass, self.current_temperature, self.temperature_unit,
+                self.precision),
             ATTR_MIN_TEMP: show_temp(
                 self.hass, self.min_temp, self.temperature_unit,
                 self.precision),
@@ -154,6 +162,16 @@ class WaterHeaterDevice(Entity):
             is_away = self.is_away_mode_on
             data[ATTR_AWAY_MODE] = STATE_ON if is_away else STATE_OFF
 
+        if supported_features & SUPPORT_TARGET_TEMPERATURE_HIGH:
+            data[ATTR_TARGET_TEMP_HIGH] = show_temp(
+                self.hass, self.target_temperature_high, self.temperature_unit,
+                self.precision)
+
+        if supported_features & SUPPORT_TARGET_TEMPERATURE_LOW:
+            data[ATTR_TARGET_TEMP_LOW] = show_temp(
+                self.hass, self.target_temperature_low, self.temperature_unit,
+                self.precision)
+
         return data
 
     @property
@@ -172,8 +190,23 @@ class WaterHeaterDevice(Entity):
         return None
 
     @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return None
+
+    @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
+        return None
+
+    @property
+    def target_temperature_high(self):
+        """Return the highbound target temperature we try to reach."""
+        return None
+
+    @property
+    def target_temperature_low(self):
+        """Return the lowbound target temperature we try to reach."""
         return None
 
     @property


### PR DESCRIPTION
water_heater piggy back on climate(thermostat) component in gui,
so these things are already supported by frontend for display
purposes. (and sort of already works by using device_state_attributes)

## Description:
This is an attempt to make the water_heater component a bit more usable without really touching
on the architectural issues with it. 

**Related issue (if applicable):** partial #19093

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
