### PR TITLE
Support multiple keys in ifttt triggers

### DIFF
--- a/homeassistant/components/ifttt/__init__.py
+++ b/homeassistant/components/ifttt/__init__.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 EVENT_RECEIVED = 'ifttt_webhook_received'
 
 ATTR_EVENT = 'event'
-ATTR_TO = 'to'
+ATTR_TARGET = 'target'
 ATTR_VALUE1 = 'value1'
 ATTR_VALUE2 = 'value2'
 ATTR_VALUE3 = 'value3'
@@ -30,7 +30,7 @@ SERVICE_TRIGGER = 'trigger'
 
 SERVICE_TRIGGER_SCHEMA = vol.Schema({
     vol.Required(ATTR_EVENT): cv.string,
-    vol.Optional(ATTR_TO): vol.Any([cv.string], cv.string),
+    vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(ATTR_VALUE1): cv.string,
     vol.Optional(ATTR_VALUE2): cv.string,
     vol.Optional(ATTR_VALUE3): cv.string,
@@ -48,37 +48,32 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    conf_keys = config[DOMAIN][CONF_KEY]
-    if isinstance(conf_keys, str):
-        conf_keys = {"default": conf_keys}
+    api_keys = config[DOMAIN][CONF_KEY]
+    if isinstance(api_keys, str):
+        api_keys = {"default": api_keys}
 
     def trigger_service(call):
         """Handle IFTTT trigger service calls."""
         event = call.data[ATTR_EVENT]
-        send_to = call.data.get(ATTR_TO, None)
+        targets = call.data.get(ATTR_TARGET, list(api_keys))
         value1 = call.data.get(ATTR_VALUE1)
         value2 = call.data.get(ATTR_VALUE2)
         value3 = call.data.get(ATTR_VALUE3)
 
-        if send_to is None:
-            send_to = list(conf_keys.keys())
-        elif isinstance(send_to, str):
-            send_to = [send_to]
-
-        keys = dict()
-        for key_name in send_to:
-            if key_name not in conf_keys.keys():
-                _LOGGER.error("No IFTTT key %s", key_name)
+        target_keys = dict()
+        for target in targets:
+            if target not in api_keys:
+                _LOGGER.error("No IFTTT api key for %s", target)
                 continue
-            keys[key_name] = conf_keys[key_name]
+            target_keys[target] = api_keys[target]
 
         try:
             import pyfttt
-            for key_name, key in keys.items():
+            for target, key in target_keys.items():
                 res = pyfttt.send_event(key, event, value1, value2, value3)
                 if res.status_code != 200:
                     _LOGGER.error("IFTTT reported error sending event to %s.",
-                                  key_name)
+                                  target)
         except requests.exceptions.RequestException:
             _LOGGER.exception("Error communicating with IFTTT")
 


### PR DESCRIPTION
## Description:

- With this PR, multiple ifttt keys are allowed to trigger webhook notifications to multiple users.
- Backwards compatibility is preserved in config files and schemas.
- No tests were added as I could not find tests for ifttt triggers and I do not know how to write one.

**Related issue (if applicable):** (no issue created)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8751

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
ifttt:
  key: 
    YOUR_KEY_NAME1: YOUR_API_KEY1
    YOUR_KEY_NAME2: YOUR_API_KEY2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable **(No new dependencies)**
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`. **(No new dependencies)**
  - [x] New files were added to `.coveragerc`. **(No new files)**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
