### PR TITLE
Don't wait until final position of Velux cover is reached

### DIFF
--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -12,7 +12,7 @@ DATA_VELUX = "data_velux"
 SUPPORTED_DOMAINS = ['cover', 'scene']
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyvlx==0.2.9']
+REQUIREMENTS = ['pyvlx==0.2.10']
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -71,11 +71,11 @@ class VeluxCover(CoverDevice):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        await self.node.close()
+        await self.node.close(wait_for_completion=False)
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        await self.node.open()
+        await self.node.open(wait_for_completion=False)
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
@@ -83,8 +83,9 @@ class VeluxCover(CoverDevice):
             position_percent = 100 - kwargs[ATTR_POSITION]
             from pyvlx import Position
             await self.node.set_position(
-                Position(position_percent=position_percent))
+                Position(position_percent=position_percent),
+                wait_for_completion=False)
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        await self.node.stop()
+        await self.node.stop(wait_for_completion=False)

--- a/homeassistant/components/velux/scene.py
+++ b/homeassistant/components/velux/scene.py
@@ -29,4 +29,4 @@ class VeluxScene(Scene):
 
     async def async_activate(self):
         """Activate the scene."""
-        await self.scene.run()
+        await self.scene.run(wait_for_completion=False)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1444,7 +1444,7 @@ pyvesync==0.1.1
 pyvizio==0.0.4
 
 # homeassistant.components.velux
-pyvlx==0.2.9
+pyvlx==0.2.10
 
 # homeassistant.components.notify.html5
 pywebpush==1.6.0


### PR DESCRIPTION
## Description:

* Bump version to latest version of pyvlx: 0.2.10. Library more failure tolerant, when detecting an unsupported device.
* When calling API (e.g. run scene, change position) don't wait until device has reached target position (This caused  HASS to be flaky while the device was moving)
* Support for vertical and horizontal awnings.
