### PR TITLE
Onboarding broken after patch

### DIFF
--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -74,7 +74,6 @@ class UserOnboardingView(_BaseOnboardingView):
         vol.Required('name'): str,
         vol.Required('username'): str,
         vol.Required('password'): str,
-        vol.Required('client_id'): str,
     }))
     async def post(self, request, data):
         """Return the manifest.json."""
@@ -104,7 +103,7 @@ class UserOnboardingView(_BaseOnboardingView):
 
             # Return an authorization code to allow fetching tokens.
             auth_code = hass.components.auth.create_auth_code(
-                data['client_id'], user
+                data['username'], user
             )
             return self.json({
                 'auth_code': auth_code


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #21777 

Onboarding isn't working after #21777 . This fixes the issue so that onboarding now works, although I'm not sure it is consistent with the intent of the original patch. Possibly the front end needs to have `username` be renamed `client_id` ? I haven't done any front end stuff as yet so can't confirm.

## To reproduce:

```
hass -c new_folder
```

Attempt to do the onboarding login, you get a data validation error. This patches the issue.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.