### PR TITLE
[RFC] Add sensors for signal strength to Homematic IP 

### DIFF
--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -12,12 +12,9 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['homematicip_cloud']
 
 ATTR_TEMPERATURE_OFFSET = 'temperature_offset'
-ATTR_VALVE_STATE = 'valve_state'
-ATTR_VALVE_POSITION = 'valve_position'
 ATTR_WIND_DIRECTION = 'wind_direction'
 ATTR_WIND_DIRECTION_VARIATION = 'wind_direction_variation_in_degree'
-ATTR_HUMIDITY = 'humidity'
-ATTR_RSSIPEER = 'rssi_peer_in_dbm'
+ATTR_RSSI_PEER = 'rssi_peer_in_dbm'
 
 
 async def async_setup_platform(
@@ -286,7 +283,7 @@ class HomematicipSignalStrengthSensor(HomematicipGenericDevice):
         # dimmer(!), ...) will ever deliver a rssi peer value.
         attr = super().device_state_attributes
         if self._device.rssiPeerValue is not None:
-            attr[ATTR_RSSIPEER] = self._device.rssiPeerValue
+            attr[ATTR_RSSI_PEER] = self._device.rssiPeerValue
         return attr
 
 

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -299,7 +299,6 @@ class HomematicipWindspeedSensor(HomematicipGenericDevice):
         """Represenation of the HomematicIP wind speed value."""
         return self._device.windSpeed
 
-
     @property
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""


### PR DESCRIPTION
## Description:
 
This PR adds sensors for signal strength  to Homematic IP

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23