### PR TITLE
Add generic scheduler

### DIFF
--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -126,7 +126,6 @@ class Schedule:
 
     def handle_state(self, entity, old_state, new_state):
         """Handle state changes of the monitored entities."""
-        # TODO only do this if all entities are loaded
         _LOGGER.info("State change detected for %s", entity)
         self.exec_schedule(dt.now())
 
@@ -202,15 +201,12 @@ class Schedule:
                     new_state[rule.entity] = rule.value
 
         for entity in self.monitored:
-            if entity in new_state:
-                value = new_state[entity]
-            else:
-                value = self.defaults[entity]
-            self.setValue(entity, value)
+            value = new_state.get(entity, self.defaults[entity])
+            self.set_value(entity, value)
         _LOGGER.info("Schedule executed, result = %s", json.dumps(new_state))
         self.active_status = new_state
 
-    def setValue(self, entity, value):
+    def set_value(self, entity, value):
         """Set the entity value.
 
         Calls a service based on the entity's domain to set
@@ -332,8 +328,6 @@ class Rule:
         current_time = now.time()
         start = dt.parse_time(self._start)
         end = dt.parse_time(self._end)
-        if (self._days[now.weekday()]
-                and start <= current_time
-                and current_time < end):
+        if (self._days[now.weekday()] and start <= current_time < end):
             return True
         return False

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -1,0 +1,339 @@
+"""
+Schedules temperature updates to components.
+
+Example component configuration:
+
+schedule:
+  entities:
+    -climate.home
+"""
+import json
+import logging
+
+import voluptuous as vol
+
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.util import dt
+from homeassistant.helpers.event import (
+    async_track_time_change)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_ENTITIES
+from homeassistant.core import callback, split_entity_id
+from homeassistant.helpers.storage import Store
+from homeassistant.components import websocket_api
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "schedule"
+
+STORAGE_VERSION = 1
+STORAGE_KEY = 'schedule'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ENTITIES): cv.comp_entity_ids,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+WS_TYPE_SCHEDULE_RULES = 'schedule/rules'
+SCHEMA_WEBSOCKET_GET_RULES = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        'type': WS_TYPE_SCHEDULE_RULES
+    })
+
+WS_TYPE_SCHEDULE_ENTITIES = 'schedule/entities'
+SCHEMA_WEBSOCKET_GET_ENTITIES = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        'type': WS_TYPE_SCHEDULE_ENTITIES
+    })
+
+WS_TYPE_SCHEDULE_CLEAR = 'schedule/clear'
+SCHEMA_WEBSOCKET_CLEAR = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        'type': WS_TYPE_SCHEDULE_CLEAR
+    })
+
+WS_TYPE_SCHEDULE_SAVE = 'schedule/save'
+SCHEMA_WEBSOCKET_SAVE = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        'type': WS_TYPE_SCHEDULE_SAVE,
+        'rules': list
+    })
+
+# Valid domains for entities with a schedule
+SCHEDULE_VALID_DOMAINS = ['climate', 'switch', 'light', 'input_boolean']
+SCHEDULE_SWITCHABLE_DOMAINS = ['switch', 'light', 'input_boolean']
+
+
+async def async_setup(hass, config):
+    """Track states and offer events for switches."""
+    monitored_pre = config[DOMAIN].get(CONF_ENTITIES, [])
+    monitored = []
+    for entity in monitored_pre:
+        if check_entity(hass, entity):
+            monitored.append(entity)
+
+    hass.data[DOMAIN] = Schedule(hass, monitored)
+    await hass.components.frontend.async_register_built_in_panel(
+        'schedule', 'Schedule', 'mdi:calendar')
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SCHEDULE_RULES, hass.data[DOMAIN].websocket_handle_rules,
+        SCHEMA_WEBSOCKET_GET_RULES)
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SCHEDULE_ENTITIES, hass.data[DOMAIN].websocket_handle_entities,
+        SCHEMA_WEBSOCKET_GET_ENTITIES)
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SCHEDULE_CLEAR, hass.data[DOMAIN].websocket_handle_clear,
+        SCHEMA_WEBSOCKET_CLEAR)
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SCHEDULE_SAVE, hass.data[DOMAIN].websocket_handle_save,
+        SCHEMA_WEBSOCKET_SAVE)
+
+    return True
+
+
+def check_entity(hass, entity):
+    """Check if the entity domain is accepted by the schedule."""
+    domain = split_entity_id(entity)[0]
+    if domain not in SCHEDULE_VALID_DOMAINS:
+        _LOGGER.error("Domain %s is not accepted by the schedule.", domain)
+        return False
+    return True
+
+
+class Schedule:
+    """Represents a generic schedule."""
+
+    def __init__(self, hass, monitored):
+        """Initialize the Schedule."""
+        self.hass = hass
+        self.store = Store(hass, STORAGE_VERSION,
+                           STORAGE_KEY)
+        self.monitored = monitored
+        self.rules = []
+        self.unsubs = []
+        self.defaults = {}
+        self.hass.loop.create_task(self.async_load_rules())
+
+        self.active_status = {}
+        async_track_state_change(hass, monitored, self.handle_state)
+
+    def handle_state(self, entity, old_state, new_state):
+        """Handle state changes of the monitored entities."""
+        # TODO only do this if all entities are loaded
+        _LOGGER.info("State change detected for %s", entity)
+        self.exec_schedule(dt.now())
+
+    def load_rules_dict(self, loaded_rules):
+        """Generate rules array from dictionary."""
+        self.rules = []
+        for rule in loaded_rules:
+            if dt.parse_time(rule['start']) >= dt.parse_time(rule['end']):
+                _LOGGER.error("Rule end is before start")
+                return None
+            self.rules.append(
+                Rule(rule))
+        self.update_rule_listeners()
+
+    async def async_load_rules(self):
+        """Load rules from storage."""
+        loaded_rules = await self.store.async_load()
+        if loaded_rules is None:
+            self.generate_defaults()
+            await self.async_save_rules()
+        else:
+            self.load_rules_dict(loaded_rules["rules"])
+            self.defaults = loaded_rules["defaults"]
+
+    def update_rule_listeners(self):
+        """Add listeners for all times that have rule changes."""
+        for unsub in self.unsubs:
+            unsub()
+
+        times_set = set()
+        for rule in self.rules:
+            times_set.add(rule.start)
+            times_set.add(rule.end)
+        self.unsubs = []
+        for time in times_set:
+            r_time = dt.parse_time(time)
+            self.unsubs.append(async_track_time_change(self.hass,
+                                                       self.exec_schedule,
+                                                       hour=r_time.hour,
+                                                       minute=r_time.minute,
+                                                       second=0))
+
+    async def async_save_rules(self):
+        """Save rules to storage."""
+        await self.store.async_save({
+            'rules': list(map(lambda r: r.to_dict(), self.rules)),
+            'defaults': self.defaults
+        })
+
+    def generate_defaults(self):
+        """Generate default values for the monitored entities."""
+        for entity in self.monitored:
+            domain = split_entity_id(entity)[0]
+            if domain == 'climate':
+                self.defaults[entity] = 20
+            elif domain in SCHEDULE_SWITCHABLE_DOMAINS:
+                self.defaults[entity] = False
+            else:
+                self.defaults[entity] = False
+
+    def exec_schedule(self, now):
+        """Execute the configured schedule."""
+        new_state = {}
+        # Aggregate active states from all rules
+        for rule in self.rules:
+            if rule.should_update(now):
+                if rule.entity in new_state:
+                    _LOGGER.warning(
+                        "Overlapping rules running for entity %s!",
+                        rule.entity)
+
+                else:
+                    new_state[rule.entity] = rule.value
+
+        for entity in self.monitored:
+            if entity in new_state:
+                value = new_state[entity]
+            else:
+                value = self.defaults[entity]
+            self.setValue(entity, value)
+        _LOGGER.info("Schedule executed, result = %s", json.dumps(new_state))
+        self.active_status = new_state
+
+    def setValue(self, entity, value):
+        """Set the entity value.
+
+        Calls a service based on the entity's domain to set
+        the value
+        """
+        domain = domain = split_entity_id(entity)[0]
+        if domain == "climate":
+            self.hass.loop.create_task(
+                self.hass.services.async_call(
+                    'climate',
+                    'set_temperature',
+                    {
+                        'entity_id': entity,
+                        'temperature': value
+                    }))
+        elif domain in SCHEDULE_SWITCHABLE_DOMAINS:
+            self.hass.loop.create_task(
+                self.hass.services.async_call(
+                    domain,
+                    'turn_on' if value else 'turn_off',
+                    {
+                        'entity_id': entity,
+                    }))
+
+    @callback
+    def websocket_handle_rules(self, hass, connection, msg):
+        """Handle getting the rules."""
+        connection.send_message(websocket_api.result_message(msg['id'], {
+            'rules': list(map(lambda r: r.to_dict(), self.rules))
+        }))
+
+    @callback
+    def websocket_handle_entities(self, hass, connection, msg):
+        """Handle getting the monitored entities."""
+        connection.send_message(websocket_api.result_message(msg['id'], {
+            'entities': self.monitored
+        }))
+
+    @callback
+    def websocket_handle_clear(self, hass, connection, msg):
+        """Handle clearing all the rules."""
+        self.rules = []
+
+        self.hass.loop.create_task(self.async_save_rules())
+
+        connection.send_message(websocket_api.result_message(msg['id'], {
+            'completed': True
+        }))
+
+    @callback
+    def websocket_handle_save(self, hass, connection, msg):
+        """Handle updating the rules."""
+        self.load_rules_dict(msg["rules"])
+        self.hass.loop.create_task(self.async_save_rules())
+        connection.send_message(websocket_api.result_message(msg['id'], {
+            'completed': True
+        }))
+
+
+class Rule:
+    """Represents a rule."""
+
+    def __init__(self, rule_dict):
+        """Initialize the rule from a dictionary."""
+        self._active = rule_dict['active']
+        self._start = rule_dict['start']
+        self._end = rule_dict['end']
+        self._entity = rule_dict['entity']
+        self._value = rule_dict['value']
+        self._days = rule_dict['days']
+
+    def to_dict(self):
+        """Generate a dictionary containing the rule's information."""
+        return {
+            'active': self._active,
+            'start': self._start,
+            'end': self._end,
+            'entity': self._entity,
+            'value': self._value,
+            'days': self._days
+        }
+
+    @property
+    def active(self):
+        """Indicate if the rule is enabled."""
+        return self._active
+
+    @property
+    def start(self):
+        """Start time of the rule."""
+        return self._start
+
+    @property
+    def end(self):
+        """End time of the rule."""
+        return self._end
+
+    @property
+    def entity(self):
+        """Id of the entity affected by the rule."""
+        return self._entity
+
+    @property
+    def value(self):
+        """Value to be set when the rule is active."""
+        return self._value
+
+    @property
+    def days(self):
+        """Days in which rule should run."""
+        return self._days
+
+    def should_update(self, time):
+        """Calculate if rule is active at the given time."""
+        if not self._active:
+            return False
+
+        now = dt.as_local(time)
+        current_time = now.time()
+        start = dt.parse_time(self._start)
+        end = dt.parse_time(self._end)
+        if (self._days[now.weekday()]
+                and start <= current_time
+                and current_time < end):
+            return True
+        return False

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -135,10 +135,11 @@ class Schedule:
         for rule in loaded_rules:
             if dt.parse_time(rule['start']) >= dt.parse_time(rule['end']):
                 _LOGGER.error("Rule end is before start")
