### PR TITLE
Return Netatmo climate operation_mode instead of boiler status

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -4,10 +4,10 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.const import (
-    STATE_OFF, TEMP_CELSIUS, ATTR_TEMPERATURE, STATE_UNKNOWN, CONF_NAME)
+    STATE_OFF, TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_NAME)
 from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (
-    STATE_HEAT, STATE_IDLE, SUPPORT_ON_OFF, SUPPORT_TARGET_TEMPERATURE,
+    STATE_HEAT, SUPPORT_ON_OFF, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_OPERATION_MODE, SUPPORT_AWAY_MODE, STATE_MANUAL, STATE_AUTO,
     STATE_ECO, STATE_COOL)
 from homeassistant.util import Throttle
@@ -92,6 +92,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             room_data = ThermostatData(netatmo.NETATMO_AUTH, home)
         except pyatmo.NoDevice:
             continue
+        devices = []
         for room_id in room_data.get_room_ids():
             room_name = room_data.homedata.rooms[home][room_id]['name']
             _LOGGER.debug("Setting up %s (%s) ...", room_name, room_id)
@@ -100,7 +101,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 continue
             _LOGGER.debug("Adding devices for room %s (%s) ...",
                           room_name, room_id)
-            add_entities([NetatmoThermostat(room_data, room_id)], True)
+            devices.append(NetatmoThermostat(room_data, room_id))
+        add_entities(devices, True)
 
 
 class NetatmoThermostat(ClimateDevice):
@@ -161,12 +163,7 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def current_operation(self):
         """Return the current state of the thermostat."""
-        state = self._data.room_status[self._room_id]['heating_status']
-        if state is False:
-            return STATE_IDLE
-        if state is True:
-            return STATE_HEAT
-        return STATE_UNKNOWN
+        return self.operation_mode
 
     @property
     def operation_list(self):

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -163,17 +163,12 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def current_operation(self):
         """Return the current state of the thermostat."""
-        return self.operation_mode
+        return self._operation_mode
 
     @property
     def operation_list(self):
         """Return the operation modes list."""
         return self._operation_list
-
-    @property
-    def operation_mode(self):
-        """Return current operation ie. heat, cool, idle."""
-        return self._operation_mode
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Description:
This is two small fixes on netatmo/climate according to the reviewer's comments after the merging of #19407.
1. Breaking change: return `_operation_mode` in function `current_operation`.
2. Merge devices into one list before calling `add_entities`.

**Breaking change:**
`current_operation` will no longer return the the boiler status, but the `operation_mode`.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
