### PR TITLE
Add available property to Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -215,12 +215,15 @@ SENSOR_TYPES = {
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN:
         vol.Schema({
-            vol.Required(CONF_APP_KEY): cv.string,
-            vol.Required(CONF_API_KEY): cv.string,
+            vol.Required(CONF_APP_KEY):
+                cv.string,
+            vol.Required(CONF_API_KEY):
+                cv.string,
             vol.Optional(CONF_MONITORED_CONDITIONS):
                 vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
         })
-}, extra=vol.ALLOW_EXTRA)
+},
+                           extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):
@@ -356,8 +359,10 @@ class AmbientStation:
                     ]
 
                 self.stations[station['macAddress']] = {
-                    ATTR_LAST_DATA: station['lastData'],
-                    ATTR_LOCATION: station.get('info', {}).get('location'),
+                    ATTR_LAST_DATA:
+                        station['lastData'],
+                    ATTR_LOCATION:
+                        station.get('info', {}).get('location'),
                     ATTR_NAME:
                         station.get('info', {}).get(
                             'name', station['macAddress']),
@@ -412,12 +417,17 @@ class AmbientWeatherEntity(Entity):
         self._station_name = station_name
 
     @property
+    def available(self):
+        """Return True if entity is available."""
+        return bool(
+            self._ambient.stations[self._mac_address][ATTR_LAST_DATA].get(
+                self._sensor_type))
+
+    @property
     def device_info(self):
         """Return device registry information for this entity."""
         return {
-            'identifiers': {
-                (DOMAIN, self._mac_address)
-            },
+            'identifiers': {(DOMAIN, self._mac_address)},
             'name': self._station_name,
             'manufacturer': 'Ambient Weather',
         }
@@ -439,6 +449,7 @@ class AmbientWeatherEntity(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
+
         @callback
         def update():
             """Update the state."""

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -446,7 +446,6 @@ class AmbientWeatherEntity(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-
         @callback
         def update():
             """Update the state."""

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -215,15 +215,12 @@ SENSOR_TYPES = {
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN:
         vol.Schema({
-            vol.Required(CONF_APP_KEY):
-                cv.string,
-            vol.Required(CONF_API_KEY):
-                cv.string,
+            vol.Required(CONF_APP_KEY): cv.string,
+            vol.Required(CONF_API_KEY): cv.string,
             vol.Optional(CONF_MONITORED_CONDITIONS):
                 vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
         })
-},
-                           extra=vol.ALLOW_EXTRA)
+}, extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):
@@ -359,10 +356,8 @@ class AmbientStation:
                     ]
 
                 self.stations[station['macAddress']] = {
-                    ATTR_LAST_DATA:
-                        station['lastData'],
-                    ATTR_LOCATION:
-                        station.get('info', {}).get('location'),
+                    ATTR_LAST_DATA: station['lastData'],
+                    ATTR_LOCATION: station.get('info', {}).get('location'),
                     ATTR_NAME:
                         station.get('info', {}).get(
                             'name', station['macAddress']),
@@ -427,7 +422,9 @@ class AmbientWeatherEntity(Entity):
     def device_info(self):
         """Return device registry information for this entity."""
         return {
-            'identifiers': {(DOMAIN, self._mac_address)},
+            'identifiers': {
+                (DOMAIN, self._mac_address)
+            },
             'name': self._station_name,
             'manufacturer': 'Ambient Weather',
         }


### PR DESCRIPTION
## Description:

The Ambient Weather websocket only returns the data that it receives; this means that it's possible for sensors to become unavailable. This PR adds logic to render then unavailable, rather than removing them from the UI.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
