### PR TITLE
Nanoleaf availability check

### DIFF
--- a/homeassistant/components/light/nanoleaf.py
+++ b/homeassistant/components/light/nanoleaf.py
@@ -19,7 +19,7 @@ from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pynanoleaf==0.0.2']
+REQUIREMENTS = ['pynanoleaf==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,7 +78,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     nanoleaf_light.token = token
 
-    if nanoleaf_light.on is None:
+    try:
+       available = nanoleaf_light.available
+    except Exception as err:
         _LOGGER.error(
             "Could not connect to Nanoleaf Light: %s on %s", name, host)
         return
@@ -92,6 +94,7 @@ class NanoleafLight(Light):
 
     def __init__(self, light, name):
         """Initialize an Nanoleaf light."""
+        self._available = True
         self._brightness = None
         self._color_temp = None
         self._effect = None
@@ -100,6 +103,11 @@ class NanoleafLight(Light):
         self._name = name
         self._hs_color = None
         self._state = None
+
+    @property
+    def available(self):
+        """Return availability."""
+        return self._available
 
     @property
     def brightness(self):
@@ -187,9 +195,15 @@ class NanoleafLight(Light):
 
     def update(self):
         """Fetch new state data for this light."""
-        self._brightness = self._light.brightness
-        self._color_temp = self._light.color_temperature
-        self._effect = self._light.effect
-        self._effects_list = self._light.effects
-        self._hs_color = self._light.hue, self._light.saturation
-        self._state = self._light.on
+        try:
+            self._available = self._light.available
+            self._brightness = self._light.brightness
+            self._color_temp = self._light.color_temperature
+            self._effect = self._light.effect
+            self._effects_list = self._light.effects
+            self._hs_color = self._light.hue, self._light.saturation
+            self._state = self._light.on
+        except Exception as err:  # pylint:disable=broad-except
+            _LOGGER.error("Could not update status for %s (%s)",
+                            self.name, err)
+            self._available = False

--- a/homeassistant/components/light/nanoleaf.py
+++ b/homeassistant/components/light/nanoleaf.py
@@ -19,7 +19,7 @@ from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pynanoleaf==0.0.4']
+REQUIREMENTS = ['pynanoleaf==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Nanoleaf light."""
-    import pynanoleaf
+    from pynanoleaf import Nanoleaf, Unavailable
     if DATA_NANOLEAF not in hass.data:
         hass.data[DATA_NANOLEAF] = dict()
 
@@ -63,7 +63,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         name = config[CONF_NAME]
         token = config[CONF_TOKEN]
 
-    nanoleaf_light = pynanoleaf.Nanoleaf(host)
+    nanoleaf_light = Nanoleaf(host)
 
     if not token:
         token = nanoleaf_light.request_token()
@@ -79,8 +79,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     nanoleaf_light.token = token
 
     try:
-       available = nanoleaf_light.available
-    except Exception as err:
+        nanoleaf_light.available
+    except Unavailable:
         _LOGGER.error(
             "Could not connect to Nanoleaf Light: %s on %s", name, host)
         return
@@ -205,5 +205,5 @@ class NanoleafLight(Light):
             self._state = self._light.on
         except Exception as err:  # pylint:disable=broad-except
             _LOGGER.error("Could not update status for %s (%s)",
-                            self.name, err)
+                          self.name, err)
             self._available = False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1171,7 +1171,7 @@ pymyq==1.1.0
 pymysensors==0.18.0
 
 # homeassistant.components.light.nanoleaf
-pynanoleaf==0.0.2
+pynanoleaf==0.0.5
 
 # homeassistant.components.lock.nello
 pynello==2.0.2


### PR DESCRIPTION
## Description:
Added availability check for Nanoleaf lights. Needs bump of pynanoleaf to timeout gracefully

**Related issue (if applicable):** None
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** None

## Example entry for `configuration.yaml` (if applicable): None

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
