### PR TITLE
Fix regression introduced by #21933

### DIFF
--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -236,7 +236,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
         """Send open command."""
         await self.async_set_cover_position(position=100)
 
-    async def close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs):
         """Send close command."""
         await self.async_set_cover_position(position=0)
 


### PR DESCRIPTION
## Description:

While working on support for stop for homekit_controller's cover support I noticed close_cover escaped #21933. This fixes the problem.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

