### PR TITLE
Fix double events on Lutron Pico keypads

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -145,8 +145,15 @@ class LutronButton:
             # A single-action button; the Lutron controller won't tell us
             # when the button is released, so use a different action name
             # than for buttons where we expect a release event.
-            action = 'single'
+            #
+            # Some Lutron keypads lie about their button types, though,
+            # and send release notifications even for single-action
+            # buttons. So we need to check that this is indeed a press.
+            if event == Button.Event.PRESSED:
+                action = 'single'
+            else:
+                action = None
 
-        data = {ATTR_ID: self._id, ATTR_ACTION: action}
-
-        self._hass.bus.fire(self._event, data)
+        if action:
+            data = {ATTR_ID: self._id, ATTR_ACTION: action}
+            self._hass.bus.fire(self._event, data)

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -134,25 +134,17 @@ class LutronButton:
         """Fire an event about a button being pressed or released."""
         from pylutron import Button
 
+        # Events per button type:
+        #   RaiseLower -> pressed/released
+        #   SingleAction -> single
+        action = None
         if self._has_release_event:
-            # A raise/lower button; we will get callbacks when the button is
-            # pressed and when it's released, so fire events for each.
             if event == Button.Event.PRESSED:
                 action = 'pressed'
             else:
                 action = 'released'
-        else:
-            # A single-action button; the Lutron controller won't tell us
-            # when the button is released, so use a different action name
-            # than for buttons where we expect a release event.
-            #
-            # Some Lutron keypads lie about their button types, though,
-            # and send release notifications even for single-action
-            # buttons. So we need to check that this is indeed a press.
-            if event == Button.Event.PRESSED:
-                action = 'single'
-            else:
-                action = None
+        elif event == Button.Event.PRESSED:
+            action = 'single'
 
         if action:
             data = {ATTR_ID: self._id, ATTR_ACTION: action}


### PR DESCRIPTION
## Description:

Some Lutron keypads seem to lie about their button capabilities (they claim to only notify about button presses, but actually also notify about button releases) which led the Lutron component to fire duplicate button events.

Rather than try to add special cases for those specific keypad types to treat the buttons as raise/lower buttons, filter out the release events so the buttons act the way the repeater claims they do and only fire a single event per physical press/release.

I have tested that this change doesn't break anything on keypad types that don't exhibit the bad behavior, but I don't own one of the affected keypads so can't confirm that this actually fixes the problem for those keypads. But based on the details of issue #21235, there's no reason to believe it won't do the trick.

**Related issue (if applicable):** fixes #21235 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23