### PR TITLE
Fix Name of Homematic IP accesspoint in devices, if name is configured

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -52,7 +52,6 @@ async def async_setup_entry(hass, entry):
     """Set up an access point from a config entry."""
     hap = HomematicipHAP(hass, entry)
     hapid = entry.data[HMIPC_HAPID].replace('-', '').upper()
-    hapname = entry.data[HMIPC_NAME]
     hass.data[DOMAIN][hapid] = hap
 
     if not await hap.async_setup():
@@ -63,7 +62,7 @@ async def async_setup_entry(hass, entry):
     home = hap.home
     # Add the HAP name from config if set.
     hapname = home.label \
-        if hapname == '' else "{} {}".format(home.label, hapname)
+        if home.name == '' else "{} {}".format(home.label, home.name)
     device_registry.async_get_or_create(
         config_entry_id=home.id,
         identifiers={(DOMAIN, home.id)},

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -52,6 +52,7 @@ async def async_setup_entry(hass, entry):
     """Set up an access point from a config entry."""
     hap = HomematicipHAP(hass, entry)
     hapid = entry.data[HMIPC_HAPID].replace('-', '').upper()
+    hapname = entry.data[HMIPC_NAME]
     hass.data[DOMAIN][hapid] = hap
 
     if not await hap.async_setup():
@@ -60,11 +61,14 @@ async def async_setup_entry(hass, entry):
     # Register hap as device in registry.
     device_registry = await dr.async_get_registry(hass)
     home = hap.home
+    # Add the HAP name from config if set.
+    hapname = home.label \
+        if hapname == '' else "{} {}".format(home.label, hapname)
     device_registry.async_get_or_create(
         config_entry_id=home.id,
         identifiers={(DOMAIN, home.id)},
         manufacturer='eQ-3',
-        name=home.label,
+        name= hapname,
         model=home.modelType,
         sw_version=home.currentAPVersion,
     )

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass, entry):
         config_entry_id=home.id,
         identifiers={(DOMAIN, home.id)},
         manufacturer='eQ-3',
-        name= hapname,
+        name=hapname,
         model=home.modelType,
         sw_version=home.currentAPVersion,
     )

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -62,7 +62,7 @@ async def async_setup_entry(hass, entry):
     home = hap.home
     # Add the HAP name from config if set.
     hapname = home.label \
-        if home.name == '' else "{} {}".format(home.label, home.name)
+        if not home.name else "{} {}".format(home.label, home.name)
     device_registry.async_get_or_create(
         config_entry_id=home.id,
         identifiers={(DOMAIN, home.id)},

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -60,7 +60,7 @@ async def async_setup_entry(hass, entry):
     # Register hap as device in registry.
     device_registry = await dr.async_get_registry(hass)
     home = hap.home
-    # Add the HAP name from config if set.
+    # Add the HAP name from configuration if set.
     hapname = home.label \
         if not home.name else "{} {}".format(home.label, home.name)
     device_registry.async_get_or_create(


### PR DESCRIPTION
## Description:
PR #21241 adds device info to Homematic IP.
If multiple access point are configured then all access point have the same name in device registry.

This fix takes the configured name from config, if available, and appends it to the default name.
This is NOT a breaking change, just a naming issue, but it might confuse users.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. 
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
