### PR TITLE
Set default value for input_datetime

### DIFF
--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -122,17 +122,14 @@ class InputDatetime(RestoreEntity):
             if old_state is not None:
                 restore_val = old_state.state
 
+        if not restore_val:
+            restore_val = DEFAULT_VALUE
+
         if not self.has_date:
-            if not restore_val:
-                restore_val = DEFAULT_VALUE.split()[1]
             self._current_datetime = dt_util.parse_time(restore_val)
         elif not self.has_time:
-            if not restore_val:
-                restore_val = DEFAULT_VALUE.split()[0]
             self._current_datetime = dt_util.parse_date(restore_val)
         else:
-            if not restore_val:
-                restore_val = DEFAULT_VALUE
             self._current_datetime = dt_util.parse_datetime(restore_val)
 
     @property

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -120,13 +120,15 @@ class InputDatetime(RestoreEntity):
             if old_state is not None:
                 restore_val = old_state.state
 
-        if restore_val is not None:
-            if not self.has_date:
-                self._current_datetime = dt_util.parse_time(restore_val)
-            elif not self.has_time:
-                self._current_datetime = dt_util.parse_date(restore_val)
-            else:
-                self._current_datetime = dt_util.parse_datetime(restore_val)
+        if not self.has_date:
+            restore_val = restore_val if not None else '00:00:00'
+            self._current_datetime = dt_util.parse_time(restore_val)
+        elif not self.has_time:
+            restore_val = restore_val if not None else '1970-01-01'
+            self._current_datetime = dt_util.parse_date(restore_val)
+        else:
+            restore_val = restore_val if not None else '1970-01-01 00:00:00'
+            self._current_datetime = dt_util.parse_datetime(restore_val)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -20,6 +20,8 @@ CONF_HAS_DATE = 'has_date'
 CONF_HAS_TIME = 'has_time'
 CONF_INITIAL = 'initial'
 
+DEFAULT_VALUE = '1970-01-01 00:00:00'
+
 ATTR_DATE = 'date'
 ATTR_TIME = 'time'
 
@@ -121,13 +123,16 @@ class InputDatetime(RestoreEntity):
                 restore_val = old_state.state
 
         if not self.has_date:
-            restore_val = restore_val if not None else '00:00:00'
+            if not restore_val:
+                restore_val = DEFAULT_VALUE.split()[0]
             self._current_datetime = dt_util.parse_time(restore_val)
         elif not self.has_time:
-            restore_val = restore_val if not None else '1970-01-01'
+            if not restore_val:
+                restore_val = DEFAULT_VALUE.split()[1]
             self._current_datetime = dt_util.parse_date(restore_val)
         else:
-            restore_val = restore_val if not None else '1970-01-01 00:00:00'
+            if not restore_val:
+                restore_val = DEFAULT_VALUE
             self._current_datetime = dt_util.parse_datetime(restore_val)
 
     @property

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -122,14 +122,17 @@ class InputDatetime(RestoreEntity):
             if old_state is not None:
                 restore_val = old_state.state
 
-        if not restore_val:
-            restore_val = DEFAULT_VALUE
-
         if not self.has_date:
+            if not restore_val:
+                restore_val = DEFAULT_VALUE.split()[1]
             self._current_datetime = dt_util.parse_time(restore_val)
         elif not self.has_time:
+            if not restore_val:
+                restore_val = DEFAULT_VALUE.split()[0]
             self._current_datetime = dt_util.parse_date(restore_val)
         else:
+            if not restore_val:
+                restore_val = DEFAULT_VALUE
             self._current_datetime = dt_util.parse_datetime(restore_val)
 
     @property

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -124,11 +124,11 @@ class InputDatetime(RestoreEntity):
 
         if not self.has_date:
             if not restore_val:
-                restore_val = DEFAULT_VALUE.split()[0]
+                restore_val = DEFAULT_VALUE.split()[1]
             self._current_datetime = dt_util.parse_time(restore_val)
         elif not self.has_time:
             if not restore_val:
-                restore_val = DEFAULT_VALUE.split()[1]
+                restore_val = DEFAULT_VALUE.split()[0]
             self._current_datetime = dt_util.parse_date(restore_val)
         else:
             if not restore_val:

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -199,6 +199,36 @@ def test_restore_state(hass):
     assert state_bogus.state == str(initial)
 
 
+@asyncio.coroutine
+def test_default_value(hass):
+    """Test default value if none has been set via inital or restore state."""
+    yield from async_setup_component(hass, DOMAIN, {
+        DOMAIN: {
+            'test_time': {
+                'has_time': True,
+                'has_date': False
+            },
+            'test_date': {
+                'has_time': False,
+                'has_date': True
+            },
+            'test_datetime': {
+                'has_time': True,
+                'has_date': True
+            },
+        }})
+
+    dt_obj = datetime.datetime(1970, 1, 1, 0, 0)
+    state_time = hass.states.get('input_datetime.test_time')
+    assert state_time.state == str(dt_obj.time())
+
+    state_date = hass.states.get('input_datetime.test_date')
+    assert state_date.state == str(dt_obj.date())
+
+    state_datetime = hass.states.get('input_datetime.test_datetime')
+    assert state_datetime.state == str(dt_obj)
+
+
 async def test_input_datetime_context(hass, hass_admin_user):
     """Test that input_datetime context works."""
     assert await async_setup_component(hass, 'input_datetime', {

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -221,12 +221,15 @@ def test_default_value(hass):
     dt_obj = datetime.datetime(1970, 1, 1, 0, 0)
     state_time = hass.states.get('input_datetime.test_time')
     assert state_time.state == str(dt_obj.time())
+    assert state_time.attributes.get('timestamp') is not None
 
     state_date = hass.states.get('input_datetime.test_date')
     assert state_date.state == str(dt_obj.date())
+    assert state_date.attributes.get('timestamp') is not None
 
     state_datetime = hass.states.get('input_datetime.test_datetime')
     assert state_datetime.state == str(dt_obj)
+    assert state_datetime.attributes.get('timestamp') is not None
 
 
 async def test_input_datetime_context(hass, hass_admin_user):


### PR DESCRIPTION
## Description:
If no initial value is set and no value is available to be restored, set the default value as specified in the docs to 1970-01-01 00:00.


**Related issue (if applicable):** fixes #21917 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
N/A - This fixes the code to match the documentation

If the code communicates with devices, web services, or third-party tools:
N/A

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
