### PR TITLE
Updated to newest pyeconet

### DIFF
--- a/homeassistant/components/water_heater/econet.py
+++ b/homeassistant/components/water_heater/econet.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyeconet==0.0.8']
+REQUIREMENTS = ['pyeconet==0.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1004,7 +1004,7 @@ pydukeenergy==0.0.6
 pyebox==1.1.4
 
 # homeassistant.components.water_heater.econet
-pyeconet==0.0.8
+pyeconet==0.0.9
 
 # homeassistant.components.switch.edimax
 pyedimax==0.1


### PR DESCRIPTION
## Description:
Updated to newest pyeconet

**Related issue (if applicable):** fixes #21742 


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
