### PR TITLE
Remove temp unit assumption from SmartThings Sensor platform

### DIFF
--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -89,7 +89,7 @@ CAPABILITY_TO_SENSORS = {
     'powerSource': [
         Map('powerSource', "Power Source", None, None)],
     'refrigerationSetpoint': [
-        Map('refrigerationSetpoint', "Refrigeration Setpoint", TEMP_CELSIUS,
+        Map('refrigerationSetpoint', "Refrigeration Setpoint", None,
             DEVICE_CLASS_TEMPERATURE)],
     'relativeHumidityMeasurement': [
         Map('humidity', "Relative Humidity Measurement", '%',
@@ -107,15 +107,15 @@ CAPABILITY_TO_SENSORS = {
     'smokeDetector': [
         Map('smoke', "Smoke Detector", None, None)],
     'temperatureMeasurement': [
-        Map('temperature', "Temperature Measurement", TEMP_CELSIUS,
+        Map('temperature', "Temperature Measurement", None,
             DEVICE_CLASS_TEMPERATURE)],
     'thermostatCoolingSetpoint': [
-        Map('coolingSetpoint', "Thermostat Cooling Setpoint", TEMP_CELSIUS,
+        Map('coolingSetpoint', "Thermostat Cooling Setpoint", None,
             DEVICE_CLASS_TEMPERATURE)],
     'thermostatFanMode': [
         Map('thermostatFanMode', "Thermostat Fan Mode", None, None)],
     'thermostatHeatingSetpoint': [
-        Map('heatingSetpoint', "Thermostat Heating Setpoint", TEMP_CELSIUS,
+        Map('heatingSetpoint', "Thermostat Heating Setpoint", None,
             DEVICE_CLASS_TEMPERATURE)],
     'thermostatMode': [
         Map('thermostatMode', "Thermostat Mode", None, None)],
@@ -123,7 +123,7 @@ CAPABILITY_TO_SENSORS = {
         Map('thermostatOperatingState', "Thermostat Operating State",
             None, None)],
     'thermostatSetpoint': [
-        Map('thermostatSetpoint', "Thermostat Setpoint", TEMP_CELSIUS,
+        Map('thermostatSetpoint', "Thermostat Setpoint", None,
             DEVICE_CLASS_TEMPERATURE)],
     'threeAxis': [
         Map('threeAxis', "Three Axis", None, None)],


### PR DESCRIPTION
## Description:
Removes the default temperature unit for attributes that officially define no default unit in the SmartThings Capability reference.  This ensures we display no unit when the unit is not populated by devices not properly implementing capabilities instead of making an assumption and potentially displaying the wrong unit/converted value.

**Related issue (if applicable):** fixes #22009

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  