### PR TITLE
Fix progress for Plex media_players

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -409,10 +409,10 @@ class PlexClient(MediaPlayerDevice):
                 self._is_player_available = False
 
             # Calculate throttled position for proper progress display.
-            position = self._session.viewOffset
+            position = int(self._session.viewOffset / 1000)
             now = dt_util.utcnow()
             if self._media_position and self._media_position_updated_at:
-                pos_diff = (position - self._last_position) / 1000.0
+                pos_diff = (position - self._media_position)
                 time_diff = now - self._media_position_updated_at
                 if (pos_diff != 0 and
                         abs(time_diff.total_seconds() - pos_diff) > 5):
@@ -430,7 +430,7 @@ class PlexClient(MediaPlayerDevice):
 
         if self._is_player_active and self._session is not None:
             self._session_type = self._session.type
-            self._media_duration = self._session.duration
+            self._media_duration = int(self._session.duration / 1000)
             #  title (movie name, tv episode name, music song name)
             self._media_title = self._session.title
             # media type

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -313,7 +313,6 @@ class PlexClient(MediaPlayerDevice):
         self._media_title = None
         self._media_position = None
         self._media_position_updated_at = None
-        self._last_position = None
         # Music
         self._media_album_artist = None
         self._media_album_name = None

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -312,6 +312,8 @@ class PlexClient(MediaPlayerDevice):
         self._media_image_url = None
         self._media_title = None
         self._media_position = None
+        self._last_media_position = None
+        self._media_position_updated_at = None
         # Music
         self._media_album_artist = None
         self._media_album_name = None
@@ -407,7 +409,12 @@ class PlexClient(MediaPlayerDevice):
                 self._make = self._player.device
             else:
                 self._is_player_available = False
-            self._media_position = self._session.viewOffset
+
+            position = self._session.viewOffset
+            if self._last_media_position != position:
+                self._media_position_updated_at = dt_util.utcnow()
+                self._media_position = self._last_media_position = position
+
             self._media_content_id = self._session.ratingKey
             self._media_content_rating = getattr(
                 self._session, 'contentRating', None)
@@ -610,6 +617,16 @@ class PlexClient(MediaPlayerDevice):
     def media_duration(self):
         """Return the duration of current playing media in seconds."""
         return self._media_duration
+
+    @property
+    def media_position(self):
+        """Return the duration of current playing media in seconds."""
+        return self._media_position
+
+    @property
+    def media_position_updated_at(self):
+        """When was the position of the current playing media valid."""
+        return self._media_position_updated_at
 
     @property
     def media_image_url(self):

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -313,7 +313,6 @@ class PlexClient(MediaPlayerDevice):
         self._media_title = None
         self._media_position = None
         self._media_position_updated_at = None
-        self._last_position = None
         # Music
         self._media_album_artist = None
         self._media_album_name = None
@@ -353,7 +352,6 @@ class PlexClient(MediaPlayerDevice):
         self._media_duration = None
         self._media_image_url = None
         self._media_title = None
-        self._media_position = None
         # Music
         self._media_album_artist = None
         self._media_album_name = None
@@ -413,18 +411,16 @@ class PlexClient(MediaPlayerDevice):
             # Calculate throttled position for proper progress display.
             position = self._session.viewOffset
             now = dt_util.utcnow()
-            if self._last_position and self._media_position_updated_at:
+            if self._media_position and self._media_position_updated_at:
                 pos_diff = (position - self._last_position) / 1000.0
                 time_diff = now - self._media_position_updated_at
                 if (pos_diff != 0 and
                         abs(time_diff.total_seconds() - pos_diff) > 5):
                     self._media_position_updated_at = now
-                    self._media_position = self._last_position = position
-                else:
-                    self._media_position = self._last_position
+                    self._media_position = position
             else:
                 self._media_position_updated_at = now
-                self._media_position = self._last_position = position
+                self._media_position = position
 
             self._media_content_id = self._session.ratingKey
             self._media_content_rating = getattr(

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -411,7 +411,7 @@ class PlexClient(MediaPlayerDevice):
             # Calculate throttled position for proper progress display.
             position = int(self._session.viewOffset / 1000)
             now = dt_util.utcnow()
-            if self._media_position and self._media_position_updated_at:
+            if self._media_position is not None:
                 pos_diff = (position - self._media_position)
                 time_diff = now - self._media_position_updated_at
                 if (pos_diff != 0 and

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -313,6 +313,7 @@ class PlexClient(MediaPlayerDevice):
         self._media_title = None
         self._media_position = None
         self._media_position_updated_at = None
+        self._last_position = None
         # Music
         self._media_album_artist = None
         self._media_album_name = None


### PR DESCRIPTION
## Description:
Adds `media_position` and `media_position_updated_at` properties which are necessary for UI media players to properly display progress.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
    - platform: plex
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23