### PR TITLE
Avoid playing queue pollution when restoring Sonos snapshots

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -1037,8 +1037,13 @@ class SonosEntity(MediaPlayerDevice):
             if entity.state == STATE_PLAYING:
                 entity.media_pause()
 
-        # Bring back the original group topology
         if with_group:
+            # Unjoin slaves that are not already in their target group
+            for entity in [e for e in entities if not e.is_coordinator]:
+                if entity._snapshot_group != entity._sonos_group:
+                    entity.unjoin()
+
+            # Bring back the original group topology
             for entity in (e for e in entities if e._snapshot_group):
                 if entity._snapshot_group[0] == entity:
                     entity.join(entity._snapshot_group)


### PR DESCRIPTION
## Description:

A follow-up to #21411, improving restore in some cases. Details in the commit message.

Since this is quite tricky and I am working on further refinements before the beta, I will assume lazy consensus if I get no objections within 12 hours.

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  sonos_dance:
    sequence:
      - service: media_player.sonos_unjoin
        entity_id:
          - media_player.a
          - media_player.b
          - media_player.c
      - delay: 5
      - service: media_player.sonos_join
        data:
          master: media_player.a
          entity_id: media_player.b
      - delay: 5
      - service: media_player.sonos_snapshot
      - service: media_player.sonos_unjoin
        entity_id:
          - media_player.b
      - delay: 5
      - service: media_player.sonos_join
        data:
          master: media_player.b
          entity_id: media_player.c
      - delay: 5
      - service: media_player.sonos_restore
      # media_player.c is now playing a new queue
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23