### PR TITLE
Person schema for merge_packages #21307

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -50,7 +50,7 @@ PERSON_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    vol.Optional(DOMAIN): vol.All(cv.ensure_list, vol.Any([PERSON_SCHEMA], []))
+    vol.Optional(DOMAIN): vol.All(cv.ensure_list, vol.Any([PERSON_SCHEMA], [{}]))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()
@@ -80,6 +80,8 @@ class PersonManager:
 
         config_data = self.config_data = OrderedDict()
         for conf in config_persons:
+            if not conf:
+                continue
             person_id = conf[CONF_ID]
 
             if person_id in config_data:

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -51,7 +51,7 @@ PERSON_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     vol.Optional(DOMAIN): vol.All(
-        cv.ensure_list, vol.Any([PERSON_SCHEMA], [{}]))
+        cv.ensure_list, vol.Any([PERSON_SCHEMA], [vol.Schema({})]))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()
@@ -82,7 +82,9 @@ class PersonManager:
         config_data = self.config_data = OrderedDict()
         for conf in config_persons:
             if not conf:
+                _LOGGER.warning("log config empty")
                 continue
+            _LOGGER.warning("log config ok %s", conf)
             person_id = conf[CONF_ID]
 
             if person_id in config_data:
@@ -270,7 +272,9 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
     """Set up the person component."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     conf_persons = config.get(DOMAIN, [])
+    _LOGGER.warning(conf_persons)
     manager = hass.data[DOMAIN] = PersonManager(hass, component, conf_persons)
+    _LOGGER.warning(manager.config_data)
     await manager.async_initialize()
 
     websocket_api.async_register_command(hass, ws_list_person)

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -51,7 +51,7 @@ PERSON_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     vol.Optional(DOMAIN): vol.All(
-        cv.ensure_none, cv.ensure_list, vol.Any([PERSON_SCHEMA], []))
+        cv.ensure_list, cv.remove_falsy, vol.Any([PERSON_SCHEMA], []))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -50,7 +50,7 @@ PERSON_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    vol.Optional(DOMAIN): vol.All(cv.ensure_list, vol.Any([PERSON_SCHEMA], {}))
+    vol.Optional(DOMAIN): vol.All(cv.ensure_list, vol.Any([PERSON_SCHEMA], []))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -50,7 +50,8 @@ PERSON_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    vol.Optional(DOMAIN): vol.All(cv.ensure_list, vol.Any([PERSON_SCHEMA], [{}]))
+    vol.Optional(DOMAIN): vol.All(
+        cv.ensure_list, vol.Any([PERSON_SCHEMA], [{}]))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -50,7 +50,7 @@ PERSON_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    vol.Optional(DOMAIN): vol.Any(vol.All(cv.ensure_list, [PERSON_SCHEMA]), {})
+    vol.Optional(DOMAIN): vol.All(cv.ensure_list, vol.Any([PERSON_SCHEMA], {}))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -51,7 +51,7 @@ PERSON_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     vol.Optional(DOMAIN): vol.All(
-        cv.ensure_list, vol.Any([PERSON_SCHEMA], [vol.Schema({})]))
+        cv.ensure_none, cv.ensure_list, vol.Any([PERSON_SCHEMA], []))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()
@@ -81,10 +81,6 @@ class PersonManager:
 
         config_data = self.config_data = OrderedDict()
         for conf in config_persons:
-            if not conf:
-                _LOGGER.warning("log config empty")
-                continue
-            _LOGGER.warning("log config ok %s", conf)
             person_id = conf[CONF_ID]
 
             if person_id in config_data:
@@ -272,9 +268,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
     """Set up the person component."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     conf_persons = config.get(DOMAIN, [])
-    _LOGGER.warning(conf_persons)
     manager = hass.data[DOMAIN] = PersonManager(hass, component, conf_persons)
-    _LOGGER.warning(manager.config_data)
     await manager.async_initialize()
 
     websocket_api.async_register_command(hass, ws_list_person)

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -51,7 +51,7 @@ PERSON_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     vol.Optional(DOMAIN): vol.All(
-        cv.ensure_list, cv.remove_falsy, vol.Any([PERSON_SCHEMA], []))
+        cv.ensure_list, cv.remove_falsy, [PERSON_SCHEMA])
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -166,7 +166,7 @@ def isdir(value: Any) -> str:
 
 def ensure_list(value: Union[T, Sequence[T]]) -> Sequence[T]:
     """Wrap value in list if it is not one."""
