### PR TITLE
Synology sensor quick return if attr is null

### DIFF
--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -230,7 +230,7 @@ class SynoNasStorageSensor(SynoNasSensor):
                 attr = getattr(
                     self._api.storage, self.var_id)(self.monitor_device)
                
-                if attr == None:
+                if attr is None:
                     return None
 
                 if self._api.temp_unit == TEMP_CELSIUS:

--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -229,6 +229,9 @@ class SynoNasStorageSensor(SynoNasSensor):
             if self.var_id in temp_sensors:
                 attr = getattr(
                     self._api.storage, self.var_id)(self.monitor_device)
+               
+                if attr == None:
+                    return None
 
                 if self._api.temp_unit == TEMP_CELSIUS:
                     return attr

--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -229,7 +229,7 @@ class SynoNasStorageSensor(SynoNasSensor):
             if self.var_id in temp_sensors:
                 attr = getattr(
                     self._api.storage, self.var_id)(self.monitor_device)
-               
+
                 if attr is None:
                     return None
 


### PR DESCRIPTION
## Description:
There are some case where attr is null. Returning null doesn't change anything (in my case this is mapped to a volume that doesn't exist, not sure what others are seeing). 

If you have confirmed you hass instance for C instead of F you do not see this error since in the C case you indirectly do the quick return and don't try to convert a None value.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

