### PR TITLE
Fix lifx light async error

### DIFF
--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.service import extract_entity_ids
+from homeassistant.helpers.service import async_extract_entity_ids
 import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -250,7 +250,7 @@ class LIFXManager:
         async def service_handler(service):
             """Apply a service."""
             tasks = []
-            for light in self.service_to_entities(service):
+            for light in await self.async_service_to_entities(service):
                 if service.service == SERVICE_LIFX_SET_STATE:
                     task = light.set_state(**service.data)
                 tasks.append(self.hass.async_create_task(task))
@@ -265,7 +265,7 @@ class LIFXManager:
         """Register the LIFX effects as hass service calls."""
         async def service_handler(service):
             """Apply a service, i.e. start an effect."""
-            entities = self.service_to_entities(service)
+            entities = await self.async_service_to_entities(service)
             if entities:
                 await self.start_effect(
                     entities, service.service, **service.data)
@@ -314,9 +314,9 @@ class LIFXManager:
         elif service == SERVICE_EFFECT_STOP:
             await self.effects_conductor.stop(bulbs)
 
-    def service_to_entities(self, service):
+    async def async_service_to_entities(self, service):
         """Return the known entities that a service call mentions."""
-        entity_ids = extract_entity_ids(self.hass, service)
+        entity_ids = await async_extract_entity_ids(self.hass, service)
         if entity_ids:
             entities = [entity for entity in self.entities.values()
                         if entity.entity_id in entity_ids]


### PR DESCRIPTION
## Description:

`extract_entity_ids` changed implementation in #21472, need change the caller code if caller is a coroutine.

We have only 4 components still called `extract_entity_ids`. 
nuki, onvif, and neato all okay since those callers are not coroutine.

However the caller in lifx light is called by a coroutine, it has to be change to call `async_extract_entity_ids` 

**Related issue (if applicable):** fixes #22026 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

