### PR TITLE
Loosen field retrieval from Pollen.com

### DIFF
--- a/homeassistant/components/pollen/sensor.py
+++ b/homeassistant/components/pollen/sensor.py
@@ -239,8 +239,8 @@ class ForecastSensor(BaseSensor):
 
         if self._kind == TYPE_ALLERGY_FORECAST:
             outlook = self.pollen.data[TYPE_ALLERGY_OUTLOOK]
-            self._attrs[ATTR_OUTLOOK] = outlook['Outlook']
-            self._attrs[ATTR_SEASON] = outlook['Season']
+            self._attrs[ATTR_OUTLOOK] = outlook.get('Outlook')
+            self._attrs[ATTR_SEASON] = outlook.get('Season')
 
         self._state = average
 


### PR DESCRIPTION
## Description:

Pollen.com continues to arbitrarily struggle to return fields at certain points. This PR handles two more fields that, when missing from the response, would throw unhandled exceptions.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
    - platform: pollen
      zip_code: !secret pollen_zip_code
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
