### PR TITLE
Bring back the boiler status

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -187,7 +187,7 @@ class NetatmoThermostat(ClimateDevice):
             "module_id": self._data.room_status[self._room_id]['module_id']
         }
         if module_type == NA_THERM:
-            state_attributes["boiler_status"] = self.current_operation
+            state_attributes["boiler_status"] = self._data.boilerstatus
         elif module_type == NA_VALVE:
             state_attributes["heating_power_request"] = \
                 self._data.room_status[self._room_id]['heating_power_request']


### PR DESCRIPTION
## Description:
In the past the state returned whether the the device was heating or idle. Now the state returns the operation mode which can be auto, manual, etc. and is a different thing.

The `boiler_status` attribute returned the operation mode which has changed to the actual mode not the state of the boiler.
This PR brings back the actual boiler status.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
