### PR TITLE
Philips js state

### DIFF
--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     CONF_API_VERSION, CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.script import Script
-from homeassistant.util import Throttle
 
 REQUIREMENTS = ['ha-philipsjs==0.0.5']
 

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -122,8 +122,6 @@ class PhilipsTV(MediaPlayerDevice):
         if source in self._source_mapping:
             self._tv.setSource(self._source_mapping.get(source))
             self._source = source
-            if not self._tv.on:
-                self._state = STATE_OFF
             self._watching_tv = bool(self._tv.source_id == 'tv')
 
     @property
@@ -144,26 +142,18 @@ class PhilipsTV(MediaPlayerDevice):
     def turn_off(self):
         """Turn off the device."""
         self._tv.sendKey('Standby')
-        if not self._tv.on:
-            self._state = STATE_OFF
 
     def volume_up(self):
         """Send volume up command."""
         self._tv.sendKey('VolumeUp')
-        if not self._tv.on:
-            self._state = STATE_OFF
 
     def volume_down(self):
         """Send volume down command."""
         self._tv.sendKey('VolumeDown')
-        if not self._tv.on:
-            self._state = STATE_OFF
 
     def mute_volume(self, mute):
         """Send mute command."""
         self._tv.sendKey('Mute')
-        if not self._tv.on:
-            self._state = STATE_OFF
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -153,7 +153,9 @@ class PhilipsTV(MediaPlayerDevice):
 
     def mute_volume(self, mute):
         """Send mute command."""
-        self._tv.sendKey('Mute')
+        if self._muted != mute:
+            self._tv.sendKey('Mute')
+            self._muted = mute
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -121,8 +121,6 @@ class PhilipsTV(MediaPlayerDevice):
         """Set the input source."""
         if source in self._source_mapping:
             self._tv.setSource(self._source_mapping.get(source))
-            self._source = source
-            self._watching_tv = bool(self._tv.source_id == 'tv')
 
     @property
     def volume_level(self):

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -25,7 +25,7 @@ REQUIREMENTS = ['ha-philipsjs==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=30)
 
 SUPPORT_PHILIPS_JS = SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | \
                      SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
@@ -186,7 +186,6 @@ class PhilipsTV(MediaPlayerDevice):
             return '{} - {}'.format(self._source, self._channel_name)
         return self._source
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data and update device state."""
         self._tv.update()

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -72,8 +72,6 @@ class PhilipsTV(MediaPlayerDevice):
         self._tv = tv
         self._name = name
         self._state = None
-        self._min_volume = None
-        self._max_volume = None
         self._volume = None
         self._muted = False
         self._program_name = None
@@ -189,8 +187,6 @@ class PhilipsTV(MediaPlayerDevice):
     def update(self):
         """Get the latest data and update device state."""
         self._tv.update()
-        self._min_volume = self._tv.min_volume
-        self._max_volume = self._tv.max_volume
         self._volume = self._tv.volume
         self._muted = self._tv.muted
         if self._tv.source_id:


### PR DESCRIPTION
## Description:
This cleans up some issues in philips_js implementation, mute only working as a toggle, delay between issuing command and state being reflected in gui.

**Related issue (if applicable):**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: philips_js
    host: 192.168.16.21
    name: 'Living Room TV'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
