### PR TITLE
Standardized temperature units for LCN sensors

### DIFF
--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -1,5 +1,8 @@
+# coding: utf-8
 """Constants for the LCN component."""
 import re
+
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 
 DOMAIN = 'lcn'
 DATA_LCN = 'lcn'
@@ -49,9 +52,9 @@ THRESHOLDS = ['THRS1', 'THRS2', 'THRS3', 'THRS4', 'THRS5',
 S0_INPUTS = ['S0INPUT1', 'S0INPUT2', 'S0INPUT3', 'S0INPUT4']
 
 VAR_UNITS = ['', 'LCN', 'NATIVE',
-             'CELSIUS', '\u00b0CELSIUS', '\u00b0C',
-             'KELVIN', '\u00b0KELVIN', '\u00b0K',
-             'FAHRENHEIT', '\u00b0FAHRENHEIT', '\u00b0F'
+             TEMP_CELSIUS,
+             '°K',
+             TEMP_FAHRENHEIT,
              'LUX_T', 'LX_T',
              'LUX_I', 'LUX', 'LX',
              'M/S', 'METERPERSECOND',
@@ -59,4 +62,4 @@ VAR_UNITS = ['', 'LCN', 'NATIVE',
              'PPM',
              'VOLT', 'V',
              'AMPERE', 'AMP', 'A',
-             'DEGREE', '\u00b0']
+             'DEGREE', '°']

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -43,8 +43,8 @@ class LcnVariableSensor(LcnDevice):
         super().__init__(config, address_connection)
 
         self.variable = self.pypck.lcn_defs.Var[config[CONF_SOURCE]]
-        self.unit = self.pypck.lcn_defs.VarUnit[
-            config[CONF_UNIT_OF_MEASUREMENT]]
+        self.unit = self.pypck.lcn_defs.VarUnit.parse(
+            config[CONF_UNIT_OF_MEASUREMENT])
 
         self._value = None
 


### PR DESCRIPTION
Use the standardized temperature units for Celsius and Fahrenheit for the LCN sensor compoenent.
Also the corresponding documentation has been updated.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8734

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
