### PR TITLE
Add availability and next run datetime to RainMachine switches

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -19,7 +19,7 @@ from .config_flow import configured_instances
 from .const import (
     DATA_CLIENT, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN)
 
-REQUIREMENTS = ['regenmaschine==1.2.0']
+REQUIREMENTS = ['regenmaschine==1.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/switch.rainmachine/
 """
 import logging
+from datetime import datetime
 
 from homeassistant.components.rainmachine import (
     DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN, PROGRAM_UPDATE_TOPIC,
@@ -19,6 +20,7 @@ DEPENDENCIES = ['rainmachine']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_NEXT_RUN = 'next_run'
 ATTR_AREA = 'area'
 ATTR_CS_ON = 'cs_on'
 ATTR_CURRENT_CYCLE = 'current_cycle'
@@ -111,20 +113,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities = []
 
-    programs = await rainmachine.client.programs.all()
+    programs = await rainmachine.client.programs.all(include_inactive=True)
     for program in programs:
-        if not program.get('active'):
-            continue
-
-        _LOGGER.debug('Adding program: %s', program)
         entities.append(RainMachineProgram(rainmachine, program))
 
-    zones = await rainmachine.client.zones.all()
+    zones = await rainmachine.client.zones.all(include_inactive=True)
     for zone in zones:
-        if not zone.get('active'):
-            continue
-
-        _LOGGER.debug('Adding zone: %s', zone)
         entities.append(
             RainMachineZone(
                 rainmachine, zone, rainmachine.default_zone_runtime))
@@ -145,14 +139,14 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
         self._switch_type = switch_type
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return bool(self._obj.get('active'))
+
+    @property
     def icon(self) -> str:
         """Return the icon."""
         return 'mdi:water'
-
-    @property
-    def is_enabled(self) -> bool:
-        """Return whether the entity is enabled."""
-        return self._obj.get('active')
 
     @property
     def unique_id(self) -> str:
@@ -222,8 +216,17 @@ class RainMachineProgram(RainMachineSwitch):
             self._obj = await self.rainmachine.client.programs.get(
                 self._rainmachine_entity_id)
 
+            try:
+                next_run = datetime.strptime(
+                    '{0} {1}'.format(
+                        self._obj['nextRun'], self._obj['startTime']),
+                    '%Y-%m-%d %H:%M').isoformat()
+            except ValueError:
+                next_run = None
+
             self._attrs.update({
                 ATTR_ID: self._obj['uid'],
+                ATTR_NEXT_RUN: next_run,
                 ATTR_SOAK: self._obj.get('soak'),
                 ATTR_STATUS: PROGRAM_STATUS_MAP[self._obj.get('status')],
                 ATTR_ZONES: ', '.join(z['name'] for z in self.zones)
@@ -297,13 +300,13 @@ class RainMachineZone(RainMachineSwitch):
                 ATTR_CURRENT_CYCLE:
                     self._obj.get('cycle'),
                 ATTR_FIELD_CAPACITY:
-                    self._properties_json.get('waterSense')
-                    .get('fieldCapacity'),
+                    self._properties_json.get('waterSense').get(
+                        'fieldCapacity'),
                 ATTR_NO_CYCLES:
                     self._obj.get('noOfCycles'),
                 ATTR_PRECIP_RATE:
-                    self._properties_json.get('waterSense')
-                    .get('precipitationRate'),
+                    self._properties_json.get('waterSense').get(
+                        'precipitationRate'),
                 ATTR_RESTRICTIONS:
                     self._obj.get('restriction'),
                 ATTR_SLOPE:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1487,7 +1487,7 @@ raspyrfm-client==1.2.8
 recollect-waste==1.0.1
 
 # homeassistant.components.rainmachine
-regenmaschine==1.2.0
+regenmaschine==1.4.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ pyunifi==2.16
 pywebpush==1.6.0
 
 # homeassistant.components.rainmachine
-regenmaschine==1.2.0
+regenmaschine==1.4.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8


### PR DESCRIPTION
## Description:

This PR:

1. adds a `next_run` attribute (denoting the next run date/time) to program switches.
2. shows all programs and zones – inactive or active – by default. This is done in order to complement the enable/disable services proposed in https://github.com/home-assistant/home-assistant/pull/21785; previously, inactive programs/zones would not be loaded, rendering those services useless.

Note that this does not require #21785 to be merged first; either order is fine.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: 192.168.1.101
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
