### PR TITLE
Changed source priority for Person

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -379,7 +379,7 @@ class Person(RestoreEntity):
 
     @callback
     def _update_state(self):
-        def _get_latest(prev,curr):
+        def _get_latest(prev, curr):
             return curr if prev is None or curr.last_updated > prev.last_updated else prev
 
         """Update the state."""
@@ -391,11 +391,11 @@ class Person(RestoreEntity):
                 continue
 
             if state.attributes.get(ATTR_SOURCE_TYPE) == SOURCE_TYPE_GPS:
-                latest_gps = _get_latest(latest_gps,state)
+                latest_gps = _get_latest(latest_gps, state)
             elif state.state == STATE_HOME:
-                latest_home = _get_latest(latest_home,state)
+                latest_home = _get_latest(latest_home, state)
             elif state.state == STATE_NOT_HOME:
-                latest_not_home = _get_latest(latest_not_home,state)
+                latest_not_home = _get_latest(latest_not_home, state)
 
         if latest_home:
             latest = latest_home

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -10,7 +10,8 @@ from homeassistant.components import websocket_api
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN)
 from homeassistant.const import (
-    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_ID, CONF_NAME,
+    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_GPS_ACCURACY,
+    CONF_ID, CONF_NAME,
     EVENT_HOMEASSISTANT_START, STATE_UNKNOWN, STATE_UNAVAILABLE)
 from homeassistant.core import callback, Event
 from homeassistant.auth import EVENT_USER_REMOVED
@@ -285,6 +286,7 @@ class Person(RestoreEntity):
         self._editable = editable
         self._latitude = None
         self._longitude = None
+        self._gps_accuracy = None
         self._source = None
         self._state = None
         self._unsub_track_device = None
@@ -318,6 +320,8 @@ class Person(RestoreEntity):
             data[ATTR_LATITUDE] = round(self._latitude, 5)
         if self._longitude is not None:
             data[ATTR_LONGITUDE] = round(self._longitude, 5)
+        if self._gps_accuracy is not None:
+            data[ATTR_LONGITUDE] = round(self._gps_accuracy, 1)
         if self._source is not None:
             data[ATTR_SOURCE] = self._source
         user_id = self._config.get(CONF_USER_ID)
@@ -393,6 +397,7 @@ class Person(RestoreEntity):
             self._source = None
             self._latitude = None
             self._longitude = None
+            self._gps_accuracy = None
 
         self.async_schedule_update_ha_state()
 
@@ -406,6 +411,7 @@ class Person(RestoreEntity):
         self._source = state.entity_id
         self._latitude = state.attributes.get(ATTR_LATITUDE)
         self._longitude = state.attributes.get(ATTR_LONGITUDE)
+        self._gps_accuracy = state.attributes.get(ATTR_GPS_ACCURACY)
 
 
 @websocket_api.websocket_command({

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -382,10 +382,8 @@ class Person(RestoreEntity):
                if prev is None or curr.last_updated > prev.last_updated \
                else prev
 
-
     @callback
     def _update_state(self):
-
         """Update the state."""
         latest_home = latest_not_home = latest_gps = latest = None
         for entity_id in self._config.get(CONF_DEVICE_TRACKERS, []):

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -321,7 +321,7 @@ class Person(RestoreEntity):
         if self._longitude is not None:
             data[ATTR_LONGITUDE] = round(self._longitude, 5)
         if self._gps_accuracy is not None:
-            data[ATTR_LONGITUDE] = round(self._gps_accuracy, 1)
+            data[ATTR_GPS_ACCURACY] = round(self._gps_accuracy, 1)
         if self._source is not None:
             data[ATTR_SOURCE] = self._source
         user_id = self._config.get(CONF_USER_ID)

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -190,8 +190,8 @@ async def test_setup_two_trackers(hass, hass_admin_user):
             ATTR_GPS_ACCURACY: 12,
             ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})
     await hass.async_block_till_done()
