### PR TITLE
Fix resetting access token on streams with keepalive

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -120,9 +120,15 @@ class Stream:
         """Remove provider output stream."""
         if provider.format in self._outputs:
             del self._outputs[provider.format]
+            self.check_idle()
 
         if not self._outputs:
             self.stop()
+
+    def check_idle(self):
+        """Reset access token if all providers are idle."""
+        if all([p.idle for p in self._outputs.values()]):
+            self.access_token = None
 
     def start(self):
         """Start a stream."""


### PR DESCRIPTION
## Description:
This PR will successfully remove the stream's access token while remaining active if it was created with the `keepalive` option.  Previously it removed the stream entirely.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.