### PR TITLE
Remove confusing warning for TTS without entity_id

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID, ATTR_MEDIA_CONTENT_TYPE, MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA)
 from homeassistant.components.media_player.const import DOMAIN as DOMAIN_MP
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform
@@ -126,7 +126,7 @@ async def async_setup(hass, config):
 
         async def async_say_handle(service):
             """Service handle for say."""
-            entity_ids = service.data.get(ATTR_ENTITY_ID)
+            entity_ids = service.data.get(ATTR_ENTITY_ID, ENTITY_MATCH_ALL)
             message = service.data.get(ATTR_MESSAGE)
             cache = service.data.get(ATTR_CACHE)
             language = service.data.get(ATTR_LANGUAGE)
@@ -144,10 +144,8 @@ async def async_setup(hass, config):
             data = {
                 ATTR_MEDIA_CONTENT_ID: url,
                 ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
+                ATTR_ENTITY_ID: entity_ids,
             }
-
-            if entity_ids:
-                data[ATTR_ENTITY_ID] = entity_ids
 
             await hass.services.async_call(
                 DOMAIN_MP, SERVICE_PLAY_MEDIA, data, blocking=True)


### PR DESCRIPTION
## Description:

The TTS say service calls `media_player.play_media`. This PR is to make TTS always pass `entity_id` in that call, avoiding this confusing warning (that mentions the wrong service call):

```
2019-03-11 09:28:09 WARNING (MainThread) [homeassistant.helpers.service] Not passing an entity ID to a service to target all entities is deprecated. Update your call to media_player.play_media to be instead: entity_id: all
```

The TTS call itself should probably have a deprecation warning as well. I think we want some general infrastructure to provide that so I did not add it in this PR.

**Related issue (if applicable):** fixes #21831

## Example entry for `configuration.yaml` (if applicable):
```yaml
service: tts.google_say
data:
  message: 'May the Force be with you.'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
