### PR TITLE
Added support for transitions for nanoleaf light

### DIFF
--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -182,6 +182,8 @@ class NanoleafLight(Light):
             hue, saturation = hs_color
             self._light.hue = int(hue)
             self._light.saturation = int(saturation)
+        if color_temp_mired:
+            self._light.color_temperature = mired_to_kelvin(color_temp_mired)
 
         if transition:
             if brightness:  # tune to the required brightness in n seconds
@@ -193,8 +195,7 @@ class NanoleafLight(Light):
             self._light.on = True
             if brightness:
                 self._light.brightness = int(brightness / 2.55)
-        if color_temp_mired:
-            self._light.color_temperature = mired_to_kelvin(color_temp_mired)
+
         if effect:
             self._light.effect = effect
 

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -10,8 +10,9 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_HS_COLOR,
-    PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP,
-    SUPPORT_EFFECT, Light)
+    ATTR_TRANSITION, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT,
+    SUPPORT_TRANSITION, Light)
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import color as color_util
@@ -32,7 +33,7 @@ CONFIG_FILE = '.nanoleaf.conf'
 ICON = 'mdi:triangle-outline'
 
 SUPPORT_NANOLEAF = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT |
-                    SUPPORT_COLOR)
+                    SUPPORT_COLOR | SUPPORT_TRANSITION)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -171,27 +172,40 @@ class NanoleafLight(Light):
 
     def turn_on(self, **kwargs):
         """Instruct the light to turn on."""
-        self._light.on = True
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         hs_color = kwargs.get(ATTR_HS_COLOR)
         color_temp_mired = kwargs.get(ATTR_COLOR_TEMP)
         effect = kwargs.get(ATTR_EFFECT)
+        transition = kwargs.get(ATTR_TRANSITION)
 
         if hs_color:
             hue, saturation = hs_color
             self._light.hue = int(hue)
             self._light.saturation = int(saturation)
 
+        if transition:
+            if brightness: #tune to the required brightness in n seconds
+                self._light.brightness_transition(
+                    int(brightness / 2.55), int(transition))
+            # If brightness is not specified, assume full brightness
+            else:
+                self._light.brightness_transition(100, int(transition))
+        else: #If no transition is occurring, turn on the light
+            self._light.on = True
+            if brightness:
+                self._light.brightness = int(brightness / 2.55)
         if color_temp_mired:
             self._light.color_temperature = mired_to_kelvin(color_temp_mired)
-        if brightness:
-            self._light.brightness = int(brightness / 2.55)
         if effect:
             self._light.effect = effect
 
     def turn_off(self, **kwargs):
         """Instruct the light to turn off."""
-        self._light.on = False
+        transition = kwargs.get(ATTR_TRANSITION)
+        if transition:
+            self._light.brightness_transition(0, int(transition))
+        else:
+            self._light.on = False
 
     def update(self):
         """Fetch new state data for this light."""

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -187,8 +187,7 @@ class NanoleafLight(Light):
             if brightness:  # tune to the required brightness in n seconds
                 self._light.brightness_transition(
                     int(brightness / 2.55), int(transition))
-            # If brightness is not specified, assume full brightness
-            else:
+            else:  # If brightness is not specified, assume full brightness
                 self._light.brightness_transition(100, int(transition))
         else:  # If no transition is occurring, turn on the light
             self._light.on = True

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -184,13 +184,13 @@ class NanoleafLight(Light):
             self._light.saturation = int(saturation)
 
         if transition:
-            if brightness: #tune to the required brightness in n seconds
+            if brightness:  # tune to the required brightness in n seconds
                 self._light.brightness_transition(
                     int(brightness / 2.55), int(transition))
             # If brightness is not specified, assume full brightness
             else:
                 self._light.brightness_transition(100, int(transition))
-        else: #If no transition is occurring, turn on the light
+        else:  # If no transition is occurring, turn on the light
             self._light.on = True
             if brightness:
                 self._light.brightness = int(brightness / 2.55)


### PR DESCRIPTION
## Description:
Added support for transitions for Nanoleaf lights. Now it is possible to set e.g. the *mynanoleaf* light to half brightness with a transition time of 60 seconds with a call to `light.turn_on` with 
```
{
  "entity_id": "light.mynanoleaf",
  "transition": 60,
  "brightness": 122
}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
