### PR TITLE
Added ELV PCA 301 smart emeter switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -607,6 +607,7 @@ omit =
     homeassistant/components/switch/mystrom.py
     homeassistant/components/switch/netio.py
     homeassistant/components/switch/orvibo.py
+    homeassistant/components/switch/pca.py
     homeassistant/components/switch/pencom.py
     homeassistant/components/switch/pulseaudio_loopback.py
     homeassistant/components/switch/rainbird.py

--- a/homeassistant/components/switch/pca.py
+++ b/homeassistant/components/switch/pca.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import (
-    SwitchDevice, PLATFORM_SCHEMA, ATTR_CURRENT_POWER_W, ATTR_TODAY_ENERGY_KWH)
+    SwitchDevice, PLATFORM_SCHEMA, ATTR_CURRENT_POWER_W)
 from homeassistant.const import (
     CONF_NAME, CONF_DEVICE, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/switch/pca.py
+++ b/homeassistant/components/switch/pca.py
@@ -5,14 +5,13 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.pca/
 """
 import logging
-import time
 
 import voluptuous as vol
 
 from homeassistant.components.switch import (
     SwitchDevice, PLATFORM_SCHEMA, ATTR_CURRENT_POWER_W, ATTR_TODAY_ENERGY_KWH)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, ATTR_VOLTAGE, CONF_DEVICE, EVENT_HOMEASSISTANT_STOP)
+    CONF_NAME, CONF_DEVICE, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pypca==0.0.1']
@@ -51,6 +50,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, pca.close)
 
     pca.start_scan()
+
 
 class SmartPlugSwitch(SwitchDevice):
     """Representation of a TPLink Smart Plug switch."""
@@ -94,10 +94,11 @@ class SmartPlugSwitch(SwitchDevice):
 
     def update(self):
         """Update the TP-Link switch's state."""
-        import pypca
         try:
-            self._emeter_params[ATTR_CURRENT_POWER_W] = "{:.1f}".format(self._pca.get_current_power(self._deviceId))
-            self._emeter_params[ATTR_TOTAL_ENERGY_KWH] = "{:.2f}".format(self._pca.get_total_consumption(self._deviceId))
+            self._emeter_params[ATTR_CURRENT_POWER_W] = "{:.1f}".format(
+                self._pca.get_current_power(self._deviceId))
+            self._emeter_params[ATTR_TOTAL_ENERGY_KWH] = "{:.2f}".format(
+                self._pca.get_total_consumption(self._deviceId))
 
             self._available = True
             self._state = self._pca.get_state(self._deviceId)

--- a/homeassistant/components/switch/pca.py
+++ b/homeassistant/components/switch/pca.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_DEVICE, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pypca==0.0.1']
+REQUIREMENTS = ['pypca==0.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/pca.py
+++ b/homeassistant/components/switch/pca.py
@@ -80,11 +80,11 @@ class SmartPlugSwitch(SwitchDevice):
         """Return true if switch is on."""
         return self._state
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._pca.turn_on(self._device_id)
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
         """Turn the switch off."""
         self._pca.turn_off(self._device_id)
 

--- a/homeassistant/components/switch/pca.py
+++ b/homeassistant/components/switch/pca.py
@@ -1,0 +1,110 @@
+"""
+Support for PCA 301 smart switch.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.pca/
+"""
+import logging
+import time
+
+import voluptuous as vol
+
+from homeassistant.components.switch import (
+    SwitchDevice, PLATFORM_SCHEMA, ATTR_CURRENT_POWER_W, ATTR_TODAY_ENERGY_KWH)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, ATTR_VOLTAGE, CONF_DEVICE, EVENT_HOMEASSISTANT_STOP)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pypca==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_TOTAL_ENERGY_KWH = 'total_energy_kwh'
+
+DEFAULT_DEVICE = '/dev/ttyUSB0'
+DEFAULT_NAME = 'PCA 301'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the TPLink switch platform."""
+    import pypca
+    from serial import SerialException
+
+    name = config.get(CONF_NAME)
+    usb_device = config.get(CONF_DEVICE)
+
+    try:
+        pca = pypca.PCA(usb_device)
+        pca.open()
+        for device in pca.get_devices():
+            add_entities([SmartPlugSwitch(pca, device, name)], True)
+
+    except SerialException as exc:
+        _LOGGER.warning("Unable to open serial port: %s", exc)
+        return False
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, pca.close)
+
+    pca.start_scan()
+
+class SmartPlugSwitch(SwitchDevice):
+    """Representation of a TPLink Smart Plug switch."""
+
+    def __init__(self, pca, deviceId, name):
+        """Initialize the switch."""
+        self._deviceId = deviceId
+        self._name = name
+        self._state = pca.get_state(self._deviceId)
+        self._available = True
+        self._emeter_params = {}
+        self._pca = pca
+
+    @property
+    def name(self):
+        """Return the name of the Smart Plug, if any."""
+        return self._name
+
+    @property
+    def available(self) -> bool:
+        """Return if switch is available."""
+        return self._available
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state
+
+    def turn_on(self):
+        """Turn the switch on."""
+        self._pca.turn_on(self._deviceId)
+
+    def turn_off(self):
+        """Turn the switch off."""
+        self._pca.turn_off(self._deviceId)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        return self._emeter_params
+
+    def update(self):
+        """Update the TP-Link switch's state."""
+        import pypca
+        try:
+            self._emeter_params[ATTR_CURRENT_POWER_W] = "{:.1f}".format(self._pca.get_current_power(self._deviceId))
+            self._emeter_params[ATTR_TOTAL_ENERGY_KWH] = "{:.2f}".format(self._pca.get_total_consumption(self._deviceId))
+
+            self._available = True
+            self._state = self._pca.get_state(self._deviceId)
+
+        except (OSError) as ex:
+            print("try failed")
+            if self._available:
+                _LOGGER.warning(
+                    "Could not read state for %s: %s", self.name, ex)
+                self._available = False

--- a/homeassistant/components/switch/pca.py
+++ b/homeassistant/components/switch/pca.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_DEVICE, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pypca==0.0.2']
+REQUIREMENTS = ['pypca==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/pca.py
+++ b/homeassistant/components/switch/pca.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_DEVICE, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pypca==0.0.3']
+REQUIREMENTS = ['pypca==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1198,7 +1198,7 @@ pyowlet==1.0.2
 pyowm==2.10.0
 
 # homeassistant.components.switch.pca
-pypca==0.0.2
+pypca==0.0.3
 
 # homeassistant.components.lcn
 pypck==0.5.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1198,7 +1198,7 @@ pyowlet==1.0.2
 pyowm==2.10.0
 
 # homeassistant.components.switch.pca
-pypca==0.0.1
+pypca==0.0.2
 
 # homeassistant.components.lcn
 pypck==0.5.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -78,7 +78,7 @@ TravisPy==0.3.5
 TwitterAPI==2.5.9
 
 # homeassistant.components.sensor.waze_travel_time
-WazeRouteCalculator==0.6
+WazeRouteCalculator==0.9
 
 # homeassistant.components.notify.yessssms
 YesssSMS==0.2.3
@@ -118,7 +118,7 @@ aioharmony==0.1.8
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.0
+aiohue==1.9.1
 
 # homeassistant.components.sensor.iliad_italy
 aioiliad==0.1.1
@@ -154,7 +154,7 @@ amcrest==1.2.3
 anel_pwrctrl-homeassistant==0.0.1.dev2
 
 # homeassistant.components.media_player.anthemav
-anthemav==1.1.8
+anthemav==1.1.9
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.13
@@ -196,7 +196,7 @@ batinfo==0.4.2
 beautifulsoup4==4.7.1
 
 # homeassistant.components.zha
-bellows==0.7.0
+bellows-homeassistant==0.7.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.5.3
@@ -292,7 +292,7 @@ construct==2.9.45
 # credstash==1.15.0
 
 # homeassistant.components.sensor.crimereports
-crimereports==1.0.0
+crimereports==1.0.1
 
 # homeassistant.components.datadog
 datadog==0.15.0
@@ -577,7 +577,7 @@ influxdb==5.2.0
 # homeassistant.components.insteon
 insteonplm==0.15.2
 
-# homeassistant.components.sensor.iperf3
+# homeassistant.components.iperf3
 iperf3==0.1.10
 
 # homeassistant.components.route53
@@ -606,7 +606,7 @@ kiwiki-client==0.1.1
 konnected==0.1.4
 
 # homeassistant.components.eufy
-lakeside==0.11
+lakeside==0.12
 
 # homeassistant.components.owntracks
 libnacl==1.6.1
@@ -681,8 +681,8 @@ mbddns==0.1.2
 # homeassistant.components.notify.message_bird
 messagebird==1.2.0
 
-# homeassistant.components.sensor.meteo_france
-meteofrance==0.2.7
+# homeassistant.components.meteo_france
+meteofrance==0.3.4
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
@@ -722,7 +722,7 @@ nanoleaf==0.4.1
 ndms2_client==0.0.6
 
 # homeassistant.components.ness_alarm
-nessclient==0.9.9
+nessclient==0.9.10
 
 # homeassistant.components.sensor.netdata
 netdata==0.1.2
@@ -752,7 +752,7 @@ nuheat==0.3.0
 # homeassistant.components.image_processing.opencv
 # homeassistant.components.image_processing.tensorflow
 # homeassistant.components.sensor.pollen
-numpy==1.16.0
+numpy==1.16.1
 
 # homeassistant.components.google
 oauth2client==4.0.0
@@ -773,7 +773,10 @@ openevsewifi==0.4
 openhomedevice==0.4.2
 
 # homeassistant.components.air_quality.opensensemap
-opensensemap-api==0.1.3
+opensensemap-api==0.1.4
+
+# homeassistant.components.device_tracker.luci
+openwrt-luci-rpc==1.0.5
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
@@ -853,7 +856,7 @@ prometheus_client==0.2.0
 protobuf==3.6.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.5.0
+psutil==5.5.1
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.3
@@ -889,13 +892,12 @@ py17track==2.1.1
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13
 
-# homeassistant.components.light.tplink
-# homeassistant.components.switch.tplink
+# homeassistant.components.tplink
 pyHS100==0.3.4
 
 # homeassistant.components.air_quality.norway_air
 # homeassistant.components.weather.met
-pyMetno==0.4.5
+pyMetno==0.4.6
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.23
@@ -949,6 +951,9 @@ pyblackbird==0.5
 # homeassistant.components.neato
 pybotvac==0.0.13
 
+# homeassistant.components.nissan_leaf
+pycarwings2==2.8
+
 # homeassistant.components.cloudflare
 pycfdns==0.0.1
 
@@ -977,10 +982,10 @@ pycsspeechtts==1.0.2
 pydaikin==0.9
 
 # homeassistant.components.danfoss_air
-pydanfossair==0.0.6
+pydanfossair==0.0.7
 
 # homeassistant.components.deconz
-pydeconz==47
+pydeconz==52
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
@@ -1053,13 +1058,13 @@ pygtt==1.1.2
 pyhaversion==2.0.3
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.1.9
+pyhik==0.2.2
 
 # homeassistant.components.hive
 pyhiveapi==0.2.17
 
 # homeassistant.components.homematic
-pyhomematic==0.1.55
+pyhomematic==0.1.56
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6
@@ -1185,9 +1190,15 @@ pyotgw==0.4b1
 # homeassistant.components.sensor.otp
 pyotp==2.2.6
 
+# homeassistant.components.owlet
+pyowlet==1.0.2
+
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
 pyowm==2.10.0
+
+# homeassistant.components.switch.pca
+pypca==0.0.1
 
 # homeassistant.components.lcn
 pypck==0.5.9
@@ -1196,10 +1207,13 @@ pypck==0.5.9
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.0.8
+pypoint==1.1.1
 
 # homeassistant.components.sensor.pollen
 pypollencom==2.2.2
+
+# homeassistant.components.ps4
+pyps4-homeassistant==0.3.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8
@@ -1218,6 +1232,9 @@ pyruter==1.1.0
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.1.0
+
+# homeassistant.components.switch.sony_projector
+pysdcp==1
 
 # homeassistant.components.climate.sensibo
 pysensibo==1.0.3
@@ -1241,7 +1258,7 @@ pysma==0.3.1
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.2
+pysmartthings==0.6.3
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
@@ -1394,7 +1411,7 @@ pytile==2.0.5
 pytouchline==0.7
 
 # homeassistant.components.device_tracker.traccar
-pytraccar==0.2.1
+pytraccar==0.3.0
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5
@@ -1404,6 +1421,9 @@ pytradfri[async]==6.0.1
 
 # homeassistant.components.sensor.trafikverket_weatherstation
 pytrafikverket==0.1.5.8
+
+# homeassistant.components.device_tracker.ubee
+pyubee==0.2
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.16
@@ -1424,7 +1444,7 @@ pyvesync==0.1.1
 pyvizio==0.0.4
 
 # homeassistant.components.velux
-pyvlx==0.2.8
+pyvlx==0.2.9
 
 # homeassistant.components.notify.html5
 pywebpush==1.6.0
@@ -1493,7 +1513,7 @@ rocketchat-API==0.6.1
 roombapy==1.3.1
 
 # homeassistant.components.sensor.rova
-rova==0.0.2
+rova==0.1.0
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.7
@@ -1533,7 +1553,7 @@ sense_energy==0.6.0
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.sensor.shodan
-shodan==1.10.4
+shodan==1.11.0
 
 # homeassistant.components.notify.simplepush
 simplepush==1.1.4
@@ -1596,13 +1616,13 @@ spotipy-homeassistant==2.4.4.dev1
 
 # homeassistant.components.recorder
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.17
+sqlalchemy==1.2.18
 
 # homeassistant.components.sensor.srp_energy
 srpenergy==1.0.5
 
 # homeassistant.components.sensor.starlingbank
-starlingbank==1.2
+starlingbank==3.0
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -1626,7 +1646,7 @@ suds-py3==1.3.3.0
 swisshydrodata==0.0.3
 
 # homeassistant.components.device_tracker.synology_srm
-synology-srm==0.0.4
+synology-srm==0.0.6
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.14
@@ -1784,7 +1804,7 @@ yeelight==0.4.3
 yeelightsunflower==0.0.10
 
 # homeassistant.components.media_extractor
-youtube_dl==2019.02.08
+youtube_dl==2019.02.18
 
 # homeassistant.components.light.zengge
 zengge==0.2
@@ -1802,13 +1822,13 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.0.1
+zigpy-deconz==0.1.1
 
 # homeassistant.components.zha
-zigpy-xbee==0.1.1
+zigpy-homeassistant==0.3.0
 
 # homeassistant.components.zha
-zigpy==0.2.0
+zigpy-xbee-homeassistant==0.1.2
 
 # homeassistant.components.zoneminder
 zm-py==0.3.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -78,7 +78,7 @@ TravisPy==0.3.5
 TwitterAPI==2.5.9
 
 # homeassistant.components.sensor.waze_travel_time
-WazeRouteCalculator==0.9
+WazeRouteCalculator==0.6
 
 # homeassistant.components.notify.yessssms
 YesssSMS==0.2.3
@@ -118,7 +118,7 @@ aioharmony==0.1.8
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.1
+aiohue==1.9.0
 
 # homeassistant.components.sensor.iliad_italy
 aioiliad==0.1.1
@@ -154,7 +154,7 @@ amcrest==1.2.3
 anel_pwrctrl-homeassistant==0.0.1.dev2
 
 # homeassistant.components.media_player.anthemav
-anthemav==1.1.9
+anthemav==1.1.8
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.13
@@ -196,7 +196,7 @@ batinfo==0.4.2
 beautifulsoup4==4.7.1
 
 # homeassistant.components.zha
-bellows-homeassistant==0.7.1
+bellows==0.7.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.5.3
@@ -292,7 +292,7 @@ construct==2.9.45
 # credstash==1.15.0
 
 # homeassistant.components.sensor.crimereports
-crimereports==1.0.1
+crimereports==1.0.0
 
 # homeassistant.components.datadog
 datadog==0.15.0
@@ -577,7 +577,7 @@ influxdb==5.2.0
 # homeassistant.components.insteon
 insteonplm==0.15.2
 
-# homeassistant.components.iperf3
+# homeassistant.components.sensor.iperf3
 iperf3==0.1.10
 
 # homeassistant.components.route53
@@ -606,7 +606,7 @@ kiwiki-client==0.1.1
 konnected==0.1.4
 
 # homeassistant.components.eufy
-lakeside==0.12
+lakeside==0.11
 
 # homeassistant.components.owntracks
 libnacl==1.6.1
@@ -681,8 +681,8 @@ mbddns==0.1.2
 # homeassistant.components.notify.message_bird
 messagebird==1.2.0
 
-# homeassistant.components.meteo_france
-meteofrance==0.3.4
+# homeassistant.components.sensor.meteo_france
+meteofrance==0.2.7
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
@@ -722,7 +722,7 @@ nanoleaf==0.4.1
 ndms2_client==0.0.6
 
 # homeassistant.components.ness_alarm
-nessclient==0.9.10
+nessclient==0.9.9
 
 # homeassistant.components.sensor.netdata
 netdata==0.1.2
@@ -752,7 +752,7 @@ nuheat==0.3.0
 # homeassistant.components.image_processing.opencv
 # homeassistant.components.image_processing.tensorflow
 # homeassistant.components.sensor.pollen
-numpy==1.16.1
+numpy==1.16.0
 
 # homeassistant.components.google
 oauth2client==4.0.0
@@ -773,10 +773,7 @@ openevsewifi==0.4
 openhomedevice==0.4.2
 
 # homeassistant.components.air_quality.opensensemap
-opensensemap-api==0.1.4
-
-# homeassistant.components.device_tracker.luci
-openwrt-luci-rpc==1.0.5
+opensensemap-api==0.1.3
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
@@ -790,9 +787,6 @@ panacotta==0.1
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.3.1
-
-# homeassistant.components.switch.pca
-pypca==0.0.1
 
 # homeassistant.components.media_player.dunehd
 pdunehd==1.3
@@ -859,7 +853,7 @@ prometheus_client==0.2.0
 protobuf==3.6.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.5.1
+psutil==5.5.0
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.3
@@ -895,12 +889,13 @@ py17track==2.1.1
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13
 
-# homeassistant.components.tplink
+# homeassistant.components.light.tplink
+# homeassistant.components.switch.tplink
 pyHS100==0.3.4
 
 # homeassistant.components.air_quality.norway_air
 # homeassistant.components.weather.met
-pyMetno==0.4.6
+pyMetno==0.4.5
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.23
@@ -954,9 +949,6 @@ pyblackbird==0.5
 # homeassistant.components.neato
 pybotvac==0.0.13
 
-# homeassistant.components.nissan_leaf
-pycarwings2==2.8
-
 # homeassistant.components.cloudflare
 pycfdns==0.0.1
 
@@ -985,10 +977,10 @@ pycsspeechtts==1.0.2
 pydaikin==0.9
 
 # homeassistant.components.danfoss_air
-pydanfossair==0.0.7
+pydanfossair==0.0.6
 
 # homeassistant.components.deconz
-pydeconz==52
+pydeconz==47
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
@@ -1061,13 +1053,13 @@ pygtt==1.1.2
 pyhaversion==2.0.3
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.2.2
+pyhik==0.1.9
 
 # homeassistant.components.hive
 pyhiveapi==0.2.17
 
 # homeassistant.components.homematic
-pyhomematic==0.1.56
+pyhomematic==0.1.55
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6
@@ -1193,9 +1185,6 @@ pyotgw==0.4b1
 # homeassistant.components.sensor.otp
 pyotp==2.2.6
 
-# homeassistant.components.owlet
-pyowlet==1.0.2
-
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
 pyowm==2.10.0
@@ -1207,13 +1196,10 @@ pypck==0.5.9
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.1.1
+pypoint==1.0.8
 
 # homeassistant.components.sensor.pollen
 pypollencom==2.2.2
-
-# homeassistant.components.ps4
-pyps4-homeassistant==0.3.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8
@@ -1232,9 +1218,6 @@ pyruter==1.1.0
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.1.0
-
-# homeassistant.components.switch.sony_projector
-pysdcp==1
 
 # homeassistant.components.climate.sensibo
 pysensibo==1.0.3
@@ -1258,7 +1241,7 @@ pysma==0.3.1
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.3
+pysmartthings==0.6.2
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
@@ -1411,7 +1394,7 @@ pytile==2.0.5
 pytouchline==0.7
 
 # homeassistant.components.device_tracker.traccar
-pytraccar==0.3.0
+pytraccar==0.2.1
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5
@@ -1421,9 +1404,6 @@ pytradfri[async]==6.0.1
 
 # homeassistant.components.sensor.trafikverket_weatherstation
 pytrafikverket==0.1.5.8
-
-# homeassistant.components.device_tracker.ubee
-pyubee==0.2
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.16
@@ -1444,7 +1424,7 @@ pyvesync==0.1.1
 pyvizio==0.0.4
 
 # homeassistant.components.velux
-pyvlx==0.2.9
+pyvlx==0.2.8
 
 # homeassistant.components.notify.html5
 pywebpush==1.6.0
@@ -1513,7 +1493,7 @@ rocketchat-API==0.6.1
 roombapy==1.3.1
 
 # homeassistant.components.sensor.rova
-rova==0.1.0
+rova==0.0.2
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.7
@@ -1553,7 +1533,7 @@ sense_energy==0.6.0
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.sensor.shodan
-shodan==1.11.0
+shodan==1.10.4
 
 # homeassistant.components.notify.simplepush
 simplepush==1.1.4
@@ -1616,13 +1596,13 @@ spotipy-homeassistant==2.4.4.dev1
 
 # homeassistant.components.recorder
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.18
+sqlalchemy==1.2.17
 
 # homeassistant.components.sensor.srp_energy
 srpenergy==1.0.5
 
 # homeassistant.components.sensor.starlingbank
-starlingbank==3.0
+starlingbank==1.2
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -1646,7 +1626,7 @@ suds-py3==1.3.3.0
 swisshydrodata==0.0.3
 
 # homeassistant.components.device_tracker.synology_srm
-synology-srm==0.0.6
+synology-srm==0.0.4
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.14
@@ -1804,7 +1784,7 @@ yeelight==0.4.3
 yeelightsunflower==0.0.10
 
 # homeassistant.components.media_extractor
-youtube_dl==2019.02.18
+youtube_dl==2019.02.08
 
 # homeassistant.components.light.zengge
 zengge==0.2
@@ -1822,13 +1802,13 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.1.1
+zigpy-deconz==0.0.1
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.3.0
+zigpy-xbee==0.1.1
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.1.2
+zigpy==0.2.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -791,6 +791,9 @@ panacotta==0.1
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.3.1
 
+# homeassistant.components.switch.pca
+pypca==0.0.1
+
 # homeassistant.components.media_player.dunehd
 pdunehd==1.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -41,16 +41,13 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.1
+aiohue==1.9.0
 
 # homeassistant.components.unifi
 aiounifi==4
 
 # homeassistant.components.notify.apns
 apns2==0.3.0
-
-# homeassistant.components.zha
-bellows-homeassistant==0.7.1
 
 # homeassistant.components.calendar.caldav
 caldav==0.5.0
@@ -151,7 +148,7 @@ mficlient==0.3.0
 # homeassistant.components.image_processing.opencv
 # homeassistant.components.image_processing.tensorflow
 # homeassistant.components.sensor.pollen
-numpy==1.16.1
+numpy==1.16.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
@@ -180,20 +177,21 @@ pushbullet.py==0.11.0
 # homeassistant.components.canary
 py-canary==0.5.0
 
-# homeassistant.components.tplink
+# homeassistant.components.light.tplink
+# homeassistant.components.switch.tplink
 pyHS100==0.3.4
 
 # homeassistant.components.media_player.blackbird
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==52
+pydeconz==47
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.56
+pyhomematic==0.1.55
 
 # homeassistant.components.litejet
 pylitejet==0.1
@@ -213,9 +211,6 @@ pyopenuv==1.0.4
 # homeassistant.components.sensor.otp
 pyotp==2.2.6
 
-# homeassistant.components.ps4
-pyps4-homeassistant==0.3.0
-
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8
 
@@ -223,7 +218,7 @@ pyqwikswitch==0.8
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.3
+pysmartthings==0.6.2
 
 # homeassistant.components.sonos
 pysonos==0.0.6
@@ -282,7 +277,7 @@ somecomfort==0.5.2
 
 # homeassistant.components.recorder
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.18
+sqlalchemy==1.2.17
 
 # homeassistant.components.sensor.srp_energy
 srpenergy==1.0.5
@@ -307,6 +302,3 @@ wakeonlan==1.1.6
 
 # homeassistant.components.cloud
 warrant==0.6.1
-
-# homeassistant.components.zha
-zigpy-homeassistant==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -41,13 +41,16 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.0
+aiohue==1.9.1
 
 # homeassistant.components.unifi
 aiounifi==4
 
 # homeassistant.components.notify.apns
 apns2==0.3.0
+
+# homeassistant.components.zha
+bellows-homeassistant==0.7.1
 
 # homeassistant.components.calendar.caldav
 caldav==0.5.0
@@ -148,7 +151,7 @@ mficlient==0.3.0
 # homeassistant.components.image_processing.opencv
 # homeassistant.components.image_processing.tensorflow
 # homeassistant.components.sensor.pollen
-numpy==1.16.0
+numpy==1.16.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
@@ -177,21 +180,20 @@ pushbullet.py==0.11.0
 # homeassistant.components.canary
 py-canary==0.5.0
 
-# homeassistant.components.light.tplink
-# homeassistant.components.switch.tplink
+# homeassistant.components.tplink
 pyHS100==0.3.4
 
 # homeassistant.components.media_player.blackbird
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==47
+pydeconz==52
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.55
+pyhomematic==0.1.56
 
 # homeassistant.components.litejet
 pylitejet==0.1
@@ -211,6 +213,9 @@ pyopenuv==1.0.4
 # homeassistant.components.sensor.otp
 pyotp==2.2.6
 
+# homeassistant.components.ps4
+pyps4-homeassistant==0.3.0
+
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8
 
@@ -218,7 +223,7 @@ pyqwikswitch==0.8
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.2
+pysmartthings==0.6.3
 
 # homeassistant.components.sonos
 pysonos==0.0.6
@@ -277,7 +282,7 @@ somecomfort==0.5.2
 
 # homeassistant.components.recorder
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.17
+sqlalchemy==1.2.18
 
 # homeassistant.components.sensor.srp_energy
 srpenergy==1.0.5
@@ -302,3 +307,6 @@ wakeonlan==1.1.6
 
 # homeassistant.components.cloud
 warrant==0.6.1
+
+# homeassistant.components.zha
+zigpy-homeassistant==0.3.0


### PR DESCRIPTION
## Description:
Added the 868 MHz ELV PCA 301 smart emeter switch.


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8717

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
    - platform: pca
       device: '/dev/ttyUSB0'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
