### PR TITLE
Upgrade Dockerfile.dev prefetched tox env to py37

### DIFF
--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -51,7 +51,7 @@ COPY homeassistant/const.py homeassistant/const.py
 
 # Prefetch dependencies for tox
 COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
-RUN tox -e py36 --notest
+RUN tox -e py37 --notest
 
 # END: Development additions
 


### PR DESCRIPTION
## Description:

We already upgrade the  docker base image to Python 3.7, should upgrade this tox command as well, otherwise I got following error during docker build

```
/usr/local/lib/python3.7/site-packages/tox/config/__init__.py:579: UserWarning: conflicting basepython version (set 37, should be 36) for env 'py36';resolve conflict or set ignore_basepython_conflict
  proposed_version, implied_version, testenv_config.envname
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

