### PR TITLE
Expose create/delete cloudhook

### DIFF
--- a/homeassistant/components/cloud/cloudhooks.py
+++ b/homeassistant/components/cloud/cloudhooks.py
@@ -14,6 +14,9 @@ class Cloudhooks:
 
     async def async_publish_cloudhooks(self):
         """Inform the Relayer of the cloudhooks that we support."""
+        if not self.cloud.is_connected:
+            return
+
         cloudhooks = self.cloud.prefs.cloudhooks
         await self.cloud.iot.async_send_message('webhook-register', {
             'cloudhook_ids': [info['cloudhook_id'] for info

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -32,3 +32,7 @@ You have been logged out of Home Assistant Cloud because we have been unable
 to verify your credentials. Please [log in](/config/cloud) again to continue
 using the service.
 """
+
+STATE_CONNECTING = 'connecting'
+STATE_CONNECTED = 'connected'
+STATE_DISCONNECTED = 'disconnected'

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -16,14 +16,13 @@ from homeassistant.util.aiohttp import MockRequest
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from . import auth_api
 from . import utils
-from .const import MESSAGE_EXPIRATION, MESSAGE_AUTH_FAIL
+from .const import (
+    MESSAGE_EXPIRATION, MESSAGE_AUTH_FAIL, STATE_CONNECTED, STATE_CONNECTING,
+    STATE_DISCONNECTED
+)
 
 HANDLERS = Registry()
 _LOGGER = logging.getLogger(__name__)
-
-STATE_CONNECTING = 'connecting'
-STATE_CONNECTED = 'connected'
-STATE_DISCONNECTED = 'disconnected'
 
 
 class UnknownHandler(Exception):

--- a/tests/components/cloud/test_cloudhooks.py
+++ b/tests/components/cloud/test_cloudhooks.py
@@ -70,5 +70,27 @@ async def test_disable(mock_cloudhooks):
     }
 
 
-async def test_create_without_connected(mock_cloudhooks):
-    """Test that we can create a cloudhook without being connected."""
+async def test_create_without_connected(mock_cloudhooks, aioclient_mock):
+    """Test we don't publish a hook if not connected."""
+    mock_cloudhooks.cloud.is_connected = False
+    # Make sure we fail test when we send a message.
+    mock_cloudhooks.cloud.iot.async_send_message.side_effect = ValueError
+
+    aioclient_mock.post('https://webhook-create.url', json={
+        'cloudhook_id': 'mock-cloud-id',
+        'url': 'https://hooks.nabu.casa/ZXCZCXZ',
+    })
+
+    hook = {
+            'webhook_id': 'mock-webhook-id',
+            'cloudhook_id': 'mock-cloud-id',
+            'cloudhook_url': 'https://hooks.nabu.casa/ZXCZCXZ',
+        }
+
+    assert hook == await mock_cloudhooks.async_create('mock-webhook-id')
+
+    assert mock_cloudhooks.cloud.prefs.cloudhooks == {
+        'mock-webhook-id': hook
+    }
+
+    assert len(mock_cloudhooks.cloud.iot.async_send_message.mock_calls) == 0

--- a/tests/components/cloud/test_cloudhooks.py
+++ b/tests/components/cloud/test_cloudhooks.py
@@ -68,3 +68,7 @@ async def test_disable(mock_cloudhooks):
     assert publish_calls[0][1][1] == {
         'cloudhook_ids': []
     }
+
+
+async def test_create_without_connected(mock_cloudhooks):
+    """Test that we can create a cloudhook without being connected."""


### PR DESCRIPTION
## Description:
Allow other components to check if a user is logged in to the cloud and to create/delete cloudwebhooks.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
