### PR TITLE
Return config entry ID after creation

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -118,6 +118,16 @@ class ConfigManagerFlowIndexView(FlowManagerIndexView):
         # pylint: disable=no-value-for-parameter
         return await super().post(request)
 
+    def _prepare_result_json(self, result):
+        """Convert result to JSON."""
+        if result['type'] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+            return super()._prepare_result_json(result)
+
+        data = result.copy()
+        data['result'] = data['result'].entry_id
+        data.pop('data')
+        return data
+
 
 class ConfigManagerFlowResourceView(FlowManagerResourceView):
     """View to interact with the flow manager."""
@@ -142,6 +152,16 @@ class ConfigManagerFlowResourceView(FlowManagerResourceView):
 
         # pylint: disable=no-value-for-parameter
         return await super().post(request, flow_id)
+
+    def _prepare_result_json(self, result):
+        """Convert result to JSON."""
+        if result['type'] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+            return super()._prepare_result_json(result)
+
+        data = result.copy()
+        data['result'] = data['result'].entry_id
+        data.pop('data')
+        return data
 
 
 class ConfigManagerAvailableFlowView(HomeAssistantView):
@@ -175,7 +195,7 @@ class OptionManagerFlowIndexView(FlowManagerIndexView):
         return await super().post(request)
 
 
-class OptionManagerFlowResourceView(ConfigManagerFlowResourceView):
+class OptionManagerFlowResourceView(FlowManagerResourceView):
     """View to interact with the option flow manager."""
 
     url = '/api/config/config_entries/options/flow/{flow_id}'

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -255,6 +255,10 @@ def test_create_account(hass, client):
                                       json={'handler': 'test'})
 
     assert resp.status == 200
+
+    entries = hass.config_entries.async_entries('test')
+    assert len(entries) == 1
+
     data = yield from resp.json()
     data.pop('flow_id')
     assert data == {
@@ -262,6 +266,7 @@ def test_create_account(hass, client):
         'title': 'Test Entry',
         'type': 'create_entry',
         'version': 1,
+        'result': entries[0].entry_id,
         'description': None,
         'description_placeholders': None,
     }
@@ -317,6 +322,10 @@ def test_two_step_flow(hass, client):
             '/api/config/config_entries/flow/{}'.format(flow_id),
             json={'user_title': 'user-title'})
         assert resp.status == 200
+
+        entries = hass.config_entries.async_entries('test')
+        assert len(entries) == 1
+
         data = yield from resp.json()
         data.pop('flow_id')
         assert data == {
@@ -324,6 +333,7 @@ def test_two_step_flow(hass, client):
             'type': 'create_entry',
             'title': 'user-title',
             'version': 1,
+            'result': entries[0].entry_id,
             'description': None,
             'description_placeholders': None,
         }


### PR DESCRIPTION
## Description:

When creating a config entry ID, populate the `result` key in the resulting dict with the ID of the config entry that was just created.

Will be used for https://github.com/home-assistant/home-assistant-polymer/pull/2932

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
