### PR TITLE
Created functionality that allows a user to customize manifest.json

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -37,15 +37,28 @@ JS_OPTIONS = ['es5', 'latest', 'auto']
 
 DEFAULT_THEME_COLOR = '#03A9F4'
 
+CONF_MANIFEST_JSON = 'manifest_json'
+CONF_MANIFEST_JSON_SETTINGS = ['display', 'short_name', 'start_url']
+CONF_MANIFEST_JSON_DISPLAY = 'display'
+CONF_MANIFEST_JSON_DISPLAY_DEFAULT = 'standalone'
+CONF_MANIFEST_JSON_SHORT_NAME = 'short_name'
+CONF_MANIFEST_JSON_SHORT_NAME_DEFAULT = 'Assistant'
+CONF_MANIFEST_JSON_START_URL = 'start_url'
+CONF_MANIFEST_JSON_START_URL_DEFAULT = '/?homescreen=1'
+MANIFEST_JSON_DISPLAY_OPTIONS = [
+    'fullscreen',
+    'standalone',
+    'minimal-ui',
+    'browser'
+]
+
 MANIFEST_JSON = {
     'background_color': '#FFFFFF',
     'description': 'Open-source home automation platform running on Python 3.',
     'dir': 'ltr',
-    'display': 'standalone',
     'icons': [],
     'lang': 'en-US',
     'name': 'Home Assistant',
-    'short_name': 'Assistant',
     'start_url': '/?homescreen=1',
     'theme_color': DEFAULT_THEME_COLOR
 }
@@ -81,7 +94,26 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_EXTRA_HTML_URL_ES5):
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_JS_VERSION, default=JS_DEFAULT_OPTION):
-            vol.In(JS_OPTIONS)
+            vol.In(JS_OPTIONS),
+        vol.Optional(CONF_MANIFEST_JSON, default={
+            CONF_MANIFEST_JSON_DISPLAY: CONF_MANIFEST_JSON_DISPLAY_DEFAULT,
+            CONF_MANIFEST_JSON_SHORT_NAME:
+                CONF_MANIFEST_JSON_SHORT_NAME_DEFAULT,
+            CONF_MANIFEST_JSON_START_URL: CONF_MANIFEST_JSON_START_URL_DEFAULT
+        }): vol.Schema({
+            cv.string: cv.string,
+            vol.Optional(
+                CONF_MANIFEST_JSON_DISPLAY,
+                default=CONF_MANIFEST_JSON_DISPLAY_DEFAULT
+            ):
+            vol.In(MANIFEST_JSON_DISPLAY_OPTIONS),
+            vol.Optional(
+                CONF_MANIFEST_JSON_SHORT_NAME,
+                default=CONF_MANIFEST_JSON_SHORT_NAME_DEFAULT): cv.string,
+            vol.Optional(
+                CONF_MANIFEST_JSON_START_URL,
+                default=CONF_MANIFEST_JSON_START_URL_DEFAULT): cv.string,
+        }),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -203,6 +235,14 @@ async def async_setup(hass, config):
     hass.http.register_view(ManifestJSONView)
 
     conf = config.get(DOMAIN, {})
+
+    manifest_json_data = conf.get(CONF_MANIFEST_JSON)
+    if manifest_json_data is not None:
+        for manifest_setting in CONF_MANIFEST_JSON_SETTINGS:
+            add_manifest_json_key(
+                manifest_setting,
+                manifest_json_data[manifest_setting]
+            )
 
     repo_path = conf.get(CONF_FRONTEND_REPO)
     is_dev = repo_path is not None

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1,6 +1,7 @@
 """The tests for Home Assistant frontend."""
 import asyncio
 import re
+import json
 from unittest.mock import patch
 
 import pytest
@@ -8,7 +9,11 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
     DOMAIN, CONF_JS_VERSION, CONF_THEMES, CONF_EXTRA_HTML_URL,
-    CONF_EXTRA_HTML_URL_ES5)
+    CONF_EXTRA_HTML_URL_ES5, CONF_MANIFEST_JSON,
+    CONF_MANIFEST_JSON_DISPLAY, CONF_MANIFEST_JSON_START_URL,
+    CONF_MANIFEST_JSON_SHORT_NAME, CONF_MANIFEST_JSON_DISPLAY_DEFAULT,
+    CONF_MANIFEST_JSON_START_URL_DEFAULT,
+    CONF_MANIFEST_JSON_SHORT_NAME_DEFAULT)
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 
 from tests.common import mock_coro
@@ -65,6 +70,51 @@ def mock_onboarded():
     with patch('homeassistant.components.onboarding.async_is_onboarded',
                return_value=True):
         yield
