### PR TITLE
Update enigma2 based on review comments

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -69,7 +69,7 @@ SERVICE_HANDLERS = {
     SERVICE_HASSIO: ('hassio', None),
     SERVICE_AXIS: ('axis', None),
     SERVICE_APPLE_TV: ('apple_tv', None),
-    SERVICE_ENIGMA2: ('enigma2', None),
+    SERVICE_ENIGMA2: ('media_player', 'enigma2'),
     SERVICE_ROKU: ('roku', None),
     SERVICE_WINK: ('wink', None),
     SERVICE_XIAOMI_GW: ('xiaomi_aqara', None),

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==2.4.0']
+REQUIREMENTS = ['netdisco==2.3.0']
 
 DOMAIN = 'discovery'
 

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==2.3.0']
+REQUIREMENTS = ['netdisco==2.4.0']
 
 DOMAIN = 'discovery'
 

--- a/homeassistant/components/enigma2/__init__.py
+++ b/homeassistant/components/enigma2/__init__.py
@@ -1,18 +1,1 @@
 """Support for Enigma2 devices."""
-from homeassistant.components.discovery import SERVICE_ENIGMA2
-from homeassistant.helpers.discovery import load_platform
-from homeassistant.helpers import discovery
-
-DOMAIN = 'enigma2'
-
-
-def setup(hass, config):
-    """Set up the Enigma2 platform."""
-    def device_discovered(service, info):
-        """Handle when an Enigma2 device has been discovered."""
-        load_platform(hass, 'media_player', DOMAIN, info, config)
-
-    discovery.listen(
-        hass, SERVICE_ENIGMA2, device_discovered)
-
-    return True

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -1,6 +1,5 @@
 """Support for Enigma2 media players."""
 import logging
-import asyncio
 
 import voluptuous as vol
 
@@ -195,8 +194,7 @@ class Enigma2Device(MediaPlayerDevice):
         """List of available input sources."""
         return self.e2_box.source_list
 
-    @asyncio.coroutine
-    def async_select_source(self, source):
+    def select_source(self, source):
         """Select input source."""
         self.e2_box.select_source(self.e2_box.sources[source])
 
@@ -206,7 +204,13 @@ class Enigma2Device(MediaPlayerDevice):
 
     @property
     def device_state_attributes(self):
-        """Return device specific state attributes."""
+        """Return device specific state attributes.
+
+        isRecording:        Is the box currently recording.
+        currservice_fulldescription: Full program description.
+        currservice_begin:  is in the format '21:00'.
+        currservice_end:    is in the format '21:00'.
+        """
         attributes = {}
         if not self.e2_box.in_standby:
             attributes[ATTR_MEDIA_CURRENTLY_RECORDING] = \

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ nessclient==0.9.14
 netdata==0.1.2
 
 # homeassistant.components.discovery
-netdisco==2.4.0
+netdisco==2.3.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ nessclient==0.9.14
 netdata==0.1.2
 
 # homeassistant.components.discovery
-netdisco==2.3.0
+netdisco==2.4.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
There were some extra comments rasied by @MartinHjelmare after my Enigma2 component got merged, so this PR is to address those.

* Bumping netdisco to `2.4.0` since this includes Enigma2 discovery in PR https://github.com/home-assistant/home-assistant/pull/21914. Thanks @balloob for the bump on that.

**Related issue (if applicable):** fixes #21271


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.