### PR TITLE
Fix group-switch availability for Homematic IP

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -208,7 +208,7 @@ class HomematicipSecuritySensorGroup(HomematicipSecurityZoneSensorGroup,
 
     @property
     def is_on(self):
-        """Return true if security issue detected."""
+        """Return true if safety issue detected."""
         parent_is_on = super().is_on
         from homematicip.base.enums import SmokeDetectorAlarmType
         if parent_is_on or \

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -152,13 +152,13 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
         attr = super().device_state_attributes
 
         if self._device.motionDetected:
-            attr.update({ATTR_MOTIONDETECTED: True})
+            attr[ATTR_MOTIONDETECTED] = True
         if self._device.presenceDetected:
-            attr.update({ATTR_PRESENCEDETECTED: True})
+            attr[ATTR_PRESENCEDETECTED] = True
         from homematicip.base.enums import WindowState
         if self._device.windowState is not None and \
                 self._device.windowState != WindowState.CLOSED:
-            attr.update({ATTR_WINDOWSTATE: str(self._device.windowState)})
+            attr[ATTR_WINDOWSTATE] = str(self._device.windowState)
         if self._device.unreach:
             attr[ATTR_GROUP_MEMBER_UNREACHABLE] = True
         return attr
@@ -192,17 +192,17 @@ class HomematicipSecuritySensorGroup(HomematicipSecurityZoneSensorGroup,
         attr = super().device_state_attributes
 
         if self._device.powerMainsFailure:
-            attr.update({ATTR_POWERMAINSFAILURE: True})
+            attr[ATTR_POWERMAINSFAILURE] = True
         if self._device.moistureDetected:
-            attr.update({ATTR_MOISTUREDETECTED: True})
+            attr[ATTR_MOISTUREDETECTED] = True
         if self._device.waterlevelDetected:
-            attr.update({ATTR_WATERLEVELDETECTED: True})
+            attr[ATTR_WATERLEVELDETECTED] = True
         from homematicip.base.enums import SmokeDetectorAlarmType
         if self._device.smokeDetectorAlarmType is not None and \
                 self._device.smokeDetectorAlarmType != \
                 SmokeDetectorAlarmType.IDLE_OFF:
-            attr.update({ATTR_SMOKEDETECTORALARM: str(
-                self._device.smokeDetectorAlarmType)})
+            attr[ATTR_SMOKEDETECTORALARM] = \
+                self._device.smokeDetectorAlarmType
 
         return attr
 

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -160,7 +160,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
                 self._device.windowState != WindowState.CLOSED:
             attr.update({ATTR_WINDOWSTATE: str(self._device.windowState)})
         if self._device.unreach:
-            attr.update({ATTR_GROUP_MEMBER_UNREACHABLE: True})
+            attr[ATTR_GROUP_MEMBER_UNREACHABLE] = True
         return attr
 
     @property

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -138,6 +138,13 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
         return 'safety'
 
     @property
+    def available(self):
+        """Device available."""
+        # A group must be available, and should not be affected by the
+        # individual availability of group members.
+        return True
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes of the security zone group."""
         attr = super().device_state_attributes

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -168,7 +168,8 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
         """Return true if security issue detected."""
         if self._device.motionDetected or \
                 self._device.presenceDetected or \
-                self._device.unreach:
+                self._device.unreach or \
+                self._device.sabotage:
             return True
         from homematicip.base.enums import WindowState
         if self._device.windowState is not None and \

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -169,7 +169,8 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
         if self._device.motionDetected or \
                 self._device.presenceDetected or \
                 self._device.unreach or \
-                self._device.sabotage:
+                self._device.sabotage or \
+                self._device.lowBat:
             return True
         from homematicip.base.enums import WindowState
         if self._device.windowState is not None and \

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.homematicip_cloud import (
     DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice)
 from homeassistant.components.homematicip_cloud.device import (
-    ATTR_GROUPMEMBERUNREADCHABLE)
+    ATTR_GROUP_MEMBER_UNREACHABLE)
 
 DEPENDENCIES = ['homematicip_cloud']
 
@@ -160,7 +160,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
                 self._device.windowState != WindowState.CLOSED:
             attr.update({ATTR_WINDOWSTATE: str(self._device.windowState)})
         if self._device.unreach:
-            attr.update({ATTR_GROUPMEMBERUNREADCHABLE: True})
+            attr.update({ATTR_GROUP_MEMBER_UNREACHABLE: True})
         return attr
 
     @property
@@ -169,8 +169,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
         if self._device.motionDetected or \
                 self._device.presenceDetected or \
                 self._device.unreach or \
-                self._device.sabotage or \
-                self._device.lowBat:
+                self._device.sabotage:
             return True
         from homematicip.base.enums import WindowState
         if self._device.windowState is not None and \
@@ -215,7 +214,8 @@ class HomematicipSecuritySensorGroup(HomematicipSecurityZoneSensorGroup,
         if parent_is_on or \
                 self._device.powerMainsFailure or \
                 self._device.moistureDetected or \
-                self._device.waterlevelDetected:
+                self._device.waterlevelDetected or \
+                self._device.lowBat:
             return True
         if self._device.smokeDetectorAlarmType is not None and \
                 self._device.smokeDetectorAlarmType != \

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -141,9 +141,9 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
 
     @property
     def available(self):
-        """Device available."""
-        # A group must be available, and should not be affected by the
-        # individual availability of group members.
+        """Security-Group available."""
+        # A security-group must be available, and should not be affected by
+        # the individual availability of group members.
         return True
 
     @property

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -202,7 +202,7 @@ class HomematicipSecuritySensorGroup(HomematicipSecurityZoneSensorGroup,
                 self._device.smokeDetectorAlarmType != \
                 SmokeDetectorAlarmType.IDLE_OFF:
             attr[ATTR_SMOKEDETECTORALARM] = \
-                self._device.smokeDetectorAlarmType
+                str(self._device.smokeDetectorAlarmType)
 
         return attr
 

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -21,7 +21,7 @@ ATTR_OPERATION_LOCK = 'operation_lock'
 ATTR_SABOTAGE = 'sabotage'
 ATTR_STATUS_UPDATE = 'status_update'
 ATTR_UNREACHABLE = 'unreachable'
-ATTR_GROUPMEMBERUNREADCHABLE = 'member device unreachable'
+ATTR_GROUP_MEMBER_UNREACHABLE = 'group_member_unreachable'
 
 
 class HomematicipGenericDevice(Entity):

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -21,6 +21,7 @@ ATTR_OPERATION_LOCK = 'operation_lock'
 ATTR_SABOTAGE = 'sabotage'
 ATTR_STATUS_UPDATE = 'status_update'
 ATTR_UNREACHABLE = 'unreachable'
+ATTR_GROUPMEMBERUNREADCHABLE = 'member device unreachable'
 
 
 class HomematicipGenericDevice(Entity):

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -92,6 +92,15 @@ class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
         """Return true if group is on."""
         return self._device.on
 
+    @property
+    def available(self):
+        """Device available."""
+        # A group must be available, and should not be affected by the
+        # individual availability of group members.
+        # This allows switching even when individual group members
+        # are not available.
+        return True
+
     async def async_turn_on(self, **kwargs):
         """Turn the group on."""
         await self._device.turn_on()

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.components.homematicip_cloud import (
     DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice)
 from homeassistant.components.homematicip_cloud.device import (
-    ATTR_GROUPMEMBERUNREADCHABLE)
+    ATTR_GROUP_MEMBER_UNREACHABLE)
 from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['homematicip_cloud']
@@ -108,7 +108,7 @@ class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
         """Return the state attributes of the switch-group."""
         attr = {}
         if self._device.unreach:
-            attr.update({ATTR_GROUPMEMBERUNREADCHABLE: True})
+            attr.update({ATTR_GROUP_MEMBER_UNREACHABLE: True})
         return attr
 
     async def async_turn_on(self, **kwargs):

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -96,8 +96,8 @@ class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
 
     @property
     def available(self):
-        """Device available."""
-        # A group must be available, and should not be affected by the
+        """Switch-Group available."""
+        # A switch-group must be available, and should not be affected by the
         # individual availability of group members.
         # This allows switching even when individual group members
         # are not available.
@@ -105,7 +105,7 @@ class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
 
     @property
     def device_state_attributes(self):
-        """Return the state attributes of the generic device."""
+        """Return the state attributes of the switch-group."""
         attr = {}
         if self._device.unreach:
             attr.update({ATTR_GROUPMEMBERUNREADCHABLE: True})

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -108,7 +108,7 @@ class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
         """Return the state attributes of the switch-group."""
         attr = {}
         if self._device.unreach:
-            attr.update({ATTR_GROUP_MEMBER_UNREACHABLE: True})
+            attr[ATTR_GROUP_MEMBER_UNREACHABLE] = True
         return attr
 
     async def async_turn_on(self, **kwargs):


### PR DESCRIPTION
## Description:
The property unreach of a group is a calculated value in Homematic IP Cloud. If one group member is unreach then the group also unreach.

In HA the property unreach is used to determine if a device is available. This is good for devices, but not for groups-switches, because group-switches that are unavailable cannot be used for switching of  other available group members.

**Related PR:** fixes #21076

This PR sets the return of a group-switch to be always True, so  this switching is always possible.
It also adds a state_attribute if a group member is unreachable.

This also relates to groups that are shown as binary_sensors.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
