### PR TITLE
Fix Season sensor local time offset

### DIFF
--- a/homeassistant/components/season/sensor.py
+++ b/homeassistant/components/season/sensor.py
@@ -130,5 +130,5 @@ class Season(Entity):
 
     def update(self):
         """Update season."""
-        self.datetime = datetime.now()
+        self.datetime = datetime.utcnow()
         self.season = get_season(self.datetime, self.hemisphere, self.type)


### PR DESCRIPTION
## Description:
Discovered today during the season change that the Season sensor does not change at the correct time in my time zone - this is because ephem works in UTC time, not local time. Since the sensor was comparing UTC to local, it ended up 7 hours off of the actual official change. This is a very simple change to correct this behavior.

**Related issue (if applicable):** No related issue.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** No related documentation changes.

## Example entry for `configuration.yaml` (if applicable):
No new configuration needed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
