### PR TITLE
Telegram_bot: Allow fetching data from unverified SSL endpoints (#22067)

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -48,6 +48,7 @@ ATTR_TEXT = 'text'
 ATTR_URL = 'url'
 ATTR_USER_ID = 'user_id'
 ATTR_USERNAME = 'username'
+ATTR_VERIFY_SSL = 'verify_ssl'
 
 CONF_ALLOWED_CHAT_IDS = 'allowed_chat_ids'
 CONF_PROXY_URL = 'proxy_url'
@@ -108,6 +109,7 @@ SERVICE_SCHEMA_SEND_FILE = BASE_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_USERNAME): cv.string,
     vol.Optional(ATTR_PASSWORD): cv.string,
     vol.Optional(ATTR_AUTHENTICATION): cv.string,
+    vol.Optional(ATTR_VERIFY_SSL): cv.boolean,
 })
 
 SERVICE_SCHEMA_SEND_LOCATION = BASE_SERVICE_SCHEMA.extend({
@@ -164,7 +166,7 @@ SERVICE_MAP = {
 
 
 def load_data(hass, url=None, filepath=None, username=None, password=None,
-              authentication=None, num_retries=5):
+              authentication=None, num_retries=5, verify_ssl=None):
     """Load data into ByteIO/File container from a source."""
     try:
         if url is not None:
@@ -175,6 +177,8 @@ def load_data(hass, url=None, filepath=None, username=None, password=None,
                     params["auth"] = HTTPDigestAuth(username, password)
                 else:
                     params["auth"] = HTTPBasicAuth(username, password)
+            if verify_ssl is not None:
+                params["verify"] = verify_ssl
             retry_num = 0
             while retry_num < num_retries:
                 req = requests.get(url, **params)
@@ -536,6 +540,7 @@ class TelegramNotificationService:
             username=kwargs.get(ATTR_USERNAME),
             password=kwargs.get(ATTR_PASSWORD),
             authentication=kwargs.get(ATTR_AUTHENTICATION),
+            verify_ssl=kwargs.get(ATTR_VERIFY_SSL),
         )
         if file_content:
             for chat_id in self._get_target_chat_ids(target):

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -177,7 +177,7 @@ def load_data(hass, url=None, filepath=None, username=None, password=None,
                     params["auth"] = HTTPDigestAuth(username, password)
                 else:
                     params["auth"] = HTTPBasicAuth(username, password)
-            if verify_ssl is not None:
+            if verify_ssl:
                 params["verify"] = verify_ssl
             retry_num = 0
             while retry_num < num_retries:

--- a/homeassistant/components/telegram_bot/services.yaml
+++ b/homeassistant/components/telegram_bot/services.yaml
@@ -52,6 +52,9 @@ send_photo:
     disable_notification:
       description: Sends the message silently. iOS users and Web users will not receive a notification, Android users will receive a notification with no sound.
       example: true
+    verify_ssl:
+      description: Enable or disable SSL certificate verification. Set to false if you're downloading the file from a URL and you don't want to validate the SSL certificate of the server.
+      example: false
     keyboard:
       description: List of rows of commands, comma-separated, to make a custom keyboard.
       example: '["/command1, /command2", "/command3"]'
@@ -80,6 +83,9 @@ send_sticker:
     disable_notification:
       description: Sends the message silently. iOS users and Web users will not receive a notification, Android users will receive a notification with no sound.
       example: true
+    verify_ssl:
+      description: Enable or disable SSL certificate verification. Set to false if you're downloading the file from a URL and you don't want to validate the SSL certificate of the server.
+      example: false
     keyboard:
       description: List of rows of commands, comma-separated, to make a custom keyboard.
       example: '["/command1, /command2", "/command3"]'
@@ -111,6 +117,9 @@ send_video:
     disable_notification:
       description: Sends the message silently. iOS users and Web users will not receive a notification, Android users will receive a notification with no sound.
       example: true
+    verify_ssl:
+      description: Enable or disable SSL certificate verification. Set to false if you're downloading the file from a URL and you don't want to validate the SSL certificate of the server.
+      example: false
     keyboard:
       description: List of rows of commands, comma-separated, to make a custom keyboard.
       example: '["/command1, /command2", "/command3"]'
@@ -142,6 +151,9 @@ send_document:
     disable_notification:
       description: Sends the message silently. iOS users and Web users will not receive a notification, Android users will receive a notification with no sound.
       example: true
+    verify_ssl:
+      description: Enable or disable SSL certificate verification. Set to false if you're downloading the file from a URL and you don't want to validate the SSL certificate of the server.
+      example: false
     keyboard:
       description: List of rows of commands, comma-separated, to make a custom keyboard.
       example: '["/command1, /command2", "/command3"]'


### PR DESCRIPTION
## Description:

This patch adds an extra option to the payload that describes the resource to send to disable the SSL server verification when polling data from URLs. This could be useful when downloading content from endpoints in the LAN with self-signed certificates that only expose a SSL entrypoint. The original behaviour if not set is kept.

**Related issue:** fixes #22067 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** https://github.com/home-assistant/home-assistant.io/pull/8950

## Example entry for `configuration.yaml`
```yaml
action:
  service: notify.NOTIFIER_NAME
  data:
    title: Send an image
    message: "That's an example that sends an image."
    data:
      photo:
        - url: https://192.168.1.28/camera.jpg
          username: admin
          password: secrete
          verify_ssl: false
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  - [ ] Tests have been added to verify that the new code works.

*This is a PoC that has not been tested locally yet*. I will be happy to increase the test coverage and contribute to the documentation if the change proposal goes through.

Thanks for reviewing!

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
