### PR TITLE
Fix for broken snips component after snips platform update

### DIFF
--- a/homeassistant/components/snips/__init__.py
+++ b/homeassistant/components/snips/__init__.py
@@ -105,10 +105,10 @@ async def async_setup(hass, config):
             _LOGGER.error('Received invalid JSON: %s', payload)
             return
 
-        if (request['intent']['probability']
+        if (request['intent']['confidenceScore']
                 < config[DOMAIN].get(CONF_PROBABILITY)):
             _LOGGER.warning("Intent below probaility threshold %s < %s",
-                            request['intent']['probability'],
+                            request['intent']['confidenceScore'],
                             config[DOMAIN].get(CONF_PROBABILITY))
             return
 
@@ -130,7 +130,7 @@ async def async_setup(hass, config):
                 'value': slot['rawValue']}
         slots['site_id'] = {'value': request.get('siteId')}
         slots['session_id'] = {'value': request.get('sessionId')}
-        slots['probability'] = {'value': request['intent']['probability']}
+        slots['confidenceScore'] = {'value': request['intent']['confidenceScore']}
 
         try:
             intent_response = await intent.async_handle(

--- a/tests/components/snips/test_init.py
+++ b/tests/components/snips/test_init.py
@@ -113,7 +113,7 @@ async def test_snips_intent(hass):
         "input": "turn the lights green",
         "intent": {
             "intentName": "Lights",
-            "probability": 1
+            "confidenceScore": 1
         },
         "slots": [
             {
@@ -140,7 +140,7 @@ async def test_snips_intent(hass):
     assert intent
     assert intent.slots == {'light_color': {'value': 'green'},
                             'light_color_raw': {'value': 'green'},
-                            'probability': {'value': 1},
+                            'confidenceScore': {'value': 1},
                             'site_id': {'value': 'default'},
                             'session_id': {'value': '1234567890ABCDEF'}}
     assert intent.text_input == 'turn the lights green'
@@ -161,7 +161,7 @@ async def test_snips_service_intent(hass):
         "input": "turn the light on",
         "intent": {
             "intentName": "Lights",
-            "probability": 0.85
+            "confidenceScore": 0.85
         },
         "siteId": "default",
         "slots": [
@@ -188,7 +188,7 @@ async def test_snips_service_intent(hass):
     assert calls[0].domain == 'light'
     assert calls[0].service == 'turn_on'
     assert calls[0].data['entity_id'] == 'light.kitchen'
-    assert 'probability' not in calls[0].data
+    assert 'confidenceScore' not in calls[0].data
     assert 'site_id' not in calls[0].data
 
 
@@ -205,7 +205,7 @@ async def test_snips_intent_with_duration(hass):
       "input": "set a timer of five minutes",
       "intent": {
         "intentName": "SetTimer",
-        "probability": 1
+        "confidenceScore": 1
       },
       "slots": [
         {
@@ -241,7 +241,7 @@ async def test_snips_intent_with_duration(hass):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'SetTimer'
-    assert intent.slots == {'probability': {'value': 1},
+    assert intent.slots == {'confidenceScore': {'value': 1},
                             'site_id': {'value': None},
                             'session_id': {'value': None},
                             'timer_duration': {'value': 300},
@@ -274,7 +274,7 @@ async def test_intent_speech_response(hass):
         "sessionId": "abcdef0123456789",
         "intent": {
             "intentName": "spokenIntent",
-            "probability": 1
+            "confidenceScore": 1
         },
         "slots": []
     }
@@ -306,7 +306,7 @@ async def test_unknown_intent(hass, caplog):
         "sessionId": "abcdef1234567890",
         "intent": {
             "intentName": "unknownIntent",
-            "probability": 1
+            "confidenceScore": 1
         },
         "slots": []
     }
@@ -330,7 +330,7 @@ async def test_snips_intent_user(hass):
         "input": "what to do",
         "intent": {
             "intentName": "user_ABCDEF123__Lights",
-            "probability": 1
+            "confidenceScore": 1
         },
         "slots": []
     }
@@ -359,7 +359,7 @@ async def test_snips_intent_username(hass):
         "input": "what to do",
         "intent": {
             "intentName": "username:Lights",
-            "probability": 1
+            "confidenceScore": 1
         },
         "slots": []
     }
@@ -391,7 +391,7 @@ async def test_snips_low_probability(hass, caplog):
         "input": "I am not sure what to say",
         "intent": {
             "intentName": "LightsMaybe",
-            "probability": 0.49
+            "confidenceScore": 0.49
         },
         "slots": []
     }
@@ -419,7 +419,7 @@ async def test_intent_special_slots(hass):
                 "action": {
                     "service": "light.turn_on",
                     "data_template": {
-                        "probability": "{{ probability }}",
+                        "confidenceScore": "{{ confidenceScore }}",
                         "site_id": "{{ site_id }}"
                     }
                 }
@@ -432,7 +432,7 @@ async def test_intent_special_slots(hass):
         "input": "turn the light on",
         "intent": {
             "intentName": "Lights",
-            "probability": 0.85
+            "confidenceScore": 0.85
         },
         "siteId": "default",
         "slots": []
@@ -444,7 +444,7 @@ async def test_intent_special_slots(hass):
     assert len(calls) == 1
     assert calls[0].domain == 'light'
     assert calls[0].service == 'turn_on'
-    assert calls[0].data['probability'] == '0.85'
+    assert calls[0].data['confidenceScore'] == '0.85'
     assert calls[0].data['site_id'] == 'default'
 
 


### PR DESCRIPTION
## Description:
Snips.ai platform update had a breaking change, where hermes API was changed. probability was renamed to confidenceScore.

**Related issue (if applicable):** fixes #21441

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
