### PR TITLE
Add area name to id for Lutron button events

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -73,7 +73,7 @@ def setup(hass, base_config):
                             (area.name, keypad.name, button, led))
 
                 hass.data[LUTRON_BUTTONS].append(
-                    LutronButton(hass, keypad, button))
+                    LutronButton(hass, area, keypad, button))
 
     for component in ('light', 'cover', 'switch', 'scene'):
         discovery.load_platform(hass, component, DOMAIN, None, base_config)
@@ -120,9 +120,9 @@ class LutronButton:
     represented as an entity; it simply fires events.
     """
 
-    def __init__(self, hass, keypad, button):
+    def __init__(self, hass, area, keypad, button):
         """Register callback for activity on the button."""
-        name = '{}: {}'.format(keypad.name, button.name)
+        name = '{}: {}: {}'.format(area.name, keypad.name, button.name)
         self._hass = hass
         self._has_release_event = 'RaiseLower' in button.button_type
         self._id = slugify(name)


### PR DESCRIPTION
## Description:

Adding area name to the ID field for Lutron SeeTouch button presses.  This will resolve some cases with Hybrid Keypads that would otherwise be ambigious. For example, in my house, I have two areas: "Jack" and "Sallys", each of which have a hybrid keypad named "Lights" and scenes named "Bedtime".  The current configuration omits the area name so keypads in each room will both raise a event with id "lights_bedtime" which is ambiguous.  

After this change the area name will be in the event -- for example "jack_lights_bedtime".  **This is a breaking change**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>  <--  I will amend the documentation and first want to get this up for discussion.

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.