### PR TITLE
Beta Fix: FFMPEG and Stream component

### DIFF
--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -76,8 +76,3 @@ class FFmpegCamera(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._name
-
-    @property
-    def stream_source(self):
-        """Return the source of the stream."""
-        return self._input

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -35,7 +35,7 @@ DEFAULT_NAME = 'Generic Camera'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STILL_IMAGE_URL): cv.template,
-    vol.Optional(CONF_STREAM_SOURCE, default=None): cv.string,
+    vol.Optional(CONF_STREAM_SOURCE, default=None): vol.Any(None, cv.string),
     vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_LIMIT_REFETCH_TO_URL_CHANGE, default=False): cv.boolean,

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -28,12 +28,14 @@ _LOGGER = logging.getLogger(__name__)
 CONF_CONTENT_TYPE = 'content_type'
 CONF_LIMIT_REFETCH_TO_URL_CHANGE = 'limit_refetch_to_url_change'
 CONF_STILL_IMAGE_URL = 'still_image_url'
+CONF_STREAM_SOURCE = 'stream_source'
 CONF_FRAMERATE = 'framerate'
 
 DEFAULT_NAME = 'Generic Camera'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STILL_IMAGE_URL): cv.template,
+    vol.Optional(CONF_STREAM_SOURCE, default=None): cv.string,
     vol.Optional(CONF_AUTHENTICATION, default=HTTP_BASIC_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_LIMIT_REFETCH_TO_URL_CHANGE, default=False): cv.boolean,
@@ -62,6 +64,7 @@ class GenericCamera(Camera):
         self._authentication = device_info.get(CONF_AUTHENTICATION)
         self._name = device_info.get(CONF_NAME)
         self._still_image_url = device_info[CONF_STILL_IMAGE_URL]
+        self._stream_source = device_info[CONF_STREAM_SOURCE]
         self._still_image_url.hass = hass
         self._limit_refetch = device_info[CONF_LIMIT_REFETCH_TO_URL_CHANGE]
         self._frame_interval = 1 / device_info[CONF_FRAMERATE]
@@ -141,3 +144,8 @@ class GenericCamera(Camera):
     def name(self):
         """Return the name of this device."""
         return self._name
+
+    @property
+    def stream_source(self):
+        """Return the source of the stream."""
+        return self._stream_source

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -230,8 +230,3 @@ class ONVIFHassCamera(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._name
-
-    @property
-    def stream_source(self):
-        """Return the source of the stream."""
-        return self._input


### PR DESCRIPTION
## Description:

This resolves the issue @balloob and I were having on our production docker environments where HASS frontend would not be able to communicate with the backend when a stream was started and FFMPEG tried to fetch a new image while a stream was in progress.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8956

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: generic
    still_image_url: http://my.cam/image.jpg
    stream_source: rtsp://my.cam:554
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)