### PR TITLE
Add HomematicIP HmIP-OC8 support

### DIFF
--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -50,8 +50,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         elif isinstance(device, PlugableSwitch):
             devices.append(HomematicipSwitch(home, device))
         elif isinstance(device, OpenCollector8Module):
-            for index in range(0, 7):
-                device.append(HomematicipMultiSwitch(home, device, index))
+            for index in range(1, 9):
+                devices.append(HomematicipMultiSwitch(home, device, index))
 
     if devices:
         async_add_entities(devices)
@@ -94,18 +94,23 @@ class HomematicipSwitchMeasuring(HomematicipSwitch):
         return round(self._device.energyCounter)
 
 
-class HomematicipMultiSwitch(HomematicipSwitch):
+class HomematicipMultiSwitch(HomematicipGenericDevice, SwitchDevice):
     """Representation of a HomematicIP Cloud multi switch device."""
 
-    def __init__(self, home, device, channelIndex):
-        """Initialize the switch device."""
-        self.channelIndex = channelIndex
-        super().__init__(home, device, 'channel{}'.format(channelIndex))
+    def __init__(self, home, device, index):
+        """Initialize the multi switch device."""
+        self.channelIndex = index
+        super().__init__(home, device, 'channel{}'.format(index))
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return "{}_{}_{}".format(self.__class__.__name__, self.post, self._device.id)
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._device.on
+        return self._device.on[self.channelIndex]
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
@@ -114,11 +119,3 @@ class HomematicipMultiSwitch(HomematicipSwitch):
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
         await self._device.turn_off(self.channelIndex)
-
-
-def getHomematicIPOpenCollector8(home, device, index):
-    """Initialize the 8 channel open collector switch device."""
-    self.channels = []
-    for index in range(0, 7):
-        self.channels.append(HomematicipMultiSwitch(home, device, index))
-    return channels

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -100,7 +100,7 @@ class HomematicipMultiSwitch(HomematicipGenericDevice, SwitchDevice):
     def __init__(self, home, device, index):
         """Initialize the multi switch device."""
         self.channelIndex = index
-        super().__init__(home, device, 'channel{}'.format(index))
+        super().__init__(home, device, 'ch{}'.format(index))
 
     @property
     def unique_id(self):
@@ -110,7 +110,7 @@ class HomematicipMultiSwitch(HomematicipGenericDevice, SwitchDevice):
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._device.on[self.channelIndex]
+        return self._device.functionalChannels[self.channelIndex].on
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""

--- a/tests/components/homematicip_cloud/test_switch.py
+++ b/tests/components/homematicip_cloud/test_switch.py
@@ -1,0 +1,57 @@
+"""Test HomematicIP Cloud switch devices."""
+
+from unittest.mock import Mock, patch
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components import homematicip_cloud as hmipc
+from homeassistant.bootstrap import async_setup_component
+
+from tests.common import mock_coro, MockConfigEntry
+
+from homeassistant.components.homematicip_cloud import (
+    HomematicipGenericDevice)
+from homeassistant.components.homematicip_cloud.switch import (
+    HomematicipSwitch, HomematicipOpenCollector8)
+
+
+async def test_switch_is_on(hass):
+    """Test switch is on HomematicIP Cloud."""
+
+    from homematicip.aio.device import AsyncPlugableSwitch
+    connection = Mock()
+    home = Mock()
+    device = AsyncPlugableSwitch(connection)
+    device.on = True
+    switch = HomematicipSwitch(home, device)
+    assert switch.is_on is True
+
+async def test_switch_turn_on_and_off(hass):
+    """Test turning on and off HomematicIP Cloud switch."""
+
+    from homematicip.aio.device import AsyncPlugableSwitch
+    connection = Mock()
+    home = Mock()
+    device = AsyncPlugableSwitch(connection)
+    switch = HomematicipSwitch(home, device)
+    with patch.object(device, 'set_switch_state',
+        return_value = mock_coro(True)):
+        await switch.async_turn_on()
+        assert device.set_switch_state.called
+        await switch.async_turn_off()
+        assert device.set_switch_state.called
+
+
+async def test_switch_turn_on_and_off(hass):
+    """Test turning on and off HomematicIP Cloud switch."""
+
+    from homematicip.aio.device import AsyncOpenCollector8Module
+    connection = Mock()
+    home = Mock()
+    device = AsyncOpenCollector8Module(connection)
+    switch = HomematicipOpenCollector8(home, device)
+    with patch.object(device, 'set_switch_state',
+        return_value = mock_coro(True)):
+        await switch.async_turn_on()
+        assert device.set_switch_state.called
+        await switch.async_turn_off()
+        assert device.set_switch_state.called


### PR DESCRIPTION
## Description:
Add support for the HmIP-OC8 module

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
