### PR TITLE
Bump pyflunearyou to 1.0.3

### DIFF
--- a/homeassistant/components/sensor/flunearyou.py
+++ b/homeassistant/components/sensor/flunearyou.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyflunearyou==1.0.2']
+REQUIREMENTS = ['pyflunearyou==1.0.3']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CITY = 'city'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1034,7 +1034,7 @@ pyflexit==0.3
 pyflic-homeassistant==0.4.dev0
 
 # homeassistant.components.sensor.flunearyou
-pyflunearyou==1.0.2
+pyflunearyou==1.0.3
 
 # homeassistant.components.light.futurenow
 pyfnip==0.2


### PR DESCRIPTION
## Description:

Changelog: https://github.com/bachya/pyflunearyou/releases/tag/1.0.3

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/21599

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: flunearyou
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
