### PR TITLE
Fix pylint warning on python 3.7.2

### DIFF
--- a/homeassistant/components/climate/eq3btsmart.py
+++ b/homeassistant/components/climate/eq3btsmart.py
@@ -184,7 +184,8 @@ class EQ3BTSmartThermostat(ClimateDevice):
 
     def update(self):
         """Update the data from the thermostat."""
-        from bluepy.btle import BTLEException  # pylint: disable=import-error
+        # pylint: disable=import-error,no-name-in-module
+        from bluepy.btle import BTLEException
         try:
             self._thermostat.update()
         except BTLEException as ex:


### PR DESCRIPTION
## Description:

Run pylint on python 3.7.2 got following error 
```
pylint homeassistant
************* Module homeassistant.components.climate.eq3btsmart
homeassistant/components/climate/eq3btsmart.py:187:8: E0611: No name 'btle' in module 'bluepy' (no-name-in-module)

------------------------------------
Your code has been rated at 10.00/10

Exited with code 2
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

