### PR TITLE
Fix _async_add_entity (EntityPlatform) polls entity state of push platforms

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -349,7 +349,8 @@ class EntityPlatform:
 
         await entity.async_added_to_hass()
 
-        await entity.async_update_ha_state()
+        if entity.should_poll:
+            await entity.async_update_ha_state()
 
     async def async_reset(self):
         """Remove all entities and reset data.


### PR DESCRIPTION
## Description:
```_async_add_entity``` (EntityPlatform) should only poll entity state if entity uses polling. Push platforms will update HA state when received from device.

**Related issue (if applicable):** fixes #21893

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
