### PR TITLE
Android TV integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -27,6 +27,7 @@ omit =
     homeassistant/components/ambient_station/*
     homeassistant/components/amcrest/*
     homeassistant/components/android_ip_webcam/*
+    homeassistant/components/androidtv/*
     homeassistant/components/apcupsd/*
     homeassistant/components/apiai/*
     homeassistant/components/apple_tv/*

--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -1,0 +1,6 @@
+"""
+Support for functionality to interact with FireTV devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.firetv/
+"""

--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -1,6 +1,6 @@
 """
-Support for functionality to interact with FireTV devices.
+Support for functionality to interact with Android TV devices.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/media_player.firetv/
+https://home-assistant.io/components/media_player.androidtv/
 """

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -1,0 +1,338 @@
+"""
+Support for functionality to interact with FireTV devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.firetv/
+"""
+import functools
+import logging
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    MediaPlayerDevice, PLATFORM_SCHEMA)
+from homeassistant.components.media_player.const import (
+    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SELECT_SOURCE, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
+from homeassistant.const import (
+    ATTR_COMMAND, ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, STATE_IDLE,
+    STATE_OFF, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY)
+import homeassistant.helpers.config_validation as cv
+
+FIRETV_DOMAIN = 'firetv'
+
+REQUIREMENTS = ['firetv==1.0.9']
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_FIRETV = SUPPORT_PAUSE | SUPPORT_PLAY | \
+    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PREVIOUS_TRACK | \
+    SUPPORT_NEXT_TRACK | SUPPORT_SELECT_SOURCE | SUPPORT_STOP
+
+CONF_ADBKEY = 'adbkey'
+CONF_ADB_SERVER_IP = 'adb_server_ip'
+CONF_ADB_SERVER_PORT = 'adb_server_port'
+CONF_APPS = 'apps'
+CONF_GET_SOURCES = 'get_sources'
+
+DEFAULT_NAME = 'Amazon Fire TV'
+DEFAULT_PORT = 5555
+DEFAULT_ADB_SERVER_PORT = 5037
+DEFAULT_GET_SOURCES = True
+DEFAULT_APPS = {}
+
+SERVICE_ADB_COMMAND = 'adb_command'
+
+SERVICE_ADB_COMMAND_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_COMMAND): cv.string,
+})
+
+
+def has_adb_files(value):
+    """Check that ADB key files exist."""
+    priv_key = value
+    pub_key = '{}.pub'.format(value)
+    cv.isfile(pub_key)
+    return cv.isfile(priv_key)
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_ADBKEY): has_adb_files,
+    vol.Optional(CONF_ADB_SERVER_IP): cv.string,
+    vol.Optional(
+        CONF_ADB_SERVER_PORT, default=DEFAULT_ADB_SERVER_PORT): cv.port,
+    vol.Optional(CONF_GET_SOURCES, default=DEFAULT_GET_SOURCES): cv.boolean,
+    vol.Optional(
+        CONF_APPS, default=DEFAULT_APPS): vol.Schema({cv.string: cv.string})
+})
+
+# Translate from `FireTV` reported state to HA state.
+FIRETV_STATES = {'off': STATE_OFF,
+                 'idle': STATE_IDLE,
+                 'standby': STATE_STANDBY,
+                 'playing': STATE_PLAYING,
+                 'paused': STATE_PAUSED}
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the FireTV platform."""
+    from firetv import FireTV
+
+    hass.data.setdefault(FIRETV_DOMAIN, {})
+
+    host = '{0}:{1}'.format(config[CONF_HOST], config[CONF_PORT])
+
+    if CONF_ADB_SERVER_IP not in config:
+        # Use "python-adb" (Python ADB implementation)
+        if CONF_ADBKEY in config:
+            ftv = FireTV(host, config[CONF_ADBKEY])
+            adb_log = " using adbkey='{0}'".format(config[CONF_ADBKEY])
+        else:
+            ftv = FireTV(host)
+            adb_log = ""
+    else:
+        # Use "pure-python-adb" (communicate with ADB server)
+        ftv = FireTV(host, adb_server_ip=config[CONF_ADB_SERVER_IP],
+                     adb_server_port=config[CONF_ADB_SERVER_PORT])
+        adb_log = " using ADB server at {0}:{1}".format(
+            config[CONF_ADB_SERVER_IP], config[CONF_ADB_SERVER_PORT])
+
+    if not ftv.available:
+        _LOGGER.warning("Could not connect to Fire TV at %s%s", host, adb_log)
+        return
+
+    name = config[CONF_NAME]
+    get_sources = config[CONF_GET_SOURCES]
+    apps = config[CONF_APPS]
+
+    if host in hass.data[FIRETV_DOMAIN]:
+        _LOGGER.warning("Platform already setup on %s, skipping", host)
+    else:
+        device = FireTVDevice(ftv, name, get_sources, apps)
+        add_entities([device])
+        _LOGGER.debug("Setup Fire TV at %s%s", host, adb_log)
+        hass.data[FIRETV_DOMAIN][host] = device
+
+    if hass.services.has_service(FIRETV_DOMAIN, SERVICE_ADB_COMMAND):
+        return
+
+    def service_adb_command(service):
+        """Dispatch service calls to target entities."""
+        cmd = service.data.get(ATTR_COMMAND)
+        entity_id = service.data.get(ATTR_ENTITY_ID)
+        target_devices = [dev for dev in hass.data[FIRETV_DOMAIN].values()
+                          if dev.entity_id in entity_id]
+
+        for target_device in target_devices:
+            output = target_device.adb_command(cmd)
+
+            # log the output if there is any
+            if output:
+                _LOGGER.info("Output of command '%s' from '%s': %s",
+                             cmd, target_device.entity_id, repr(output))
+
+    hass.services.register(FIRETV_DOMAIN, SERVICE_ADB_COMMAND,
+                           service_adb_command,
+                           schema=SERVICE_ADB_COMMAND_SCHEMA)
+
+
+def adb_decorator(override_available=False):
+    """Send an ADB command if the device is available and catch exceptions."""
+    def _adb_decorator(func):
+        """Wait if previous ADB commands haven't finished."""
+        @functools.wraps(func)
+        def _adb_exception_catcher(self, *args, **kwargs):
+            # If the device is unavailable, don't do anything
+            if not self.available and not override_available:
+                return None
+
+            try:
+                return func(self, *args, **kwargs)
+            except self.exceptions as err:
+                _LOGGER.error(
+                    "Failed to execute an ADB command. ADB connection re-"
+                    "establishing attempt in the next update. Error: %s", err)
+                self._available = False  # pylint: disable=protected-access
+                return None
+
+        return _adb_exception_catcher
+
+    return _adb_decorator
+
+
+class FireTVDevice(MediaPlayerDevice):
+    """Representation of an Amazon Fire TV device on the network."""
+
+    def __init__(self, ftv, name, get_sources, apps):
+        """Initialize the FireTV device."""
+        from firetv import APPS, KEYS
+        self.apps = APPS
+        self.keys = KEYS
+
+        self.apps.update(apps)
+
+        self.firetv = ftv
+
+        self._name = name
+        self._get_sources = get_sources
+
+        # ADB exceptions to catch
+        if not self.firetv.adb_server_ip:
+            # Using "python-adb" (Python ADB implementation)
+            from adb.adb_protocol import (InvalidChecksumError,
+                                          InvalidCommandError,
+                                          InvalidResponseError)
+            from adb.usb_exceptions import TcpTimeoutException
+
+            self.exceptions = (AttributeError, BrokenPipeError, TypeError,
+                               ValueError, InvalidChecksumError,
+                               InvalidCommandError, InvalidResponseError,
+                               TcpTimeoutException)
+        else:
+            # Using "pure-python-adb" (communicate with ADB server)
+            self.exceptions = (ConnectionResetError,)
+
+        self._state = None
+        self._available = self.firetv.available
+        self._current_app = None
+        self._running_apps = None
+
+    @property
+    def name(self):
+        """Return the device name."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Device should be polled."""
+        return True
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_FIRETV
+
+    @property
+    def state(self):
+        """Return the state of the player."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return whether or not the ADB connection is valid."""
+        return self._available
+
+    @property
+    def app_id(self):
+        """Return the current app."""
+        return self._current_app
+
+    @property
+    def app_name(self):
+        """Return the friendly name of the current app."""
+        return self.apps.get(self._current_app, self._current_app)
+
+    @property
+    def source(self):
+        """Return the current app."""
+        return self._current_app
+
+    @property
+    def source_list(self):
+        """Return a list of running apps."""
+        return self._running_apps
+
+    @adb_decorator(override_available=True)
+    def update(self):
+        """Update the device state and, if necessary, re-connect."""
+        # Check if device is disconnected.
+        if not self._available:
+            # Try to connect
+            self._available = self.firetv.connect()
+
+            # To be safe, wait until the next update to run ADB commands.
+            return
+
+        # If the ADB connection is not intact, don't update.
+        if not self._available:
+            return
+
+        # Get the `state`, `current_app`, and `running_apps`.
+        ftv_state, self._current_app, self._running_apps = \
+            self.firetv.update(self._get_sources)
+
+        self._state = FIRETV_STATES[ftv_state]
+
+    @adb_decorator()
+    def turn_on(self):
+        """Turn on the device."""
+        self.firetv.turn_on()
+
+    @adb_decorator()
+    def turn_off(self):
+        """Turn off the device."""
+        self.firetv.turn_off()
+
+    @adb_decorator()
+    def media_play(self):
+        """Send play command."""
+        self.firetv.media_play()
+
+    @adb_decorator()
+    def media_pause(self):
+        """Send pause command."""
+        self.firetv.media_pause()
+
+    @adb_decorator()
+    def media_play_pause(self):
+        """Send play/pause command."""
+        self.firetv.media_play_pause()
+
+    @adb_decorator()
+    def media_stop(self):
+        """Send stop (back) command."""
+        self.firetv.back()
+
+    @adb_decorator()
+    def volume_up(self):
+        """Send volume up command."""
+        self.firetv.volume_up()
+
+    @adb_decorator()
+    def volume_down(self):
+        """Send volume down command."""
+        self.firetv.volume_down()
+
+    @adb_decorator()
+    def media_previous_track(self):
+        """Send previous track command (results in rewind)."""
+        self.firetv.media_previous()
+
+    @adb_decorator()
+    def media_next_track(self):
+        """Send next track command (results in fast-forward)."""
+        self.firetv.media_next()
+
+    @adb_decorator()
+    def select_source(self, source):
+        """Select input source.
+
+        If the source starts with a '!', then it will close the app instead of
+        opening it.
+        """
+        if isinstance(source, str):
+            if not source.startswith('!'):
+                self.firetv.launch_app(source)
+            else:
+                self.firetv.stop_app(source[1:].lstrip())
+
+    @adb_decorator()
+    def adb_command(self, cmd):
+        """Send an ADB command to a Fire TV device."""
+        key = self.keys.get(cmd)
+        if key:
+            return self.firetv.adb_shell('input keyevent {}'.format(key))
+        return self.firetv.adb_shell(cmd)

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -217,6 +217,11 @@ class AndroidTVDevice(MediaPlayerDevice):
         return SUPPORT_ANDROIDTV
 
     @property
+    def unique_id(self):
+        """Return the device unique id."""
+        return self._unique_id
+
+    @property
     def state(self):
         """Return the state of the player."""
         return self._state

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -262,7 +262,7 @@ class AndroidTVDevice(MediaPlayerDevice):
         # Check if device is disconnected.
         if not self._available:
             # Try to connect
-            self._available = self.androidtv.connect()
+            self._available = self.androidtv.connect(always_log_errors=False)
 
             # To be safe, wait until the next update to run ADB commands.
             return

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -21,7 +21,7 @@ import homeassistant.helpers.config_validation as cv
 
 ANDROIDTV_DOMAIN = 'androidtv'
 
-REQUIREMENTS = ['androidtv==0.0.8']
+REQUIREMENTS = ['androidtv==0.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/androidtv/services.yaml
+++ b/homeassistant/components/androidtv/services.yaml
@@ -1,0 +1,11 @@
+# Describes the format for available Fire TV services
+
+adb_command:
+  description: Send an ADB command to a Fire TV device.
+  fields:
+    entity_id:
+      description: Name(s) of Fire TV entities.
+      example: 'media_player.fire_tv_living_room'
+    command:
+      description: Either a key command or an ADB shell command.
+      example: 'HOME'

--- a/homeassistant/components/androidtv/services.yaml
+++ b/homeassistant/components/androidtv/services.yaml
@@ -1,11 +1,11 @@
-# Describes the format for available Fire TV services
+# Describes the format for available Android TV services
 
 adb_command:
-  description: Send an ADB command to a Fire TV device.
+  description: Send an ADB command to an Android TV device.
   fields:
     entity_id:
-      description: Name(s) of Fire TV entities.
-      example: 'media_player.fire_tv_living_room'
+      description: Name(s) of Android TV entities.
+      example: 'media_player.android_tv_living_room'
     command:
-      description: Either a key command or an ADB shell command.
+      description: Either an action or an ADB shell command.
       example: 'HOME'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -154,6 +154,9 @@ alpha_vantage==2.1.0
 # homeassistant.components.amcrest
 amcrest==1.2.3
 
+# homeassistant.components.androidtv.media_player
+androidtv==0.0.8
+
 # homeassistant.components.switch.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -155,7 +155,7 @@ alpha_vantage==2.1.0
 amcrest==1.2.3
 
 # homeassistant.components.androidtv.media_player
-androidtv==0.0.8
+androidtv==0.0.9
 
 # homeassistant.components.switch.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:

Allow for configuring Android TV devices as media players in Home Assistant.  This is almost identical to the Fire TV component.  

This builds off the work by @a1ex4 in https://github.com/home-assistant/home-assistant/pull/19157.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8829

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
media_player:
  # Use the Python ADB implementation without authentication
  - platform: androidtv
    name: Android TV 1
    host: 192.168.0.111

  # Use the Python ADB implementation with authentication
  - platform: androidtv
    name: Android TV 2
    host: 192.168.0.222
    adbkey: "/config/android/adbkey"

  # Use an ADB server for sending ADB commands
  - platform: androidtv
    name: Android TV 3
    host: 192.168.0.123
    adb_server_ip: 127.0.0.1
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
