### PR TITLE
Add WS subscription command for MQTT

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -1080,7 +1080,7 @@ async def websocket_subscribe(hass, connection, msg):
             'qos': qos,
         }))
 
-    connection.event_listeners[msg['id']] = await async_subscribe(
+    connection.subscriptions[msg['id']] = await async_subscribe(
         hass, msg['topic'], forward_messages)
 
     connection.send_message(websocket_api.result_message(msg['id']))

--- a/homeassistant/components/websocket_api/__init__.py
+++ b/homeassistant/components/websocket_api/__init__.py
@@ -14,6 +14,7 @@ ActiveConnection = connection.ActiveConnection
 BASE_COMMAND_MESSAGE_SCHEMA = messages.BASE_COMMAND_MESSAGE_SCHEMA
 error_message = messages.error_message
 result_message = messages.result_message
+event_message = messages.event_message
 async_response = decorators.async_response
 require_admin = decorators.require_admin
 ws_require_user = decorators.ws_require_user

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -54,7 +54,7 @@ def handle_subscribe_events(hass, connection, msg):
             msg['id'], event.as_dict()
         ))
 
-    connection.event_listeners[msg['id']] = hass.bus.async_listen(
+    connection.subscriptions[msg['id']] = hass.bus.async_listen(
         msg['event_type'], forward_events)
 
     connection.send_message(messages.result_message(msg['id']))
@@ -72,8 +72,8 @@ def handle_unsubscribe_events(hass, connection, msg):
     """
     subscription = msg['subscription']
 
-    if subscription in connection.event_listeners:
-        connection.event_listeners.pop(subscription)()
+    if subscription in connection.subscriptions:
+        connection.subscriptions.pop(subscription)()
         connection.send_message(messages.result_message(msg['id']))
     else:
         connection.send_message(messages.error_message(

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -24,15 +24,6 @@ def async_register_commands(hass):
     async_reg(handle_ping)
 
 
-def event_message(iden, event):
-    """Return an event message."""
-    return {
-        'id': iden,
-        'type': 'event',
-        'event': event.as_dict(),
-    }
-
-
 def pong_message(iden):
     """Return a pong message."""
     return {
@@ -59,7 +50,9 @@ def handle_subscribe_events(hass, connection, msg):
         if event.event_type == EVENT_TIME_CHANGED:
             return
 
-        connection.send_message(event_message(msg['id'], event))
+        connection.send_message(messages.event_message(
+            msg['id'], event.as_dict()
+        ))
 
     connection.event_listeners[msg['id']] = hass.bus.async_listen(
         msg['event_type'], forward_events)

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -21,7 +21,7 @@ class ActiveConnection:
         else:
             self.refresh_token_id = None
 
-        self.event_listeners = {}
+        self.subscriptions = {}
         self.last_id = 0
 
     def context(self, msg):
@@ -82,7 +82,7 @@ class ActiveConnection:
     @callback
     def async_close(self):
         """Close down connection."""
-        for unsub in self.event_listeners.values():
+        for unsub in self.subscriptions.values():
             unsub()
 
     @callback

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -40,3 +40,12 @@ def error_message(iden, code, message):
             'message': message,
         },
     }
+
+
+def event_message(iden, event):
+    """Return an event message."""
+    return {
+        'id': iden,
+        'type': 'event',
+        'event': event,
+    }

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -767,3 +767,38 @@ async def test_message_callback_exception_gets_logged(hass, caplog):
     assert \
         "Exception in bad_handler when handling msg on 'test-topic':" \
         " 'test'" in caplog.text
+
+
+async def test_mqtt_ws_subscription(hass, hass_ws_client):
+    """Test MQTT websocket subscription."""
+    await async_mock_mqtt_component(hass)
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        'id': 5,
+        'type': 'mqtt/subscribe',
+        'topic': 'test-topic',
+    })
+    response = await client.receive_json()
+
+    assert response['success']
+
+    async_fire_mqtt_message(hass, 'test-topic', 'test1')
+    async_fire_mqtt_message(hass, 'test-topic', 'test2')
+
+    response = await client.receive_json()
+    assert response['event']['topic'] == 'test-topic'
+    assert response['event']['payload'] == 'test1'
+
+    response = await client.receive_json()
+    assert response['event']['topic'] == 'test-topic'
+    assert response['event']['payload'] == 'test2'
+
+    # Unsubscribe
+    await client.send_json({
+        'id': 8,
+        'type': 'unsubscribe_events',
+        'subscription': 5,
+    })
+    response = await client.receive_json()
+    assert response['success']

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -780,7 +780,6 @@ async def test_mqtt_ws_subscription(hass, hass_ws_client):
         'topic': 'test-topic',
     })
     response = await client.receive_json()
-
     assert response['success']
 
     async_fire_mqtt_message(hass, 'test-topic', 'test1')


### PR DESCRIPTION
## Description:
Create an MQTT endpoint to allow the frontend to subscribe to MQTT topics and get it forwarded to the frontend over the websocket API.

This will power an MQTT dev panel upgrade.

To be done: 
 - [x] tests
 - [x] When we shut down Home Assistant, by the time the websocket API is handling unsubscribes of any active subscriptions, the MQTT server is already disconnected, raising the following exception:

```
2019-03-05 15:09:40 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/home-assistant/homeassistant/components/mqtt/__init__.py", line 730, in _async_unsubscribe
    _raise_on_error(result)
  File "/Users/paulus/dev/hass/home-assistant/homeassistant/components/mqtt/__init__.py", line 825, in _raise_on_error
    'Error talking to MQTT: {}'.format(mqtt.error_string(result_code)))
homeassistant.exceptions.HomeAssistantError: Error talking to MQTT: The client is not currently connected.
```


Frontend will require a new HAWS version which includes https://github.com/home-assistant/home-assistant-js-websocket/pull/85

CC @emontnemery 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
