### PR TITLE
Bumping aioasuswrt

### DIFF
--- a/homeassistant/components/asuswrt/__init__.py
+++ b/homeassistant/components/asuswrt/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['aioasuswrt==1.1.20']
+REQUIREMENTS = ['aioasuswrt==1.1.21']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -97,7 +97,7 @@ afsapi==0.0.4
 aioambient==0.1.3
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.1.20
+aioasuswrt==1.1.21
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:
Bumps aioasuswrt to version 1.1.21

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
