### PR TITLE
Bump loopenergy to 0.1.0

### DIFF
--- a/homeassistant/components/sensor/loopenergy.py
+++ b/homeassistant/components/sensor/loopenergy.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyloopenergy==0.0.18']
+REQUIREMENTS = ['pyloopenergy==0.1.0']
 
 CONF_ELEC = 'electricity'
 CONF_GAS = 'gas'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1126,7 +1126,7 @@ pylinky==0.3.0
 pylitejet==0.1
 
 # homeassistant.components.sensor.loopenergy
-pyloopenergy==0.0.18
+pyloopenergy==0.1.0
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.5.0


### PR DESCRIPTION
## Description:

Loop updated their socket.io server from 0.9 to 2.0 yesterday - which stopped this component getting data. This PR switches to a new version of the pyloopenergy library which used sockedio 2.0 and works with the change loop server.

**Related issue (if applicable):** 
https://github.com/pavoni/pyloopenergy/issues/30

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
