### PR TITLE
Fix AttributeError traceback with darksky

### DIFF
--- a/homeassistant/components/weather/darksky.py
+++ b/homeassistant/components/weather/darksky.py
@@ -232,4 +232,7 @@ class DarkSkyData:
     @property
     def units(self):
         """Get the unit system of returned data."""
-        return self.data.json.get('flags').get('units')
+        if self.data is not None:
+            return self.data.json.get('flags').get('units')
+        else:
+            return None


### PR DESCRIPTION
## Description:

When self.data is None, returning self.data.get('flags').get('units') fails with an AttributeError

**Related issue (if applicable):** fixes #20596

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: darksky
    api_key: !secret darksky_api
    mode: hourly
    name: "Hourly Forecast"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
