### PR TITLE
Add LCN sensor platform

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -5,11 +5,14 @@ import voluptuous as vol
 
 from homeassistant.components.lcn.const import (
     CONF_CONNECTIONS, CONF_DIM_MODE, CONF_DIMMABLE, CONF_MOTOR, CONF_OUTPUT,
-    CONF_SK_NUM_TRIES, CONF_TRANSITION, DATA_LCN, DEFAULT_NAME, DIM_MODES,
-    DOMAIN, MOTOR_PORTS, OUTPUT_PORTS, PATTERN_ADDRESS, RELAY_PORTS)
+    CONF_SK_NUM_TRIES, CONF_SOURCE, CONF_TRANSITION, DATA_LCN, DEFAULT_NAME,
+    DIM_MODES, DOMAIN, LED_PORTS, LOGICOP_PORTS, MOTOR_PORTS, OUTPUT_PORTS,
+    PATTERN_ADDRESS, RELAY_PORTS, S0_INPUTS, SETPOINTS, THRESHOLDS, VAR_UNITS,
+    VARIABLES)
 from homeassistant.const import (
     CONF_ADDRESS, CONF_COVERS, CONF_HOST, CONF_LIGHTS, CONF_NAME,
-    CONF_PASSWORD, CONF_PORT, CONF_SWITCHES, CONF_USERNAME)
+    CONF_PASSWORD, CONF_PORT, CONF_SENSORS, CONF_SWITCHES,
+    CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
@@ -78,6 +81,17 @@ LIGHTS_SCHEMA = vol.Schema({
                 lambda value: value * 1000),
 })
 
+SENSORS_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_ADDRESS): is_address,
+    vol.Required(CONF_SOURCE): vol.All(vol.Upper,
+                                       vol.In(VARIABLES + SETPOINTS +
+                                              THRESHOLDS + S0_INPUTS +
+                                              LED_PORTS + LOGICOP_PORTS)),
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT, default='native'):
+        vol.All(vol.Upper, vol.In(VAR_UNITS))
+})
+
 SWITCHES_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_ADDRESS): is_address,
@@ -104,6 +118,8 @@ CONFIG_SCHEMA = vol.Schema({
             cv.ensure_list, [COVERS_SCHEMA]),
         vol.Optional(CONF_LIGHTS): vol.All(
             cv.ensure_list, [LIGHTS_SCHEMA]),
+        vol.Optional(CONF_SENSORS): vol.All(
+            cv.ensure_list, [SENSORS_SCHEMA]),
         vol.Optional(CONF_SWITCHES): vol.All(
             cv.ensure_list, [SWITCHES_SCHEMA])
     })
