### PR TITLE
Removed overly broad exception handling for nanoleaf light

### DIFF
--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -195,6 +195,7 @@ class NanoleafLight(Light):
 
     def update(self):
         """Fetch new state data for this light."""
+        from pynanoleaf import Unavailable
         try:
             self._available = self._light.available
             self._brightness = self._light.brightness
@@ -203,7 +204,7 @@ class NanoleafLight(Light):
             self._effects_list = self._light.effects
             self._hs_color = self._light.hue, self._light.saturation
             self._state = self._light.on
-        except Exception as err:  # pylint:disable=broad-except
+        except Unavailable as err:
             _LOGGER.error("Could not update status for %s (%s)",
                           self.name, err)
             self._available = False


### PR DESCRIPTION
## Description:
Instead of checking for all exceptions, check for the concrete exception in case the light is unavailable and let the library handle the rest.
If the import inside `update()` is bad form I'd welcome alternatives!
(see also comment on https://github.com/home-assistant/home-assistant/pull/21945 )

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.