### PR TITLE
Add custom holidays to workday sensor

### DIFF
--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -50,6 +50,7 @@ DEFAULT_WORKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri']
 DEFAULT_EXCLUDES = ['sat', 'sun', 'holiday']
 DEFAULT_NAME = 'Workday Sensor'
 DEFAULT_OFFSET = 0
+DEFAULT_ADDHOLIDAYS = ['']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COUNTRY): vol.In(ALL_COUNTRIES),
@@ -60,7 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-    vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list),
+    vol.Optional(CONF_ADDHOLIDAYS, default=DEFAULT_ADDHOLIDAYS): vol.All(cv.ensure_list),
 })
 
 
@@ -95,7 +96,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                           province, country)
             return
 
-    #add custom holidays
+    # add custom holidays
     obj_holidays.append(add_holidays)
 
     _LOGGER.debug("Found the following holidays for your configuration:")

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-    vol.Optional(CONF_ADD_HOLIDAYS): vol.All(cv.ensure_list, cv.string),
+    vol.Optional(CONF_ADD_HOLIDAYS): vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -95,7 +95,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                           province, country)
             return
 
-    # add custom holidays
+    # Add custom holidays
     try:
         obj_holidays.append(add_holidays)
     except TypeError:

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -42,6 +42,7 @@ CONF_PROVINCE = 'province'
 CONF_WORKDAYS = 'workdays'
 CONF_EXCLUDES = 'excludes'
 CONF_OFFSET = 'days_offset'
+CONF_ADDHOLIDAYS = 'add_holidays'
 
 # By default, Monday - Friday are workdays
 DEFAULT_WORKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri']
@@ -59,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-	vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list),
+    vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list),
 })
 
 
@@ -93,7 +94,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             _LOGGER.error("There is no province/state %s in country %s",
                           province, country)
             return
-    
+
     #add custom holidays
     obj_holidays.append(add_holidays)
 

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-	vol.Optional(CONF_ADD_HOLIDAYS): vol.All(cv.ensure_list, cv.string),
+    vol.Optional(CONF_ADD_HOLIDAYS): vol.All(cv.ensure_list, cv.string),
 })
 
 

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -50,7 +50,6 @@ DEFAULT_WORKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri']
 DEFAULT_EXCLUDES = ['sat', 'sun', 'holiday']
 DEFAULT_NAME = 'Workday Sensor'
 DEFAULT_OFFSET = 0
-DEFAULT_ADDHOLIDAYS = ['']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COUNTRY): vol.In(ALL_COUNTRIES),
@@ -61,8 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-    vol.Optional(CONF_ADDHOLIDAYS, default=DEFAULT_ADDHOLIDAYS):
-        vol.All(cv.ensure_list),
+    vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list),
 })
 
 
@@ -98,7 +96,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             return
 
     # add custom holidays
-    obj_holidays.append(add_holidays)
+    try:
+        obj_holidays.append(add_holidays)
+    except:
+        _LOGGER.debug("No custom holidays or custom holidays were improperly formatted")
 
     _LOGGER.debug("Found the following holidays for your configuration:")
     for date, name in sorted(obj_holidays.items()):

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-    vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list),
+    vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list)
 })
 
 

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -59,6 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
+	vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list),
 })
 
 
@@ -72,6 +73,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     workdays = config.get(CONF_WORKDAYS)
     excludes = config.get(CONF_EXCLUDES)
     days_offset = config.get(CONF_OFFSET)
+    add_holidays = config.get(CONF_ADDHOLIDAYS)
 
     year = (get_date(datetime.today()) + timedelta(days=days_offset)).year
     obj_holidays = getattr(holidays, country)(years=year)
@@ -91,6 +93,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             _LOGGER.error("There is no province/state %s in country %s",
                           province, country)
             return
+    
+    #add custom holidays
+    obj_holidays.append(add_holidays)
 
     _LOGGER.debug("Found the following holidays for your configuration:")
     for date, name in sorted(obj_holidays.items()):

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -98,8 +98,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # add custom holidays
     try:
         obj_holidays.append(add_holidays)
-    except:
-        _LOGGER.debug("No custom holidays or custom holidays were improperly formatted")
+    except TypeError:
+        _LOGGER.debug("No custom holidays or invalid holidays")
 
     _LOGGER.debug("Found the following holidays for your configuration:")
     for date, name in sorted(obj_holidays.items()):

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -61,7 +61,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-    vol.Optional(CONF_ADDHOLIDAYS, default=DEFAULT_ADDHOLIDAYS): vol.All(cv.ensure_list),
+    vol.Optional(CONF_ADDHOLIDAYS, default=DEFAULT_ADDHOLIDAYS):
+        vol.All(cv.ensure_list),
 })
 
 

--- a/homeassistant/components/binary_sensor/workday.py
+++ b/homeassistant/components/binary_sensor/workday.py
@@ -42,7 +42,7 @@ CONF_PROVINCE = 'province'
 CONF_WORKDAYS = 'workdays'
 CONF_EXCLUDES = 'excludes'
 CONF_OFFSET = 'days_offset'
-CONF_ADDHOLIDAYS = 'add_holidays'
+CONF_ADD_HOLIDAYS = 'add_holidays'
 
 # By default, Monday - Friday are workdays
 DEFAULT_WORKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri']
@@ -60,7 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PROVINCE): cv.string,
     vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS):
         vol.All(cv.ensure_list, [vol.In(ALLOWED_DAYS)]),
-    vol.Optional(CONF_ADDHOLIDAYS): vol.All(cv.ensure_list)
+	vol.Optional(CONF_ADD_HOLIDAYS): vol.All(cv.ensure_list, cv.string),
 })
 
 
@@ -74,7 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     workdays = config.get(CONF_WORKDAYS)
     excludes = config.get(CONF_EXCLUDES)
     days_offset = config.get(CONF_OFFSET)
-    add_holidays = config.get(CONF_ADDHOLIDAYS)
+    add_holidays = config.get(CONF_ADD_HOLIDAYS)
 
     year = (get_date(datetime.today()) + timedelta(days=days_offset)).year
     obj_holidays = getattr(holidays, country)(years=year)


### PR DESCRIPTION
## Description:
Add custom holidays to workday sensor (such as company, personal holidays, or vacations)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8887

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
- platform: workday
  country: US
  workdays: [mon,tue,wed,thu,fri]
  excludes: [sat,sun,holiday]
  add_holidays: ['2018-12-26','2018-12-27','2018-12-28','2018-12-31']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
