### PR TITLE
Add hourly forecasts to Dark Sky sensor platform

### DIFF
--- a/tests/components/darksky/test_sensor.py
+++ b/tests/components/darksky/test_sensor.py
@@ -20,6 +20,7 @@ VALID_CONFIG_MINIMAL = {
         'platform': 'darksky',
         'api_key': 'foo',
         'forecast': [1, 2],
+        'hourly_forecast': [1, 2],
         'monitored_conditions': ['summary', 'icon', 'temperature_high'],
         'scan_interval': timedelta(seconds=120),
     }
@@ -30,6 +31,7 @@ INVALID_CONFIG_MINIMAL = {
         'platform': 'darksky',
         'api_key': 'foo',
         'forecast': [1, 2],
+        'hourly_forecast': [1, 2],
         'monitored_conditions': ['sumary', 'iocn', 'temperature_high'],
         'scan_interval': timedelta(seconds=120),
     }
@@ -40,6 +42,7 @@ VALID_CONFIG_LANG_DE = {
         'platform': 'darksky',
         'api_key': 'foo',
         'forecast': [1, 2],
+        'hourly_forecast': [1, 2],
         'units': 'us',
         'language': 'de',
         'monitored_conditions': ['summary', 'icon', 'temperature_high',
@@ -54,6 +57,7 @@ INVALID_CONFIG_LANG = {
         'platform': 'darksky',
         'api_key': 'foo',
         'forecast': [1, 2],
+        'hourly_forecast': [1, 2],
         'language': 'yz',
         'monitored_conditions': ['summary', 'icon', 'temperature_high'],
         'scan_interval': timedelta(seconds=120),
@@ -157,7 +161,7 @@ class TestDarkSkySetup(unittest.TestCase):
 
         assert mock_get_forecast.called
         assert mock_get_forecast.call_count == 1
-        assert len(self.hass.states.entity_ids()) == 8
+        assert len(self.hass.states.entity_ids()) == 12
 
         state = self.hass.states.get('sensor.dark_sky_summary')
         assert state is not None


### PR DESCRIPTION
## Breaking change: 

Changes the suffix in daily forecast sensors by appending a `d`.

## Description:

Dark Sky provides hourly forecasts for various monitored conditions.  This change creates new sensors for each hourly forecasted condition with suffix `_<hour>h` while adding the suffix `_<day>d` to the daily forecasted conditions. For example, now a `sensor.dark_sky_summary_<day>d` and `sensor.dark_sky_summary_<hour>h` will be created if the `forecast` and `hourly_forecast` parameters are populated.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8871

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: darksky
    api_key: !secret darksky_api_key
    forecast:
      - 0
      - 1
    hourly_forecast:
      - 1
      - 2
      - 3
    monitored_conditions:
      - summary
      - precip_type
      - precip_intensity
      - precip_probability
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
