### PR TITLE
Introduce target_temperature_state_address for climate device

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -11,7 +11,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import Script
 
-REQUIREMENTS = ['xknx==0.9.4']
+REQUIREMENTS = ['xknx==0.10.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ CONF_KNX_LOCAL_IP = "local_ip"
 CONF_KNX_FIRE_EVENT = "fire_event"
 CONF_KNX_FIRE_EVENT_FILTER = "fire_event_filter"
 CONF_KNX_STATE_UPDATER = "state_updater"
+CONF_KNX_RATE_LIMIT = "rate_limit"
 CONF_KNX_EXPOSE = "expose"
 CONF_KNX_EXPOSE_TYPE = "type"
 CONF_KNX_EXPOSE_ADDRESS = "address"
@@ -62,6 +63,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Inclusive(CONF_KNX_FIRE_EVENT_FILTER, 'fire_ev'):
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_KNX_STATE_UPDATER, default=True): cv.boolean,
+        vol.Optional(CONF_KNX_RATE_LIMIT, default=20):
+            vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
         vol.Optional(CONF_KNX_EXPOSE):
             vol.All(
                 cv.ensure_list,
@@ -138,7 +141,8 @@ class KNXModule:
     def init_xknx(self):
         """Initialize of KNX object."""
         from xknx import XKNX
-        self.xknx = XKNX(config=self.config_file(), loop=self.hass.loop)
+        self.xknx = XKNX(config=self.config_file(), loop=self.hass.loop,
+                         rate_limit=self.config[DOMAIN][CONF_KNX_RATE_LIMIT])
 
     async def start(self):
         """Start KNX object. Connect to tunneling or Routing device."""

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -17,6 +17,7 @@ CONF_SETPOINT_SHIFT_MAX = 'setpoint_shift_max'
 CONF_SETPOINT_SHIFT_MIN = 'setpoint_shift_min'
 CONF_TEMPERATURE_ADDRESS = 'temperature_address'
 CONF_TARGET_TEMPERATURE_ADDRESS = 'target_temperature_address'
+CONF_TARGET_TEMPERATURE_STATE_ADDRESS = 'target_temperature_state_address'
 CONF_OPERATION_MODE_ADDRESS = 'operation_mode_address'
 CONF_OPERATION_MODE_STATE_ADDRESS = 'operation_mode_state_address'
 CONF_CONTROLLER_STATUS_ADDRESS = 'controller_status_address'
@@ -57,7 +58,8 @@ OPERATION_MODES_INV = dict((
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
-    vol.Required(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
+    vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
+    vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_STEP,
@@ -136,9 +138,11 @@ def async_add_entities_config(hass, config, async_add_entities):
     climate = xknx.devices.Climate(
         hass.data[DATA_KNX].xknx,
         name=config.get(CONF_NAME),
-        group_address_temperature=config.get(CONF_TEMPERATURE_ADDRESS),
+        group_address_temperature=config[CONF_TEMPERATURE_ADDRESS],
         group_address_target_temperature=config.get(
             CONF_TARGET_TEMPERATURE_ADDRESS),
+        group_address_target_temperature_state=config[
+            CONF_TARGET_TEMPERATURE_STATE_ADDRESS],
         group_address_setpoint_shift=config.get(CONF_SETPOINT_SHIFT_ADDRESS),
         group_address_setpoint_shift_state=config.get(
             CONF_SETPOINT_SHIFT_STATE_ADDRESS),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1778,7 +1778,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.knx
-xknx==0.9.4
+xknx==0.10.0
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.startca


### PR DESCRIPTION
## Description:

**breaking change**: users will need to update their configuration and change `target_temperature_address` to `target_temperature_state_address`.

Update xknx to version [0.10.0](https://github.com/XKNX/xknx/releases/tag/0.10.0) which contains the following fixes and features:

- (breaking change) Introduce `target_temperature_state_address` for climate devices (fixes #20106), users will need to update their configuration after this release and change `target_temperature_address` to `target_temperature_state_address`.
- Connection config can now be configured in xknx.yml.
- Introduce a configurable rate limit which limits the number of KNX telegrams sent to the bus per second.
- Users who configured their lights via `xknx.yml` no longer need to manually set min_kelvin and max_kelvin (fixes #21251)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8785

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
