### PR TITLE
Fix TypeError

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -351,7 +351,7 @@ class DerivativeDSMREntity(DSMREntity):
                 # Recalculate the rate
                 diff = current_reading - self._previous_reading
                 timediff = timestamp - self._previous_timestamp
-                self._state = diff / timediff * 3600
+                self._state = diff / timediff.total_seconds() * 3600
 
             self._previous_reading = current_reading
             self._previous_timestamp = timestamp

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -352,7 +352,8 @@ class DerivativeDSMREntity(DSMREntity):
                 # Recalculate the rate
                 diff = current_reading - self._previous_reading
                 timediff = timestamp - self._previous_timestamp
-                self._state = round(diff / Decimal(timediff.total_seconds()) * 3600, 3)
+                total_seconds = timediff.total_seconds()
+                self._state = round(diff / Decimal(timediff) * 3600, 3)
 
             self._previous_reading = current_reading
             self._previous_timestamp = timestamp

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/sensor.dsmr/
 """
 import asyncio
 from datetime import timedelta
-from decimal import Decimal
 from functools import partial
 import logging
 
@@ -353,7 +352,7 @@ class DerivativeDSMREntity(DSMREntity):
                 diff = current_reading - self._previous_reading
                 timediff = timestamp - self._previous_timestamp
                 total_seconds = timediff.total_seconds()
-                self._state = round(diff / Decimal(total_seconds) * 3600, 3)
+                self._state = round(float(diff) / total_seconds * 3600, 3)
 
             self._previous_reading = current_reading
             self._previous_timestamp = timestamp

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -353,7 +353,7 @@ class DerivativeDSMREntity(DSMREntity):
                 diff = current_reading - self._previous_reading
                 timediff = timestamp - self._previous_timestamp
                 total_seconds = timediff.total_seconds()
-                self._state = round(diff / Decimal(timediff) * 3600, 3)
+                self._state = round(diff / Decimal(total_seconds) * 3600, 3)
 
             self._previous_reading = current_reading
             self._previous_timestamp = timestamp

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.dsmr/
 """
 import asyncio
 from datetime import timedelta
+from decimal import Decimal
 from functools import partial
 import logging
 
@@ -351,7 +352,7 @@ class DerivativeDSMREntity(DSMREntity):
                 # Recalculate the rate
                 diff = current_reading - self._previous_reading
                 timediff = timestamp - self._previous_timestamp
-                self._state = diff / timediff.total_seconds() * 3600
+                self._state = round(diff / Decimal(timediff.total_seconds()) * 3600, 3)
 
             self._previous_reading = current_reading
             self._previous_timestamp = timestamp

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -6,13 +6,13 @@ Entity to be updated with new values.
 """
 
 import asyncio
+import datetime
 from decimal import Decimal
 from unittest.mock import Mock
 
 import asynctest
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.sensor.dsmr import DerivativeDSMREntity
-import datetime
 import pytest
 from tests.common import assert_setup_component
 
@@ -106,7 +106,7 @@ def test_derivative():
     entity.telegram = {
         '1.0.0': MBusObject([
             {'value': datetime.datetime.fromtimestamp(1551642213)},
-            {'value': 745.695, 'unit': 'm3'},
+            {'value': Decimal(745.695), 'unit': 'm3'},
         ])
     }
     yield from entity.async_update()
@@ -117,12 +117,12 @@ def test_derivative():
     entity.telegram = {
         '1.0.0': MBusObject([
             {'value': datetime.datetime.fromtimestamp(1551642543)},
-            {'value': 745.698, 'unit': 'm3'},
+            {'value': Decimal(745.698), 'unit': 'm3'},
         ])
     }
     yield from entity.async_update()
 
-    assert abs(entity.state - 0.03272) < 0.00001, \
+    assert abs(entity.state - Decimal(0.033)) < 0.00001, \
         'state should be hourly usage calculated from first and second update'
 
     assert entity.unit_of_measurement == 'm3/h'

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -122,7 +122,7 @@ def test_derivative():
     }
     yield from entity.async_update()
 
-    assert abs(entity.state - Decimal(0.033)) < 0.00001, \
+    assert abs(entity.state - 0.033) < 0.00001, \
         'state should be hourly usage calculated from first and second update'
 
     assert entity.unit_of_measurement == 'm3/h'

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 import asynctest
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.sensor.dsmr import DerivativeDSMREntity
+import datetime
 import pytest
 from tests.common import assert_setup_component
 
@@ -104,7 +105,7 @@ def test_derivative():
 
     entity.telegram = {
         '1.0.0': MBusObject([
-            {'value': 1551642213},
+            {'value': datetime.datetime.fromtimestamp(1551642213)},
             {'value': 745.695, 'unit': 'm3'},
         ])
     }
@@ -115,7 +116,7 @@ def test_derivative():
 
     entity.telegram = {
         '1.0.0': MBusObject([
-            {'value': 1551642543},
+            {'value': datetime.datetime.fromtimestamp(1551642543)},
             {'value': 745.698, 'unit': 'm3'},
         ])
     }


### PR DESCRIPTION
- convert a timedelta to int
- make sure the test inputs real timestamps

## Description:
Apparently it is not possible to divide by a timedelta.
Convert the timedelta to an int.

**Related issue (if applicable):** fixes #21730

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
