### PR TITLE
Upgrade pypollencom to 2.2.3

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['numpy==1.16.1', 'pypollencom==2.2.2']
+REQUIREMENTS = ['numpy==1.16.1', 'pypollencom==2.2.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1210,7 +1210,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.sensor.pollen
-pypollencom==2.2.2
+pypollencom==2.2.3
 
 # homeassistant.components.ps4
 pyps4-homeassistant==0.3.0


### PR DESCRIPTION
## Description:

Changelog: https://github.com/bachya/pypollencom/releases/tag/2.2.3

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
