### PR TITLE
Yet another fix to stuck at home

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -382,7 +382,7 @@ class DeviceTracker:
         This method must be run in the event loop.
         """
         for device in self.devices.values():
-            if (device.track and device.last_update_home) and \
+            if (device.track and (device.state == STATE_HOME)) and \
                device.stale(now):
                 self.hass.async_create_task(device.async_update_ha_state(True))
 
@@ -399,6 +399,7 @@ class DeviceTracker:
         tasks = []
         for device in self.devices.values():
             if device.track and not device.last_seen:
+                device.last_seen = dt_util.utcnow()
                 tasks.append(self.hass.async_create_task(
                     async_init_single_device(device)))
 
@@ -420,7 +421,6 @@ class Device(RestoreEntity):
     icon = None  # type: str
 
     # Track if the last update of this device was HOME.
-    last_update_home = False
     _state = STATE_NOT_HOME
 
     def __init__(self, hass: HomeAssistantType, consider_home: timedelta,
@@ -546,7 +546,6 @@ class Device(RestoreEntity):
         """Mark the device state as stale."""
         self._state = STATE_NOT_HOME
         self.gps = None
-        self.last_update_home = False
 
     async def async_update(self):
         """Update state of entity.
@@ -554,7 +553,13 @@ class Device(RestoreEntity):
         This method is a coroutine.
         """
         if not self.last_seen:
+            self.last_seen = dt_util.utcnow()
             return
+
+        if self.stale():
+            self.mark_stale()
+            return
+
         if self.location_name:
             self._state = self.location_name
         elif self.gps is not None and self.source_type == SOURCE_TYPE_GPS:
@@ -566,11 +571,8 @@ class Device(RestoreEntity):
                 self._state = STATE_HOME
             else:
                 self._state = zone_state.name
-        elif self.stale():
-            self.mark_stale()
         else:
             self._state = STATE_HOME
-            self.last_update_home = True
 
     async def async_added_to_hass(self):
         """Add an entity."""
@@ -579,7 +581,6 @@ class Device(RestoreEntity):
         if not state:
             return
         self._state = state.state
-        self.last_update_home = (state.state == STATE_HOME)
         self.last_seen = dt_util.utcnow()
 
         for attr, var in (


### PR DESCRIPTION
Signed-off-by: Hanoch Haim <hhaim@cisco.com>

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Yet another fix to stuck at home


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
