### PR TITLE
Add Media Player component for Vizio Sound Bars

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -314,6 +314,7 @@ omit =
     homeassistant/components/media_player/squeezebox.py
     homeassistant/components/media_player/ue_smart_radio.py
     homeassistant/components/media_player/vizio.py
+    homeassistant/components/media_player/viziosoundbar.py
     homeassistant/components/media_player/vlc.py
     homeassistant/components/media_player/volumio.py
     homeassistant/components/media_player/xiaomi_tv.py

--- a/homeassistant/components/media_player/viziosoundbar.py
+++ b/homeassistant/components/media_player/viziosoundbar.py
@@ -1,0 +1,202 @@
+"""
+Vizio SmartCast SoundBar support.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.viziosoundbar/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant import util
+from homeassistant.components.media_player import (
+    MediaPlayerDevice, PLATFORM_SCHEMA)
+from homeassistant.components.media_player.const import (
+    # SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP,
+    SUPPORT_PLAY,SUPPORT_PAUSE)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON)
+from homeassistant.helpers import config_validation as cv
+
+REQUIREMENTS = ['pyviziosoundbar>=0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SUPPRESS_WARNING = 'suppress_warning'
+CONF_VOLUME_STEP = 'volume_step'
+
+DEFAULT_NAME = 'Vizio SmartCast SoundBar'
+DEFAULT_VOLUME_STEP = 1
+DEVICE_ID = 'pyviziosoundbar'
+DEVICE_NAME = 'Python Vizio Sound Bar'
+
+ICON = 'mdi:speaker'
+
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+
+SUPPORTED_COMMANDS = SUPPORT_TURN_ON | SUPPORT_TURN_OFF \
+                    | SUPPORT_SELECT_SOURCE | SUPPORT_VOLUME_MUTE \
+                    | SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_SET \
+                    | SUPPORT_PLAY | SUPPORT_PAUSE
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SUPPRESS_WARNING, default=False): cv.boolean,
+    vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP):
+        vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the VizioSoundBar media player platform."""
+    host = config.get(CONF_HOST)
+    name = config.get(CONF_NAME)
+    volume_step = config.get(CONF_VOLUME_STEP)
+
+    device = VizioSoundBarDevice(host, name, volume_step)
+    if device.validate_setup() is False:
+        _LOGGER.error("Failed to set up Vizio SoundBar platform, "
+                      "please check if host is correct")
+        return
+
+    if config.get(CONF_SUPPRESS_WARNING):
+        from requests.packages import urllib3
+        _LOGGER.warning("InsecureRequestWarning is disabled "
+                        "because of Vizio platform configuration")
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    add_entities([device], True)
+
+
+class VizioSoundBarDevice(MediaPlayerDevice):
+    """Media Player implementation which performs REST requests to SoundBar."""
+
+    def __init__(self, host, name, volume_step):
+        """Initialize Vizio device."""
+        import pyviziosoundbar
+        self._device = pyviziosoundbar.VizioSoundBar(DEVICE_ID, host, DEFAULT_NAME)
+        self._name = name
+        self._state = None
+        self._volume_level = None
+        self._volume_step = volume_step
+        self._current_input = None
+        self._available_inputs = None
+
+    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
+    def update(self):
+        """Retrieve latest state of the SoundBar."""
+        is_on = self._device.get_power_state()
+
+        if is_on:
+            self._state = STATE_ON
+
+            volume = self._device.get_current_volume()
+            if volume is not None:
+                self._volume_level = float(volume) / 32.
+
+            input_ = self._device.get_current_input()
+            if input_ is not None:
+                self._current_input = input_.meta_name
+
+            inputs = self._device.get_inputs()
+            if inputs is not None:
+                self._available_inputs = []
+                for input_ in inputs:
+                    self._available_inputs.append(input_.name)
+
+        else:
+            if is_on is None:
+                self._state = None
+            else:
+                self._state = STATE_OFF
+
+            self._volume_level = None
+            self._current_input = None
+            self._available_inputs = None
+
+    @property
+    def state(self):
+        """Return the state of the SoundBar."""
+        return self._state
+
+    @property
+    def name(self):
+        """Return the name of the SoundBar."""
+        return self._name
+
+    @property
+    def volume_level(self):
+        """Return the volume level of the SoundBar."""
+        return self._volume_level
+
+    @property
+    def source(self):
+        """Return current input of the SoundBar."""
+        return self._current_input
+
+    @property
+    def source_list(self):
+        """Return list of available inputs of the SoundBar."""
+        return self._available_inputs
+
+    @property
+    def supported_features(self):
+        """Flag SoundBar features that are supported."""
+        return SUPPORTED_COMMANDS
+
+    def turn_on(self):
+        """Turn the SoundBar player on."""
+        self._device.pow_on()
+
+    def turn_off(self):
+        """Turn the SoundBar player off."""
+        self._device.pow_off()
+
+    def mute_volume(self, mute):
+        """Mute the volume."""
+        if mute:
+            self._device.mute_on()
+        else:
+            self._device.mute_off()
+
+    # def media_previous_track(self):
+    #     """Send previous channel command."""
+    #     self._device.ch_down()
+
+    # def media_next_track(self):
+    #     """Send next channel command."""
+    #     self._device.ch_up()
+
+    def select_source(self, source):
+        """Select input source."""
+        self._device.input_switch(source)
+
+    def volume_up(self):
+        """Increasing volume of the SoundBar."""
+        self._volume_level += self._volume_step / 100.
+        self._device.vol_up(num=self._volume_step)
+
+    def volume_down(self):
+        """Decreasing volume of the SoundBar."""
+        self._volume_level -= self._volume_step / 100.
+        self._device.vol_down(num=self._volume_step)
+
+    def validate_setup(self):
+        """Validate if host is available and key is correct."""
+        return self._device.get_current_volume() is not None
+
+    def set_volume_level(self, volume):
+        """Set volume level."""
+        if self._volume_level is not None:
+            if volume > self._volume_level:
+                num = int(32*(volume - self._volume_level))
+                self._volume_level = volume
+                self._device.vol_up(num=num)
+            elif volume < self._volume_level:
+                num = int(32*(self._volume_level - volume))
+                self._volume_level = volume
+                self._device.vol_down(num=num)

