### PR TITLE
fix derived rate, fixes #20097

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -350,7 +350,7 @@ class DerivativeDSMREntity(DSMREntity):
             else:
                 # Recalculate the rate
                 diff = current_reading - self._previous_reading
-                timediff = timestamp = self._previous_timestamp
+                timediff = timestamp - self._previous_timestamp
                 self._state = diff / timediff * 3600
 
             self._previous_reading = current_reading

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -350,7 +350,8 @@ class DerivativeDSMREntity(DSMREntity):
             else:
                 # Recalculate the rate
                 diff = current_reading - self._previous_reading
-                self._state = diff
+				timediff = timestamp = self._previous_timestamp
+                self._state = diff / timediff * 3600
 
             self._previous_reading = current_reading
             self._previous_timestamp = timestamp

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -104,8 +104,8 @@ def test_derivative():
 
     entity.telegram = {
         '1.0.0': MBusObject([
-            {'value': 1},
-            {'value': 1, 'unit': 'm3'},
+            {'value': 1551642213},
+            {'value': 745.695, 'unit': 'm3'},
         ])
     }
     yield from entity.async_update()
@@ -115,13 +115,13 @@ def test_derivative():
 
     entity.telegram = {
         '1.0.0': MBusObject([
-            {'value': 2},
-            {'value': 2, 'unit': 'm3'},
+            {'value': 1551642543},
+            {'value': 745.698, 'unit': 'm3'},
         ])
     }
     yield from entity.async_update()
 
-    assert entity.state == 3600, \
+    assert entity.state == 0.03272727272649883, \
         'state should be difference between first and second update'
 
     assert entity.unit_of_measurement == 'm3/h'

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -121,7 +121,7 @@ def test_derivative():
     }
     yield from entity.async_update()
 
-    assert entity.state == 1, \
+    assert entity.state == 3600, \
         'state should be difference between first and second update'
 
     assert entity.unit_of_measurement == 'm3/h'

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -121,8 +121,8 @@ def test_derivative():
     }
     yield from entity.async_update()
 
-    assert entity.state == 0.03272727272649883, \
-        'state should be difference between first and second update'
+    assert abs(entity.state - 0.03272) < 0.00001, \
+        'state should be hourly usage calculated from first and second update'
 
     assert entity.unit_of_measurement == 'm3/h'
 


### PR DESCRIPTION
## Description:
The rate (m3/h) was calculated as current_reading - previous_reading. So time was not considered.
This PR fixes the rate by calculating the time between the readings and converting that to m3/h.

**Related issue (if applicable):** fixes #20097 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
