### PR TITLE
Override http.trusted_networks by auth_provider.trusted_networks

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -211,6 +211,14 @@ class HomeAssistantHTTP:
                 "legacy_api_password support has been enabled. If you don't "
                 "require it, remove the 'api_password' from your http config.")
 
+        for prv in hass.auth.auth_providers:
+            if prv.type == 'trusted_networks':
+                # auth_provider.trusted_networks will override
+                # http.trusted_networks, http.trusted_networks will be
+                # removed from future release
+                trusted_networks = prv.trusted_networks
+                break
+
         setup_auth(app, trusted_networks,
                    api_password if hass.auth.support_legacy else None)
 


### PR DESCRIPTION
## Description:

This should be done when we informed user `http.trusted_network` has been deprecated.

Now, user can follow our instruction, remove `http.trusted_network` after manual configure the trusted networks auth provider.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8874

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
