### PR TITLE
Start preparing for homekit_controller config entries

### DIFF
--- a/homeassistant/components/homekit_controller/.translations/en.json
+++ b/homeassistant/components/homekit_controller/.translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "title": "HomeKit Accessory",
         "step": {
-            "init": {
+            "user": {
                 "title": "Pair with HomeKit Accessory",
                 "description": "Select the device you want to pair with",
                 "data": {
@@ -18,17 +18,16 @@
             }
         },
         "error": {
-            "unknown_device": "You selected a device that is no longer visible",
-            "unable_to_pair": "Unable to pair, please try again",
+            "unable_to_pair": "Unable to pair, please try again.",
             "unknown_error": "Device reported an unknown error. Pairing failed.",
             "authentication_error": "Incorrect HomeKit code. Please check it and try again."
         },
         "abort": {
             "no_devices": "No unpaired devices could be found",
             "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
-            "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available",
-            "already_configured": "Accessory is already configured with this controller",
-            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed"
+            "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
+            "already_configured": "Accessory is already configured with this controller.",
+            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed."
         }
     }
 }

--- a/homeassistant/components/homekit_controller/.translations/en.json
+++ b/homeassistant/components/homekit_controller/.translations/en.json
@@ -1,0 +1,34 @@
+{
+    "config": {
+        "title": "HomeKit Accessory",
+        "step": {
+            "init": {
+                "title": "Pair with HomeKit Accessory",
+                "description": "Select the device you want to pair with",
+                "data": {
+                    "device": "Device"
+                }
+            },
+            "pair": {
+                "title": "Pair with {{ model }}",
+                "description": "Enter your HomeKit pairing code to use this accessory",
+                "data": {
+                    "pairing_code": "Pairing Code"
+                }
+            }
+        },
+        "error": {
+            "unknown_device": "You selected a device that is no longer visible",
+            "unable_to_pair": "Unable to pair, please try again",
+            "unknown_error": "Device reported an unknown error. Pairing failed.",
+            "authentication_error": "Incorrect HomeKit code. Please check it and try again."
+        },
+        "abort": {
+            "no_devices": "No unpaired devices could be found",
+            "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
+            "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available",
+            "already_configured": "Accessory is already configured with this controller",
+            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed"
+        }
+    }
+}

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -8,37 +8,21 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import call_later
 
+from .const import (
+    CONTROLLER, DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, KNOWN_ACCESSORIES,
+    KNOWN_DEVICES
+)
+
+
 REQUIREMENTS = ['homekit==0.12.2']
 
-DOMAIN = 'homekit_controller'
 HOMEKIT_DIR = '.homekit'
-
-# Mapping from Homekit type to component.
-HOMEKIT_ACCESSORY_DISPATCH = {
-    'lightbulb': 'light',
-    'outlet': 'switch',
-    'switch': 'switch',
-    'thermostat': 'climate',
-    'security-system': 'alarm_control_panel',
-    'garage-door-opener': 'cover',
-    'window': 'cover',
-    'window-covering': 'cover',
-    'lock-mechanism': 'lock',
-    'motion': 'binary_sensor',
-    'humidity': 'sensor',
-    'light': 'sensor',
-    'temperature': 'sensor'
-}
 
 HOMEKIT_IGNORE = [
     'BSB002',
     'Home Assistant Bridge',
     'TRADFRI gateway',
 ]