@@ -162,6 +178,7 @@ async def async_setup(hass, config):
     # load platforms
     for component, conf_key in (('cover', CONF_COVERS),
                                 ('light', CONF_LIGHTS),
+                                ('sensor', CONF_SENSORS),
                                 ('switch', CONF_SWITCHES)):
         if conf_key in config[DOMAIN]:
             hass.async_create_task(

--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -16,11 +16,47 @@ CONF_DIM_MODE = 'dim_mode'
 CONF_DIMMABLE = 'dimmable'
 CONF_TRANSITION = 'transition'
 CONF_MOTOR = 'motor'
+CONF_SOURCE = 'source'
 
 DIM_MODES = ['STEPS50', 'STEPS200']
+
 OUTPUT_PORTS = ['OUTPUT1', 'OUTPUT2', 'OUTPUT3', 'OUTPUT4']
+
 RELAY_PORTS = ['RELAY1', 'RELAY2', 'RELAY3', 'RELAY4',
                'RELAY5', 'RELAY6', 'RELAY7', 'RELAY8',
                'MOTORONOFF1', 'MOTORUPDOWN1', 'MOTORONOFF2', 'MOTORUPDOWN2',
                'MOTORONOFF3', 'MOTORUPDOWN3', 'MOTORONOFF4', 'MOTORUPDOWN4']
+
 MOTOR_PORTS = ['MOTOR1', 'MOTOR2', 'MOTOR3', 'MOTOR4']
+
+LED_PORTS = ['LED1', 'LED2', 'LED3', 'LED4', 'LED5', 'LED6',
+             'LED7', 'LED8', 'LED9', 'LED10', 'LED11', 'LED12']
+
+LOGICOP_PORTS = ['LOGICOP1', 'LOGICOP2', 'LOGICOP3', 'LOGICOP4']
+
+VARIABLES = ['VAR1ORTVAR', 'VAR2ORR1VAR', 'VAR3ORR2VAR',
+             'TVAR', 'R1VAR', 'R2VAR',
+             'VAR1', 'VAR2', 'VAR3', 'VAR4', 'VAR5', 'VAR6',
+             'VAR7', 'VAR8', 'VAR9', 'VAR10', 'VAR11', 'VAR12']
+
+SETPOINTS = ['R1VARSETPOINT', 'R2VARSETPOINT']
+
+THRESHOLDS = ['THRS1', 'THRS2', 'THRS3', 'THRS4', 'THRS5',
+              'THRS2_1', 'THRS2_2', 'THRS2_3', 'THRS2_4',
+              'THRS3_1', 'THRS3_2', 'THRS3_3', 'THRS3_4',
+              'THRS4_1', 'THRS4_2', 'THRS4_3', 'THRS4_4']
+
+S0_INPUTS = ['S0INPUT1', 'S0INPUT2', 'S0INPUT3', 'S0INPUT4']
+
+VAR_UNITS = ['', 'LCN', 'NATIVE',
+             'CELSIUS', '\u00b0CELSIUS', '\u00b0C',
+             'KELVIN', '\u00b0KELVIN', '\u00b0K',
+             'FAHRENHEIT', '\u00b0FAHRENHEIT', '\u00b0F'
+             'LUX_T', 'LX_T',
+             'LUX_I', 'LUX', 'LX',
+             'M/S', 'METERPERSECOND',
+             '%', 'PERCENT',
+             'PPM',
+             'VOLT', 'V',
+             'AMPERE', 'AMP', 'A',
+             'DEGREE', '\u00b0']

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -1,0 +1,117 @@
+"""Support for LCN sensors."""
+from homeassistant.components.lcn import LcnDevice, get_connection
+from homeassistant.components.lcn.const import (
+    CONF_CONNECTIONS, CONF_SOURCE, DATA_LCN, LED_PORTS, S0_INPUTS, SETPOINTS,
+    THRESHOLDS, VARIABLES)
+from homeassistant.const import CONF_ADDRESS, CONF_UNIT_OF_MEASUREMENT
+
+DEPENDENCIES = ['lcn']
+
+
+async def async_setup_platform(hass, hass_config, async_add_entities,
+                               discovery_info=None):
+    """Set up the LCN sensor platform."""
+    if discovery_info is None:
+        return
+
+    import pypck
+
+    devices = []
+    for config in discovery_info:
+        address, connection_id = config[CONF_ADDRESS]
+        addr = pypck.lcn_addr.LcnAddr(*address)
+        connections = hass.data[DATA_LCN][CONF_CONNECTIONS]
+        connection = get_connection(connections, connection_id)
+        address_connection = connection.get_address_conn(addr)
+
+        if config[CONF_SOURCE] in VARIABLES + SETPOINTS + THRESHOLDS + \
+                S0_INPUTS:
+            device = LcnVariableSensor(config, address_connection)
+        else:  # in LED_PORTS + LOGICOP_PORTS
+            device = LcnLedLogicSensor(config, address_connection)
+
+        devices.append(device)
+
+    async_add_entities(devices)
+
+
+class LcnVariableSensor(LcnDevice):
+    """Representation of a LCN sensor for variables."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN sensor."""
+        super().__init__(config, address_connection)
+
+        self.variable = self.pypck.lcn_defs.Var[config[CONF_SOURCE]]
+        self.unit = self.pypck.lcn_defs.VarUnit[
+            config[CONF_UNIT_OF_MEASUREMENT]]
+
+        self._value = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.variable))
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._value
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self.unit.value
+
+    def input_received(self, input_obj):
+        """Set sensor value when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusVar) or \
+                input_obj.get_var() != self.variable:
+            return
+
+        self._value = (input_obj.get_value().to_var_unit(self.unit))
+        self.async_schedule_update_ha_state()
+
+
+class LcnLedLogicSensor(LcnDevice):
+    """Representation of a LCN sensor for leds and logicops."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN sensor."""
+        super().__init__(config, address_connection)
+
+        if config[CONF_SOURCE] in LED_PORTS:
+            self.source = self.pypck.lcn_defs.LedPort[config[CONF_SOURCE]]
+        else:
+            self.source = self.pypck.lcn_defs.LogicOpPort[config[CONF_SOURCE]]
+
+        self._value = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.source))
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._value
+
+    def input_received(self, input_obj):
+        """Set sensor value when LCN input object (command) is received."""
+        if not isinstance(input_obj,
+                          self.pypck.inputs.ModStatusLedsAndLogicOps):
+            return
+
+        if self.source in self.pypck.lcn_defs.LedPort:
+            self._value = input_obj.get_led_state(
+                self.source.value).name.lower()
+        elif self.source in self.pypck.lcn_defs.LogicOpPort:
+            self._value = input_obj.get_logic_op_state(
+                self.source.value).name.lower()
+
+        self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:
This adds the LCN sensor platform. It provides functionality to monitor various LCN hardware variables and non-bolean states. With proper configured hardware modules/sensors it is possible to measure temperatures, light intensities, voltages, currents, etc.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8734

## Example entry for `configuration.yaml` (if applicable):
```yaml
lcn:
  connections:
    - name: myhome
      host: 192.168.2.41
      port: 4114
      username: !secret lcn_username
      password: !secret lcn_password

  sensors:
    - name: Temperature
      address: myhome.s0.m7
      source: var3
      unit_of_measurement: celsius

    - name: Led6 state
      address: myhome.s0.m7
      source: led6
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
