### PR TITLE
Fix incorrect pyairvisual call

### DIFF
--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -278,11 +278,11 @@ class AirVisualData:
 
         try:
             if self.city and self.state and self.country:
-                resp = await self._client.data.city(
+                resp = await self._client.api.city(
                     self.city, self.state, self.country)
                 self.longitude, self.latitude = resp['location']['coordinates']
             else:
-                resp = await self._client.data.nearest_city(
+                resp = await self._client.api.nearest_city(
                     self.latitude, self.longitude)
 
             _LOGGER.debug("New data retrieved: %s", resp)


### PR DESCRIPTION
## Description:

Follow up fix to https://github.com/home-assistant/home-assistant/pull/21520.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/21540

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: airvisual
    api_key: !secret airvisual_api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
