### PR TITLE
Mobile App: Use .get to ensure we dont get KeyError

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -23,8 +23,9 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
     if hass.data.get(DOMAIN) is None:
         hass.data[DOMAIN] = {DATA_DELETED_IDS: [], DATA_REGISTRATIONS: {}}
 
-    hass.data[DOMAIN][DATA_DELETED_IDS] = app_config[DATA_DELETED_IDS]
-    hass.data[DOMAIN][DATA_REGISTRATIONS] = app_config[DATA_REGISTRATIONS]
+    hass.data[DOMAIN][DATA_DELETED_IDS] = app_config.get(DATA_DELETED_IDS, [])
+    hass.data[DOMAIN][DATA_REGISTRATIONS] = app_config.get(DATA_REGISTRATIONS,
+                                                           {})
     hass.data[DOMAIN][DATA_STORE] = store
 
     for registration in app_config[DATA_REGISTRATIONS].values():


### PR DESCRIPTION
## Description:

Fixes this issue:

```
2019-03-12 16:37:28 ERROR (MainThread) [homeassistant.setup] Error during setup of component mobile_app

Traceback (most recent call last):
File "/usr/src/app/homeassistant/setup.py", line 151, in _async_setup_component
hass, processed_config)
File "/usr/src/app/homeassistant/components/mobile_app/__init__.py", line 26, in async_setup
hass.data[DOMAIN][DATA_DELETED_IDS] = app_config[DATA_DELETED_IDS]
KeyError: 'deleted_ids'
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
