### PR TITLE
Bump loopenergy to 0.1.0

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.loader import bind_hass
 
 from .storage import async_setup_frontend_storage
 
-REQUIREMENTS = ['home-assistant-frontend==20190305.0']
+REQUIREMENTS = ['home-assistant-frontend==20190305.1']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',

--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyloopenergy==0.0.18']
+REQUIREMENTS = ['pyloopenergy==0.1.0']
 
 CONF_ELEC = 'electricity'
 CONF_GAS = 'gas'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 89
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 89
-PATCH_VERSION = '0b2'
+PATCH_VERSION = '0b3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 89
-PATCH_VERSION = '0.dev0'
+PATCH_VERSION = '0b0'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 89
-PATCH_VERSION = '0b0'
+PATCH_VERSION = '0b1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 89
-PATCH_VERSION = '0b3'
+PATCH_VERSION = '0'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 89
-PATCH_VERSION = '0b1'
+PATCH_VERSION = '0b2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -542,7 +542,7 @@ hole==0.3.0
 holidays==0.9.9
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190305.0
+home-assistant-frontend==20190305.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1126,7 +1126,7 @@ pylinky==0.3.0
 pylitejet==0.1
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.18
+pyloopenergy==0.1.0
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -120,7 +120,7 @@ hdate==0.8.7
 holidays==0.9.9
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190305.0
+home-assistant-frontend==20190305.1
 
 # homeassistant.components.homekit_controller
 homekit==0.12.2


### PR DESCRIPTION
## Description:
Loop updated their socket.io server from 0.9 to 2.0 yesterday - which stopped this component getting data. This PR switches to a new version of the pyloopenergy library which used sockedio 2.0 and works with the change loop server.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/pavoni/pyloopenergy/issues/30

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
