### PR TITLE
Change how we import config modules

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -1,13 +1,13 @@
 """Component to configure Home Assistant via an API."""
 import asyncio
+import importlib
 import os
 
 import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import EVENT_COMPONENT_LOADED, CONF_ID
-from homeassistant.setup import (
-    async_prepare_setup_platform, ATTR_COMPONENT)
+from homeassistant.setup import ATTR_COMPONENT
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.util.yaml import load_yaml, dump
 
@@ -37,8 +37,7 @@ async def async_setup(hass, config):
 
     async def setup_panel(panel_name):
         """Set up a panel."""
-        panel = await async_prepare_setup_platform(
-            hass, config, DOMAIN, panel_name)
+        panel = importlib.import_module('.{}'.format(panel_name), __name__)
 
         if not panel:
             return

--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -8,8 +8,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.area_registry import async_get_registry
 
 
-DEPENDENCIES = ['websocket_api']
-
 WS_TYPE_LIST = 'config/area_registry/list'
 SCHEMA_WS_LIST = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_LIST,

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -7,8 +7,6 @@ from homeassistant.components.websocket_api.decorators import (
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import async_get_registry
 
-DEPENDENCIES = ['websocket_api']
-
 WS_TYPE_LIST = 'config/device_registry/list'
 SCHEMA_WS_LIST = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_LIST,

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -9,8 +9,6 @@ from homeassistant.components.websocket_api.decorators import (
     async_response, require_admin)
 from homeassistant.helpers import config_validation as cv
 
-DEPENDENCIES = ['websocket_api']
-
 WS_TYPE_LIST = 'config/entity_registry/list'
 SCHEMA_WS_LIST = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_LIST,


### PR DESCRIPTION
## Description:
Don't use the platform loading logic for when loading config modules.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/pull/21693#issuecomment-471034776

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
