### PR TITLE
Allow on/off on tado climate component.

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['python-tado==0.2.8']
+REQUIREMENTS = ['python-tado==0.2.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE)
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE, SUPPORT_ON_OFF)
 from homeassistant.const import (
     ATTR_TEMPERATURE, PRECISION_TENTHS, TEMP_CELSIUS)
 from homeassistant.util.temperature import convert as convert_temperature
@@ -42,7 +42,8 @@ OPERATION_LIST = {
     CONST_MODE_OFF: 'Off',
 }
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
+SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
+                 SUPPORT_ON_OFF)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -199,6 +200,27 @@ class TadoClimate(ClimateDevice):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         return self._target_temp
+
+    @property
+    def is_on(self):
+        """Return true if heater is on."""
+        return self._device_is_active
+
+    def turn_off(self):
+        """Turn device off."""
+        _LOGGER.info("Switching mytado.com to OFF for zone %s",
+                     self.zone_name)
+
+        self._current_operation = CONST_MODE_OFF
+        self._control_heating()
+
+    def turn_on(self):
+        """Turn device on."""
+        _LOGGER.info("Switching mytado.com to %s mode for zone %s",
+                     self._overlay_mode, self.zone_name)
+
+        self._current_operation = self._overlay_mode
+        self._control_heating()
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/homeassistant/components/tado/device_tracker.py
+++ b/homeassistant/components/tado/device_tracker.py
@@ -52,9 +52,9 @@ class TadoDeviceScanner(DeviceScanner):
 
         # If there's a home_id, we need a different API URL
         if self.home_id is None:
-            self.tadoapiurl = 'https://auth.tado.com/api/v2/me'
+            self.tadoapiurl = 'https://my.tado.com/api/v2/me'
         else:
-            self.tadoapiurl = 'https://auth.tado.com/api/v2' \
+            self.tadoapiurl = 'https://my.tado.com/api/v2' \
                               '/homes/{home_id}/mobileDevices'
 
         # The API URL always needs a username and password

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1391,7 +1391,7 @@ python-songpal==0.0.9.1
 python-synology==0.2.0
 
 # homeassistant.components.tado
-python-tado==0.2.8
+python-tado==0.2.9
 
 # homeassistant.components.telegram_bot
 python-telegram-bot==11.1.0


### PR DESCRIPTION
Patch from https://github.com/home-assistant/home-assistant/pull/21909 by @wmalgadey 

Related issue (if applicable): fixes #17559, #22208

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
