### PR TITLE
Bumb homekit python release for homekit controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -14,7 +14,7 @@ from .const import (
 )
 
 
-REQUIREMENTS = ['homekit==0.12.2']
+REQUIREMENTS = ['homekit==0.12.3']
 
 HOMEKIT_DIR = '.homekit'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -554,7 +554,7 @@ home-assistant-frontend==20190309.0
 homeassistant-pyozw==0.1.2
 
 # homeassistant.components.homekit_controller
-homekit==0.12.2
+homekit==0.12.3
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -123,7 +123,7 @@ holidays==0.9.9
 home-assistant-frontend==20190309.0
 
 # homeassistant.components.homekit_controller
-homekit==0.12.2
+homekit==0.12.3
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.6


### PR DESCRIPTION
## Description:
This fix an issue with some HomeKit devices that gives an error when updating its state.

"Can't concat bool to bytearray"

**Related issue (if applicable):** fixes #21793

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Discover some devices automatically
discovery:
  enable:
    - homekit
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([require]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[require]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/homekit_controller/__init__.py#L17

