### PR TITLE
Account for non-home stationary source_types

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -381,7 +381,7 @@ class Person(RestoreEntity):
     @callback
     def _update_state(self):
         """Update the state."""
-        latest_non_gps_home = latest_not_home = latest_gps = latest = None
+        latest_non_gps_zone = latest_not_home = latest_gps = latest = None
         for entity_id in self._config.get(CONF_DEVICE_TRACKERS, []):
             state = self.hass.states.get(entity_id)
 
@@ -390,13 +390,13 @@ class Person(RestoreEntity):
 
             if state.attributes.get(ATTR_SOURCE_TYPE) == SOURCE_TYPE_GPS:
                 latest_gps = _get_latest(latest_gps, state)
-            elif state.state == STATE_HOME:
-                latest_non_gps_home = _get_latest(latest_non_gps_home, state)
+            elif state.state != STATE_NOT_HOME:
+                latest_non_gps_zone = _get_latest(latest_non_gps_zone, state)
             elif state.state == STATE_NOT_HOME:
                 latest_not_home = _get_latest(latest_not_home, state)
 
-        if latest_non_gps_home:
-            latest = latest_non_gps_home
+        if latest_non_gps_zone:
+            latest = latest_non_gps_zone
         elif latest_gps:
             latest = latest_gps
         else:


### PR DESCRIPTION
## Description:
Current `person` logic for combining `device_tracker` entities didn't take into account 'stationary' source_types (bluetooth, bluetooth_le, router) in non-`home` zones and always prioritized GPS when away from `home`. This PR allows these other source_types to be prioritized if in any defined zone, not just `home`. This is particularly useful when using bluetooth beacons in a non-home zone.

**Related issue (if applicable):** fixes #21980

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23