### PR TITLE
Google Assistant: Create and pass context to service calls

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -190,7 +190,6 @@ class Cloud:
             self._gactions_config = ga_h.Config(
                 should_expose=should_expose,
                 allow_unlock=self.prefs.google_allow_unlock,
-                agent_user_id=self.claims['cognito:username'],
                 entity_config=conf.get(CONF_ENTITY_CONFIG),
             )
 

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -335,7 +335,9 @@ def async_handle_google_actions(hass, cloud, payload):
         return ga.turned_off_response(payload)
 
     result = yield from ga.async_handle_message(
-        hass, cloud.gactions_config, payload)
+        hass, cloud.gactions_config,
+        cloud.claims['cognito:username'],
+        payload)
     return result
 
 

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -1,4 +1,5 @@
 """Helper classes for Google Assistant integration."""
+from homeassistant.core import Context
 
 
 class SmartHomeError(Exception):
@@ -17,9 +18,10 @@ class Config:
     """Hold the configuration for Google Assistant."""
 
     def __init__(self, should_expose, allow_unlock, agent_user_id,
-                 entity_config=None):
+                 entity_config=None, context=None):
         """Initialize the configuration."""
         self.should_expose = should_expose
         self.agent_user_id = agent_user_id
         self.entity_config = entity_config or {}
         self.allow_unlock = allow_unlock
+        self.context = context or Context()

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -17,11 +17,19 @@ class SmartHomeError(Exception):
 class Config:
     """Hold the configuration for Google Assistant."""
 
-    def __init__(self, should_expose, allow_unlock, agent_user_id,
-                 entity_config=None, context=None):
+    def __init__(self, should_expose, allow_unlock,
+                 entity_config=None):
         """Initialize the configuration."""
         self.should_expose = should_expose
-        self.agent_user_id = agent_user_id
         self.entity_config = entity_config or {}
         self.allow_unlock = allow_unlock
-        self.context = context or Context()
+
+
+class RequestData:
+    """Hold data associated with a particular request."""
+
+    def __init__(self, config, user_id, request_id):
+        """Initialize the request data."""
+        self.config = config
+        self.request_id = request_id
+        self.context = Context(user_id=user_id)

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -71,17 +71,16 @@ class GoogleAssistantView(HomeAssistantView):
 
     def __init__(self, is_exposed, entity_config, allow_unlock):
         """Initialize the Google Assistant request handler."""
-        self.is_exposed = is_exposed
-        self.entity_config = entity_config
-        self.allow_unlock = allow_unlock
+        self.config = Config(is_exposed,
+                             allow_unlock,
+                             entity_config)
 
     async def post(self, request: Request) -> Response:
         """Handle Google Assistant requests."""
         message = await request.json()  # type: dict
-        config = Config(self.is_exposed,
-                        self.allow_unlock,
-                        request['hass_user'].id,
-                        self.entity_config)
         result = await async_handle_message(
-            request.app['hass'], config, message)
+            request.app['hass'],
+            self.config,
+            request['hass_user'].id,
+            message)
         return self.json(result)

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -102,7 +102,7 @@ class _Trait:
         """Test if command can be executed."""
         return command in self.commands
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a trait command."""
         raise NotImplementedError
 
@@ -159,7 +159,7 @@ class BrightnessTrait(_Trait):
 
         return response
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a brightness command."""
         domain = self.state.domain
 
@@ -168,20 +168,20 @@ class BrightnessTrait(_Trait):
                 light.DOMAIN, light.SERVICE_TURN_ON, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     light.ATTR_BRIGHTNESS_PCT: params['brightness']
-                }, blocking=True, context=self.config.context)
+                }, blocking=True, context=data.context)
         elif domain == cover.DOMAIN:
             await self.hass.services.async_call(
                 cover.DOMAIN, cover.SERVICE_SET_COVER_POSITION, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     cover.ATTR_POSITION: params['brightness']
-                }, blocking=True, context=self.config.context)
+                }, blocking=True, context=data.context)
         elif domain == media_player.DOMAIN:
             await self.hass.services.async_call(
                 media_player.DOMAIN, media_player.SERVICE_VOLUME_SET, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     media_player.ATTR_MEDIA_VOLUME_LEVEL:
                     params['brightness'] / 100
-                }, blocking=True, context=self.config.context)
+                }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -221,7 +221,7 @@ class OnOffTrait(_Trait):
             return {'on': self.state.state != cover.STATE_CLOSED}
         return {'on': self.state.state != STATE_OFF}
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute an OnOff command."""
         domain = self.state.domain
 
@@ -242,7 +242,7 @@ class OnOffTrait(_Trait):
 
         await self.hass.services.async_call(service_domain, service, {
             ATTR_ENTITY_ID: self.state.entity_id
-        }, blocking=True, context=self.config.context)
+        }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -288,7 +288,7 @@ class ColorSpectrumTrait(_Trait):
         return (command in self.commands and
                 'spectrumRGB' in params.get('color', {}))
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a color spectrum command."""
         # Convert integer to hex format and left pad with 0's till length 6
         hex_value = "{0:06x}".format(params['color']['spectrumRGB'])
