### PR TITLE
Add HTTP auth and SSL verification to REST notify

### DIFF
--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -52,7 +52,8 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the RESTful notification service."""
-    from requests.auth import HTTPBasicAuth, HTTPDigestAuth # pylint: disable=import-error
+    # pylint: disable=import-error
+    from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
     resource = config.get(CONF_RESOURCE)
     method = config.get(CONF_METHOD)

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -7,13 +7,17 @@ https://home-assistant.io/components/notify.rest/
 import logging
 
 import requests
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 import voluptuous as vol
 
 from homeassistant.components.notify import (
     ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT, BaseNotificationService,
     PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_RESOURCE, CONF_METHOD, CONF_NAME,
-                                 CONF_HEADERS)
+from homeassistant.const import (CONF_AUTHENTICATION, CONF_HEADERS,
+                                 CONF_METHOD, CONF_NAME, CONF_PASSWORD,
+                                 CONF_RESOURCE, CONF_USERNAME, CONF_VERIFY_SSL,
+                                 HTTP_BASIC_AUTHENTICATION,
+                                 HTTP_DIGEST_AUTHENTICATION)
 import homeassistant.helpers.config_validation as cv
 
 CONF_DATA = 'data'
@@ -23,6 +27,7 @@ CONF_TARGET_PARAMETER_NAME = 'target_param_name'
 CONF_TITLE_PARAMETER_NAME = 'title_param_name'
 DEFAULT_MESSAGE_PARAM_NAME = 'message'
 DEFAULT_METHOD = 'GET'
+DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -35,7 +40,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TARGET_PARAMETER_NAME): cv.string,
     vol.Optional(CONF_TITLE_PARAMETER_NAME): cv.string,
     vol.Optional(CONF_DATA): dict,
-    vol.Optional(CONF_DATA_TEMPLATE): {cv.match_all: cv.template_complex}
+    vol.Optional(CONF_DATA_TEMPLATE): {cv.match_all: cv.template_complex},
+    vol.Optional(CONF_AUTHENTICATION):
+        vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
+    vol.Optional(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,17 +61,30 @@ def get_service(hass, config, discovery_info=None):
     target_param_name = config.get(CONF_TARGET_PARAMETER_NAME)
     data = config.get(CONF_DATA)
     data_template = config.get(CONF_DATA_TEMPLATE)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    verify_ssl = config.get(CONF_VERIFY_SSL)
+
+    if username and password:
+        if config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
+            auth = HTTPDigestAuth(username, password)
+        else:
+            auth = HTTPBasicAuth(username, password)
+    else:
+        auth = None
 
     return RestNotificationService(
         hass, resource, method, headers, message_param_name,
-        title_param_name, target_param_name, data, data_template)
+        title_param_name, target_param_name, data, data_template, auth,
+        verify_ssl)
 
 
 class RestNotificationService(BaseNotificationService):
     """Implementation of a notification service for REST."""
 
     def __init__(self, hass, resource, method, headers, message_param_name,
-                 title_param_name, target_param_name, data, data_template):
+                 title_param_name, target_param_name, data, data_template,
+                 auth, verify_ssl):
         """Initialize the service."""
         self._resource = resource
         self._hass = hass
@@ -72,6 +95,8 @@ class RestNotificationService(BaseNotificationService):
         self._target_param_name = target_param_name
         self._data = data
         self._data_template = data_template
+        self._auth = auth
+        self._verify_ssl = verify_ssl
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
@@ -104,13 +129,16 @@ class RestNotificationService(BaseNotificationService):
 
         if self._method == 'POST':
             response = requests.post(self._resource, headers=self._headers,
-                                     data=data, timeout=10)
+                                     data=data, timeout=10, auth=self._auth,
+                                     verify=self._verify_ssl)
         elif self._method == 'POST_JSON':
             response = requests.post(self._resource, headers=self._headers,
-                                     json=data, timeout=10)
+                                     json=data, timeout=10, auth=self._auth,
+                                     verify=self._verify_ssl)
         else:   # default GET
             response = requests.get(self._resource, headers=self._headers,
-                                    params=data, timeout=10)
+                                    params=data, timeout=10, auth=self._auth,
+                                    verify=self._verify_ssl)
 
         success_codes = (200, 201, 202, 203, 204, 205, 206, 207, 208, 226)
         if response.status_code not in success_codes:

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/notify.rest/
 import logging
 
 import requests
-from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -53,6 +52,8 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the RESTful notification service."""
+    from requests.auth import HTTPBasicAuth, HTTPDigestAuth # pylint: disable=import-error
+
     resource = config.get(CONF_RESOURCE)
     method = config.get(CONF_METHOD)
     headers = config.get(CONF_HEADERS)

--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -52,9 +52,6 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_service(hass, config, discovery_info=None):
     """Get the RESTful notification service."""
-    # pylint: disable=import-error
-    from requests.auth import HTTPBasicAuth, HTTPDigestAuth
-
     resource = config.get(CONF_RESOURCE)
     method = config.get(CONF_METHOD)
     headers = config.get(CONF_HEADERS)
@@ -69,9 +66,9 @@ def get_service(hass, config, discovery_info=None):
 
     if username and password:
         if config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
-            auth = HTTPDigestAuth(username, password)
+            auth = requests.auth.HTTPDigestAuth(username, password)
         else:
-            auth = HTTPBasicAuth(username, password)
+            auth = requests.auth.HTTPBasicAuth(username, password)
     else:
         auth = None
 


### PR DESCRIPTION
## Breaking Change:
nothing
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
add `username`, `password`, `authentication` and `verify_ssl` to rest notification

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8935

## Example entry for `configuration.yaml` (if applicable):
```yaml
- name: nextcloud
  platform: rest
  resource: https://my-nextcloud/ocs/v2.php/apps/admin_notifications/api/v2/notifications/my-user
  method: POST
  authentication: basic
  username: my-user
  password: 1234567890
  verify_ssl: false
  headers:
    OCS-APIREQUEST: 'true'
  title_param_name: shortMessage
  message_param_name: longMessage
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - ~~[ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - ~~[ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - ~~[ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - ~~[ ] New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
