### PR TITLE
Fix issue with auto(HA) = heatcool(GA) when the device doesn't support ranges

### DIFF
--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -107,6 +107,8 @@ def hass_fixture(loop, hass):
 
     return hass
 
+# pylint: disable=redefined-outer-name
+
 
 @asyncio.coroutine
 def test_sync_request(hass_fixture, assistant_client, auth_header):


### PR DESCRIPTION
## Description:

The [`TemperatureSetting`](https://developers.google.com/actions/smarthome/traits/temperaturesetting) trait on GA has an different interpretation of what 'auto' means than HA, and it always uses a temperature range.

In HA, some climate devices have an auto mode where a range is set, and some have a single value. This PR fixes the GA trait so that the correct mode will be returned depending on the support flags set in the component.

I had a quick look through the HA climate components, the components affected by the issue are:
* coolmaster
* daikin
* demo (depending on how configured)
* ephember
* radiotherm
* sensibo
* [tuya](#19815)

venstar seems to be the only one that I could see that supported ranges that hasn't been moved into it's own component subdir (I didn't look through all the component subdirs). The upshot is the majority won't work without this bugfix.

**Related issue (if applicable):** fixes #19815
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
