### PR TITLE
Introduce Entity.async_write_ha_state() to not miss state transition

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -117,7 +117,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_write_ha_state()
+        self.async_write_hass_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -130,7 +130,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             """Switch device off after a delay."""
             self._delay_listener = None
             self._state = False
-            self.async_write_ha_state()
+            self.async_write_hass_state()
 
         @callback
         def state_message_received(_topic, payload, _qos):
@@ -159,7 +159,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._delay_listener = evt.async_call_later(
                     self.hass, off_delay, off_delay_listener)
 
-            self.async_write_ha_state()
+            self.async_write_hass_state()
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -117,7 +117,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_write_hass_state()
+        self.async_write_ha_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -130,7 +130,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             """Switch device off after a delay."""
             self._delay_listener = None
             self._state = False
-            self.async_write_hass_state()
+            self.async_write_ha_state()
 
         @callback
         def state_message_received(_topic, payload, _qos):
@@ -159,7 +159,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._delay_listener = evt.async_call_later(
                     self.hass, off_delay, off_delay_listener)
 
-            self.async_write_hass_state()
+            self.async_write_ha_state()
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -117,7 +117,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.update_ha_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -130,7 +130,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             """Switch device off after a delay."""
             self._delay_listener = None
             self._state = False
-            self.async_schedule_update_ha_state()
+            self.update_ha_state()
 
         @callback
         def state_message_received(_topic, payload, _qos):
@@ -159,7 +159,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._delay_listener = evt.async_call_later(
                     self.hass, off_delay, off_delay_listener)
 
-            self.async_schedule_update_ha_state()
+            self.update_ha_state()
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -117,7 +117,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.update_ha_state()
+        self.async_write_ha_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -130,7 +130,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             """Switch device off after a delay."""
             self._delay_listener = None
             self._state = False
-            self.update_ha_state()
+            self.async_write_ha_state()
 
         @callback
         def state_message_received(_topic, payload, _qos):
@@ -159,7 +159,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._delay_listener = evt.async_call_later(
                     self.hass, off_delay, off_delay_listener)
 
-            self.update_ha_state()
+            self.async_write_ha_state()
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -285,7 +285,10 @@ class Entity:
                 _LOGGER.exception("Update for %s fails", self.entity_id)
                 return
 
-        state, attr = stateattr or self._get_state_and_attributes()
+        if force_refresh or stateattr is None:
+            state, attr = self._get_state_and_attributes()
+        else:
+            state, attr = stateattr
 
         # Overwrite properties that have been set in the config file.
         if DATA_CUSTOMIZE in self.hass.data:
@@ -317,7 +320,9 @@ class Entity:
     def schedule_update_ha_state(self, force_refresh=False):
         """Schedule an update ha state change task.
 
-        That avoid executor dead looks.
+        Scheduling the update avoids executor dead looks.
+        The state is copied unless force_refresh is set to true to not miss
+        state transitions happening before async_update_ha_state is called.
         """
         stateattr = None
         if not force_refresh:
@@ -327,7 +332,12 @@ class Entity:
 
     @callback
     def async_schedule_update_ha_state(self, force_refresh=False):
-        """Schedule an update ha state change task."""
+        """Schedule an update ha state change task.
+
+        Scheduling the update avoids executor dead looks.
+        The state is copied unless force_refresh is set to true to not miss
+        state transitions happening before async_update_ha_state is called.
+        """
         stateattr = None
         if not force_refresh:
             stateattr = self._get_state_and_attributes()

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -222,10 +222,10 @@ class Entity:
                 _LOGGER.exception("Update for %s fails", self.entity_id)
                 return
 
-        self._async_write_hass_state()
+        self._async_write_ha_state()
 
     @callback
-    def async_write_hass_state(self):
+    def async_write_ha_state(self):
         """Write the state to the state machine."""
         if self.hass is None:
             raise RuntimeError("Attribute hass is None for {}".format(self))
@@ -237,7 +237,7 @@ class Entity:
         self._async_write_hass_state()
 
     @callback
-    def _async_write_hass_state(self):
+    def _async_write_ha_state(self):
         """Write the state to the state machine."""
         start = timer()
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -234,7 +234,7 @@ class Entity:
             raise NoEntitySpecifiedError(
                 "No entity id specified for entity {}".format(self.name))
 
