### PR TITLE
Add cloudhook support to SmartThings component

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -29,7 +29,7 @@ from .smartapp import (
     validate_webhook_requirements)
 
 REQUIREMENTS = ['pysmartapp==0.3.2', 'pysmartthings==0.6.7']
-DEPENDENCIES = ['cloud', 'webhook']
+DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -25,10 +25,11 @@ from .const import (
     TOKEN_REFRESH_INTERVAL)
 from .smartapp import (
     setup_smartapp, setup_smartapp_endpoint, smartapp_sync_subscriptions,
-    validate_installed_app)
+    unload_smartapp_endpoint, validate_installed_app,
+    validate_webhook_requirements)
 
-REQUIREMENTS = ['pysmartapp==0.3.1', 'pysmartthings==0.6.7']
-DEPENDENCIES = ['webhook']
+REQUIREMENTS = ['pysmartapp==0.3.2', 'pysmartthings==0.6.7']
+DEPENDENCIES = ['cloud', 'webhook']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Initialize config entry which represents an installed SmartApp."""
     from pysmartthings import SmartThings
 
-    if not hass.config.api.base_url.lower().startswith('https://'):
+    if not validate_webhook_requirements(hass):
         _LOGGER.warning("The 'base_url' of the 'http' component must be "
                         "configured and start with 'https://'")
         return False
@@ -200,8 +201,9 @@ async def async_remove_entry(
 
     # Remove the app if not referenced by other entries, which if already
     # removed raises a 403 error.
+    all_entries = hass.config_entries.async_entries(DOMAIN)
     app_id = entry.data[CONF_APP_ID]
-    app_count = sum(1 for entry in hass.config_entries.async_entries(DOMAIN)
+    app_count = sum(1 for entry in all_entries
                     if entry.data[CONF_APP_ID] == app_id)
     if app_count > 1:
         _LOGGER.debug("App %s was not removed because it is in use by other"
@@ -217,6 +219,9 @@ async def async_remove_entry(
         else:
             raise
     _LOGGER.debug("Removed app %s", app_id)
+
+    if len(all_entries) == 1:
+        await unload_smartapp_endpoint(hass)
 
 
 class DeviceBroker:

--- a/homeassistant/components/smartthings/config_flow.py
+++ b/homeassistant/components/smartthings/config_flow.py
@@ -13,7 +13,8 @@ from .const import (
     CONF_LOCATION_ID, CONF_OAUTH_CLIENT_ID, CONF_OAUTH_CLIENT_SECRET, DOMAIN,
     VAL_UID_MATCHER)
 from .smartapp import (
-    create_app, find_app, setup_smartapp, setup_smartapp_endpoint, update_app)
+    create_app, find_app, setup_smartapp, setup_smartapp_endpoint, update_app,
+    validate_webhook_requirements)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,10 +57,6 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
         from pysmartthings import APIResponseError, AppOAuth, SmartThings
 
         errors = {}
-        if not self.hass.config.api.base_url.lower().startswith('https://'):
-            errors['base'] = "base_url_not_https"
-            return self._show_step_user(errors)
-
         if user_input is None or CONF_ACCESS_TOKEN not in user_input:
             return self._show_step_user(errors)
 
@@ -80,6 +77,10 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
 
         # Setup end-point
         await setup_smartapp_endpoint(self.hass)
+
+        if not validate_webhook_requirements(self.hass):
+            errors['base'] = "base_url_not_https"
+            return self._show_step_user(errors)
 
         try:
             app = await find_app(self.hass, self.api)

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -8,6 +8,7 @@ APP_OAUTH_SCOPES = [
 ]
 APP_NAME_PREFIX = 'homeassistant.'
 CONF_APP_ID = 'app_id'
+CONF_CLOUDHOOK_URL = 'cloudhook_url'
 CONF_INSTALLED_APP_ID = 'installed_app_id'
 CONF_INSTALLED_APPS = 'installed_apps'
 CONF_INSTANCE_ID = 'instance_id'

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -8,11 +8,12 @@ callbacks when device states change.
 import asyncio
 import functools
 import logging
+from urllib.parse import urlparse
 from uuid import uuid4
 
 from aiohttp import web
 
-from homeassistant.components import webhook
+from homeassistant.components import cloud, webhook
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
@@ -21,9 +22,10 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import (
     APP_NAME_PREFIX, APP_OAUTH_CLIENT_NAME, APP_OAUTH_SCOPES, CONF_APP_ID,
-    CONF_INSTALLED_APP_ID, CONF_INSTALLED_APPS, CONF_INSTANCE_ID,
-    CONF_LOCATION_ID, CONF_REFRESH_TOKEN, DATA_BROKERS, DATA_MANAGER, DOMAIN,
-    SETTINGS_INSTANCE_ID, SIGNAL_SMARTAPP_PREFIX, STORAGE_KEY, STORAGE_VERSION)
+    CONF_CLOUDHOOK_URL, CONF_INSTALLED_APP_ID, CONF_INSTALLED_APPS,
+    CONF_INSTANCE_ID, CONF_LOCATION_ID, CONF_REFRESH_TOKEN, DATA_BROKERS,
+    DATA_MANAGER, DOMAIN, SETTINGS_INSTANCE_ID, SIGNAL_SMARTAPP_PREFIX,
+    STORAGE_KEY, STORAGE_VERSION)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,15 +61,36 @@ async def validate_installed_app(api, installed_app_id: str):
     return installed_app
 
 
+def validate_webhook_requirements(hass: HomeAssistantType) -> bool:
+    """Ensure HASS is setup properly to receive webhooks."""
+    if cloud.async_active_subscription(hass):
+        return True
+    return get_webhook_url(hass).lower().startswith('https://')
+
+
+def get_webhook_url(hass: HomeAssistantType) -> str:
+    """Get the URL of the webhook."""
+    cloudhook_url = hass.data[DOMAIN][CONF_CLOUDHOOK_URL]
+    if cloud.async_active_subscription(hass) and cloudhook_url is not None:
+        return cloudhook_url
+
+    return webhook.async_generate_url(hass, hass.data[DOMAIN][CONF_WEBHOOK_ID])
+
+
 def _get_app_template(hass: HomeAssistantType):
     from pysmartthings import APP_TYPE_WEBHOOK, CLASSIFICATION_AUTOMATION
+
+    endpoint = "at " + hass.config.api.base_url
+    cloudhook_url = hass.data[DOMAIN][CONF_CLOUDHOOK_URL]
+    if cloudhook_url is not None:
+        endpoint = "via Nabu Casa"
+    description = "{} {}".format(hass.config.location_name, endpoint)
 
     return {
         'app_name': APP_NAME_PREFIX + str(uuid4()),
         'display_name': 'Home Assistant',
-        'description': "Home Assistant at " + hass.config.api.base_url,
-        'webhook_target_url': webhook.async_generate_url(
-            hass, hass.data[DOMAIN][CONF_WEBHOOK_ID]),
+        'description': description,
+        'webhook_target_url': get_webhook_url(hass),
         'app_type': APP_TYPE_WEBHOOK,
         'single_instance': True,
         'classifications': [CLASSIFICATION_AUTOMATION]
@@ -162,9 +185,23 @@ async def setup_smartapp_endpoint(hass: HomeAssistantType):
         # Create config
         config = {
             CONF_INSTANCE_ID: str(uuid4()),
-            CONF_WEBHOOK_ID: webhook.generate_secret()
+            CONF_WEBHOOK_ID: webhook.generate_secret(),
+            CONF_CLOUDHOOK_URL: None
         }
         await store.async_save(config)
+
+    # Register webhook
+    webhook.async_register(hass, DOMAIN, 'SmartApp',
+                           config[CONF_WEBHOOK_ID], smartapp_webhook)
+
+    # Register cloudhook if active subscription
+    cloudhook_url = config.get(CONF_CLOUDHOOK_URL)
+    if cloudhook_url is None and cloud.async_active_subscription(hass):
+        cloudhook_url = await cloud.async_create_cloudhook(
+            hass, config[CONF_WEBHOOK_ID])
+        config[CONF_CLOUDHOOK_URL] = cloudhook_url
+        await store.async_save(config)
+        _LOGGER.debug("Created cloudhook '%s'", cloudhook_url)
 
     # SmartAppManager uses a dispatcher to invoke callbacks when push events
     # occur. Use hass' implementation instead of the built-in one.
@@ -172,23 +209,52 @@ async def setup_smartapp_endpoint(hass: HomeAssistantType):
         signal_prefix=SIGNAL_SMARTAPP_PREFIX,
         connect=functools.partial(async_dispatcher_connect, hass),
         send=functools.partial(async_dispatcher_send, hass))
-    manager = SmartAppManager(
-        webhook.async_generate_path(config[CONF_WEBHOOK_ID]),
-        dispatcher=dispatcher)
+    # Path is used in signature validation
+    path = webhook.async_generate_path(config[CONF_WEBHOOK_ID])
+    if cloudhook_url:
+        path = urlparse(cloudhook_url).path
+    manager = SmartAppManager(path, dispatcher=dispatcher)
     manager.connect_install(functools.partial(smartapp_install, hass))
     manager.connect_update(functools.partial(smartapp_update, hass))
     manager.connect_uninstall(functools.partial(smartapp_uninstall, hass))
-
-    webhook.async_register(hass, DOMAIN, 'SmartApp',
-                           config[CONF_WEBHOOK_ID], smartapp_webhook)
 
     hass.data[DOMAIN] = {
         DATA_MANAGER: manager,
         CONF_INSTANCE_ID: config[CONF_INSTANCE_ID],
         DATA_BROKERS: {},
         CONF_WEBHOOK_ID: config[CONF_WEBHOOK_ID],
+        # May not be present prior to v0.90.0
+        CONF_CLOUDHOOK_URL: config.get(CONF_CLOUDHOOK_URL),
         CONF_INSTALLED_APPS: []
     }
+
+
+async def unload_smartapp_endpoint(hass: HomeAssistantType):
+    """Tear down the component configuration."""
+    if DOMAIN not in hass.data:
+        return
+    # Remove the cloudhook if it was created
+    cloudhook_url = hass.data[DOMAIN][CONF_CLOUDHOOK_URL]
+    if cloudhook_url and cloud.async_is_logged_in(hass):
+        await cloud.async_delete_cloudhook(
+            hass, hass.data[DOMAIN][CONF_WEBHOOK_ID])
+        # Remove cloudhook from storage
+        store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        await store.async_save({
+            CONF_INSTANCE_ID: hass.data[DOMAIN][CONF_INSTANCE_ID],
+            CONF_WEBHOOK_ID: hass.data[DOMAIN][CONF_WEBHOOK_ID],
+            CONF_CLOUDHOOK_URL: None
+        })
+        _LOGGER.debug("Cloudhook '%s' was removed", cloudhook_url)
+    # Remove the webhook
+    webhook.async_unregister(hass, hass.data[DOMAIN][CONF_WEBHOOK_ID])
+    # Disconnect all brokers
+    for broker in hass.data[DOMAIN][DATA_BROKERS].values():
+        broker.disconnect()
+    # Remove all handlers from manager
+    hass.data[DOMAIN][DATA_MANAGER].dispatcher.disconnect_all()
+    # Remove the component data
+    hass.data.pop(DOMAIN)
 
 
 async def smartapp_sync_subscriptions(
@@ -285,6 +351,9 @@ async def smartapp_install(hass: HomeAssistantType, req, resp, app):
         # Store the data where the flow can find it
         hass.data[DOMAIN][CONF_INSTALLED_APPS].append(install_data)
 
+    _LOGGER.debug("Installed SmartApp '%s' under parent app '%s'",
+                  req.installed_app_id, app.app_id)
+
 
 async def smartapp_update(hass: HomeAssistantType, req, resp, app):
     """
