### PR TITLE
Upgrade motorparts to 1.1.0

### DIFF
--- a/homeassistant/components/sensor/mopar.py
+++ b/homeassistant/components/sensor/mopar.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['motorparts==1.0.2']
+REQUIREMENTS = ['motorparts==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -699,7 +699,7 @@ millheater==0.3.4
 mitemp_bt==0.0.1
 
 # homeassistant.components.sensor.mopar
-motorparts==1.0.2
+motorparts==1.1.0
 
 # homeassistant.components.tts
 mutagen==1.42.0


### PR DESCRIPTION
## Description:

Upgrade motorparts to 1.1.0. Changes: https://github.com/happyleavesaoc/python-motorparts/pull/2

**Related issue (if applicable):** fixes #16379

I cannot test this myself because I don't have a compatible vehicle.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
