### PR TITLE
Allow all success status codes in REST notify response

### DIFF
--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -112,7 +112,8 @@ class RestNotificationService(BaseNotificationService):
             response = requests.get(self._resource, headers=self._headers,
                                     params=data, timeout=10)
 
-        if response.status_code not in (200, 201, 202):
+        success_codes = (200, 201, 202, 203, 204, 205, 206, 207, 208, 226)
+        if response.status_code not in success_codes:
             _LOGGER.exception(
                 "Error sending message. Response %d: %s:",
                 response.status_code, response.reason)


### PR DESCRIPTION
## Description:
For example Discord webhooks returns a 204 success code as response, which gets logged as an error in the log, even though it is successful.
Update the allowed statuses to accept more 2xx responses as successful.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
