### PR TITLE
Write state directly in all MQTT platforms

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -868,7 +868,7 @@ class MqttAttributes(Entity):
                 json_dict = json.loads(payload)
                 if isinstance(json_dict, dict):
                     self._attributes = json_dict
-                    self.async_schedule_update_ha_state()
+                    self.async_write_ha_state()
                 else:
                     _LOGGER.warning("JSON result was not a dictionary")
                     self._attributes = None
@@ -932,7 +932,7 @@ class MqttAvailability(Entity):
             elif payload == self._avail_config[CONF_PAYLOAD_NOT_AVAILABLE]:
                 self._available = False
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         self._availability_sub_state = await async_subscribe_topics(
             self.hass, self._availability_sub_state,

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -121,7 +121,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -136,7 +136,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 _LOGGER.warning("Received unexpected payload: %s", payload)
                 return
             self._state = payload
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,

--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -97,7 +97,7 @@ class MqttCamera(MqttDiscoveryUpdate, Camera):
         config = PLATFORM_SCHEMA(discovery_payload)
         self._config = config
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -231,7 +231,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
@@ -297,7 +297,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
             try:
                 self._current_temperature = float(payload)
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
             except ValueError:
                 _LOGGER.error("Could not parse temperature from %s", payload)
 
@@ -318,7 +318,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 _LOGGER.error("Invalid mode: %s", payload)
             else:
                 self._current_operation = payload
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
 
         if self._topic[CONF_MODE_STATE_TOPIC] is not None:
             topics[CONF_MODE_STATE_TOPIC] = {
@@ -336,7 +336,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
             try:
                 self._target_temperature = float(payload)
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
             except ValueError:
                 _LOGGER.error("Could not parse temperature from %s", payload)
 
@@ -358,7 +358,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 _LOGGER.error("Invalid fan mode: %s", payload)
             else:
                 self._current_fan_mode = payload
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is not None:
             topics[CONF_FAN_MODE_STATE_TOPIC] = {
@@ -378,7 +378,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 _LOGGER.error("Invalid swing mode: %s", payload)
             else:
                 self._current_swing_mode = payload
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
 
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is not None:
             topics[CONF_SWING_MODE_STATE_TOPIC] = {
@@ -407,7 +407,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             else:
                 _LOGGER.error("Invalid away mode: %s", payload)
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is not None:
             topics[CONF_AWAY_MODE_STATE_TOPIC] = {
@@ -435,7 +435,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             else:
                 _LOGGER.error("Invalid aux mode: %s", payload)
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_AUX_STATE_TOPIC] is not None:
             topics[CONF_AUX_STATE_TOPIC] = {
@@ -451,7 +451,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                   async_render_with_possible_json_value(payload)
 
             self._hold = payload
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_HOLD_STATE_TOPIC] is not None:
             topics[CONF_HOLD_STATE_TOPIC] = {
@@ -558,7 +558,8 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                     kwargs.get(ATTR_TEMPERATURE), self._config.get(CONF_QOS),
                     self._config.get(CONF_RETAIN))
 
-        self.async_schedule_update_ha_state()
+        # Always optimistic?
+        self.async_write_ha_state()
 
     async def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""
@@ -571,7 +572,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
             self._current_swing_mode = swing_mode
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_set_fan_mode(self, fan_mode):
         """Set new target temperature."""
@@ -584,7 +585,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
             self._current_fan_mode = fan_mode
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_set_operation_mode(self, operation_mode) -> None:
         """Set new operation mode."""
@@ -609,7 +610,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_MODE_STATE_TOPIC] is None:
             self._current_operation = operation_mode
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     @property
     def current_swing_mode(self):
@@ -632,7 +633,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is None:
             self._away = True
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_away_mode_off(self):
         """Turn away mode off."""
@@ -645,7 +646,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is None:
             self._away = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_set_hold_mode(self, hold_mode):
         """Update hold mode on."""
@@ -657,7 +658,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_HOLD_STATE_TOPIC] is None:
             self._hold = hold_mode
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_aux_heat_on(self):
         """Turn auxiliary heater on."""
@@ -669,7 +670,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_AUX_STATE_TOPIC] is None:
             self._aux = True
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_aux_heat_off(self):
         """Turn auxiliary heater off."""
@@ -681,7 +682,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._topic[CONF_AUX_STATE_TOPIC] is None:
             self._aux = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     @property
     def supported_features(self):

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -195,7 +195,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _setup_from_config(self, config):
         self._config = config
@@ -224,7 +224,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
                 level = self.find_percentage_in_range(float(payload))
                 self._tilt_value = level
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
 
         @callback
         def state_message_received(topic, payload, qos):
@@ -240,7 +240,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             else:
                 _LOGGER.warning("Payload is not True or False: %s", payload)
                 return
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         @callback
         def position_message_received(topic, payload, qos):
@@ -259,7 +259,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                     "Payload is not integer within range: %s",
                     payload)
                 return
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._config.get(CONF_GET_POSITION_TOPIC):
             topics['get_position_topic'] = {
@@ -364,7 +364,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             if self._config.get(CONF_GET_POSITION_TOPIC):
                 self._position = self.find_percentage_in_range(
                     self._config.get(CONF_POSITION_OPEN), COVER_PAYLOAD)
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_close_cover(self, **kwargs):
         """Move the cover down.
@@ -381,7 +381,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             if self._config.get(CONF_GET_POSITION_TOPIC):
                 self._position = self.find_percentage_in_range(
                     self._config.get(CONF_POSITION_CLOSED), COVER_PAYLOAD)
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs):
         """Stop the device.
@@ -402,7 +402,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._config.get(CONF_RETAIN))
         if self._tilt_optimistic:
             self._tilt_value = self._config.get(CONF_TILT_OPEN_POSITION)
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_close_cover_tilt(self, **kwargs):
         """Tilt the cover closed."""
