### PR TITLE
Add logs for all response codes to REST notify

### DIFF
--- a/homeassistant/components/notify/rest.py
+++ b/homeassistant/components/notify/rest.py
@@ -139,8 +139,19 @@ class RestNotificationService(BaseNotificationService):
                                     params=data, timeout=10, auth=self._auth,
                                     verify=self._verify_ssl)
 
-        success_codes = (200, 201, 202, 203, 204, 205, 206, 207, 208, 226)
-        if response.status_code not in success_codes:
+        if response.status_code >= 500 and response.status_code < 600:
             _LOGGER.exception(
-                "Error sending message. Response %d: %s:",
+                "Server error. Response %d: %s:",
+                response.status_code, response.reason)
+        elif response.status_code >= 400 and response.status_code < 500:
+            _LOGGER.exception(
+                "Client error. Response %d: %s:",
+                response.status_code, response.reason)
+        elif response.status_code >= 200 and response.status_code < 300:
+            _LOGGER.debug(
+                "Success. Response %d: %s:",
+                response.status_code, response.reason)
+        else:
+            _LOGGER.debug(
+                "Response %d: %s:",
                 response.status_code, response.reason)


### PR DESCRIPTION
## Description:
Added specific error logs for 5xx and 4xx responses, debug log for 2xx and other statuses.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
