### PR TITLE
Set homekit controller entity as unavailable if new connections fail

### DIFF
--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -6,7 +6,7 @@ from homekit.model.services import AbstractService, ServicesTypes
 from homekit.model.characteristics import (
     AbstractCharacteristic, CharacteristicPermissions, CharacteristicsTypes)
 from homekit.model import Accessory, get_id
-
+from homekit.exceptions import AccessoryNotFoundError
 from homeassistant.components.homekit_controller import (
     DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, SERVICE_HOMEKIT)
 from homeassistant.setup import async_setup_component
@@ -26,6 +26,7 @@ class FakePairing:
         """Create a fake pairing from an accessory model."""
         self.accessories = accessories
         self.pairing_data = {}
+        self.available = True
 
     def list_accessories_and_characteristics(self):
         """Fake implementation of list_accessories_and_characteristics."""
@@ -38,6 +39,9 @@ class FakePairing:
 
     def get_characteristics(self, characteristics):
         """Fake implementation of get_characteristics."""
+        if not self.available:
+            raise AccessoryNotFoundError('Accessory not found')
+
         results = {}
         for aid, cid in characteristics:
             for accessory in self.accessories:

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -126,3 +126,29 @@ async def test_switch_read_light_state_color_temp(hass, utcnow):
     assert state.state == 'on'
     assert state.attributes['brightness'] == 255
     assert state.attributes['color_temp'] == 400
+
+
+async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
+    """Test that we can read the color_temp of a  light accessory."""
+    bulb = create_lightbulb_service_with_color_temp()
+    helper = await setup_test_component(hass, [bulb])
+
+    # Initial state is that the light is off
+    state = await helper.poll_and_get_state()
+    assert state.state == 'off'
+
+    # Test device goes offline
+    helper.pairing.available = False
+    state = await helper.poll_and_get_state()
+    assert state.state == 'unavailable'
+
+    # Simulate that someone switched on the device in the real world not via HA
+    helper.characteristics[LIGHT_ON].set_value(True)
+    helper.characteristics[LIGHT_BRIGHTNESS].value = 100
+    helper.characteristics[LIGHT_COLOR_TEMP].value = 400
+    helper.pairing.available = True
+
+    state = await helper.poll_and_get_state()
+    assert state.state == 'on'
+    assert state.attributes['brightness'] == 255
+    assert state.attributes['color_temp'] == 400

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -129,7 +129,7 @@ async def test_switch_read_light_state_color_temp(hass, utcnow):
 
 
 async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
-    """Test that we can read the color_temp of a  light accessory."""
+    """Test transition to and from unavailable state."""
     bulb = create_lightbulb_service_with_color_temp()
     helper = await setup_test_component(hass, [bulb])
 


### PR DESCRIPTION
## Description:

While working on my [config flow branch](https://github.com/home-assistant/home-assistant/compare/dev...Jc2k:homekit_config_flow) for homekit_controller I encountered some edge cases when I started HA and an accessory was switched off. If the underlying homekit library reports that an accessory cannot be found this will be mapped to the `unavailable` state. The next time a poll is successful it will go back to the available state.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.