### PR TITLE
Add Satel_integra switchable outputs and multiple partitions

### DIFF
--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -57,15 +57,9 @@ PARTITION_SCHEMA = vol.Schema(
 
 def is_alarm_code_necessary(value):
     """Check if alarm code must be configured."""
-<<<<<<< e9568e6c7d73d867f6efcc843245c24572490b4c
-    if value.get(CONF_SWITCHABLE_OUTPUTS) and CONF_DEVICE_CODE not in value:
-=======
     if not isinstance(value, dict):
         raise vol.Invalid('key dependencies require a dict')
-    if CONF_SWITCHABLE_OUTPUTS in value\
-       and value[CONF_SWITCHABLE_OUTPUTS]\
-       and CONF_DEVICE_CODE not in value:
->>>>>>> Linter fixes.
+    if value.get(CONF_SWITCHABLE_OUTPUTS) and CONF_DEVICE_CODE not in value:
         raise vol.Invalid('You need to specify alarm '
                           ' code to use switchable_outputs')
 

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -57,7 +57,15 @@ PARTITION_SCHEMA = vol.Schema(
 
 def is_alarm_code_necessary(value):
     """Check if alarm code must be configured."""
+<<<<<<< e9568e6c7d73d867f6efcc843245c24572490b4c
     if value.get(CONF_SWITCHABLE_OUTPUTS) and CONF_DEVICE_CODE not in value:
+=======
+    if not isinstance(value, dict):
+        raise vol.Invalid('key dependencies require a dict')
+    if CONF_SWITCHABLE_OUTPUTS in value\
+       and value[CONF_SWITCHABLE_OUTPUTS]\
+       and CONF_DEVICE_CODE not in value:
+>>>>>>> Linter fixes.
         raise vol.Invalid('You need to specify alarm '
                           ' code to use switchable_outputs')
 

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -34,7 +34,6 @@ CONF_OUTPUTS = 'outputs'
 CONF_SWITCHABLE_OUTPUTS = 'switchable_outputs'
 
 ZONES = 'zones'
-CONTROLLER = 'controller'
 
 SIGNAL_PANEL_MESSAGE = 'satel_integra.panel_message'
 SIGNAL_PANEL_ARM_AWAY = 'satel_integra.panel_arm_away'
@@ -112,8 +111,6 @@ async def async_setup(hass, config):
     if not result:
         return False
 
-    conf[CONTROLLER] = controller
-
     async def _close():
         controller.close()
 
@@ -134,8 +131,7 @@ async def async_setup(hass, config):
 
     hass.async_create_task(
         async_load_platform(hass, 'switch', DOMAIN,
-                            {CONTROLLER: controller,
-                             CONF_SWITCHABLE_OUTPUTS: switchable_outputs,
+                            {CONF_SWITCHABLE_OUTPUTS: switchable_outputs,
                              CONF_DEVICE_CODE: conf.get(CONF_DEVICE_CODE)},
                             config)
         )

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -10,8 +10,6 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['satel_integra==0.3.4']
-
 DEFAULT_ALARM_NAME = 'satel_integra'
 DEFAULT_PORT = 7094
 DEFAULT_CONF_ARM_HOME_MODE = 1

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -1,13 +1,16 @@
 """Support for Satel Integra devices."""
+import collections
 import logging
 
 import voluptuous as vol
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_HOST
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+REQUIREMENTS = ['satel_integra==0.3.4']
 
 DEFAULT_ALARM_NAME = 'satel_integra'
 DEFAULT_PORT = 7094
@@ -21,13 +24,14 @@ DOMAIN = 'satel_integra'
 
 DATA_SATEL = 'satel_integra'
 
-CONF_DEVICE_PORT = 'port'
-CONF_DEVICE_PARTITION = 'partition'
+CONF_DEVICE_CODE = 'code'
+CONF_DEVICE_PARTITIONS = 'partitions'
 CONF_ARM_HOME_MODE = 'arm_home_mode'
 CONF_ZONE_NAME = 'name'
 CONF_ZONE_TYPE = 'type'
 CONF_ZONES = 'zones'
 CONF_OUTPUTS = 'outputs'
+CONF_SWITCHABLE_OUTPUTS = 'switchable_outputs'
 
 ZONES = 'zones'
 
@@ -42,20 +46,38 @@ SIGNAL_OUTPUTS_UPDATED = 'satel_integra.outputs_updated'
 ZONE_SCHEMA = vol.Schema({
     vol.Required(CONF_ZONE_NAME): cv.string,
     vol.Optional(CONF_ZONE_TYPE, default=DEFAULT_ZONE_TYPE): cv.string})
+EDITABLE_OUTPUT_SCHEMA = vol.Schema({vol.Required(CONF_ZONE_NAME): cv.string})
+PARTITION_SCHEMA = vol.Schema(
+    {vol.Required(CONF_ZONE_NAME): cv.string,
+     vol.Optional(CONF_ARM_HOME_MODE, default=DEFAULT_CONF_ARM_HOME_MODE):
+     vol.In([1, 2, 3]),
+     }
+    )
+
+
+def is_alarm_code_necessary(value):
+    """Check if alarm code must be configured."""
+    if value.get(CONF_SWITCHABLE_OUTPUTS) and CONF_DEVICE_CODE not in value:
+        raise vol.Invalid('You need to specify alarm '
+                          ' code to use switchable_outputs')
+
+    return value
+
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
+    DOMAIN: vol.All({
         vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_DEVICE_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_DEVICE_PARTITION,
-                     default=DEFAULT_DEVICE_PARTITION): cv.positive_int,
-        vol.Optional(CONF_ARM_HOME_MODE,
-                     default=DEFAULT_CONF_ARM_HOME_MODE): vol.In([1, 2, 3]),
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_DEVICE_CODE): cv.string,
+        vol.Optional(CONF_DEVICE_PARTITIONS,
+                     default={}): {vol.Coerce(int): PARTITION_SCHEMA},
         vol.Optional(CONF_ZONES,
                      default={}): {vol.Coerce(int): ZONE_SCHEMA},
         vol.Optional(CONF_OUTPUTS,
                      default={}): {vol.Coerce(int): ZONE_SCHEMA},
-    }),
+        vol.Optional(CONF_SWITCHABLE_OUTPUTS,
+                     default={}): {vol.Coerce(int): EDITABLE_OUTPUT_SCHEMA},
+    }, is_alarm_code_necessary),
 }, extra=vol.ALLOW_EXTRA)
 
 
