### PR TITLE
Fix state trigger error during group reload

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -1,7 +1,7 @@
 """Offer state listening automation rules."""
 import voluptuous as vol
 
-from homeassistant.core import callback
+from homeassistant.core import callback, Context
 from homeassistant.const import MATCH_ALL, CONF_PLATFORM, CONF_FOR
 from homeassistant.helpers.event import (
     async_track_state_change, async_track_same_state)
@@ -36,6 +36,16 @@ async def async_trigger(hass, config, action, automation_info):
         @callback
         def call_action():
             """Call action with right context."""
+            if to_s is not None:
+                context = to_s.context
+            elif from_s is not None:
+                context = Context(
+                    user_id=from_s.context.user_id,
+                    parent_id=from_s.context.id,
+                )
+            else:
+                context = Context()
+
             hass.async_run_job(action({
                 'trigger': {
                     'platform': 'state',
@@ -44,7 +54,7 @@ async def async_trigger(hass, config, action, automation_info):
                     'to_state': to_s,
                     'for': time_delta,
                 }
-            }, context=to_s.context))
+            }, context=context))
 
         # Ignore changes to state attributes if from/to is in use
         if (not match_all and from_s is not None and to_s is not None and

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -59,11 +59,19 @@ async def test_if_fires_on_entity_change(hass, calls):
     assert 'state - test.entity - hello - world - None' == \
         calls[0].data['some']
 
+    # reload a group will set state to None, is that a bug in group reload?
+    hass.states.async_set('test.entity', None, context=calls[0].context)
+    await hass.async_block_till_done()
+    assert 2 == len(calls)
+    assert calls[1].context.parent_id == calls[0].context.id
+    assert 'state - test.entity - world - None - None' == \
+        calls[1].data['some']
+
     await common.async_turn_off(hass)
     await hass.async_block_till_done()
     hass.states.async_set('test.entity', 'planet')
     await hass.async_block_till_done()
-    assert 1 == len(calls)
+    assert 2 == len(calls)
 
 
 async def test_if_fires_on_entity_change_with_from_filter(hass, calls):


### PR DESCRIPTION
## Description:

During group reload, group entity's new_state be set to None, this event trigger will raise error in the automation, see #21784 

I just fixed the context issue, I am not sure whether the None state should be set at first place.   

**Related issue (if applicable):** fixes #21784

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
