### PR TITLE
Refactor Waze Travel Time

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -242,13 +242,12 @@ class WazeTravelTimeData():
         self.distance = None
         self.route = None
 
-        #Currently WazeRouteCalc only supports PRIVATE, TAXI, MOTORCYCLE.
+        # Currently WazeRouteCalc only supports PRIVATE, TAXI, MOTORCYCLE.
         if vehicle_type.upper() == 'CAR':
             # Empty means PRIVATE for waze which translates to car.
             self.vehicle_type = ''
         else:
             self.vehicle_type = vehicle_type.upper()
-
 
     def update(self):
         """Update WazeRouteCalculator Sensor."""

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -74,10 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     excl_filter = config.get(CONF_EXCL_FILTER)
     realtime = config.get(CONF_REALTIME)
     vehicle_type = config.get(CONF_VEHICLE_TYPE)
-    units = config.get(CONF_UNITS)
-
-    if units is None:
-        units = hass.config.units.name
+    units = config.get(CONF_UNITS, hass.config.units.name)
 
     data = WazeTravelTimeData(None, None, region, incl_filter,
                               excl_filter, realtime, units,

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -13,7 +13,8 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START,
-    ATTR_LATITUDE, ATTR_LONGITUDE)
+    ATTR_LATITUDE, ATTR_LONGITUDE, CONF_UNIT_SYSTEM_METRIC,
+    CONF_UNIT_SYSTEM_IMPERIAL)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
 from homeassistant.helpers.entity import Entity
@@ -40,7 +41,7 @@ DEFAULT_REALTIME = True
 
 ICON = 'mdi:car'
 
-UNITS = ['metric', 'imperial']
+UNITS = [CONF_UNIT_SYSTEM_METRIC, CONF_UNIT_SYSTEM_IMPERIAL]
 
 REGIONS = ['US', 'NA', 'EU', 'IL', 'AU']
 
@@ -255,7 +256,7 @@ class WazeTravelTimeData():
 
                 self.duration, distance = routes[route]
 
-                if self.units == 'imperial':
+                if self.units == CONF_UNIT_SYSTEM_IMPERIAL:
                     # Convert to miles.
                     self.distance = distance / 1.609
                 else:

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -48,7 +48,7 @@ UNITS = [CONF_UNIT_SYSTEM_METRIC, CONF_UNIT_SYSTEM_IMPERIAL]
 REGIONS = ['US', 'NA', 'EU', 'IL', 'AU']
 VEHICLE_TYPES = ['car', 'taxi', 'motorcycle']
 
-SCAN_INTERVAL = timedelta(minutes=1)
+SCAN_INTERVAL = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ORIGIN): cv.string,

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['WazeRouteCalculator==0.9']
+REQUIREMENTS = ['WazeRouteCalculator==0.10']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Refactored Waze Travel Time to contain a data object.

* Changed error retrieving data to a warning.
* Added distance conversion depending on region.
* Removed dependency on TRACKABLE_DOMAINS list.
* Update to use WazeRouteCalculator 0.10

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8825

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
