### PR TITLE
Add "Home Assistant" as email sender name for SendGrid

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -64,7 +64,8 @@ class SendgridNotificationService(BaseNotificationService):
                 }
             ],
             "from": {
-                "email": self.sender
+                "email": self.sender,
+                "name": "Home Assistant"
             },
             "content": [
                 {


### PR DESCRIPTION
## Description:

Set "Home Assistant" as the email sender name for SendGrid emails.

## Checklist:
* [x]  The code change is tested and works locally.
* [x]  Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
* [x]  There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

* [ ]  Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
 If the code communicates with devices, web services, or third-party tools:
 * [ ]  New dependencies have been added to the `REQUIREMENTS` variable ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14)).

* [ ]  New dependencies are only imported inside functions that use them ([example](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23)).
 
 * [ ]  New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 
     * [ ]  New files were added to `.coveragerc`.
 
 
 If the code does not interact with devices:
 
     * [ ]  Tests have been added to verify that the new code works.

