### PR TITLE
Onboarding to generate auth code

### DIFF
--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -127,6 +127,7 @@ import voluptuous as vol
 
 from homeassistant.auth.models import User, Credentials, \
     TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
+from homeassistant.loader import bind_hass
 from homeassistant.components import websocket_api
 from homeassistant.components.http import KEY_REAL_IP
 from homeassistant.components.http.auth import async_sign_path
@@ -184,9 +185,17 @@ RESULT_TYPE_USER = 'user'
 _LOGGER = logging.getLogger(__name__)
 
 
+@bind_hass
+def create_auth_code(hass, client_id: str, user: User) -> str:
+    """Create an authorization code to fetch tokens."""
+    return hass.data[DOMAIN](client_id, user)
+
+
 async def async_setup(hass, config):
     """Component to allow users to login."""
     store_result, retrieve_result = _create_auth_code_store()
+
+    hass.data[DOMAIN] = store_result
 
     hass.http.register_view(TokenView(retrieve_result))
     hass.http.register_view(LinkUserView(retrieve_result))

--- a/homeassistant/components/onboarding/__init__.py
+++ b/homeassistant/components/onboarding/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.loader import bind_hass
 
 from .const import DOMAIN, STEP_USER, STEPS
 
-DEPENDENCIES = ['http']
+DEPENDENCIES = ['auth', 'http']
 
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -74,6 +74,7 @@ class UserOnboardingView(_BaseOnboardingView):
         vol.Required('name'): str,
         vol.Required('username'): str,
         vol.Required('password'): str,
+        vol.Required('client_id'): str,
     }))
     async def post(self, request, data):
         """Return the manifest.json."""
@@ -98,7 +99,16 @@ class UserOnboardingView(_BaseOnboardingView):
                 await hass.components.person.async_create_person(
                     data['name'], user_id=user.id
                 )
+
             await self._async_mark_done(hass)
+
+            # Return an authorization code to allow fetching tokens.
+            auth_code = hass.components.auth.create_auth_code(
+                data['client_id'], user
+            )
+            return self.json({
+                'auth_code': auth_code
+            })
 
 
 @callback


### PR DESCRIPTION
## Description:
This allows onboarding to generate an authorization code to fetch refresh tokens.

This will allow us to redirect to bypass the login page when we finish onboarding. By using an authorization code, the user will get asked if they want to store their login.

Requires frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/2894

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