+
+
+@pytest.fixture
+def mock_manifest_json_no_custom(hass, aiohttp_client):
+    """Start the Hass HTTP component."""
+    hass.loop.run_until_complete(async_setup_component(hass, 'frontend', {
+        DOMAIN: {
+        }}))
+    return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
+
+
+@pytest.fixture
+def mock_manifest_json_with_custom_short_name(hass, aiohttp_client):
+    """Start the Hass HTTP component."""
+    hass.loop.run_until_complete(async_setup_component(hass, 'frontend', {
+        DOMAIN: {
+            CONF_MANIFEST_JSON: {
+                CONF_MANIFEST_JSON_SHORT_NAME: 'Home Assistant'
+             }
+        }}))
+    return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
+
+
+@pytest.fixture
+def mock_manifest_json_with_custom_start_url(hass, aiohttp_client):
+    """Start the Hass HTTP component."""
+    hass.loop.run_until_complete(async_setup_component(hass, 'frontend', {
+        DOMAIN: {
+            CONF_MANIFEST_JSON: {
+                CONF_MANIFEST_JSON_START_URL: '/'
+             }
+        }}))
+    return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
+
+
+@pytest.fixture
+def mock_manifest_json_with_custom_display(hass, aiohttp_client):
+    """Start the Hass HTTP component."""
+    hass.loop.run_until_complete(async_setup_component(hass, 'frontend', {
+        DOMAIN: {
+            CONF_MANIFEST_JSON: {
+                CONF_MANIFEST_JSON_DISPLAY: 'fullscreen'
+             }
+        }}))
+    return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
 
 
 @asyncio.coroutine
@@ -243,6 +293,60 @@ def test_extra_urls_es5(mock_http_client_with_urls, mock_onboarded):
     assert resp.status == 200
     text = yield from resp.text()
     assert text.find("href='https://domain.com/my_extra_url_es5.html'") >= 0
+
+
+@asyncio.coroutine
+def test_get_manifest_json_no_custom(
+        mock_manifest_json_no_custom,
+        mock_onboarded):
+    """Test test_get_manifest_json_no_custom command."""
+    resp = yield from mock_manifest_json_no_custom.get('/manifest.json')
+    assert resp.status == 200
+    text = yield from resp.text()
+    jsonObj = json.loads(text)
+    assert jsonObj is not None
+    assert jsonObj['display'] == CONF_MANIFEST_JSON_DISPLAY_DEFAULT
+    assert jsonObj['short_name'] == CONF_MANIFEST_JSON_SHORT_NAME_DEFAULT
+    assert jsonObj['start_url'] == CONF_MANIFEST_JSON_START_URL_DEFAULT
+
+
+@asyncio.coroutine
+def test_get_manifest_json_with_custom_short_name(
+        mock_manifest_json_with_custom_short_name,
+        mock_onboarded):
+    """Test test_get_manifest_json_with_custom_short_name command."""
+    resp = yield from mock_manifest_json_with_custom_short_name.get(
+        '/manifest.json')
+    assert resp.status == 200
+    text = yield from resp.text()
+    jsonObj = json.loads(text)
+    assert jsonObj['short_name'] == 'Home Assistant'
+
+
+@asyncio.coroutine
+def test_get_manifest_json_with_custom_start_url(
+        mock_manifest_json_with_custom_start_url,
+        mock_onboarded):
+    """Test test_get_manifest_json_with_custom_start_url command."""
+    resp = yield from mock_manifest_json_with_custom_start_url.get(
+        '/manifest.json')
+    assert resp.status == 200
+    text = yield from resp.text()
+    jsonObj = json.loads(text)
+    assert jsonObj['start_url'] == '/'
+
+
+@asyncio.coroutine
+def test_get_manifest_json_with_custom_display(
+        mock_manifest_json_with_custom_display,
+        mock_onboarded):
+    """Test test_get_manifest_json_with_custom_display command."""
+    resp = yield from mock_manifest_json_with_custom_display.get(
+        '/manifest.json')
+    assert resp.status == 200
+    text = yield from resp.text()
+    jsonObj = json.loads(text)
+    assert jsonObj['display'] == 'fullscreen'
 
 
 async def test_get_panels(hass, hass_ws_client):


### PR DESCRIPTION
Created functionality that allows a user to customize manifest.json

## Description:

This will allow users to customize the display, start_url and short_name (name displayed on andoird ios shortcut) in the manifest.json file.

Documentation updates in PR https://github.com/home-assistant/home-assistant.io/pull/8759

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
  manifest_json:
    display: fullscreen
    short_name: "Home Assistant"
    start_url: /
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
