### PR TITLE
Log exception occurred in WS service call command

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -151,9 +151,11 @@ async def handle_call_service(hass, connection, msg):
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_NOT_FOUND, 'Service not found.'))
     except HomeAssistantError as err:
+        connection.logger.exception(err)
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_HOME_ASSISTANT_ERROR, '{}'.format(err)))
     except Exception as err:  # pylint: disable=broad-except
+        connection.logger.exception(err)
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_UNKNOWN_ERROR, '{}'.format(err)))
 


### PR DESCRIPTION
## Description:

Log exceptions occurred in websocket service call command.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
