### PR TITLE
HomeKit controller config flow fixes

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -239,7 +239,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             step_id='pair',
             errors=errors,
             data_schema=vol.Schema({
-                vol.Required('pairing_code'):  str,
+                vol.Required('pairing_code'):  vol.All(str, vol.Strip),
             })
         )
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -237,12 +237,9 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         return self.async_show_form(
             step_id='pair',
-            description_placeholders={
-                'model': self.model,
-            },
             errors=errors,
             data_schema=vol.Schema({
-                vol.Required('pairing_code'):  vol.All(str, vol.Strip),
+                vol.Required('pairing_code'):  str,
             })
         )
 

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -10,7 +10,7 @@
                 }
             },
             "pair": {
-                "title": "Pair with {{ model }}",
+                "title": "Pair with HomeKit Accessory",
                 "description": "Enter your HomeKit pairing code to use this accessory",
                 "data": {
                     "pairing_code": "Pairing Code"


### PR DESCRIPTION
## Description:

This PR fixes a couple of issues I identified in my earlier PR (#21564):

 * As part of code review we tried to use `vol.Strip` - but it turns out this can't be serialized so can't be used in config flow, so I have backed out that change.

 * At some point whilst splitting off the PR from the [branch it originated in](https://github.com/home-assistant/home-assistant/compare/dev...Jc2k:homekit_config_flow) I managed to revert to an older + broken strings.json. I noticed immediately when preparing the next stage of the config flow and thought best to patch it ASAP to avoid headache for translators. 

**Related issue (if applicable):** #21564
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.