### PR TITLE
Bump starlingbank version to 3.1

### DIFF
--- a/homeassistant/components/sensor/starlingbank.py
+++ b/homeassistant/components/sensor/starlingbank.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['starlingbank==3.0']
+REQUIREMENTS = ['starlingbank==3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/starlingbank.py
+++ b/homeassistant/components/sensor/starlingbank.py
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sterling Bank sensor platform."""
-    from starlingbank import StarlingAccount  # pylint: disable=syntax-error
+    from starlingbank import StarlingAccount
 
     sensors = []
     for account in config[CONF_ACCOUNTS]:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1622,7 +1622,7 @@ sqlalchemy==1.2.18
 srpenergy==1.0.5
 
 # homeassistant.components.sensor.starlingbank
-starlingbank==3.0
+starlingbank==3.1
 
 # homeassistant.components.statsd
 statsd==3.2.1


### PR DESCRIPTION
Bump in version solves Python 3.5 compatibility issue.

Related:
https://github.com/home-assistant/home-assistant/pull/21485
https://github.com/Dullage/starlingbank/pull/6