### PR TITLE
MQTT alarm - Option to send pin code with the MQTT payload

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -196,7 +196,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_DISARM) +
                  (self._config.get(CONF_CODE_SEPARATOR) + code
-                 if self._config.get(CONF_PUBLISH_CODE) else ''),
+                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -211,7 +211,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_HOME) +
                  (self._config.get(CONF_CODE_SEPARATOR) + code
-                 if self._config.get(CONF_PUBLISH_CODE) else ''),
+                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -226,7 +226,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_AWAY) +
                  (self._config.get(CONF_CODE_SEPARATOR) + code
-                 if self._config.get(CONF_PUBLISH_CODE) else ''),
+                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 
@@ -241,7 +241,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_NIGHT) +
                  (self._config.get(CONF_CODE_SEPARATOR) + code
-                 if self._config.get(CONF_PUBLISH_CODE) else ''),
+                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
 

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -194,8 +194,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_DISARM)+
-                (self._config.get(CONF_CODE_SEPARATOR)+code
+            self._config.get(CONF_PAYLOAD_DISARM) +
+                 (self._config.get(CONF_CODE_SEPARATOR) + code
                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
@@ -209,8 +209,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_ARM_HOME)+
-                (self._config.get(CONF_CODE_SEPARATOR)+code
+            self._config.get(CONF_PAYLOAD_ARM_HOME) +
+                 (self._config.get(CONF_CODE_SEPARATOR) + code
                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
@@ -224,8 +224,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_ARM_AWAY)+
-                (self._config.get(CONF_CODE_SEPARATOR)+code
+            self._config.get(CONF_PAYLOAD_ARM_AWAY) +
+                 (self._config.get(CONF_CODE_SEPARATOR) + code
                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))
@@ -239,8 +239,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_ARM_NIGHT)+
-                (self._config.get(CONF_CODE_SEPARATOR)+code
+            self._config.get(CONF_PAYLOAD_ARM_NIGHT) +
+                 (self._config.get(CONF_CODE_SEPARATOR) + code
                  if self._config.get(CONF_PUBLISH_CODE) else ''),
             self._config.get(CONF_QOS),
             self._config.get(CONF_RETAIN))


### PR DESCRIPTION
Includes options publish_code and code_seperator.  Enables the pin code to be published in the payload.

## Description:
When using an external alarm system the code may be required to arm and disarm the system.  Using this option the code is not validated within HA and is publish via MQTT to be used by the alarm system.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8729

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: mqtt
    name: "Home Alarm"
    state_topic: "home/alarm/state"
    command_topic: "home/alarm/set"
    publish_code: true
    code_separator: '-'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23