### PR TITLE
WIP: Add templating to input_number

### DIFF
--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -61,7 +61,7 @@ def _cv_input_number(cfg):
     if state is not None and (state < minimum or state > maximum):
         raise vol.Invalid('Initial value {} not in range {}-{}'
                           .format(state, minimum, maximum))
-    if (CONF_VALUE_TEMPLATE in cfg) is not (CONF_SET_VALUE in cfg):
+    if (CONF_VALUE_TEMPLATE in cfg) is (CONF_SET_VALUE not in cfg):
         raise vol.Invalid('{} and {} must be provided together'
                           .format(CONF_VALUE_TEMPLATE, CONF_SET_VALUE))
     return cfg
@@ -285,4 +285,3 @@ class InputNumber(RestoreEntity):
                 self._current_value = float(self._template.async_render())
             except TemplateError as ex:
                 _LOGGER.error(ex)
-                #self._state = None


### PR DESCRIPTION
## Description:

This adds functionality similar to that found in `light.template`, `cover.template`, etc. to the `input_number` component.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** TODO

## Example entry for `configuration.yaml` (if applicable):
```yaml
# A simple example where modifying `volume` will cause `volume_tracker`
# to be updated, and modifying `volume_tracker` will modify `volume`
input_number:
  volume:
    name: Volume
    min: 0
    max: 100
    step: 1

  volume_tracker:
    name: Volume Tracker
    min: 0
    max: 100
    step: 1
    set_value_script:
      service: input_number.set_value
      data_template:
        entity_id: input_number.volume
        value: "{{ value }}"
    value_template: "{{ states.input_number.volume.state }}"
    entity_id: input_number.volume
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.