### PR TITLE
Fix Toon doing I/O in coroutines

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -1,6 +1,7 @@
 """Support for Toon van Eneco devices."""
 import logging
 from typing import Any, Dict
+from functools import partial
 
 import voluptuous as vol
 
@@ -48,10 +49,11 @@ async def async_setup_entry(hass: HomeAssistantType,
 
     conf = hass.data.get(DATA_TOON_CONFIG)
 
-    toon = Toon(entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD],
-                conf[CONF_CLIENT_ID], conf[CONF_CLIENT_SECRET],
-                tenant_id=entry.data[CONF_TENANT],
-                display_common_name=entry.data[CONF_DISPLAY])
+    toon = await hass.async_add_executor_job(partial(
+        Toon, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD],
+        conf[CONF_CLIENT_ID], conf[CONF_CLIENT_SECRET],
+        tenant_id=entry.data[CONF_TENANT],
+        display_common_name=entry.data[CONF_DISPLAY]))
 
     hass.data.setdefault(DATA_TOON_CLIENT, {})[entry.entry_id] = toon
 

--- a/homeassistant/components/toon/binary_sensor.py
+++ b/homeassistant/components/toon/binary_sensor.py
@@ -102,7 +102,7 @@ class ToonBinarySensor(ToonEntity, BinarySensorDevice):
 
         return value
 
-    async def async_update(self) -> None:
+    def update(self) -> None:
         """Get the latest data from the binary sensor."""
         section = getattr(self.toon, self.section)
         self._state = getattr(section, self.measurement)

--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -117,7 +117,7 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
         """Set new operation mode."""
         self.toon.thermostat_state = HA_TOON[operation_mode]
 
-    async def async_update(self) -> None:
+    def update(self) -> None:
         """Update local state."""
         if self.toon.thermostat_state is None:
             self._state = None

--- a/homeassistant/components/toon/config_flow.py
+++ b/homeassistant/components/toon/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure the Toon component."""
 from collections import OrderedDict
 import logging
+from functools import partial
 
 import voluptuous as vol
 
@@ -75,11 +76,10 @@ class ToonFlowHandler(config_entries.ConfigFlow):
 
         app = self.hass.data.get(DATA_TOON_CONFIG, {})
         try:
-            toon = Toon(user_input[CONF_USERNAME],
-                        user_input[CONF_PASSWORD],
-                        app[CONF_CLIENT_ID],
-                        app[CONF_CLIENT_SECRET],
-                        tenant_id=user_input[CONF_TENANT])
+            toon = await self.hass.async_add_executor_job(partial(
+                Toon, user_input[CONF_USERNAME], user_input[CONF_PASSWORD],
+                app[CONF_CLIENT_ID], app[CONF_CLIENT_SECRET],
+                tenant_id=user_input[CONF_TENANT]))
 
             displays = toon.display_names
 
@@ -136,12 +136,10 @@ class ToonFlowHandler(config_entries.ConfigFlow):
 
         app = self.hass.data.get(DATA_TOON_CONFIG, {})
         try:
-            Toon(self.username,
-                 self.password,
-                 app[CONF_CLIENT_ID],
-                 app[CONF_CLIENT_SECRET],
-                 tenant_id=self.tenant,
-                 display_common_name=user_input[CONF_DISPLAY])
+            await self.hass.async_add_executor_job(partial(
+                Toon, self.username, self.password, app[CONF_CLIENT_ID],
+                app[CONF_CLIENT_SECRET], tenant_id=self.tenant,
+                display_common_name=user_input[CONF_DISPLAY]))
 
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected error while authenticating")

--- a/homeassistant/components/toon/sensor.py
+++ b/homeassistant/components/toon/sensor.py
@@ -134,7 +134,7 @@ class ToonSensor(ToonEntity):
         """Return the unit this state is expressed in."""
         return self._unit_of_measurement
 
-    async def async_update(self) -> None:
+    def update(self) -> None:
         """Get the latest data from the sensor."""
         section = getattr(self.toon, self.section)
         value = None


### PR DESCRIPTION
## Description:

As pointed out by a late review by @MartinHjelmare in #21186 (Rewrite of Toon component), the component actually does I/O in coroutines and therefore blocks the event loop.

This PR takes care of this by:
- Switching to the sync API for the Entity updates
- Leveraging `async_add_executor_job` on the instantiation of Toon.

:warning: Please note, PR #21186 is already merged for 0.89. 

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
toon:
  client_id: fxiyXLtFfhimADJlmFjTjXdHoxZ8AFg7
  client_secret: kPUCx88CTCSMAaBA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