-    if value is None:
+    if value is None or (isinstance(value, dict) and not value):
         return []
     return value if isinstance(value, list) else [value]
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -171,11 +171,6 @@ def ensure_list(value: Union[T, Sequence[T]]) -> Sequence[T]:
     return value if isinstance(value, list) else [value]
 
 
-def ensure_none(value: Any) -> Any:
-    """Ensure a falsey value is None."""
-    return value if value else None
-
-
 def entity_id(value: Any) -> str:
     """Validate Entity ID."""
     value = string(value).lower()
@@ -352,6 +347,11 @@ def positive_timedelta(value: timedelta) -> timedelta:
     if value < timedelta(0):
         raise vol.Invalid('Time period should be positive')
     return value
+
+
+def remove_falsy(value: Sequence[T]) -> Sequence[T]:
+    """Remove falsy values from a list."""
+    return [v for v in value if v]
 
 
 def service(value):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -171,6 +171,11 @@ def ensure_list(value: Union[T, Sequence[T]]) -> Sequence[T]:
     return value if isinstance(value, list) else [value]
 
 
+def ensure_none(value: Any) -> Any:
+    """Ensure a falsey value is None."""
+    return value if value else None
+
+
 def entity_id(value: Any) -> str:
     """Validate Entity ID."""
     value = string(value).lower()

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -166,7 +166,7 @@ def isdir(value: Any) -> str:
 
 def ensure_list(value: Union[T, Sequence[T]]) -> Sequence[T]:
     """Wrap value in list if it is not one."""
-    if value is None or (isinstance(value, dict) and not value):
+    if value is None:
         return []
     return value if isinstance(value, list) else [value]
 

--- a/script/inspect_schemas.py
+++ b/script/inspect_schemas.py
@@ -48,7 +48,7 @@ def main():
 
         schema_type, schema = _identify_config_schema(module)
 
-        add_msg("CONFIG_SCHEMA " + schema_type, module_name + ' ' +
+        add_msg("CONFIG_SCHEMA " + str(schema_type), module_name + ' ' +
                 color('cyan', str(schema)[:60]))
 
     for key in sorted(msg):

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,20 +1,20 @@
 """The tests for the person component."""
 from unittest.mock import Mock
 
+import pytest
+
+from homeassistant.components.device_tracker import (
+    ATTR_SOURCE_TYPE, SOURCE_TYPE_GPS, SOURCE_TYPE_ROUTER)
 from homeassistant.components.person import (
     ATTR_SOURCE, ATTR_USER_ID, DOMAIN, PersonManager)
 from homeassistant.const import (
-    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_GPS_ACCURACY,
-    STATE_UNKNOWN, EVENT_HOMEASSISTANT_START)
-from homeassistant.components.device_tracker import (
-    ATTR_SOURCE_TYPE, SOURCE_TYPE_GPS, SOURCE_TYPE_ROUTER)
+    ATTR_GPS_ACCURACY, ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE,
+    EVENT_HOMEASSISTANT_START, STATE_UNKNOWN)
 from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 
-import pytest
-
 from tests.common import (
-    mock_component, mock_restore_cache, mock_coro_func, assert_setup_component)
+    assert_setup_component, mock_component, mock_coro_func, mock_restore_cache)
 
 DEVICE_TRACKER = 'device_tracker.test_tracker'
 DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
@@ -313,7 +313,7 @@ async def test_duplicate_ids(hass, hass_admin_user):
 async def test_create_person_during_run(hass):
     """Test that person is updated if created while hass is running."""
     config = {DOMAIN: {}}
-    with assert_setup_component(1):
+    with assert_setup_component(0):
         assert await async_setup_component(hass, DOMAIN, config)
     hass.states.async_set(DEVICE_TRACKER, 'home')
     await hass.async_block_till_done()

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -13,7 +13,8 @@ from homeassistant.setup import async_setup_component
 
 import pytest
 
-from tests.common import mock_component, mock_restore_cache, mock_coro_func
+from tests.common import (
+    mock_component, mock_restore_cache, mock_coro_func, assert_setup_component)
 
 DEVICE_TRACKER = 'device_tracker.test_tracker'
 DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
