### PR TITLE
Add generic_set_away_temperature service

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -10,6 +10,7 @@ import functools as ft
 
 import voluptuous as vol
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.helpers.entity_component import EntityComponent
@@ -546,19 +547,29 @@ async def async_service_aux_heat(entity, service):
         await entity.async_turn_aux_heat_off()
 
 
-async def async_service_temperature_set(entity, service):
+async def async_service_temperature_set(entity: ClimateDevice, service):
     """Handle set temperature service."""
     hass = entity.hass
-    kwargs = {}
 
-    for value, temp in service.data.items():
-        if value in CONVERTIBLE_ATTRIBUTE:
-            kwargs[value] = convert_temperature(
-                temp,
+    if entity.supported_features & SUPPORT_AWAY_MODE:
+        if entity.is_away_mode_on:
+            raise HomeAssistantError(
+                'Cannot change temperature while away mode is ON')
+
+    if entity.supported_features & SUPPORT_HOLD_MODE:
+        if entity.current_hold_mode:
+            raise HomeAssistantError(
+                'Cannot change temperature while hold mode is set')
+
+    kwargs = {}
+    for key, value in service.data.items():
+        if key in CONVERTIBLE_ATTRIBUTE:
+            kwargs[key] = convert_temperature(
+                value,
                 hass.config.units.temperature_unit,
                 entity.temperature_unit
             )
         else:
-            kwargs[value] = temp
+            kwargs[key] = value
 
     await entity.async_set_temperature(**kwargs)

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -556,11 +556,6 @@ async def async_service_temperature_set(entity: ClimateDevice, service):
             raise HomeAssistantError(
                 'Cannot change temperature while away mode is ON')
 
-    if entity.supported_features & SUPPORT_HOLD_MODE:
-        if entity.current_hold_mode:
-            raise HomeAssistantError(
-                'Cannot change temperature while hold mode is set')
-
     kwargs = {}
     for key, value in service.data.items():
         if key in CONVERTIBLE_ATTRIBUTE:

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -296,8 +296,9 @@ class GenericThermostat(ClimateDevice, RestoreEntity):
         """Turn thermostat off."""
         await self.async_set_operation_mode(STATE_OFF)
 
-    async def async_set_temperature(self, temperature, **kwargs):
+    async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             raise ValueError('temperature parameter is None')
         if ((self.supported_features & SUPPORT_AWAY_MODE)

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -311,8 +311,6 @@ class GenericThermostat(ClimateDevice, RestoreEntity):
 
     async def async_set_away_temperature(self, temperature):
         """Set new away temperature."""
-        print("async_set_away_temperature %s", temperature)
-        print(self.hass)
         if temperature is None:
             raise ValueError('temperature parameter is None')
         self._away_temp = temperature

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -148,3 +148,13 @@ sensibo_assume_state:
     state:
       description: State to set.
       example: 'idle'
+
+generic_set_away_temperature:
+  description: Set Generic Thermostat away temperatures. Change target temperature if away mode is on.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'climate.kitchen'
+    temperature:
+      description: Away temperature.
+      example: 12

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -151,9 +151,11 @@ async def handle_call_service(hass, connection, msg):
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_NOT_FOUND, 'Service not found.'))
     except HomeAssistantError as err:
+        connection.logger.exception(err)
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_HOME_ASSISTANT_ERROR, '{}'.format(err)))
     except Exception as err:  # pylint: disable=broad-except
+        connection.logger.exception(err)
         connection.send_message(messages.error_message(
             msg['id'], const.ERR_UNKNOWN_ERROR, '{}'.format(err)))
 

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -82,7 +82,6 @@ class TestDemoClimate(unittest.TestCase):
         state = self.hass.states.get(ENTITY_CLIMATE)
         assert 30 == state.attributes.get('temperature')  # away_mode is off
 
-
     def test_set_only_target_temp_with_convert(self):
         """Test the setting of the target temperature."""
         state = self.hass.states.get(ENTITY_HEATPUMP)

--- a/tests/components/climate/test_demo.py
+++ b/tests/components/climate/test_demo.py
@@ -74,7 +74,14 @@ class TestDemoClimate(unittest.TestCase):
         common.set_temperature(self.hass, 30, ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
-        assert 30.0 == state.attributes.get('temperature')
+        assert 21 == state.attributes.get('temperature')  # away_mode is on
+        common.set_away_mode(self.hass, False, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        common.set_temperature(self.hass, 30, ENTITY_CLIMATE)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_CLIMATE)
+        assert 30 == state.attributes.get('temperature')  # away_mode is off
+
 
     def test_set_only_target_temp_with_convert(self):
         """Test the setting of the target temperature."""


### PR DESCRIPTION
## Description:

My response to #20255

I agreed that current generic thermostat is not implemented correct. The target temperature should NOT be able to change during the away mode ~(or hold mode in other thermostat platform)~. So we need to change climate component's `set_temperate` service call and the actually implement per platform to disallow that. This pull request fixed generic thermostat platform.

At same time, I added a `set_away_temperature` to allow change the predefined `away_temp`. This will be useful for other automation use case.

There is no need to add service to change `saved_target_temperature`, you can add a trigger to monitor the away_mode change, and set target temperate to desire value as long as `away_mode` is off.  

EDIT: Revert the change about hold mode. Clearly, ecobee allow change target temperature in hold mode.

**Related issue (if applicable):** fixes #20154

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<<TBD>>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

