### PR TITLE
Add optional sender name for SendGrid

### DIFF
--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -18,11 +18,14 @@ REQUIREMENTS = ['sendgrid==5.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_SENDER_NAME = 'sender_name'
+
 # pylint: disable=no-value-for-parameter
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_SENDER): vol.Email(),
     vol.Required(CONF_RECIPIENT): vol.Email(),
+    vol.Optional(CONF_SENDER_NAME, default='Home Assistant'): cv.string,
 })
 
 
@@ -31,19 +34,21 @@ def get_service(hass, config, discovery_info=None):
     api_key = config.get(CONF_API_KEY)
     sender = config.get(CONF_SENDER)
     recipient = config.get(CONF_RECIPIENT)
+    sender_name = config.get(CONF_SENDER_NAME)
 
-    return SendgridNotificationService(api_key, sender, recipient)
+    return SendgridNotificationService(api_key, sender, recipient, sender_name)
 
 
 class SendgridNotificationService(BaseNotificationService):
     """Implementation the notification service for email via Sendgrid."""
 
-    def __init__(self, api_key, sender, recipient):
+    def __init__(self, api_key, sender, recipient, sender_name):
         """Initialize the service."""
         from sendgrid import SendGridAPIClient
 
         self.api_key = api_key
         self.sender = sender
+        self.sender_name = sender_name
         self.recipient = recipient
 
         self._sg = SendGridAPIClient(apikey=self.api_key)
@@ -65,7 +70,7 @@ class SendgridNotificationService(BaseNotificationService):
             ],
             "from": {
                 "email": self.sender,
-                "name": "Home Assistant"
+                "name": self.sender_name
             },
             "content": [
                 {

--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -9,7 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.notify import (
-    ATTR_TITLE, ATTR_TITLE_DEFAULT, PLATFORM_SCHEMA, BaseNotificationService)
+    ATTR_TITLE, ATTR_TITLE_DEFAULT, DOMAIN, PLATFORM_SCHEMA,
+    BaseNotificationService)
 from homeassistant.const import (
     CONF_API_KEY, CONF_SENDER, CONF_RECIPIENT, CONTENT_TYPE_TEXT_PLAIN)
 import homeassistant.helpers.config_validation as cv
@@ -20,36 +21,33 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_SENDER_NAME = 'sender_name'
 
+DEFAULT_SENDER_NAME = 'Home Assistant'
+
 # pylint: disable=no-value-for-parameter
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_SENDER): vol.Email(),
     vol.Required(CONF_RECIPIENT): vol.Email(),
-    vol.Optional(CONF_SENDER_NAME, default='Home Assistant'): cv.string,
+    vol.Optional(CONF_SENDER_NAME, default=DEFAULT_SENDER_NAME): cv.string,
 })
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the SendGrid notification service."""
-    api_key = config.get(CONF_API_KEY)
-    sender = config.get(CONF_SENDER)
-    recipient = config.get(CONF_RECIPIENT)
-    sender_name = config.get(CONF_SENDER_NAME)
-
-    return SendgridNotificationService(api_key, sender, recipient, sender_name)
+    return SendgridNotificationService(config[DOMAIN])
 
 
 class SendgridNotificationService(BaseNotificationService):
     """Implementation the notification service for email via Sendgrid."""
 
-    def __init__(self, api_key, sender, recipient, sender_name):
+    def __init__(self, config):
         """Initialize the service."""
         from sendgrid import SendGridAPIClient
 
-        self.api_key = api_key
-        self.sender = sender
-        self.sender_name = sender_name
-        self.recipient = recipient
+        self.api_key = config[CONF_API_KEY]
+        self.sender = config[CONF_SENDER]
+        self.sender_name = config[CONF_SENDER_NAME]
+        self.recipient = config[CONF_RECIPIENT]
 
         self._sg = SendGridAPIClient(apikey=self.api_key)
 

--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -9,8 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.notify import (
-    ATTR_TITLE, ATTR_TITLE_DEFAULT, DOMAIN, PLATFORM_SCHEMA,
-    BaseNotificationService)
+    ATTR_TITLE, ATTR_TITLE_DEFAULT, PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
     CONF_API_KEY, CONF_SENDER, CONF_RECIPIENT, CONTENT_TYPE_TEXT_PLAIN)
 import homeassistant.helpers.config_validation as cv
@@ -34,7 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_service(hass, config, discovery_info=None):
     """Get the SendGrid notification service."""
-    return SendgridNotificationService(config[DOMAIN])
+    return SendgridNotificationService(config)
 
 
 class SendgridNotificationService(BaseNotificationService):

--- a/homeassistant/components/notify/sendgrid.py
+++ b/homeassistant/components/notify/sendgrid.py
@@ -64,7 +64,8 @@ class SendgridNotificationService(BaseNotificationService):
                 }
             ],
             "from": {
-                "email": self.sender
+                "email": self.sender,
+                "name": "Home Assistant"
             },
             "content": [
                 {


### PR DESCRIPTION
## Description:

Add optional email sender name for SendGrid. If not set, use "Home Assistant"

  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io): https://github.com/home-assistant/home-assistant.io/pull/8807

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