-                return None
-            self.rules.append(
-                Rule(rule))
+            else:
+                self.rules.append(
+                    Rule(rule))
         self.update_rule_listeners()
+        self.exec_schedule(dt.now())
 
     async def async_load_rules(self):
         """Load rules from storage."""
@@ -147,8 +148,8 @@ class Schedule:
             self.generate_defaults()
             await self.async_save_rules()
         else:
-            self.load_rules_dict(loaded_rules["rules"])
             self.defaults = loaded_rules["defaults"]
+            self.load_rules_dict(loaded_rules["rules"])
 
     def update_rule_listeners(self):
         """Add listeners for all times that have rule changes."""

--- a/tests/components/schedule/__init__.py
+++ b/tests/components/schedule/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the schedule component."""

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -77,7 +77,7 @@ async def gen_storage(hass, rules=[], defaults=TEST_DEFAULTS_BASE):
 
 
 @pytest.fixture
-async def mock_services(hass):
+def mock_services(hass):
     """Mock the services used by the schedule."""
     calls_set_temp = async_mock_service(
         hass, DOMAIN_CLIMATE, SERVICE_SET_TEMP)

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -1,0 +1,254 @@
+"""The tests for the Schedule component."""
+from unittest.mock import patch
+from datetime import datetime
+import pytest
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components import schedule
+from homeassistant.helpers.storage import Store
+from homeassistant.components.websocket_api.const import TYPE_RESULT
+
+
+from tests.common import (async_mock_service,
+                          async_fire_time_changed)
+
+
+DOMAIN_CLIMATE = "climate"
+DOMAIN_INPUT_BOOL = "input_boolean"
+SERVICE_SET_TEMP = "set_temperature"
+SERVICE_TURN_ON = "turn_on"
+SERVICE_TURN_OFF = "turn_off"
+
+RULE_ALL_CLIMATE = {
+    "active": True,
+    "days": [True, True, True, True, True, True, True],
+    "end": "9:00",
+    "entity": "climate.fake",
+    "start": "8:00",
+    "value": 25
+}
+RULE_ALL_SWITCH = {
+    "active": True,
+    "days": [True, True, True, True, True, True, True],
+    "end": "11:00",
+    "entity": "input_boolean.fake",
+    "start": "10:00",
+    "value": True
+}
+
+RULE_TEST = {
+    "active": True,
+    "days": [True, True, False, True, True, True, True],
+    "end": "12:00",
+    "entity": "input_boolean.fake",
+    "start": "10:00",
+    "value": True
+}
+
+
+TEST_CONFIG = {
+    schedule.DOMAIN: {"entities":
+                      ["climate.fake",
+                       "input_boolean.fake"]}}
+
+TEST_DEFAULTS_BASE = {
+    "climate.fake": 20,
+    "input_boolean.fake": False
+}
+TEST_DEFAULTS_MOD = {
+    "climate.fake": 21,
+    "input_boolean.fake": True
+}
+
+
+def gen_storage_data(rules=[], defaults=TEST_DEFAULTS_BASE):
+    """Generate test storage data."""
+    return {
+        "defaults": defaults,
+        "rules": rules
+    }
+
+
+async def gen_storage(hass, rules=[], defaults=TEST_DEFAULTS_BASE):
+    """Fill the mocked storage with test.."""
+    store = Store(hass, schedule.STORAGE_VERSION,
+                  schedule.STORAGE_KEY)
+    await store.async_save(gen_storage_data(rules, defaults))
+
+
+@pytest.fixture
+async def mock_services(hass):
+    """Mock the services used by the schedule."""
+    calls_set_temp = async_mock_service(
+        hass, DOMAIN_CLIMATE, SERVICE_SET_TEMP)
+    calls_turn_on = async_mock_service(
+        hass, DOMAIN_INPUT_BOOL, SERVICE_TURN_ON)
+    calls_turn_off = async_mock_service(
+        hass, DOMAIN_INPUT_BOOL, SERVICE_TURN_OFF)
+    yield [calls_set_temp, calls_turn_on, calls_turn_off]
+
+
+def test_rule(hass):
+    """Test the Rule subclass."""
+    rule_a = schedule.Rule(RULE_TEST)
+    assert rule_a.to_dict() == RULE_TEST
+    assert rule_a.active is True
+    assert rule_a.days == [True, True, False, True, True, True, True]
+    assert rule_a.start == "10:00"
+    assert rule_a.end == "12:00"
+    assert rule_a.entity == "input_boolean.fake"
+    assert rule_a.value is True
+
+    assert rule_a.should_update(datetime(2019, 4, 1, 9, 59, 59)) is False
+    assert rule_a.should_update(datetime(2019, 4, 1, 10, 00, 00)) is True
+    assert rule_a.should_update(datetime(2019, 4, 1, 11, 00, 00)) is True
+    assert rule_a.should_update(datetime(2019, 4, 1, 11, 59, 59)) is True
+    assert rule_a.should_update(datetime(2019, 4, 1, 12, 00, 00)) is False
+    assert rule_a.should_update(datetime(2019, 4, 3, 9, 59, 59)) is False
+    assert rule_a.should_update(datetime(2019, 4, 3, 10, 00, 00)) is False
+
+    rule_a._active = False
+    assert rule_a.should_update(datetime(2019, 4, 1, 11, 00, 00)) is False
+
+
+async def test_load_rules(hass, hass_storage, mock_services):
+    """Test if the rules load correctly."""
+    await gen_storage(hass, [RULE_ALL_CLIMATE, RULE_ALL_SWITCH],
+                      TEST_DEFAULTS_MOD)
+
+    assert await async_setup_component(hass, schedule.DOMAIN, TEST_CONFIG)
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    m_schedule = hass.data[schedule.DOMAIN]
+    assert m_schedule
+
+    rules = m_schedule.rules
+    assert len(rules) == 2
+
+    assert rules[0].to_dict() == RULE_ALL_CLIMATE
+    assert rules[1].to_dict() == RULE_ALL_SWITCH
+    assert m_schedule.defaults == TEST_DEFAULTS_MOD
+
+
+async def test_default_storage_created(hass, hass_storage, mock_services):
+    """Test if the rules load correctly."""
+    assert await async_setup_component(hass, schedule.DOMAIN, TEST_CONFIG)
+    await hass.async_start()
+    await hass.async_block_till_done()
+    assert hass_storage[schedule.STORAGE_KEY]["data"] == gen_storage_data()
+
+
+async def test_schedule_exec(hass, hass_storage):
+    """Test the execution of a schedule."""
+    calls_temp = async_mock_service(
+        hass, DOMAIN_CLIMATE, SERVICE_SET_TEMP)
+    calls_turn_on = async_mock_service(
+        hass, DOMAIN_INPUT_BOOL, SERVICE_TURN_ON)
+    calls_turn_off = async_mock_service(
+        hass, DOMAIN_INPUT_BOOL, SERVICE_TURN_OFF)
+
+    now = datetime(2019, 4, 1, 7, 00, 00)
+
+    await gen_storage(hass, [RULE_ALL_CLIMATE, RULE_ALL_SWITCH],
+                      TEST_DEFAULTS_BASE)
+
+    with patch("homeassistant.util.dt.now", return_value=now):
+        assert await async_setup_component(
+            hass, schedule.DOMAIN,
+            TEST_CONFIG
+        )
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    now = datetime(2019, 4, 1, 8, 00, 00)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    now = datetime(2019, 4, 1, 9, 00, 00)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    now = datetime(2019, 4, 1, 10, 00, 00)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    now = datetime(2019, 4, 1, 12, 00, 00)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    assert len(calls_temp) == 5
+    for x in range(5):
+        assert calls_temp[x].data["entity_id"] == "climate.fake"
+        assert calls_temp[x].data["temperature"] == 25 if x == 1 else 20
+    assert len(calls_turn_on) == 1
+    assert calls_turn_on[0].data["entity_id"] == "input_boolean.fake"
+    assert len(calls_turn_off) == 4
+    for x in range(4):
+        assert calls_turn_off[x].data["entity_id"] == "input_boolean.fake"
+
+
+async def test_ws_api(hass, hass_storage, hass_ws_client, mock_services):
+    """Test the websocket api for the schedule."""
+    await gen_storage(hass, [RULE_ALL_CLIMATE, RULE_ALL_SWITCH],
+                      TEST_DEFAULTS_BASE)
+
+    assert await async_setup_component(
+        hass, schedule.DOMAIN,
+        TEST_CONFIG
+    )
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    m_schedule = hass.data[schedule.DOMAIN]
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        'id': 5,
+        'type': "schedule/entities"
+    })
+    msg = await client.receive_json()
+    assert msg['success'] is True
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['result']['entities'] == ["climate.fake", "input_boolean.fake"]
+
+    await client.send_json({
+        'id': 6,
+        'type': "schedule/rules"
+    })
+    msg = await client.receive_json()
+    assert msg['success'] is True
+    assert msg['id'] == 6
+    assert msg['type'] == TYPE_RESULT
+    data = msg['result']['rules']
+    assert data[0] == RULE_ALL_CLIMATE
+    assert data[1] == RULE_ALL_SWITCH
+
+    await client.send_json({
+        'id': 7,
+        'type': "schedule/clear"
+    })
+    msg = await client.receive_json()
+    assert msg['success'] is True
+    assert msg['id'] == 7
+    assert msg['type'] == TYPE_RESULT
+    assert msg['result']['completed'] is True
+
+    assert m_schedule.rules == []
+    assert hass_storage[schedule.STORAGE_KEY]['data']['rules'] == []
+
+    await client.send_json({
+        'id': 8,
+        'type': "schedule/save",
+        'rules': [RULE_TEST]
+    })
+    msg = await client.receive_json()
+    assert msg['success'] is True
+    assert msg['id'] == 8
+    assert msg['type'] == TYPE_RESULT
+    assert msg['result']['completed'] is True
+
+    assert len(m_schedule.rules) == 1
+    assert m_schedule.rules[0].to_dict() == RULE_TEST
+    assert hass_storage[schedule.STORAGE_KEY]['data']['rules'] == [RULE_TEST]


### PR DESCRIPTION
## Description:
_Triggered from: home-assistant/home-assistant/pull/21017 and home-assistant/architecture/issues/148_

Adds a generic schedule component that supports multiple entity types. Implements some of the ideas discussed on home-assistant/architecture/issues/148 .

Features:
- Schedule with multiple rules.
- Each rule applies to a different entity, time frame and days of the week.
- Configurable using a custom panel.

**Pull request for the frontend:** home-assistant/home-assistant-polymer/pull/2929

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
schedule:
  entities:
    - climate.main
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
