### PR TITLE
Allow 202 status code as a successful REST notify response

### DIFF
--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -112,7 +112,7 @@ class RestNotificationService(BaseNotificationService):
             response = requests.get(self._resource, headers=self._headers,
                                     params=data, timeout=10)
 
-        if response.status_code not in (200, 201):
+        if response.status_code not in (200, 201, 202):
             _LOGGER.exception(
                 "Error sending message. Response %d: %s:",
                 response.status_code, response.reason)


### PR DESCRIPTION
## Description:

The REST notification component only allows 200 + 201 as a successful response code to the 
submission. notify.me returns a 202 (Accepted) response, which works fine but gets logged as a warning in the log. Update the allowed statuses to treat the 202 as ok.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
