### PR TITLE
Resolve race condition when HA auth provider is loading

### DIFF
--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -101,6 +101,9 @@ class NotifyAuthModule(MultiFactorAuthModule):
     async def _async_load(self) -> None:
         """Load stored data."""
         async with self._init_lock:
+            if self._user_settings is not None:
+                return
+
             data = await self._user_store.async_load()
 
             if data is None:

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -79,6 +79,9 @@ class TotpAuthModule(MultiFactorAuthModule):
     async def _async_load(self) -> None:
         """Load stored data."""
         async with self._init_lock:
+            if self._users is not None:
+                return
+
             data = await self._user_store.async_load()
 
             if data is None:

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -1,4 +1,5 @@
 """Time-based One Time Password auth module."""
+import asyncio
 import logging
 from io import BytesIO
 from typing import Any, Dict, Optional, Tuple  # noqa: F401
@@ -68,6 +69,7 @@ class TotpAuthModule(MultiFactorAuthModule):
         self._users = None  # type: Optional[Dict[str, str]]
         self._user_store = hass.helpers.storage.Store(
             STORAGE_VERSION, STORAGE_KEY, private=True)
+        self._init_lock = asyncio.Lock()
 
     @property
     def input_schema(self) -> vol.Schema:
@@ -76,12 +78,13 @@ class TotpAuthModule(MultiFactorAuthModule):
 
     async def _async_load(self) -> None:
         """Load stored data."""
-        data = await self._user_store.async_load()
+        async with self._init_lock:
+            data = await self._user_store.async_load()
 
-        if data is None:
-            data = {STORAGE_USERS: {}}
+            if data is None:
+                data = {STORAGE_USERS: {}}
 
-        self._users = data.get(STORAGE_USERS, {})
+            self._users = data.get(STORAGE_USERS, {})
 
     async def _async_save(self) -> None:
         """Save data."""

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -208,7 +208,7 @@ class HassAuthProvider(AuthProvider):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize an Home Assistant auth provider."""
         super().__init__(*args, **kwargs)
-        self.data = None
+        self.data = None  # type: Optional[Data]
         self._init_lock = asyncio.Lock()
 
     async def async_initialize(self) -> None:

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -1,4 +1,5 @@
 """Home Assistant auth provider."""
+import asyncio
 import base64
 from collections import OrderedDict
 import logging
@@ -204,15 +205,21 @@ class HassAuthProvider(AuthProvider):
 
     DEFAULT_TITLE = 'Home Assistant Local'
 
-    data = None
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize an Home Assistant auth provider."""
+        super().__init__(*args, **kwargs)
+        self.data = None
+        self._init_lock = asyncio.Lock()
 
     async def async_initialize(self) -> None:
         """Initialize the auth provider."""
-        if self.data is not None:
-            return
+        async with self._init_lock:
+            if self.data is not None:
+                return
 
-        self.data = Data(self.hass)
-        await self.data.async_load()
+            data = Data(self.hass)
+            await data.async_load()
+            self.data = data
 
     async def async_login_flow(
             self, context: Optional[Dict]) -> LoginFlow:

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -1,4 +1,5 @@
 """Test the HMAC-based One Time Password (MFA) auth module."""
+import asyncio
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
@@ -395,3 +396,26 @@ async def test_not_raise_exception_when_service_not_exist(hass):
 
     # wait service call finished
     await hass.async_block_till_done()
+
+
+async def test_race_condition_in_data_loading(hass):
+    """Test race condition in the data loading."""
+    counter = 0
+
+    async def mock_load(_):
+        """Mock homeassistant.helpers.storage.Store.async_load"""
+        nonlocal counter
+        counter += 1
+        await asyncio.sleep(0)
+
+    notify_auth_module = await auth_mfa_module_from_config(hass, {
+        'type': 'notify'
+    })
+    with patch('homeassistant.helpers.storage.Store.async_load',
+               new=mock_load):
+        task1 = notify_auth_module.async_validate('user', {'code': 'value'})
+        task2 = notify_auth_module.async_validate('user', {'code': 'value'})
+        results = await asyncio.gather(task1, task2, return_exceptions=True)
+        assert counter == 1
+        assert results[0] is False
+        assert results[1] is False

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -403,7 +403,7 @@ async def test_race_condition_in_data_loading(hass):
     counter = 0
 
     async def mock_load(_):
-        """Mock homeassistant.helpers.storage.Store.async_load"""
+        """Mock homeassistant.helpers.storage.Store.async_load."""
         nonlocal counter
         counter += 1
         await asyncio.sleep(0)

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -1,4 +1,5 @@
 """Test the Time-based One Time Password (MFA) auth module."""
+import asyncio
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
@@ -128,3 +129,26 @@ async def test_login_flow_validates_mfa(hass):
             result['flow_id'], {'code': MOCK_CODE})
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result['data'].id == 'mock-user'
+
+
+async def test_race_condition_in_data_loading(hass):
+    """Test race condition in the data loading."""
+    counter = 0
+
+    async def mock_load(_):
+        """Mock of homeassistant.helpers.storage.Store.async_load"""
+        nonlocal counter
+        counter += 1
+        await asyncio.sleep(0)
+
+    totp_auth_module = await auth_mfa_module_from_config(hass, {
+        'type': 'totp'
+    })
+    with patch('homeassistant.helpers.storage.Store.async_load',
+               new=mock_load):
+        task1 = totp_auth_module.async_validate('user', {'code': 'value'})
+        task2 = totp_auth_module.async_validate('user', {'code': 'value'})
+        results = await asyncio.gather(task1, task2, return_exceptions=True)
+        assert counter == 1
+        assert results[0] is False
+        assert results[1] is False

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -136,7 +136,7 @@ async def test_race_condition_in_data_loading(hass):
     counter = 0
 
     async def mock_load(_):
-        """Mock of homeassistant.helpers.storage.Store.async_load"""
+        """Mock of homeassistant.helpers.storage.Store.async_load."""
         nonlocal counter
         counter += 1
         await asyncio.sleep(0)

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -299,7 +299,7 @@ async def test_race_condition_in_data_loading(hass):
     counter = 0
 
     async def mock_load(_):
-        """Mock of homeassistant.helpers.storage.Store.async_load"""
+        """Mock of homeassistant.helpers.storage.Store.async_load."""
         nonlocal counter
         counter += 1
         await asyncio.sleep(0)


### PR DESCRIPTION
## Description:

Fix race condition in ha auth provider and two mfa modules.

Other helpers.storage based solution also need check potential issues. Not everyone will throw exception though, for example, auth_store handle is fine, it may load data from harddisk twice if there were two `get_groups()` called at same time, but no exception will throw. So I didn't change it in this pull request.


**Related issue (if applicable):** fixes #21569
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
