### PR TITLE
Word the tplink deprecation warning more strongly

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -34,7 +34,7 @@ def async_setup_platform(hass, config, add_entities, discovery_info=None):
 
     Deprecated.
     """
-    _LOGGER.warning('Loading as a platform is deprecated, '
+    _LOGGER.warning('Loading as a platform is no longer supported, '
                     'convert to use the tplink component.')
 
 

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -29,7 +29,7 @@ def async_setup_platform(hass, config, add_entities, discovery_info=None):
 
     Deprecated.
     """
-    _LOGGER.warning('Loading as a platform is deprecated, '
+    _LOGGER.warning('Loading as a platform is no longer supported, '
                     'convert to use the tplink component.')
 
 


### PR DESCRIPTION
## Description:

The current wording confused me when testing the beta.

A deprecation usually means that the feature still works but is on its way out. When it no longer works, it is obsolete ... but I picked a more friendly wording here :)

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: tplink
    host: 10.30.2.21
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
