### PR TITLE
Add watchdog to Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -28,8 +28,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DATA_CONFIG = 'config'
 
-DEFAULT_HEALTH_CHECK_INTERVAL = timedelta(minutes=5)
 DEFAULT_SOCKET_MIN_RETRY = 15
+DEFAULT_WATCHDOG_LISTENER = timedelta(minutes=5)
 
 TYPE_24HOURRAININ = '24hourrainin'
 TYPE_BAROMABSIN = 'baromabsin'
@@ -299,7 +299,7 @@ class AmbientStation:
         """Initialize."""
         self._config_entry = config_entry
         self._hass = hass
-        self._health_timer_listener = None
+        self._watchdog_listener = None
         self._ws_reconnect_delay = DEFAULT_SOCKET_MIN_RETRY
         self.client = client
         self.monitored_conditions = monitored_conditions
@@ -319,8 +319,8 @@ class AmbientStation:
             """Define a handler to fire when the websocket is connected."""
             _LOGGER.info('Connected to websocket')
             _LOGGER.debug('Watchdog starting')
-            self._health_timer_listener = async_track_time_interval(
-                self._hass, _ws_reconnect, DEFAULT_HEALTH_CHECK_INTERVAL)
+            self._watchdog_listener = async_track_time_interval(
+                self._hass, _ws_reconnect, DEFAULT_WATCHDOG_LISTENER)
 
         def on_data(data):
             """Define a handler to fire when the data is received."""
@@ -331,9 +331,9 @@ class AmbientStation:
                 async_dispatcher_send(self._hass, TOPIC_UPDATE)
 
             _LOGGER.debug('Resetting watchdog')
-            self._health_timer_listener()
-            self._health_timer_listener = async_track_time_interval(
-                self._hass, _ws_reconnect, DEFAULT_HEALTH_CHECK_INTERVAL)
+            self._watchdog_listener()
+            self._watchdog_listener = async_track_time_interval(
+                self._hass, _ws_reconnect, DEFAULT_WATCHDOG_LISTENER)
 
         def on_disconnect():
             """Define a handler to fire when the websocket is disconnected."""

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -1,6 +1,5 @@
 """Support for Ambient Weather Station Service."""
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 
@@ -14,8 +13,7 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, async_dispatcher_send)
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import (
-    async_call_later, async_track_time_interval)
+from homeassistant.helpers.event import async_call_later
 
 from .config_flow import configured_instances
 from .const import (
@@ -29,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 DATA_CONFIG = 'config'
 
 DEFAULT_SOCKET_MIN_RETRY = 15
-DEFAULT_WATCHDOG_LISTENER = timedelta(minutes=5)
+DEFAULT_WATCHDOG_SECONDS = 5 * 60
 
 TYPE_24HOURRAININ = '24hourrainin'
 TYPE_BAROMABSIN = 'baromabsin'
@@ -319,8 +317,8 @@ class AmbientStation:
             """Define a handler to fire when the websocket is connected."""
             _LOGGER.info('Connected to websocket')
             _LOGGER.debug('Watchdog starting')
-            self._watchdog_listener = async_track_time_interval(
-                self._hass, _ws_reconnect, DEFAULT_WATCHDOG_LISTENER)
+            self._watchdog_listener = async_call_later(
+                self._hass, DEFAULT_WATCHDOG_SECONDS, _ws_reconnect)
 
         def on_data(data):
             """Define a handler to fire when the data is received."""
@@ -332,8 +330,8 @@ class AmbientStation:
 
             _LOGGER.debug('Resetting watchdog')
             self._watchdog_listener()
-            self._watchdog_listener = async_track_time_interval(
-                self._hass, _ws_reconnect, DEFAULT_WATCHDOG_LISTENER)
+            self._watchdog_listener = async_call_later(
+                self._hass, DEFAULT_WATCHDOG_SECONDS, _ws_reconnect)
 
         def on_disconnect():
             """Define a handler to fire when the websocket is disconnected."""


### PR DESCRIPTION
## Description:

While investigating https://github.com/home-assistant/home-assistant/issues/21340, I came to the conclusion that Ambient Weather's websocket had a blip wherein it stopped sending data to existing connections for a period; a HASS restart would cause data to start flowing again.

This PR implements a watchdog: if the component doesn't receive data from the websocket for 5 minutes, it will forcibly disconnect the socket and reconnect it. This should help the component recover without a HASS restart.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
