### PR TITLE
Add Freebox switch platform

### DIFF
--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -1,6 +1,5 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 import logging
-from datetime import timedelta
 import socket
 
 import voluptuous as vol

--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -25,6 +25,7 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
+
 async def async_setup(hass, config):
     """Set up the Freebox component."""
     conf = config.get(DOMAIN)

--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -1,15 +1,16 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
 import logging
+from datetime import timedelta
 import socket
 
 import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_FREEBOX
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
-from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers import config_validation as cv, discovery, dispatcher
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['aiofreepybox==0.0.6']
+REQUIREMENTS = ['aiofreepybox==0.0.7']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +26,7 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
+SCAN_INTERVAL = timedelta(minutes=1)
 
 async def async_setup(hass, config):
     """Set up the Freebox component."""
@@ -78,6 +80,8 @@ async def async_setup_freebox(hass, config, host, port):
             hass, 'sensor', DOMAIN, {}, config))
         hass.async_create_task(async_load_platform(
             hass, 'device_tracker', DOMAIN, {}, config))
+        hass.async_create_task(async_load_platform(
+            hass, 'switch', DOMAIN, {}, config))
 
         async def close_fbx(event):
             """Close Freebox connection on HA Stop."""

--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_FREEBOX
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
-from homeassistant.helpers import config_validation as cv, discovery, dispatcher
+from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.discovery import async_load_platform
 
 REQUIREMENTS = ['aiofreepybox==0.0.7']

--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -25,8 +25,6 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
-SCAN_INTERVAL = timedelta(minutes=1)
-
 async def async_setup(hass, config):
     """Set up the Freebox component."""
     conf = config.get(DOMAIN)

--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['aiofreepybox==0.0.7']
+REQUIREMENTS = ['aiofreepybox==0.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ async def async_setup_freebox(hass, config, host, port):
         }
 
     token_file = hass.config.path(FREEBOX_CONFIG_FILE)
-    api_version = 'v1'
+    api_version = 'v4'
 
     fbx = Freepybox(
         app_desc=app_desc,

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,0 +1,68 @@
+"""
+Support for Freebox devices (Freebox v6 and Freebox mini 4K).
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/switch.freebox/
+"""
+import logging
+
+from homeassistant.components.freebox import DATA_FREEBOX
+from homeassistant.components.switch import SwitchDevice
+
+DEPENDENCIES = ['freebox']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up the switch."""
+    fbx = hass.data[DATA_FREEBOX]
+    async_add_entities([FbxWifiSwitch(fbx)], True)
+
+
+class FbxWifiSwitch(SwitchDevice):
+    """Representation of a freebox wifi switch."""
+
+    def __init__(self, fbx):
+        """Initilize the Wifi switch."""
+        self._name = 'Freebox WiFi'
+        self._state = None
+        self._fbx = fbx
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    async def _async_set_state(self, enabled):
+        """Turn the switch on or off."""
+        from aiofreepybox.exceptions import InsufficientPermissionsError
+
+        wifi_config = {"enabled": enabled}
+        try:
+            await self._fbx.wifi.set_global_config(wifi_config)
+        except InsufficientPermissionsError:
+            _LOGGER.warning('Home Assistant does not have permissions to'
+                            ' modify the Freebox settings. Please refer'
+                            ' to documentation. https://home-assistant.'
+                            '.io/components/switch.freebox/')
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self._async_set_state(True)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self._async_set_state(False)
+
+    async def async_update(self):
+        """Get the state and update it."""
+        datas = await self._fbx.wifi.get_global_config()
+        active = datas['enabled']
+        self._state = bool(active)

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,6 +1,4 @@
-"""
-Support for Freebox devices (Freebox Delta, Freebox v6 and Freebox mini 4K).
-"""
+"""Support for Freebox Delta, Revolution and Mini 4K."""
 import logging
 
 from homeassistant.components.freebox import DATA_FREEBOX

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,8 +1,5 @@
 """
-Support for Freebox devices (Freebox v6 and Freebox mini 4K).
-
-For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/switch.freebox/
+Support for Freebox devices (Freebox Delta, Freebox v6 and Freebox mini 4K).
 """
 import logging
 

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -45,8 +45,7 @@ class FbxWifiSwitch(SwitchDevice):
         except InsufficientPermissionsError:
             _LOGGER.warning('Home Assistant does not have permissions to'
                             ' modify the Freebox settings. Please refer'
-                            ' to documentation. https://home-assistant.'
-                            '.io/components/switch.freebox/')
+                            ' to documentation.')
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,8 +1,9 @@
 """Support for Freebox Delta, Revolution and Mini 4K."""
 import logging
 
-from . import DATA_FREEBOX
 from homeassistant.components.switch import SwitchDevice
+
+from . import DATA_FREEBOX
 
 DEPENDENCIES = ['freebox']
 

--- a/homeassistant/components/freebox/switch.py
+++ b/homeassistant/components/freebox/switch.py
@@ -1,7 +1,7 @@
 """Support for Freebox Delta, Revolution and Mini 4K."""
 import logging
 
-from homeassistant.components.freebox import DATA_FREEBOX
+from . import DATA_FREEBOX
 from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['freebox']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -109,7 +109,7 @@ aiodns==1.1.1
 aioesphomeapi==1.6.0
 
 # homeassistant.components.freebox
-aiofreepybox==0.0.6
+aiofreepybox==0.0.7
 
 # homeassistant.components.camera.yi
 aioftp==0.12.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -109,7 +109,7 @@ aiodns==1.1.1
 aioesphomeapi==1.6.0
 
 # homeassistant.components.freebox
-aiofreepybox==0.0.7
+aiofreepybox==0.0.8
 
 # homeassistant.components.camera.yi
 aioftp==0.12.0


### PR DESCRIPTION
## Description:
Since the old PR was going crazy with a lot of versions between my local branch and the actual HA branch. This PR is up to date.

This will add a switch to control WiFi on Freebox routers.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8843

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
