### PR TITLE
Add option to override callback url

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from datetime import timedelta
 import functools
 import logging
+from typing import Optional
 
 import aiohttp
 import voluptuous as vol
@@ -22,9 +23,9 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import (
     CONF_NAME, CONF_URL, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF,
     STATE_ON, STATE_PAUSED, STATE_PLAYING)
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
@@ -39,12 +40,14 @@ DEFAULT_LISTEN_PORT = 8301
 
 CONF_LISTEN_IP = 'listen_ip'
 CONF_LISTEN_PORT = 'listen_port'
+CONF_CALLBACK_URL_OVERRIDE = 'callback_url_override'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.string,
     vol.Optional(CONF_LISTEN_IP): cv.string,
     vol.Optional(CONF_LISTEN_PORT, default=DEFAULT_LISTEN_PORT): cv.port,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_CALLBACK_URL_OVERRIDE): cv.url,
 })
 
 HOME_ASSISTANT_UPNP_CLASS_MAPPING = {
@@ -82,7 +85,12 @@ def catch_request_errors():
     return call_wrapper
 
 
-async def async_start_event_handler(hass, server_host, server_port, requester):
+async def async_start_event_handler(
+        hass: HomeAssistantType,
+        server_host: str,
+        server_port: int,
+        requester,
+        callback_url_override: Optional[str] = None):
     """Register notify view."""
     hass_data = hass.data[DLNA_DMR_DATA]
     if 'event_handler' in hass_data:
@@ -91,10 +99,14 @@ async def async_start_event_handler(hass, server_host, server_port, requester):
     # start event handler
     from async_upnp_client.aiohttp import AiohttpNotifyServer
     server = AiohttpNotifyServer(
-        requester, server_port, server_host, hass.loop)
+        requester,
+        listen_port=server_port,
+        listen_host=server_host,
+        loop=hass.loop,
+        callback_url=callback_url_override)
     await server.start_server()
     _LOGGER.info(
-        'UPNP/DLNA event handler listening on: %s', server.callback_url)
+        'UPNP/DLNA event handler listening, url: %s', server.callback_url)
     hass_data['notify_server'] = server
     hass_data['event_handler'] = server.event_handler
 
@@ -109,7 +121,10 @@ async def async_start_event_handler(hass, server_host, server_port, requester):
 
 
 async def async_setup_platform(
-        hass: HomeAssistant, config, async_add_entities, discovery_info=None):
+        hass: HomeAssistantType,
+        config,
+        async_add_entities,
+        discovery_info=None):
     """Set up DLNA DMR platform."""
     if config.get(CONF_URL) is not None:
         url = config[CONF_URL]
@@ -135,8 +150,9 @@ async def async_setup_platform(
         if server_host is None:
             server_host = get_local_ip()
         server_port = config.get(CONF_LISTEN_PORT, DEFAULT_LISTEN_PORT)
+        callback_url_override = config.get(CONF_CALLBACK_URL_OVERRIDE)
         event_handler = await async_start_event_handler(
-            hass, server_host, server_port, requester)
+            hass, server_host, server_port, requester, callback_url_override)
 
     # create upnp device
     from async_upnp_client import UpnpFactory

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.14.4']
+REQUIREMENTS = ['async-upnp-client==0.14.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -23,7 +23,7 @@ from .const import DOMAIN
 from .const import LOGGER as _LOGGER
 from .device import Device
 
-REQUIREMENTS = ['async-upnp-client==0.14.4']
+REQUIREMENTS = ['async-upnp-client==0.14.5']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -174,7 +174,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.14.4
+async-upnp-client==0.14.5
 
 # homeassistant.components.light.avion
 # avion==0.10


### PR DESCRIPTION
## Description:

Add ability to override callback/notification url.

**Related issue (if applicable):** fixes https://github.com/StevenLooman/async_upnp_client/issues/33 (non-home assistant.)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8797

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: dlna_dmr
    url: http://192.168.1.42:1936/
    callback_url_override: http://192.168.1.42:8080/notify
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)