### PR TITLE
Bump pyubee to 0.3 and add support for more Ubee models

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1424,7 +1424,7 @@ pytradfri[async]==6.0.1
 pytrafikverket==0.1.5.8
 
 # homeassistant.components.device_tracker.ubee
-pyubee==0.2
+pyubee==0.3
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.16


### PR DESCRIPTION
## Breaking Change:

If using Ubee Device Tracker component, you will have to specify model in `configuration.yaml`. Example:

```yaml
device_tracker:
  - platform: ubee
    host: 192.168.1.1
    model: EVW32C-0N
    username: admin
    password: somepassword
```

Initially, this component was written for and tested with `Ubee EVW32C-0N` model. Thanks to @StevenLooman ([#3](https://github.com/mzdrale/pyubee/pull/3)), [pyubee](https://github.com/mzdrale/pyubee) supports model `EVW3200-Wifi` as well. Since we have access to two different models and their Admin UI is different and there are probably more models with different Admin UI, we had to introduce `model` parameter.

## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8987

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: ubee
    host: 192.168.1.1
    model: EVW32C-0N
    username: admin
    password: somepassword
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
