### PR TITLE
Fix colorlog import error

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -41,15 +41,19 @@ ERROR_STR = 'General Errors'
 
 def color(the_color, *args, reset=None):
     """Color helper."""
-    from colorlog.escape_codes import escape_codes, parse_colors
     try:
-        if not args:
-            assert reset is None, "You cannot reset if nothing being printed"
-            return parse_colors(the_color)
-        return parse_colors(the_color) + ' '.join(args) + \
-            escape_codes[reset or 'reset']
-    except KeyError as k:
-        raise ValueError("Invalid color {} in {}".format(str(k), the_color))
+        from colorlog.escape_codes import escape_codes, parse_colors
+        try:
+            if not args:
+                assert reset is None, "You cannot reset if nothing being printed"
+                return parse_colors(the_color)
+            return parse_colors(the_color) + ' '.join(args) + \
+                escape_codes[reset or 'reset']
+        except KeyError as k:
+            raise ValueError("Invalid color {} in {}".format(str(k), the_color))
+    except ImportError:
+        # We should fallback to black-and-white if colorlog is not installed
+        return ' '.join(args)
 
 
 def run(script_args: List) -> int:

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -45,12 +45,13 @@ def color(the_color, *args, reset=None):
         from colorlog.escape_codes import escape_codes, parse_colors
         try:
             if not args:
-                assert reset is None, "You cannot reset if nothing being printed"
+                assert reset is None, "Cannot reset if nothing being printed"
                 return parse_colors(the_color)
             return parse_colors(the_color) + ' '.join(args) + \
                 escape_codes[reset or 'reset']
         except KeyError as k:
-            raise ValueError("Invalid color {} in {}".format(str(k), the_color))
+            raise ValueError(
+                "Invalid color {} in {}".format(str(k), the_color))
     except ImportError:
         # We should fallback to black-and-white if colorlog is not installed
         return ' '.join(args)


### PR DESCRIPTION
## Description:

colorlog is not part of core dependency. We should ignore the import error and fallback to black and white.

Fix the side effect of #20517, cc @kellerza  

See user complain here: 
https://community.home-assistant.io/t/0-89-nissan-leaf-playstation-4-point-alarm-control-owlet-baby-monitor/103767/12

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
