### PR TITLE
Fix xiaomi aqara cube with lumi.acpartner.v3 gateway

### DIFF
--- a/homeassistant/components/xiaomi_aqara/binary_sensor.py
+++ b/homeassistant/components/xiaomi_aqara/binary_sensor.py
@@ -476,18 +476,24 @@ class XiaomiCube(XiaomiBinarySensor):
             self._last_action = data[self._data_key]
 
         if 'rotate' in data:
+            action_value = float(data['rotate']
+                                 if isinstance(data['rotate'], int)
+                                 else data['rotate'].replace(",", "."))
             self._hass.bus.fire('xiaomi_aqara.cube_action', {
                 'entity_id': self.entity_id,
                 'action_type': 'rotate',
-                'action_value': float(data['rotate'].replace(",", "."))
+                'action_value': action_value
             })
             self._last_action = 'rotate'
 
         if 'rotate_degree' in data:
+            action_value = float(data['rotate_degree']
+                                 if isinstance(data['rotate_degree'], int)
+                                 else data['rotate_degree'].replace(",", "."))
             self._hass.bus.fire('xiaomi_aqara.cube_action', {
                 'entity_id': self.entity_id,
                 'action_type': 'rotate',
-                'action_value': float(data['rotate_degree'].replace(",", "."))
+                'action_value': action_value
             })
             self._last_action = 'rotate'
 


### PR DESCRIPTION
## Description:
xiaomi aqara cube with lumi.acpartner.v3 gateway has different data type.
should process the rotate and rotate_degree data before call replace method. 

This is data from xiaomi aqara cube with lumi.acpartner.v3 gateway:
```
{
  'cube_status': 'rotate', 
  'detect_time': 500, 
  'rotate_degree': 21, 
  'raw_data': [{'cube_status': 'rotate'}, {'detect_time': 500}, {'rotate_degree': 21}]
}
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
