### PR TITLE
system_log fix for #21660

### DIFF
--- a/homeassistant/components/system_log/__init__.py
+++ b/homeassistant/components/system_log/__init__.py
@@ -91,15 +91,15 @@ class LogEntry:
         self.first_occured = self.timestamp = record.created
         self.level = record.levelname
         self.message = record.getMessage()
+        self.exception = ''
+        self.root_cause = None
         if record.exc_info:
             self.exception = ''.join(
                 traceback.format_exception(*record.exc_info))
             _, _, tb = record.exc_info  # pylint: disable=invalid-name
             # Last line of traceback contains the root cause of the exception
-            self.root_cause = str(traceback.extract_tb(tb)[-1])
-        else:
-            self.exception = ''
-            self.root_cause = None
+            if traceback.extract_tb(tb):
+                self.root_cause = str(traceback.extract_tb(tb)[-1])
         self.source = source
         self.count = 1
 


### PR DESCRIPTION
## Description:

Sometimes the traceback is empty.

**Related issue (if applicable):** fixes #21660

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
