### PR TITLE
Add a service require_admin wrapper

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -340,6 +340,7 @@ async def _handle_service_platform_call(func, data, entities, context):
 
 def require_admin(handler, hass=None):
     """Decorate a service handler to require an admin user."""
+    # This will allow this function also to be used as a decorator.
     if hass is None:
         return lambda hass: require_admin(handler, hass)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -338,8 +338,11 @@ async def _handle_service_platform_call(func, data, entities, context):
             future.result()  # pop exception if have
 
 
-def require_admin(hass, handler):
+def require_admin(handler, hass=None):
     """Decorate a service handler to require an admin user."""
+    if hass is None:
+        return lambda hass: require_admin(handler, hass)
+
     @wraps(handler)
     async def admin_handler(call):
         if call.context.user_id:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -339,7 +339,20 @@ async def _handle_service_platform_call(func, data, entities, context):
 
 
 def require_admin(handler, hass=None):
-    """Decorate a service handler to require an admin user."""
+    """Decorate a service handler to require an admin user.
+
+    # Pass in hass later
+    @require_admin
+    async def service_handler(call):
+
+    hass.services.async_register('domain', 'service', service_handler(hass))
+
+    # Pass in hass direct
+    async def service_handler(call):
+
+    hass.services.async_register('domain', 'service',
+                                 require_admin(service_handler, hass))
+    """
     # This will allow this function also to be used as a decorator.
     if hass is None:
         return lambda hass: require_admin(handler, hass)

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -12,7 +12,6 @@ import homeassistant.components  # noqa
 from homeassistant import core as ha, loader, exceptions
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ENTITY_ID
 from homeassistant.setup import async_setup_component
-from homeassistant import exceptions
 import homeassistant.helpers.config_validation as cv
 from homeassistant.auth.permissions import PolicyPermissions
 from homeassistant.helpers import (

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -402,11 +402,11 @@ async def test_require_admin_decorator(hass, hass_read_only_user,
     """Test the require_admin decorator."""
     calls = []
 
+    @service.require_admin
     async def mock_service(call):
         calls.append(call)
 
-    hass.services.async_register(
-        'test', 'test', service.require_admin(hass, mock_service))
+    hass.services.async_register('test', 'test', mock_service(hass))
 
     with pytest.raises(exceptions.UnknownUser):
         await hass.services.async_call(

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import unittest
 from unittest.mock import Mock, patch
 
+import voluptuous as vol
 import pytest
 
 # To prevent circular import when running just this file
@@ -396,16 +397,17 @@ async def test_call_with_omit_entity_id(hass, mock_service_platform_call,
             'all entities is deprecated') in caplog.text
 
 
-async def test_require_admin_decorator(hass, hass_read_only_user,
-                                       hass_admin_user):
-    """Test the require_admin decorator."""
+async def test_register_admin_service(hass, hass_read_only_user,
+                                      hass_admin_user):
+    """Test the register admin service."""
     calls = []
 
-    @service.require_admin
     async def mock_service(call):
         calls.append(call)
 
-    hass.services.async_register('test', 'test', mock_service(hass))
+    hass.helpers.service.async_register_admin_service(
+        'test', 'test', mock_service, vol.Schema({})
+    )
 
     with pytest.raises(exceptions.UnknownUser):
         await hass.services.async_call(


### PR DESCRIPTION
## Description:
Add a helper method to register a service that is limited to admin users.

```python
hass.helpers.service.async_register_admin_service(
    'zha', 'pair', pair_service, vol.Schema({})
)
```

https://github.com/home-assistant/developers.home-assistant/pull/197

## Old description, no longer relevant
Add a function to wrap around admin only services to ensure called by an admin user.

Because the admin check requires a `hass` object, decorating a service handler with `@service.require_admin`, will make it a factory function requiring `hass` to be passed in.

```python
# Usage 1
@service.require_admin
async def mock_service(call):

hass.services.async_register('test', 'test', mock_service(hass))

# Usage 2
async def mock_service(call):

hass.services.async_register('test', 'test', service.require_admin(mock_service, hass))

```

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** TBD

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
