### PR TITLE
Add SmartThings sensor support for Three Axis

### DIFF
--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -167,9 +167,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for capability in broker.get_assigned(device.device_id, 'sensor'):
             if capability == Capability.three_axis:
                 sensors.extend(
-                    [SmartThingsThreeAxisSensor(
-                        device, index) for index
-                        in range(len(THREE_AXIS_NAMES))])
+                    [SmartThingsThreeAxisSensor(device, index)
+                     for index in range(len(THREE_AXIS_NAMES))])
             else:
                 maps = CAPABILITY_TO_SENSORS[capability]
                 sensors.extend([

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -125,6 +125,8 @@ CAPABILITY_TO_SENSORS = {
     'thermostatSetpoint': [
         Map('thermostatSetpoint', "Thermostat Setpoint", TEMP_CELSIUS,
             DEVICE_CLASS_TEMPERATURE)],
+    'threeAxis': [
+        Map('threeAxis', "Three Axis", None, None)],
     'tvChannel': [
         Map('tvChannel', "Tv Channel", None, None)],
     'tvocMeasurement': [
@@ -147,6 +149,12 @@ UNITS = {
     'F': TEMP_FAHRENHEIT
 }
 
+THREE_AXIS_NAMES = {
+    0: 'X Coordinate',
+    1: 'Y Coordinate',
+    2: 'Z Coordinate'
+}
+
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -156,16 +164,22 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add binary sensors for a config entry."""
+    from pysmartthings import Capability
     broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
     sensors = []
     for device in broker.devices.values():
         for capability in broker.get_assigned(device.device_id, 'sensor'):
-            maps = CAPABILITY_TO_SENSORS[capability]
-            sensors.extend([
-                SmartThingsSensor(
-                    device, m.attribute, m.name, m.default_unit,
-                    m.device_class)
-                for m in maps])
+            if capability == Capability.three_axis:
+                sensors.extend(
+                    [SmartThingsThreeAxisSensor(
+                        device, index) for index in range(0, 3)])
+            else:
+                maps = CAPABILITY_TO_SENSORS[capability]
+                sensors.extend([
+                    SmartThingsSensor(
+                        device, m.attribute, m.name, m.default_unit,
+                        m.device_class)
+                    for m in maps])
     async_add_entities(sensors)
 
 
@@ -176,7 +190,7 @@ def get_capabilities(capabilities: Sequence[str]) -> Optional[Sequence[str]]:
 
 
 class SmartThingsSensor(SmartThingsEntity):
-    """Define a SmartThings Binary Sensor."""
+    """Define a SmartThings Sensor."""
 
     def __init__(self, device, attribute: str, name: str,
                  default_unit: str, device_class: str):
@@ -212,3 +226,34 @@ class SmartThingsSensor(SmartThingsEntity):
         """Return the unit this state is expressed in."""
         unit = self._device.status.attributes[self._attribute].unit
         return UNITS.get(unit, unit) if unit else self._default_unit
+
+
+class SmartThingsThreeAxisSensor(SmartThingsEntity):
+    """Define a SmartThings Three Axis Sensor."""
+
+    def __init__(self, device, index):
+        """Init the class."""
+        super().__init__(device)
+        self._index = index
+
+    @property
+    def name(self) -> str:
+        """Return the name of the binary sensor."""
+        return '{} {}'.format(
+            self._device.label, THREE_AXIS_NAMES[self._index])
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return '{}.{}'.format(
+            self._device.device_id, THREE_AXIS_NAMES[self._index])
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        from pysmartthings import Attribute
+        three_axis = self._device.status.attributes[Attribute.three_axis].value
+        try:
+            return three_axis[self._index]
+        except Exception:  # pylint:disable=broad-except
+            return None

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -252,5 +252,5 @@ class SmartThingsThreeAxisSensor(SmartThingsEntity):
         three_axis = self._device.status.attributes[Attribute.three_axis].value
         try:
             return three_axis[self._index]
-        except (TypeError, KeyError, IndexError):
+        except (TypeError, IndexError):
             return None

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -149,11 +149,7 @@ UNITS = {
     'F': TEMP_FAHRENHEIT
 }
 
-THREE_AXIS_NAMES = {
-    0: 'X Coordinate',
-    1: 'Y Coordinate',
-    2: 'Z Coordinate'
-}
+THREE_AXIS_NAMES = ['X Coordinate', 'Y Coordinate', 'Z Coordinate']
 
 
 async def async_setup_platform(
@@ -172,7 +168,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if capability == Capability.three_axis:
                 sensors.extend(
                     [SmartThingsThreeAxisSensor(
-                        device, index) for index in range(0, 3)])
+                        device, index) for index
+                        in range(len(THREE_AXIS_NAMES))])
             else:
                 maps = CAPABILITY_TO_SENSORS[capability]
                 sensors.extend([
@@ -255,5 +252,5 @@ class SmartThingsThreeAxisSensor(SmartThingsEntity):
         three_axis = self._device.status.attributes[Attribute.three_axis].value
         try:
             return three_axis[self._index]
-        except Exception:  # pylint:disable=broad-except
+        except (TypeError, KeyError, IndexError):
             return None

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -11,7 +11,8 @@ from homeassistant.components.sensor import (
 from homeassistant.components.smartthings import sensor
 from homeassistant.components.smartthings.const import (
     DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
-from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -34,7 +35,7 @@ async def test_async_setup_platform():
 
 
 async def test_entity_state(hass, device_factory):
-    """Tests the state attributes properly match the light types."""
+    """Tests the state attributes properly match the sensor types."""
     device = device_factory('Sensor 1', [Capability.battery],
                             {Attribute.battery: 100})
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
@@ -43,6 +44,38 @@ async def test_entity_state(hass, device_factory):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == '%'
     assert state.attributes[ATTR_FRIENDLY_NAME] ==\
         device.label + " Battery"
+
+
+async def test_entity_three_axis_state(hass, device_factory):
+    """Tests the state attributes properly match the three axis types."""
+    device = device_factory('Three Axis', [Capability.three_axis],
+                            {Attribute.three_axis: [100, 75, 25]})
+    await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
+    state = hass.states.get('sensor.three_axis_x_coordinate')
+    assert state.state == '100'
+    assert state.attributes[ATTR_FRIENDLY_NAME] ==\
+        device.label + " X Coordinate"
+    state = hass.states.get('sensor.three_axis_y_coordinate')
+    assert state.state == '75'
+    assert state.attributes[ATTR_FRIENDLY_NAME] ==\
+        device.label + " Y Coordinate"
+    state = hass.states.get('sensor.three_axis_z_coordinate')
+    assert state.state == '25'
+    assert state.attributes[ATTR_FRIENDLY_NAME] ==\
+        device.label + " Z Coordinate"
+
+
+async def test_entity_three_axis_invalid_state(hass, device_factory):
+    """Tests the state attributes properly match the three axis types."""
+    device = device_factory('Three Axis', [Capability.three_axis],
+                            {Attribute.three_axis: []})
+    await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
+    state = hass.states.get('sensor.three_axis_x_coordinate')
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get('sensor.three_axis_y_coordinate')
+    assert state.state == STATE_UNKNOWN
+    state = hass.states.get('sensor.three_axis_z_coordinate')
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_entity_and_device_attributes(hass, device_factory):


### PR DESCRIPTION
## Description:
Adds support for the `Three Axis` capability to the SmartThings sensor platform.  The value is represented as three discrete sensors for each coordinate (x, y, z).

**Related issue (if applicable):** fixes #21781

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#8879
 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