@@ -413,7 +413,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._config.get(CONF_RETAIN))
         if self._tilt_optimistic:
             self._tilt_value = self._config.get(CONF_TILT_CLOSED_POSITION)
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position."""
@@ -458,7 +458,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._state = percentage_position == \
                     self._config.get(CONF_POSITION_CLOSED)
                 self._position = percentage_position
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
 
     def find_percentage_in_range(self, position, range_type=TILT_PAYLOAD):
         """Find the 0-100% value within the specified range."""

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -158,7 +158,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
@@ -219,7 +219,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._state = True
             elif payload == self._payload[STATE_OFF]:
                 self._state = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_STATE_TOPIC] is not None:
             topics[CONF_STATE_TOPIC] = {
@@ -237,7 +237,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._speed = SPEED_MEDIUM
             elif payload == self._payload[SPEED_HIGH]:
                 self._speed = SPEED_HIGH
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_SPEED_STATE_TOPIC] is not None:
             topics[CONF_SPEED_STATE_TOPIC] = {
@@ -254,7 +254,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._oscillation = True
             elif payload == self._payload[OSCILLATE_OFF_PAYLOAD]:
                 self._oscillation = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_OSCILLATION_STATE_TOPIC] is not None:
             topics[CONF_OSCILLATION_STATE_TOPIC] = {
@@ -360,7 +360,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._optimistic_speed:
             self._speed = speed
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation.
@@ -381,7 +381,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         if self._optimistic_oscillation:
             self._oscillation = oscillating
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     @property
     def unique_id(self):

--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -174,7 +174,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
@@ -265,7 +265,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._state = True
             elif payload == self._payload['off']:
                 self._state = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_STATE_TOPIC] is not None:
             topics[CONF_STATE_TOPIC] = {
@@ -288,7 +288,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             percent_bright = \
                 device_value / self._config.get(CONF_BRIGHTNESS_SCALE)
             self._brightness = percent_bright * 255
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is not None:
             topics[CONF_BRIGHTNESS_STATE_TOPIC] = {
@@ -318,7 +318,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 percent_bright = \
                     float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
                 self._brightness = percent_bright * 255
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_RGB_STATE_TOPIC] is not None:
             topics[CONF_RGB_STATE_TOPIC] = {
@@ -342,7 +342,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 return
 
             self._color_temp = int(payload)
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_COLOR_TEMP_STATE_TOPIC] is not None:
             topics[CONF_COLOR_TEMP_STATE_TOPIC] = {
@@ -367,7 +367,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 return
 
             self._effect = payload
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_EFFECT_STATE_TOPIC] is not None:
             topics[CONF_EFFECT_STATE_TOPIC] = {
@@ -394,7 +394,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             try:
                 hs_color = [float(val) for val in payload.split(',', 2)]
                 self._hs = hs_color
-                self.async_schedule_update_ha_state()
+                self.async_write_ha_state()
             except ValueError:
                 _LOGGER.debug("Failed to parse hs state update: '%s'",
                               payload)
@@ -424,7 +424,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             percent_white = \
                 device_value / self._config.get(CONF_WHITE_VALUE_SCALE)
             self._white_value = percent_white * 255
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_WHITE_VALUE_STATE_TOPIC] is not None:
             topics[CONF_WHITE_VALUE_STATE_TOPIC] = {
@@ -451,7 +451,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
             xy_color = [float(val) for val in payload.split(',')]
             self._hs = color_util.color_xy_to_hs(*xy_color)
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_XY_STATE_TOPIC] is not None:
             topics[CONF_XY_STATE_TOPIC] = {
@@ -742,7 +742,7 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             should_update = True
 
         if should_update:
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off.
@@ -756,4 +756,4 @@ class MqttLight(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         if self._optimistic:
             # Optimistically assume that the light has changed state.
             self._state = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -136,7 +136,7 @@ class MqttLightJson(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
@@ -276,7 +276,7 @@ class MqttLightJson(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 except ValueError:
                     _LOGGER.warning("Invalid white value received")
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topic[CONF_STATE_TOPIC] is not None:
             self._sub_state = await subscription.async_subscribe_topics(
@@ -456,7 +456,7 @@ class MqttLightJson(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             should_update = True
 
         if should_update:
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off.
@@ -475,4 +475,4 @@ class MqttLightJson(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         if self._optimistic:
             # Optimistically assume that the light has changed state.
             self._state = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -124,7 +124,7 @@ class MqttTemplate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
@@ -250,7 +250,7 @@ class MqttTemplate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 else:
                     _LOGGER.warning("Unsupported effect value received")
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._topics[CONF_STATE_TOPIC] is not None:
             self._sub_state = await subscription.async_subscribe_topics(
@@ -400,7 +400,7 @@ class MqttTemplate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         )
 
         if self._optimistic:
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off.
@@ -421,7 +421,7 @@ class MqttTemplate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         )
 
         if self._optimistic:
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     @property
     def supported_features(self):

--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -111,7 +111,7 @@ class MqttLock(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -130,7 +130,7 @@ class MqttLock(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             elif payload == self._config[CONF_PAYLOAD_UNLOCK]:
                 self._state = False
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._config.get(CONF_STATE_TOPIC) is None:
             # Force into optimistic mode.
@@ -185,9 +185,9 @@ class MqttLock(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN])
         if self._optimistic:
-            # Optimistically assume that switch has changed state.
+            # Optimistically assume that the lock has changed state.
             self._state = True
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_unlock(self, **kwargs):
         """Unlock the device.
