### PR TITLE
MQTT Alarm publish code in payload

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -196,7 +196,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_DISARM) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                if self._config.get(CONF_PUBLISH_CODE) else ''),
+                 if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -211,7 +211,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_HOME) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                if self._config.get(CONF_PUBLISH_CODE) else ''),
+                 if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -226,7 +226,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_AWAY) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                if self._config.get(CONF_PUBLISH_CODE) else ''),
+                 if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -241,7 +241,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_NIGHT) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                if self._config.get(CONF_PUBLISH_CODE) else ''),
+                 if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -196,7 +196,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_DISARM) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                    if self._config.get(CONF_PUBLISH_CODE) else ''),
+                if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -211,7 +211,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_HOME) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                    if self._config.get(CONF_PUBLISH_CODE) else ''),
+                if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -226,7 +226,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_AWAY) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                    if self._config.get(CONF_PUBLISH_CODE) else ''),
+                if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -241,7 +241,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_NIGHT) +
                 (self._config.get(CONF_CODE_SEPARATOR)+code
-                    if self._config.get(CONF_PUBLISH_CODE) else ''),
+                if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -32,12 +32,16 @@ CONF_PAYLOAD_DISARM = 'payload_disarm'
 CONF_PAYLOAD_ARM_HOME = 'payload_arm_home'
 CONF_PAYLOAD_ARM_AWAY = 'payload_arm_away'
 CONF_PAYLOAD_ARM_NIGHT = 'payload_arm_night'
+CONF_PUBLISH_CODE = 'publish_code'
+CONF_CODE_SEPARATOR = 'code_separator'
 
 DEFAULT_ARM_NIGHT = 'ARM_NIGHT'
 DEFAULT_ARM_AWAY = 'ARM_AWAY'
 DEFAULT_ARM_HOME = 'ARM_HOME'
 DEFAULT_DISARM = 'DISARM'
 DEFAULT_NAME = 'MQTT Alarm'
+DEFAULT_CODE_SEPARATOR = ':'
+DEFAULT_PUBLISH_CODE = False
 DEPENDENCIES = ['mqtt']
 
 PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
@@ -52,6 +56,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_DISARM, default=DEFAULT_DISARM): cv.string,
     vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
+    vol.Optional(CONF_PUBLISH_CODE, default=DEFAULT_PUBLISH_CODE): cv.boolean,
+    vol.Optional(CONF_CODE_SEPARATOR, default=DEFAULT_CODE_SEPARATOR): cv.string,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema).extend(
     mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 
@@ -188,7 +194,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_DISARM),
+            self._config.get(CONF_PAYLOAD_DISARM) +
+                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -201,7 +208,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_ARM_HOME),
+            self._config.get(CONF_PAYLOAD_ARM_HOME) +
+                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -214,7 +222,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_ARM_AWAY),
+            self._config.get(CONF_PAYLOAD_ARM_AWAY) +
+                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -227,14 +236,16 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_ARM_NIGHT),
+            self._config.get(CONF_PAYLOAD_ARM_NIGHT) + 
+                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
     def _validate_code(self, code, state):
         """Validate given code."""
         conf_code = self._config.get(CONF_CODE)
-        check = conf_code is None or code == conf_code
+        publish_code = self._config.get(CONF_PUBLISH_CODE)
+        check = conf_code is None or code == conf_code or (publish_code and code is not None)
         if not check:
             _LOGGER.warning('Wrong code entered for %s', state)
         return check

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -195,7 +195,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_DISARM) +
-                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
+                (self._config.get(CONF_CODE_SEPARATOR)+code
+                    if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -209,7 +210,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_HOME) +
-                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
+                (self._config.get(CONF_CODE_SEPARATOR)+code
+                    if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -223,7 +225,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_AWAY) +
-                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
+                (self._config.get(CONF_CODE_SEPARATOR)+code
+                    if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -236,8 +239,9 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_ARM_NIGHT) + 
-                (self._config.get(CONF_CODE_SEPARATOR)+code if self._config.get(CONF_PUBLISH_CODE) else ''),
+            self._config.get(CONF_PAYLOAD_ARM_NIGHT) +
+                (self._config.get(CONF_CODE_SEPARATOR)+code
+                    if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -245,7 +249,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """Validate given code."""
         conf_code = self._config.get(CONF_CODE)
         publish_code = self._config.get(CONF_PUBLISH_CODE)
-        check = conf_code is None or code == conf_code or (publish_code and code is not None)
+        check = conf_code is None or code == conf_code or
+                (publish_code and code is not None)
         if not check:
             _LOGGER.warning('Wrong code entered for %s', state)
         return check


### PR DESCRIPTION
Includes options publish_code and code_seperator.  Enables the pin code to be published in the payload.

## Description:
When using an external alarm system the code may be required to arm and disarm the system.  Using this option the code is not validated within HA and is publish via MQTT to be used by the alarm system.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8729

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: mqtt
    name: "Home Alarm"
    state_topic: "home/alarm/state"
    command_topic: "home/alarm/set"
    publish_code: true
    code_separator: '-'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
