### PR TITLE
Add connection quality related attributes to Homematic IP

### DIFF
--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -6,21 +6,13 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_CONNECTED = 'connected'
-ATTR_DEVICE_ID = 'device_id'
-ATTR_DEVICE_LABEL = 'device_label'
-ATTR_DEVICE_RSSI = 'device_rssi'
-ATTR_DUTY_CYCLE = 'duty_cycle'
-ATTR_FIRMWARE_STATE = 'firmware_state'
-ATTR_GROUP_TYPE = 'group_type'
-ATTR_HOME_ID = 'home_id'
-ATTR_HOME_NAME = 'home_name'
 ATTR_LOW_BATTERY = 'low_battery'
 ATTR_MODEL_TYPE = 'model_type'
-ATTR_OPERATION_LOCK = 'operation_lock'
+# RSSI HAP -> Device
+ATTR_RSSI_DEVICE = 'rssi_device'
+# RSSI Device -> HAP
+ATTR_RSSI_PEER = 'rssi_peer'
 ATTR_SABOTAGE = 'sabotage'
-ATTR_STATUS_UPDATE = 'status_update'
-ATTR_UNREACHABLE = 'unreachable'
 ATTR_GROUP_MEMBER_UNREACHABLE = 'group_member_unreachable'
 
 
@@ -101,7 +93,13 @@ class HomematicipGenericDevice(Entity):
         """Return the state attributes of the generic device."""
         attr = {ATTR_MODEL_TYPE: self._device.modelType}
         if hasattr(self._device, 'lowBat') and self._device.lowBat:
-            attr.update({ATTR_LOW_BATTERY: self._device.lowBat})
+            attr[ATTR_LOW_BATTERY] = self._device.lowBat
         if hasattr(self._device, 'sabotage') and self._device.sabotage:
-            attr.update({ATTR_SABOTAGE: self._device.sabotage})
+            attr[ATTR_SABOTAGE] = self._device.sabotage
+        if hasattr(self._device, 'rssiDeviceValue') and \
+                self._device.rssiDeviceValue:
+            attr[ATTR_RSSI_DEVICE] = self._device.rssiDeviceValue
+        if hasattr(self._device, 'rssiPeerValue') and \
+                self._device.rssiPeerValue:
+            attr[ATTR_RSSI_PEER] = self._device.rssiPeerValue
         return attr


### PR DESCRIPTION
## Description:
This PR adds extra attributes to Homematic IP devices to determine connection quality, and helps to identify issues with it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
