### PR TITLE
Remove config check over supervisor

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -252,7 +252,7 @@ async def async_setup(hass, config):
             _LOGGER.error(errors)
             hass.components.persistent_notification.async_create(
                 "Config error. See dev-info panel for details.",
-                "Config validating", "{0}.check_config".format(ha.DOMAIN))
+                "Config validating", "{0}.check_config".format(HASS_DOMAIN))
             return
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components import SERVICE_CHECK_CONFIG
+import homeassistant.config as conf_util
 from homeassistant.const import (
     ATTR_NAME, SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP)
 from homeassistant.core import DOMAIN as HASS_DOMAIN, callback
@@ -130,23 +131,6 @@ def is_hassio(hass):
     return DOMAIN in hass.config.components
 
 
-@bind_hass
-async def async_check_config(hass):
-    """Check configuration over Hass.io API."""
-    hassio = hass.data[DOMAIN]
-
-    try:
-        result = await hassio.check_homeassistant_config()
-    except HassioAPIError as err:
-        _LOGGER.error("Error on Hass.io API: %s", err)
-        raise HomeAssistantError() from None
-    else:
-        if result['result'] == "error":
-            return result['message']
-
-    return None
-
-
 async def async_setup(hass, config):
     """Set up the Hass.io component."""
     # Check local setup
@@ -259,12 +243,16 @@ async def async_setup(hass, config):
             await hassio.stop_homeassistant()
             return
 
-        error = await async_check_config(hass)
-        if error:
-            _LOGGER.error(error)
+        try:
+            errors = await conf_util.async_check_ha_config_file(hass)
+        except HomeAssistantError:
+            return
+
+        if errors:
+            _LOGGER.error(errors)
             hass.components.persistent_notification.async_create(
                 "Config error. See dev-info panel for details.",
-                "Config validating", "{0}.check_config".format(HASS_DOMAIN))
+                "Config validating", "{0}.check_config".format(ha.DOMAIN))
             return
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -97,13 +97,6 @@ class HassIO:
         """
         return self.send_command("/homeassistant/stop")
 
-    def check_homeassistant_config(self):
-        """Check Home-Assistant config with Hass.io API.
-
-        This method return a coroutine.
-        """
-        return self.send_command("/homeassistant/check", timeout=600)
-
     @_api_data
     def retrieve_discovery_messages(self):
         """Return all discovery data from Hass.io API.

--- a/tests/components/hassio/test_handler.py
+++ b/tests/components/hassio/test_handler.py
@@ -74,17 +74,6 @@ async def test_api_homeassistant_restart(hassio_handler, aioclient_mock):
     assert aioclient_mock.call_count == 1
 
 
-async def test_api_homeassistant_config(hassio_handler, aioclient_mock):
-    """Test setup with API HomeAssistant config."""
-    aioclient_mock.post(
-        "http://127.0.0.1/homeassistant/check", json={
-            'result': 'ok', 'data': {'test': 'bla'}})
-
-    data = await hassio_handler.check_homeassistant_config()
-    assert data['data']['test'] == 'bla'
-    assert aioclient_mock.call_count == 1
-
-
 async def test_api_addon_info(hassio_handler, aioclient_mock):
     """Test setup with API Add-on info."""
     aioclient_mock.get(

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -7,8 +7,7 @@ import pytest
 
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.setup import async_setup_component
-from homeassistant.components.hassio import (
-    STORAGE_KEY, async_check_config)
+from homeassistant.components.hassio import STORAGE_KEY
 
 from tests.common import mock_coro
 
@@ -311,8 +310,6 @@ def test_service_calls_core(hassio_env, hass, aioclient_mock):
         "http://127.0.0.1/homeassistant/restart", json={'result': 'ok'})
     aioclient_mock.post(
         "http://127.0.0.1/homeassistant/stop", json={'result': 'ok'})
-    aioclient_mock.post(
-        "http://127.0.0.1/homeassistant/check", json={'result': 'ok'})
 
     yield from hass.services.async_call('homeassistant', 'stop')
     yield from hass.async_block_till_done()
@@ -322,32 +319,9 @@ def test_service_calls_core(hassio_env, hass, aioclient_mock):
     yield from hass.services.async_call('homeassistant', 'check_config')
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 3
+    assert aioclient_mock.call_count == 2
 
     yield from hass.services.async_call('homeassistant', 'restart')
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 5
-
-
-@asyncio.coroutine
-def test_check_config_ok(hassio_env, hass, aioclient_mock):
-    """Check Config that is okay."""
-    assert (yield from async_setup_component(hass, 'hassio', {}))
-
-    aioclient_mock.post(
-        "http://127.0.0.1/homeassistant/check", json={'result': 'ok'})
-
-    assert (yield from async_check_config(hass)) is None
-
-
-@asyncio.coroutine
-def test_check_config_fail(hassio_env, hass, aioclient_mock):
-    """Check Config that is wrong."""
-    assert (yield from async_setup_component(hass, 'hassio', {}))
-
-    aioclient_mock.post(
-        "http://127.0.0.1/homeassistant/check", json={
-            'result': 'error', 'message': "Error"})
-
-    assert (yield from async_check_config(hass)) == "Error"
+    assert aioclient_mock.call_count == 3

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -321,7 +321,12 @@ def test_service_calls_core(hassio_env, hass, aioclient_mock):
 
     assert aioclient_mock.call_count == 2
 
-    yield from hass.services.async_call('homeassistant', 'restart')
-    yield from hass.async_block_till_done()
+    with patch(
+        'homeassistant.config.async_check_ha_config_file',
+        return_value=mock_coro()
+    ) as mock_check_config:
+        yield from hass.services.async_call('homeassistant', 'restart')
+        yield from hass.async_block_till_done()
+        assert mock_check_config.called
 
     assert aioclient_mock.call_count == 3


### PR DESCRIPTION
## Change

Remove the config check over the supervisor. Since we backport the config output checking from the supervisor, we don't need that solution anymore. That makes the restart on ARM device much faster.
