### PR TITLE
Always load Hass.io component on Hass.io

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -199,10 +199,6 @@ async def async_setup(hass, config):
         """Schedule the first discovery when Home Assistant starts up."""
         async_track_point_in_utc_time(hass, scan_devices, dt_util.utcnow())
 
-        # Discovery for local services
-        if 'HASSIO' in os.environ:
-            hass.async_create_task(new_service_found(SERVICE_HASSIO, {}))
-
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, schedule_first)
 
     return True

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -9,7 +9,6 @@ loaded before the EVENT_PLATFORM_DISCOVERED is fired.
 import json
 from datetime import timedelta
 import logging
-import os
 
 import voluptuous as vol
 

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -142,21 +142,6 @@ def test_discover_duplicates(hass):
         SERVICE_NO_PLATFORM_COMPONENT, BASE_CONFIG)
 
 
-@asyncio.coroutine
-def test_load_component_hassio(hass):
-    """Test load hassio component."""
-    def discover(netdisco):
-        """Fake discovery."""
-        return []
-
-    with patch.dict(os.environ, {'HASSIO': "FAKE_HASSIO"}), \
-            patch('homeassistant.components.hassio.async_setup',
-                  return_value=mock_coro(return_value=True)) as mock_hassio:
-        yield from mock_discovery(hass, discover)
-
-    assert mock_hassio.called
-
-
 async def test_discover_config_flow(hass):
     """Test discovery triggering a config flow."""
     discovery_info = {

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the discovery component."""
 import asyncio
-import os
 from unittest.mock import patch, MagicMock
 
 import pytest

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -34,7 +34,7 @@ def test_from_config_file(hass):
     }
 
     with patch_yaml_files(files, True):
-        yield from bootstrap.async_from_config_file('config.yaml')
+        yield from bootstrap.async_from_config_file('config.yaml', hass)
 
     assert components == hass.config.components
 
@@ -103,3 +103,12 @@ async def test_async_from_config_file_not_mount_deps_folder(loop):
 
         await bootstrap.async_from_config_file('mock-path', hass)
         assert len(mock_mount.mock_calls) == 0
+
+
+async def test_load_hassio(hass):
+    """Test that we load Hass.io component."""
+    with patch.dict(os.environ, {}, clear=True):
+        assert bootstrap._get_components(hass, {}) == set()
+
+    with patch.dict(os.environ, {'HASSIO': '1'}):
+        assert bootstrap._get_components(hass, {}) == {'hassio'}


### PR DESCRIPTION

## Description:
Always load the Hass.io component on hass.io instead of relying on the discovery component.

**Related issue (if applicable):** fixes #22154

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
