### PR TITLE
Bump androidtv to 0.0.11

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 
 ANDROIDTV_DOMAIN = 'androidtv'
 
-REQUIREMENTS = ['androidtv==0.0.10']
+REQUIREMENTS = ['androidtv==0.0.11']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -158,7 +158,7 @@ alpha_vantage==2.1.0
 amcrest==1.2.5
 
 # homeassistant.components.androidtv.media_player
-androidtv==0.0.10
+androidtv==0.0.11
 
 # homeassistant.components.switch.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:

This fixes the volume level for the `androidtv` integration (for Android TV devices).  

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/22019

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.