### PR TITLE
Upgrade blinkpy==0.13.1 (Fixes #21559)

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS, CONF_SENSORS, CONF_FILENAME,
     CONF_MONITORED_CONDITIONS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['blinkpy==0.12.1']
+REQUIREMENTS = ['blinkpy==0.13.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -44,7 +44,7 @@ BINARY_SENSORS = {
 SENSORS = {
     TYPE_TEMPERATURE: ['Temperature', TEMP_FAHRENHEIT, 'mdi:thermometer'],
     TYPE_BATTERY: ['Battery', '%', 'mdi:battery-80'],
-    TYPE_WIFI_STRENGTH: ['Wifi Signal', 'bars', 'mdi:wifi-strength-2'],
+    TYPE_WIFI_STRENGTH: ['Wifi Signal', 'dBm', 'mdi:wifi-strength-2'],
 }
 
 BINARY_SENSOR_SCHEMA = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -202,7 +202,7 @@ bellows-homeassistant==0.7.1
 bimmer_connected==0.5.3
 
 # homeassistant.components.blink
-blinkpy==0.12.1
+blinkpy==0.13.1
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description:
A blink api endpoint changed (again) which broke the home-assistant integration.  This fix, well, fixes that.

Additionally:
- API calls have internal throttling to help prevent users from accidentally triggering api calls in rapid succession
- Wifi strength for cameras is reported in dBm again (a result of the new api endpoint)

**Related issue (if applicable):** fixes #21559 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8796
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
