### PR TITLE
Set default parallel_update value should base on async_update

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -61,10 +61,6 @@ class EntityPlatform:
     def _get_parallel_updates_semaphore(self):
         """Get or create a semaphore for parallel updates."""
         if self.parallel_updates_semaphore is None:
-            # Even if self.parallel_updates is 0 or None, we still create
-            # a semaphore its default value is 1. The decision whether
-            # apply this semaphore to entity is in _async_add_entity() base on
-            # if entity has `async_update` method
             self.parallel_updates_semaphore = asyncio.Semaphore(
                 self.parallel_updates if self.parallel_updates else 1,
                 loop=self.hass.loop

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -55,7 +55,7 @@ class EntityPlatform:
             return
 
         # Async platforms do all updates in parallel by default
-        if hasattr(platform, 'async_setup_platform'):
+        if hasattr(platform, 'async_update'):
             default_parallel_updates = 0
         else:
             default_parallel_updates = 1

--- a/tests/common.py
+++ b/tests/common.py
@@ -499,7 +499,8 @@ class MockPlatform:
     # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,
                  platform_schema=None, async_setup_platform=None,
-                 async_setup_entry=None, scan_interval=None):
+                 async_setup_entry=None, scan_interval=None,
+                 update=None, async_update=None):
         """Initialize the platform."""
         self.DEPENDENCIES = dependencies or []
 
@@ -513,14 +514,24 @@ class MockPlatform:
             # We run this in executor, wrap it in function
             self.setup_platform = lambda *args: setup_platform(*args)
 
+        if update is not None:
+            # We run this in executor, wrap it in function
+            self.update = lambda *args: update(*args)
+
         if async_setup_platform is not None:
             self.async_setup_platform = async_setup_platform
 
         if async_setup_entry is not None:
             self.async_setup_entry = async_setup_entry
 
+        if async_update is not None:
+            self.async_update = async_update
+
         if setup_platform is None and async_setup_platform is None:
             self.async_setup_platform = mock_coro_func()
+
+        if update is None and async_update is None:
+            self.async_update = mock_coro_func()
 
 
 class MockEntityPlatform(entity_platform.EntityPlatform):

--- a/tests/common.py
+++ b/tests/common.py
@@ -499,8 +499,7 @@ class MockPlatform:
     # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,
                  platform_schema=None, async_setup_platform=None,
-                 async_setup_entry=None, scan_interval=None,
-                 update=None, async_update=None):
+                 async_setup_entry=None, scan_interval=None):
         """Initialize the platform."""
         self.DEPENDENCIES = dependencies or []
 
@@ -514,24 +513,14 @@ class MockPlatform:
             # We run this in executor, wrap it in function
             self.setup_platform = lambda *args: setup_platform(*args)
 
-        if update is not None:
-            # We run this in executor, wrap it in function
-            self.update = lambda *args: update(*args)
-
         if async_setup_platform is not None:
             self.async_setup_platform = async_setup_platform
 
         if async_setup_entry is not None:
             self.async_setup_entry = async_setup_entry
 
-        if async_update is not None:
-            self.async_update = async_update
-
         if setup_platform is None and async_setup_platform is None:
             self.async_setup_platform = mock_coro_func()
-
-        if update is None and async_update is None:
-            self.async_update = mock_coro_func()
 
 
 class MockEntityPlatform(entity_platform.EntityPlatform):


### PR DESCRIPTION
## Description:

Current platform's `parallel_update` value was set by entity_platform base on whether `async_setup_platform` exists in platform. 

Because `parallel_update` controlled update operation's behavior, use `async_update` as the indicator if platform is async-ized is better. 

**Related issue (if applicable):** fixes #21925

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
