### PR TITLE
Handle possible exception during Ambient PWS reconnect

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -304,15 +304,27 @@ class AmbientStation:
         self.monitored_conditions = monitored_conditions
         self.stations = {}
 
-    async def ws_connect(self):
-        """Register handlers and connect to the websocket."""
+    async def _attempt_connect(self):
+        """Attempt to connect to the socket (retrying later on fail)."""
         from aioambient.errors import WebsocketError
 
+        try:
+            await self.client.websocket.connect()
+        except WebsocketError as err:
+            _LOGGER.error("Error with the websocket connection: %s", err)
+            self._ws_reconnect_delay = min(
+                2 * self._ws_reconnect_delay, 480)
+            async_call_later(
+                self._hass, self._ws_reconnect_delay, self.ws_connect)
+
+
+    async def ws_connect(self):
+        """Register handlers and connect to the websocket."""
         async def _ws_reconnect(event_time):
             """Forcibly disconnect from and reconnect to the websocket."""
             _LOGGER.debug('Watchdog expired; forcing socket reconnection')
             await self.client.websocket.disconnect()
-            await self.client.websocket.connect()
+            await self._attempt_connect()
 
         def on_connect():
             """Define a handler to fire when the websocket is connected."""
@@ -381,15 +393,7 @@ class AmbientStation:
         self.client.websocket.on_disconnect(on_disconnect)
         self.client.websocket.on_subscribed(on_subscribed)
 
-        try:
-            await self.client.websocket.connect()
-        except WebsocketError as err:
-            _LOGGER.error("Error with the websocket connection: %s", err)
-
-            self._ws_reconnect_delay = min(2 * self._ws_reconnect_delay, 480)
-
-            async_call_later(
-                self._hass, self._ws_reconnect_delay, self.ws_connect)
+        await self._attempt_connect()
 
     async def ws_disconnect(self):
         """Disconnect from the websocket."""

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -317,7 +317,6 @@ class AmbientStation:
             async_call_later(
                 self._hass, self._ws_reconnect_delay, self.ws_connect)
 
-
     async def ws_connect(self):
         """Register handlers and connect to the websocket."""
         async def _ws_reconnect(event_time):


### PR DESCRIPTION
## Description:

This PR addresses the possibility of socket connection failure upon reconnection (which is currently an unhandled exception).

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