-    hass.states.async_set(DEVICE_TRACKER, 'not_home',
-        {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
+    hass.states.async_set(
+        DEVICE_TRACKER, 'not_home', {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
     await hass.async_block_till_done()
 
     state = hass.states.get('person.tracked_person')

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -135,10 +135,10 @@ async def test_setup_tracker(hass, hass_admin_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
     hass.states.async_set(
-        DEVICE_TRACKER, 'not_home',
-        {ATTR_LATITUDE: 10.123456, 
-         ATTR_LONGITUDE: 11.123456,
-         ATTR_GPS_ACCURACY: 10})
+        DEVICE_TRACKER, 'not_home', {
+            ATTR_LATITUDE: 10.123456,
+            ATTR_LONGITUDE: 11.123456,
+            ATTR_GPS_ACCURACY: 10})
     await hass.async_block_till_done()
 
     state = hass.states.get('person.tracked_person')
@@ -184,11 +184,11 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
     hass.states.async_set(
-        DEVICE_TRACKER_2, 'not_home',
-        {ATTR_LATITUDE: 12.123456,
-         ATTR_LONGITUDE: 13.123456,
-         ATTR_GPS_ACCURACY: 12,
-         ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})
+        DEVICE_TRACKER_2, 'not_home', {
+            ATTR_LATITUDE: 12.123456,
+            ATTR_LONGITUDE: 13.123456,
+            ATTR_GPS_ACCURACY: 12,
+            ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})
     await hass.async_block_till_done()
     hass.states.async_set(DEVICE_TRACKER, 'not_home',
         {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -171,8 +171,7 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
     hass.states.async_set(
-        DEVICE_TRACKER, 'home',
-        {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
+        DEVICE_TRACKER, 'home', {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
     await hass.async_block_till_done()
 
     state = hass.states.get('person.tracked_person')

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -170,7 +170,8 @@ async def test_setup_two_trackers(hass, hass_admin_user):
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
-    hass.states.async_set(DEVICE_TRACKER, 'home',
+    hass.states.async_set(
+        DEVICE_TRACKER, 'home',
         {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
     await hass.async_block_till_done()
 
@@ -212,7 +213,8 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     assert state.state == 'zone1'
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER_2
 
-    hass.states.async_set(DEVICE_TRACKER, 'home',
+    hass.states.async_set(
+        DEVICE_TRACKER, 'home',
         {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
     await hass.async_block_till_done()
     hass.states.async_set(

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -212,8 +212,7 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER_2
 
     hass.states.async_set(
-        DEVICE_TRACKER, 'home',
-        {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
+        DEVICE_TRACKER, 'home', {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
     await hass.async_block_till_done()
     hass.states.async_set(
         DEVICE_TRACKER_2, 'zone2', {ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -18,6 +18,7 @@ from tests.common import mock_component, mock_restore_cache, mock_coro_func
 DEVICE_TRACKER = 'device_tracker.test_tracker'
 DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
 
+
 @pytest.fixture
 def storage_setup(hass, hass_storage, hass_admin_user):
     """Storage setup."""

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -205,8 +205,7 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
     hass.states.async_set(
-        DEVICE_TRACKER_2, 'zone1',
-        {ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})
+        DEVICE_TRACKER_2, 'zone1', {ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})
     await hass.async_block_till_done()
 
     state = hass.states.get('person.tracked_person')
@@ -218,8 +217,7 @@ async def test_setup_two_trackers(hass, hass_admin_user):
         {ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER})
     await hass.async_block_till_done()
     hass.states.async_set(
-        DEVICE_TRACKER_2, 'zone2',
-        {ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})
+        DEVICE_TRACKER_2, 'zone2', {ATTR_SOURCE_TYPE: SOURCE_TYPE_GPS})
     await hass.async_block_till_done()
 
     state = hass.states.get('person.tracked_person')


### PR DESCRIPTION
## Description:

Added GPS accuracy to Person.
Changed source priority for Person. Status of Person determined next way:
1. If there are sources with status 'home', than latest of this sources will be taken.
2. If there are sources with source type 'gps', than latest of this sources will be taken.
3. Other wise will be taken latest source with status 'not_home'.

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/8773

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
