### PR TITLE
Track only json_attributes, truncate value if len > 255

### DIFF
--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -158,7 +158,7 @@ class RestSensor(Entity):
                         self._attributes = attrs
                         attrs_str = json.dumps(attrs)
                         value = (attrs_str[:252] + '...') \
-                            if len (attrs_str) > 255 else attrs_str
+                            if len(attrs_str) > 255 else attrs_str
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -156,6 +156,8 @@ class RestSensor(Entity):
                         attrs = {k: json_dict[k] for k in self._json_attrs
                                  if k in json_dict}
                         self._attributes = attrs
+                        attrs_str = json.dumps(attrs)
+                        value = (attrs_str[:252] + '...') if len (attrs_str) > 255 else attrs_str
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -157,7 +157,8 @@ class RestSensor(Entity):
                                  if k in json_dict}
                         self._attributes = attrs
                         attrs_str = json.dumps(attrs)
-                        value = (attrs_str[:252] + '...') if len (attrs_str) > 255 else attrs_str
+                        value = (attrs_str[:252] + '...') \
+                            if len (attrs_str) > 255 else attrs_str
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:


### PR DESCRIPTION
* When json_attributes is specified in a Rest sensor, use only the JSON attributes specified as values for the sensor value, truncate sensor value if it exceeds 255 chars in length allowing larger json payloads to work.

## Description:
The purpose of json_attributes is to extract data of interest from a JSON payload and use that for sensor attribute data.   With the current implementation if the payload retrieved exceeds 255 characters in length when converted to a string, the entity state fails to update with a state validation error: 

```2019-03-01 00:03:05 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/helpers/entity_platform.py", line 351, in _async_add_entity
    await entity.async_update_ha_state()
  File "/usr/local/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 310, in async_update_ha_state
    self.entity_id, state, attr, self.force_update, self._context)
  File "/usr/local/lib/python3.6/site-packages/homeassistant/core.py", line 903, in async_set
    context)
  File "/usr/local/lib/python3.6/site-packages/homeassistant/core.py", line 673, in __init__
    "State max length is 255 characters.").format(entity_id))
homeassistant.exceptions.InvalidStateError: Invalid state encountered for entity id: sensor.tesla_vitals. State max length is 255 characters.
```
This patch discards data not specified in the json_attributes from being retained in value, and additionally truncates value to 255 chars if it's length exceeds that allowing large payloads to be processed.

**Related issue (if applicable):**  #12235 (helps with length constraint)