### PR TITLE
Fix botvac when no map exists

### DIFF
--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -187,10 +187,12 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
         if self._robot_has_map:
             if self._state['availableServices']['maps'] != "basic-1":
-                robot_map_id = self._robot_maps[self._robot_serial][0]['id']
+                if self._robot_maps[self._robot_serial]:
+                    robot_map_id = (
+                        self._robot_maps[self._robot_serial][0]['id'])
 
-                self._robot_boundaries = self.robot.get_map_boundaries(
-                    robot_map_id).json()
+                    self._robot_boundaries = self.robot.get_map_boundaries(
+                        robot_map_id).json()
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:

After #21752 that fixed #21732 it was discovered that some users who had a supported model did not have any maps which resulted in the same error.  This now ignores robots that do not use a persistent map to avoid additional start up errors.  This was also reported in the forums as well: https://community.home-assistant.io/t/neato-vacuum-startup-error/104224

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
