### PR TITLE
Add unit_of_measurement_template to template sensor

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -16,13 +16,15 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE,
     CONF_ICON_TEMPLATE, CONF_ENTITY_PICTURE_TEMPLATE, ATTR_ENTITY_ID,
     CONF_SENSORS, EVENT_HOMEASSISTANT_START, CONF_FRIENDLY_NAME_TEMPLATE,
-    CONF_UNIT_OF_MEASUREMENT_TEMPLATE, MATCH_ALL, CONF_DEVICE_CLASS)
+    MATCH_ALL, CONF_DEVICE_CLASS)
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_UNIT_OF_MEASUREMENT_TEMPLATE = 'unit_of_measurement_template'
 
 SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
@@ -38,7 +40,6 @@ SENSOR_SCHEMA = vol.Schema({
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENSORS): cv.schema_with_slug_keys(SENSOR_SCHEMA),
 })
-
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -13,10 +13,10 @@ from homeassistant.core import callback
 from homeassistant.components.sensor import ENTITY_ID_FORMAT, \
     PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
+    ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE,
     CONF_ICON_TEMPLATE, CONF_ENTITY_PICTURE_TEMPLATE, ATTR_ENTITY_ID,
     CONF_SENSORS, EVENT_HOMEASSISTANT_START, CONF_FRIENDLY_NAME_TEMPLATE,
-    MATCH_ALL, CONF_DEVICE_CLASS)
+    CONF_UNIT_OF_MEASUREMENT_TEMPLATE, MATCH_ALL, CONF_DEVICE_CLASS)
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
@@ -30,7 +30,7 @@ SENSOR_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
     vol.Optional(CONF_FRIENDLY_NAME_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
-    vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT_TEMPLATE): cv.template,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
@@ -52,7 +52,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             CONF_ENTITY_PICTURE_TEMPLATE)
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         friendly_name_template = device_config.get(CONF_FRIENDLY_NAME_TEMPLATE)
-        unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
+        unit_of_measurement_template = device_config.get(CONF_UNIT_OF_MEASUREMENT_TEMPLATE)
         device_class = device_config.get(CONF_DEVICE_CLASS)
 
         entity_ids = set()
@@ -64,6 +64,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                 (CONF_ICON_TEMPLATE, icon_template),
                 (CONF_ENTITY_PICTURE_TEMPLATE, entity_picture_template),
                 (CONF_FRIENDLY_NAME_TEMPLATE, friendly_name_template),
+                (CONF_UNIT_OF_MEASUREMENT_TEMPLATE, unit_of_measurement_template),
         ):
             if template is None:
                 continue
@@ -98,7 +99,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                 device,
                 friendly_name,
                 friendly_name_template,
-                unit_of_measurement,
+                unit_of_measurement_template,
                 state_template,
                 icon_template,
                 entity_picture_template,
@@ -117,7 +118,7 @@ class SensorTemplate(Entity):
     """Representation of a Template Sensor."""
 
     def __init__(self, hass, device_id, friendly_name, friendly_name_template,
-                 unit_of_measurement, state_template, icon_template,
+                 unit_of_measurement_template, state_template, icon_template,
                  entity_picture_template, entity_ids, device_class):
         """Initialize the sensor."""
         self.hass = hass
@@ -125,13 +126,14 @@ class SensorTemplate(Entity):
                                                   hass=hass)
         self._name = friendly_name
         self._friendly_name_template = friendly_name_template
-        self._unit_of_measurement = unit_of_measurement
+        self._unit_of_measurement_template = unit_of_measurement_template
         self._template = state_template
         self._state = None
         self._icon_template = icon_template
         self._entity_picture_template = entity_picture_template
         self._icon = None
         self._entity_picture = None
+        self._unit_of_measurement = None
         self._entities = entity_ids
         self._device_class = device_class
 
@@ -207,7 +209,8 @@ class SensorTemplate(Entity):
         for property_name, template in (
                 ('_icon', self._icon_template),
                 ('_entity_picture', self._entity_picture_template),
-                ('_name', self._friendly_name_template)):
+                ('_name', self._friendly_name_template),
+                ('_unit_of_measurement', self._unit_of_measurement_template)):
             if template is None:
                 continue
 

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -52,7 +52,8 @@ async def async_setup_platform(hass, config, async_add_entities,
             CONF_ENTITY_PICTURE_TEMPLATE)
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         friendly_name_template = device_config.get(CONF_FRIENDLY_NAME_TEMPLATE)
-        unit_of_measurement_template = device_config.get(CONF_UNIT_OF_MEASUREMENT_TEMPLATE)
+        unit_of_measurement_template = 
+            device_config.get(CONF_UNIT_OF_MEASUREMENT_TEMPLATE)
         device_class = device_config.get(CONF_DEVICE_CLASS)
 
         entity_ids = set()
