### PR TITLE
Fix yeelight flow action param for declared effects

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -161,14 +161,20 @@ def _cmd(func):
 
 
 def _parse_custom_effects(effects_config):
+    import yeelight
+
     effects = {}
     for config in effects_config:
         params = config[CONF_FLOW_PARAMS]
+        action = yeelight.Flow.actions[params[ATTR_ACTION]]
         transitions = YeelightLight.transitions_config_parser(
             params[ATTR_TRANSITIONS])
 
-        effects[config[CONF_NAME]] = \
-            {ATTR_COUNT: params[ATTR_COUNT], ATTR_TRANSITIONS: transitions}
+        effects[config[CONF_NAME]] = {
+            ATTR_COUNT: params[ATTR_COUNT],
+            ATTR_ACTION: action,
+            ATTR_TRANSITIONS: transitions
+        }
 
     return effects
 


### PR DESCRIPTION
## Description:
Fix handling flow action parameter, introduced here: https://github.com/home-assistant/home-assistant/pull/21195. It was working only when used via service call, and ignored when used in custom effects declared in config

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/wake-up-with-yeelight/97741/11