### PR TITLE
Proxmox VE integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -524,6 +524,7 @@ omit =
     homeassistant/components/pollen/sensor.py
     homeassistant/components/postnl/sensor.py
     homeassistant/components/prezzibenzina/sensor.py
+    homeassistant/components/proxmox/*
     homeassistant/components/pushbullet/sensor.py
     homeassistant/components/pvoutput/sensor.py
     homeassistant/components/pyload/sensor.py

--- a/homeassistant/components/proxmox/__init__.py
+++ b/homeassistant/components/proxmox/__init__.py
@@ -1,0 +1,144 @@
+"""Support for Proxmox Virtual Environment."""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME, CONF_VERIFY_SSL)
+from homeassistant.core import callback
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+
+REQUIREMENTS = ['proxmoxer==1.0.3']
+DOMAIN = 'proxmox'
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+UPDATE_INTERVAL = timedelta(seconds=30)
+
+_LOGGER = logging.getLogger(__name__)
+DATA_PROXMOX_NODES = 'proxmox_nodes'
+DATA_PROXMOX_CONTROL = 'proxmox_control'
+SIGNAL_PROXMOX_UPDATED = 'proxmox_updated'
+DEFAULT_PORT = 8006
+DEFAULT_REALM = 'pam'
+DEFAULT_VERIFY_SSL = True
+
+CONF_REALM = 'realm'
+CONF_NODES = 'nodes'
+CONF_VMS = 'vms'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_REALM, default=DEFAULT_REALM): cv.string,
+        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+        vol.Optional(CONF_NODES, default=[]): [cv.string],
+        vol.Optional(CONF_VMS, default=[]): [int],
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Set up the Proxmox VE component."""
+    from proxmoxer import ProxmoxAPI
+    from proxmoxer.backends.https import AuthenticationError
+    conf = config.get(DOMAIN)
+    if conf is not None:
+        host = conf.get(CONF_HOST)
+        port = conf.get(CONF_PORT)
+        user = conf.get(CONF_USERNAME)
+        realm = conf.get(CONF_REALM)
+        password = conf.get(CONF_PASSWORD)
+        verify_ssl = conf.get(CONF_VERIFY_SSL)
+        try:
+            proxmox = ProxmoxAPI(
+                host, user=user + '@' + realm, password=password,
+                port=port, verify_ssl=verify_ssl)
+            await setup_proxmox(hass, proxmox, config)
+        except AuthenticationError:
+            # Error authenticating to Proxmox VE
+            _LOGGER.exception("Invalid username or password.")
+            return False
+    return True
+
+
+@callback
+async def setup_proxmox(hass, proxmox, config):
+    """Create entities and load data from Proxmox VE."""
+    conf = config.get(DOMAIN)
+    conf_nodes = conf.get(CONF_NODES)
+    conf_vms = conf.get(CONF_VMS)
+    await update_data(hass, proxmox, conf_nodes, conf_vms)
+
+    async def start(item):
+        """Start the VM or container."""
+        vm_type = 'qemu'
+        if 'type' in item:
+            vm_type = item['type']
+        uri = '{}/{}/{}/status/start'.format(
+            item['node'], vm_type, item['vmid'])
+        result = proxmox.nodes(uri).post()
+        _LOGGER.info(result)
+        fix_status(hass, item, 'running')
+
+    async def stop(item):
+        """Stop the VM or container."""
+        vm_type = 'qemu'
+        if 'type' in item:
+            vm_type = item['type']
+        uri = '{}/{}/{}/status/stop'.format(
+            item['node'], vm_type, item['vmid'])
+        result = proxmox.nodes(uri).post()
+        _LOGGER.info(result)
+        fix_status(hass, item, 'stopped')
+
+    hass.data[DATA_PROXMOX_CONTROL] = {'start': start, 'stop': stop}
+    hass.async_create_task(
+        discovery.async_load_platform(hass, 'sensor', DOMAIN, {}, config))
+    hass.async_create_task(
+        discovery.async_load_platform(hass, 'switch', DOMAIN, {}, config))
+    hass.async_create_task(
+        discovery.async_load_platform(
+            hass, 'binary_sensor', DOMAIN, {}, config))
+
+    async def async_update_proxmox(now):
+        await update_data(hass, proxmox, conf_nodes, conf_vms)
+        async_dispatcher_send(hass, SIGNAL_PROXMOX_UPDATED, None)
+
+    async_track_time_interval(hass, async_update_proxmox, UPDATE_INTERVAL)
+
+
+async def update_data(hass, proxmox, conf_nodes, conf_vms):
+    """Update Proxmox VE data."""
+    nodes = proxmox.nodes.get()
+    node_dict = {}
+    for node in nodes:
+        name = node['node']
+        if not bool(conf_nodes) or name in conf_nodes:
+            node_dict[name] = node
+            cts = proxmox.nodes(name).lxc.get()
+            for item in cts:
+                if not bool(conf_vms) or int(item['vmid']) in conf_vms:
+                    item['node'] = name
+                    key = "{} - {}".format(item['name'], item['vmid'])
+                    node_dict[key] = item
+            vms = proxmox.nodes(name).qemu.get()
+            for item in vms:
+                if not bool(conf_vms) or int(item['vmid']) in conf_vms:
+                    item['node'] = name
+                    key = "{} - {}".format(item['name'], item['vmid'])
+                    node_dict[key] = item
+    hass.data[DATA_PROXMOX_NODES] = node_dict
+
+
+def fix_status(hass, item, status):
+    """Update the currently cached data with the new status of the vm."""
+    data = hass.data[DATA_PROXMOX_NODES]
+    item['status'] = status
+    data["{} - {}".format(item['name'], item['vmid'])] = item
+    hass.data[DATA_PROXMOX_NODES] = data

--- a/homeassistant/components/proxmox/binary_sensor.py
+++ b/homeassistant/components/proxmox/binary_sensor.py
@@ -2,17 +2,27 @@
 import homeassistant.components.proxmox as proxmox
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
+DEVICE_CLASS = 'connectivity'
+
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up Proxmox VE binary sensor."""
     nodes = hass.data[proxmox.DATA_PROXMOX_NODES]
     sensors = []
+    attributes = {
+        'status': 'status',
+        'vcpu_count': 'cpus',
+        'mem_used': 'mem',
+        'max_memory': 'maxmem',
+        'disk_used': 'disk',
+        'max_disk': 'maxdisk'
+    }
 
     for node_name in nodes.keys():
         item = nodes[node_name]
         if 'type' not in item or item['type'] != 'node':
-            sensor = PXMXBinarySensor(hass, node_name, 'Status')
+            sensor = PXMXBinarySensor(hass, node_name, item, attributes)
             sensors.append(sensor)
 
     async_add_entities(sensors)
@@ -21,18 +31,26 @@ async def async_setup_platform(
 class PXMXBinarySensor(BinarySensorDevice):
     """Define a binary sensor for Proxmox VE VM/Container state."""
 
-    def __init__(self, hass, node_name, sensor_name):
+    def __init__(self, hass, node_name, item, attributes):
         """Initialize Proxmox VE binary sensor."""
         self._hass = hass
         self._node_name = node_name
-        self._sensor_name = sensor_name
         self._is_available = False
         self._state = None
+        self._attributes = attributes
+        self._vm_id = item['vmid']
+        self._item = item
+        self._unique_id = proxmox.DOMAIN + '_status_' + item['vmid']
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return '{} ({})'.format(self._sensor_name, self._node_name)
+        return '{} ({})'.format('Status', self._node_name)
 
     @property
     def is_on(self):
@@ -44,10 +62,31 @@ class PXMXBinarySensor(BinarySensorDevice):
         """Return True if sensor is available."""
         return self._is_available
 
+    @property
+    def device_class(self) -> str:
+        """Return the class of this device."""
+        return DEVICE_CLASS
+
+    @property
+    def state_attributes(self):
+        """Return state attributes of the vm."""
+        attributes = {}
+        for key in self._attributes.keys():
+            attributes[key] = self._item[self._attributes[key]]
+        return attributes
+
+    @property
+    def device_state_attributes(self):
+        """Return device attributes of the vm."""
+        return {
+            'vmid': self._vm_id
+        }
+
     def update(self):
         """Update the sensor."""
         nodes = self._hass.data[proxmox.DATA_PROXMOX_NODES]
         node = nodes[self._node_name]
+        self._item = node
         if not node:
             self._state = None
             self._is_available = False

--- a/homeassistant/components/proxmox/binary_sensor.py
+++ b/homeassistant/components/proxmox/binary_sensor.py
@@ -1,0 +1,56 @@
+"""Support for binary sensors to display Proxmox VE data."""
+import homeassistant.components.proxmox as proxmox
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up Proxmox VE binary sensor."""
+    nodes = hass.data[proxmox.DATA_PROXMOX_NODES]
+    sensors = []
+
+    for node_name in nodes.keys():
+        item = nodes[node_name]
+        if 'type' not in item or item['type'] != 'node':
+            sensor = PXMXBinarySensor(hass, node_name, 'Status')
+            sensors.append(sensor)
+
+    async_add_entities(sensors)
+
+
+class PXMXBinarySensor(BinarySensorDevice):
+    """Define a binary sensor for Proxmox VE VM/Container state."""
+
+    def __init__(self, hass, node_name, sensor_name):
+        """Initialize Proxmox VE binary sensor."""
+        self._hass = hass
+        self._node_name = node_name
+        self._sensor_name = sensor_name
+        self._is_available = False
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} ({})'.format(self._sensor_name, self._node_name)
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return True if sensor is available."""
+        return self._is_available
+
+    def update(self):
+        """Update the sensor."""
+        nodes = self._hass.data[proxmox.DATA_PROXMOX_NODES]
+        node = nodes[self._node_name]
+        if not node:
+            self._state = None
+            self._is_available = False
+        else:
+            self._state = node['status'] == 'running'
+            self._is_available = True

--- a/homeassistant/components/proxmox/sensor.py
+++ b/homeassistant/components/proxmox/sensor.py
@@ -1,0 +1,143 @@
+"""Support for sensors to show the resource usages of Proxmox VE."""
+import homeassistant.components.proxmox as proxmox
+from homeassistant.helpers.entity import Entity
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up Proxmox VE sensors."""
+    nodes = hass.data[proxmox.DATA_PROXMOX_NODES]
+    sensors = []
+
+    for name in nodes.keys():
+        item = nodes[name]
+        if 'type' in item and item['type'] == 'node':
+            sensors.append(
+                PXMXSensor(
+                    hass, name, 'Uptime', uptime, "min", 'mdi:clock-outline'))
+        else:
+            sensors.append(
+                PXMXSensor(hass, name, 'VCPU Count', vcpus, None, 'mdi:chip'))
+        sensors.append(
+            PXMXSensor(hass, name, 'Memory', ram, "%", 'mdi:memory'))
+        sensors.append(
+            PXMXSensor(hass, name, 'Disk', disk, "%", 'mdi:harddisk'))
+        sensors.append(
+            PXMXSensor(hass, name, 'CPU', cpu, "%", 'mdi:chip'))
+        sensors.append(
+            PXMXSensor(
+                hass, name, 'Max. Memory', mem_max, 'GB', 'mdi:memory'))
+        sensors.append(
+            PXMXSensor(
+                hass, name, 'Memory Used', mem_used, 'GB', 'mdi:memory'))
+        sensors.append(
+            PXMXSensor(
+                hass, name, 'Max. Disk', disk_max, 'GB', 'mdi:harddisk'))
+        sensors.append(
+            PXMXSensor(
+                hass, name, 'Disk Used', disk_used, 'GB', 'mdi:harddisk'))
+        sensors.append(
+            PXMXSensor(hass, name, 'Status', status, None, None))
+
+    async_add_entities(sensors)
+
+
+class PXMXSensor(Entity):
+    """Sensors to show the resource usages of Proxmox VE nodes & VMs."""
+
+    def __init__(self, hass, node_name, sensor_name, value, unit, icon):
+        """Initialize Proxmox VE sensor."""
+        self._hass = hass
+        self._node_name = node_name
+        self._unit = unit
+        self._icon = icon
+        self._sensor_name = sensor_name
+        self._value = value
+        self._state = None
+        self._is_available = False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} ({})'.format(self._sensor_name, self._node_name)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit
+
+    @property
+    def available(self):
+        """Return True if Monitor is available."""
+        return self._is_available
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
+
+    def update(self):
+        """Update the sensor."""
+        nodes = self._hass.data[proxmox.DATA_PROXMOX_NODES]
+        node = nodes[self._node_name]
+        if not node:
+            self._state = None
+            self._is_available = False
+        else:
+            self._state = self._value(node)
+            self._is_available = True
+
+
+def uptime(node):
+    """Return uptime of the given node in minutes."""
+    return "{:.0f}".format(node['uptime']/60)
+
+
+def vcpus(node):
+    """Return the no. of vcpus in the given vm."""
+    return node['cpus']
+
+
+def ram(node):
+    """Return the memory usage as a percentage."""
+    return "{:.2f}".format(node['mem'] * 100 / node['maxmem'])
+
+
+def disk(node):
+    """Return the disk usage as a percentage."""
+    return "{:.2f}".format(int(node['disk']) * 100 / int(node['maxdisk']))
+
+
+def cpu(node):
+    """Return the cpu usage as a percentage."""
+    return "{:.2f}".format(node['cpu'] * 100)
+
+
+def mem_max(node):
+    """Return the max. memory allocate to the given node in GB."""
+    return "{:.2f}".format(node['maxmem']/1073741824)
+
+
+def mem_used(node):
+    """Return the memory used by the given node in GB."""
+    return "{:.2f}".format(node['mem']/1073741824)
+
+
+def disk_max(node):
+    """Return the max. disk space allocate to the given node in GB."""
+    return "{:.2f}".format(int(node['maxdisk'])/1073741824)
+
+
+def disk_used(node):
+    """Return the disk space used by the given node in GB."""
+    return "{:.2f}".format(int(node['disk'])/1073741824)
+
+
+def status(node):
+    """Return the current status."""
+    return node['status']

--- a/homeassistant/components/proxmox/switch.py
+++ b/homeassistant/components/proxmox/switch.py
@@ -1,0 +1,77 @@
+"""Support for switches to turn on/off Proxmox VE VMs/Containers."""
+import homeassistant.components.proxmox as proxmox
+from homeassistant.components.switch import SwitchDevice
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up Proxmox VE switch."""
+    nodes = hass.data[proxmox.DATA_PROXMOX_NODES]
+    control = hass.data[proxmox.DATA_PROXMOX_CONTROL]
+    sensors = []
+
+    for node_name in nodes.keys():
+        item = nodes[node_name]
+        if 'type' not in item or item['type'] != 'node':
+            sensor = PXMXSwitch(
+                hass, node_name, 'Switch', control['start'], control['stop'])
+            sensors.append(sensor)
+
+    async_add_entities(sensors)
+
+
+class PXMXSwitch(SwitchDevice):
+    """Switch to turn on / turn off a Proxmox VE Virtual Machine/Container."""
+
+    def __init__(self, hass, node_name, sensor_name, start, stop):
+        """Initialize monitor sensor."""
+        self._hass = hass
+        self._node_name = node_name
+        self._sensor_name = sensor_name
+        self._start = start
+        self._stop = stop
+        self._state = None
+        self._is_available = False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} ({})'.format(self._sensor_name, self._node_name)
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return True if Monitor is available."""
+        return self._is_available
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the VM/Container on."""
+        node = self.get_node()
+        if node:
+            await self._start(node)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the VM/Container off."""
+        node = self.get_node()
+        if node:
+            await self._stop(node)
+
+    def update(self):
+        """Update the sensor."""
+        node = self.get_node()
+        if not node:
+            self._state = None
+            self._is_available = False
+        else:
+            self._state = node['status'] == 'running'
+            self._is_available = True
+
+    def get_node(self):
+        """Get current status."""
+        nodes = self._hass.data[proxmox.DATA_PROXMOX_NODES]
+        node = nodes[self._node_name]
+        return node

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -874,6 +874,9 @@ prometheus_client==0.2.0
 # homeassistant.components.tensorflow.image_processing
 protobuf==3.6.1
 
+# homeassistant.components.proxmox
+proxmoxer==1.0.3
+
 # homeassistant.components.systemmonitor.sensor
 psutil==5.5.1
 


### PR DESCRIPTION
## Description:
Based on proxmoxer 1.0.3
Uses Proxmox API v2

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8973

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
proxmox:
   host: 192.168.1.100
   port: 8006
   verify_ssl: False
   username: user
   password: mysupersecretpassword
   realm: pam
   nodes:
     - node1
     - node2
   vms:
     - 101
     - 102
     - 205
   start_stop_all_vms: False
   start_stop_vms:
     - 109
     - 101
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
