### PR TITLE
Make pytest in tox quite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}
 commands =
-     pytest --timeout=9 --duration=10 {posargs}
+     pytest --timeout=9 --duration=10 -qq -o console_output_style=count -p no:sugar {posargs}
      {toxinidir}/script/check_dirty
 deps =
      -r{toxinidir}/requirements_test_all.txt
@@ -13,7 +13,7 @@ deps =
 
 [testenv:cov]
 commands =
-     pytest --timeout=9 --duration=10 --cov --cov-report= {posargs}
+     pytest --timeout=9 --duration=10 -qq -o console_output_style=count -p no:sugar --cov --cov-report= {posargs}
      {toxinidir}/script/check_dirty
 deps =
      -r{toxinidir}/requirements_test_all.txt


### PR DESCRIPTION
## Description:

Current pytest output a beautiful progress bar, it is cool watching it in term. However it is meaningless in CI environment. 

Add following options to pytest to quite the output as much as possible.

| option |  |
| --- | --- |
| `-qq` | quite and quiter |
| `-o console_output_style=count` | change default percent progress to count |
| `-p no:sugar`  | disable beautiful `pytest-sugar` plugin |

It will reduce some scrolling time I spent on finding the actual pytest error message on travis.

Reduced to 668 lines from 1200 lines of log 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

