### PR TITLE
Add an asyncio Lock around pairing, which cant be used concurrently

### DIFF
--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -74,28 +74,28 @@ class HomeKitAlarmControlPanel(HomeKitEntity, AlarmControlPanel):
         """Return the state of the device."""
         return self._state
 
-    def alarm_disarm(self, code=None):
+    async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
-        self.set_alarm_state(STATE_ALARM_DISARMED, code)
+        await self.set_alarm_state(STATE_ALARM_DISARMED, code)
 
-    def alarm_arm_away(self, code=None):
+    async def async_alarm_arm_away(self, code=None):
         """Send arm command."""
-        self.set_alarm_state(STATE_ALARM_ARMED_AWAY, code)
+        await self.set_alarm_state(STATE_ALARM_ARMED_AWAY, code)
 
-    def alarm_arm_home(self, code=None):
+    async def async_alarm_arm_home(self, code=None):
         """Send stay command."""
-        self.set_alarm_state(STATE_ALARM_ARMED_HOME, code)
+        await self.set_alarm_state(STATE_ALARM_ARMED_HOME, code)
 
-    def alarm_arm_night(self, code=None):
+    async def async_alarm_arm_night(self, code=None):
         """Send night command."""
-        self.set_alarm_state(STATE_ALARM_ARMED_NIGHT, code)
+        await self.set_alarm_state(STATE_ALARM_ARMED_NIGHT, code)
 
-    def set_alarm_state(self, state, code=None):
+    async def set_alarm_state(self, state, code=None):
         """Send state command."""
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['security-system-state.target'],
                             'value': TARGET_STATE_MAP[state]}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -80,21 +80,21 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
     def _update_temperature_target(self, value):
         self._target_temp = value
 
-    def set_temperature(self, **kwargs):
+    async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         temp = kwargs.get(ATTR_TEMPERATURE)
 
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['temperature.target'],
                             'value': temp}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
-    def set_operation_mode(self, operation_mode):
+    async def async_set_operation_mode(self, operation_mode):
         """Set new target operation mode."""
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['heating-cooling.target'],
                             'value': MODE_HASS_TO_HOMEKIT[operation_mode]}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
     @property
     def state(self):

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -114,20 +114,20 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverDevice):
         """Return if the cover is opening or not."""
         return self._state == STATE_OPENING
 
-    def open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs):
         """Send open command."""
-        self.set_door_state(STATE_OPEN)
+        await self.set_door_state(STATE_OPEN)
 
-    def close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs):
         """Send close command."""
-        self.set_door_state(STATE_CLOSED)
+        await self.set_door_state(STATE_CLOSED)
 
-    def set_door_state(self, state):
+    async def set_door_state(self, state):
         """Send state command."""
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['door-state.target'],
                             'value': TARGET_GARAGE_STATE_MAP[state]}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
     @property
     def device_state_attributes(self):
@@ -232,41 +232,41 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
         """Return if the cover is opening or not."""
         return self._state == STATE_OPENING
 
-    def open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs):
         """Send open command."""
-        self.set_cover_position(position=100)
+        await self.async_set_cover_position(position=100)
 
-    def close_cover(self, **kwargs):
+    async def close_cover(self, **kwargs):
         """Send close command."""
-        self.set_cover_position(position=0)
+        await self.async_set_cover_position(position=0)
 
-    def set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs):
         """Send position command."""
         position = kwargs[ATTR_POSITION]
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['position.target'],
                             'value': position}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
     @property
     def current_cover_tilt_position(self):
         """Return current position of cover tilt."""
         return self._tilt_position
 
-    def set_cover_tilt_position(self, **kwargs):
+    async def async_set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position."""
         tilt_position = kwargs[ATTR_TILT_POSITION]
         if 'vertical-tilt.target' in self._chars:
             characteristics = [{'aid': self._aid,
                                 'iid': self._chars['vertical-tilt.target'],
                                 'value': tilt_position}]
-            self.put_characteristics(characteristics)
+            await self._accessory.put_characteristics(characteristics)
         elif 'horizontal-tilt.target' in self._chars:
             characteristics = [{'aid': self._aid,
                                 'iid':
                                 self._chars['horizontal-tilt.target'],
                                 'value': tilt_position}]
-            self.put_characteristics(characteristics)
+            await self._accessory.put_characteristics(characteristics)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -101,7 +101,7 @@ class HomeKitLight(HomeKitEntity, Light):
         """Flag supported features."""
         return self._features
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Turn the specified light on."""
         hs_color = kwargs.get(ATTR_HS_COLOR)
         temperature = kwargs.get(ATTR_COLOR_TEMP)
@@ -127,11 +127,11 @@ class HomeKitLight(HomeKitEntity, Light):
         characteristics.append({'aid': self._aid,
                                 'iid': self._chars['on'],
                                 'value': True})
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Turn the specified light off."""
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['on'],
                             'value': False}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -75,20 +75,20 @@ class HomeKitLock(HomeKitEntity, LockDevice):
         """Return True if entity is available."""
         return self._state is not None
 
-    def lock(self, **kwargs):
+    async def async_lock(self, **kwargs):
         """Lock the device."""
-        self._set_lock_state(STATE_LOCKED)
+        await self._set_lock_state(STATE_LOCKED)
 
-    def unlock(self, **kwargs):
+    async def async_unlock(self, **kwargs):
         """Unlock the device."""
-        self._set_lock_state(STATE_UNLOCKED)
+        await self._set_lock_state(STATE_UNLOCKED)
 
-    def _set_lock_state(self, state):
+    async def _set_lock_state(self, state):
         """Send state command."""
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['lock-mechanism.target-state'],
                             'value': TARGET_STATE_MAP[state]}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -48,20 +48,20 @@ class HomeKitSwitch(HomeKitEntity, SwitchDevice):
         """Return true if device is on."""
         return self._on
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Turn the specified switch on."""
         self._on = True
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['on'],
                             'value': True}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Turn the specified switch off."""
         characteristics = [{'aid': self._aid,
                             'iid': self._chars['on'],
                             'value': False}]
-        self.put_characteristics(characteristics)
+        await self._accessory.put_characteristics(characteristics)
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Description:

I'll need to rebase this after #21901 is merged to fix a conflict in the `update()` method.

I was recently discussing plans for homekit_controller with another user/contributor and realised that there is no explicit locking around the pairing. The homekit_controller Pairing object is not safe to use concurrently, so users with bridges may be experiencing glitches as the asynchronicity trips up the session encryption.

I think there is already some logic around EntityPlatforms that limits concurrent polls (`PARALLEL_UPDATES`) which means you are unlikely to see problems with just polling. However if you have concurrent writes (or a write and poll at the same time) then you'll get a AccessoryDisconnected error and the request will fail. In one of my longer running branches to add BLE homekit support I actually noticed this quite a lot with even a single device. BLE requests are quite slow so multi tapping on UI elements was enough to trigger the problem.

It seemed like it would be easiest to reason about this if we used the async_ version of the entity API as much as possible and handled the locking needed for the pairing object on the HA side as close to the pairing object as possible. I also wanted an approach that played well with future plans to make an asyncio variant of homekit_python (the upstream we are using for this component).

I have tested this with a homekit_python demoserver.py setup as a fake bridge that has 50 fake light bulbs attached to it, and the tests pass locally.

As I was editing an adjacent function i've removed `update_characteristics` as its no longer used.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
