### PR TITLE
Added ability to set device name for tplink component in configuration.yaml

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
 import homeassistant.helpers.config_validation as cv
@@ -14,7 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'tplink'
 
 TPLINK_HOST_SCHEMA = vol.Schema({
-    vol.Required(CONF_HOST): cv.string
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
 })
 
 CONF_LIGHT = 'light'
@@ -95,7 +96,18 @@ async def async_setup_entry(hass, config_entry):
             for entry in config_data[type_]:
                 try:
                     host = entry['host']
+
+                    friendly_name = None
+                    if "name" in entry:
+                        friendly_name = entry['name']
+                        _LOGGER.debug("Name SET FOR TPLINK DEVICE %s" % friendly_name)
+
                     dev = _device_for_type(host, type_)
+                    # not sure this is the best way to carry forward this, but works.
+                    # also, do this so i don't have to check in the Device Class if the property exits on 'dev'
+                    # it will always exist and be None if config wasn't set.
+                    dev.friendly_name = friendly_name
+
                     devices[host] = dev
                     _LOGGER.debug("Succesfully added %s %s: %s",
                                   type_, host, dev)

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -100,8 +100,8 @@ async def async_setup_entry(hass, config_entry):
                     friendly_name = None
                     if "name" in entry:
                         friendly_name = entry['name']
-                        _LOGGER.debug("Name SET FOR TPLINK DEVICE %s"
-                                      % friendly_name)
+                        _LOGGER.debug("Name set for TP-LINK devices %s",
+                                      friendly_name)
 
                     dev = _device_for_type(host, type_)
                     # not sure this is the best way to carry forward this,

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -100,11 +100,13 @@ async def async_setup_entry(hass, config_entry):
                     friendly_name = None
                     if "name" in entry:
                         friendly_name = entry['name']
-                        _LOGGER.debug("Name SET FOR TPLINK DEVICE %s" % friendly_name)
+                        _LOGGER.debug("Name SET FOR TPLINK DEVICE %s"
+                                      % friendly_name)
 
                     dev = _device_for_type(host, type_)
-                    # not sure this is the best way to carry forward this, but works.
-                    # also, do this so i don't have to check in the Device Class if the property exits on 'dev'
+                    # not sure this is the best way to carry forward this,
+                    # but works. also, do this so i don't have to check in the
+                    # Device Class if the property exits on 'dev'
                     # it will always exist and be None if config wasn't set.
                     dev.friendly_name = friendly_name
 

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -87,8 +87,7 @@ class TPLinkSmartBulb(Light):
         """Return the name of the Smart Bulb."""
         if self.friendly_name is None:
             return self._sysinfo["alias"]
-        else:
-            return self.friendly_name
+        return self.friendly_name
 
     @property
     def device_info(self):

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -75,6 +75,7 @@ class TPLinkSmartBulb(Light):
         self._min_mireds = None
         self._max_mireds = None
         self._emeter_params = {}
+        self.friendly_name = smartbulb.friendly_name
 
     @property
     def unique_id(self):
@@ -84,7 +85,10 @@ class TPLinkSmartBulb(Light):
     @property
     def name(self):
         """Return the name of the Smart Bulb."""
-        return self._sysinfo["alias"]
+        if self.friendly_name is None:
+            return self._sysinfo["alias"]
+        else:
+            return self.friendly_name
 
     @property
     def device_info(self):

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -55,6 +55,7 @@ class SmartPlugSwitch(SwitchDevice):
         self._available = False
         # Set up emeter cache
         self._emeter_params = {}
+        self.friendly_name = smartplug.friendly_name
 
     @property
     def unique_id(self):
@@ -64,13 +65,16 @@ class SmartPlugSwitch(SwitchDevice):
     @property
     def name(self):
         """Return the name of the Smart Plug."""
-        return self._sysinfo["alias"]
+        if self.friendly_name is None:
+            return self._sysinfo["alias"]
+        else:
+            return self.friendly_name
 
     @property
     def device_info(self):
         """Return information about the device."""
         return {
-            "name": self.name,
+            "name": self._sysinfo["alias"],
             "model": self._sysinfo["model"],
             "manufacturer": 'TP-Link',
             "connections": {

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -67,8 +67,7 @@ class SmartPlugSwitch(SwitchDevice):
         """Return the name of the Smart Plug."""
         if self.friendly_name is None:
             return self._sysinfo["alias"]
-        else:
-            return self.friendly_name
+        return self.friendly_name
 
     @property
     def device_info(self):

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -74,7 +74,7 @@ class SmartPlugSwitch(SwitchDevice):
     def device_info(self):
         """Return information about the device."""
         return {
-            "name": self._sysinfo["alias"],
+            "name": self.name,
             "model": self._sysinfo["model"],
             "manufacturer": 'TP-Link',
             "connections": {


### PR DESCRIPTION
## Description:
added ability to use `name` in configuration file as an optional attribute to `switch` and `lamp`.

entity_id is based upon device name, so this should make the tplink component more backward compatible with the old 'platform' method of setting up tplink in configuration.yaml.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

have yet to get to docs

## Example entry for `configuration.yaml` (if applicable):
```yaml
tplink:
  discovery: false
  switch:
    - host: 192.168.1.111
      name: Porch Switch
    - host: 192.168.1.112
  light:
    - host: 192.168.1.113
      name: Basement Lamp 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** (yes, lots of errors are tossed that I know nothing about and are not related to the component i changed. so "yes?"
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)


If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
