### PR TITLE
Ps4 remove throttling

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -2,7 +2,7 @@
 Support for PlayStation 4 consoles.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/media_player.ps4/
+https://home-assistant.io/components/ps4/
 """
 import logging
 import socket

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -4,14 +4,12 @@ Support for PlayStation 4 consoles.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.ps4/
 """
-from datetime import timedelta
 import logging
 import socket
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-import homeassistant.util as util
 from homeassistant.components.media_player import (
     MediaPlayerDevice, ENTITY_IMAGE_URL)
 from homeassistant.components.media_player.const import (
@@ -37,9 +35,6 @@ PS4_DATA = 'ps4_data'
 ICON = 'mdi:playstation'
 GAMES_FILE = '.ps4-games.json'
 MEDIA_IMAGE_DEFAULT = None
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
-MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=10)
 
 COMMANDS = (
     'up',
@@ -139,7 +134,6 @@ class PS4Device(MediaPlayerDevice):
         """Subscribe PS4 events."""
         self.hass.data[PS4_DATA].devices.append(self)
 
-    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Retrieve the latest data."""
         try:


### PR DESCRIPTION
## Description:
Remove unnecessary throttling for state updates. Allows for faster state updates.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
