### PR TITLE
Add 'ssl' parameter for FiOS Quantum Gateway and upgrade Pypi

### DIFF
--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
                                                      DeviceScanner)
-from homeassistant.const import (CONF_HOST, CONF_PASSWORD)
+from homeassistant.const import (CONF_HOST, CONF_PASSWORD, CONF_SSL)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['quantum-gateway==0.0.5']
@@ -19,11 +19,10 @@ REQUIREMENTS = ['quantum-gateway==0.0.5']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_HOST = 'myfiosgateway.com'
-USE_HTTPS = 'use_https'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-    vol.Optional(USE_HTTPS, default=True): cv.boolean,
+    vol.Optional(CONF_SSL, default=True): cv.boolean,
     vol.Required(CONF_PASSWORD): cv.string
 })
 
@@ -44,7 +43,7 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
 
         self.host = config[CONF_HOST]
         self.password = config[CONF_PASSWORD]
-        self.use_https = config[USE_HTTPS]
+        self.use_https = config[CONF_SSL]
         _LOGGER.debug('Initializing')
 
         try:

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -14,14 +14,16 @@ from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
 from homeassistant.const import (CONF_HOST, CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['quantum-gateway==0.0.3']
+REQUIREMENTS = ['quantum-gateway==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_HOST = 'myfiosgateway.com'
+USE_HTTPS = 'use_https'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(USE_HTTPS, default=True): cv.boolean,
     vol.Required(CONF_PASSWORD): cv.string
 })
 
@@ -42,10 +44,12 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
 
         self.host = config[CONF_HOST]
         self.password = config[CONF_PASSWORD]
+        self.use_https = config[USE_HTTPS]
         _LOGGER.debug('Initializing')
 
         try:
-            self.quantum = QuantumGatewayScanner(self.host, self.password)
+            self.quantum = QuantumGatewayScanner(self.host, self.password,
+                                                 self.use_https)
             self.success_init = self.quantum.success_init
         except RequestException:
             self.success_init = False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1466,7 +1466,7 @@ pyzbar==0.1.7
 qnapstats==0.2.7
 
 # homeassistant.components.device_tracker.quantum_gateway
-quantum-gateway==0.0.3
+quantum-gateway==0.0.5
 
 # homeassistant.components.rachio
 rachiopy==0.1.3


### PR DESCRIPTION
## Description:
Added HTTPS support for Quantum Gateway routers which may have been pushed a firmware update forcing HTTPS connections to query the device list.

**Related issue (if applicable):** fixes #21692

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8826

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
