### PR TITLE
Fix config entry exception in Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -296,6 +296,7 @@ class AmbientStation:
     def __init__(self, hass, config_entry, client, monitored_conditions):
         """Initialize."""
         self._config_entry = config_entry
+        self._entry_setup_complete = False
         self._hass = hass
         self._watchdog_listener = None
         self._ws_reconnect_delay = DEFAULT_SOCKET_MIN_RETRY
@@ -362,12 +363,18 @@ class AmbientStation:
                             'name', station['macAddress']),
                 }
 
-            for component in ('binary_sensor', 'sensor'):
-                self._hass.async_create_task(
-                    self._hass.config_entries.async_forward_entry_setup(
-                        self._config_entry, component))
+            # If the websocket disconnects and reconnects, the on_subscribed
+            # hanlder will get called again; in that case, we don't want to
+            # attempt forward setup of the config entry (because it will have
+            # already been done):
+            if not self._entry_setup_complete:
+                for component in ('binary_sensor', 'sensor'):
+                    self._hass.async_create_task(
+                        self._hass.config_entries.async_forward_entry_setup(
+                            self._config_entry, component))
+                self._entry_setup_complete = True
 
-                self._ws_reconnect_delay = DEFAULT_SOCKET_MIN_RETRY
+            self._ws_reconnect_delay = DEFAULT_SOCKET_MIN_RETRY
 
         self.client.websocket.on_connect(on_connect)
         self.client.websocket.on_data(on_data)


### PR DESCRIPTION
## Description:

When the `ambient_station` component unexpectedly disconnects from the Ambient Weather websocket, it automatically reconnects (good). Currently, however, such a reconnection will also attempt to redo forward setup of the Ambient PWS config entry (bad). This PR fixes that.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/21829

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
