### PR TITLE
Add an 'ap_name' attribute to the Unifi device tracker

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -156,7 +156,8 @@ class UnifiScanner(DeviceScanner):
         attributes = {}
         for variable in self._monitored_conditions:
             if variable == "ap_name" and "ap_mac" in client:
-                attributes["ap_name"] = self._apnames.get(client["ap_mac"], "unknown")
+                attributes["ap_name"] = self._apnames.get(
+                    client["ap_mac"], "unknown")
             if variable in client:
                 attributes[variable] = client[variable]
 


### PR DESCRIPTION
## Breaking Change: No

## Description:
Creates an additional attribute 'ap_name' to be included in 'monitored_conditions' which returns the friendly name of the access point that the device is connected to (if connected wirelessly).

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23