### PR TITLE
Fix script load module issue

### DIFF
--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -52,15 +52,10 @@ def run(args: List) -> int:
     hass = HomeAssistant(loop)
     pkgload = PackageLoadable(hass)
     for req in getattr(script, 'REQUIREMENTS', []):
-        try:
-            loop.run_until_complete(pkgload.loadable(req))
+        if loop.run_until_complete(pkgload.loadable(req)):
             continue
-        except ImportError:
-            pass
 
-        returncode = install_package(req, **_pip_kwargs)
-
-        if not returncode:
+        if not install_package(req, **_pip_kwargs):
             print('Aborting script, could not install dependency', req)
             return 1
 

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -41,20 +41,15 @@ ERROR_STR = 'General Errors'
 
 def color(the_color, *args, reset=None):
     """Color helper."""
+    from colorlog.escape_codes import escape_codes, parse_colors
     try:
-        from colorlog.escape_codes import escape_codes, parse_colors
-        try:
-            if not args:
-                assert reset is None, "Cannot reset if nothing being printed"
-                return parse_colors(the_color)
-            return parse_colors(the_color) + ' '.join(args) + \
-                escape_codes[reset or 'reset']
-        except KeyError as k:
-            raise ValueError(
-                "Invalid color {} in {}".format(str(k), the_color))
-    except ImportError:
-        # We should fallback to black-and-white if colorlog is not installed
-        return ' '.join(args)
+        if not args:
+            assert reset is None, "You cannot reset if nothing being printed"
+            return parse_colors(the_color)
+        return parse_colors(the_color) + ' '.join(args) + \
+            escape_codes[reset or 'reset']
+    except KeyError as k:
+        raise ValueError("Invalid color {} in {}".format(str(k), the_color))
 
 
 def run(script_args: List) -> int:


### PR DESCRIPTION
## Description:

Proper fix the colorlog install issue in check_config script

To test, have some config folder contains invalid config
``` shell
> pip uninstall colorlog
> hass --script check_config -c ../ha-config
INFO:homeassistant.util.package:Attempting install of colorlog==4.0.2
Testing configuration at ...

> pip install colorlog==3.1.2
> hass --script check_config -c ../ha-config
INFO:homeassistant.util.package:Attempting install of colorlog==4.0.2
Testing configuration at

> hass --script check_config -c ../ha-config
Testing configuration at

```


**Related issue (if applicable):** reverts #21754 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
