### PR TITLE
PS4: When selecting source (ie from a service call), add support for turning the device on

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -376,9 +376,9 @@ class PS4Device(MediaPlayerDevice):
 
     def select_source(self, source):
         """Select input source. If device is off, turn it on and wait until it's on."""
-        if (self._state == "off"):
+        if (self._state == STATE_OFF):
             self.turn_on()
-            while (self._state == "off"):
+            while (self._state == STATE_OFF):
                 pass
         for title_id, game in self._games.items():
             if source == game:

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -375,7 +375,11 @@ class PS4Device(MediaPlayerDevice):
         self.send_remote_control('ps')
 
     def select_source(self, source):
-        """Select input source."""
+        """Select input source. If device is off, turn it on and wait until it's on."""
+        if (self._state == "off"):
+            self.turn_on()
+            while (self._state == "off"):
+                pass
         for title_id, game in self._games.items():
             if source == game:
                 _LOGGER.debug(

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -375,7 +375,8 @@ class PS4Device(MediaPlayerDevice):
         self.send_remote_control('ps')
 
     def select_source(self, source):
-        """Select input source. If device is off, turn it on and wait until it's on."""
+        """Select input source. If device is off,
+           turn it on and wait until it's on."""
         if (self._state == STATE_OFF):
             self.turn_on()
             while (self._state == STATE_OFF):


### PR DESCRIPTION
## Description:
PS4: When selecting source (ie from a service call), add support for turning the device on

This allows HA to turn on a PS4, and switch to the selected title in the same call (handles a synchronous wait until the device is turned on, before selecting the source.


## Checklist:
  - [V] The code change is tested and works locally.
  - [V] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [V] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [NA] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [NA] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [NA] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [NA] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [NA] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [NA] Tests have been added to verify that the new code works.
