### PR TITLE
Bump amcrest to 1.2.6 & use new exceptions

### DIFF
--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -4,8 +4,6 @@ from datetime import timedelta
 
 import aiohttp
 import voluptuous as vol
-from requests.exceptions import HTTPError, ConnectTimeout
-from requests.exceptions import ConnectionError as ConnectError
 
 from homeassistant.const import (
     CONF_NAME, CONF_HOST, CONF_PORT, CONF_USERNAME, CONF_PASSWORD,
@@ -13,7 +11,8 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['amcrest==1.2.5']
+
+REQUIREMENTS = ['amcrest==1.2.6']
 DEPENDENCIES = ['ffmpeg']
 
 _LOGGER = logging.getLogger(__name__)
@@ -91,7 +90,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up the Amcrest IP Camera component."""
-    from amcrest import AmcrestCamera
+    from amcrest import AmcrestCamera, CommError, LoginError
 
     hass.data[DATA_AMCREST] = {}
     amcrest_cams = config[DOMAIN]
@@ -105,7 +104,7 @@ def setup(hass, config):
             # pylint: disable=pointless-statement
             camera.current_time
 
-        except (ConnectError, ConnectTimeout, HTTPError) as ex:
+        except (CommError, LoginError) as ex:
             _LOGGER.error("Unable to connect to Amcrest camera: %s", str(ex))
             hass.components.persistent_notification.create(
                 'Error: {}<br />'

--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -90,7 +90,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up the Amcrest IP Camera component."""
-    from amcrest import AmcrestCamera, CommError, LoginError
+    from amcrest import AmcrestCamera, AmcrestError
 
     hass.data[DATA_AMCREST] = {}
     amcrest_cams = config[DOMAIN]
@@ -104,7 +104,7 @@ def setup(hass, config):
             # pylint: disable=pointless-statement
             camera.current_time
 
-        except (CommError, LoginError) as ex:
+        except AmcrestError as ex:
             _LOGGER.error("Unable to connect to Amcrest camera: %s", str(ex))
             hass.components.persistent_notification.create(
                 'Error: {}<br />'

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -49,7 +49,7 @@ class AmcrestCam(Camera):
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""
-        from amcrest import CommError
+        from amcrest import AmcrestError
 
         async with self._snapshot_lock:
             try:
@@ -57,7 +57,7 @@ class AmcrestCam(Camera):
                 response = await self.hass.async_add_executor_job(
                     self._camera.snapshot, self._resolution)
                 return response.data
-            except CommError as error:
+            except AmcrestError as error:
                 _LOGGER.error(
                     'Could not get camera image due to error %s', error)
                 return None

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -2,8 +2,7 @@
 import asyncio
 import logging
 
-from requests import RequestException
-from urllib3.exceptions import ReadTimeoutError
+from amcrest import CommError
 
 from homeassistant.components.amcrest import (
     DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT)
@@ -57,7 +56,7 @@ class AmcrestCam(Camera):
                 response = await self.hass.async_add_executor_job(
                     self._camera.snapshot, self._resolution)
                 return response.data
-            except (RequestException, ReadTimeoutError, ValueError) as error:
+            except CommError as error:
                 _LOGGER.error(
                     'Could not get camera image due to error %s', error)
                 return None

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -2,8 +2,6 @@
 import asyncio
 import logging
 
-from amcrest import CommError
-
 from homeassistant.components.amcrest import (
     DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT)
 from homeassistant.components.camera import Camera
@@ -12,6 +10,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_web,
     async_aiohttp_proxy_stream)
+
 
 DEPENDENCIES = ['amcrest', 'ffmpeg']
 
@@ -50,6 +49,8 @@ class AmcrestCam(Camera):
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""
+        from amcrest import CommError
+
         async with self._snapshot_lock:
             try:
                 # Send the request to snap a picture and return raw jpg data

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -155,7 +155,7 @@ alarmdecoder==1.13.2
 alpha_vantage==2.1.0
 
 # homeassistant.components.amcrest
-amcrest==1.2.5
+amcrest==1.2.6
 
 # homeassistant.components.switch.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:
Per @amelchio's comment/suggestion in PR #21664:

"It's a shame the library does not handle these exceptions and raises its own instead."

the amcrest package was changed to handle exceptions coming from urllib3 & requests and raise its own unique exceptions instead to make it easier on the "user" (in this case, the amcrest homeassistant component.) Therefore this PR bumps the amcrest package version and changes the amcrest homeassistant component accordingly.

**Related issue (if applicable):** None

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** None

## Example entry for `configuration.yaml` (if applicable):
Does not affect configuration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
