### PR TITLE
Remove unused services option

### DIFF
--- a/homeassistant/components/camera/services.yaml
+++ b/homeassistant/components/camera/services.yaml
@@ -50,9 +50,6 @@ play_stream:
     format:
       description: (Optional) Stream format supported by media player.
       example: 'hls'
-    keepalive:
-      description: (Optional) Keep the stream worker alive for fast access.
-      example: 'true'
 
 local_file_update_file_path:
   description: Update the file_path for a local_file camera.


### PR DESCRIPTION
## Description:

Delete previously removed service option from `play_stream` service. This option was removed, but made it through in the `services.yaml`