### PR TITLE
Always print invalid configuration data

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -210,6 +210,12 @@ def clear_discovery_hash(hass, discovery_hash):
     del hass.data[ALREADY_DISCOVERED][discovery_hash]
 
 
+class MQTTConfig(dict):
+    """Dummy class to allow adding attributes."""
+
+    pass
+
+
 async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
                       config_entry=None) -> bool:
     """Initialize of MQTT Discovery."""
@@ -236,7 +242,7 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
                                 object_id, payload)
                 return
 
-        payload = dict(payload)
+        payload = MQTTConfig(payload)
 
         for key in list(payload.keys()):
             abbreviated_key = key
@@ -264,6 +270,7 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         discovery_hash = (component, discovery_id)
 
         if payload:
+            setattr(payload, '__configuration_topic__', topic)
             if CONF_PLATFORM in payload and 'schema' not in payload:
                 platform = payload[CONF_PLATFORM]
                 if (component in DEPRECATED_PLATFORM_TO_SCHEMA and

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -271,7 +271,8 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
 
         if payload:
             # Attach MQTT topic to the payload, used for debug prints
-            setattr(payload, '__configuration_topic__', topic)
+            setattr(payload, '__configuration_source__',
+                    "MQTT (topic: '{}')".format(topic))
 
             if CONF_PLATFORM in payload and 'schema' not in payload:
                 platform = payload[CONF_PLATFORM]

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -270,7 +270,9 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         discovery_hash = (component, discovery_id)
 
         if payload:
+            # Attach MQTT topic to the payload, used for debug prints
             setattr(payload, '__configuration_topic__', topic)
+
             if CONF_PLATFORM in payload and 'schema' not in payload:
                 platform = payload[CONF_PLATFORM]
                 if (component in DEPRECATED_PLATFORM_TO_SCHEMA and

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -708,7 +708,7 @@ class HASchema(vol.Schema):
                         redacted_data[k] = v
                     else:
                         redacted_data[k] = '<redacted>'
-                submsg += " (Offending data: {}".format(
+                submsg += "\n(Offending data: {}".format(
                     json.dumps(redacted_data))
 
                 msg += submsg

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -697,6 +697,9 @@ class HASchema(vol.Schema):
                 if hasattr(data, '__config_file__'):
                     submsg += " (See {}, line {}). ".format(
                         data.__config_file__, data.__line__)
+                if hasattr(data, '__configuration_topic__'):
+                    submsg += " (Received on MQTT topic {}). ".format(
+                        data.__configuration_topic__)
                 redacted_data = {}
 
                 for k, v in data.items():

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,6 +1,5 @@
 """Helpers for config validation using voluptuous."""
 import inspect
-import homeassistant.util.yaml
 import logging
 import os
 import re
@@ -690,7 +689,7 @@ class HASchema(vol.Schema):
                 if hasattr(data, '__config_file__'):
                     submsg += " (See {}, line {}). ".format(
                         data.__config_file__, data.__line__)
-                submsg += "\nOffending data:\n{}".format(homeassistant.util.yaml.dump(data))
+                submsg += " (Offending data: {})".format(data)
                 msg += submsg
                 logging.getLogger(__name__).warning(msg)
                 INVALID_EXTRA_KEYS_FOUND.append(submsg)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -689,6 +689,7 @@ class HASchema(vol.Schema):
                 if hasattr(data, '__config_file__'):
                     submsg += " (See {}, line {}). ".format(
                         data.__config_file__, data.__line__)
+                submsg += " (Offending data: {})".format(data)
                 msg += submsg
                 logging.getLogger(__name__).warning(msg)
                 INVALID_EXTRA_KEYS_FOUND.append(submsg)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,5 +1,6 @@
 """Helpers for config validation using voluptuous."""
 import inspect
+import homeassistant.util.yaml
 import logging
 import os
 import re
@@ -689,7 +690,7 @@ class HASchema(vol.Schema):
                 if hasattr(data, '__config_file__'):
                     submsg += " (See {}, line {}). ".format(
                         data.__config_file__, data.__line__)
-                submsg += " (Offending data: {})".format(data)
+                submsg += "\nOffending data:\n{}".format(homeassistant.util.yaml.dump(data))
                 msg += submsg
                 logging.getLogger(__name__).warning(msg)
                 INVALID_EXTRA_KEYS_FOUND.append(submsg)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -704,10 +704,10 @@ class HASchema(vol.Schema):
                 submsg += " (See {}, line {}). ".format(
                     data.__config_file__, data.__line__)
 
-            # Add MQTT topic information, if available
-            if hasattr(data, '__configuration_topic__'):
-                submsg += " (Received on MQTT topic {}). ".format(
-                    data.__configuration_topic__)
+            # Add configuration source information, if available
+            if hasattr(data, '__configuration_source__'):
+                submsg += "\nConfiguration source: {}. ".format(
+                    data.__configuration_source__)
             redacted_data = {}
 
             # Print configuration causing the error, but filter any potentially
@@ -718,7 +718,7 @@ class HASchema(vol.Schema):
                     redacted_data[k] = v
                 else:
                     redacted_data[k] = '<redacted>'
-            submsg += "\n(Offending data: {}".format(
+            submsg += "\nOffending data: {}".format(
                 json.dumps(redacted_data))
 
             msg += submsg


### PR DESCRIPTION
## Description:
There are many issues where the user has problems finding which configuration is causing errors.
Try to improve by:
- Always printing invalid configuration data make it easier for the user to track down where the key error is from.
- Print MQTT topic if the offending configuration was received in an MQTT discovery message.

Example print (`(Offending data: ...` is added by this PR):
```
2019-04-24 21:18:14 WARNING (MainThread) [homeassistant.helpers.config_validation] Your configuration contains extra keys that the platform does not support.
Please remove [json_attributes].  (Received on MQTT topic homeassistant/binary_sensor/0x00158d000244e5ff/occupancy/config).
 (Offending data: {"payload_on": "<redacted>", "payload_off": "<redacted>", "value_template": "<redacted>", "device_class": "<redacted>", "json_attributes": ["linkquality", "battery", "voltage"], "state_topic": "zigbee2mqtt/0x00158d000244e5ff", "availability_topic": "zigbee2mqtt/bridge/state", "name": "0x00158d000244e5ff", "unique_id": "<redacted>", "platform": "mqtt"}
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
