### PR TITLE
Fix ephember doing http call from property

### DIFF
--- a/homeassistant/components/climate/ephember.py
+++ b/homeassistant/components/climate/ephember.py
@@ -117,7 +117,8 @@ class EphEmberThermostat(ClimateDevice):
     @property
     def current_operation(self):
         """Return current operation ie. heat, cool, idle."""
-        mode = self._ember.get_zone_mode(self._zone_name)
+        from pyephember.pyephember import ZoneMode
+        mode = ZoneMode(self._zone['mode'])
         return self.map_mode_eph_hass(mode)
 
     @property


### PR DESCRIPTION
## Description:

This should fix the warning related to #4210 for the ephember platform

**Related issue (if applicable):** #4210 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