@@ -64,7 +65,8 @@ async def async_setup_platform(hass, config, async_add_entities,
                 (CONF_ICON_TEMPLATE, icon_template),
                 (CONF_ENTITY_PICTURE_TEMPLATE, entity_picture_template),
                 (CONF_FRIENDLY_NAME_TEMPLATE, friendly_name_template),
-                (CONF_UNIT_OF_MEASUREMENT_TEMPLATE, unit_of_measurement_template),
+                (CONF_UNIT_OF_MEASUREMENT_TEMPLATE, 
+                    unit_of_measurement_template),
         ):
             if template is None:
                 continue

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.components.sensor import ENTITY_ID_FORMAT, \
     PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE,
+    ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
     CONF_ICON_TEMPLATE, CONF_ENTITY_PICTURE_TEMPLATE, ATTR_ENTITY_ID,
     CONF_SENSORS, EVENT_HOMEASSISTANT_START, CONF_FRIENDLY_NAME_TEMPLATE,
     MATCH_ALL, CONF_DEVICE_CLASS)
@@ -32,6 +32,7 @@ SENSOR_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
     vol.Optional(CONF_FRIENDLY_NAME_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
+    vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT_TEMPLATE): cv.template,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
@@ -53,6 +54,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             CONF_ENTITY_PICTURE_TEMPLATE)
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         friendly_name_template = device_config.get(CONF_FRIENDLY_NAME_TEMPLATE)
+        unit_of_measurement = device_config.get(ATTR_UNIT_OF_MEASUREMENT)
         unit_of_measurement_template = device_config.get(
             CONF_UNIT_OF_MEASUREMENT_TEMPLATE)
         device_class = device_config.get(CONF_DEVICE_CLASS)

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -52,8 +52,8 @@ async def async_setup_platform(hass, config, async_add_entities,
             CONF_ENTITY_PICTURE_TEMPLATE)
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         friendly_name_template = device_config.get(CONF_FRIENDLY_NAME_TEMPLATE)
-        unit_of_measurement_template =
-            device_config.get(CONF_UNIT_OF_MEASUREMENT_TEMPLATE)
+        unit_of_measurement_template = device_config.get(
+            CONF_UNIT_OF_MEASUREMENT_TEMPLATE)
         device_class = device_config.get(CONF_DEVICE_CLASS)
 
         entity_ids = set()

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -52,7 +52,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             CONF_ENTITY_PICTURE_TEMPLATE)
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         friendly_name_template = device_config.get(CONF_FRIENDLY_NAME_TEMPLATE)
-        unit_of_measurement_template = 
+        unit_of_measurement_template =
             device_config.get(CONF_UNIT_OF_MEASUREMENT_TEMPLATE)
         device_class = device_config.get(CONF_DEVICE_CLASS)
 
@@ -65,7 +65,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                 (CONF_ICON_TEMPLATE, icon_template),
                 (CONF_ENTITY_PICTURE_TEMPLATE, entity_picture_template),
                 (CONF_FRIENDLY_NAME_TEMPLATE, friendly_name_template),
-                (CONF_UNIT_OF_MEASUREMENT_TEMPLATE, 
+                (CONF_UNIT_OF_MEASUREMENT_TEMPLATE,
                     unit_of_measurement_template),
         ):
             if template is None:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -146,6 +146,7 @@ CONF_TRIGGER_TIME = 'trigger_time'
 CONF_TTL = 'ttl'
 CONF_TYPE = 'type'
 CONF_UNIT_OF_MEASUREMENT = 'unit_of_measurement'
+CONF_UNIT_OF_MEASUREMENT_TEMPLATE = 'unit_of_measurement_template'
 CONF_UNIT_SYSTEM = 'unit_system'
 
 # Deprecated in 0.88.0, invalidated in 0.91.0, remove in 0.92.0

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -162,6 +162,37 @@ class TestTemplateSensor:
         state = self.hass.states.get('sensor.test_template_sensor')
         assert state.attributes['friendly_name'] == 'It Works.'
 
+    def test_unit_of_measurement_template(self):
+        """Test unit_of_measurement template."""
+        with assert_setup_component(1):
+            assert setup_component(self.hass, 'sensor', {
+                'sensor': {
+                    'platform': 'template',
+                    'sensors': {
+                        'test_template_sensor': {
+                            'value_template':
+                                "{{ states.sensor.test_state.state }}",
+                            'unit_of_measurement_template':
+                                "{% if states.sensor.test_state.state == "
+                                "'Works' %}"
+                                "degrees"
+                                "{% endif %}"
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('sensor.test_template_sensor')
+        assert state.attributes.get('unit_of_measurement') == ''
+
+        self.hass.states.set('sensor.test_state', 'Works')
+        self.hass.block_till_done()
+        state = self.hass.states.get('sensor.test_template_sensor')
+        assert state.attributes['unit_of_measurement'] == 'degrees'
+
     def test_template_syntax_error(self):
         """Test templating syntax error."""
         with assert_setup_component(0):


### PR DESCRIPTION
## Description:
The template sensor has been changed to accept a unit_of_measurement_template.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9135

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: time_date
    display_options:
      - 'time'

  - platform: template
    sensors:
      my_sensor:
        entity_id: sensor.time
        friendly_name: "Time"
        value_template: "{{ states.sensor.time.state }}"
        unit_of_measurement_template: >-
          {% if (now().minute % 2 == 0) %}
            Even
          {% else %}
            Odd
          {% endif %}

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