@@ -200,6 +200,6 @@ class MqttLock(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             self._config[CONF_QOS],
             self._config[CONF_RETAIN])
         if self._optimistic:
-            # Optimistically assume that switch has changed state.
+            # Optimistically assume that the lock has changed state.
             self._state = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -124,7 +124,7 @@ class MqttSensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -169,7 +169,7 @@ class MqttSensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 payload = template.async_render_with_possible_json_value(
                     payload, self._state)
             self._state = payload
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,
@@ -189,7 +189,7 @@ class MqttSensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """Triggered when value is expired."""
         self._expiration_trigger = None
         self._state = None
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/mqtt/switch.py
+++ b/homeassistant/components/mqtt/switch.py
@@ -121,7 +121,7 @@ class MqttSwitch(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
@@ -153,7 +153,7 @@ class MqttSwitch(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             elif payload == self._state_off:
                 self._state = False
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         if self._config.get(CONF_STATE_TOPIC) is None:
             # Force into optimistic mode.
@@ -222,7 +222,7 @@ class MqttSwitch(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         if self._optimistic:
             # Optimistically assume that switch has changed state.
             self._state = True
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off.
@@ -238,4 +238,4 @@ class MqttSwitch(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         if self._optimistic:
             # Optimistically assume that switch has changed state.
             self._state = False
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -264,7 +264,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self):
         """Subscribe MQTT events."""
@@ -346,7 +346,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 if fan_speed is not None:
                     self._fan_speed = fan_speed
 
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
         topics_list = {topic for topic in self._state_topics.values() if topic}
         self._sub_state = await subscription.async_subscribe_topics(
@@ -434,7 +434,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._payloads[CONF_PAYLOAD_TURN_ON],
                            self._qos, self._retain)
         self._status = 'Cleaning'
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the vacuum off."""
@@ -445,7 +445,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._payloads[CONF_PAYLOAD_TURN_OFF],
                            self._qos, self._retain)
         self._status = 'Turning Off'
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_stop(self, **kwargs):
         """Stop the vacuum."""
@@ -456,7 +456,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._payloads[CONF_PAYLOAD_STOP],
                            self._qos, self._retain)
         self._status = 'Stopping the current task'
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_clean_spot(self, **kwargs):
         """Perform a spot clean-up."""
@@ -467,7 +467,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._payloads[CONF_PAYLOAD_CLEAN_SPOT],
                            self._qos, self._retain)
         self._status = "Cleaning spot"
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_locate(self, **kwargs):
         """Locate the vacuum (usually by playing a song)."""
@@ -478,7 +478,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._payloads[CONF_PAYLOAD_LOCATE],
                            self._qos, self._retain)
         self._status = "Hi, I'm over here!"
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_start_pause(self, **kwargs):
         """Start, pause or resume the cleaning task."""
@@ -489,7 +489,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._payloads[CONF_PAYLOAD_START_PAUSE],
                            self._qos, self._retain)
         self._status = 'Pausing/Resuming cleaning...'
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_return_to_base(self, **kwargs):
         """Tell the vacuum to return to its dock."""
@@ -500,7 +500,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                            self._payloads[CONF_PAYLOAD_RETURN_TO_BASE],
                            self._qos, self._retain)
         self._status = 'Returning home...'
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_set_fan_speed(self, fan_speed, **kwargs):
         """Set fan speed."""
@@ -512,7 +512,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         mqtt.async_publish(self.hass, self._set_fan_speed_topic,
                            fan_speed, self._qos, self._retain)
         self._status = "Setting fan to {}...".format(fan_speed)
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_send_command(self, command, params=None, **kwargs):
         """Send a command to a vacuum cleaner."""
@@ -522,4 +522,4 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         mqtt.async_publish(self.hass, self._send_command_topic,
                            command, self._qos, self._retain)
         self._status = "Sending command {}...".format(command)
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -105,6 +105,7 @@ async def test_custom_availability_payload(hass, mqtt_mock):
 
     async_fire_mqtt_message(hass, 'availability_topic', 'good')
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     state = hass.states.get('fan.test')
     assert state.state is not STATE_UNAVAILABLE

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -235,6 +235,7 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'test_light_rgb',
                             '{"state":"ON", "color":{"x":0.135,"y":0.135}}')
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     light_state = hass.states.get('light.test')
     assert (0.141, 0.14) == \


### PR DESCRIPTION
## Description:
Write state directly from all MQTT platforms by calling `Entity.async_write_ha_state()`  instead of `Entity.async_schedule_update_ha_state()`

This is a follow-up to: #21590

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
