### PR TITLE
Add Android TV functionality to Fire TV component

### DIFF
--- a/homeassistant/components/firetv/__init__.py
+++ b/homeassistant/components/firetv/__init__.py
@@ -1,5 +1,5 @@
 """
-Support for functionality to interact with FireTV devices.
+Support for functionality to interact with Android TV and Fire TV devices.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.firetv/

--- a/homeassistant/components/firetv/media_player.py
+++ b/homeassistant/components/firetv/media_player.py
@@ -312,9 +312,9 @@ class AndroidTVDevice(ADBDevice):
 
         self._device = None
         self._muted = None
-        self._properties = self.aftv.properties
+        self._device_properties = self.aftv.device_properties
         self._unique_id = 'androidtv-{}-{}'.format(
-            name, self._properties['serialno'])
+            name, self._device_properties['serialno'])
         self._volume = None
 
     @adb_decorator(override_available=True)

--- a/homeassistant/components/firetv/media_player.py
+++ b/homeassistant/components/firetv/media_player.py
@@ -252,6 +252,7 @@ class ADBDevice(MediaPlayerDevice):
     @property
     def should_poll(self):
         """Device should be polled."""
+        return True
 
     @property
     def state(self):

--- a/homeassistant/components/firetv/media_player.py
+++ b/homeassistant/components/firetv/media_player.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 
 FIRETV_DOMAIN = 'firetv'
 
-REQUIREMENTS = ['androidtv==0.0.9']
+REQUIREMENTS = ['https://github.com/JeffLIrion/python-androidtv/zipball/firetv#androidtv==0.0.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/firetv/media_player.py
+++ b/homeassistant/components/firetv/media_player.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 
 FIRETV_DOMAIN = 'firetv'
 
-REQUIREMENTS = ['https://github.com/JeffLIrion/python-androidtv/zipball/firetv#androidtv==0.0.10']
+REQUIREMENTS = ['androidtv==0.0.10']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -118,6 +118,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             config[CONF_ADB_SERVER_IP], config[CONF_ADB_SERVER_PORT])
 
     if not aftv.available:
+        # Determine the name that will be used for the device in the log
         if CONF_NAME in config:
             device_name = config[CONF_NAME]
         elif config[CONF_DEVICE_CLASS] == DEVICE_ANDROIDTV:
@@ -126,6 +127,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             device_name = 'Fire TV device'
         else:
             device_name = 'Android TV / Fire TV device'
+
         _LOGGER.warning("Could not connect to %s at %s%s",
                         device_name, host, adb_log)
         return
@@ -300,6 +302,10 @@ class ADBDevice(MediaPlayerDevice):
         key = self._keys.get(cmd)
         if key:
             return self.aftv.adb_shell('input keyevent {}'.format(key))
+
+        if cmd == 'GET_PROPERTIES':
+            return self.aftv.get_properties_dict()
+
         return self.aftv.adb_shell(cmd)
 
 
@@ -438,6 +444,7 @@ class FireTVDevice(ADBDevice):
     @adb_decorator()
     def select_source(self, source):
         """Select input source.
+
         If the source starts with a '!', then it will close the app instead of
         opening it.
         """

--- a/homeassistant/components/firetv/services.yaml
+++ b/homeassistant/components/firetv/services.yaml
@@ -1,10 +1,10 @@
-# Describes the format for available Fire TV services
+# Describes the format for available Android TV and Fire TV services
 
 adb_command:
-  description: Send an ADB command to a Fire TV device.
+  description: Send an ADB command to an Android TV / Fire TV device.
   fields:
     entity_id:
-      description: Name(s) of Fire TV entities.
+      description: Name(s) of Android TV / Fire TV entities.
       example: 'media_player.fire_tv_living_room'
     command:
       description: Either a key command or an ADB shell command.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -157,6 +157,9 @@ alpha_vantage==2.1.0
 # homeassistant.components.amcrest
 amcrest==1.2.5
 
+# homeassistant.components.firetv.media_player
+androidtv==0.0.10
+
 # homeassistant.components.switch.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2
 
@@ -425,9 +428,6 @@ fiblary3==0.1.7
 
 # homeassistant.components.sensor.fints
 fints==1.0.1
-
-# homeassistant.components.firetv.media_player
-firetv==1.0.9
 
 # homeassistant.components.sensor.fitbit
 fitbit==0.3.0


### PR DESCRIPTION
## Description:

Allow for configuring Android TV devices as part of the Fire TV media player component. 

## Android TV vs. Fire TV devices

I haven't documented this yet, but there is a new config parameter `device_class`. Allowed values are:

* `auto` (default): determine whether it is an Android TV device or Fire TV device (manufacturer == "Amazon")
* `androidtv`: setup an Android TV device
* `firetv`: setup a Fire TV device

@rytilahti this implements phase 1 of what we discussed in https://github.com/home-assistant/home-assistant/pull/21674#issuecomment-470952084. 

This builds off the work by @a1ex4 in https://github.com/home-assistant/home-assistant/pull/19157.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8893

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
media_player:
  # Use the Python ADB implementation without authentication
  - platform: firetv
    name: Fire TV 1
    host: 192.168.0.111

  # Use the Python ADB implementation with authentication
  - platform: firetv
    name: Android TV 2
    host: 192.168.0.222
    adbkey: "/config/android/adbkey"

  # Use an ADB server for sending ADB commands
  - platform: firetv
    name: Fire TV 3
    host: 192.168.0.123
    adb_server_ip: 127.0.0.1
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23