### PR TITLE
Fix Sonos snapshot/restore

### DIFF
--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -49,6 +49,14 @@ class MusicLibraryMock():
         return []
 
 
+class CacheMock():
+    """Mock class for the _zgs_cache property on pysonos.SoCo object."""
+
+    def clear(self):
+        """Clear cache."""
+        pass
+
+
 class SoCoMock():
     """Mock class for the pysonos.SoCo object."""
 
@@ -63,6 +71,7 @@ class SoCoMock():
         self.dialog_mode = False
         self.music_library = MusicLibraryMock()
         self.avTransport = AvTransportMock()
+        self._zgs_cache = CacheMock()
 
     def get_sonos_favorites(self):
         """Get favorites list from sonos."""
@@ -126,7 +135,7 @@ def add_entities_factory(hass):
     """Add entities factory."""
     def add_entities(entities, update_befor_add=False):
         """Fake add entity."""
-        hass.data[sonos.DATA_SONOS].entities = entities
+        hass.data[sonos.DATA_SONOS].entities = list(entities)
 
     return add_entities
 
@@ -162,7 +171,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
             'host': '192.0.2.1'
         })
 
-        entities = list(self.hass.data[sonos.DATA_SONOS].entities)
+        entities = self.hass.data[sonos.DATA_SONOS].entities
         assert len(entities) == 1
         assert entities[0].name == 'Kitchen'
 
@@ -242,7 +251,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
     def test_ensure_setup_sonos_discovery(self, *args):
         """Test a single device using the autodiscovery provided by Sonos."""
         sonos.setup_platform(self.hass, {}, add_entities_factory(self.hass))
-        entities = list(self.hass.data[sonos.DATA_SONOS].entities)
+        entities = self.hass.data[sonos.DATA_SONOS].entities
         assert len(entities) == 1
         assert entities[0].name == 'Kitchen'
 
@@ -254,7 +263,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_entities_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        entity = list(self.hass.data[sonos.DATA_SONOS].entities)[-1]
+        entity = self.hass.data[sonos.DATA_SONOS].entities[-1]
         entity.hass = self.hass
 
         entity.set_sleep_timer(30)
@@ -268,7 +277,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_entities_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        entity = list(self.hass.data[sonos.DATA_SONOS].entities)[-1]
+        entity = self.hass.data[sonos.DATA_SONOS].entities[-1]
         entity.hass = self.hass
 
         entity.set_sleep_timer(None)
@@ -282,7 +291,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_entities_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        entity = list(self.hass.data[sonos.DATA_SONOS].entities)[-1]
+        entity = self.hass.data[sonos.DATA_SONOS].entities[-1]
         entity.hass = self.hass
         alarm1 = alarms.Alarm(pysonos_mock)
         alarm1.configure_mock(_alarm_id="1", start_time=None, enabled=False,
@@ -312,11 +321,14 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_entities_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        entity = list(self.hass.data[sonos.DATA_SONOS].entities)[-1]
+        entities = self.hass.data[sonos.DATA_SONOS].entities
+        entity = entities[-1]
         entity.hass = self.hass
 
         snapshotMock.return_value = True
-        entity.snapshot()
+        entity.soco.group = mock.MagicMock()
+        entity.soco.group.members = [e.soco for e in entities]
+        sonos.snapshot(entities, True)
         assert snapshotMock.call_count == 1
         assert snapshotMock.call_args == mock.call()
 
@@ -330,13 +342,14 @@ class TestSonosMediaPlayer(unittest.TestCase):
         sonos.setup_platform(self.hass, {}, add_entities_factory(self.hass), {
             'host': '192.0.2.1'
         })
-        entity = list(self.hass.data[sonos.DATA_SONOS].entities)[-1]
+        entities = self.hass.data[sonos.DATA_SONOS].entities
+        entity = entities[-1]
         entity.hass = self.hass
 
         restoreMock.return_value = True
-        entity._snapshot_coordinator = mock.MagicMock()
-        entity._snapshot_coordinator.soco_entity = SoCoMock('192.0.2.17')
-        entity._soco_snapshot = Snapshot(entity._player)
-        entity.restore()
+        entity._snapshot_group = mock.MagicMock()
+        entity._snapshot_group.members = [e.soco for e in entities]
+        entity._soco_snapshot = Snapshot(entity.soco)
+        sonos.restore(entities, True)
         assert restoreMock.call_count == 1
-        assert restoreMock.call_args == mock.call(False)
+        assert restoreMock.call_args == mock.call()


### PR DESCRIPTION
## Description:

The snapshot feature of the Sonos media player has been very unreliable when `with_group` is enabled (as it is by default).

I have redone the whole thing and in my testing it is now predictable. It restores groups correctly and the playing state is restored as well as the (unofficial) Sonos API allows. The functions now run under our topology lock and use the HA-based group cache to ensure consistency.

As everything is new, it does not make sense to compare to the old implementation but I will be happy to provide details on the new one if you have questions.

I have updated the documentation with some notes about the limitations of this feature.

**Related issue (if applicable):** fixes #14849, fixes #20861, fixes #21215

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8724

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
