### PR TITLE
Replace einder lib with horimote

### DIFF
--- a/homeassistant/components/horizon/media_player.py
+++ b/homeassistant/components/horizon/media_player.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['einder==0.3.1']
+REQUIREMENTS = ['horimote==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,8 +44,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Horizon platform."""
-    from einder import Client, keys
-    from einder.exceptions import AuthenticationError
+    from horimote import Client, keys
+    from horimote.exceptions import AuthenticationError
 
     host = config[CONF_HOST]
     name = config[CONF_NAME]
@@ -162,7 +162,7 @@ class HorizonDevice(MediaPlayerDevice):
 
     def _send(self, key=None, channel=None):
         """Send a key to the Horizon device."""
-        from einder.exceptions import AuthenticationError
+        from horimote.exceptions import AuthenticationError
 
         try:
             if key:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -379,9 +379,6 @@ edp_redy==0.0.3
 # homeassistant.components.device_tracker.ee_brightbox
 eebrightbox==0.0.4
 
-# homeassistant.components.horizon.media_player
-einder==0.3.1
-
 # homeassistant.components.eliqonline.sensor
 eliqonline==1.2.2
 
@@ -564,6 +561,9 @@ homekit[IP]==0.13.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.6
+
+# homeassistant.components.horizon.media_player
+horimote==0.4.1
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk


### PR DESCRIPTION
## Description:
Unitymedia Germany changed the port and XML filename which is used by the horizon component to check the online/available state. As the original maintainer of the used _einder_ lib does not want to maintain it anymore (i talked to him, he does also not use it anymore), it is replaced by horimote. Horimote is a einder fork with updated port and filename.


**Related issue (if applicable):** Horizon cannot detect state and allows no device control.



## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
