### PR TITLE
Allow non-admins to listen to certain events

### DIFF
--- a/homeassistant/components/websocket_api/permissions.py
+++ b/homeassistant/components/websocket_api/permissions.py
@@ -1,0 +1,23 @@
+"""Permission constants for the websocket API.
+
+Separate file to avoid circular imports.
+"""
+from homeassistant.const import (
+    EVENT_COMPONENT_LOADED,
+    EVENT_SERVICE_REGISTERED,
+    EVENT_SERVICE_REMOVED,
+    EVENT_STATE_CHANGED,
+    EVENT_THEMES_UPDATED)
+from homeassistant.components.persistent_notification import (
+    EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)
+
+# These are events that do not contain any sensitive data
+# Except for state_changed, which is handled accordingly.
+SUBSCRIBE_WHITELIST = {
+    EVENT_COMPONENT_LOADED,
+    EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
+    EVENT_SERVICE_REGISTERED,
+    EVENT_SERVICE_REMOVED,
+    EVENT_STATE_CHANGED,
+    EVENT_THEMES_UPDATED,
+}


### PR DESCRIPTION
## Description:
Allow users that are not in the admin group to listen to certain events. Otherwise the frontend will look like it works but not actually update.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant-polymer/issues/2954

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
