### PR TITLE
Better handling of HomeKit accessory-information service

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import call_later
 
+from .connection import get_accessory_information
 from .const import (
     CONTROLLER, DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, KNOWN_ACCESSORIES,
     KNOWN_DEVICES
@@ -204,11 +205,9 @@ class HomeKitEntity(Entity):
     def __init__(self, accessory, devinfo):
         """Initialise a generic HomeKit device."""
         self._available = True
-        self._name = accessory.model
         self._accessory = accessory
         self._aid = devinfo['aid']
         self._iid = devinfo['iid']
-        self._address = "homekit-{}-{}".format(devinfo['serial'], self._iid)
         self._features = 0
         self._chars = {}
         self.setup()
@@ -232,6 +231,7 @@ class HomeKitEntity(Entity):
         for accessory in pairing_data.get('accessories', []):
             if accessory['aid'] != self._aid:
                 continue
+            self._accessory_info = get_accessory_information(accessory)
             for service in accessory['services']:
                 if service['iid'] != self._iid:
                     continue
@@ -304,12 +304,13 @@ class HomeKitEntity(Entity):
     @property
     def unique_id(self):
         """Return the ID of this device."""
-        return self._address
+        serial = self._accessory_info.get('serial-number', 'unknown')
+        return "homekit-{}-{}".format(serial, self._iid)
 
     @property
     def name(self):
         """Return the name of the device if any."""
-        return self._name
+        return self._accessory_info.get('name', None)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -304,13 +304,13 @@ class HomeKitEntity(Entity):
     @property
     def unique_id(self):
         """Return the ID of this device."""
-        serial = self._accessory_info.get('serial-number', 'unknown')
+        serial = self._accessory_info['serial-number']
         return "homekit-{}-{}".format(serial, self._iid)
 
     @property
     def name(self):
         """Return the name of the device if any."""
-        return self._accessory_info.get('name', None)
+        return self._accessory_info.get('name')
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -74,20 +74,13 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverDevice):
             CharacteristicsTypes.DOOR_STATE_CURRENT,
             CharacteristicsTypes.DOOR_STATE_TARGET,
             CharacteristicsTypes.OBSTRUCTION_DETECTED,
-            CharacteristicsTypes.NAME,
         ]
-
-    def _setup_name(self, char):
-        self._name = char['value']
 
     def _update_door_state_current(self, value):
         self._state = CURRENT_GARAGE_STATE_MAP[value]
 
     def _update_obstruction_detected(self, value):
         self._obstruction_detected = value
-
-    def _update_name(self, value):
-        self._name = value
 
     @property
     def available(self):
@@ -172,11 +165,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
             CharacteristicsTypes.HORIZONTAL_TILT_CURRENT,
             CharacteristicsTypes.HORIZONTAL_TILT_TARGET,
             CharacteristicsTypes.OBSTRUCTION_DETECTED,
-            CharacteristicsTypes.NAME,
         ]
-
-    def _setup_name(self, char):
-        self._name = char['value']
 
     def _update_position_state(self, value):
         self._state = CURRENT_WINDOW_STATE_MAP[value]

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -26,14 +26,14 @@ async def test_koogeek_ls1_setup(hass):
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
     # Assert that the entity is correctly added to the entity registry
-    entity = entity_registry.async_get('light.testdevice')
-    assert entity.unique_id == 'homekit-AAAA011111111111-7'
+    entry = entity_registry.async_get('light.koogeek_ls1_20833f')
+    assert entry.unique_id == 'homekit-AAAA011111111111-7'
 
-    helper = Helper(hass, 'light.testdevice', pairing, accessories[0])
+    helper = Helper(hass, 'light.koogeek_ls1_20833f', pairing, accessories[0])
     state = await helper.poll_and_get_state()
 
     # Assert that the friendly name is detected correctly
-    assert state.attributes['friendly_name'] == 'TestDevice'
+    assert state.attributes['friendly_name'] == 'Koogeek-LS1-20833F'
 
     # Assert that all optional features the LS1 supports are detected
     assert state.attributes['supported_features'] == (
@@ -54,7 +54,7 @@ async def test_recover_from_failure(hass, utcnow, failure_cls):
     accessories = setup_accessories_from_file(profile_path)
     pairing = await setup_test_accessories(hass, accessories)
 
-    helper = Helper(hass, 'light.testdevice', pairing, accessories[0])
+    helper = Helper(hass, 'light.koogeek_ls1_20833f', pairing, accessories[0])
 
     # Set light state on fake device to off
     helper.characteristics[LIGHT_ON].set_value(False)


### PR DESCRIPTION
## Description:

This is from my homekit_controller configentry branch.

The main change is it tweaks how homekit_controller handles entity names. The model name as published in zeroconf does not make a good name. For example, a hue bridge appears in zeroconf as `BSB002`. Slightly better but still pretty crap UX, the Koogeek Lightstrip shows up as `LS1`. After this tweak we use the name from the accessory information service instead, which is more inline with the expected behaviour of Apple accessories.

As part of the change I get the serial number from the accessory information object too. This avoids having to pass it through in `devinfo`.

This removes custom code from cover to make it consistent with how other entities are named.

The serial number is still the same, so the `unique_id` doesn't actually change. The name does change. I checked when testing that existing entity ids are stable and manual names are stable. They were, so I don't think this is a breaking change.

I also applied a review feedback request from @MartinHjelmare that didn't make it into the previous PR (#22141).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR