### PR TITLE
Added a digit for precipitation and bumped smhi-pkg lib

### DIFF
--- a/homeassistant/components/smhi/__init__.py
+++ b/homeassistant/components/smhi/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import Config, HomeAssistant
 from .config_flow import smhi_locations  # noqa: F401
 from .const import DOMAIN  # noqa: F401
 
-REQUIREMENTS = ['smhi-pkg==1.0.8']
+REQUIREMENTS = ['smhi-pkg==1.0.10']
 
 DEFAULT_NAME = 'smhi'
 

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -218,7 +218,7 @@ class SmhiWeather(WeatherEntity):
                 ATTR_FORECAST_TEMP: forecast.temperature_max,
                 ATTR_FORECAST_TEMP_LOW: forecast.temperature_min,
                 ATTR_FORECAST_PRECIPITATION:
-                    round(forecast.total_precipitation),
+                    round(forecast.total_precipitation, 1),
                 ATTR_FORECAST_CONDITION: condition,
             })
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1585,7 +1585,7 @@ smappy==0.2.16
 # smbus-cffi==0.5.1
 
 # homeassistant.components.smhi
-smhi-pkg==1.0.8
+smhi-pkg==1.0.10
 
 # homeassistant.components.media_player.snapcast
 snapcast==2.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -275,7 +275,7 @@ simplisafe-python==3.1.14
 sleepyq==0.6
 
 # homeassistant.components.smhi
-smhi-pkg==1.0.8
+smhi-pkg==1.0.10
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.5.2


### PR DESCRIPTION
## Description:
Added a digit in the forecast precipitation. Rounding to integer seems too low resolution. Original SMHI webservice use one digit so this would make more sense to SMHI users.

Also bumped lib to v1.0.10 to support.

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
