### PR TITLE
Remove hass.config from aws_lambda notify payload

### DIFF
--- a/homeassistant/components/notify/aws_lambda.py
+++ b/homeassistant/components/notify/aws_lambda.py
@@ -39,8 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_service(hass, config, discovery_info=None):
     """Get the AWS Lambda notification service."""
-    context_str = json.dumps({'hass': hass.config.as_dict(),
-                              'custom': config[CONF_CONTEXT]}, cls=JSONEncoder)
+    context_str = json.dumps({'custom': config[CONF_CONTEXT]}, cls=JSONEncoder)
     context_b64 = base64.b64encode(context_str.encode('utf-8'))
     context = context_b64.decode('utf-8')
 


### PR DESCRIPTION
## Breaking Change:

`hass.config` has been removed from `aws_lambda` notify's payload.

An integration should not expose `hass.config` by default since it included some sensitive information.  If user still want to pass those information to a lambda function, he/she can do so by pass it through `context` field explicitly.

## Description:

aws_lambda notify platform is passing `hass.config` to lamba function's context even user does not set `context` in his/her configuration.

Removed hass.config from aws_lambda notify payload. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8966

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: NOTIFIER_NAME
    platform: aws_lambda
    aws_access_key_id: AWS_ACCESS_KEY_ID
    aws_secret_access_key: AWS_SECRET_ACCESS_KEY
    region_name: 'us-east-1'
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

