### PR TITLE
Improved exception handling and logging

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -163,7 +163,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             output = target_device.adb_command(cmd)
 
             # log the output if there is any
-            if output:
+            if output and (not isinstance(output, str) or output.strip()):
                 _LOGGER.info("Output of command '%s' from '%s': %s",
                              cmd, target_device.entity_id, repr(output))
 
@@ -223,7 +223,7 @@ class ADBDevice(MediaPlayerDevice):
                                TcpTimeoutException)
         else:
             # Using "pure-python-adb" (communicate with ADB server)
-            self.exceptions = (ConnectionResetError,)
+            self.exceptions = (ConnectionResetError, RuntimeError)
 
         # Property attributes
         self._available = self.aftv.available


### PR DESCRIPTION
## Description:

Catch RuntimeError exceptions. Don't log ADB command output if there isn't any.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.