@@ -44,7 +45,8 @@ def storage_setup(hass, hass_storage, hass_admin_user):
 async def test_minimal_setup(hass):
     """Test minimal config with only name."""
     config = {DOMAIN: {'id': '1234', 'name': 'test person'}}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(1):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_person')
     assert state.state == STATE_UNKNOWN
@@ -57,13 +59,15 @@ async def test_minimal_setup(hass):
 async def test_setup_no_id(hass):
     """Test config with no id."""
     config = {DOMAIN: {'name': 'test user'}}
-    assert not await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(0):
+        assert not await async_setup_component(hass, DOMAIN, config)
 
 
 async def test_setup_no_name(hass):
     """Test config with no name."""
     config = {DOMAIN: {'id': '1234'}}
-    assert not await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(0):
+        assert not await async_setup_component(hass, DOMAIN, config)
 
 
 async def test_setup_user_id(hass, hass_admin_user):
@@ -71,7 +75,8 @@ async def test_setup_user_id(hass, hass_admin_user):
     user_id = hass_admin_user.id
     config = {
         DOMAIN: {'id': '1234', 'name': 'test person', 'user_id': user_id}}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(1):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_person')
     assert state.state == STATE_UNKNOWN
@@ -88,7 +93,8 @@ async def test_valid_invalid_user_ids(hass, hass_admin_user):
     config = {DOMAIN: [
         {'id': '1234', 'name': 'test valid user', 'user_id': user_id},
         {'id': '5678', 'name': 'test bad user', 'user_id': 'bad_user_id'}]}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(2):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_valid_user')
     assert state.state == STATE_UNKNOWN