-
-KNOWN_ACCESSORIES = "{}-accessories".format(DOMAIN)
-KNOWN_DEVICES = "{}-devices".format(DOMAIN)
-CONTROLLER = "{}-controller".format(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -5,7 +5,6 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
 from homeassistant.core import callback
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -102,7 +102,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             )
 
         return self.async_show_form(
-            step_id='init',
+            step_id='user',
             errors=errors,
             data_schema=vol.Schema({
                 vol.Required('device'): vol.In(self.devices.keys()),
@@ -178,10 +178,10 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         # Device isn't paired with us or anyone else.
         # But we have a 'complete' config entry for it - that is probably
-        # invalid.
+        # invalid. Remove it automatically.
         existing = find_existing_host(self.hass, hkid)
         if existing:
-            return self.async_abort(reason='invalid_config_entry')
+            await self.hass.config_entries.async_remove(existing.entry_id)
 
         self.model = model
         self.hkid = hkid

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -216,7 +216,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         errors = {}
 
         if pair_info:
-            code = pair_info['pairing_code'].strip()
+            code = pair_info['pairing_code']
             controller = homekit.Controller()
             try:
                 await self.hass.async_add_executor_job(

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -243,7 +243,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             },
             errors=errors,
             data_schema=vol.Schema({
-                vol.Required('pairing_code'):  vol.All(cv.string, vol.Strip),
+                vol.Required('pairing_code'):  vol.Strip,
             })
         )
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -242,7 +242,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             },
             errors=errors,
             data_schema=vol.Schema({
-                vol.Required('pairing_code'):  vol.Strip,
+                vol.Required('pairing_code'):  vol.All(str, vol.Strip),
             })
         )
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -1,0 +1,263 @@
+"""Config flow to configure homekit_controller."""
+import os
+import json
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import DOMAIN, KNOWN_DEVICES
+from .connection import get_bridge_information, get_accessory_name
+
+
+HOMEKIT_IGNORE = [
+    'BSB002',
+    'Home Assistant Bridge',
+    'TRADFRI gateway',
+]
+HOMEKIT_DIR = '.homekit'
+PAIRING_FILE = 'pairing.json'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def load_old_pairings(hass):
+    """Load any old pairings from on-disk json fragments."""
+    old_pairings = {}
+
+    data_dir = os.path.join(hass.config.path(), HOMEKIT_DIR)
+    pairing_file = os.path.join(data_dir, PAIRING_FILE)
+
+    # Find any pairings created with in HA 0.85 / 0.86
+    if os.path.exists(pairing_file):
+        with open(pairing_file) as pairing_file:
+            old_pairings.update(json.load(pairing_file))
+
+    # Find any pairings created in HA <= 0.84
+    if os.path.exists(data_dir):
+        for device in os.listdir(data_dir):
+            if not device.startswith('hk-'):
+                continue
+            alias = device[3:]
+            if alias in old_pairings:
+                continue
+            with open(os.path.join(data_dir, device)) as pairing_data_fp:
+                old_pairings[alias] = json.load(pairing_data_fp)
+
+    return old_pairings
+
+
+@callback
+def find_existing_host(hass, serial):
+    """Return a set of the configured hosts."""
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.data['AccessoryPairingID'] == serial:
+            return entry
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class HomekitControllerFlowHandler(config_entries.ConfigFlow):
+    """Handle a HomeKit config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self):
+        """Initialize the homekit_controller flow."""
+        self.model = None
+        self.hkid = None
+        self.devices = {}
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        return await self.async_step_init(user_input)
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow start."""
+        import homekit
+
+        errors = {}
+
+        if user_input is not None and 'device' in user_input:
+            key = user_input['device']
+            if key in self.devices:
+                props = self.devices[key]['properties']
+                self.hkid = props['id']
+                self.model = props['md']
+                return await self.async_step_pair()
+
+            errors['device'] = 'unknown_device'
+
+        controller = homekit.Controller()
+        all_hosts = await self.hass.async_add_executor_job(
+            controller.discover, 5
+        )
+
+        self.devices = {}
+        for host in all_hosts:
+            status_flags = int(host['properties']['sf'])
+            paired = not status_flags & 0x01
+            if paired:
+                continue
+            self.devices[host['properties']['id']] = host
+
+        if not self.devices:
+            return self.async_abort(
+                reason='no_devices'
+            )
+
+        return self.async_show_form(
+            step_id='init',
+            errors=errors,
+            data_schema=vol.Schema({
+                vol.Required('device'): vol.In(self.devices.keys()),
+            })
+        )
+
+    async def async_import_legacy_pairing(self, discovery_props, pairing_data):
+        """Migrate a legacy pairing to config entries."""
+        from homekit.controller import Pairing
+
+        hkid = discovery_props['id']
+
+        existing = find_existing_host(self.hass, hkid)
+        if existing:
+            _LOGGER.info(
+                ("Legacy configuration for homekit accessory %s"
+                 "not loaded as already migrated"), hkid)
+            return self.async_abort(reason='already_configured')
+
+        _LOGGER.info(
+            ("Legacy configuration %s for homekit"
+             "accessory migrated to config entries"), hkid)
+
+        pairing = Pairing(pairing_data)
+
+        return await self._entry_from_accessory(pairing)
+
+    async def async_step_discovery(self, discovery_info):
+        """Handle a discovered HomeKit accessory.
+
+        This flow is triggered by the discovery component.
+        """
+        # Normalize properties from discovery
+        # homekit_python has code to do this, but not in a form we can
+        # easily use, so do the bare minimum ourselves here instead.
+        properties = {
+            key.lower(): value
+            for (key, value) in discovery_info['properties'].items()
+        }
+
+        # The hkid is a unique random number that looks like a pairing code.
+        # It changes if a device is factory reset.
+        hkid = properties['id']
+        model = properties['md']
+
+        status_flags = int(properties['sf'])
+        paired = not status_flags & 0x01
+
+        # The configuration number increases every time the characteristic map
+        # needs updating. Some devices use a slightly off-spec name so handle
+        # both cases.
+        try:
+            config_num = int(properties['c#'])
+        except KeyError:
+            _LOGGER.warning(
+                "HomeKit device %s: c# not exposed, in violation of spec",
+                hkid)
+            config_num = None
+
+        if paired:
+            if hkid in self.hass.data.get(KNOWN_DEVICES, {}):
+                # The device is already paired and known to us
+                # According to spec we should monitor c# (config_num) for
+                # changes. If it changes, we check for new entities
+                conn = self.hass.data[KNOWN_DEVICES][hkid]
+                if conn.config_num != config_num:
+                    _LOGGER.debug(
+                        "HomeKit info %s: c# incremented, refreshing entities",
+                        hkid)
+                    self.hass.async_create_task(
+                        conn.async_config_num_changed(config_num))
+                return self.async_abort(reason='already_configured')
+
+            old_pairings = load_old_pairings(self.hass)
+            if hkid in old_pairings:
+                return await self.async_import_legacy_pairing(
+                    properties,
+                    old_pairings[hkid]
+                )
+
+            # Device is paired but not to us - ignore it
+            _LOGGER.debug("HomeKit device %s ignored as already paired", hkid)
+            return self.async_abort(reason='already_paired')
+
+        # Devices in HOMEKIT_IGNORE have native local integrations - users
+        # should be encouraged to use native integration and not confused
+        # by alternative HK API.
+        if model in HOMEKIT_IGNORE:
+            return self.async_abort(reason='ignored_model')
+
+        # Device isn't paired with us or anyone else.
+        # But we have a 'complete' config entry for it - that is probably
+        # invalid.
+        existing = find_existing_host(self.hass, hkid)
+        if existing:
+            return self.async_abort(reason='invalid_config_entry')
+
+        self.model = model
+        self.hkid = hkid
+        return await self.async_step_pair()
+
+    async def async_step_pair(self, pair_info=None):
+        """Pair with a new HomeKit accessory."""
+        import homekit  # pylint: disable=import-error
+
+        errors = {}
+
+        if pair_info and 'pairing_code' in pair_info:
+            code = pair_info['pairing_code'].strip()
+            controller = homekit.Controller()
+            try:
+                await self.hass.async_add_executor_job(
+                    controller.perform_pairing, self.hkid, self.hkid, code
+                )
+
+                pairing = controller.pairings.get(self.hkid)
+                if pairing:
+                    return await self._entry_from_accessory(
+                        pairing)
+
+                errors['pairing_code'] = 'unable_to_pair'
+            except homekit.AuthenticationError:
+                errors['pairing_code'] = 'authentication_error'
+            except homekit.UnknownError:
+                errors['pairing_code'] = 'unknown_error'
+            except homekit.UnavailableError:
+                return self.async_abort(reason='already_paired')
+
+        return self.async_show_form(
+            step_id='pair',
+            description_placeholders={
+                'model': self.model,
+            },
+            errors=errors,
+            data_schema=vol.Schema({
+                vol.Required("pairing_code"): str,
+            })
+        )
+
+    async def _entry_from_accessory(self, pairing):
+        """Return a config entry from an initialized bridge."""
+        accessories = await self.hass.async_add_executor_job(
+            pairing.list_accessories_and_characteristics
+        )
+        bridge_info = get_bridge_information(accessories)
+        name = get_accessory_name(bridge_info)
+
+        return self.async_create_entry(
+            title=name,
+            data=pairing.pairing_data,
+        )

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -1,0 +1,35 @@
+"""Helpers for managing a pairing with a HomeKit accessory or bridge."""
+
+
+def get_accessory_information(accessory):
+    """Obtain the accessory information service of a HomeKit device."""
+    # pylint: disable=import-error
+    from homekit.model.services import ServicesTypes
+    from homekit.model.characteristics import CharacteristicsTypes
+
+    result = {}
+    for service in accessory['services']:
+        stype = service['type'].upper()
+        if ServicesTypes.get_short(stype) != 'accessory-information':
+            continue
+        for characteristic in service['characteristics']:
+            ctype = CharacteristicsTypes.get_short(characteristic['type'])
+            if 'value' in characteristic:
+                result[ctype] = characteristic['value']
+    return result
+
+
+def get_bridge_information(accessories):
+    """Return the accessory info for the bridge."""
+    for accessory in accessories:
+        if accessory['aid'] == 1:
+            return get_accessory_information(accessory)
+    return get_accessory_information(accessories[0])
+
+
+def get_accessory_name(accessory_info):
+    """Return the name field of an accessory."""
+    for field in ('name', 'model', 'manufacturer'):
+        if field in accessory_info:
+            return accessory_info[field]
+    return None

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -1,0 +1,23 @@
+"""Constants for the homekit_controller component."""
+DOMAIN = 'homekit_controller'
+
+KNOWN_ACCESSORIES = "{}-accessories".format(DOMAIN)
+KNOWN_DEVICES = "{}-devices".format(DOMAIN)
+CONTROLLER = "{}-controller".format(DOMAIN)
+
+# Mapping from Homekit type to component.
+HOMEKIT_ACCESSORY_DISPATCH = {
+    'lightbulb': 'light',
+    'outlet': 'switch',
+    'switch': 'switch',
+    'thermostat': 'climate',
+    'security-system': 'alarm_control_panel',
+    'garage-door-opener': 'cover',
+    'window': 'cover',
+    'window-covering': 'cover',
+    'lock-mechanism': 'lock',
+    'motion': 'binary_sensor',
+    'humidity': 'sensor',
+    'light': 'sensor',
+    'temperature': 'sensor'
+}

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -2,7 +2,7 @@
     "config": {
         "title": "HomeKit Accessory",
         "step": {
-            "init": {
+            "user": {
                 "title": "Pair with HomeKit Accessory",
                 "description": "Select the device you want to pair with",
                 "data": {
@@ -18,17 +18,16 @@
             }
         },
         "error": {
-            "unknown_device": "You selected a device that is no longer visible",
-            "unable_to_pair": "Unable to pair, please try again",
+            "unable_to_pair": "Unable to pair, please try again.",
             "unknown_error": "Device reported an unknown error. Pairing failed.",
             "authentication_error": "Incorrect HomeKit code. Please check it and try again."
         },
         "abort": {
             "no_devices": "No unpaired devices could be found",
             "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
-            "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available",
-            "already_configured": "Accessory is already configured with this controller",
-            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed"
+            "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
+            "already_configured": "Accessory is already configured with this controller.",
+            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed."
         }
     }
 }

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -1,0 +1,34 @@
+{
+    "config": {
+        "title": "HomeKit Accessory",
+        "step": {
+            "init": {
+                "title": "Pair with HomeKit Accessory",
+                "description": "Select the device you want to pair with",
+                "data": {
+                    "device": "Device"
+                }
+            },
+            "pair": {
+                "title": "Pair with {{ model }}",
+                "description": "Enter your HomeKit pairing code to use this accessory",
+                "data": {
+                    "pairing_code": "Pairing Code"
+                }
+            }
+        },
+        "error": {
+            "unknown_device": "You selected a device that is no longer visible",
+            "unable_to_pair": "Unable to pair, please try again",
+            "unknown_error": "Device reported an unknown error. Pairing failed.",
+            "authentication_error": "Incorrect HomeKit code. Please check it and try again."
+        },
+        "abort": {
+            "no_devices": "No unpaired devices could be found",
+            "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
+            "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available",
+            "already_configured": "Accessory is already configured with this controller",
+            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed"
+        }
+    }
+}

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,0 +1,774 @@
+"""Tests for homekit_controller config flow."""
+import json
+from unittest import mock
+
+import homekit
+
+from homeassistant.components.homekit_controller import config_flow
+from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
+from tests.common import MockConfigEntry
+from tests.components.homekit_controller.common import (
+    Accessory, FakeService, setup_platform
+)
+
+
+async def test_discovery_works(hass):
+    """Test a device being discovered."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    pairing = mock.Mock(pairing_data={
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    })
+
+    pairing.list_accessories_and_characteristics.return_value = [{
+        "aid": 1,
+        "services": [{
+            "characteristics": [{
+                "type": "23",
+                "value": "Koogeek-LS1-20833F"
+            }],
+            "type": "3e",
+        }]
+    }]
+
+    controller = mock.Mock()
+    controller.pairings = {
+        '00:00:00:00:00:00': pairing,
+    }
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'Koogeek-LS1-20833F'
+    assert result['data'] == pairing.pairing_data
+
+
+async def test_discovery_works_upper_case(hass):
+    """Test a device being discovered."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'MD': 'TestDevice',
+            'ID': '00:00:00:00:00:00',
+            'C#': 1,
+            'SF': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    pairing = mock.Mock(pairing_data={
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    })
+
+    pairing.list_accessories_and_characteristics.return_value = [{
+        "aid": 1,
+        "services": [{
+            "characteristics": [{
+                "type": "23",
+                "value": "Koogeek-LS1-20833F"
+            }],
+            "type": "3e",
+        }]
+    }]
+
+    controller = mock.Mock()
+    controller.pairings = {
+        '00:00:00:00:00:00': pairing,
+    }
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'Koogeek-LS1-20833F'
+    assert result['data'] == pairing.pairing_data
+
+
+async def test_discovery_works_missing_csharp(hass):
+    """Test a device being discovered that has missing mdns attrs."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    pairing = mock.Mock(pairing_data={
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    })
+
+    pairing.list_accessories_and_characteristics.return_value = [{
+        "aid": 1,
+        "services": [{
+            "characteristics": [{
+                "type": "23",
+                "value": "Koogeek-LS1-20833F"
+            }],
+            "type": "3e",
+        }]
+    }]
+
+    controller = mock.Mock()
+    controller.pairings = {
+        '00:00:00:00:00:00': pairing,
+    }
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'Koogeek-LS1-20833F'
+    assert result['data'] == pairing.pairing_data
+
+
+async def test_pair_already_paired_1(hass):
+    """Already paired."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 0,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'already_paired'
+
+
+async def test_discovery_ignored_model(hass):
+    """Already paired."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'BSB002',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'ignored_model'
+
+
+async def test_discovery_invalid_config_entry(hass):
+    """Already configured."""
+    MockConfigEntry(domain='homekit_controller', data={
+        'AccessoryPairingID': '00:00:00:00:00:00'
+    }).add_to_hass(hass)
+
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'invalid_config_entry'
+
+
+async def test_discovery_already_configured(hass):
+    """Already configured."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 0,
+        }
+    }
+
+    await setup_platform(hass)
+
+    conn = mock.Mock()
+    conn.config_num = 1
+    hass.data[KNOWN_DEVICES]['00:00:00:00:00:00'] = conn
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'already_configured'
+
+    conn.async_config_num_changed.assert_not_called()
+
+
+async def test_discovery_already_configured_config_change(hass):
+    """Already configured."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 2,
+            'sf': 0,
+        }
+    }
+
+    await setup_platform(hass)
+
+    conn = mock.Mock()
+    conn.config_num = 1
+    hass.data[KNOWN_DEVICES]['00:00:00:00:00:00'] = conn
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'already_configured'
+
+    conn.async_config_num_changed.assert_called_once_with(2)
+
+
+async def test_pair_unable_to_pair(hass):
+    """Pairing completed without exception, but didn't create a pairing."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    controller = mock.Mock()
+    controller.pairings = {}
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+
+    assert result['type'] == 'form'
+    assert result['errors']['pairing_code'] == 'unable_to_pair'
+
+
+async def test_pair_authentication_error(hass):
+    """Pairing code is incorrect."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    controller = mock.Mock()
+    controller.pairings = {}
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        exc = homekit.AuthenticationError('Invalid pairing code')
+        controller.perform_pairing.side_effect = exc
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+
+    assert result['type'] == 'form'
+    assert result['errors']['pairing_code'] == 'authentication_error'
+
+
+async def test_pair_unknown_error(hass):
+    """Pairing failed for an unknown rason."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    controller = mock.Mock()
+    controller.pairings = {}
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        exc = homekit.UnknownError('Unknown error')
+        controller.perform_pairing.side_effect = exc
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+
+    assert result['type'] == 'form'
+    assert result['errors']['pairing_code'] == 'unknown_error'
+
+
+async def test_pair_already_paired(hass):
+    """Device is already paired."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_discovery(discovery_info)
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    controller = mock.Mock()
+    controller.pairings = {}
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        exc = homekit.UnavailableError('Unavailable error')
+        controller.perform_pairing.side_effect = exc
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'already_paired'
+
+
+async def test_import_works(hass):
+    """Test a device being discovered."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    import_info = {
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    }
+
+    pairing = mock.Mock(pairing_data={
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    })
+
+    pairing.list_accessories_and_characteristics.return_value = [{
+        "aid": 1,
+        "services": [{
+            "characteristics": [{
+                "type": "23",
+                "value": "Koogeek-LS1-20833F"
+            }],
+            "type": "3e",
+        }]
+    }]
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+        pairing_cls.return_value = pairing
+        result = await flow.async_import_legacy_pairing(
+            discovery_info['properties'], import_info)
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'Koogeek-LS1-20833F'
+    assert result['data'] == pairing.pairing_data
+
+
+async def test_import_already_configured(hass):
+    """Test importing a device from .homekit that is already a ConfigEntry."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    import_info = {
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    }
+
+    config_entry = MockConfigEntry(
+        domain='homekit_controller',
+        data=import_info
+    )
+    config_entry.add_to_hass(hass)
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_import_legacy_pairing(
+        discovery_info['properties'], import_info)
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'already_configured'
+
+
+async def test_user_works(hass):
+    """Test user initiated disovers devices."""
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    pairing = mock.Mock(pairing_data={
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    })
+    pairing.list_accessories_and_characteristics.return_value = [{
+        "aid": 1,
+        "services": [{
+            "characteristics": [{
+                "type": "23",
+                "value": "Koogeek-LS1-20833F"
+            }],
+            "type": "3e",
+        }]
+    }]
+
+    controller = mock.Mock()
+    controller.pairings = {
+        '00:00:00:00:00:00': pairing,
+    }
+    controller.discover.return_value = [
+        discovery_info,
+    ]
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        result = await flow.async_step_user()
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'init'
+
+    result = await flow.async_step_init({
+        'device': '00:00:00:00:00:00',
+    })
+    assert result['type'] == 'form'
+    assert result['step_id'] == 'pair'
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value = controller
+        result = await flow.async_step_pair({
+            'pairing_code': '111-22-33',
+        })
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'Koogeek-LS1-20833F'
+    assert result['data'] == pairing.pairing_data
+
+
+async def test_user_no_devices(hass):
+    """Test user initiated pairing where no devices discovered."""
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value.discover.return_value = []
+        result = await flow.async_step_user()
+
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'no_devices'
+
+
+async def test_user_no_unpaired_devices(hass):
+    """Test user initiated pairing where no unpaired devices discovered."""
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 0,
+        }
+    }
+
+    with mock.patch('homekit.Controller') as controller_cls:
+        controller_cls.return_value.discover.return_value = [
+            discovery_info,
+        ]
+        result = await flow.async_step_user()
+
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'no_devices'
+
+
+async def test_parse_new_homekit_json(hass):
+    """Test migrating recent .homekit/pairings.json files."""
+    service = FakeService('public.hap.service.lightbulb')
+    on_char = service.add_characteristic('on')
+    on_char.value = 1
+
+    accessory = Accessory('TestDevice', 'example.com', 'Test', '0001', '0.1')
+    accessory.services.append(service)
+
+    fake_controller = await setup_platform(hass)
+    pairing = fake_controller.add([accessory])
+    pairing.pairing_data = {
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    }
+
+    mock_path = mock.Mock()
+    mock_path.exists.side_effect = [True, False]
+
+    read_data = {
+        '00:00:00:00:00:00': pairing.pairing_data,
+    }
+    mock_open = mock.mock_open(read_data=json.dumps(read_data))
+
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 0,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+        pairing_cls.return_value = pairing
+        with mock.patch('builtins.open', mock_open):
+            with mock.patch('os.path', mock_path):
+                result = await flow.async_step_discovery(discovery_info)
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'TestDevice'
+    assert result['data']['AccessoryPairingID'] == '00:00:00:00:00:00'
+
+
+async def test_parse_old_homekit_json(hass):
+    """Test migrating original .homekit/hk-00:00:00:00:00:00 files."""
+    service = FakeService('public.hap.service.lightbulb')
+    on_char = service.add_characteristic('on')
+    on_char.value = 1
+
+    accessory = Accessory('TestDevice', 'example.com', 'Test', '0001', '0.1')
+    accessory.services.append(service)
+
+    fake_controller = await setup_platform(hass)
+    pairing = fake_controller.add([accessory])
+    pairing.pairing_data = {
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    }
+
+    mock_path = mock.Mock()
+    mock_path.exists.side_effect = [False, True]
+
+    mock_listdir = mock.Mock()
+    mock_listdir.return_value = [
+        'hk-00:00:00:00:00:00',
+        'pairings.json'
+    ]
+
+    read_data = {
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    }
+    mock_open = mock.mock_open(read_data=json.dumps(read_data))
+
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 0,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+        pairing_cls.return_value = pairing
+        with mock.patch('builtins.open', mock_open):
+            with mock.patch('os.path', mock_path):
+                with mock.patch('os.listdir', mock_listdir):
+                    result = await flow.async_step_discovery(discovery_info)
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'TestDevice'
+    assert result['data']['AccessoryPairingID'] == '00:00:00:00:00:00'
+
+
+async def test_parse_overlapping_homekit_json(hass):
+    """Test migrating .homekit/pairings.json files when hk- exists too."""
+    service = FakeService('public.hap.service.lightbulb')
+    on_char = service.add_characteristic('on')
+    on_char.value = 1
+
+    accessory = Accessory('TestDevice', 'example.com', 'Test', '0001', '0.1')
+    accessory.services.append(service)
+
+    fake_controller = await setup_platform(hass)
+    pairing = fake_controller.add([accessory])
+    pairing.pairing_data = {
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    }
+
+    mock_listdir = mock.Mock()
+    mock_listdir.return_value = [
+        'hk-00:00:00:00:00:00',
+        'pairings.json'
+    ]
+
+    mock_path = mock.Mock()
+    mock_path.exists.side_effect = [True, True]
+
+    # First file to get loaded is .homekit/pairing.json
+    read_data_1 = {
+        '00:00:00:00:00:00': {
+            'AccessoryPairingID': '00:00:00:00:00:00',
+        }
+    }
+    mock_open_1 = mock.mock_open(read_data=json.dumps(read_data_1))
+
+    # Second file to get loaded is .homekit/hk-00:00:00:00:00:00
+    read_data_2 = {
+        'AccessoryPairingID': '00:00:00:00:00:00',
+    }
+    mock_open_2 = mock.mock_open(read_data=json.dumps(read_data_2))
+
+    side_effects = [mock_open_1.return_value, mock_open_2.return_value]
+
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 0,
+        }
+    }
+
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+
+    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+        pairing_cls.return_value = pairing
+        with mock.patch('builtins.open', side_effect=side_effects):
+            with mock.patch('os.path', mock_path):
+                with mock.patch('os.listdir', mock_listdir):
+                    result = await flow.async_step_discovery(discovery_info)
+
+        await hass.async_block_till_done()
+
+    assert result['type'] == 'create_entry'
+    assert result['title'] == 'TestDevice'
+    assert result['data']['AccessoryPairingID'] == '00:00:00:00:00:00'

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -548,7 +548,7 @@ async def test_user_works(hass):
     assert result['type'] == 'form'
     assert result['step_id'] == 'init'
 
-    result = await flow.async_step_init({
+    result = await flow.async_step_user({
         'device': '00:00:00:00:00:00',
     })
     assert result['type'] == 'form'


### PR DESCRIPTION
## Description:

This branch is the first part of my work to migrate homekit_controller to config entries.

This branch *does not* activate the config entries code yet, but it does have quite a bit of test coverage for the new code. It's quite a large diff so i'd like to try and lock in this first part - the other related code is [here](https://github.com/home-assistant/home-assistant/compare/dev...Jc2k:homekit_config_flow).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Tests have been added to verify that the new code works.