@@ -301,7 +370,7 @@ async def smartapp_update(hass: HomeAssistantType, req, resp, app):
         entry.data[CONF_REFRESH_TOKEN] = req.refresh_token
         hass.config_entries.async_update_entry(entry)
 
-    _LOGGER.debug("SmartApp '%s' under parent app '%s' was updated",
+    _LOGGER.debug("Updated SmartApp '%s' under parent app '%s'",
                   req.installed_app_id, app.app_id)
 
 
@@ -316,11 +385,12 @@ async def smartapp_uninstall(hass: HomeAssistantType, req, resp, app):
                   req.installed_app_id),
                  None)
     if entry:
-        _LOGGER.debug("SmartApp '%s' under parent app '%s' was removed",
-                      req.installed_app_id, app.app_id)
         # Add as job not needed because the current coroutine was invoked
         # from the dispatcher and is not being awaited.
         await hass.config_entries.async_remove(entry.entry_id)
+
+    _LOGGER.debug("Uninstalled SmartApp '%s' under parent app '%s'",
+                  req.installed_app_id, app.app_id)
 
 
 async def smartapp_webhook(hass: HomeAssistantType, webhook_id: str, request):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1268,7 +1268,7 @@ pysher==1.0.1
 pysma==0.3.1
 
 # homeassistant.components.smartthings
