### PR TITLE
Add SmartThingsAccelCluster to ZHA binary_sensor

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -12,7 +12,7 @@ from .core.const import (
     DATA_ZHA, DATA_ZHA_DISPATCHERS, ZHA_DISCOVERY_NEW, ON_OFF_CHANNEL,
     LEVEL_CHANNEL, ZONE_CHANNEL, SIGNAL_ATTR_UPDATED, SIGNAL_MOVE_LEVEL,
     SIGNAL_SET_LEVEL, ATTRIBUTE_CHANNEL, UNKNOWN, OPENING, ZONE, OCCUPANCY,
-    ATTR_LEVEL, SENSOR_TYPE)
+    ATTR_LEVEL, SENSOR_TYPE, ACCELERATION)
 from .entity import ZhaEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,6 +27,7 @@ CLASS_MAPPING = {
     0x002a: 'moisture',
     0x002b: 'gas',
     0x002d: 'vibration',
+    0xfc02: 'moving',
 }
 
 
@@ -41,6 +42,7 @@ DEVICE_CLASS_REGISTRY = {
     OPENING: OPENING,
     ZONE: get_ias_device_class,
     OCCUPANCY: OCCUPANCY,
+    ACCELERATION: ACCELERATION,
 }
 
 

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -27,7 +27,6 @@ CLASS_MAPPING = {
     0x002a: 'moisture',
     0x002b: 'gas',
     0x002d: 'vibration',
-    0xfc02: 'moving',
 }
 
 
@@ -42,7 +41,7 @@ DEVICE_CLASS_REGISTRY = {
     OPENING: OPENING,
     ZONE: get_ias_device_class,
     OCCUPANCY: OCCUPANCY,
-    ACCELERATION: ACCELERATION,
+    ACCELERATION: 'moving',
 }
 
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -68,6 +68,7 @@ UNKNOWN = 'unknown'
 OPENING = 'opening'
 ZONE = 'zone'
 OCCUPANCY = 'occupancy'
+ACCELERATION = 'acceleration'
 
 ATTR_LEVEL = 'level'
 

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -452,7 +452,6 @@ def establish_device_mappings():
     NO_SENSOR_CLUSTERS.append(
         zcl.clusters.general.PowerConfiguration.cluster_id)
     NO_SENSOR_CLUSTERS.append(zcl.clusters.lightlink.LightLink.cluster_id)
-    NO_SENSOR_CLUSTERS.append(SMARTTHINGS_ACCELERATION_CLUSTER)
 
     BINDABLE_CLUSTERS.append(zcl.clusters.general.LevelControl.cluster_id)
     BINDABLE_CLUSTERS.append(zcl.clusters.general.OnOff.cluster_id)

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -501,6 +501,7 @@ def establish_device_mappings():
         zcl.clusters.security.IasZone: 'binary_sensor',
         zcl.clusters.measurement.OccupancySensing: 'binary_sensor',
         zcl.clusters.hvac.Fan: 'fan',
+        SMARTTHINGS_ACCELERATION_CLUSTER: 'binary_sensor',
     })
 
     SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS.update({

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -524,7 +524,8 @@ def establish_device_mappings():
     BINARY_SENSOR_TYPES.update({
         zcl.clusters.measurement.OccupancySensing.cluster_id: OCCUPANCY,
         zcl.clusters.security.IasZone.cluster_id: ZONE,
-        zcl.clusters.general.OnOff.cluster_id: OPENING
+        zcl.clusters.general.OnOff.cluster_id: OPENING,
+        SMARTTHINGS_ACCELERATION_CLUSTER: ACCELERATION,
     })
 
     CLUSTER_REPORT_CONFIGS.update({

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -23,7 +23,7 @@ from .const import (
     REPORT_CONFIG_ASAP, REPORT_CONFIG_DEFAULT, REPORT_CONFIG_MIN_INT,
     REPORT_CONFIG_MAX_INT, REPORT_CONFIG_OP, SIGNAL_REMOVE,
     NO_SENSOR_CLUSTERS, POWER_CONFIGURATION_CHANNEL, BINDABLE_CLUSTERS,
-    DATA_ZHA_GATEWAY)
+    DATA_ZHA_GATEWAY, ACCELERATION)
 from .device import ZHADevice, DeviceStatus
 from ..device_entity import ZhaDeviceEntity
 from .channels import (


### PR DESCRIPTION
## Description:
Adds binary_sensor for acceleration attribute of centralite/smartthings devices. Currently committed devices include [Centralite 3321-S](https://github.com/dmulcahey/zha-device-handlers/pull/17) and [SmartThings multiv4](https://github.com/dmulcahey/zha-device-handlers/pull/21).

Edit (3/4/18): Rebased
~~Depends on [PR #21500](https://github.com/home-assistant/home-assistant/pull/21500).~~

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.