### PR TITLE
Add sense guard clause

### DIFF
--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -44,7 +44,7 @@ async def async_setup(hass, config):
         _LOGGER.error("Could not authenticate with sense server")
         return False
     hass.async_create_task(
-        async_load_platform(hass, 'sensor', DOMAIN, None, config))
+        async_load_platform(hass, 'sensor', DOMAIN, {}, config))
     hass.async_create_task(
-        async_load_platform(hass, 'binary_sensor', DOMAIN, None, config))
+        async_load_platform(hass, 'binary_sensor', DOMAIN, {}, config))
     return True

--- a/homeassistant/components/sense/binary_sensor.py
+++ b/homeassistant/components/sense/binary_sensor.py
@@ -52,6 +52,8 @@ MDI_ICONS = {
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Sense binary sensor."""
+    if discovery_info is None:
+        return
     data = hass.data[SENSE_DATA]
 
     sense_devices = await data.get_discovered_device_data()

--- a/homeassistant/components/sense/sensor.py
+++ b/homeassistant/components/sense/sensor.py
@@ -48,6 +48,8 @@ SENSOR_VARIANTS = [PRODUCTION_NAME.lower(), CONSUMPTION_NAME.lower()]
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Sense sensor."""
+    if discovery_info is None:
+        return
     data = hass.data[SENSE_DATA]
 
     @Throttle(MIN_TIME_BETWEEN_DAILY_UPDATES)


### PR DESCRIPTION

Changes in response to comments in: https://github.com/home-assistant/home-assistant/pull/21698/files/21debdb3476fdc2f83ddf8497c214c31c2d918e0

Prevents components from loading if they are loaded not through discovery (I'm not sure why someone would do that, but I guess they could).