### PR TITLE
Update honeywell.py to read current humidity for US Thermostats

### DIFF
--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -272,12 +272,12 @@ class HoneywellUSThermostat(ClimateDevice):
     def current_temperature(self):
         """Return the current temperature."""
         return self._device.current_temperature
-    
+
     @property
     def current_humidity(self):
         """Return the current humidity."""
         return self._device.current_humidity
-    
+
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""

--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -277,7 +277,7 @@ class HoneywellUSThermostat(ClimateDevice):
     def current_humidity(self):
         """Return the current humidity."""
         return self._device.current_humidity
-
+    
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""

--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -272,6 +272,11 @@ class HoneywellUSThermostat(ClimateDevice):
     def current_temperature(self):
         """Return the current temperature."""
         return self._device.current_temperature
+    
+    @property
+    def current_humidity(self):
+        """Return the current humidity."""
+        return self._device.current_humidity
 
     @property
     def target_temperature(self):


### PR DESCRIPTION
Add thermostat humidity reading available in somecomfort for US thermostats.

## Description:
This will define the current_humidity property so it can be read from somecomfort for US Honeywell Thermostats..

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
