### PR TITLE
ZHA fixes

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -64,6 +64,13 @@ class OnOffChannel(ZigbeeChannel):
             await self.get_attribute_value(self.ON_OFF, from_cache=from_cache))
         await super().async_initialize(from_cache)
 
+    async def async_update(self):
+        """Initialize channel."""
+        _LOGGER.debug("Attempting to update onoff state")
+        self._state = bool(
+            await self.get_attribute_value(self.ON_OFF, from_cache=False))
+        await super().async_update()
+
 
 class LevelControlChannel(ZigbeeChannel):
     """Channel for the LevelControl Zigbee cluster."""

--- a/homeassistant/components/zha/core/channels/registry.py
+++ b/homeassistant/components/zha/core/channels/registry.py
@@ -43,4 +43,5 @@ def populate_channel_registry():
         zcl.clusters.general.Basic.cluster_id: BasicChannel,
         zcl.clusters.security.IasZone.cluster_id: IASZoneChannel,
         zcl.clusters.hvac.Fan.cluster_id: FanChannel,
+        zcl.clusters.lightlink.LightLink.cluster_id: ZigbeeChannel,
     })

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -452,8 +452,11 @@ def establish_device_mappings():
     NO_SENSOR_CLUSTERS.append(zcl.clusters.general.Basic.cluster_id)
     NO_SENSOR_CLUSTERS.append(
         zcl.clusters.general.PowerConfiguration.cluster_id)
+    NO_SENSOR_CLUSTERS.append(zcl.clusters.lightlink.LightLink.cluster_id)
+
     BINDABLE_CLUSTERS.append(zcl.clusters.general.LevelControl.cluster_id)
     BINDABLE_CLUSTERS.append(zcl.clusters.general.OnOff.cluster_id)
+    BINDABLE_CLUSTERS.append(zcl.clusters.lighting.Color.cluster_id)
 
     DEVICE_CLASS[zha.PROFILE_ID].update({
         zha.DeviceType.ON_OFF_SWITCH: 'binary_sensor',
@@ -537,6 +540,7 @@ def establish_device_mappings():
         zcl.clusters.general.PollControl.cluster_id: [],
         zcl.clusters.general.GreenPowerProxy.cluster_id: [],
         zcl.clusters.general.OnOffConfiguration.cluster_id: [],
+        zcl.clusters.lightlink.LightLink.cluster_id: [],
         zcl.clusters.general.OnOff.cluster_id: [{
             'attr': 'on_off',
             'config': REPORT_CONFIG_IMMEDIATE

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -28,7 +28,7 @@ CAPABILITIES_COLOR_XY = 0x08
 CAPABILITIES_COLOR_TEMP = 0x10
 
 UNSUPPORTED_ATTRIBUTE = 0x86
-LIFELINE_INTERVAL = timedelta(minutes=10)
+LIFELINE_INTERVAL = timedelta(minutes=60)
 
 
 async def async_setup_platform(hass, config, async_add_entities,

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -71,11 +71,19 @@ class Switch(ZhaEntity, SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
-        await self._on_off_channel.on()
+        success = await self._on_off_channel.on()
+        if not success:
+            return
+        self._state = True
+        self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
-        await self._on_off_channel.off()
+        success = await self._on_off_channel.off()
+        if not success:
+            return
+        self._state = False
+        self.async_schedule_update_ha_state()
 
     def async_set_state(self, state):
         """Handle state update from channel."""


### PR DESCRIPTION
This PR:

- prevents attr reporting on cluster 0x1000 (it is the light link cluster and we shouldn't do it)
- uses a semaphore to prevent flooding the network during configuration and initialization
- updates switch to use the same mechanism to set state after interaction as light
- adds a 60 minute lifeline pulse to lights to prevent them from going unavailable