### PR TITLE
Handle occassional 502 Bad Gateway from SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -109,7 +109,13 @@ async def async_setup_entry(hass, config_entry):
         """Refresh data from the SimpliSafe account."""
         for system in systems:
             _LOGGER.debug('Updating system data: %s', system.system_id)
-            await system.update()
+
+            try:
+                await system.update()
+            except SimplipyError as err:
+                _LOGGER.error('There was an error while updating: %s', err)
+                return
+
             async_dispatcher_send(hass, TOPIC_UPDATE.format(system.system_id))
 
             if system.api.refresh_token_dirty:


### PR DESCRIPTION
## Description:

Every now an again, SimpliSafe sends back a `502`; it doesn't cause any further issues (i.e., the component will merely try again later), but it leaves an unsightly exception in the logs. This PR handles logging the error.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N.A

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
