### PR TITLE
Improve new Sonos snapshot/restore

### DIFF
--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -328,7 +328,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         snapshotMock.return_value = True
         entity.soco.group = mock.MagicMock()
         entity.soco.group.members = [e.soco for e in entities]
-        sonos.snapshot_entities(entities, True)
+        sonos.SonosEntity.snapshot_multi(entities, True)
         assert snapshotMock.call_count == 1
         assert snapshotMock.call_args == mock.call()
 
@@ -350,6 +350,6 @@ class TestSonosMediaPlayer(unittest.TestCase):
         entity._snapshot_group = mock.MagicMock()
         entity._snapshot_group.members = [e.soco for e in entities]
         entity._soco_snapshot = Snapshot(entity.soco)
-        sonos.restore_entities(entities, True)
+        sonos.SonosEntity.restore_multi(entities, True)
         assert restoreMock.call_count == 1
         assert restoreMock.call_args == mock.call()

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -328,7 +328,7 @@ class TestSonosMediaPlayer(unittest.TestCase):
         snapshotMock.return_value = True
         entity.soco.group = mock.MagicMock()
         entity.soco.group.members = [e.soco for e in entities]
-        sonos.snapshot(entities, True)
+        sonos.snapshot_entities(entities, True)
         assert snapshotMock.call_count == 1
         assert snapshotMock.call_args == mock.call()
 
@@ -350,6 +350,6 @@ class TestSonosMediaPlayer(unittest.TestCase):
         entity._snapshot_group = mock.MagicMock()
         entity._snapshot_group.members = [e.soco for e in entities]
         entity._soco_snapshot = Snapshot(entity.soco)
-        sonos.restore(entities, True)
+        sonos.restore_entities(entities, True)
         assert restoreMock.call_count == 1
         assert restoreMock.call_args == mock.call()


### PR DESCRIPTION
## Description:

After stress testing #21411 a bit I realized that we can still easily lose a race between unjoin and restore. The issue is that the playing state cannot be restored while speakers are still in slave mode.

So this PR sets restore up to potentially be called on topology change events. Then we know that the speaker is indeed a coordinator.

The change involves splitting up the entity/group parts of snapshot/restore.

I now contemplate moving the group snapshotting into pysonos. However, that will be quite hard so I think this PR is a good fix to include for now.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23