### PR TITLE
Bump tado version

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['python-tado==0.2.3']
+REQUIREMENTS = ['python-tado==0.2.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tado/device_tracker.py
+++ b/homeassistant/components/tado/device_tracker.py
@@ -52,9 +52,9 @@ class TadoDeviceScanner(DeviceScanner):
 
         # If there's a home_id, we need a different API URL
         if self.home_id is None:
-            self.tadoapiurl = 'https://my.tado.com/api/v2/me'
+            self.tadoapiurl = 'https://auth.tado.com/api/v2/me'
         else:
-            self.tadoapiurl = 'https://my.tado.com/api/v2' \
+            self.tadoapiurl = 'https://auth.tado.com/api/v2' \
                               '/homes/{home_id}/mobileDevices'
 
         # The API URL always needs a username and password

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ python-songpal==0.0.9.1
 python-synology==0.2.0
 
 # homeassistant.components.tado
-python-tado==0.2.3
+python-tado==0.2.8
 
 # homeassistant.components.telegram_bot
 python-telegram-bot==11.1.0


### PR DESCRIPTION
## Description:

Bump python-tado to 0.2.8, upstream version holds an API endpoint change
Change references from old endpoint to new one

**Related issue (if applicable):** fixes #22048

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - N/A Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - N/A New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - N/A New files were added to `.coveragerc`.

If the code does not interact with devices:
  - N/A Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
