### PR TITLE
homekit_controller: Bump homekit to 0.13.0

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -15,7 +15,7 @@ from .const import (
 )
 
 
-REQUIREMENTS = ['homekit==0.12.2']
+REQUIREMENTS = ['homekit[IP]==0.13.0']
 
 HOMEKIT_DIR = '.homekit'
 
@@ -314,7 +314,7 @@ def setup(hass, config):
     """Set up for Homekit devices."""
     # pylint: disable=import-error
     import homekit
-    from homekit.controller import Pairing
+    from homekit.controller.ip_implementation import IpPairing
 
     hass.data[CONTROLLER] = controller = homekit.Controller()
 
@@ -335,7 +335,7 @@ def setup(hass, config):
             continue
         with open(os.path.join(data_dir, device)) as pairing_data_fp:
             pairing_data = json.load(pairing_data_fp)
-        controller.pairings[alias] = Pairing(pairing_data)
+        controller.pairings[alias] = IpPairing(pairing_data)
         controller.save_data(pairing_file)
 
     def discovery_dispatch(service, discovery_info):

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -189,7 +189,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
     async def async_import_legacy_pairing(self, discovery_props, pairing_data):
         """Migrate a legacy pairing to config entries."""
-        from homekit.controller import Pairing
+        from homekit.controller.ip_implementation import IpPairing
 
         hkid = discovery_props['id']
 
@@ -204,7 +204,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             ("Legacy configuration %s for homekit"
              "accessory migrated to config entries"), hkid)
 
-        pairing = Pairing(pairing_data)
+        pairing = IpPairing(pairing_data)
 
         return await self._entry_from_accessory(pairing)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -554,7 +554,7 @@ home-assistant-frontend==20190309.0
 homeassistant-pyozw==0.1.2
 
 # homeassistant.components.homekit_controller
-homekit==0.12.2
+homekit[IP]==0.13.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -122,6 +122,9 @@ holidays==0.9.9
 # homeassistant.components.frontend
 home-assistant-frontend==20190309.0
 
+# homeassistant.components.homekit_controller
+homekit[IP]==0.13.0
+
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -123,7 +123,7 @@ holidays==0.9.9
 home-assistant-frontend==20190309.0
 
 # homeassistant.components.homekit_controller
-homekit==0.12.2
+homekit[IP]==0.13.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -122,9 +122,6 @@ holidays==0.9.9
 # homeassistant.components.frontend
 home-assistant-frontend==20190309.0
 
-# homeassistant.components.homekit_controller
-homekit[IP]==0.13.0
-
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.6
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -67,7 +67,7 @@ TEST_REQUIREMENTS = (
     'hdate',
     'holidays',
     'home-assistant-frontend',
-    'homekit',
+    'homekit[IP]',
     'homematicip',
     'influxdb',
     'jsonpath',

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -104,7 +104,7 @@ TEST_REQUIREMENTS = (
     'python-forecastio',
     'python-nest',
     'python_awair',
-    'pytradfri\\[async\\]',
+    'pytradfri[async]',
     'pyunifi',
     'pyupnp-async',
     'pywebpush',
@@ -288,7 +288,7 @@ def requirements_test_output(reqs):
     output.append('\n')
     filtered = {key: value for key, value in reqs.items()
                 if any(
-                    re.search(r'(^|#){}($|[=><])'.format(ign),
+                    re.search(r'(^|#){}($|[=><])'.format(re.escape(ign)),
                               key) is not None for ign in TEST_REQUIREMENTS)}
     output.append(generate_requirements_list(filtered))
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -471,7 +471,9 @@ async def test_import_works(hass):
     flow = config_flow.HomekitControllerFlowHandler()
     flow.hass = hass
 
-    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+
+    with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
         result = await flow.async_import_legacy_pairing(
             discovery_info['properties'], import_info)
@@ -649,7 +651,9 @@ async def test_parse_new_homekit_json(hass):
     flow = config_flow.HomekitControllerFlowHandler()
     flow.hass = hass
 
-    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+
+    with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
         with mock.patch('builtins.open', mock_open):
             with mock.patch('os.path', mock_path):
@@ -703,7 +707,9 @@ async def test_parse_old_homekit_json(hass):
     flow = config_flow.HomekitControllerFlowHandler()
     flow.hass = hass
 
-    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+
+    with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
         with mock.patch('builtins.open', mock_open):
             with mock.patch('os.path', mock_path):
@@ -769,7 +775,9 @@ async def test_parse_overlapping_homekit_json(hass):
     flow = config_flow.HomekitControllerFlowHandler()
     flow.hass = hass
 
-    with mock.patch('homekit.controller.Pairing') as pairing_cls:
+    pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
+
+    with mock.patch(pairing_cls_imp) as pairing_cls:
         pairing_cls.return_value = pairing
         with mock.patch('builtins.open', side_effect=side_effects):
             with mock.patch('os.path', mock_path):


### PR DESCRIPTION
## Description:

Our upstream dependency has released 0.13.0 which includes the minimal changes required to have HomeKit BLE devices work in HA. This won't immediately enable support for BLE devices, but bumping allows me to start to open PR for work in my homekit bluetooth branch.

The new release uses extra_requires metadata to differentiate between IP and bluetooth dependencies, which is why the dependency is now expressed as `homekit[IP]` - there is also a `homekit[BLE]` but that will pull in extra dependencies we aren't yet ready for. I had to update `TEST_REQUIREMENTS` in `gen_requirements_all` because of this. Note that the actual dependencies for IP accessories haven't actually changed.

It also supercedes #21904 (0.13.0 was released since that PR was opened). 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.