@@ -298,7 +298,7 @@ class ColorSpectrumTrait(_Trait):
         await self.hass.services.async_call(light.DOMAIN, SERVICE_TURN_ON, {
             ATTR_ENTITY_ID: self.state.entity_id,
             light.ATTR_HS_COLOR: color
-        }, blocking=True, context=self.config.context)
+        }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -355,7 +355,7 @@ class ColorTemperatureTrait(_Trait):
         return (command in self.commands and
                 'temperature' in params.get('color', {}))
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a color temperature command."""
         temp = color_util.color_temperature_kelvin_to_mired(
             params['color']['temperature'])
@@ -371,7 +371,7 @@ class ColorTemperatureTrait(_Trait):
         await self.hass.services.async_call(light.DOMAIN, SERVICE_TURN_ON, {
             ATTR_ENTITY_ID: self.state.entity_id,
             light.ATTR_COLOR_TEMP: temp,
-        }, blocking=True, context=self.config.context)
+        }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -400,14 +400,14 @@ class SceneTrait(_Trait):
         """Return scene query attributes."""
         return {}
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a scene command."""
         # Don't block for scripts as they can be slow.
         await self.hass.services.async_call(
             self.state.domain, SERVICE_TURN_ON, {
                 ATTR_ENTITY_ID: self.state.entity_id
             }, blocking=self.state.domain != script.DOMAIN,
-            context=self.config.context)
+            context=data.context)
 
 
 @register_trait
@@ -435,12 +435,12 @@ class DockTrait(_Trait):
         """Return dock query attributes."""
         return {'isDocked': self.state.state == vacuum.STATE_DOCKED}
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a dock command."""
         await self.hass.services.async_call(
             self.state.domain, vacuum.SERVICE_RETURN_TO_BASE, {
                 ATTR_ENTITY_ID: self.state.entity_id
-            }, blocking=True, context=self.config.context)
+            }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -474,30 +474,30 @@ class StartStopTrait(_Trait):
             'isPaused': self.state.state == vacuum.STATE_PAUSED,
         }
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a StartStop command."""
         if command == COMMAND_STARTSTOP:
             if params['start']:
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_START, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True, context=self.config.context)
+                    }, blocking=True, context=data.context)
             else:
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_STOP, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True, context=self.config.context)
+                    }, blocking=True, context=data.context)
         elif command == COMMAND_PAUSEUNPAUSE:
             if params['pause']:
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_PAUSE, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True, context=self.config.context)
+                    }, blocking=True, context=data.context)
             else:
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_START, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True, context=self.config.context)
+                    }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -585,7 +585,7 @@ class TemperatureSettingTrait(_Trait):
 
         return response
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute a temperature point or mode command."""
         # All sent in temperatures are always in Celsius
         unit = self.hass.config.units.temperature_unit
@@ -609,7 +609,7 @@ class TemperatureSettingTrait(_Trait):
                 climate.DOMAIN, climate.SERVICE_SET_TEMPERATURE, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     ATTR_TEMPERATURE: temp
-                }, blocking=True, context=self.config.context)
+                }, blocking=True, context=data.context)
 
         elif command == COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE:
             temp_high = temp_util.convert(
@@ -641,7 +641,7 @@ class TemperatureSettingTrait(_Trait):
                     ATTR_ENTITY_ID: self.state.entity_id,
                     climate.ATTR_TARGET_TEMP_HIGH: temp_high,
                     climate.ATTR_TARGET_TEMP_LOW: temp_low,
-                }, blocking=True, context=self.config.context)
+                }, blocking=True, context=data.context)
 
         elif command == COMMAND_THERMOSTAT_SET_MODE:
             await self.hass.services.async_call(
@@ -649,7 +649,7 @@ class TemperatureSettingTrait(_Trait):
                     ATTR_ENTITY_ID: self.state.entity_id,
                     climate.ATTR_OPERATION_MODE:
                         self.google_to_hass[params['thermostatMode']],
-                }, blocking=True, context=self.config.context)
+                }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -682,7 +682,7 @@ class LockUnlockTrait(_Trait):
         allowed_unlock = not params['lock'] and self.config.allow_unlock
         return params['lock'] or allowed_unlock
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute an LockUnlock command."""
         if params['lock']:
             service = lock.SERVICE_LOCK
