### PR TITLE
Fix botvac connected maps call as it is not a supported model

### DIFF
--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -186,10 +186,11 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self._battery_level = self._state['details']['charge']
 
         if self._robot_has_map:
-            robot_map_id = self._robot_maps[self._robot_serial][0]['id']
+            if self._state['availableServices']['maps'] != "basic-1":
+                robot_map_id = self._robot_maps[self._robot_serial][0]['id']
 
-            self._robot_boundaries = self.robot.get_map_boundaries(
-                robot_map_id).json()
+                self._robot_boundaries = self.robot.get_map_boundaries(
+                    robot_map_id).json()
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:

The botvac connected model does not support no go lines and zone cleaning even though the vacuum has a map ID which is used for zoned cleaning.  This will now ignore unsupported models so they do not receive an error.  This is the only unsupported service version according to the official docs:

https://developers.neatorobotics.com/api/robot-remote-protocol/maps

**Related issue (if applicable):** fixes #21732 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
