### PR TITLE
Remove UTF8 decoding for Waze

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -218,7 +218,6 @@ class WazeTravelTime(Entity):
 
                 route = sorted(routes, key=(lambda key: routes[key][0]))[0]
                 duration, distance = routes[route]
-                route = bytes(route, 'ISO-8859-1').decode('UTF-8')
                 self._state = {
                     'duration': duration,
                     'distance': distance,


### PR DESCRIPTION
## Description:
Removes the UFT8 decoding for the Waze sensor, which broke in 0.89.

I've tested this locally, but would appreciate any help running `tox` or anything like that for tests, if deemed necessary.

Currently the Waze travel sensor is broken, so would be good if this could be added to the beta to go out with 0.90.

**Related issue (if applicable):** fixes #21739

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
