### PR TITLE
Fix whois error, check updated_date for list and pick first

### DIFF
--- a/homeassistant/components/sensor/whois.py
+++ b/homeassistant/components/sensor/whois.py
@@ -134,7 +134,11 @@ class WhoisSensor(Entity):
                 attrs[ATTR_NAME_SERVERS] = ' '.join(response['nameservers'])
 
             if 'updated_date' in response:
-                attrs[ATTR_UPDATED] = response['updated_date'].isoformat()
+                update_date = response['updated_date']
+                if isinstance(update_date, list):
+                    attrs[ATTR_UPDATED] = update_date[0].isoformat()
+                else:
+                    attrs[ATTR_UPDATED] = update_date.isoformat()
 
             if 'registrar' in response:
                 attrs[ATTR_REGISTRAR] = response['registrar']


### PR DESCRIPTION
## Description:
Check the whois response type for updated_date to avoid Attribute errors due to calling isoformat() on a list.
Now takes the first element of the list, this may not always be correct but from the response there is no way to determine what the elements of the list are. (

**Related issue (if applicable):** fixes #22007 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
 26 # Sensors                                                                       
 27 sensor:                                                                         
 28   # Weather prediction                                                          
 29   - platform: yr                                                                
 30                                                                                 
 31   - platform: whois                                                             
 32     domain: google.com                                                          
 33                                                                                 
 34   - platform: whois                                                             
 35     domain: apple.com  
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
