### PR TITLE
Add cpu_use_percent as a new resource to the Glances sensor

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -47,6 +47,7 @@ SENSOR_TYPES = {
     'process_total': ['Total', 'Count', 'mdi:memory'],
     'process_thread': ['Thread', 'Count', 'mdi:memory'],
     'process_sleeping': ['Sleeping', 'Count', 'mdi:memory'],
+    'cpu_use_percent': ['CPU used', '%', 'mdi:memory'],
     'cpu_temp': ['CPU Temp', TEMP_CELSIUS, 'mdi:thermometer'],
     'docker_active': ['Containers active', '', 'mdi:docker'],
     'docker_cpu_use': ['Containers CPU used', '%', 'mdi:docker'],
@@ -177,6 +178,8 @@ class GlancesSensor(Entity):
                 self._state = value['processcount']['thread']
             elif self.type == 'process_sleeping':
                 self._state = value['processcount']['sleeping']
+            elif self.type == 'cpu_use_percent':
+                self._state = value['quicklook']['cpu']
             elif self.type == 'cpu_temp':
                 for sensor in value['sensors']:
                     if sensor['label'] in ['CPU', "Package id 0",


### PR DESCRIPTION
## Description:
Add `cpu_use_percent` as a new resource to the Glances sensor.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#8752

## Example entry for `configuration.yaml`:
```yaml
sensor:
  - platform: glances
    host: IP_ADDRESS
    resources:
      - cpu_use_percent
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
