### PR TITLE
Bump quirks for ZHA and handle resulting battery % change

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -32,7 +32,7 @@ REQUIREMENTS = [
     'bellows-homeassistant==0.7.1',
     'zigpy-homeassistant==0.3.0',
     'zigpy-xbee-homeassistant==0.1.2',
-    'zha-quirks==0.0.6',
+    'zha-quirks==0.0.7',
     'zigpy-deconz==0.1.2'
 ]
 

--- a/homeassistant/components/zha/device_entity.py
+++ b/homeassistant/components/zha/device_entity.py
@@ -146,7 +146,7 @@ class ZhaDeviceEntity(ZhaEntity):
         """Get the latest battery reading from channels cache."""
         battery = await self._battery_channel.get_attribute_value(
             'battery_percentage_remaining')
-        # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
-        battery = battery / 2
         if battery is not None:
+            # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
+            battery = battery / 2
             self._device_state_attributes['battery_level'] = battery

--- a/homeassistant/components/zha/device_entity.py
+++ b/homeassistant/components/zha/device_entity.py
@@ -149,4 +149,5 @@ class ZhaDeviceEntity(ZhaEntity):
         if battery is not None:
             # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
             battery = battery / 2
+            battery = int(round(battery))
             self._device_state_attributes['battery_level'] = battery

--- a/homeassistant/components/zha/device_entity.py
+++ b/homeassistant/components/zha/device_entity.py
@@ -146,5 +146,7 @@ class ZhaDeviceEntity(ZhaEntity):
         """Get the latest battery reading from channels cache."""
         battery = await self._battery_channel.get_attribute_value(
             'battery_percentage_remaining')
+        # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
+        battery = battery / 2
         if battery is not None:
             self._device_state_attributes['battery_level'] = battery

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1826,7 +1826,7 @@ zengge==0.2
 zeroconf==0.21.3
 
 # homeassistant.components.zha
-zha-quirks==0.0.6
+zha-quirks==0.0.7
 
 # homeassistant.components.climate.zhong_hong
 zhong_hong_hvac==1.0.9


### PR DESCRIPTION
This updates the quirks module for ZHA and handles a change that pulled battery reporting in line with the ZCL specs. 