### PR TITLE
Check if mac is set when more than 2 gateways

### DIFF
--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -61,8 +61,16 @@ SERVICE_SCHEMA_REMOVE_DEVICE = vol.Schema({
 })
 
 
-GATEWAY_CONFIG = vol.Schema({
+GATEWAY_CONFIG_MAC_OPT = vol.Schema({
     vol.Optional(CONF_KEY):
+        vol.All(cv.string, vol.Length(min=16, max=16)),
+    vol.Optional(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=9898): cv.port,
+    vol.Optional(CONF_DISABLE, default=False): cv.boolean,
+})
+
+GATEWAY_CONFIG_MAC_REQ = vol.Schema({
+    vol.Required(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=9898): cv.port,
@@ -89,10 +97,9 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_GATEWAYS, default={}):
             vol.All(cv.ensure_list, vol.Any(
-                vol.All([{vol.Optional(CONF_MAC, default=None):
-                          vol.Any(GW_MAC, None)}], vol.Length(max=1)),
-                vol.All([{vol.Required(CONF_MAC): GW_MAC}], vol.Length(min=2))
-            ), [GATEWAY_CONFIG], [_fix_conf_defaults]),
+                vol.All([GATEWAY_CONFIG_MAC_OPT], vol.Length(max=1)),
+                vol.All([GATEWAY_CONFIG_MAC_REQ], vol.Length(min=2))
+            ), [_fix_conf_defaults]),
         vol.Optional(CONF_INTERFACE, default='any'): cv.string,
         vol.Optional(CONF_DISCOVERY_RETRY, default=3): cv.positive_int
     })

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -62,7 +62,6 @@ SERVICE_SCHEMA_REMOVE_DEVICE = vol.Schema({
 
 
 GATEWAY_CONFIG = vol.Schema({
-    vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None),
     vol.Optional(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,
@@ -89,7 +88,10 @@ def _fix_conf_defaults(config):
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_GATEWAYS, default={}):
-            vol.All(cv.ensure_list, [GATEWAY_CONFIG], [_fix_conf_defaults]),
+            vol.All(cv.ensure_list, vol.Any(
+                vol.All([{vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None)}], vol.Length(max=1)),
+                vol.All([{vol.Required(CONF_MAC): GW_MAC}], vol.Length(min=2))
+            ), [GATEWAY_CONFIG], [_fix_conf_defaults]),
         vol.Optional(CONF_INTERFACE, default='any'): cv.string,
         vol.Optional(CONF_DISCOVERY_RETRY, default=3): cv.positive_int
     })

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -89,7 +89,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_GATEWAYS, default={}):
             vol.All(cv.ensure_list, vol.Any(
-                vol.All([{vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None)}], vol.Length(max=1)),
+                vol.All([{vol.Optional(CONF_MAC, default=None): 
+                          vol.Any(GW_MAC, None)}], vol.Length(max=1)),
                 vol.All([{vol.Required(CONF_MAC): GW_MAC}], vol.Length(min=2))
             ), [GATEWAY_CONFIG], [_fix_conf_defaults]),
         vol.Optional(CONF_INTERFACE, default='any'): cv.string,

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -89,7 +89,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_GATEWAYS, default={}):
             vol.All(cv.ensure_list, vol.Any(
-                vol.All([{vol.Optional(CONF_MAC, default=None): 
+                vol.All([{vol.Optional(CONF_MAC, default=None):
                           vol.Any(GW_MAC, None)}], vol.Length(max=1)),
                 vol.All([{vol.Required(CONF_MAC): GW_MAC}], vol.Length(min=2))
             ), [GATEWAY_CONFIG], [_fix_conf_defaults]),


### PR DESCRIPTION
When more than 2 gateways mac is required for each of them. Now voluptuous will require it.

## Description:


**Related issue (if applicable):** 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

## Example entry for `configuration.yaml` (if applicable):
```yaml
xiaomi_aqara:
    discovery_retries: 5
    gateways:
        - mac: XXXXX
          key: XXXXX
        - mac: YYYYY
          key: YYYYY
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
