### PR TITLE
Add urlbase as a configuration parameter to the sabnzbd module

### DIFF
--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -24,12 +24,15 @@ DATA_SABNZBD = 'sabznbd'
 
 _CONFIGURING = {}
 
+CONF_URLBASE = 'urlbase'
+
 ATTR_SPEED = 'speed'
-BASE_URL_FORMAT = '{}://{}:{}/'
+BASE_URL_FORMAT = '{}://{}:{}/{}'
 CONFIG_FILE = 'sabnzbd.conf'
 DEFAULT_HOST = 'localhost'
 DEFAULT_NAME = 'SABnzbd'
 DEFAULT_PORT = 8080
+DEFAULT_URLBASE = ''
 DEFAULT_SPEED_LIMIT = '100'
 DEFAULT_SSL = False
 
@@ -68,6 +71,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SENSORS):
             vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
         vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        vol.Optional(CONF_URLBASE, default=DEFAULT_URLBASE): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -91,8 +95,11 @@ async def async_configure_sabnzbd(hass, config, use_ssl, name=DEFAULT_NAME,
 
     host = config[CONF_HOST]
     port = config[CONF_PORT]
+    urlbase = config[CONF_URLBASE]
+    if urlbase:
+        urlbase = '{}/'.format(config[CONF_URLBASE].strip('/'))
     uri_scheme = 'https' if use_ssl else 'http'
-    base_url = BASE_URL_FORMAT.format(uri_scheme, host, port)
+    base_url = BASE_URL_FORMAT.format(uri_scheme, host, port, urlbase)
     if api_key is None:
         conf = await hass.async_add_job(load_json,
                                         hass.config.path(CONFIG_FILE))


### PR DESCRIPTION
This allows users of sabnzbd to use the module if their installation is exposed behind a non-standard urlbase.

## Description:
Allows users of reverse proxies to use the sabnzbd module with a custom urlbase.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8861

## Example entry for `configuration.yaml` (if applicable):
```yaml
sabnzbd:
  api_key: YOUR_API_KEY
  host: my.sabnzbd.host
  port: 443
  urlbase: /sabnzbd/
  ssl: true
  sensors:
    - current_status
    - speed
    - queue_size
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
