### PR TITLE
Make !include_dir_list use alphanumeric order

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -144,7 +144,7 @@ def _find_files(directory: str, pattern: str) -> Iterator[str]:
     """Recursively load files in a directory."""
     for root, dirs, files in os.walk(directory, topdown=True):
         dirs[:] = [d for d in dirs if _is_file_valid(d)]
-        for basename in files:
+        for basename in sorted(files):
             if _is_file_valid(basename) and fnmatch.fnmatch(basename, pattern):
                 filename = os.path.join(root, basename)
                 yield filename

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -95,7 +95,7 @@ class TestYaml(unittest.TestCase):
     def test_include_dir_list(self, mock_walk):
         """Test include dir list yaml."""
         mock_walk.return_value = [
-            ['/tmp', [], ['one.yaml', 'two.yaml']],
+            ['/tmp', [], ['two.yaml', 'one.yaml']],
         ]
 
         with patch_yaml_files({
@@ -105,7 +105,7 @@ class TestYaml(unittest.TestCase):
             conf = "key: !include_dir_list /tmp"
             with io.StringIO(conf) as file:
                 doc = yaml.yaml.safe_load(file)
-                assert sorted(doc["key"]) == sorted(["one", "two"])
+                assert doc["key"] == sorted(["one", "two"])
 
     @patch('homeassistant.util.yaml.os.walk')
     def test_include_dir_list_recursive(self, mock_walk):


### PR DESCRIPTION
## Description:

When using !include_dir_list in YAML to bring in the contents of multiple YAML files as entries in a list, there is currently no way to control the order of that list.    A typical use is when creating Lovelace views: if you use one file per tab then they appear in random order.

This one-word patch causes files to be incorporated in alphanumeric order, which makes it predictable and controllable.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io).  The PR is [here](https://github.com/home-assistant/home-assistant.io/pull/8899).

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
