### PR TITLE
bumped toonapilib to 3.1.0. 

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -15,7 +15,7 @@ from .const import (
     CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_DISPLAY, CONF_TENANT,
     DATA_TOON_CLIENT, DATA_TOON_CONFIG, DOMAIN)
 
-REQUIREMENTS = ['toonapilib==3.0.9']
+REQUIREMENTS = ['toonapilib==3.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1689,7 +1689,7 @@ tikteck==0.4
 todoist-python==7.0.17
 
 # homeassistant.components.toon
-toonapilib==3.0.9
+toonapilib==3.1.0
 
 # homeassistant.components.alarm_control_panel.totalconnect
 total_connect_client==0.22

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -50,10 +50,6 @@ PyMVGLive==1.1.4
 # homeassistant.components.arduino
 PyMata==2.14
 
-# homeassistant.components.mobile_app
-# homeassistant.components.owntracks
-PyNaCl==1.3.0
-
 # homeassistant.auth.mfa_modules.totp
 PyQRCode==1.2.1
 
@@ -67,7 +63,7 @@ PyRMVtransport==0.1.3
 PyTransportNSW==0.1.1
 
 # homeassistant.components.xiaomi_aqara
-PyXiaomiGateway==0.12.0
+PyXiaomiGateway==0.11.2
 
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.5
@@ -82,7 +78,7 @@ TravisPy==0.3.5
 TwitterAPI==2.5.9
 
 # homeassistant.components.sensor.waze_travel_time
-WazeRouteCalculator==0.9
+WazeRouteCalculator==0.6
 
 # homeassistant.components.notify.yessssms
 YesssSMS==0.2.3
@@ -94,10 +90,10 @@ abodepy==0.15.0
 afsapi==0.0.4
 
 # homeassistant.components.ambient_station
-aioambient==0.1.3
+aioambient==0.1.2
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.1.21
+aioasuswrt==1.1.20
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5
@@ -106,7 +102,7 @@ aioautomatic==0.6.5
 aiodns==1.1.1
 
 # homeassistant.components.esphome
-aioesphomeapi==1.6.0
+aioesphomeapi==1.5.0
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.6
@@ -122,7 +118,7 @@ aioharmony==0.1.8
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.1
+aiohue==1.9.0
 
 # homeassistant.components.sensor.iliad_italy
 aioiliad==0.1.1
@@ -158,7 +154,7 @@ amcrest==1.2.3
 anel_pwrctrl-homeassistant==0.0.1.dev2
 
 # homeassistant.components.media_player.anthemav
-anthemav==1.1.9
+anthemav==1.1.8
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.13
@@ -200,13 +196,13 @@ batinfo==0.4.2
 beautifulsoup4==4.7.1
 
 # homeassistant.components.zha
-bellows-homeassistant==0.7.1
+bellows==0.7.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.5.3
 
 # homeassistant.components.blink
-blinkpy==0.13.1
+blinkpy==0.12.1
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8
@@ -296,7 +292,7 @@ construct==2.9.45
 # credstash==1.15.0
 
 # homeassistant.components.sensor.crimereports
-crimereports==1.0.1
+crimereports==1.0.0
 
 # homeassistant.components.datadog
 datadog==0.15.0
@@ -423,8 +419,8 @@ fiblary3==0.1.7
 # homeassistant.components.sensor.fints
 fints==1.0.1
 
-# homeassistant.components.firetv.media_player
-firetv==1.0.9
+# homeassistant.components.media_player.firetv
+firetv==1.0.7
 
 # homeassistant.components.sensor.fitbit
 fitbit==0.3.0
@@ -539,7 +535,7 @@ hole==0.3.0
 holidays==0.9.9
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190303.0
+home-assistant-frontend==20190220.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.2
@@ -548,7 +544,7 @@ homeassistant-pyozw==0.1.2
 homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.6
+homematicip==0.10.5
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk
@@ -572,7 +568,7 @@ ibmiotf==0.3.4
 iglo==1.2.7
 
 # homeassistant.components.ihc
-ihcsdk==2.3.0
+ihcsdk==2.2.0
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
@@ -581,7 +577,7 @@ influxdb==5.2.0
 # homeassistant.components.insteon
 insteonplm==0.15.2
 
-# homeassistant.components.iperf3
+# homeassistant.components.sensor.iperf3
 iperf3==0.1.10
 
 # homeassistant.components.route53
@@ -610,7 +606,10 @@ kiwiki-client==0.1.1
 konnected==0.1.4
 
 # homeassistant.components.eufy
-lakeside==0.12
+lakeside==0.11
+
+# homeassistant.components.owntracks
+libnacl==1.6.1
 
 # homeassistant.components.dyson
 libpurecoollink==0.4.2
@@ -682,8 +681,8 @@ mbddns==0.1.2
 # homeassistant.components.notify.message_bird
 messagebird==1.2.0
 
-# homeassistant.components.meteo_france
-meteofrance==0.3.4
+# homeassistant.components.sensor.meteo_france
+meteofrance==0.2.7
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
@@ -699,7 +698,7 @@ millheater==0.3.4
 mitemp_bt==0.0.1
 
 # homeassistant.components.sensor.mopar
-motorparts==1.1.0
+motorparts==1.0.2
 
 # homeassistant.components.tts
 mutagen==1.42.0
@@ -723,7 +722,7 @@ nanoleaf==0.4.1
 ndms2_client==0.0.6
 
 # homeassistant.components.ness_alarm
-nessclient==0.9.13
+nessclient==0.9.9
 
 # homeassistant.components.sensor.netdata
 netdata==0.1.2
@@ -753,7 +752,7 @@ nuheat==0.3.0
 # homeassistant.components.image_processing.opencv
 # homeassistant.components.image_processing.tensorflow
 # homeassistant.components.sensor.pollen
-numpy==1.16.2
+numpy==1.16.0
 
 # homeassistant.components.google
 oauth2client==4.0.0
@@ -774,10 +773,7 @@ openevsewifi==0.4
 openhomedevice==0.4.2
 
 # homeassistant.components.air_quality.opensensemap
-opensensemap-api==0.1.5
-
-# homeassistant.components.device_tracker.luci
-openwrt-luci-rpc==1.0.5
+opensensemap-api==0.1.3
 
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
@@ -841,9 +837,6 @@ pocketcasts==0.1
 # homeassistant.components.sensor.postnl
 postnl_api==1.0.2
 
-# homeassistant.components.reddit.sensor
-praw==6.1.1
-
 # homeassistant.components.sensor.islamic_prayer_times
 prayer_times_calculator==0.0.3
 
@@ -860,7 +853,7 @@ prometheus_client==0.2.0
 protobuf==3.6.1
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.5.1
+psutil==5.5.0
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.3
@@ -891,17 +884,18 @@ py-melissa-climate==2.0.0
 py-synology==0.2.0
 
 # homeassistant.components.sensor.seventeentrack
-py17track==2.2.2
+py17track==2.1.1
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13
 
-# homeassistant.components.tplink
+# homeassistant.components.light.tplink
+# homeassistant.components.switch.tplink
 pyHS100==0.3.4
 
 # homeassistant.components.air_quality.norway_air
 # homeassistant.components.weather.met
-pyMetno==0.4.6
+pyMetno==0.4.5
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.23
@@ -910,7 +904,7 @@ pyRFXtrx==0.23
 # pySwitchmate==0.4.5
 
 # homeassistant.components.tibber
-pyTibber==0.9.6
+pyTibber==0.9.4
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
@@ -928,7 +922,7 @@ pyads==3.0.7
 pyaftership==0.1.2
 
 # homeassistant.components.sensor.airvisual
-pyairvisual==3.0.1
+pyairvisual==2.0.1
 
 # homeassistant.components.alarm_control_panel.alarmdotcom
 pyalarmdotcom==0.3.2
@@ -954,9 +948,6 @@ pyblackbird==0.5
 
 # homeassistant.components.neato
 pybotvac==0.0.13
-
-# homeassistant.components.nissan_leaf
-pycarwings2==2.8
 
 # homeassistant.components.cloudflare
 pycfdns==0.0.1
@@ -986,10 +977,10 @@ pycsspeechtts==1.0.2
 pydaikin==0.9
 
 # homeassistant.components.danfoss_air
-pydanfossair==0.0.7
+pydanfossair==0.0.6
 
 # homeassistant.components.deconz
-pydeconz==52
+pydeconz==47
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
@@ -1004,7 +995,7 @@ pydukeenergy==0.0.6
 pyebox==1.1.4
 
 # homeassistant.components.water_heater.econet
-pyeconet==0.0.8
+pyeconet==0.0.6
 
 # homeassistant.components.switch.edimax
 pyedimax==0.1
@@ -1034,7 +1025,7 @@ pyflexit==0.3
 pyflic-homeassistant==0.4.dev0
 
 # homeassistant.components.sensor.flunearyou
-pyflunearyou==1.0.3
+pyflunearyou==1.0.1
 
 # homeassistant.components.light.futurenow
 pyfnip==0.2
@@ -1062,13 +1053,13 @@ pygtt==1.1.2
 pyhaversion==2.0.3
 
 # homeassistant.components.binary_sensor.hikvision
-pyhik==0.2.2
+pyhik==0.1.9
 
 # homeassistant.components.hive
 pyhiveapi==0.2.17
 
 # homeassistant.components.homematic
-pyhomematic==0.1.57
+pyhomematic==0.1.55
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6
@@ -1117,7 +1108,7 @@ pylgnetcast-homeassistant==0.2.0.dev0
 pylgtv==0.1.9
 
 # homeassistant.components.sensor.linky
-pylinky==0.3.0
+pylinky==0.1.8
 
 # homeassistant.components.litejet
 pylitejet==0.1
@@ -1178,7 +1169,7 @@ pynut2==2.1.2
 pynx584==0.4
 
 # homeassistant.components.openuv
-pyopenuv==1.0.9
+pyopenuv==1.0.4
 
 # homeassistant.components.light.opple
 pyoppleio==1.0.5
@@ -1194,9 +1185,6 @@ pyotgw==0.4b1
 # homeassistant.components.sensor.otp
 pyotp==2.2.6
 
-# homeassistant.components.owlet
-pyowlet==1.0.2
-
 # homeassistant.components.sensor.openweathermap
 # homeassistant.components.weather.openweathermap
 pyowm==2.10.0
@@ -1208,13 +1196,10 @@ pypck==0.5.9
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.1.1
+pypoint==1.0.8
 
 # homeassistant.components.sensor.pollen
-pypollencom==2.2.3
-
-# homeassistant.components.ps4
-pyps4-homeassistant==0.3.0
+pypollencom==2.2.2
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8
@@ -1233,9 +1218,6 @@ pyruter==1.1.0
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.1.0
-
-# homeassistant.components.switch.sony_projector
-pysdcp==1
 
 # homeassistant.components.climate.sensibo
 pysensibo==1.0.3
@@ -1259,7 +1241,7 @@ pysma==0.3.1
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.3
+pysmartthings==0.6.2
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp
@@ -1267,7 +1249,7 @@ pysmartthings==0.6.3
 pysnmp==4.4.8
 
 # homeassistant.components.sonos
-pysonos==0.0.8
+pysonos==0.0.6
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0
@@ -1346,7 +1328,7 @@ python-mpd2==1.0.0
 
 # homeassistant.components.light.mystrom
 # homeassistant.components.switch.mystrom
-python-mystrom==0.5.0
+python-mystrom==0.4.4
 
 # homeassistant.components.nest
 python-nest==4.1.0
@@ -1385,7 +1367,7 @@ python-telegram-bot==11.1.0
 python-twitch-client==0.6.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.22
+python-velbus==2.0.21
 
 # homeassistant.components.media_player.vlc
 python-vlc==1.1.2
@@ -1406,13 +1388,13 @@ pythonegardia==1.0.39
 pythonwhois==2.4.3
 
 # homeassistant.components.device_tracker.tile
-pytile==2.0.6
+pytile==2.0.5
 
 # homeassistant.components.climate.touchline
 pytouchline==0.7
 
 # homeassistant.components.device_tracker.traccar
-pytraccar==0.3.0
+pytraccar==0.2.1
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5
@@ -1422,9 +1404,6 @@ pytradfri[async]==6.0.1
 
 # homeassistant.components.sensor.trafikverket_weatherstation
 pytrafikverket==0.1.5.8
-
-# homeassistant.components.device_tracker.ubee
-pyubee==0.2
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.16
@@ -1439,13 +1418,13 @@ pyuptimerobot==0.0.5
 pyvera==0.2.45
 
 # homeassistant.components.switch.vesync
-pyvesync_v2==0.9.6
+pyvesync==0.1.1
 
 # homeassistant.components.media_player.vizio
 pyvizio==0.0.4
 
 # homeassistant.components.velux
-pyvlx==0.2.9
+pyvlx==0.2.8
 
 # homeassistant.components.notify.html5
 pywebpush==1.6.0
@@ -1454,7 +1433,7 @@ pywebpush==1.6.0
 pywemo==0.4.34
 
 # homeassistant.components.camera.xeoma
-pyxeoma==1.4.1
+pyxeoma==1.4.0
 
 # homeassistant.components.zabbix
 pyzabbix==0.7.4
@@ -1487,7 +1466,7 @@ raspyrfm-client==1.2.8
 recollect-waste==1.0.1
 
 # homeassistant.components.rainmachine
-regenmaschine==1.2.0
+regenmaschine==1.1.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8
@@ -1514,7 +1493,7 @@ rocketchat-API==0.6.1
 roombapy==1.3.1
 
 # homeassistant.components.sensor.rova
-rova==0.1.0
+rova==0.0.2
 
 # homeassistant.components.switch.rpi_rf
 # rpi-rf==0.9.7
@@ -1554,13 +1533,13 @@ sense_energy==0.6.0
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.sensor.shodan
-shodan==1.11.1
+shodan==1.10.4
 
 # homeassistant.components.notify.simplepush
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.4.1
+simplisafe-python==3.1.14
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.1
@@ -1589,7 +1568,7 @@ smappy==0.2.16
 # smbus-cffi==0.5.1
 
 # homeassistant.components.smhi
-smhi-pkg==1.0.10
+smhi-pkg==1.0.8
 
 # homeassistant.components.media_player.snapcast
 snapcast==2.0.9
@@ -1617,13 +1596,13 @@ spotipy-homeassistant==2.4.4.dev1
 
 # homeassistant.components.recorder
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.18
+sqlalchemy==1.2.17
 
 # homeassistant.components.sensor.srp_energy
 srpenergy==1.0.5
 
 # homeassistant.components.sensor.starlingbank
-starlingbank==3.1
+starlingbank==1.2
 
 # homeassistant.components.statsd
 statsd==3.2.1
@@ -1647,7 +1626,7 @@ suds-py3==1.3.3.0
 swisshydrodata==0.0.3
 
 # homeassistant.components.device_tracker.synology_srm
-synology-srm==0.0.6
+synology-srm==0.0.4
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.14
@@ -1689,7 +1668,7 @@ tikteck==0.4
 todoist-python==7.0.17
 
 # homeassistant.components.toon
-toonapilib==3.1.0
+toonlib==1.1.3
 
 # homeassistant.components.alarm_control_panel.totalconnect
 total_connect_client==0.22
@@ -1805,7 +1784,7 @@ yeelight==0.4.3
 yeelightsunflower==0.0.10
 
 # homeassistant.components.media_extractor
-youtube_dl==2019.02.18
+youtube_dl==2019.02.08
 
 # homeassistant.components.light.zengge
 zengge==0.2
@@ -1823,13 +1802,13 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.1.2
+zigpy-deconz==0.0.1
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.3.0
+zigpy-xbee==0.1.1
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.1.2
+zigpy==0.2.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -21,10 +21,6 @@ requests_mock==1.5.2
 # homeassistant.components.homekit
 HAP-python==2.4.2
 
-# homeassistant.components.mobile_app
-# homeassistant.components.owntracks
-PyNaCl==1.3.0
-
 # homeassistant.components.sensor.rmvtransport
 PyRMVtransport==0.1.3
 
@@ -35,7 +31,7 @@ PyTransportNSW==0.1.1
 YesssSMS==0.2.3
 
 # homeassistant.components.ambient_station
-aioambient==0.1.3
+aioambient==0.1.2
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5
@@ -45,16 +41,13 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.1
+aiohue==1.9.0
 
 # homeassistant.components.unifi
 aiounifi==4
 
 # homeassistant.components.notify.apns
 apns2==0.3.0
-
-# homeassistant.components.zha
-bellows-homeassistant==0.7.1
 
 # homeassistant.components.calendar.caldav
 caldav==0.5.0
@@ -120,13 +113,13 @@ hdate==0.8.7
 holidays==0.9.9
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190303.0
+home-assistant-frontend==20190220.0
 
 # homeassistant.components.homekit_controller
 homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.6
+homematicip==0.10.5
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb
@@ -155,7 +148,7 @@ mficlient==0.3.0
 # homeassistant.components.image_processing.opencv
 # homeassistant.components.image_processing.tensorflow
 # homeassistant.components.sensor.pollen
-numpy==1.16.2
+numpy==1.16.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
@@ -184,20 +177,21 @@ pushbullet.py==0.11.0
 # homeassistant.components.canary
 py-canary==0.5.0
 
-# homeassistant.components.tplink
+# homeassistant.components.light.tplink
+# homeassistant.components.switch.tplink
 pyHS100==0.3.4
 
 # homeassistant.components.media_player.blackbird
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==52
+pydeconz==47
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.57
+pyhomematic==0.1.55
 
 # homeassistant.components.litejet
 pylitejet==0.1
@@ -210,15 +204,12 @@ pymonoprice==0.3
 pynx584==0.4
 
 # homeassistant.components.openuv
-pyopenuv==1.0.9
+pyopenuv==1.0.4
 
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.sensor.otp
 pyotp==2.2.6
-
-# homeassistant.components.ps4
-pyps4-homeassistant==0.3.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8
@@ -227,10 +218,10 @@ pyqwikswitch==0.8
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.3
+pysmartthings==0.6.2
 
 # homeassistant.components.sonos
-pysonos==0.0.8
+pysonos==0.0.6
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0
@@ -258,7 +249,7 @@ pyunifi==2.16
 pywebpush==1.6.0
 
 # homeassistant.components.rainmachine
-regenmaschine==1.2.0
+regenmaschine==1.1.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8
@@ -273,29 +264,26 @@ ring_doorbell==0.2.2
 rxv==0.6.0
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.4.1
+simplisafe-python==3.1.14
 
 # homeassistant.components.sleepiq
 sleepyq==0.6
 
 # homeassistant.components.smhi
-smhi-pkg==1.0.10
+smhi-pkg==1.0.8
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.5.2
 
 # homeassistant.components.recorder
 # homeassistant.components.sensor.sql
-sqlalchemy==1.2.18
+sqlalchemy==1.2.17
 
 # homeassistant.components.sensor.srp_energy
 srpenergy==1.0.5
 
 # homeassistant.components.statsd
 statsd==3.2.1
-
-# homeassistant.components.toon
-toonapilib==3.1.0
 
 # homeassistant.components.camera.uvc
 uvcclient==0.11.0
@@ -314,6 +302,3 @@ wakeonlan==1.1.6
 
 # homeassistant.components.cloud
 warrant==0.6.1
-
-# homeassistant.components.zha
-zigpy-homeassistant==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -295,7 +295,7 @@ srpenergy==1.0.5
 statsd==3.2.1
 
 # homeassistant.components.toon
-toonapilib==3.0.9
+toonapilib==3.1.0
 
 # homeassistant.components.camera.uvc
 uvcclient==0.11.0


### PR DESCRIPTION
This version fixes a bug where thermostat states cannot be changed if program is on and implements a new data object that exposes rrd metrics for graph and flow data for power and gas.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
