### PR TITLE
Upgrade to async_upnp_client to 0.14.6

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.14.5']
+REQUIREMENTS = ['async-upnp-client==0.14.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -23,7 +23,7 @@ from .const import DOMAIN
 from .const import LOGGER as _LOGGER
 from .device import Device
 
-REQUIREMENTS = ['async-upnp-client==0.14.5']
+REQUIREMENTS = ['async-upnp-client==0.14.6']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -177,7 +177,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.dlna_dmr.media_player
-async-upnp-client==0.14.5
+async-upnp-client==0.14.6
 
 # homeassistant.components.stream
 av==6.1.2


### PR DESCRIPTION
## Description:

Upgrade to async_upnp_client==0.14.6, fixing the issue with Panasonic Viera (42AS650) where it does not accept media to be played.

**Related issue (if applicable):** fixes #20749

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
