### PR TITLE
Upgrade toonapilib to 3.2.2 + lower interval

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -16,7 +16,7 @@ from .const import (
     CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_DISPLAY, CONF_TENANT,
     DATA_TOON_CLIENT, DATA_TOON_CONFIG, DOMAIN)
 
-REQUIREMENTS = ['toonapilib==3.2.1']
+REQUIREMENTS = ['toonapilib==3.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/toon/binary_sensor.py
+++ b/homeassistant/components/toon/binary_sensor.py
@@ -17,7 +17,7 @@ DEPENDENCIES = ['toon']
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
-SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=300)
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry,

--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
-SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=300)
 
 HA_TOON = {
     STATE_AUTO: 'Comfort',

--- a/homeassistant/components/toon/sensor.py
+++ b/homeassistant/components/toon/sensor.py
@@ -16,7 +16,7 @@ DEPENDENCIES = ['toon']
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
-SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=300)
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1706,7 +1706,7 @@ tikteck==0.4
 todoist-python==7.0.17
 
 # homeassistant.components.toon
-toonapilib==3.2.1
+toonapilib==3.2.2
 
 # homeassistant.components.totalconnect.alarm_control_panel
 total_connect_client==0.22

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -297,7 +297,7 @@ srpenergy==1.0.5
 statsd==3.2.1
 
 # homeassistant.components.toon
-toonapilib==3.2.1
+toonapilib==3.2.2
 
 # homeassistant.components.camera.uvc
 uvcclient==0.11.0


### PR DESCRIPTION
## Description:

Recently the Toon component was rewritten. I've been contacted by Quby (company behind the Toon) about their API being hammered too much and they are considering banning users. We had a friendly conversation about this and came up with a temporary solution to relief their API.

This PR updates the `toonapilib` to 3.2.2, which raises the TTL for its internal cache from 30 seconds to 300 seconds. Implemented in costastf/toonapilib#32.

https://github.com/costastf/toonapilib/blob/master/HISTORY.rst#322-18-03-2019

I've updated the `SCAN_INTERVAL`'s in this component to match that value.

⚠️ **Please consider marking this PR to be cherry picked into `0.90` to prevent our users from being banned!** Thank you for considering.

For an upcoming version, I'll be implementing a more central way of updating the entities that will allow us to control the updates, instead of dropping that responsibility at the upstream library.

**Related issue (does not fix):** costastf/toonapilib#31 costastf/toonapilib#33 #21825

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8975

## Example entry for `configuration.yaml` (if applicable):
```yaml
toon:
  client_id: fxiyXLtFfhimADJlmFjTjXdHoxZ8AFg7
  client_secret: kPUCx88CTCSMAaBA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
