### PR TITLE
Envsalink arm night

### DIFF
--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -60,6 +60,17 @@ envisalink_alarm_keypress:
       description: 'String to send to the alarm panel (1-6 characters).'
       example: '*71'
 
+envisalink_alarm_arm_max:
+  description: >
+    Arms the alarm control panel in "max" mode.
+  fields:
+    entity_id:
+      description: Name of alarm control panel to arm.
+      example: 'alarm_control_panel.downstairs'
+    code:
+      description: The alarm panel code, if not configured in configuration.yaml.
+      example: "1234"
+
 alarmdecoder_alarm_toggle_chime:
   description: Send the alarm the toggle chime command.
   fields:

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['pyenvisalink==3.8']
+REQUIREMENTS = ['pyenvisalink==3.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -174,7 +174,8 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
             self.hass.data[DATA_EVL].arm_night_partition(
                 str(self._code), self._partition_number)
 
-    async def async_alarm_arm_max(self, code=None):
+    @callback
+    def async_alarm_arm_max(self, code=None):
         """Send arm max command."""
         if code:
             self.hass.data[DATA_EVL].arm_max_partition(

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -7,7 +7,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.components.alarm_control_panel as alarm
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.alarm_control_panel import ALARM_SERVICE_SCHEMA
 from homeassistant.components.envisalink import (
     DATA_EVL, EnvisalinkDevice, PARTITION_SCHEMA, CONF_CODE, CONF_PANIC,
     CONF_PARTITIONNAME, SIGNAL_KEYPAD_UPDATE, SIGNAL_PARTITION_UPDATE)
@@ -27,6 +26,11 @@ ATTR_KEYPRESS = 'keypress'
 ALARM_KEYPRESS_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_KEYPRESS): cv.string
+})
+
+ALARM_ARM_MAX_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_CODE): cv.string
 })
 
 
@@ -61,7 +65,7 @@ async def async_setup_platform(
 
     hass.services.async_register(
         alarm.DOMAIN, SERVICE_ALARM_ARM_MAX, alarm_arm_max_handler,
-        schema=ALARM_SERVICE_SCHEMA)
+        schema=ALARM_ARM_MAX_SCHEMA)
 
     @callback
     def alarm_keypress_handler(service):

--- a/homeassistant/components/envisalink/services.yaml
+++ b/homeassistant/components/envisalink/services.yaml
@@ -13,16 +13,3 @@ invoke_custom_function:
     pgm:
       description: The PGM number to trigger on the alarm panel. This will be 1-4.
       example: "2"
-
-envisalink_alarm_arm_max:
-  description: >
-    Arms the alarm control panel in "max" mode.
-  fields:
-    partition: >
-      description: >
-        The alarm panel partition to arm.
-        Typically this is just "1".
-      example: "1"
-    code:
-      description: The alarm panel code, if not configured in configuration.yaml.
-      example: "1234"

--- a/homeassistant/components/envisalink/services.yaml
+++ b/homeassistant/components/envisalink/services.yaml
@@ -13,3 +13,16 @@ invoke_custom_function:
     pgm:
       description: The PGM number to trigger on the alarm panel. This will be 1-4.
       example: "2"
+
+envisalink_alarm_arm_max:
+  description: >
+    Arms the alarm control panel in "max" mode.
+  fields:
+    partition: >
+      description: >
+        The alarm panel partition to arm.
+        Typically this is just "1".
+      example: "1"
+    code:
+      description: The alarm panel code, if not configured in configuration.yaml.
+      example: "1234"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1015,7 +1015,7 @@ pyeight==0.1.1
 pyemby==1.6
 
 # homeassistant.components.envisalink
-pyenvisalink==3.8
+pyenvisalink==3.9
 
 # homeassistant.components.climate.ephember
 pyephember==0.2.0


### PR DESCRIPTION
## Description:
Adding the ability to call the arm_night service, as requested by the community.  Also adding a custom service for "arm_max" which is another arming mode offered by the envisalink device.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8886

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
