### PR TITLE
Tellstick sensor configuration cleanup

### DIFF
--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -81,10 +81,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if not config[CONF_ONLY_NAMED]:
             sensor_name = str(tellcore_sensor.id)
         else:
-            if not tellcore_sensor.id in named_sensors:
+            if tellcore_sensor.id not in named_sensors:
                 continue
             sensor_name = named_sensors[tellcore_sensor.id]
-            
+
         for datatype in sensor_value_descriptions:
             if datatype & datatype_mask and \
                tellcore_sensor.has_value(datatype):

--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -81,11 +81,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if not config[CONF_ONLY_NAMED]:
             sensor_name = str(tellcore_sensor.id)
         else:
-            if tellcore_sensor.id in named_sensors:
-                sensor_name = named_sensors[tellcore_sensor.id]
-            else:
+            if not tellcore_sensor.id in named_sensors:
                 continue
-
+            sensor_name = named_sensors[tellcore_sensor.id]
+            
         for datatype in sensor_value_descriptions:
             if datatype & datatype_mask and \
                tellcore_sensor.has_value(datatype):

--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -33,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [vol.Schema({
                 vol.Required(CONF_ID): cv.positive_int,
                 vol.Required(CONF_NAME): cv.string,
-        })])
+                })])
 })
 
 
@@ -91,7 +91,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     if tellcore_sensor.has_value(datatype):
                         sensor_info = sensor_value_descriptions[datatype]
                         sensors.append(TellstickSensor(
-                            sensor_name, tellcore_sensor, datatype, sensor_info))
+                            sensor_name, tellcore_sensor, 
+                            datatype, sensor_info))
 
     add_entities(sensors)
 

--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -91,7 +91,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     if tellcore_sensor.has_value(datatype):
                         sensor_info = sensor_value_descriptions[datatype]
                         sensors.append(TellstickSensor(
-                            sensor_name, tellcore_sensor, 
+                            sensor_name, tellcore_sensor,
                             datatype, sensor_info))
 
     add_entities(sensors)

--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -83,7 +83,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         else:
             if tellcore_sensor.id in named_sensors:
                 sensor_name = named_sensors[tellcore_sensor.id]
-            else: 
+            else:
                 continue
 
         for datatype in sensor_value_descriptions:

--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -31,9 +31,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.positive_int,
     vol.Optional(CONF_ONLY_NAMED, default=[]):
         vol.All(cv.ensure_list, [vol.Schema({
-                vol.Required(CONF_ID): cv.positive_int,
-                vol.Required(CONF_NAME): cv.string,
-                })])
+            vol.Required(CONF_ID): cv.positive_int,
+            vol.Required(CONF_NAME): cv.string,
+            })])
 })
 
 
@@ -91,7 +91,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     if tellcore_sensor.has_value(datatype):
                         sensor_info = sensor_value_descriptions[datatype]
                         sensors.append(TellstickSensor(
-                            sensor_name, tellcore_sensor,
+                            sensor_name, tellcore_sensor, 
                             datatype, sensor_info))
 
     add_entities(sensors)

--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -88,10 +88,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for datatype in sensor_value_descriptions:
             if datatype & datatype_mask and \
                tellcore_sensor.has_value(datatype):
-                    sensor_info = sensor_value_descriptions[datatype]
-                    sensors.append(TellstickSensor(
-                        sensor_name, tellcore_sensor,
-                        datatype, sensor_info))
+                sensor_info = sensor_value_descriptions[datatype]
+                sensors.append(TellstickSensor(
+                    sensor_name, tellcore_sensor,
+                    datatype, sensor_info))
 
     add_entities(sensors)
 


### PR DESCRIPTION
## Breaking Changes
The way Tellsick sensor configuration was set up using dynamic values for named sensors will not be supported in future versions of Home Assistant.  

Users that have configured the optional named sensors initiated with `only_named` will have to update their configuration.

**Previous releases:**
```yaml
  - platform: tellstick
    only_named: true
    92: Outdoor
    19: Rain
```
From v0.88 users would receive warning for this type of configuration.  

**New way of configuring named sensors:**
```yaml
  - platform: tellstick
    only_named:
       - id: 92
         name: Outdoor
       - id: 19
         name: Rain
```


## Description:
Corrected an invalid way of having dynamic keys in configuration. This will prevent the component to break in coming release(s).

Issue was highlighted from 0.88.x as a warning notification for keys in configuration that is not supported in coming versions.

**Related issue (if applicable):** fixes #21395

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8716

## Example entry for `configuration.yaml` (if applicable):
Old way - wrong:
```yaml
  - platform: tellstick
    only_named: true
    92: Utomhus
    19: Regn
```

New way - corrected:
```yaml
  - platform: tellstick
    only_named:
       - id: 92
         name: Utomhus
       - id: 19
         name: Regn
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
