### PR TITLE
Add Swedish backend translation for ZHA component

### DIFF
--- a/homeassistant/components/zha/.translations/sv.json
+++ b/homeassistant/components/zha/.translations/sv.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Endast en enda konfiguration av ZHA är tillåten."
+        },
+        "error": {
+            "cannot_connect": "Det gick inte att ansluta till ZHA enhet."
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "radio_type": "Typ av radio",
+                    "usb_path": "USB-enhetens sökväg"
+                },
+                "title": "ZHA"
+            }
+        },
+        "title": "ZHA"
+    }
+}


### PR DESCRIPTION
## Description:

Adding Swedish backend translation for ZHA component.  Lokalise already contains this Swedish translation for ZHA.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

NA

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
