### PR TITLE
Fix opentherm_gw climate TypeError in current_temperature if no temperature is known.

### DIFF
--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -37,8 +37,8 @@ class OpenThermGateway(ClimateDevice):
         self.floor_temp = config.get(CONF_FLOOR_TEMP)
         self.temp_precision = config.get(CONF_PRECISION)
         self._current_operation = STATE_IDLE
-        self._current_temperature = 0.0
-        self._target_temperature = 0.0
+        self._current_temperature = None
+        self._target_temperature = None
         self._away_mode_a = None
         self._away_mode_b = None
         self._away_state_a = False
@@ -124,6 +124,8 @@ class OpenThermGateway(ClimateDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
+        if self._current_temperature is None:
+            return
         if self.floor_temp is True:
             if self.temp_precision == PRECISION_HALVES:
                 return int(2 * self._current_temperature) / 2


### PR DESCRIPTION
## Description:
Fix TypeError in the opentherm_gw climate platform in case the library doesn't report a temperature value. Initialize _current_temperature and _target_temperature to `None` instead of `0.0`.


**Related issue (if applicable):** fixes #21695

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - N/A

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
