### PR TITLE
fix error in LutronButton init if Button doesn't have a type

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -124,7 +124,8 @@ class LutronButton:
         """Register callback for activity on the button."""
         name = '{}: {}'.format(keypad.name, button.name)
         self._hass = hass
-        self._has_release_event = 'RaiseLower' in button.button_type
+        self._has_release_event = (button.button_type is not None and
+                                   'RaiseLower' in button.button_type)
         self._id = slugify(name)
         self._event = 'lutron_event'
 


### PR DESCRIPTION
## Description:
RadioRA2 main repeater buttons don't always have ButtonType - this causes an error in LutronButton init. This commit handles that scenario.

**Related issue (if applicable):** None found, I didn't open one. I can open one if you like.



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