-pysmartapp==0.3.1
+pysmartapp==0.3.2
 
 # homeassistant.components.smartthings
 pysmartthings==0.6.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -224,7 +224,7 @@ pyps4-homeassistant==0.4.8
 pyqwikswitch==0.8
 
 # homeassistant.components.smartthings
-pysmartapp==0.3.1
+pysmartapp==0.3.2
 
 # homeassistant.components.smartthings
 pysmartthings==0.6.7

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -85,7 +85,7 @@ def app_fixture(hass, config_file):
         'appType': 'WEBHOOK_SMART_APP',
         'classifications': [CLASSIFICATION_AUTOMATION],
         'displayName': 'Home Assistant',
-        'description': "Home Assistant at " + hass.config.api.base_url,
+        'description': "test home at " + hass.config.api.base_url,
         'singleInstance': True,
         'webhookSmartApp': {
             'targetUrl': webhook.async_generate_url(

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -85,7 +85,8 @@ def app_fixture(hass, config_file):
         'appType': 'WEBHOOK_SMART_APP',
         'classifications': [CLASSIFICATION_AUTOMATION],
         'displayName': 'Home Assistant',
-        'description': "test home at " + hass.config.api.base_url,
+        'description':
+            hass.config.location_name + " at " + hass.config.api.base_url,
         'singleInstance': True,
         'webhookSmartApp': {
             'targetUrl': webhook.async_generate_url(

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -6,6 +6,8 @@ from aiohttp import ClientResponseError
 from pysmartthings import APIResponseError
 
 from homeassistant import data_entry_flow
+from homeassistant.components import cloud
+from homeassistant.components.smartthings import smartapp
 from homeassistant.components.smartthings.config_flow import (
     SmartThingsFlowHandler)
 from homeassistant.components.smartthings.const import (
@@ -191,6 +193,38 @@ async def test_app_created_then_show_wait_form(
 
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'wait_install'
+
+
+async def test_cloudhook_app_created_then_show_wait_form(
+        hass, app, app_oauth_client, smartthings_mock):
+    """Test SmartApp is created with a cloudhoko and shows wait form."""
+    # Unload the endpoint so we can reload it under the cloud.
+    await smartapp.unload_smartapp_endpoint(hass)
+
+    mock_async_active_subscription = Mock(return_value=True)
+    mock_create_cloudhook = Mock(return_value=mock_coro(
+        return_value="http://cloud.test"))
+    with patch.object(cloud, 'async_active_subscription',
+                      new=mock_async_active_subscription), \
+        patch.object(cloud, 'async_create_cloudhook',
+                     new=mock_create_cloudhook):
+
+        await smartapp.setup_smartapp_endpoint(hass)
+
+        flow = SmartThingsFlowHandler()
+        flow.hass = hass
+        smartthings = smartthings_mock.return_value
+        smartthings.apps.return_value = mock_coro(return_value=[])
+        smartthings.create_app.return_value = \
+            mock_coro(return_value=(app, app_oauth_client))
+        smartthings.update_app_settings.return_value = mock_coro()
+        smartthings.update_app_oauth.return_value = mock_coro()
+
+        result = await flow.async_step_user({'access_token': str(uuid4())})
+
+        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+        assert result['step_id'] == 'wait_install'
+        assert mock_create_cloudhook.call_count == 1
 
 
 async def test_app_updated_then_show_wait_form(

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_base_url_not_https(hass):
     hass.config.api.base_url = 'http://0.0.0.0'
     flow = SmartThingsFlowHandler()
     flow.hass = hass
-    result = await flow.async_step_import()
+    result = await flow.async_step_user({'access_token': str(uuid4())})
 
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'user'


### PR DESCRIPTION
## Description:
Adds cloudhook support through Home Assistant Cloud (Nabu Casa) to the SmartThings component.  Highlights:
- The default behavior for new integrations will be to use a cloudhook via Home Assistant Cloud (when logged in with a non-expired subscription) to receive push updates from the SmartThings cloud.  **This eliminates the need to expose the local Home Assistant to the internet and greatly simplifies setup.**
- Existing configured integrations will continue to function using the local webhook and must be removed in order to activate the new feature.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#8902

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