@@ -65,13 +87,20 @@ async def async_setup(hass, config):
 
     zones = conf.get(CONF_ZONES)
     outputs = conf.get(CONF_OUTPUTS)
+    switchable_outputs = conf.get(CONF_SWITCHABLE_OUTPUTS)
     host = conf.get(CONF_HOST)
-    port = conf.get(CONF_DEVICE_PORT)
-    partition = conf.get(CONF_DEVICE_PARTITION)
+    port = conf.get(CONF_PORT)
+    partitions = conf.get(CONF_DEVICE_PARTITIONS)
 
     from satel_integra.satel_integra import AsyncSatel
 
-    controller = AsyncSatel(host, port, hass.loop, zones, outputs, partition)
+    monitored_outputs = collections.OrderedDict(
+        list(outputs.items()) +
+        list(switchable_outputs.items())
+        )
+
+    controller = AsyncSatel(host, port, hass.loop,
+                            zones, monitored_outputs, partitions)
 
     hass.data[DATA_SATEL] = controller
 
@@ -94,7 +123,15 @@ async def async_setup(hass, config):
 
     hass.async_create_task(
         async_load_platform(hass, 'binary_sensor', DOMAIN,
-                            {CONF_ZONES: zones, CONF_OUTPUTS: outputs}, config)
+                            {CONF_ZONES: zones,
+                             CONF_OUTPUTS: outputs}, config)
+        )
+
+    hass.async_create_task(
+        async_load_platform(hass, 'switch', DOMAIN,
+                            {CONF_SWITCHABLE_OUTPUTS: switchable_outputs,
+                             CONF_DEVICE_CODE: conf.get(CONF_DEVICE_CODE)},
+                            config)
         )
 
     @callback

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -57,8 +57,6 @@ PARTITION_SCHEMA = vol.Schema(
 
 def is_alarm_code_necessary(value):
     """Check if alarm code must be configured."""
-    if not isinstance(value, dict):
-        raise vol.Invalid('key dependencies require a dict')
     if value.get(CONF_SWITCHABLE_OUTPUTS) and CONF_DEVICE_CODE not in value:
         raise vol.Invalid('You need to specify alarm '
                           ' code to use switchable_outputs')

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -34,6 +34,7 @@ CONF_OUTPUTS = 'outputs'
 CONF_SWITCHABLE_OUTPUTS = 'switchable_outputs'
 
 ZONES = 'zones'
+CONTROLLER = 'controller'
 
 SIGNAL_PANEL_MESSAGE = 'satel_integra.panel_message'
 SIGNAL_PANEL_ARM_AWAY = 'satel_integra.panel_arm_away'
@@ -111,6 +112,8 @@ async def async_setup(hass, config):
     if not result:
         return False
 
+    conf[CONTROLLER] = controller
+
     async def _close():
         controller.close()
 
@@ -131,7 +134,8 @@ async def async_setup(hass, config):
 
     hass.async_create_task(
         async_load_platform(hass, 'switch', DOMAIN,
-                            {CONF_SWITCHABLE_OUTPUTS: switchable_outputs,
+                            {CONTROLLER: controller,
+                             CONF_SWITCHABLE_OUTPUTS: switchable_outputs,
                              CONF_DEVICE_CODE: conf.get(CONF_DEVICE_CODE)},
                             config)
         )

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
-    CONF_ARM_HOME_MODE, CONF_DEVICE_PARTITIONS, CONTROLLER, CONF_ZONE_NAME,
+    CONF_ARM_HOME_MODE, CONF_DEVICE_PARTITIONS, DATA_SATEL, CONF_ZONE_NAME,
     SIGNAL_PANEL_MESSAGE)
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ async def async_setup_platform(
         return
 
     configured_partitions = discovery_info[CONF_DEVICE_PARTITIONS]
-    controller = discovery_info[CONTROLLER]
+    controller = hass.data[DATA_SATEL]
 
     devices = []
 

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -150,5 +150,5 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
         _LOGGER.debug("Arming home")
 
         if code:
-            await self._satel\
-                      .arm(code, [self._partition_id], self._arm_home_mode)
+            await self._satel.arm(
+                code, [self._partition_id], self._arm_home_mode)

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -50,7 +50,6 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
         self._partition_id = partition_id
         self._satel = None
 
-
     async def async_added_to_hass(self):
         """Update alarm status and register callbacks for future updates."""
         _LOGGER.debug("Starts listening for panel messages")

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
     CONF_OUTPUTS, CONF_ZONE_NAME, CONF_ZONE_TYPE, CONF_ZONES,
-    SIGNAL_OUTPUTS_UPDATED, SIGNAL_ZONES_UPDATED, CONTROLLER)
+    SIGNAL_OUTPUTS_UPDATED, SIGNAL_ZONES_UPDATED, DATA_SATEL)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ async def async_setup_platform(
         return
 
     configured_zones = discovery_info[CONF_ZONES]
-    controller = discovery_info[CONTROLLER]
+    controller = hass.data[DATA_SATEL]
 
     devices = []
 

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -57,7 +57,6 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-
         if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
             if self._device_number in self._satel.violated_outputs:
                 self._state = 1

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -53,7 +53,6 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         self._react_to_signal = react_to_signal
         self._satel = None
 
-
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._satel = self.hass.data[DATA_SATEL]

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -51,18 +51,20 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         self._zone_type = zone_type
         self._state = 0
         self._react_to_signal = react_to_signal
+        self._satel = None
+
 
     async def async_added_to_hass(self):
         """Register callbacks."""
+        self._satel = self.hass.data[DATA_SATEL]
+
         if self._react_to_signal == SIGNAL_OUTPUTS_UPDATED:
-            if self._device_number in\
-               self.hass.data[DATA_SATEL].violated_outputs:
+            if self._device_number in self._satel.violated_outputs:
                 self._state = 1
             else:
                 self._state = 0
         else:
-            if self._device_number in\
-               self.hass.data[DATA_SATEL].violated_zones:
+            if self._device_number in self._satel.violated_zones:
                 self._state = 1
             else:
                 self._state = 0

--- a/homeassistant/components/satel_integra/manifest.json
+++ b/homeassistant/components/satel_integra/manifest.json
@@ -3,7 +3,7 @@
   "name": "Satel integra",
   "documentation": "https://www.home-assistant.io/components/satel_integra",
   "requirements": [
-    "satel_integra==0.3.2"
+    "satel_integra==0.3.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -90,11 +90,8 @@ class SatelIntegraSwitch(SwitchDevice):
 
     def _read_state(self):
         """Read state of the device."""
-        if self._device_number in\
-                self.hass.data[DATA_SATEL].violated_outputs:
-                return True
-        else:
-                return False
+        return self._device_number in\
+            self.hass.data[DATA_SATEL].violated_outputs
 
     @property
     def name(self):

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -1,5 +1,4 @@
 """Support for Satel Integra modifiable outputs represented as switches."""
-import asyncio
 import logging
 
 
@@ -45,9 +44,11 @@ class SatelIntegraSwitch(SwitchDevice):
         self._name = device_name
         self._state = False
         self._code = code
+        self._satel = None
 
     async def async_added_to_hass(self):
         """Register callbacks."""
+        self._satel = self.hass.data[DATA_SATEL]
         async_dispatcher_connect(
             self.hass, SIGNAL_OUTPUTS_UPDATED, self._devices_updated)
 
@@ -66,20 +67,14 @@ class SatelIntegraSwitch(SwitchDevice):
         """Turn the device on."""
         _LOGGER.debug("Switch: %s status: %s,"
                       " turning on", self._name, self._state)
-        await self.hass.data[DATA_SATEL]\
-                  .set_output(self._code, self._device_number, True)
-        await asyncio.sleep(0.3)
-        self._state = True
+        await self._satel.set_output(self._code, self._device_number, True)
         self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
         _LOGGER.debug("Switch name: %s status: %s,"
                       " turning off", self._name, self._state)
-        await self.hass.data[DATA_SATEL]\
-                  .set_output(self._code, self._device_number, False)
-        await asyncio.sleep(0.3)
-        self._state = False
+        await self._satel.set_output(self._code, self._device_number, False)
         self.async_schedule_update_ha_state()
 
     @property
@@ -90,8 +85,7 @@ class SatelIntegraSwitch(SwitchDevice):
 
     def _read_state(self):
         """Read state of the device."""
-        return self._device_number in\
-            self.hass.data[DATA_SATEL].violated_outputs
+        return self._device_number in self._satel.violated_outputs
 
     @property
     def name(self):

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
     CONF_DEVICE_CODE, CONF_SWITCHABLE_OUTPUTS, CONF_ZONE_NAME,
-    DATA_SATEL, SIGNAL_OUTPUTS_UPDATED)
+    SIGNAL_OUTPUTS_UPDATED, CONTROLLER)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +22,7 @@ async def async_setup_platform(
         return
 
     configured_zones = discovery_info[CONF_SWITCHABLE_OUTPUTS]
+    controller = discovery_info[CONTROLLER]
 
     devices = []
 
@@ -29,7 +30,7 @@ async def async_setup_platform(
         zone_name = device_config_data[CONF_ZONE_NAME]
 
         device = SatelIntegraSwitch(
-            zone_num, zone_name, discovery_info[CONF_DEVICE_CODE])
+            controller, zone_num, zone_name, discovery_info[CONF_DEVICE_CODE])
         devices.append(device)
 
     async_add_entities(devices)
@@ -38,17 +39,16 @@ async def async_setup_platform(
 class SatelIntegraSwitch(SwitchDevice):
     """Representation of an Satel switch."""
 
-    def __init__(self, device_number, device_name, code):
+    def __init__(self, controller, device_number, device_name, code):
         """Initialize the binary_sensor."""
         self._device_number = device_number
         self._name = device_name
         self._state = False
         self._code = code
-        self._satel = None
+        self._satel = controller
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._satel = self.hass.data[DATA_SATEL]
         async_dispatcher_connect(
             self.hass, SIGNAL_OUTPUTS_UPDATED, self._devices_updated)
 

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -1,7 +1,6 @@
 """Support for Satel Integra modifiable outputs represented as switches."""
 import logging
 
-
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -55,7 +54,7 @@ class SatelIntegraSwitch(SwitchDevice):
     @callback
     def _devices_updated(self, zones):
         """Update switch state, if needed."""
-        _LOGGER.debug("Update switch name: %s zones: %s.", self._name, zones)
+        _LOGGER.debug("Update switch name: %s zones: %s", self._name, zones)
         if self._device_number in zones:
             new_state = self._read_state()
             _LOGGER.debug("New state: %s", new_state)

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -1,0 +1,107 @@
+"""Support for Satel Integra modifiable outputs represented as switches."""
+import asyncio
+import logging
+
+
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import (
+    CONF_DEVICE_CODE, CONF_SWITCHABLE_OUTPUTS, CONF_ZONE_NAME,
+    DATA_SATEL, SIGNAL_OUTPUTS_UPDATED)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['satel_integra']
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up the Satel Integra switch devices."""
+    if not discovery_info:
+        return
+
+    configured_zones = discovery_info[CONF_SWITCHABLE_OUTPUTS]
+
+    devices = []
+
+    for zone_num, device_config_data in configured_zones.items():
+        zone_name = device_config_data[CONF_ZONE_NAME]
+
+        device = SatelIntegraSwitch(
+            zone_num, zone_name, discovery_info[CONF_DEVICE_CODE])
+        devices.append(device)
+
+    async_add_entities(devices)
+
+
+class SatelIntegraSwitch(SwitchDevice):
+    """Representation of an Satel switch."""
+
+    def __init__(self, device_number, device_name, code):
+        """Initialize the binary_sensor."""
+        self._device_number = device_number
+        self._name = device_name
+        self._state = False
+        self._code = code
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_OUTPUTS_UPDATED, self._devices_updated)
+
+    @callback
+    def _devices_updated(self, zones):
+        """Update switch state, if needed."""
+        _LOGGER.debug("Update switch name: %s zones: %s.", self._name, zones)
+        if self._device_number in zones:
+            new_state = self._read_state()
+            _LOGGER.debug("New state: %s", new_state)
+            if new_state != self._state:
+                self._state = new_state
+                self.async_schedule_update_ha_state()
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        _LOGGER.debug("Switch: %s status: %s,"
+                      " turning on", self._name, self._state)
+        await self.hass.data[DATA_SATEL]\
+                  .set_output(self._code, self._device_number, True)
+        await asyncio.sleep(0.3)
+        self._state = True
+        self.async_schedule_update_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        _LOGGER.debug("Switch name: %s status: %s,"
+                      " turning off", self._name, self._state)
+        await self.hass.data[DATA_SATEL]\
+                  .set_output(self._code, self._device_number, False)
+        await asyncio.sleep(0.3)
+        self._state = False
+        self.async_schedule_update_ha_state()
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        self._state = self._read_state()
+        return self._state
+
+    def _read_state(self):
+        """Read state of the device."""
+        if self._device_number in\
+                self.hass.data[DATA_SATEL].violated_outputs:
+                return True
+        else:
+                return False
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Don't poll."""
+        return False

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
     CONF_DEVICE_CODE, CONF_SWITCHABLE_OUTPUTS, CONF_ZONE_NAME,
-    SIGNAL_OUTPUTS_UPDATED, CONTROLLER)
+    SIGNAL_OUTPUTS_UPDATED, DATA_SATEL)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ async def async_setup_platform(
         return
 
     configured_zones = discovery_info[CONF_SWITCHABLE_OUTPUTS]
-    controller = discovery_info[CONTROLLER]
+    controller = hass.data[DATA_SATEL]
 
     devices = []
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1534,7 +1534,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.satel_integra
-satel_integra==0.3.2
+satel_integra==0.3.4
 
 # homeassistant.components.deutsche_bahn
 schiene==0.23

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1534,7 +1534,7 @@ rxv==0.6.0
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.satel_integra
-satel_integra==0.3.4
+satel_integra==0.3.2
 
 # homeassistant.components.deutsche_bahn
 schiene==0.23


### PR DESCRIPTION
## Description:

Added multiple partitions support as well as editable outputs, so one can use Satel outputs as switches. Additionally improved reporting of arming and disarming states of the alarm.

**Breaking change:** 
The component now supports multiple partitions and this forced change in config: instead of single parameters `partition `and `single_home_mode` there is now section `partitions:`. If your config so far was:

```
satel_integra:
  host: 192.168.1.100
  port: 7094
  partition: 1
  arm_home_mode: 1
  zones:
   (...)
```
... change it to:
```
satel_integra:
  host: 192.168.1.100
  port: 7094
  partitions: 
    01:
      name: 'House'
      arm_home_mode: 1
  zones:
    (...)
```
... and your config will be OK again after upgrade.

**Related issue (if applicable):** fixes #21589, fixes #19796, fixes #19361.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8922

## Example entry for `configuration.yaml` (if applicable):
```yaml
satel_integra:
  host: 192.168.17.141
  port: 7094
  code: !secret alarm_code  
  partitions:
    01:
      name: 'Dom'
      arm_home_mode: 2
  zones:
    01:
      name: 'czujka wejście'
      type: 'motion'
    02:
      name: 'hol'
      type: 'motion'
    05:
      name: 'salon'
      type: 'motion'
  outputs:
    06:
      name: 'salon zb'
      type: 'motion'
    07:
      name: 'kuchnia dym'
      type: 'smoke'
  switchable_outputs:
    8:
      name: 'Brama garaż'
    9:
      name: 'Otwarcie bramy'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
