### PR TITLE
Handle on/off through TemperatureSetting trait

### DIFF
--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -231,10 +231,7 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'HeatPump'
     },
-    'traits': [
-        'action.devices.traits.OnOff',
-        'action.devices.traits.TemperatureSetting'
-    ],
+    'traits': ['action.devices.traits.TemperatureSetting'],
     'type': 'action.devices.types.THERMOSTAT',
     'willReportState': False
 }, {

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -205,7 +205,6 @@ def test_query_climate_request(hass_fixture, assistant_client, auth_header):
     devices = body['payload']['devices']
     assert len(devices) == 3
     assert devices['climate.heatpump'] == {
-        'on': True,
         'online': True,
         'thermostatTemperatureSetpoint': 20.0,
         'thermostatTemperatureAmbient': 25.0,
@@ -262,7 +261,6 @@ def test_query_climate_request_f(hass_fixture, assistant_client, auth_header):
     devices = body['payload']['devices']
     assert len(devices) == 3
     assert devices['climate.heatpump'] == {
-        'on': True,
         'online': True,
         'thermostatTemperatureSetpoint': -6.7,
         'thermostatTemperatureAmbient': -3.9,


### PR DESCRIPTION
## Description: 

For climate(in HA)/[thermostat](https://developers.google.com/actions/smarthome/guides/thermostat) (in GA), the reccomended traits are the [`TemperatureSetting`](https://developers.google.com/actions/smarthome/traits/temperaturesetting) trait only, and not the [`OnOff`](https://developers.google.com/actions/smarthome/traits/onoff) trait.

GA actually completely ignores the OnOff trait, and will process "turn on <climate-device>" and "turn off <climate device>" commands only through the TemperatureSetting trait. 

I have fixed this by removing climate from OnOff, and passing on turn on / off properly (by calling the `turn_on` and `turn_off` services).  

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
