### PR TITLE
Add device HMIP-eTRV-C to HomematicIP

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -15,7 +15,7 @@ from .const import (
 from .device import HomematicipGenericDevice  # noqa: F401
 from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
-REQUIREMENTS = ['homematicip==0.10.5']
+REQUIREMENTS = ['homematicip==0.10.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -5,7 +5,7 @@ from homeassistant.components.homematicip_cloud import (
     DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice)
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE, DEVICE_CLASS_TEMPERATURE,
-    TEMP_CELSIUS, POWER_WATT)
+    POWER_WATT, TEMP_CELSIUS)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,8 @@ async def async_setup_platform(
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the HomematicIP Cloud sensors from a config entry."""
     from homematicip.aio.device import (
-        AsyncHeatingThermostat, AsyncTemperatureHumiditySensorWithoutDisplay,
+        AsyncHeatingThermostat, AsyncHeatingThermostatCompact,
+        AsyncTemperatureHumiditySensorWithoutDisplay,
         AsyncTemperatureHumiditySensorDisplay, AsyncMotionDetectorIndoor,
         AsyncTemperatureHumiditySensorOutdoor,
         AsyncMotionDetectorPushButton, AsyncLightSensor,
@@ -37,8 +38,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = [HomematicipAccesspointStatus(home)]
     for device in home.devices:
-        if isinstance(device, AsyncHeatingThermostat):
+        if isinstance(device, (AsyncHeatingThermostat,
+                               AsyncHeatingThermostatCompact)):
             devices.append(HomematicipHeatingThermostat(home, device))
+            devices.append(
+                HomematicipThermostatTemperatureSensor(home, device))
         if isinstance(device, (AsyncTemperatureHumiditySensorDisplay,
                                AsyncTemperatureHumiditySensorWithoutDisplay,
                                AsyncTemperatureHumiditySensorOutdoor)):
@@ -169,6 +173,29 @@ class HomematicipTemperatureSensor(HomematicipGenericDevice):
     def state(self):
         """Return the state."""
         return self._device.actualTemperature
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return TEMP_CELSIUS
+
+
+class HomematicipThermostatTemperatureSensor(HomematicipGenericDevice):
+    """Representation of a HomematicIP Cloud thermostat device."""
+
+    def __init__(self, home, device):
+        """Initialize the thermometer device."""
+        super().__init__(home, device, 'Temperature')
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return DEVICE_CLASS_TEMPERATURE
+
+    @property
+    def state(self):
+        """Return the state."""
+        return self._device.valveActualTemperature
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -41,8 +41,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if isinstance(device, (AsyncHeatingThermostat,
                                AsyncHeatingThermostatCompact)):
             devices.append(HomematicipHeatingThermostat(home, device))
-            devices.append(
-                HomematicipThermostatTemperatureSensor(home, device))
         if isinstance(device, (AsyncTemperatureHumiditySensorDisplay,
                                AsyncTemperatureHumiditySensorWithoutDisplay,
                                AsyncTemperatureHumiditySensorOutdoor)):
@@ -173,29 +171,6 @@ class HomematicipTemperatureSensor(HomematicipGenericDevice):
     def state(self):
         """Return the state."""
         return self._device.actualTemperature
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit this state is expressed in."""
-        return TEMP_CELSIUS
-
-
-class HomematicipThermostatTemperatureSensor(HomematicipGenericDevice):
-    """Representation of a HomematicIP Cloud thermostat device."""
-
-    def __init__(self, home, device):
-        """Initialize the thermometer device."""
-        super().__init__(home, device, 'Temperature')
-
-    @property
-    def device_class(self):
-        """Return the device class of the sensor."""
-        return DEVICE_CLASS_TEMPERATURE
-
-    @property
-    def state(self):
-        """Return the state."""
-        return self._device.valveActualTemperature
 
     @property
     def unit_of_measurement(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -548,7 +548,7 @@ homeassistant-pyozw==0.1.2
 homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.5
+homematicip==0.10.6
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -126,7 +126,7 @@ home-assistant-frontend==20190228.0
 homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.5
+homematicip==0.10.6
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb


### PR DESCRIPTION
## Description:
- Update homematicip_cloud dependency to 0.10.6
- Add device HMIP-eTRV-C to HomematicIP

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8810

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
