### PR TITLE
Set SCAN_INTERVAL for CO2Signal component

### DIFF
--- a/homeassistant/components/sensor/co2signal.py
+++ b/homeassistant/components/sensor/co2signal.py
@@ -55,6 +55,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                           country_code,
                           lat,
                           lon,
+                          hass,
                           scan_interval))
     add_entities(devs, True)
 
@@ -62,14 +63,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class CO2Sensor(Entity):
     """Implementation of the CO2Signal sensor."""
 
-    def __init__(self, token, country_code, lat, lon, scan_interval=SCAN_INTERVAL):
+    def __init__(self, token, country_code, lat, lon, hass, scan_interval=SCAN_INTERVAL):
         """Initialize the sensor."""
         self._token = token
         self._country_code = country_code
         self._latitude = lat
         self._longitude = lon
         self._data = None
-        self._scan_interval = scan_interval
 
         if country_code is not None:
             device_name = country_code
@@ -79,6 +79,8 @@ class CO2Sensor(Entity):
                         lon=round(self._longitude, 2))
 
         self._friendly_name = 'CO2 intensity - {}'.format(device_name)
+
+        track_time_interval(hass, self.update, scan_interval)
 
     @property
     def name(self):
@@ -121,6 +123,3 @@ class CO2Sensor(Entity):
                 latitude=self._latitude, longitude=self._longitude)
 
         self._data = round(self._data, 2)
-
-        # update values every CONF_SCAN_INTERVAL
-        track_time_interval(hass, update, self._scan_interval)

--- a/homeassistant/components/sensor/co2signal.py
+++ b/homeassistant/components/sensor/co2signal.py
@@ -109,7 +109,7 @@ class CO2Sensor(Entity):
         """Return the state attributes of the last update."""
         return {ATTR_ATTRIBUTION: ATTRIBUTION}
 
-    @Throttle(SCAN_INTERVAL)  # at most call it every 60 seconds (SCAN_INTERVAL)
+    @Throttle(SCAN_INTERVAL)  # at most call it every SCAN_INTERVAL
     def update(self):
         """Get the latest data and updates the states."""
         import CO2Signal

--- a/homeassistant/components/sensor/co2signal.py
+++ b/homeassistant/components/sensor/co2signal.py
@@ -10,7 +10,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, CONF_TOKEN, CONF_LATITUDE, CONF_LONGITUDE, CONF_SCAN_INTERVAL)
+    ATTR_ATTRIBUTION, CONF_TOKEN, CONF_LATITUDE, CONF_LONGITUDE,
+    CONF_SCAN_INTERVAL)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
@@ -63,7 +64,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class CO2Sensor(Entity):
     """Implementation of the CO2Signal sensor."""
 
-    def __init__(self, token, country_code, lat, lon, hass, scan_interval=SCAN_INTERVAL):
+    def __init__(self, token, country_code, lat, lon, hass,
+                 scan_interval=SCAN_INTERVAL):
         """Initialize the sensor."""
         self._token = token
         self._country_code = country_code
@@ -107,7 +109,7 @@ class CO2Sensor(Entity):
         """Return the state attributes of the last update."""
         return {ATTR_ATTRIBUTION: ATTRIBUTION}
 
-    @Throttle(SCAN_INTERVAL) # at most call it every 60 seconds (SCAN_INTERVAL)
+    @Throttle(SCAN_INTERVAL)  # at most call it every 60 seconds (SCAN_INTERVAL)
     def update(self):
         """Get the latest data and updates the states."""
         import CO2Signal


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #21139 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io
Todo

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: co2signal
    token: YOUR_CO2SIGNAL_API_KEY
    scan_interval: 120
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
