### PR TITLE
Plex media player non ssl thumbs

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -779,7 +779,7 @@ class MediaPlayerDevice(Entity):
         return state_attr
 
 
-async def _async_fetch_image(hass, url):
+async def _async_fetch_image(hass, url, verify_ssl=True):
     """Fetch image.
 
     Images are cached in memory (the images are typically 10-100kB in size).
@@ -798,7 +798,7 @@ async def _async_fetch_image(hass, url):
             return cache_images[url][CACHE_CONTENT]
 
         content, content_type = (None, None)
-        websession = async_get_clientsession(hass)
+        websession = async_get_clientsession(hass, verify_ssl)
         try:
             with async_timeout.timeout(10, loop=hass.loop):
                 response = await websession.get(url)

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -779,7 +779,10 @@ class MediaPlayerDevice(Entity):
         return state_attr
 
 
-async def _async_fetch_image(hass, url, verify_ssl=True):
+# This method has been copied into components.media_player.plex, to support
+# skipping SSL verification. If you need to do this again, please consider
+# changing the base class to support this instead.
+async def _async_fetch_image(hass, url):
     """Fetch image.
 
     Images are cached in memory (the images are typically 10-100kB in size).
@@ -798,7 +801,7 @@ async def _async_fetch_image(hass, url, verify_ssl=True):
             return cache_images[url][CACHE_CONTENT]
 
         content, content_type = (None, None)
-        websession = async_get_clientsession(hass, verify_ssl)
+        websession = async_get_clientsession(hass)
         try:
             with async_timeout.timeout(10, loop=hass.loop):
                 response = await websession.get(url)

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -4,25 +4,30 @@ Support to interface with the Plex API.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.plex/
 """
+import asyncio
 from datetime import timedelta
 import json
 import logging
+from urllib.parse import urlparse
 
+from aiohttp.hdrs import CONTENT_TYPE
+import async_timeout
 import requests
 import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.components.media_player import (
+    CACHE_CONTENT, CACHE_IMAGES, CACHE_LOCK, CACHE_MAXSIZE, ENTITY_IMAGE_CACHE,
     MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW,
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    MediaPlayerDevice, _async_fetch_image)
+    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET)
 from homeassistant.const import (
     CONF_VERIFY_SSL, DEVICE_DEFAULT_NAME, STATE_IDLE, STATE_OFF,
     STATE_PAUSED, STATE_PLAYING)
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import load_json, save_json
@@ -876,3 +881,45 @@ class PlexClient(MediaPlayerDevice):
         }
 
         return attr
+
+
+# This is almost a direct copy of the function from the parent package, except
+# it allows us to skip SSL verification. #20073
+async def _async_fetch_image(hass, url, verify_ssl=True):
+    """Fetch image.
+
+    Images are cached in memory (the images are typically 10-100kB in size).
+    """
+    cache_images = ENTITY_IMAGE_CACHE[CACHE_IMAGES]
+    cache_maxsize = ENTITY_IMAGE_CACHE[CACHE_MAXSIZE]
+
+    if urlparse(url).hostname is None:
+        url = hass.config.api.base_url + url
+
+    if url not in cache_images:
+        cache_images[url] = {CACHE_LOCK: asyncio.Lock(loop=hass.loop)}
+
+    async with cache_images[url][CACHE_LOCK]:
+        if CACHE_CONTENT in cache_images[url]:
+            return cache_images[url][CACHE_CONTENT]
+
+        content, content_type = (None, None)
+        websession = async_get_clientsession(hass, verify_ssl)
+        try:
+            with async_timeout.timeout(10, loop=hass.loop):
+                response = await websession.get(url)
+
+                if response.status == 200:
+                    content = await response.read()
+                    content_type = response.headers.get(CONTENT_TYPE)
+                    if content_type:
+                        content_type = content_type.split(';')[0]
+                    cache_images[url][CACHE_CONTENT] = content, content_type
+
+        except asyncio.TimeoutError:
+            pass
+
+        while len(cache_images) > cache_maxsize:
+            cache_images.popitem(last=False)
+
+        return content, content_type

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -17,9 +17,11 @@ from homeassistant.components.media_player import (
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW,
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET)
+    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
+    MediaPlayerDevice, _async_fetch_image)
 from homeassistant.const import (
-    DEVICE_DEFAULT_NAME, STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
+    CONF_VERIFY_SSL, DEVICE_DEFAULT_NAME, STATE_IDLE, STATE_OFF,
+    STATE_PAUSED, STATE_PLAYING)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import track_utc_time_change
 from homeassistant.util import dt as dt_util
@@ -109,6 +111,7 @@ def setup_plexserver(
         _LOGGER.info("Ignoring SSL verification")
         cert_session = requests.Session()
         cert_session.verify = False
+        config[CONF_VERIFY_SSL] = False
     try:
         plexserver = plexapi.server.PlexServer(
             '%s://%s' % (http_prefix, host),
@@ -310,6 +313,7 @@ class PlexClient(MediaPlayerDevice):
         self._media_content_type = None
         self._media_duration = None
         self._media_image_url = None
+        self._verify_ssl = self.config.get(CONF_VERIFY_SSL, True)
         self._media_title = None
         self._media_position = None
         # Music
@@ -615,6 +619,14 @@ class PlexClient(MediaPlayerDevice):
     def media_image_url(self):
         """Return the image URL of current playing media."""
         return self._media_image_url
+
+    async def async_get_media_image(self):
+        """Fetch media image of current playing image."""
+        url = self.media_image_url
+        if url is None:
+            return None, None
+
+        return await _async_fetch_image(self.hass, url, self._verify_ssl)
 
     @property
     def media_title(self):


### PR DESCRIPTION
## Description:
Duplicates #20073 which I closed because it got stuck in Waffle limbo, unreviewed for over a month.

---

Allows SSL verification bypass, for Plex media players specifically, but adds allows other media player entities to support it too.

Fixes: #19676

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - **N/A** Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
