### PR TITLE
Fix breaking on HTML email without images

### DIFF
--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -246,7 +246,8 @@ def _build_html_msg(text, html, images):
             name = os.path.basename(atch_name)
             try:
                 with open(atch_name, 'rb') as attachment_file:
-                    attachment = MIMEImage(attachment_file.read(), filename=name)
+                    attachment = MIMEImage(attachment_file.read(),
+                                           filename=name)
                 msg.attach(attachment)
                 attachment.add_header('Content-ID', '<{}>'.format(name))
             except FileNotFoundError:

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -241,14 +241,15 @@ def _build_html_msg(text, html, images):
     alternative.attach(MIMEText(html, ATTR_HTML, _charset='utf-8'))
     msg.attach(alternative)
 
-    for atch_num, atch_name in enumerate(images):
-        name = os.path.basename(atch_name)
-        try:
-            with open(atch_name, 'rb') as attachment_file:
-                attachment = MIMEImage(attachment_file.read(), filename=name)
-            msg.attach(attachment)
-            attachment.add_header('Content-ID', '<{}>'.format(name))
-        except FileNotFoundError:
-            _LOGGER.warning("Attachment %s [#%s] not found. Skipping",
-                            atch_name, atch_num)
+    if images is not None:
+        for atch_num, atch_name in enumerate(images):
+            name = os.path.basename(atch_name)
+            try:
+                with open(atch_name, 'rb') as attachment_file:
+                    attachment = MIMEImage(attachment_file.read(), filename=name)
+                msg.attach(attachment)
+                attachment.add_header('Content-ID', '<{}>'.format(name))
+            except FileNotFoundError:
+                _LOGGER.warning("Attachment %s [#%s] not found. Skipping",
+                                atch_name, atch_num)
     return msg

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -151,7 +151,7 @@ class MailNotificationService(BaseNotificationService):
         if data:
             if ATTR_HTML in data:
                 msg = _build_html_msg(
-                    message, data[ATTR_HTML], images=data.get(ATTR_IMAGES))
+                    message, data[ATTR_HTML], images=data.get(ATTR_IMAGES, []))
             else:
                 msg = _build_multipart_msg(
                     message, images=data.get(ATTR_IMAGES))
@@ -241,16 +241,14 @@ def _build_html_msg(text, html, images):
     alternative.attach(MIMEText(html, ATTR_HTML, _charset='utf-8'))
     msg.attach(alternative)
 
-    if images is not None:
-        for atch_num, atch_name in enumerate(images):
-            name = os.path.basename(atch_name)
-            try:
-                with open(atch_name, 'rb') as attachment_file:
-                    attachment = MIMEImage(attachment_file.read(),
-                                           filename=name)
-                msg.attach(attachment)
-                attachment.add_header('Content-ID', '<{}>'.format(name))
-            except FileNotFoundError:
-                _LOGGER.warning("Attachment %s [#%s] not found. Skipping",
-                                atch_name, atch_num)
+    for atch_num, atch_name in enumerate(images):
+        name = os.path.basename(atch_name)
+        try:
+            with open(atch_name, 'rb') as attachment_file:
+                attachment = MIMEImage(attachment_file.read(), filename=name)
+            msg.attach(attachment)
+            attachment.add_header('Content-ID', '<{}>'.format(name))
+        except FileNotFoundError:
+            _LOGGER.warning("Attachment %s [#%s] not found. Skipping",
+                            atch_name, atch_num)
     return msg

--- a/homeassistant/components/notify/smtp.py
+++ b/homeassistant/components/notify/smtp.py
@@ -154,7 +154,7 @@ class MailNotificationService(BaseNotificationService):
                     message, data[ATTR_HTML], images=data.get(ATTR_IMAGES, []))
             else:
                 msg = _build_multipart_msg(
-                    message, images=data.get(ATTR_IMAGES))
+                    message, images=data.get(ATTR_IMAGES, []))
         else:
             msg = _build_text_msg(message)
 


### PR DESCRIPTION


## Breaking Change:

no

## Description:

If using html emails with no images the code breaks since it is not tested for empty (uninitialized) key images.

**Related issue (if applicable):** fixes #22142

## Example entry for `configuration.yaml` (if applicable):
```yaml
- alias: notify_test
  initial_state: 'on'
  trigger:
      platform: time_pattern
      minutes: '/2'
  action:
      service: notify.smtp
      data_template:
          title: >
              [ShuFu] Test
          message: |
              Test text
          data:
              html: >
                  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//DE" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
                  <html lang="de" xmlns="http://www.w3.org/1999/xhtml">
                  <head>
                  </head>
                  <body>
                  TEST html
                  </body>
                  </html>
```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x ] There is no commented out code in this PR.