@@ -108,7 +114,8 @@ async def test_setup_tracker(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(1):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
@@ -159,7 +166,8 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(1):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
@@ -231,7 +239,8 @@ async def test_ignore_unavailable_states(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(1):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
@@ -275,7 +284,8 @@ async def test_restore_home_state(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(1):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == 'home'
@@ -292,7 +302,8 @@ async def test_duplicate_ids(hass, hass_admin_user):
     config = {DOMAIN: [
         {'id': '1234', 'name': 'test user 1'},
         {'id': '1234', 'name': 'test user 2'}]}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(2):
+        assert await async_setup_component(hass, DOMAIN, config)
 
     assert len(hass.states.async_entity_ids('person')) == 1
     assert hass.states.get('person.test_user_1') is not None
@@ -302,7 +313,8 @@ async def test_duplicate_ids(hass, hass_admin_user):
 async def test_create_person_during_run(hass):
     """Test that person is updated if created while hass is running."""
     config = {DOMAIN: {}}
-    assert await async_setup_component(hass, DOMAIN, config)
+    with assert_setup_component(1):
+        assert await async_setup_component(hass, DOMAIN, config)
     hass.states.async_set(DEVICE_TRACKER, 'home')
     await hass.async_block_till_done()
 

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,20 +1,19 @@
 """The tests for the person component."""
 from unittest.mock import Mock
 
-import pytest
-
-from homeassistant.components.device_tracker import (
-    ATTR_SOURCE_TYPE, SOURCE_TYPE_GPS, SOURCE_TYPE_ROUTER)
 from homeassistant.components.person import (
     ATTR_SOURCE, ATTR_USER_ID, DOMAIN, PersonManager)
 from homeassistant.const import (
-    ATTR_GPS_ACCURACY, ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE,
-    EVENT_HOMEASSISTANT_START, STATE_UNKNOWN)
+    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_GPS_ACCURACY,
+    STATE_UNKNOWN, EVENT_HOMEASSISTANT_START)
+from homeassistant.components.device_tracker import (
+    ATTR_SOURCE_TYPE, SOURCE_TYPE_GPS, SOURCE_TYPE_ROUTER)
 from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    assert_setup_component, mock_component, mock_coro_func, mock_restore_cache)
+import pytest
+
+from tests.common import mock_component, mock_restore_cache, mock_coro_func
 
 DEVICE_TRACKER = 'device_tracker.test_tracker'
 DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
@@ -45,8 +44,7 @@ def storage_setup(hass, hass_storage, hass_admin_user):
 async def test_minimal_setup(hass):
     """Test minimal config with only name."""
     config = {DOMAIN: {'id': '1234', 'name': 'test person'}}
-    with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_person')
     assert state.state == STATE_UNKNOWN
@@ -59,15 +57,13 @@ async def test_minimal_setup(hass):
 async def test_setup_no_id(hass):
     """Test config with no id."""
     config = {DOMAIN: {'name': 'test user'}}
-    with assert_setup_component(0):
-        assert not await async_setup_component(hass, DOMAIN, config)
+    assert not await async_setup_component(hass, DOMAIN, config)
 
 
 async def test_setup_no_name(hass):
     """Test config with no name."""
     config = {DOMAIN: {'id': '1234'}}
-    with assert_setup_component(0):
-        assert not await async_setup_component(hass, DOMAIN, config)
+    assert not await async_setup_component(hass, DOMAIN, config)
 
 
 async def test_setup_user_id(hass, hass_admin_user):
@@ -75,8 +71,7 @@ async def test_setup_user_id(hass, hass_admin_user):
     user_id = hass_admin_user.id
     config = {
         DOMAIN: {'id': '1234', 'name': 'test person', 'user_id': user_id}}
-    with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_person')
     assert state.state == STATE_UNKNOWN
@@ -93,8 +88,7 @@ async def test_valid_invalid_user_ids(hass, hass_admin_user):
     config = {DOMAIN: [
         {'id': '1234', 'name': 'test valid user', 'user_id': user_id},
         {'id': '5678', 'name': 'test bad user', 'user_id': 'bad_user_id'}]}
-    with assert_setup_component(2):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_valid_user')
     assert state.state == STATE_UNKNOWN
@@ -114,8 +108,7 @@ async def test_setup_tracker(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
-    with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
@@ -166,8 +159,7 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
-    with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
@@ -239,8 +231,7 @@ async def test_ignore_unavailable_states(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
-    with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
@@ -284,8 +275,7 @@ async def test_restore_home_state(hass, hass_admin_user):
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
-    with assert_setup_component(1):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == 'home'
@@ -302,8 +292,7 @@ async def test_duplicate_ids(hass, hass_admin_user):
     config = {DOMAIN: [
         {'id': '1234', 'name': 'test user 1'},
         {'id': '1234', 'name': 'test user 2'}]}
-    with assert_setup_component(2):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
 
     assert len(hass.states.async_entity_ids('person')) == 1
     assert hass.states.get('person.test_user_1') is not None
@@ -313,8 +302,7 @@ async def test_duplicate_ids(hass, hass_admin_user):
 async def test_create_person_during_run(hass):
     """Test that person is updated if created while hass is running."""
     config = {DOMAIN: {}}
-    with assert_setup_component(0):
-        assert await async_setup_component(hass, DOMAIN, config)
+    assert await async_setup_component(hass, DOMAIN, config)
     hass.states.async_set(DEVICE_TRACKER, 'home')
     await hass.async_block_till_done()
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1,15 +1,15 @@
 """Test config validators."""
-from datetime import timedelta, datetime, date
+from datetime import date, datetime, timedelta
 import enum
 import os
 from socket import _GLOBAL_DEFAULT_TIMEOUT
 from unittest.mock import Mock, patch
 import uuid
 
-import homeassistant
 import pytest
 import voluptuous as vol
 
+import homeassistant
 import homeassistant.helpers.config_validation as cv
 
 
@@ -289,6 +289,11 @@ def test_time_period():
     assert timedelta(seconds=180) == schema('180')
     assert timedelta(hours=23, minutes=59) == schema('23:59')
     assert -1 * timedelta(hours=1, minutes=15) == schema('-1:15')
+
+
+def test_remove_falsy():
+    """Test remove falsy."""
+    assert cv.remove_falsy([0, None, 1, "1", {}, [], ""]) == [1, "1"]
 
 
 def test_service():
@@ -908,7 +913,7 @@ def test_matches_regex():
         schema("  nrtd   ")
 
     test_str = "This is a test including uiae."
-    assert (schema(test_str) == test_str)
+    assert schema(test_str) == test_str
 
 
 def test_is_regex():
@@ -982,6 +987,6 @@ def test_uuid4_hex(caplog):
         # the 17th char should be 8-a
         schema('a03d31b22eee4acc7b90eec40be6ed23')
 
-    hex = uuid.uuid4().hex
-    assert schema(hex) == hex
-    assert schema(hex.upper()) == hex
+    _hex = uuid.uuid4().hex
+    assert schema(_hex) == _hex
+    assert schema(_hex.upper()) == _hex


### PR DESCRIPTION
## Description:
Change person schema to always be a list. Skip an empty `{}` dict

**Related issue (if applicable):** fixes #21307

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `lazytox`
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

