### PR TITLE
Add program/zone enable/disable services to RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/services.yaml
+++ b/homeassistant/components/rainmachine/services.yaml
@@ -1,6 +1,30 @@
 # Describes the format for available RainMachine services
 
 ---
+disable_program:
+  description: Disable a program.
+  fields:
+    program_id:
+      description: The program to disable.
+      example: 3
+disable_zone:
+  description: Disable a zone.
+  fields:
+    zone_id:
+      description: The zone to disable.
+      example: 3
+enable_program:
+  description: Enable a program.
+  fields:
+    program_id:
+      description: The program to enable.
+      example: 3
+enable_zone:
+  description: Enable a zone.
+  fields:
+    zone_id:
+      description: The zone to enable.
+      example: 3
 pause_watering:
   description: Pause all watering for a number of seconds.
   fields:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1487,7 +1487,7 @@ raspyrfm-client==1.2.8
 recollect-waste==1.0.1
 
 # homeassistant.components.rainmachine
-regenmaschine==1.2.0
+regenmaschine==1.4.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ pyunifi==2.16
 pywebpush==1.6.0
 
 # homeassistant.components.rainmachine
-regenmaschine==1.2.0
+regenmaschine==1.4.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8


### PR DESCRIPTION
## Description:

This PR adds the ability to enable/disable RainMachine programs and zones via services.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8860

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: 192.168.1.101
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
