### PR TITLE
Fix missing code_required check in async_alarm_arm_night

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -230,8 +230,6 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         code_required = self._config.get(CONF_CODE_ARM_REQUIRED)
         if code_required and not self._validate_code(code, 'arming night'):
             return
-        if not self._validate_code(code, 'arming night'):
-            return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
             self._config.get(CONF_PAYLOAD_ARM_NIGHT),

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -227,6 +227,9 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         This method is a coroutine.
         """
+        code_required = self._config.get(CONF_CODE_ARM_REQUIRED)
+        if code_required and not self._validate_code(code, 'arming night'):
+            return
         if not self._validate_code(code, 'arming night'):
             return
         mqtt.async_publish(

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -135,6 +135,27 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.hass.block_till_done()
         assert call_count == self.mock_publish.call_count
 
+    def test_arm_home_publishes_mqtt_when_code_not_req(self):
+        """Test publishing of MQTT messages.
+
+        When code_arm_required = False
+        """
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+            alarm_control_panel.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'alarm/state',
+                'command_topic': 'alarm/command',
+                'code': '1234',
+                'code_arm_required': False
+            }
+        })
+
+        common.alarm_arm_home(self.hass)
+        self.hass.block_till_done()
+        self.mock_publish.async_publish.assert_called_once_with(
+            'alarm/command', 'ARM_HOME', 0, False)
+
     def test_arm_away_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
@@ -229,6 +250,27 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         common.alarm_arm_night(self.hass, 'abcd')
         self.hass.block_till_done()
         assert call_count == self.mock_publish.call_count
+
+    def test_arm_night_publishes_mqtt_when_code_not_req(self):
+        """Test publishing of MQTT messages.
+
+        When code_arm_required = False
+        """
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+            alarm_control_panel.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'alarm/state',
+                'command_topic': 'alarm/command',
+                'code': '1234',
+                'code_arm_required': False
+            }
+        })
+
+        common.alarm_arm_night(self.hass)
+        self.hass.block_till_done()
+        self.mock_publish.async_publish.assert_called_once_with(
+            'alarm/command', 'ARM_NIGHT', 0, False)
 
     def test_disarm_publishes_mqtt(self):
         """Test publishing of MQTT messages while disarmed."""


### PR DESCRIPTION
## Description:
Fix missing code_required check in async_alarm_arm_night in  PR #19558 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