-        self._async_write_hass_state()
+        self._async_write_ha_state()
 
     @callback
     def _async_write_ha_state(self):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -207,6 +207,13 @@ class Entity:
 
         This method must be run in the event loop.
         """
+        if self.hass is None:
+            raise RuntimeError("Attribute hass is None for {}".format(self))
+
+        if self.entity_id is None:
+            raise NoEntitySpecifiedError(
+                "No entity id specified for entity {}".format(self.name))
+
         # update entity data
         if force_refresh:
             try:
@@ -215,10 +222,10 @@ class Entity:
                 _LOGGER.exception("Update for %s fails", self.entity_id)
                 return
 
-        self.async_write_ha_state()
+        self._async_write_hass_state()
 
     @callback
-    def async_write_ha_state(self):
+    def async_write_hass_state(self):
         """Write the state to the state machine."""
         if self.hass is None:
             raise RuntimeError("Attribute hass is None for {}".format(self))
@@ -227,6 +234,11 @@ class Entity:
             raise NoEntitySpecifiedError(
                 "No entity id specified for entity {}".format(self.name))
 
+        self._async_write_hass_state()
+
+    @callback
+    def _async_write_hass_state(self):
+        """Write the state to the state machine."""
         start = timer()
 
         if not self.available:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -201,7 +201,7 @@ class Entity:
         self._context_set = dt_util.utcnow()
 
     def _get_state_and_attributes(self):
-        """Get state and attributes"""
+        """Get state and attributes."""
         start = timer()
 
         if not self.available:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -328,7 +328,7 @@ class Entity:
     def schedule_update_ha_state(self, force_refresh=False):
         """Schedule an update ha state change task.
 
-        Scheduling the update avoids executor dead looks.
+        Scheduling the update avoids executor deadlocks.
 
         Entity state and attributes are read when the update ha state change
         task is executed.
@@ -342,7 +342,7 @@ class Entity:
         """Schedule an update ha state change task.
 
         This method must be run in the event loop.
-        Scheduling the update avoids executor dead looks.
+        Scheduling the update avoids executor deadlocks.
 
         Entity state and attributes are read when the update ha state change
         task is executed.

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -328,13 +328,27 @@ class Entity:
     def schedule_update_ha_state(self, force_refresh=False):
         """Schedule an update ha state change task.
 
-        That avoid executor dead looks.
+        Scheduling the update avoids executor dead looks.
+
+        Entity state and attributes are read when the update ha state change
+        task is executed.
+        If state is changed more than once before the ha state change task has
+        been executed, the intermediate state transitions will be missed.
         """
         self.hass.add_job(self.async_update_ha_state(force_refresh))
 
     @callback
     def async_schedule_update_ha_state(self, force_refresh=False):
-        """Schedule an update ha state change task."""
+        """Schedule an update ha state change task.
+
+        This method must be run in the event loop.
+        Scheduling the update avoids executor dead looks.
+
+        Entity state and attributes are read when the update ha state change
+        task is executed.
+        If state is changed more than once before the ha state change task has
+        been executed, the intermediate state transitions will be missed.
+        """
         self.hass.async_create_task(self.async_update_ha_state(force_refresh))
 
     async def async_device_update(self, warning=True):

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -275,16 +275,16 @@ async def test_entity_media_states(hass: HomeAssistantType):
     state = hass.states.get('media_player.speaker')
     assert state.state == 'playing'
 
-    entity.new_media_status(media_status)
     media_status.player_is_playing = False
     media_status.player_is_paused = True
+    entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get('media_player.speaker')
     assert state.state == 'paused'
 
-    entity.new_media_status(media_status)
     media_status.player_is_paused = False
     media_status.player_is_idle = True
+    entity.new_media_status(media_status)
     await hass.async_block_till_done()
     state = hass.states.get('media_player.speaker')
     assert state.state == 'idle'


### PR DESCRIPTION
## Description:
Introduce `Entity.async_write_ha_state()` which can be called instead of `Entity.schedule_update_ha_state` / `Entity.async_schedule_update_ha_state` to immediately update hass state and thus make sure state transitions are never missed.
By calling `Entity.async_write_ha_state()`, [state triggers](https://www.home-assistant.io/docs/automation/trigger/#state-trigger) have a deterministic behavior.

As an example, if an `open` event from a door sensor is delayed and arrives to HA at the same time as the `closed` event, the state may be back to `closed` once Entity.async_update_ha_state() is called. In such a case, any automation triggering on an `open` state event from the door sensor will never be executed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.