### PR TITLE
Adding new PlanifNeige component/sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -520,6 +520,7 @@ omit =
     homeassistant/components/otp/sensor.py
     homeassistant/components/pi_hole/sensor.py
     homeassistant/components/plex/sensor.py
+    homeassistant/components/planifneige/*
     homeassistant/components/pocketcasts/sensor.py
     homeassistant/components/pollen/sensor.py
     homeassistant/components/postnl/sensor.py

--- a/homeassistant/components/planifneige/__init__.py
+++ b/homeassistant/components/planifneige/__init__.py
@@ -1,0 +1,100 @@
+"""Platform for the City of Montreal's Planif-Neige snow removal APIs."""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_SCAN_INTERVAL
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+
+DOMAIN = 'planifneige'
+DATA_PLANIFNEIGE = 'data_planifneige'
+
+DATA_UPDATED = '{}_data_updated'.format(DOMAIN)
+
+PLANIFNEIGE_ATTRIBUTION = "Information provided by the City of Montreal "
+
+REQUIREMENTS = ['planif-neige-client==0.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_STREET_ID = 'street_id'
+CONF_STREETS = 'streets'
+
+DEFAULT_INTERVAL = timedelta(minutes=5)
+
+STREET_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_STREET_ID): cv.positive_int
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL,
+                     default=DEFAULT_INTERVAL): vol.All(
+                         cv.time_period, cv.positive_timedelta),
+        vol.Required(CONF_STREETS): [STREET_SCHEMA]
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Set up the PlanifNeige component."""
+    from planif_neige_client import planif_neige_client
+    db_path = hass.config.path('planifneige.db')
+    conf = config[DOMAIN]
+
+    pn_client = planif_neige_client.PlanifNeigeClient(conf.get(
+        CONF_API_KEY), db_path)
+    pn_client.get_planification_for_date()
+
+    data = hass.data[DATA_PLANIFNEIGE] = PlanifNeigeData(
+        hass, pn_client, conf.get(CONF_STREETS))
+
+    async_track_time_interval(
+        hass, data.update, conf[CONF_SCAN_INTERVAL]
+        )
+
+    def update(call=None):
+        """Service call to manually update the data."""
+        data.update()
+
+    hass.services.async_register(DOMAIN, 'update', update)
+
+    hass.async_create_task(
+        async_load_platform(
+            hass,
+            SENSOR_DOMAIN,
+            DOMAIN,
+            conf[CONF_STREETS],
+            config
+        )
+    )
+
+    return True
+
+
+class PlanifNeigeData:
+    """Get the latest data from PlanifNeige."""
+
+    def __init__(self, hass, pn, streets):
+        """Initialize the data object."""
+        self.data = []
+        self._hass = hass
+        self._streets = streets
+        self._pn = pn
+
+    def update(self, now=None):
+        """Get the latest data from PlanifNeige."""
+        self._pn.get_planification_for_date()
+
+        for street in self._streets:
+            self.data.append(
+                self._pn.get_planification_for_street(street['street_id']))
+
+        dispatcher_send(self._hass, DATA_UPDATED)

--- a/homeassistant/components/planifneige/__init__.py
+++ b/homeassistant/components/planifneige/__init__.py
@@ -38,7 +38,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SCAN_INTERVAL,
                      default=DEFAULT_INTERVAL): vol.All(
                          cv.time_period, cv.positive_timedelta),
-        vol.Required(CONF_STREETS): [STREET_SCHEMA]
+        vol.Required(CONF_STREETS): vol.All(
+            cv.ensure_list, [STREET_SCHEMA])
     })
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/planifneige/__init__.py
+++ b/homeassistant/components/planifneige/__init__.py
@@ -50,12 +50,11 @@ async def async_setup(hass, config):
     db_path = hass.config.path('planifneige.db')
     conf = config[DOMAIN]
 
-    pn_client = planif_neige_client.PlanifNeigeClient(conf.get(
-        CONF_API_KEY), db_path)
+    pn_client = planif_neige_client.PlanifNeigeClient(conf[CONF_API_KEY], db_path)
     pn_client.get_planification_for_date()
 
     data = hass.data[DATA_PLANIFNEIGE] = PlanifNeigeData(
-        hass, pn_client, conf.get(CONF_STREETS))
+        hass, pn_client, conf[CONF_STREETS])
 
     async_track_time_interval(
         hass, data.update, conf[CONF_SCAN_INTERVAL]

--- a/homeassistant/components/planifneige/sensor.py
+++ b/homeassistant/components/planifneige/sensor.py
@@ -34,6 +34,8 @@ STREET_STATE = {
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the PlanifNeige platform."""
+    if discovery_info is None:
+        return
     data = hass.data[DATA_PLANIFNEIGE]
     async_add_entities(
         [PlanifNeigeSensor(data, sensor) for sensor in discovery_info]

--- a/homeassistant/components/planifneige/sensor.py
+++ b/homeassistant/components/planifneige/sensor.py
@@ -1,0 +1,134 @@
+"""Sensor for the City of Montreal's Planif-Neige snow removal APIs."""
+from datetime import datetime
+import logging
+
+from homeassistant.components.planifneige import (
+    CONF_STREET_ID, DATA_PLANIFNEIGE, PLANIFNEIGE_ATTRIBUTION)
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+from homeassistant.helpers.restore_state import RestoreEntity
+
+DEPENDENCIES = ['planifneige']
+
+_LOGGER = logging.getLogger(__name__)
+
+DB_TIMEFORMAT = '%Y-%m-%d %H:%M:%S'
+
+ATTR_STREET_SIDE_ID = 'street_side_id'
+ATTR_START_PLAN_DATE = 'start_plan_date'
+ATTR_END_PLAN_DATE = 'end_plan_date'
+ATTR_START_REPLAN_DATE = 'start_replan_date'
+ATTR_END_REPLAN_DATE = 'end_replan_date'
+ATTR_UPDATED = 'updated'
+
+STREET_STATE = {
+    '0': ['Snowed', 'mdi:snowflake'],  # street is snowed in
+    '1': ['Clear', 'mdi:road'],  # street is clear
+    '2': ['Planned', 'mdi:clock-outline'],  # street is planned for clearing
+    '3': ['Replanned', 'mdi:clock-alert-outline'],  # clearing date replanned
+    '4': ['Snowed', 'mdi:snowflake'],  # to be planned, still snowed in
+    '5': ['Clearing', 'mdi:bulldozer'],  # trucks loading, still clearing
+    '10': ['Ploughed', 'mdi:road']  # street cleared, snow not loaded
+}
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the PlanifNeige platform."""
+    data = hass.data[DATA_PLANIFNEIGE]
+    async_add_entities(
+        [PlanifNeigeSensor(data, sensor) for sensor in discovery_info]
+    )
+
+
+class PlanifNeigeSensor(RestoreEntity):
+    """PlanifNeige sensor."""
+
+    def __init__(self, data, sensor):
+        """Initialize the sensor."""
+        self._data = data.data
+        self._state = None
+        self._name = sensor[CONF_NAME]
+        self._street_id = sensor[CONF_STREET_ID]
+        self._icon = ""
+        self._start_plan_date = None
+        self._end_plan_date = None
+        self._start_replan_date = None
+        self._end_replan_date = None
+        self._date_updated = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def street_id(self):
+        """Return the street_id of the sensor."""
+        return self._street_id
+
+    @property
+    def start_plan_date(self):
+        """Return the start planned date of the sensor."""
+        return self.format_dbtime(self._start_plan_date)
+
+    @property
+    def end_plan_date(self):
+        """Return the end planned date of the sensor."""
+        return self.format_dbtime(self._end_plan_date)
+
+    @property
+    def start_replan_date(self):
+        """Return the start replanned date of the sensor."""
+        return self.format_dbtime(self._start_replan_date)
+
+    @property
+    def end_replan_date(self):
+        """Return the end replanned date of the sensor."""
+        return self.format_dbtime(self._end_replan_date)
+
+    @property
+    def date_updated(self):
+        """Return the date updated of the sensor."""
+        return self.format_dbtime(self._date_updated)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Update device state."""
+        for street in self._data:
+            if street[1] == self._street_id:
+                self._state = STREET_STATE[str(street[2])][0]
+                self._icon = STREET_STATE[str(street[2])][1]
+                self._start_plan_date = street[3]
+                self._end_plan_date = street[4]
+                self._start_replan_date = street[5]
+                self._end_replan_date = street[6]
+                self._date_updated = street[7]
+
+    @staticmethod
+    def format_dbtime(db_timestamp):
+        """Return DB timestamp format in ISO8601 format."""
+        if db_timestamp is None:
+            return None
+        return datetime.strptime(db_timestamp, DB_TIMEFORMAT)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_STREET_SIDE_ID: self.street_id,
+            ATTR_START_PLAN_DATE: self.start_plan_date,
+            ATTR_END_PLAN_DATE: self.end_plan_date,
+            ATTR_START_REPLAN_DATE: self.start_replan_date,
+            ATTR_END_REPLAN_DATE: self.end_replan_date,
+            ATTR_UPDATED: self.date_updated,
+            ATTR_ATTRIBUTION: PLANIFNEIGE_ATTRIBUTION
+        }
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._icon

--- a/homeassistant/components/planifneige/services.yaml
+++ b/homeassistant/components/planifneige/services.yaml
@@ -1,0 +1,2 @@
+update:
+  description: Immediately update the PlanifNeige sensors

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -836,6 +836,9 @@ pillow==5.4.1
 # homeassistant.components.dominos
 pizzapi==0.0.3
 
+# homeassistant.components.planifneige
+planif-neige-client==0.1.1
+
 # homeassistant.components.plex.media_player
 # homeassistant.components.plex.sensor
 plexapi==3.0.6


### PR DESCRIPTION
## Description:

_I messed up some commits in a [previous pull request](https://github.com/home-assistant/home-assistant/pull/21343) and ended up destroying the history of my fork trying to fix it. I've closed the PR and am creating a new one. Hope this is acceptable to the team. Apologies for the inconvenience._

This is a pull request for a new platform and sensor for Montreal's street-by-street snow removal APIs.
The component can be used to monitor snow removal operations on nearby streets and notify the user to move his car to avoid getting it towed, and/or receiving a ticket.

The dataset/API used for this component is from the [City of Montreal's open data initiative](http://donnees.ville.montreal.qc.ca/dataset/deneigement) (website in French).


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#8654

## Example entry for `configuration.yaml` (if applicable):
```
planifneige:
  api_key: YOUR_API_KEY
  streets:
    - name: 2-22 Sainte-Catherine (Right)
      streetid: 13812091
    - name: 1030-1116 Saint-Laurent (Left)
      streetid: 13811012
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
