### PR TITLE
Stream: Only add base url when needed

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -566,7 +566,7 @@ async def async_handle_play_stream_service(camera, service_call):
     url = request_stream(hass, camera.stream_source, fmt=fmt)
     data = {
         ATTR_ENTITY_ID: entity_ids,
-        ATTR_MEDIA_CONTENT_ID: url,
+        ATTR_MEDIA_CONTENT_ID: "{}{}".format(hass.config.api.base_url, url),
         ATTR_MEDIA_CONTENT_TYPE: FORMAT_CONTENT_TYPE[fmt]
     }
 

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -59,7 +59,7 @@ def request_stream(hass, stream_source, *, fmt='hls',
             stream.access_token = generate_secret()
             stream.start()
         return hass.data[DOMAIN][ATTR_ENDPOINTS][fmt].format(
-            hass.config.api.base_url, stream.access_token)
+            stream.access_token)
     except Exception:
         raise HomeAssistantError('Unable to get stream')
 

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -18,7 +18,7 @@ def async_setup_hls(hass):
     """Set up api endpoints."""
     hass.http.register_view(HlsPlaylistView())
     hass.http.register_view(HlsSegmentView())
-    return '{}/api/hls/{}/playlist.m3u8'
+    return '/api/hls/{}/playlist.m3u8'
 
 
 class HlsPlaylistView(StreamView):


### PR DESCRIPTION
## Description:
Only add the base url to the stream url when it's needed for the camera.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