--- a/homeassistant/components/media_player/viziosoundbar.py
+++ b/homeassistant/components/media_player/viziosoundbar.py
@@ -13,15 +13,14 @@ from homeassistant import util
 from homeassistant.components.media_player import (
     MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.components.media_player.const import (
-    # SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP,
-    SUPPORT_PLAY,SUPPORT_PAUSE)
+    SUPPORT_PLAY, SUPPORT_PAUSE)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON)
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pyviziosoundbar>=0.0.1']
+REQUIREMENTS = ['pyviziosoundbar==0.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -162,14 +161,6 @@ class VizioSoundBarDevice(MediaPlayerDevice):
             self._device.mute_on()
         else:
             self._device.mute_off()
-
-    # def media_previous_track(self):
-    #     """Send previous channel command."""
-    #     self._device.ch_down()
-
-    # def media_next_track(self):
-    #     """Send next channel command."""
-    #     self._device.ch_up()
 
     def select_source(self, source):
         """Select input source."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1444,6 +1444,9 @@ pyvesync_v2==0.9.6
 # homeassistant.components.media_player.vizio
 pyvizio==0.0.4
 
+# homeassistant.components.media_player.viziosoundbar
+pyviziosoundbar==0.0.1
+
 # homeassistant.components.velux
 pyvlx==0.2.9
 


### PR DESCRIPTION
## Description: I created a new media player component to support Vizio Sound Bars. It's functionally very similar to the Vizio TV component, the only difference is there is no pairing or auth process.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: viziosoundbar
    suppress_warning: 'True'
    name: Sound Bar
    host: <HOST_IP>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
