### PR TITLE
HomeKit controller light - remove code that can never execute

### DIFF
--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -25,11 +25,11 @@ class HomeKitLight(HomeKitEntity, Light):
     def __init__(self, *args):
         """Initialise the light."""
         super().__init__(*args)
-        self._on = None
-        self._brightness = None
-        self._color_temperature = None
-        self._hue = None
-        self._saturation = None
+        self._on = False
+        self._brightness = 0
+        self._color_temperature = 0
+        self._hue = 0
+        self._saturation = 0
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
@@ -78,23 +78,17 @@ class HomeKitLight(HomeKitEntity, Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        if self._features & SUPPORT_BRIGHTNESS:
-            return self._brightness * 255 / 100
-        return None
+        return self._brightness * 255 / 100
 
     @property
     def hs_color(self):
         """Return the color property."""
-        if self._features & SUPPORT_COLOR:
-            return (self._hue, self._saturation)
-        return None
+        return (self._hue, self._saturation)
 
     @property
     def color_temp(self):
         """Return the color temperature."""
-        if self._features & SUPPORT_COLOR_TEMP:
-            return self._color_temperature
-        return None
+        return self._color_temperature
 
     @property
     def supported_features(self):


### PR DESCRIPTION
## Description:

I have a few changes in my [config flow branch](https://github.com/home-assistant/home-assistant/compare/dev...Jc2k:homekit_config_flow) that aren't strictly to do with config flow. I'm pulling them into seperate PR's so that the remaining config flow stuff is easier to review.

I've done a lot of work on test coverage via that branch and this PR is a small change I made to get the coverage on light to 100%. The properties do not need to be conditional on `self._features` because the `Light` base class actually only inspects these properties when they are supported. This was creating 3x `return None` branches that were never executed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.