### PR TITLE
Pin isort to solve Travis timing out

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -26,3 +26,7 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
+
+# Newer version causes pylint to take forever
+# https://github.com/timothycrosley/isort/issues/848
+isort==4.3.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -160,6 +160,10 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
+
+# Newer version causes pylint to take forever
+# https://github.com/timothycrosley/isort/issues/848
+isort==4.3.4
 """
 
 


### PR DESCRIPTION
This solves the Travis timeout. isort 4.3.5 is slower and it is causing the pylint task to run out of time. This PR will make sure that we pin isort until it is resolved.

Upstream issue: https://github.com/timothycrosley/isort/issues/848