### PR TITLE
Add tesla components to the entity registry

### DIFF
--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -30,6 +30,13 @@ class TeslaBinarySensor(TeslaDevice, BinarySensorDevice):
         self._sensor_type = sensor_type
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        s = "-"
+        parts = ['binary_sensor', 'tesla', self.tesla_id]
+        return s.join(parts)
+
+    @property
     def device_class(self):
         """Return the class of this binary sensor."""
         return self._sensor_type

--- a/homeassistant/components/tesla/binary_sensor.py
+++ b/homeassistant/components/tesla/binary_sensor.py
@@ -32,9 +32,7 @@ class TeslaBinarySensor(TeslaDevice, BinarySensorDevice):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        s = "-"
-        parts = ['binary_sensor', 'tesla', self.tesla_id]
-        return s.join(parts)
+        return self.tesla_id
 
     @property
     def device_class(self):

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -36,6 +36,13 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
         self._temperature = None
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        s = "-"
+        parts = ['climate', 'tesla', self.tesla_id]
+        return s.join(parts)
+
+    @property
     def supported_features(self):
         """Return the list of supported features."""
         return SUPPORT_FLAGS

--- a/homeassistant/components/tesla/climate.py
+++ b/homeassistant/components/tesla/climate.py
@@ -38,9 +38,7 @@ class TeslaThermostat(TeslaDevice, ClimateDevice):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        s = "-"
-        parts = ['climate', 'tesla', self.tesla_id]
-        return s.join(parts)
+        return self.tesla_id
 
     @property
     def supported_features(self):

--- a/homeassistant/components/tesla/device_tracker.py
+++ b/homeassistant/components/tesla/device_tracker.py
@@ -51,3 +51,10 @@ class TeslaDeviceTracker:
                     dev_id=dev_id, host_name=name,
                     gps=(lat, lon), attributes=attrs
                 )
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        s = "-"
+        parts = ['device_tracker', 'tesla', self.tesla_id]
+        return s.join(parts)

--- a/homeassistant/components/tesla/device_tracker.py
+++ b/homeassistant/components/tesla/device_tracker.py
@@ -51,10 +51,3 @@ class TeslaDeviceTracker:
                     dev_id=dev_id, host_name=name,
                     gps=(lat, lon), attributes=attrs
                 )
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        s = "-"
-        parts = ['device_tracker', 'tesla', self.tesla_id]
-        return s.join(parts)

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -38,6 +38,13 @@ class TeslaLock(TeslaDevice, LockDevice):
         self.tesla_device.unlock()
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        s = "-"
+        parts = ['lock', 'tesla', self.tesla_id]
+        return s.join(parts)
+
+    @property
     def is_locked(self):
         """Get whether the lock is in locked state."""
         return self._state == STATE_LOCKED

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -40,10 +40,8 @@ class TeslaLock(TeslaDevice, LockDevice):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        s = "-"
-        parts = ['lock', 'tesla', self.tesla_id]
-        return s.join(parts)
-
+        return self.tesla_id
+        
     @property
     def is_locked(self):
         """Get whether the lock is in locked state."""

--- a/homeassistant/components/tesla/lock.py
+++ b/homeassistant/components/tesla/lock.py
@@ -41,7 +41,7 @@ class TeslaLock(TeslaDevice, LockDevice):
     def unique_id(self) -> str:
         """Return a unique ID."""
         return self.tesla_id
-        
+
     @property
     def is_locked(self):
         """Get whether the lock is in locked state."""

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -49,6 +49,13 @@ class TeslaSensor(TeslaDevice, Entity):
             self.entity_id = ENTITY_ID_FORMAT.format(self.tesla_id)
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        s = "-"
+        parts = ['sensor', 'tesla', self.tesla_id]
+        return s.join(parts)
+
+    @property
     def state(self):
         """Return the state of the sensor."""
         return self.current_value

--- a/homeassistant/components/tesla/sensor.py
+++ b/homeassistant/components/tesla/sensor.py
@@ -51,9 +51,7 @@ class TeslaSensor(TeslaDevice, Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        s = "-"
-        parts = ['sensor', 'tesla', self.tesla_id]
-        return s.join(parts)
+        return self.tesla_id
 
     @property
     def state(self):

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -42,6 +42,13 @@ class ChargerSwitch(TeslaDevice, SwitchDevice):
         self.tesla_device.stop_charge()
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        s = "-"
+        parts = ["switch", 'tesla', self.tesla_id]
+        return s.join(parts)
+
+    @property
     def is_on(self):
         """Get whether the switch is in on state."""
         return self._state == STATE_ON
@@ -72,6 +79,13 @@ class RangeSwitch(TeslaDevice, SwitchDevice):
         """Send the off command."""
         _LOGGER.debug("Disable max range charging: %s", self._name)
         self.tesla_device.set_standard()
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        s = "-"
+        parts = ['switch', 'tesla', self.tesla_id]
+        return s.join(parts)
 
     @property
     def is_on(self):

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -83,9 +83,7 @@ class RangeSwitch(TeslaDevice, SwitchDevice):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        s = "-"
-        parts = ['switch', 'tesla', self.tesla_id]
-        return s.join(parts)
+        return self.tesla_id
 
     @property
     def is_on(self):

--- a/homeassistant/components/tesla/switch.py
+++ b/homeassistant/components/tesla/switch.py
@@ -44,9 +44,7 @@ class ChargerSwitch(TeslaDevice, SwitchDevice):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        s = "-"
-        parts = ["switch", 'tesla', self.tesla_id]
-        return s.join(parts)
+        return self.tesla_id
 
     @property
     def is_on(self):


### PR DESCRIPTION
## Description:

This adds Tesla components to entity registry.

Tesla components have unique IDs, enough to work inside the entity registry at least. This adds `unique_id` implementations to all of its components so everything works.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
