### PR TITLE
Fix SmartThings base_url check during startup with Cloud

### DIFF
--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -65,6 +65,8 @@ def validate_webhook_requirements(hass: HomeAssistantType) -> bool:
     """Ensure HASS is setup properly to receive webhooks."""
     if cloud.async_active_subscription(hass):
         return True
+    if hass.data[DOMAIN][CONF_CLOUDHOOK_URL] is not None:
+        return True
     return get_webhook_url(hass).lower().startswith('https://')
 
 


### PR DESCRIPTION
## Description:
Fixes an issue during startup where SmartThings falls back to checking `base_url` when using cloudhooks because the cloud isn't yet connected and assumed not available and added a new test for this condition.

CC @robbiet480 

**Related issue (if applicable):** fixes #22232

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  
If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
