### PR TITLE
Z-Wave usb_path in configuration.yaml overrides config entry usb_path

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -169,8 +169,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): cv.boolean,
         vol.Optional(CONF_POLLING_INTERVAL, default=DEFAULT_POLLING_INTERVAL):
             cv.positive_int,
-        vol.Optional(CONF_USB_STICK_PATH, default=DEFAULT_CONF_USB_STICK_PATH):
-            cv.string,
+        vol.Optional(CONF_USB_STICK_PATH): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -239,7 +238,8 @@ async def async_setup(hass, config):
         hass.async_create_task(hass.config_entries.flow.async_init(
             DOMAIN, context={'source': config_entries.SOURCE_IMPORT},
             data={
-                CONF_USB_STICK_PATH: conf[CONF_USB_STICK_PATH],
+                CONF_USB_STICK_PATH: conf.get(
+                    CONF_USB_STICK_PATH, DEFAULT_CONF_USB_STICK_PATH),
                 CONF_NETWORK_KEY: conf.get(CONF_NETWORK_KEY),
             }
         ))
@@ -271,9 +271,13 @@ async def async_setup_entry(hass, config_entry):
         config.get(CONF_DEVICE_CONFIG_DOMAIN),
         config.get(CONF_DEVICE_CONFIG_GLOB))
 
+    usb_path = config.get(
+        CONF_USB_STICK_PATH, config_entry.data[CONF_USB_STICK_PATH])
+
+    _LOGGER.info('Zwave  USB path is %s', usb_path)
     # Setup options
     options = ZWaveOption(
-        config_entry.data[CONF_USB_STICK_PATH],
+        usb_path,
         user_path=hass.config.config_dir,
         config_path=config.get(CONF_CONFIG_PATH))
 

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -274,7 +274,8 @@ async def async_setup_entry(hass, config_entry):
     usb_path = config.get(
         CONF_USB_STICK_PATH, config_entry.data[CONF_USB_STICK_PATH])
 
-    _LOGGER.info('Zwave  USB path is %s', usb_path)
+    _LOGGER.info('Z-Wave  USB path is %s', usb_path)
+
     # Setup options
     options = ZWaveOption(
         usb_path,
@@ -378,7 +379,7 @@ async def async_setup_entry(hass, config_entry):
 
     def network_ready():
         """Handle the query of all awake nodes."""
-        _LOGGER.info("Zwave network is ready for use. All awake nodes "
+        _LOGGER.info("Z-Wave network is ready for use. All awake nodes "
                      "have been queried. Sleeping nodes will be "
                      "queried when they awake.")
         hass.bus.fire(const.EVENT_NETWORK_READY)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -274,7 +274,7 @@ async def async_setup_entry(hass, config_entry):
     usb_path = config.get(
         CONF_USB_STICK_PATH, config_entry.data[CONF_USB_STICK_PATH])
 
-    _LOGGER.info('Z-Wave  USB path is %s', usb_path)
+    _LOGGER.info('Z-Wave USB path is %s', usb_path)
 
     # Setup options
     options = ZWaveOption(


### PR DESCRIPTION
## Breaking Change:
Potentially a breaking change if people have a stale `usb_path` setting in configuration.yaml that's no longer accurate.

## Description:
Updates Z-Wave so that if a `usb_path` is specified in configuration.yaml, it will override the usb_path that is in the zwave config entry. Had to remove the default path in the voluptuous schema as part of this. It's very possible that `zwave:` will be specified in configuration.yaml without a usb_path since there's a number of configuration.yaml-only settings for zwave.

This should help reduce the number of people that need to manually edit the `storage/core.config_entries` file if their usb_path changes.

## Example entry for `configuration.yaml` (if applicable):
```yaml
zwave:
  usb_path: /dev/zwave
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)