### PR TITLE
Modbus write_register accept single value and array

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -60,7 +60,9 @@ SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
     vol.Optional(ATTR_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
+    vol.Required(ATTR_VALUE): vol.Any(
+        cv.positive_int,
+        vol.All(cv.ensure_list, [cv.positive_int]))
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({

--- a/homeassistant/components/modbus/services.yaml
+++ b/homeassistant/components/modbus/services.yaml
@@ -9,4 +9,4 @@ write_register:
   fields:
     address: {description: Address of the holding register to write to., example: 0}
     unit: {description: Address of the modbus unit., example: 21}
-    value: {description: Value to write., example: 0}
+    value: {description: Value (single value or array) to write., example: 0 or [4,0]}


### PR DESCRIPTION
## Description:

Updated voluptuous schema to accept single value and array. That way the correct function code modbus function code is called (0x06 for integer (single register), 0x10 for list (multiple registers)).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8814

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
