### PR TITLE
Plex: Avoid refreshing by both device and session methods

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -170,21 +170,31 @@ def setup_plexserver(
                     config, device, None, plex_sessions, update_devices,
                     update_sessions)
                 plex_clients[device.machineIdentifier] = new_client
+                _LOGGER.debug("New device: %s", device.machineIdentifier)
                 new_plex_clients.append(new_client)
             else:
+                _LOGGER.debug("Refreshing device: %s",
+                        device.machineIdentifier)
                 plex_clients[device.machineIdentifier].refresh(device, None)
 
         # add devices with a session and no client (ex. PlexConnect Apple TV's)
         if config.get(CONF_INCLUDE_NON_CLIENTS):
             for machine_identifier, (session, player) in plex_sessions.items():
+                if machine_identifier in available_client_ids:
+                    # Avoid using session if already added as a device.
+                    _LOGGER.debug("Skipping session, device exists: %s",
+                            machine_identifier)
+                    continue
                 if (machine_identifier not in plex_clients
                         and machine_identifier is not None):
                     new_client = PlexClient(
                         config, player, session, plex_sessions, update_devices,
                         update_sessions)
                     plex_clients[machine_identifier] = new_client
+                    _LOGGER.debug("New session: %s", machine_identifier)
                     new_plex_clients.append(new_client)
                 else:
+                    _LOGGER.debug("Refreshing session: %s", machine_identifier)
                     plex_clients[machine_identifier].refresh(None, session)
 
         clients_to_remove = []

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -174,7 +174,7 @@ def setup_plexserver(
                 new_plex_clients.append(new_client)
             else:
                 _LOGGER.debug("Refreshing device: %s",
-                        device.machineIdentifier)
+                              device.machineIdentifier)
                 plex_clients[device.machineIdentifier].refresh(device, None)
 
         # add devices with a session and no client (ex. PlexConnect Apple TV's)
@@ -183,7 +183,7 @@ def setup_plexserver(
                 if machine_identifier in available_client_ids:
                     # Avoid using session if already added as a device.
                     _LOGGER.debug("Skipping session, device exists: %s",
-                            machine_identifier)
+                                  machine_identifier)
                     continue
                 if (machine_identifier not in plex_clients
                         and machine_identifier is not None):


### PR DESCRIPTION
## Description:

Some Plex clients would be refreshed twice during each poll if the `include_non_clients` parameter was set, adding unnecessary overhead.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
    - platform: plex
      include_non_clients: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23