### PR TITLE
Upgrade toonapilib to 3.2.1

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -16,7 +16,7 @@ from .const import (
     CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_DISPLAY, CONF_TENANT,
     DATA_TOON_CLIENT, DATA_TOON_CONFIG, DOMAIN)
 
-REQUIREMENTS = ['toonapilib==3.1.0']
+REQUIREMENTS = ['toonapilib==3.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1689,7 +1689,7 @@ tikteck==0.4
 todoist-python==7.0.17
 
 # homeassistant.components.toon
-toonapilib==3.1.0
+toonapilib==3.2.1
 
 # homeassistant.components.alarm_control_panel.totalconnect
 total_connect_client==0.22

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -295,7 +295,7 @@ srpenergy==1.0.5
 statsd==3.2.1
 
 # homeassistant.components.toon
-toonapilib==3.1.0
+toonapilib==3.2.1
 
 # homeassistant.components.camera.uvc
 uvcclient==0.11.0


### PR DESCRIPTION
## Description:

Installing `toonapilib` into a virtual environment added files to the current directory that didn't belong there.

Has been fixed in v3.2.1 by the author of the `toonapilib` (@costastf) as reported by @balloob in costastf/toonapilib#30.

I've tested it in a separate venv to ensure it fixes the issue and also tested all functionality of the component to ensure its working. Tox passes locally.

https://github.com/costastf/toonapilib/blob/master/HISTORY.rst#321-06-03-2019

**Related issue (if applicable):** fixes #21700

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
toon:
  client_id: fxiyXLtFfhimADJlmFjTjXdHoxZ8AFg7
  client_secret: kPUCx88CTCSMAaBA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
