### PR TITLE
Re-thrown exception occurred in the blocking service call

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -153,7 +153,7 @@ async def handle_call_service(hass, connection, msg):
     except HomeAssistantError as err:
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_HOME_ASSISTANT_ERROR, '{}'.format(err)))
-    except Exception as err:
+    except Exception as err:  # pylint: disable=broad-except
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_UNKNOWN_ERROR, '{}'.format(err)))
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -3,7 +3,8 @@ import voluptuous as vol
 
 from homeassistant.const import MATCH_ALL, EVENT_TIME_CHANGED
 from homeassistant.core import callback, DOMAIN as HASS_DOMAIN
-from homeassistant.exceptions import Unauthorized, ServiceNotFound
+from homeassistant.exceptions import Unauthorized, ServiceNotFound, \
+    HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_get_all_descriptions
 
@@ -149,6 +150,12 @@ async def handle_call_service(hass, connection, msg):
     except ServiceNotFound:
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_NOT_FOUND, 'Service not found.'))
+    except HomeAssistantError as err:
+        connection.send_message(messages.error_message(
+            msg['id'], const.ERR_HOME_ASSISTANT_ERROR, '{}'.format(err)))
+    except Exception as err:
+        connection.send_message(messages.error_message(
+            msg['id'], const.ERR_UNKNOWN_ERROR, '{}'.format(err)))
 
 
 @callback

--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -9,6 +9,7 @@ MAX_PENDING_MSG = 512
 ERR_ID_REUSE = 'id_reuse'
 ERR_INVALID_FORMAT = 'invalid_format'
 ERR_NOT_FOUND = 'not_found'
+ERR_HOME_ASSISTANT_ERROR = 'home_assistant_error'
 ERR_UNKNOWN_COMMAND = 'unknown_command'
 ERR_UNKNOWN_ERROR = 'unknown_error'
 ERR_UNAUTHORIZED = 'unauthorized'

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -272,7 +272,10 @@ async def entity_service_call(hass, platforms, func, call, service_name=''):
     ]
 
     if tasks:
-        await asyncio.wait(tasks)
+        done, pending = await asyncio.wait(tasks)
+        assert not pending
+        for future in done:
+            future.result()  # pop exception if have
 
 
 async def _handle_service_platform_call(func, data, entities, context):
@@ -294,4 +297,7 @@ async def _handle_service_platform_call(func, data, entities, context):
             tasks.append(entity.async_update_ha_state(True))
 
     if tasks:
-        await asyncio.wait(tasks)
+        done, pending = await asyncio.wait(tasks)
+        assert not pending
+        for future in done:
+            future.result()  # pop exception if have

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -1,6 +1,8 @@
 """deCONZ climate platform tests."""
 from unittest.mock import Mock, patch
 
+import asynctest
+
 from homeassistant import config_entries
 from homeassistant.components import deconz
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -43,8 +45,14 @@ ENTRY_CONFIG = {
 async def setup_gateway(hass, data, allow_clip_sensor=True):
     """Load the deCONZ sensor platform."""
     from pydeconz import DeconzSession
-    loop = Mock()
-    session = Mock()
+
+    session = Mock(put=asynctest.CoroutineMock(
+        return_value=Mock(status=200,
+                          json=asynctest.CoroutineMock(),
+                          text=asynctest.CoroutineMock(),
+                          )
+        )
+    )
 
     ENTRY_CONFIG[deconz.const.CONF_ALLOW_CLIP_SENSOR] = allow_clip_sensor
 
@@ -52,7 +60,7 @@ async def setup_gateway(hass, data, allow_clip_sensor=True):
         1, deconz.DOMAIN, 'Mock Title', ENTRY_CONFIG, 'test',
         config_entries.CONN_CLASS_LOCAL_PUSH)
     gateway = deconz.DeconzGateway(hass, config_entry)
-    gateway.api = DeconzSession(loop, session, **config_entry.data)
+    gateway.api = DeconzSession(hass.loop, session, **config_entry.data)
     gateway.api.config = Mock()
     hass.data[deconz.DOMAIN] = gateway
 


### PR DESCRIPTION
## Description:
Re-thrown exception occurred in the blocking service call, so that the caller (frontend) can get proper error feedback

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
