### PR TITLE
Update tellduslive state in actuator methods

### DIFF
--- a/homeassistant/components/tellduslive/cover.py
+++ b/homeassistant/components/tellduslive/cover.py
@@ -44,11 +44,14 @@ class TelldusLiveCover(TelldusLiveEntity, CoverDevice):
     def close_cover(self, **kwargs):
         """Close the cover."""
         self.device.down()
+        self._update_callback()
 
     def open_cover(self, **kwargs):
         """Open the cover."""
         self.device.up()
+        self._update_callback()
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
         self.device.stop()
+        self._update_callback()

--- a/homeassistant/components/tellduslive/light.py
+++ b/homeassistant/components/tellduslive/light.py
@@ -45,6 +45,7 @@ class TelldusLiveLight(TelldusLiveEntity, Light):
     def changed(self):
         """Define a property of the device that might have changed."""
         self._last_brightness = self.brightness
+        self._update_callback()
 
     @property
     def brightness(self):

--- a/homeassistant/components/tellduslive/switch.py
+++ b/homeassistant/components/tellduslive/switch.py
@@ -44,7 +44,9 @@ class TelldusLiveSwitch(TelldusLiveEntity, ToggleEntity):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self.device.turn_on()
+        self._update_callback()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         self.device.turn_off()
+        self._update_callback()


### PR DESCRIPTION
## Description:

#18780 removed `self.schedule_update_ha_state()` after a entity is toggled, that made HA think that the device still had the old value. I.e., when toggling a switch the switch changes state and then goes back to the old state (until the next scheduled update), this fixes that https://github.com/home-assistant/home-assistant/issues/20169#issuecomment-469895841.
 
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
