### PR TITLE
Add config entry remove callback

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -452,7 +452,7 @@ class MockModule:
                  requirements=None, config_schema=None, platform_schema=None,
                  platform_schema_base=None, async_setup=None,
                  async_setup_entry=None, async_unload_entry=None,
-                 async_migrate_entry=None):
+                 async_migrate_entry=None, async_remove_entry=None):
         """Initialize the mock module."""
         self.__name__ = 'homeassistant.components.{}'.format(domain)
         self.DOMAIN = domain
@@ -486,6 +486,9 @@ class MockModule:
 
         if async_migrate_entry is not None:
             self.async_migrate_entry = async_migrate_entry
+
+        if async_remove_entry is not None:
+            self.async_remove_entry = async_remove_entry
 
 
 class MockPlatform:


### PR DESCRIPTION
## Description:
Adds support for defining `async_remove_entry(hass, entry) -> None` at the component level, which will be invoked during removal of a config entry:
- This is optional for components to implement
- Use this method to perform clean-up before removal of a config entry.
- This callback is invoked during the removal process after `async_unload_entry`
- No return value is needed and if the callback excepts, it is logged, but does not stop removal.

**Related issue (if applicable):** https://github.com/home-assistant/architecture/issues/158#issuecomment-468051285

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.