### PR TITLE
Cast displaytime to int for Kodi notifications

### DIFF
--- a/homeassistant/components/notify/kodi.py
+++ b/homeassistant/components/notify/kodi.py
@@ -90,7 +90,7 @@ class KodiNotificationService(BaseNotificationService):
         try:
             data = kwargs.get(ATTR_DATA) or {}
 
-            displaytime = data.get(ATTR_DISPLAYTIME, 10000)
+            displaytime = int(data.get(ATTR_DISPLAYTIME, 10000))
             icon = data.get(ATTR_ICON, "info")
             title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
             await self._server.GUI.ShowNotification(


### PR DESCRIPTION
## Description:
Casts displaytime from string to int to fix the Protocol Error raised by JSON RPC. Passing string object caused error resulting in Home Assistant never sending the notification to Kodi.

**Related issue (if applicable):** fixes #21258

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

