### PR TITLE
Fix trusted networks deprecated warning message

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -55,6 +55,9 @@ NO_LOGIN_ATTEMPT_THRESHOLD = -1
 
 def trusted_networks_deprecated(value):
     """Warn user trusted_networks config is deprecated."""
+    if not value:
+        return value
+
     _LOGGER.warning(
         "Configuring trusted_networks via the http component has been"
         " deprecated. Use the trusted networks auth provider instead."


### PR DESCRIPTION
## Description:

`http.trusted_networks` has default value, so that the deprecated warning message will always print regardless whether user configured it in yaml.

**Related issue (if applicable):** fixes beta finding

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

