### PR TITLE
Improve opentherm gw startup

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -8,9 +8,8 @@ from homeassistant.components.binary_sensor import DOMAIN as COMP_BINARY_SENSOR
 from homeassistant.components.sensor import DOMAIN as COMP_SENSOR
 from homeassistant.const import (
     ATTR_DATE, ATTR_ID, ATTR_TEMPERATURE, ATTR_TIME, CONF_DEVICE,
-    CONF_MONITORED_VARIABLES, CONF_NAME, EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP, PRECISION_HALVES, PRECISION_TENTHS,
-    PRECISION_WHOLE)
+    CONF_MONITORED_VARIABLES, CONF_NAME, EVENT_HOMEASSISTANT_STOP,
+    PRECISION_HALVES, PRECISION_TENTHS, PRECISION_WHOLE)
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -122,12 +122,9 @@ async def async_setup(hass, config):
     if monitored_vars:
         hass.async_create_task(setup_monitored_vars(
             hass, config, monitored_vars))
-
-    def schedule_connect(event):
-        """Schedule the connect_and_subscribe coroutine."""
-        hass.async_create_task(
-            connect_and_subscribe(hass, conf[CONF_DEVICE], gateway))
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, schedule_connect)
+    # Schedule directly on the loop to avoid blocking HA startup.
+    hass.loop.create_task(
+        connect_and_subscribe(hass, conf[CONF_DEVICE], gateway))
     return True
 
 


### PR DESCRIPTION
## Description:
Schedule the connect_and_subscribe coroutine directly on the loop rather than waiting for EVENT_HOMEASSISTANT_START as per the suggestion from @MartinHjelmare in #22106 

**Related issue (if applicable):** #22074 #22106 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - N/A

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
