### PR TITLE
Upgrade toonapilib to 3.1.0

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -15,7 +15,7 @@ from .const import (
     CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_DISPLAY, CONF_TENANT,
     DATA_TOON_CLIENT, DATA_TOON_CONFIG, DOMAIN)
 
-REQUIREMENTS = ['toonapilib==3.0.9']
+REQUIREMENTS = ['toonapilib==3.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1689,7 +1689,7 @@ tikteck==0.4
 todoist-python==7.0.17
 
 # homeassistant.components.toon
-toonapilib==3.0.9
+toonapilib==3.1.0
 
 # homeassistant.components.alarm_control_panel.totalconnect
 total_connect_client==0.22

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -295,7 +295,7 @@ srpenergy==1.0.5
 statsd==3.2.1
 
 # homeassistant.components.toon
-toonapilib==3.0.9
+toonapilib==3.1.0
 
 # homeassistant.components.camera.uvc
 uvcclient==0.11.0


### PR DESCRIPTION
## Description:

Updates `toonapilib` from 3.0.9 to 3.1.0, which fixes a bug with the Thermostat operation mode and temperature being unsettable for the user while the Toon Thermostat program is active.

<https://github.com/costastf/toonapilib/blob/master/HISTORY.rst#310-04-03-2019>

CC: @costastf

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
toon:
  client_id: fxiyXLtFfhimADJlmFjTjXdHoxZ8AFg7
  client_secret: kPUCx88CTCSMAaBA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
