### PR TITLE
Use voluptuous error string for websocket validation error

### DIFF
--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -97,7 +97,7 @@ class ActiveConnection:
         else:
             code = const.ERR_UNKNOWN_ERROR
             err_message = 'Unknown error'
-        
+
         self.logger.exception('Error handling message: %s', msg)
         self.send_message(
             messages.error_message(msg['id'], code, err_message))

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -95,9 +95,9 @@ class ActiveConnection:
             code = const.ERR_INVALID_FORMAT
             err_message = str(err)
         else:
-            self.logger.exception('Error handling message: %s', msg)
             code = const.ERR_UNKNOWN_ERROR
             err_message = 'Unknown error'
-
+        
+        self.logger.exception('Error handling message: %s', msg)
         self.send_message(
             messages.error_message(msg['id'], code, err_message))

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -98,6 +98,6 @@ class ActiveConnection:
             code = const.ERR_UNKNOWN_ERROR
             err_message = 'Unknown error'
 
-        self.logger.exception('Error handling message: %s', msg)
+        self.logger.exception('Error handling message: %s', err_message)
         self.send_message(
             messages.error_message(msg['id'], code, err_message))

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -93,7 +93,7 @@ class ActiveConnection:
             err_message = 'Unauthorized'
         elif isinstance(err, vol.Invalid):
             code = const.ERR_INVALID_FORMAT
-            err_message = 'Invalid format'
+            err_message = str(err)
         else:
             self.logger.exception('Error handling message: %s', msg)
             code = const.ERR_UNKNOWN_ERROR

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -93,7 +93,7 @@ class ActiveConnection:
             err_message = 'Unauthorized'
         elif isinstance(err, vol.Invalid):
             code = const.ERR_INVALID_FORMAT
-            err_message = str(err)
+            err_message = vol.humanize.humanize_error(msg, err)
         else:
             code = const.ERR_UNKNOWN_ERROR
             err_message = 'Unknown error'

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -1,5 +1,0 @@
-"""Test connection of websocket API."""
-
-from homeassistant.components.websocket.connection import ActiveConnection
-
-def test_auth_via_msg(no_auth_websocket_client, legacy_auth):

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -1,0 +1,5 @@
+"""Test connection of websocket API."""
+
+from homeassistant.components.websocket.connection import ActiveConnection
+
+def test_auth_via_msg(no_auth_websocket_client, legacy_auth):

--- a/tests/components/websocket_api/test_init.py
+++ b/tests/components/websocket_api/test_init.py
@@ -99,7 +99,7 @@ async def test_invalid_vol(hass, websocket_client):
         'bla', Mock(side_effect=TypeError),
         messages.BASE_COMMAND_MESSAGE_SCHEMA.extend({
             'type': 'bla',
-             vol.Required('test_config'): str,
+            vol.Required('test_config'): str
         }))
 
     await websocket_client.send_json({

--- a/tests/components/websocket_api/test_init.py
+++ b/tests/components/websocket_api/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, Mock
 
 from aiohttp import WSMsgType
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.websocket_api import const, messages
 
@@ -90,3 +91,26 @@ async def test_handler_failing(hass, websocket_client):
     assert msg['type'] == const.TYPE_RESULT
     assert not msg['success']
     assert msg['error']['code'] == const.ERR_UNKNOWN_ERROR
+
+
+async def test_invalid_vol(hass, websocket_client):
+    """Test a command that raises invalid vol error."""
+    hass.components.websocket_api.async_register_command(
+        'bla', Mock(side_effect=TypeError),
+        messages.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+            'type': 'bla',
+             vol.Required('test_config'): str,
+        }))
+
+    await websocket_client.send_json({
+        'id': 5,
+        'type': 'bla',
+        'test_config': 5
+    })
+
+    msg = await websocket_client.receive_json()
+    assert msg['id'] == 5
+    assert msg['type'] == const.TYPE_RESULT
+    assert not msg['success']
+    assert msg['error']['code'] == const.ERR_INVALID_FORMAT
+    assert 'expected str for dictionary value' in msg['error']['message']


### PR DESCRIPTION
## Description:
Instead of returning a generic error message vol.Invalid has a __repr__ override to return why the validation was invalid. Instead of a generic message we get `{'code': 'invalid_format', 'message': "required key not provided @ data['entity_id']"}}`

## Checklist:
  - [ x] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.

