### PR TITLE
Stream fixes

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -63,20 +63,28 @@ def stream_worker(hass, stream, quit_event):
     first_packet = True
     sequence = 1
     audio_packets = {}
+    last_dts = 0
 
     while not quit_event.is_set():
         try:
             packet = next(container.demux(video_stream))
             if packet.dts is None:
+                if first_packet:
+                    continue
                 # If we get a "flushing" packet, the stream is done
-                raise StopIteration
+                raise StopIteration("No dts in packet")
         except (av.AVError, StopIteration) as ex:
             # End of stream, clear listeners and stop thread
             for fmt, _ in outputs.items():
                 hass.loop.call_soon_threadsafe(
                     stream.outputs[fmt].put, None)
-            _LOGGER.error("Error demuxing stream: %s", ex)
+            _LOGGER.error("Error demuxing stream: %s", str(ex))
             break
+
+        # Skip non monotonically increasing dts in feed
+        if last_dts >= packet.dts:
+            continue
+        last_dts = packet.dts
 
         # Reset segment on every keyframe
         if packet.is_keyframe:

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -63,7 +63,7 @@ def stream_worker(hass, stream, quit_event):
     first_packet = True
     sequence = 1
     audio_packets = {}
-    last_dts = 0
+    last_dts = None
 
     while not quit_event.is_set():
         try:
@@ -82,7 +82,7 @@ def stream_worker(hass, stream, quit_event):
             break
 
         # Skip non monotonically increasing dts in feed
-        if last_dts >= packet.dts:
+        if not first_packet and last_dts >= packet.dts:
             continue
         last_dts = packet.dts
 


### PR DESCRIPTION
## Description:

This fixes a couple issues with stream sources from some camera models.  The ReoLink cameras send an empty first packet when establishing a connection, so the `StopIteration` was being hit at the beginning (instead of when a feed died).

We also ran into issues where `mux(packet)` was throwing an exception if the timestamps were out of order.  This is fixed for now simply by discarding packets, which will cause data loss, but at least the stream will still be alive.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.