### PR TITLE
Don't hang forever if manually added cast is down

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -2,7 +2,7 @@
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
 
-REQUIREMENTS = ['pychromecast==2.5.2']
+REQUIREMENTS = ['pychromecast==3.0.0']
 
 DOMAIN = 'cast'
 

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -477,18 +477,11 @@ class CastDevice(MediaPlayerDevice):
                     cast_info.friendly_name
                 ))
         self._chromecast = chromecast
-        self._chromecast.start()
         self._status_listener = CastStatusListener(self, chromecast)
-        # Initialise connection status as connected because we can only
-        # register the connection listener *after* the initial connection
-        # attempt. If the initial connection failed, we would never reach
-        # this code anyway.
-        self._available = True
+        self._available = False
         self.cast_status = chromecast.status
         self.media_status = chromecast.media_controller.status
-        _LOGGER.debug("[%s %s (%s:%s)] Connection successful!",
-                      self.entity_id, self._cast_info.friendly_name,
-                      self._cast_info.host, self._cast_info.port)
+        self._chromecast.start()
         self.async_schedule_update_ha_state()
 
     async def async_del_cast_info(self, cast_info):

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -463,8 +463,8 @@ class CastDevice(MediaPlayerDevice):
             chromecast = await self.hass.async_add_job(
                 pychromecast._get_chromecast_from_host, (
                     cast_info.host, cast_info.port, cast_info.uuid,
-                    cast_info.model_name, cast_info.friendly_name,
-                ), None, None, None, True, True)
+                    cast_info.model_name, cast_info.friendly_name
+                ))
         else:
             _LOGGER.debug(
                 "[%s %s (%s:%s)] Connecting to cast device by service %s",
@@ -477,6 +477,7 @@ class CastDevice(MediaPlayerDevice):
                     cast_info.friendly_name
                 ))
         self._chromecast = chromecast
+        self._chromecast.start()
         self._status_listener = CastStatusListener(self, chromecast)
         # Initialise connection status as connected because we can only
         # register the connection listener *after* the initial connection

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -292,7 +292,7 @@ async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
         if cast_device is not None:
             async_add_entities([cast_device])
 
-    remove_handler = async_dispatcher_connect(
+    async_dispatcher_connect(
         hass, SIGNAL_CAST_DISCOVERED, async_cast_discovered)
     # Re-play the callback for all past chromecasts, store the objects in
     # a list to avoid concurrent modification resulting in exception.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -964,7 +964,7 @@ pycfdns==0.0.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==2.5.2
+pychromecast==3.0.0
 
 # homeassistant.components.media_player.cmus
 pycmus==0.1.1

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -7,7 +7,6 @@ from uuid import UUID
 
 import attr
 import pytest
-from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED
 
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.typing import HomeAssistantType
@@ -256,9 +255,8 @@ async def test_entity_media_states(hass: HomeAssistantType):
                return_value=full_info):
         chromecast, entity = await async_setup_media_player_cast(hass, info)
 
-    connection_status = MagicMock()
-    connection_status.status = CONNECTION_STATUS_CONNECTED
-    entity.new_connection_status(connection_status)
+    entity._available = True
+    entity.schedule_update_ha_state()
     await hass.async_block_till_done()
 
     state = hass.states.get('media_player.speaker')


### PR DESCRIPTION
## Description:
Don't hang forever if manually added cast is down when HA starts.
Also improve logging if exceptions are thrown when starting the platform.

**Related issue (if applicable):** fixes #17282

Note: Depends on balloob/pychromecast#271

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.