### PR TITLE
Add support for Cisco Mobility Express

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -68,6 +68,7 @@ omit =
     homeassistant/components/camera/xiaomi.py
     homeassistant/components/camera/yi.py
     homeassistant/components/cast/*
+    homeassistant/components/cisco_mobility_express/device_tracker.py
     homeassistant/components/climate/coolmaster.py
     homeassistant/components/climate/ephember.py
     homeassistant/components/climate/eq3btsmart.py

--- a/homeassistant/components/cisco_mobility_express/__init__.py
+++ b/homeassistant/components/cisco_mobility_express/__init__.py
@@ -1,0 +1,1 @@
+"""Component to embed Cisco Mobility Express."""

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -32,7 +32,7 @@ def get_scanner(hass, config):
     from ciscomobilityexpress.ciscome import CiscoMobilityExpress
     config = config[DOMAIN]
 
-    scanner = CiscoMEDeviceScanner(config)
+    scanner = CiscoMEDeviceScanner(controller)
     scanner.controller = CiscoMobilityExpress(
         config[CONF_HOST],
         config[CONF_USERNAME],

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -49,7 +49,7 @@ class CiscoMEDeviceScanner(DeviceScanner):
 
     def __init__(self, controller):
         """Initialize the scanner."""
-        self.controller = None
+        self.controller = controller
         self.last_results = {}
 
     def scan_devices(self):

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -1,0 +1,82 @@
+"""Support for Cisco Mobility Express."""
+import logging
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import (
+    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_SSL, CONF_VERIFY_SSL)
+
+
+REQUIREMENTS = ['ciscomobilityexpress==0.1.2']
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SSL = False
+DEFAULT_VERIFY_SSL = True
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+})
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Cisco ME scanner."""
+    scanner = CiscoMEDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+class CiscoMEDeviceScanner(DeviceScanner):
+    """This class scans for devices associated to a Cisco ME controller."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        from ciscomobilityexpress.ciscome import CiscoMobilityExpress
+
+        self.controller = CiscoMobilityExpress(
+            config[CONF_HOST],
+            config[CONF_USERNAME],
+            config[CONF_PASSWORD],
+            config[CONF_SSL],
+            config[CONF_VERIFY_SSL])
+
+        self.last_results = {}
+        self.success_init = self.controller.is_logged_in()
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return [device.macaddr for device in self.last_results]
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        name = next((
+            result.clId for result in self.last_results
+            if result.macaddr == device), None)
+        return name
+
+    def get_extra_attributes(self, device):
+        """
+        Get extra attributes of a device.
+
+        Some known extra attributes that may be returned in the device tuple
+        include SSID, PT (eg 802.11ac), devtype (eg iPhone 7) among others.
+        """
+        device = next((
+            result for result in self.last_results
+            if result.macaddr == device), None)
+        return device._asdict()
+
+    def _update_info(self):
+        """Check the Cisco ME controller for devices."""
+        self.last_results = self.controller.get_associated_devices()
+        _LOGGER.debug("Cisco Mobility Express controller returned:"
+                      " %s", self.last_results)

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -47,7 +47,7 @@ def get_scanner(hass, config):
 class CiscoMEDeviceScanner(DeviceScanner):
     """This class scans for devices associated to a Cisco ME controller."""
 
-    def __init__(self, config):
+    def __init__(self, controller):
         """Initialize the scanner."""
         self.controller = None
         self.last_results = {}

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -32,14 +32,14 @@ def get_scanner(hass, config):
     from ciscomobilityexpress.ciscome import CiscoMobilityExpress
     config = config[DOMAIN]
 
-    scanner = CiscoMEDeviceScanner(controller)
     controller = CiscoMobilityExpress(
         config[CONF_HOST],
         config[CONF_USERNAME],
         config[CONF_PASSWORD],
         config.get(CONF_SSL),
         config.get(CONF_VERIFY_SSL))
-    success_init = scanner.controller.is_logged_in()
+    success_init = controller.is_logged_in()
+    scanner = CiscoMEDeviceScanner(controller)
 
     return scanner if success_init else None
 

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -38,10 +38,9 @@ def get_scanner(hass, config):
         config[CONF_PASSWORD],
         config.get(CONF_SSL),
         config.get(CONF_VERIFY_SSL))
-    success_init = controller.is_logged_in()
-    scanner = CiscoMEDeviceScanner(controller)
-
-    return scanner if success_init else None
+    if not controller.is_logged_in():
+        return None
+    return CiscoMEDeviceScanner(controller)
 
 
 class CiscoMEDeviceScanner(DeviceScanner):

--- a/homeassistant/components/cisco_mobility_express/device_tracker.py
+++ b/homeassistant/components/cisco_mobility_express/device_tracker.py
@@ -33,7 +33,7 @@ def get_scanner(hass, config):
     config = config[DOMAIN]
 
     scanner = CiscoMEDeviceScanner(controller)
-    scanner.controller = CiscoMobilityExpress(
+    controller = CiscoMobilityExpress(
         config[CONF_HOST],
         config[CONF_USERNAME],
         config[CONF_PASSWORD],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -258,6 +258,9 @@ buienradar==0.91
 # homeassistant.components.calendar.caldav
 caldav==0.5.0
 
+# homeassistant.components.cisco_mobility_express.device_tracker
+ciscomobilityexpress==0.1.2
+
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
 


### PR DESCRIPTION
## Description:
This platform adds device tracker support for Cisco Mobility Express wireless controllers.

![screenshot 2019-02-27 at 14 32 11](https://user-images.githubusercontent.com/254309/53497682-9c1d8400-3a9c-11e9-8305-f2d9848552d2.png)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#8777

## Example entry for `configuration.yaml` (if applicable):
```yaml
 # Example configuration.yaml entry
 device_tracker:
   - platform: cisco_mobility_express
     host: CONTROLLER_IP_ADDRESS
     username: YOUR_ADMIN_USERNAME
     password: YOUR_ADMIN_PASSWORD
 ```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23