### PR TITLE
Increase Travis CI Timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ cache:
     - $HOME/.cache/pip
 install: pip install -U tox coveralls
 language: python
-script: travis_wait 30 tox --develop
+script: travis_wait 40 tox --develop
 services:
   - docker
 before_deploy:


### PR DESCRIPTION
## Description:
Bumps the Travis CI invocation timeout to 40min so the `pylint` build has more time to complete.

@balloob cleared the Travis cache, but it had no effect.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.