### PR TITLE
Allow inverting netdata sensor values

### DIFF
--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -26,6 +26,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 CONF_DATA_GROUP = 'data_group'
 CONF_ELEMENT = 'element'
+CONF_INVERT = 'invert'
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_NAME = 'Netdata'
@@ -37,6 +38,7 @@ RESOURCE_SCHEMA = vol.Any({
     vol.Required(CONF_DATA_GROUP): cv.string,
     vol.Required(CONF_ELEMENT): cv.string,
     vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.icon,
+    vol.Optional(CONF_INVERT, default=False): cv.boolean,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -69,6 +71,7 @@ async def async_setup_platform(
         icon = data[CONF_ICON]
         sensor = data[CONF_DATA_GROUP]
         element = data[CONF_ELEMENT]
+        invert = data[CONF_INVERT]
         sensor_name = entry
         try:
             resource_data = netdata.api.metrics[sensor]
@@ -79,7 +82,7 @@ async def async_setup_platform(
             continue
 
         dev.append(NetdataSensor(
-            netdata, name, sensor, sensor_name, element, icon, unit))
+            netdata, name, sensor, sensor_name, element, icon, unit, invert))
 
     async_add_entities(dev, True)
 
@@ -88,7 +91,7 @@ class NetdataSensor(Entity):
     """Implementation of a Netdata sensor."""
 
     def __init__(
-            self, netdata, name, sensor, sensor_name, element, icon, unit):
+            self, netdata, name, sensor, sensor_name, element, icon, unit, invert):
         """Initialize the Netdata sensor."""
         self.netdata = netdata
         self._state = None
@@ -99,6 +102,7 @@ class NetdataSensor(Entity):
         self._name = name
         self._icon = icon
         self._unit_of_measurement = unit
+        self._invert = invert
 
     @property
     def name(self):
@@ -129,7 +133,7 @@ class NetdataSensor(Entity):
         """Get the latest data from Netdata REST API."""
         await self.netdata.async_update()
         resource_data = self.netdata.api.metrics.get(self._sensor)
-        self._state = round(
+        self._state = -1 if self._invert else 1 * round(
             resource_data['dimensions'][self._element]['value'], 2)
 
 

--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -91,7 +91,8 @@ class NetdataSensor(Entity):
     """Implementation of a Netdata sensor."""
 
     def __init__(
-            self, netdata, name, sensor, sensor_name, element, icon, unit, invert):
+            self, netdata, name, sensor, sensor_name, element, icon, unit,
+            invert):
         """Initialize the Netdata sensor."""
         self.netdata = netdata
         self._state = None

--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -134,8 +134,9 @@ class NetdataSensor(Entity):
         """Get the latest data from Netdata REST API."""
         await self.netdata.async_update()
         resource_data = self.netdata.api.metrics.get(self._sensor)
-        self._state = -1 if self._invert else 1 * round(
-            resource_data['dimensions'][self._element]['value'], 2)
+        self._state = round(
+            resource_data['dimensions'][self._element]['value'], 2) \
+            * (-1 if self._invert else 1)
 
 
 class NetdataData:


### PR DESCRIPTION
## Description:
Netdata returns all bandwidth related sensors as positive/negative numbers related to the interface. When you are uploading at 10Mbps, the `net.eno1 / sent` sensor it will report a speed of -10 Mbps. When you are downloading at 10Mbps, the `net.eno / received` sensor will report a speed of 10 Mbps. This is only useful when you want to put both values on a graph. For automations, graphs, ... it's counter-intuitive that the value is negative also.


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8883

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: netdata
  name: netdata-proxmox
  host: proxmox.local
  resources:
    internet_upstream:
      data_group: net.eno2
      element: sent
      icon: mdi:upload-network
      invert: true
    internet_downstream:
      data_group: net.eno2
      element: received
      icon: mdi:download-network
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
