### PR TITLE
Bump teslajsonpy to 0.0.24

### DIFF
--- a/homeassistant/components/tesla/__init__.py
+++ b/homeassistant/components/tesla/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['teslajsonpy==0.0.23']
+REQUIREMENTS = ['teslajsonpy==0.0.24']
 
 DOMAIN = 'tesla'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1674,7 +1674,7 @@ temescal==0.1
 temperusb==1.5.3
 
 # homeassistant.components.tesla
-teslajsonpy==0.0.23
+teslajsonpy==0.0.24
 
 # homeassistant.components.sensor.thermoworks_smoke
 thermoworks_smoke==0.1.8


### PR DESCRIPTION
## Description:
This updates to the newer version of teslajsonpy which now will try to wake_up the Tesla if it detects the Tesla is asleep when issuing commands. It will also retry commands to address a situation where the Tesla is awake but unable to issue the command internally.

**NOTE:** This version of teslajsonpy will not attempt to wake sleeping Tesla vehicles for standard updates to conserve battery.  This means HA state will not update until the car is detected as awake. 
 The prior release would potentially wake vehicles resulting in potential phantom drain particularly for users who were not charging daily.  In addition, Tesla implements certain deep sleep algorithms which would be prevented by constant updates.  We will monitor the issues to see if this results in any major complaints from users to see if we need to expose a manual wake_up service.

**Related issue (if applicable):** fixes #17272

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
Not applicable as no functional changes to component code.

## Example entry for `configuration.yaml` (if applicable):
Not applicable as no functional changes to component code.
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
Not applicable as no functional changes to component code.

  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
