### PR TITLE
Avoid playing queue pollution with Sonos unjoin

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -1012,7 +1012,11 @@ class SonosEntity(MediaPlayerDevice):
         """Unjoin several players from their group."""
         def _unjoin_all(entities):
             """Sync helper."""
-            for entity in entities:
+            # Unjoin slaves first to prevent inheritance of queues
+            coordinators = [e for e in entities if e.is_coordinator]
+            slaves = [e for e in entities if not e.is_coordinator]
+
+            for entity in slaves + coordinators:
                 entity.unjoin()
 
         async with hass.data[DATA_SONOS].topology_lock:
@@ -1079,7 +1083,7 @@ class SonosEntity(MediaPlayerDevice):
                     entity.media_pause()
 
             if with_group:
-                # Unjoin slaves that are not already in their target group
+                # Unjoin slaves first to prevent inheritance of queues
                 for entity in [e for e in entities if not e.is_coordinator]:
                     if entity._snapshot_group != entity._sonos_group:
                         entity.unjoin()


### PR DESCRIPTION
## Description:

This is the same fix as in #21963, but for explicit `sonos_unjoin` service calls rather than the implicit unjoin that a `sonos_restore` service call can do. I missed this case because the affected method did not exist until the refactor in #21985.

Imagine three speakers in a group, ABC, playing the A queue. If we unjoin A, the remaining group BC will elect a new coordinator that must drop its own queue in order to not interrupt the playing A queue. If we then unjoin B, we have three separate speakers but at least one of them will have had its queue replaced.

In contrast, unjoining in the order B then C will make them each restore their own queues while A keeps playing. We now end up with three separate speakers that have maintained their original queues.

So it is better to unjoin coordinators last and that is what this PR does. Note, however, that this only helps if all speakers are unjoined by a single service call.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
