### PR TITLE
Avoid recorder thread crashing

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -318,6 +318,10 @@ class Recorder(threading.Thread):
                                   CONNECT_RETRY_WAIT)
                     tries += 1
 
+                except exc.SQLAlchemyError:
+                    updated = True
+                    _LOGGER.exception("Error saving event: %s", event)
+
             if not updated:
                 _LOGGER.error("Error in database update. Could not save "
                               "after %d tries. Giving up", tries)


### PR DESCRIPTION
## Description:
If an event is longer than 32 characters, the recorder thread crashes, avoiding history from being recorder until Home Assistant is restarted.

This fixes it by making sure we never fully crash.

I tried writing a test but it seems like in memory databases don't raise when text length is exceeded. Realize now that SQLite just trims. It's other databases that raise.

```python
def test_too_long_events(hass_recorder):
    """Test saving and restoring an event."""
    hass = hass_recorder()
    events = _add_events(hass, ['test_very_long_event' * 5, 'test2'])
    assert len(events) == 1
    assert events[0].event_type == 'test2'

```


