### PR TITLE
Log if aiohttp hits error during IndieAuth

### DIFF
--- a/homeassistant/components/auth/indieauth.py
+++ b/homeassistant/components/auth/indieauth.py
@@ -82,7 +82,7 @@ async def fetch_redirect_uris(hass, url):
                         break
 
     except (asyncio.TimeoutError, ClientError) as ex:
-        _LOGGER.error("Error while looking up redirect_uri: %s", ex)
+        _LOGGER.error("Error while looking up redirect_uri %s: %s", url, ex)
         pass
 
     # Authorization endpoints verifying that a redirect_uri is allowed for use

--- a/homeassistant/components/auth/indieauth.py
+++ b/homeassistant/components/auth/indieauth.py
@@ -1,4 +1,5 @@
 """Helpers to resolve client ID/secret."""
+import logging
 import asyncio
 from ipaddress import ip_address
 from html.parser import HTMLParser
@@ -8,6 +9,8 @@ import aiohttp
 from aiohttp.client_exceptions import ClientError
 
 from homeassistant.util.network import is_local
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def verify_redirect_uri(hass, client_id, redirect_uri):
@@ -78,7 +81,8 @@ async def fetch_redirect_uris(hass, url):
                     if chunks == 10:
                         break
 
-    except (asyncio.TimeoutError, ClientError):
+    except (asyncio.TimeoutError, ClientError) as ex:
+        _LOGGER.error("Error while looking up redirect_uri: %s", ex)
         pass
 
     # Authorization endpoints verifying that a redirect_uri is allowed for use


### PR DESCRIPTION
So a user came to me the other day with a very interesting bug around IndieAuth. They were trying to auth with the iOS app but kept getting `invalid client_id`. I helped them through adding some debug logging around IndieAuth. We finally determined that the `client_id` lookup was entirely failing most likely due to an IPv6 issue. The error was getting eaten by this `except`-`pass` though. 

This PR adds a log error if we hit an error during `redirect_uri` lookup.

Thanks to Yeitso for identifying this issue and working with me to determine where exactly it happened.