### PR TITLE
Add stream source for amcrest component

### DIFF
--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -97,3 +97,8 @@ class AmcrestCam(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._name
+
+    @property
+    def stream_source(self):
+        """Return the source of the stream."""
+        return self._camera.rtsp_url(typeno=self._resolution)


### PR DESCRIPTION
## Description:

Add the RTSP stream source for amcrest to support the new stream component.

Tested this using an Amcrest IP2M-841B streaming to Google Home Hub.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
amcrest:
 - host: 192.168.x.x
   username: username
   password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
