### PR TITLE
Remove port duplicate check on Yamaha MusicCast

### DIFF
--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -71,10 +71,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.warning("Host %s:%d already registered", host, port)
         return
 
-    if [item for item in known_hosts if item[1] == port]:
-        _LOGGER.warning("Port %s:%d already registered", host, port)
-        return
-
     reg_host = (ipaddr, port)
     known_hosts.append(reg_host)
 


### PR DESCRIPTION
Only rely on hostname.
This prevented HA to work with multiple musiccast receivers that was each using the same port.

## Description:

See [this discussion](https://community.home-assistant.io/t/yamaha-musiccast/31963/2).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