@@ -691,7 +691,7 @@ class LockUnlockTrait(_Trait):
 
         await self.hass.services.async_call(lock.DOMAIN, service, {
             ATTR_ENTITY_ID: self.state.entity_id
-        }, blocking=True, context=self.config.context)
+        }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -761,13 +761,13 @@ class FanSpeedTrait(_Trait):
 
         return response
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute an SetFanSpeed command."""
         await self.hass.services.async_call(
             fan.DOMAIN, fan.SERVICE_SET_SPEED, {
                 ATTR_ENTITY_ID: self.state.entity_id,
                 fan.ATTR_SPEED: params['fanSpeed']
-            }, blocking=True, context=self.config.context)
+            }, blocking=True, context=data.context)
 
 
 @register_trait
@@ -935,7 +935,7 @@ class ModesTrait(_Trait):
 
         return response
 
-    async def execute(self, command, params):
+    async def execute(self, command, data, params):
         """Execute an SetModes command."""
         settings = params.get('updateModeSettings')
         requested_source = settings.get(
@@ -952,4 +952,4 @@ class ModesTrait(_Trait):
                         media_player.SERVICE_SELECT_SOURCE, {
                             ATTR_ENTITY_ID: self.state.entity_id,
                             media_player.ATTR_INPUT_SOURCE: source
-                        }, blocking=True, context=self.config.context)
+                        }, blocking=True, context=data.context)

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -168,20 +168,20 @@ class BrightnessTrait(_Trait):
                 light.DOMAIN, light.SERVICE_TURN_ON, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     light.ATTR_BRIGHTNESS_PCT: params['brightness']
-                }, blocking=True)
+                }, blocking=True, context=self.config.context)
         elif domain == cover.DOMAIN:
             await self.hass.services.async_call(
                 cover.DOMAIN, cover.SERVICE_SET_COVER_POSITION, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     cover.ATTR_POSITION: params['brightness']
-                }, blocking=True)
+                }, blocking=True, context=self.config.context)
         elif domain == media_player.DOMAIN:
             await self.hass.services.async_call(
                 media_player.DOMAIN, media_player.SERVICE_VOLUME_SET, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     media_player.ATTR_MEDIA_VOLUME_LEVEL:
                     params['brightness'] / 100
-                }, blocking=True)
+                }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -242,7 +242,7 @@ class OnOffTrait(_Trait):
 
         await self.hass.services.async_call(service_domain, service, {
             ATTR_ENTITY_ID: self.state.entity_id
-        }, blocking=True)
+        }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -298,7 +298,7 @@ class ColorSpectrumTrait(_Trait):
         await self.hass.services.async_call(light.DOMAIN, SERVICE_TURN_ON, {
             ATTR_ENTITY_ID: self.state.entity_id,
             light.ATTR_HS_COLOR: color
-        }, blocking=True)
+        }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -371,7 +371,7 @@ class ColorTemperatureTrait(_Trait):
         await self.hass.services.async_call(light.DOMAIN, SERVICE_TURN_ON, {
             ATTR_ENTITY_ID: self.state.entity_id,
             light.ATTR_COLOR_TEMP: temp,
-        }, blocking=True)
+        }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -406,7 +406,8 @@ class SceneTrait(_Trait):
         await self.hass.services.async_call(
             self.state.domain, SERVICE_TURN_ON, {
                 ATTR_ENTITY_ID: self.state.entity_id
-            }, blocking=self.state.domain != script.DOMAIN)
+            }, blocking=self.state.domain != script.DOMAIN,
+            context=self.config.context)
 
 
 @register_trait
@@ -439,7 +440,7 @@ class DockTrait(_Trait):
         await self.hass.services.async_call(
             self.state.domain, vacuum.SERVICE_RETURN_TO_BASE, {
                 ATTR_ENTITY_ID: self.state.entity_id
-            }, blocking=True)
+            }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -480,23 +481,23 @@ class StartStopTrait(_Trait):
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_START, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True)
+                    }, blocking=True, context=self.config.context)
             else:
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_STOP, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True)
+                    }, blocking=True, context=self.config.context)
         elif command == COMMAND_PAUSEUNPAUSE:
             if params['pause']:
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_PAUSE, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True)
+                    }, blocking=True, context=self.config.context)
             else:
                 await self.hass.services.async_call(
                     self.state.domain, vacuum.SERVICE_START, {
                         ATTR_ENTITY_ID: self.state.entity_id
-                    }, blocking=True)
+                    }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -608,7 +609,7 @@ class TemperatureSettingTrait(_Trait):
                 climate.DOMAIN, climate.SERVICE_SET_TEMPERATURE, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     ATTR_TEMPERATURE: temp
-                }, blocking=True)
+                }, blocking=True, context=self.config.context)
 
         elif command == COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE:
             temp_high = temp_util.convert(
@@ -640,7 +641,7 @@ class TemperatureSettingTrait(_Trait):
                     ATTR_ENTITY_ID: self.state.entity_id,
                     climate.ATTR_TARGET_TEMP_HIGH: temp_high,
                     climate.ATTR_TARGET_TEMP_LOW: temp_low,
-                }, blocking=True)
+                }, blocking=True, context=self.config.context)
 
         elif command == COMMAND_THERMOSTAT_SET_MODE:
             await self.hass.services.async_call(
@@ -648,7 +649,7 @@ class TemperatureSettingTrait(_Trait):
                     ATTR_ENTITY_ID: self.state.entity_id,
                     climate.ATTR_OPERATION_MODE:
                         self.google_to_hass[params['thermostatMode']],
-                }, blocking=True)
+                }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -690,7 +691,7 @@ class LockUnlockTrait(_Trait):
 
         await self.hass.services.async_call(lock.DOMAIN, service, {
             ATTR_ENTITY_ID: self.state.entity_id
-        }, blocking=True)
+        }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -766,7 +767,7 @@ class FanSpeedTrait(_Trait):
             fan.DOMAIN, fan.SERVICE_SET_SPEED, {
                 ATTR_ENTITY_ID: self.state.entity_id,
                 fan.ATTR_SPEED: params['fanSpeed']
-            }, blocking=True)
+            }, blocking=True, context=self.config.context)
 
 
 @register_trait
@@ -951,4 +952,4 @@ class ModesTrait(_Trait):
                         media_player.SERVICE_SELECT_SOURCE, {
                             ATTR_ENTITY_ID: self.state.entity_id,
                             media_player.ATTR_INPUT_SOURCE: source
-                        }, blocking=True)
+                        }, blocking=True, context=self.config.context)

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -19,8 +19,7 @@ from tests.common import (mock_device_registry, mock_registry,
 
 BASIC_CONFIG = helpers.Config(
     should_expose=lambda state: True,
-    allow_unlock=False,
-    agent_user_id='test-agent',
+    allow_unlock=False
 )
 REQ_ID = 'ff36a3cc-ec34-11e6-b1a0-64510650abcf'
 
@@ -56,7 +55,6 @@ async def test_sync_message(hass):
     config = helpers.Config(
         should_expose=lambda state: state.entity_id != 'light.not_expose',
         allow_unlock=False,
-        agent_user_id='test-agent',
         entity_config={
             'light.demo_light': {
                 const.CONF_ROOM_HINT: 'Living Room',
@@ -68,12 +66,14 @@ async def test_sync_message(hass):
     events = []
     hass.bus.async_listen(EVENT_SYNC_RECEIVED, events.append)
 
-    result = await sh.async_handle_message(hass, config, {
-        "requestId": REQ_ID,
-        "inputs": [{
-            "intent": "action.devices.SYNC"
-        }]
-    })
+    result = await sh.async_handle_message(
+        hass, config, 'test-agent',
+        {
+            "requestId": REQ_ID,
+            "inputs": [{
+                "intent": "action.devices.SYNC"
+            }]
+        })
 
     assert result == {
         'requestId': REQ_ID,
@@ -114,6 +114,7 @@ async def test_sync_message(hass):
     }
 
 
+# pylint: disable=redefined-outer-name
 async def test_sync_in_area(hass, registries):
     """Test a sync message where room hint comes from area."""
     area = registries.area.async_create("Living Room")
@@ -142,19 +143,20 @@ async def test_sync_in_area(hass, registries):
     config = helpers.Config(
         should_expose=lambda _: True,
         allow_unlock=False,
-        agent_user_id='test-agent',
         entity_config={}
     )
 
     events = []
     hass.bus.async_listen(EVENT_SYNC_RECEIVED, events.append)
 
-    result = await sh.async_handle_message(hass, config, {
-        "requestId": REQ_ID,
-        "inputs": [{
-            "intent": "action.devices.SYNC"
-        }]
-    })
+    result = await sh.async_handle_message(
+        hass, config, 'test-agent',
+        {
+            "requestId": REQ_ID,
+            "inputs": [{
+                "intent": "action.devices.SYNC"
+            }]
+        })
 
     assert result == {
         'requestId': REQ_ID,
@@ -216,21 +218,23 @@ async def test_query_message(hass):
     events = []
     hass.bus.async_listen(EVENT_QUERY_RECEIVED, events.append)
 
-    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
-        "requestId": REQ_ID,
-        "inputs": [{
-            "intent": "action.devices.QUERY",
-            "payload": {
-                "devices": [{
-                    "id": "light.demo_light",
-                }, {
-                    "id": "light.another_light",
-                }, {
-                    "id": "light.non_existing",
-                }]
-            }
-        }]
-    })
+    result = await sh.async_handle_message(
+        hass, BASIC_CONFIG, 'test-agent',
+        {
+            "requestId": REQ_ID,
+            "inputs": [{
+                "intent": "action.devices.QUERY",
+                "payload": {
+                    "devices": [{
+                        "id": "light.demo_light",
+                    }, {
+                        "id": "light.another_light",
+                    }, {
+                        "id": "light.non_existing",
+                    }]
+                }
+            }]
+        })
 
     assert result == {
         'requestId': REQ_ID,
@@ -290,32 +294,34 @@ async def test_execute(hass):
     service_events = []
     hass.bus.async_listen(EVENT_CALL_SERVICE, service_events.append)
 
-    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
-        "requestId": REQ_ID,
-        "inputs": [{
-            "intent": "action.devices.EXECUTE",
-            "payload": {
-                "commands": [{
-                    "devices": [
-                        {"id": "light.non_existing"},
-                        {"id": "light.ceiling_lights"},
-                    ],
-                    "execution": [{
-                        "command": "action.devices.commands.OnOff",
-                        "params": {
-                            "on": True
-                        }
-                    }, {
-                        "command":
-                            "action.devices.commands.BrightnessAbsolute",
-                        "params": {
-                            "brightness": 20
-                        }
+    result = await sh.async_handle_message(
+        hass, BASIC_CONFIG, None,
+        {
+            "requestId": REQ_ID,
+            "inputs": [{
+                "intent": "action.devices.EXECUTE",
+                "payload": {
+                    "commands": [{
+                        "devices": [
+                            {"id": "light.non_existing"},
+                            {"id": "light.ceiling_lights"},
+                        ],
+                        "execution": [{
+                            "command": "action.devices.commands.OnOff",
+                            "params": {
+                                "on": True
+                            }
+                        }, {
+                            "command":
+                                "action.devices.commands.BrightnessAbsolute",
+                            "params": {
+                                "brightness": 20
+                            }
+                        }]
                     }]
-                }]
-            }
-        }]
-    })
+                }
+            }]
+        })
 
     assert result == {
         "requestId": REQ_ID,
@@ -418,26 +424,28 @@ async def test_raising_error_trait(hass):
     hass.bus.async_listen(EVENT_COMMAND_RECEIVED, events.append)
     await hass.async_block_till_done()
 
-    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
-        "requestId": REQ_ID,
-        "inputs": [{
-            "intent": "action.devices.EXECUTE",
-            "payload": {
-                "commands": [{
-                    "devices": [
-                        {"id": "climate.bla"},
-                    ],
-                    "execution": [{
-                        "command": "action.devices.commands."
-                                   "ThermostatTemperatureSetpoint",
-                        "params": {
-                            "thermostatTemperatureSetpoint": 10
-                        }
+    result = await sh.async_handle_message(
+        hass, BASIC_CONFIG, 'test-agent',
+        {
+            "requestId": REQ_ID,
+            "inputs": [{
+                "intent": "action.devices.EXECUTE",
+                "payload": {
+                    "commands": [{
+                        "devices": [
+                            {"id": "climate.bla"},
+                        ],
+                        "execution": [{
+                            "command": "action.devices.commands."
+                                       "ThermostatTemperatureSetpoint",
+                            "params": {
+                                "thermostatTemperatureSetpoint": 10
+                            }
+                        }]
                     }]
-                }]
-            }
-        }]
-    })
+                }
+            }]
+        })
 
     assert result == {
         "requestId": REQ_ID,
@@ -467,6 +475,7 @@ async def test_raising_error_trait(hass):
 async def test_serialize_input_boolean(hass):
     """Test serializing an input boolean entity."""
     state = State('input_boolean.bla', 'on')
+    # pylint: disable=protected-access
     entity = sh._GoogleEntity(hass, BASIC_CONFIG, state)
     result = await entity.sync_serialize()
     assert result == {
@@ -487,15 +496,17 @@ async def test_unavailable_state_doesnt_sync(hass):
     )
     light.hass = hass
     light.entity_id = 'light.demo_light'
-    light._available = False
+    light._available = False    # pylint: disable=protected-access
     await light.async_update_ha_state()
 
-    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
-        "requestId": REQ_ID,
-        "inputs": [{
-            "intent": "action.devices.SYNC"
-        }]
-    })
+    result = await sh.async_handle_message(
+        hass, BASIC_CONFIG, 'test-agent',
+        {
+            "requestId": REQ_ID,
+            "inputs": [{
+                "intent": "action.devices.SYNC"
+            }]
+        })
 
     assert result == {
         'requestId': REQ_ID,
@@ -516,12 +527,14 @@ async def test_empty_name_doesnt_sync(hass):
     light.entity_id = 'light.demo_light'
     await light.async_update_ha_state()
 
-    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
-        "requestId": REQ_ID,
-        "inputs": [{
-            "intent": "action.devices.SYNC"
-        }]
-    })
+    result = await sh.async_handle_message(
+        hass, BASIC_CONFIG, 'test-agent',
+        {
+            "requestId": REQ_ID,
+            "inputs": [{
+                "intent": "action.devices.SYNC"
+            }]
+        })
 
     assert result == {
         'requestId': REQ_ID,
@@ -534,11 +547,13 @@ async def test_empty_name_doesnt_sync(hass):
 
 async def test_query_disconnect(hass):
     """Test a disconnect message."""
-    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
-        'inputs': [
-            {'intent': 'action.devices.DISCONNECT'}
-        ],
-        'requestId': REQ_ID
-    })
+    result = await sh.async_handle_message(
+        hass, BASIC_CONFIG, 'test-agent',
+        {
+            'inputs': [
+                {'intent': 'action.devices.DISCONNECT'}
+            ],
+            'requestId': REQ_ID
+        })
 
     assert result is None

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -25,13 +25,19 @@ from tests.common import async_mock_service
 
 BASIC_CONFIG = helpers.Config(
     should_expose=lambda state: True,
-    allow_unlock=False,
-    agent_user_id='test-agent',
+    allow_unlock=False
+)
+
+REQ_ID = 'ff36a3cc-ec34-11e6-b1a0-64510650abcf'
+
+BASIC_DATA = helpers.RequestData(
+    BASIC_CONFIG,
+    'test-agent',
+    REQ_ID,
 )
 
 UNSAFE_CONFIG = helpers.Config(
     should_expose=lambda state: True,
-    agent_user_id='test-agent',
     allow_unlock=True,
 )
 
@@ -55,9 +61,9 @@ async def test_brightness_light(hass):
     hass.bus.async_listen(EVENT_CALL_SERVICE, events.append)
 
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
-    await trt.execute(trait.COMMAND_BRIGHTNESS_ABSOLUTE, {
-        'brightness': 50
-    })
+    await trt.execute(
+        trait.COMMAND_BRIGHTNESS_ABSOLUTE, BASIC_DATA,
+        {'brightness': 50})
     await hass.async_block_till_done()
 
     assert len(calls) == 1
@@ -67,7 +73,6 @@ async def test_brightness_light(hass):
     }
 
     assert len(events) == 1
-    assert events[0].context == BASIC_CONFIG.context
     assert events[0].data == {
         'domain': 'light',
         'service': 'turn_on',
@@ -92,9 +97,9 @@ async def test_brightness_cover(hass):
 
     calls = async_mock_service(
         hass, cover.DOMAIN, cover.SERVICE_SET_COVER_POSITION)
-    await trt.execute(trait.COMMAND_BRIGHTNESS_ABSOLUTE, {
-        'brightness': 50
-    })
+    await trt.execute(
+        trait.COMMAND_BRIGHTNESS_ABSOLUTE, BASIC_DATA,
+        {'brightness': 50})
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'cover.bla',
@@ -120,9 +125,9 @@ async def test_brightness_media_player(hass):
 
     calls = async_mock_service(
         hass, media_player.DOMAIN, media_player.SERVICE_VOLUME_SET)
-    await trt.execute(trait.COMMAND_BRIGHTNESS_ABSOLUTE, {
-        'brightness': 60
-    })
+    await trt.execute(
+        trait.COMMAND_BRIGHTNESS_ABSOLUTE, BASIC_DATA,
+        {'brightness': 60})
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'media_player.bla',
@@ -150,18 +155,18 @@ async def test_onoff_group(hass):
     }
 
     on_calls = async_mock_service(hass, HA_DOMAIN, SERVICE_TURN_ON)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'group.bla',
     }
 
     off_calls = async_mock_service(hass, HA_DOMAIN, SERVICE_TURN_OFF)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'group.bla',
@@ -189,9 +194,9 @@ async def test_onoff_input_boolean(hass):
     }
 
     on_calls = async_mock_service(hass, input_boolean.DOMAIN, SERVICE_TURN_ON)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'input_boolean.bla',
@@ -199,9 +204,9 @@ async def test_onoff_input_boolean(hass):
 
     off_calls = async_mock_service(hass, input_boolean.DOMAIN,
                                    SERVICE_TURN_OFF)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'input_boolean.bla',
@@ -229,18 +234,18 @@ async def test_onoff_switch(hass):
     }
 
     on_calls = async_mock_service(hass, switch.DOMAIN, SERVICE_TURN_ON)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'switch.bla',
     }
 
     off_calls = async_mock_service(hass, switch.DOMAIN, SERVICE_TURN_OFF)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'switch.bla',
@@ -265,18 +270,18 @@ async def test_onoff_fan(hass):
     }
 
     on_calls = async_mock_service(hass, fan.DOMAIN, SERVICE_TURN_ON)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'fan.bla',
     }
 
     off_calls = async_mock_service(hass, fan.DOMAIN, SERVICE_TURN_OFF)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'fan.bla',
@@ -303,18 +308,18 @@ async def test_onoff_light(hass):
     }
 
     on_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'light.bla',
     }
 
     off_calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_OFF)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'light.bla',
@@ -342,9 +347,9 @@ async def test_onoff_cover(hass):
     }
 
     on_calls = async_mock_service(hass, cover.DOMAIN, cover.SERVICE_OPEN_COVER)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'cover.bla',
@@ -352,9 +357,9 @@ async def test_onoff_cover(hass):
 
     off_calls = async_mock_service(hass, cover.DOMAIN,
                                    cover.SERVICE_CLOSE_COVER)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'cover.bla',
@@ -382,9 +387,9 @@ async def test_onoff_media_player(hass):
     }
 
     on_calls = async_mock_service(hass, media_player.DOMAIN, SERVICE_TURN_ON)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'media_player.bla',
@@ -393,9 +398,9 @@ async def test_onoff_media_player(hass):
     off_calls = async_mock_service(hass, media_player.DOMAIN,
                                    SERVICE_TURN_OFF)
 
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'media_player.bla',
@@ -423,9 +428,9 @@ async def test_onoff_climate(hass):
     }
 
     on_calls = async_mock_service(hass, climate.DOMAIN, SERVICE_TURN_ON)
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': True
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': True})
     assert len(on_calls) == 1
     assert on_calls[0].data == {
         ATTR_ENTITY_ID: 'climate.bla',
@@ -434,9 +439,9 @@ async def test_onoff_climate(hass):
     off_calls = async_mock_service(hass, climate.DOMAIN,
                                    SERVICE_TURN_OFF)
 
-    await trt_on.execute(trait.COMMAND_ONOFF, {
-        'on': False
-    })
+    await trt_on.execute(
+        trait.COMMAND_ONOFF, BASIC_DATA,
+        {'on': False})
     assert len(off_calls) == 1
     assert off_calls[0].data == {
         ATTR_ENTITY_ID: 'climate.bla',
@@ -458,7 +463,8 @@ async def test_dock_vacuum(hass):
 
     calls = async_mock_service(hass, vacuum.DOMAIN,
                                vacuum.SERVICE_RETURN_TO_BASE)
-    await trt.execute(trait.COMMAND_DOCK, {})
+    await trt.execute(
+        trait.COMMAND_DOCK, BASIC_DATA, {})
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'vacuum.bla',
@@ -482,7 +488,7 @@ async def test_startstop_vacuum(hass):
 
     start_calls = async_mock_service(hass, vacuum.DOMAIN,
                                      vacuum.SERVICE_START)
-    await trt.execute(trait.COMMAND_STARTSTOP, {'start': True})
+    await trt.execute(trait.COMMAND_STARTSTOP, BASIC_DATA, {'start': True})
     assert len(start_calls) == 1
     assert start_calls[0].data == {
         ATTR_ENTITY_ID: 'vacuum.bla',
@@ -490,7 +496,7 @@ async def test_startstop_vacuum(hass):
 
     stop_calls = async_mock_service(hass, vacuum.DOMAIN,
                                     vacuum.SERVICE_STOP)
-    await trt.execute(trait.COMMAND_STARTSTOP, {'start': False})
+    await trt.execute(trait.COMMAND_STARTSTOP, BASIC_DATA, {'start': False})
     assert len(stop_calls) == 1
     assert stop_calls[0].data == {
         ATTR_ENTITY_ID: 'vacuum.bla',
@@ -498,7 +504,7 @@ async def test_startstop_vacuum(hass):
 
     pause_calls = async_mock_service(hass, vacuum.DOMAIN,
                                      vacuum.SERVICE_PAUSE)
-    await trt.execute(trait.COMMAND_PAUSEUNPAUSE, {'pause': True})
+    await trt.execute(trait.COMMAND_PAUSEUNPAUSE, BASIC_DATA, {'pause': True})
     assert len(pause_calls) == 1
     assert pause_calls[0].data == {
         ATTR_ENTITY_ID: 'vacuum.bla',
@@ -506,7 +512,7 @@ async def test_startstop_vacuum(hass):
 
     unpause_calls = async_mock_service(hass, vacuum.DOMAIN,
                                        vacuum.SERVICE_START)
-    await trt.execute(trait.COMMAND_PAUSEUNPAUSE, {'pause': False})
+    await trt.execute(trait.COMMAND_PAUSEUNPAUSE, BASIC_DATA, {'pause': False})
     assert len(unpause_calls) == 1
     assert unpause_calls[0].data == {
         ATTR_ENTITY_ID: 'vacuum.bla',
@@ -545,7 +551,7 @@ async def test_color_spectrum_light(hass):
     })
 
     calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
-    await trt.execute(trait.COMMAND_COLOR_ABSOLUTE, {
+    await trt.execute(trait.COMMAND_COLOR_ABSOLUTE, BASIC_DATA, {
         'color': {
             'spectrumRGB': 1052927
         }
@@ -594,14 +600,14 @@ async def test_color_temperature_light(hass):
     calls = async_mock_service(hass, light.DOMAIN, SERVICE_TURN_ON)
 
     with pytest.raises(helpers.SmartHomeError) as err:
-        await trt.execute(trait.COMMAND_COLOR_ABSOLUTE, {
+        await trt.execute(trait.COMMAND_COLOR_ABSOLUTE, BASIC_DATA, {
             'color': {
                 'temperature': 5555
             }
         })
     assert err.value.code == const.ERR_VALUE_OUT_OF_RANGE
 
-    await trt.execute(trait.COMMAND_COLOR_ABSOLUTE, {
+    await trt.execute(trait.COMMAND_COLOR_ABSOLUTE, BASIC_DATA, {
         'color': {
             'temperature': 2857
         }
@@ -639,7 +645,7 @@ async def test_scene_scene(hass):
     assert trt.can_execute(trait.COMMAND_ACTIVATE_SCENE, {})
 
     calls = async_mock_service(hass, scene.DOMAIN, SERVICE_TURN_ON)
-    await trt.execute(trait.COMMAND_ACTIVATE_SCENE, {})
+    await trt.execute(trait.COMMAND_ACTIVATE_SCENE, BASIC_DATA, {})
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'scene.bla',
@@ -656,7 +662,7 @@ async def test_scene_script(hass):
     assert trt.can_execute(trait.COMMAND_ACTIVATE_SCENE, {})
 
     calls = async_mock_service(hass, script.DOMAIN, SERVICE_TURN_ON)
-    await trt.execute(trait.COMMAND_ACTIVATE_SCENE, {})
+    await trt.execute(trait.COMMAND_ACTIVATE_SCENE, BASIC_DATA, {})
 
     # We don't wait till script execution is done.
     await hass.async_block_till_done()
@@ -708,10 +714,11 @@ async def test_temperature_setting_climate_range(hass):
 
     calls = async_mock_service(
         hass, climate.DOMAIN, climate.SERVICE_SET_TEMPERATURE)
-    await trt.execute(trait.COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE, {
-        'thermostatTemperatureSetpointHigh': 25,
-        'thermostatTemperatureSetpointLow': 20,
-    })
+    await trt.execute(
+        trait.COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE, BASIC_DATA, {
+            'thermostatTemperatureSetpointHigh': 25,
+            'thermostatTemperatureSetpointLow': 20,
+        })
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'climate.bla',
@@ -721,7 +728,7 @@ async def test_temperature_setting_climate_range(hass):
 
     calls = async_mock_service(
         hass, climate.DOMAIN, climate.SERVICE_SET_OPERATION_MODE)
-    await trt.execute(trait.COMMAND_THERMOSTAT_SET_MODE, {
+    await trt.execute(trait.COMMAND_THERMOSTAT_SET_MODE, BASIC_DATA, {
         'thermostatMode': 'heatcool',
     })
     assert len(calls) == 1
@@ -731,9 +738,9 @@ async def test_temperature_setting_climate_range(hass):
     }
 
     with pytest.raises(helpers.SmartHomeError) as err:
-        await trt.execute(trait.COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT, {
-            'thermostatTemperatureSetpoint': -100,
-        })
+        await trt.execute(
+            trait.COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT, BASIC_DATA,
+            {'thermostatTemperatureSetpoint': -100})
     assert err.value.code == const.ERR_VALUE_OUT_OF_RANGE
     hass.config.units.temperature_unit = TEMP_CELSIUS
 
@@ -775,13 +782,13 @@ async def test_temperature_setting_climate_setpoint(hass):
         hass, climate.DOMAIN, climate.SERVICE_SET_TEMPERATURE)
 
     with pytest.raises(helpers.SmartHomeError):
-        await trt.execute(trait.COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT, {
-            'thermostatTemperatureSetpoint': -100,
-        })
+        await trt.execute(
+            trait.COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT, BASIC_DATA,
+            {'thermostatTemperatureSetpoint': -100})
 
-    await trt.execute(trait.COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT, {
-        'thermostatTemperatureSetpoint': 19,
-    })
+    await trt.execute(
+        trait.COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT, BASIC_DATA,
+        {'thermostatTemperatureSetpoint': 19})
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'climate.bla',
@@ -806,7 +813,7 @@ async def test_lock_unlock_lock(hass):
     assert trt.can_execute(trait.COMMAND_LOCKUNLOCK, {'lock': True})
 
     calls = async_mock_service(hass, lock.DOMAIN, lock.SERVICE_LOCK)
-    await trt.execute(trait.COMMAND_LOCKUNLOCK, {'lock': True})
+    await trt.execute(trait.COMMAND_LOCKUNLOCK, BASIC_DATA, {'lock': True})
 
     assert len(calls) == 1
     assert calls[0].data == {
@@ -843,7 +850,7 @@ async def test_lock_unlock_unlock(hass):
     assert trt.can_execute(trait.COMMAND_LOCKUNLOCK, {'lock': False})
 
     calls = async_mock_service(hass, lock.DOMAIN, lock.SERVICE_UNLOCK)
-    await trt.execute(trait.COMMAND_LOCKUNLOCK, {'lock': False})
+    await trt.execute(trait.COMMAND_LOCKUNLOCK, BASIC_DATA, {'lock': False})
 
     assert len(calls) == 1
     assert calls[0].data == {
@@ -923,7 +930,8 @@ async def test_fan_speed(hass):
         trait.COMMAND_FANSPEED, params={'fanSpeed': 'medium'})
 
     calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_SET_SPEED)
-    await trt.execute(trait.COMMAND_FANSPEED, params={'fanSpeed': 'medium'})
+    await trt.execute(
+        trait.COMMAND_FANSPEED, BASIC_DATA, {'fanSpeed': 'medium'})
 
     assert len(calls) == 1
     assert calls[0].data == {
@@ -1008,7 +1016,7 @@ async def test_modes(hass):
     calls = async_mock_service(
         hass, media_player.DOMAIN, media_player.SERVICE_SELECT_SOURCE)
     await trt.execute(
-        trait.COMMAND_MODES, params={
+        trait.COMMAND_MODES, BASIC_DATA, {
             'updateModeSettings': {
                 trt.HA_TO_GOOGLE.get(media_player.ATTR_INPUT_SOURCE): 'media'
             }})


### PR DESCRIPTION
## Description:

Create context for incoming google assistant requests, and pass it to all service calls.

**Related issue:** fixes issue raised in [review](https://github.com/home-assistant/home-assistant/pull/20204#issuecomment-467999240) of #20204 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
