### PR TITLE
Identify camera name in the logs

### DIFF
--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -128,7 +128,7 @@ class GenericCamera(Camera):
                         url, auth=self._auth)
                 self._last_image = await response.read()
             except asyncio.TimeoutError:
-                _LOGGER.error("Timeout getting camera image")
+                _LOGGER.error("Timeout getting image from: %s", self._name)
                 return self._last_image
             except aiohttp.ClientError as err:
                 _LOGGER.error("Error getting new camera image: %s", err)


### PR DESCRIPTION
Right now, a timeout results in a generic error message `Timeout getting camera image`. However, as the number of cameras in HA grows, it becomes difficult to isolate the culprit. This PR adds the camera name to the logs for users to identify the camera. 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
