### PR TITLE
Add pause/unpause services to RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -19,7 +19,7 @@ from .config_flow import configured_instances
 from .const import (
     DATA_CLIENT, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN)
 
-REQUIREMENTS = ['regenmaschine==1.1.0']
+REQUIREMENTS = ['regenmaschine==1.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ ZONE_UPDATE_TOPIC = '{0}_zone_update'.format(DOMAIN)
 
 CONF_CONTROLLERS = 'controllers'
 CONF_PROGRAM_ID = 'program_id'
+CONF_SECONDS = 'seconds'
 CONF_ZONE_ID = 'zone_id'
 CONF_ZONE_RUN_TIME = 'zone_run_time'
 
@@ -71,6 +72,10 @@ BINARY_SENSOR_SCHEMA = vol.Schema({
 SENSOR_SCHEMA = vol.Schema({
     vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)):
         vol.All(cv.ensure_list, [vol.In(SENSORS)])
+})
+
+SERVICE_PAUSE_WATERING = vol.Schema({
+    vol.Required(CONF_SECONDS): cv.positive_int,
 })
 
 SERVICE_START_PROGRAM_SCHEMA = vol.Schema({
@@ -184,6 +189,11 @@ async def async_setup_entry(hass, config_entry):
             refresh,
             timedelta(seconds=config_entry.data[CONF_SCAN_INTERVAL]))
 
+    async def pause_watering(service):
+        """Pause watering for a set number of seconds."""
+        await rainmachine.client.watering.pause_all(service.data[CONF_SECONDS])
+        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+
     async def start_program(service):
         """Start a particular program."""
         await rainmachine.client.programs.start(service.data[CONF_PROGRAM_ID])
@@ -210,12 +220,19 @@ async def async_setup_entry(hass, config_entry):
         await rainmachine.client.zones.stop(service.data[CONF_ZONE_ID])
         async_dispatcher_send(hass, ZONE_UPDATE_TOPIC)
 
+    async def unpause_watering(service):
+        """Unpause watering."""
+        await rainmachine.client.watering.unpause_all()
+        async_dispatcher_send(hass, PROGRAM_UPDATE_TOPIC)
+
     for service, method, schema in [
+            ('pause_watering', pause_watering, SERVICE_PAUSE_WATERING),
             ('start_program', start_program, SERVICE_START_PROGRAM_SCHEMA),
             ('start_zone', start_zone, SERVICE_START_ZONE_SCHEMA),
             ('stop_all', stop_all, {}),
             ('stop_program', stop_program, SERVICE_STOP_PROGRAM_SCHEMA),
-            ('stop_zone', stop_zone, SERVICE_STOP_ZONE_SCHEMA)
+            ('stop_zone', stop_zone, SERVICE_STOP_ZONE_SCHEMA),
+            ('unpause_watering', unpause_watering, {}),
     ]:
         hass.services.async_register(DOMAIN, service, method, schema=schema)
 

--- a/homeassistant/components/rainmachine/services.yaml
+++ b/homeassistant/components/rainmachine/services.yaml
@@ -1,6 +1,12 @@
 # Describes the format for available RainMachine services
 
 ---
+pause_watering:
+  description: Pause all watering for a number of seconds.
+  fields:
+    seconds:
+      description: The number of seconds to pause.
+      example: 30
 start_program:
   description: Start a program.
   fields:
@@ -30,3 +36,5 @@ stop_zone:
     zone_id:
       description: The zone to stop.
       example: 3
+unpause_watering:
+  description: Unpause all watering.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1486,7 +1486,7 @@ raspyrfm-client==1.2.8
 recollect-waste==1.0.1
 
 # homeassistant.components.rainmachine
-regenmaschine==1.1.0
+regenmaschine==1.2.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -254,7 +254,7 @@ pyunifi==2.16
 pywebpush==1.6.0
 
 # homeassistant.components.rainmachine
-regenmaschine==1.1.0
+regenmaschine==1.2.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8


### PR DESCRIPTION
## Description:

This PR adds services to support pausing and unpausing watering activities in RainMachine.

To do this, bumps `regenmaschine` to 1.2.0. Changelog: https://github.com/bachya/regenmaschine/releases/tag/1.2.0

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8788

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_1_ip
      password: !secret rainmachine_1_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
