### PR TITLE
Rename Google Assistant evenets

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -44,6 +44,6 @@ ERR_UNKNOWN_ERROR = 'unknownError'
 ERR_FUNCTION_NOT_SUPPORTED = 'functionNotSupported'
 
 # Event types
-EVENT_COMMAND_RECEIVED = 'google_assistant_command_received'
-EVENT_QUERY_RECEIVED = 'google_assistant_query_received'
-EVENT_SYNC_RECEIVED = 'google_assistant_sync_received'
+EVENT_COMMAND_RECEIVED = 'google_assistant_command'
+EVENT_QUERY_RECEIVED = 'google_assistant_query'
+EVENT_SYNC_RECEIVED = 'google_assistant_sync'


### PR DESCRIPTION
## Description:
Rename the Google Events to be less than 32 characters, as that's the column length of the recorder.
