### PR TITLE
Remove broken elevation helper

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -253,10 +253,6 @@ def create_default_config(config_dir: str, detect_location: bool = True)\
                 continue
             info[attr] = getattr(location_info, prop) or default
 
-        if location_info.latitude and location_info.longitude:
-            info[CONF_ELEVATION] = loc_util.elevation(
-                location_info.latitude, location_info.longitude)
-
     # Writing files with YAML does not create the most human readable results
     # So we're hard coding a YAML template.
     try:
@@ -570,13 +566,6 @@ async def async_process_ha_core_config(
         if hac.time_zone is None:
             set_time_zone(info.time_zone)
             discovered.append(('time_zone', info.time_zone))
-
-    if hac.elevation is None and hac.latitude is not None and \
-       hac.longitude is not None:
-        elevation = await hass.async_add_executor_job(
-            loc_util.elevation, hac.latitude, hac.longitude)
-        hac.elevation = elevation
-        discovered.append(('elevation', elevation))
 
     if discovered:
         _LOGGER.warning(

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -9,7 +9,6 @@ from typing import Any, Optional, Tuple, Dict
 
 import requests
 
-ELEVATION_URL = 'http://maps.googleapis.com/maps/api/elevation/json'
 IP_API = 'http://ip-api.com/json'
 IPAPI = 'https://ipapi.co/json/'
 

--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -63,28 +63,6 @@ def distance(lat1: Optional[float], lon1: Optional[float],
     return result * 1000
 
 
-def elevation(latitude: float, longitude: float) -> int:
-    """Return elevation for given latitude and longitude."""
-    try:
-        req = requests.get(
-            ELEVATION_URL,
-            params={
-                'locations': '{},{}'.format(latitude, longitude),
-                'sensor': 'false',
-            },
-            timeout=10)
-    except requests.RequestException:
-        return 0
-
-    if req.status_code != 200:
-        return 0
-
-    try:
-        return int(float(req.json()['results'][0]['elevation']))
-    except (ValueError, KeyError, IndexError):
-        return 0
-
-
 # Author: https://github.com/maurycyp
 # Source: https://github.com/maurycyp/vincenty
 # License: https://github.com/maurycyp/vincenty/blob/master/LICENSE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,6 @@ def check_real(func):
 
 # Guard a few functions that would make network connections
 location.detect_location_info = check_real(location.detect_location_info)
-location.elevation = check_real(location.elevation)
 util.get_local_ip = lambda: '127.0.0.1'
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,10 +174,9 @@ class TestConfig(unittest.TestCase):
                     '0.0.0.0', 'US', 'United States', 'CA', 'California',
                     'San Diego', '92122', 'America/Los_Angeles', 32.8594,
                     -117.2073, True))
-    @mock.patch('homeassistant.util.location.elevation', return_value=101)
     @mock.patch('builtins.print')
     def test_create_default_config_detect_location(self, mock_detect,
-                                                   mock_elev, mock_print):
+                                                   mock_print):
         """Test that detect location sets the correct config keys."""
         config_util.ensure_config_exists(CONFIG_DIR)
 
@@ -190,7 +189,7 @@ class TestConfig(unittest.TestCase):
         expected_values = {
             CONF_LATITUDE: 32.8594,
             CONF_LONGITUDE: -117.2073,
-            CONF_ELEVATION: 101,
+            CONF_ELEVATION: 0,
             CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
             CONF_NAME: 'Home',
             CONF_TIME_ZONE: 'America/Los_Angeles',
@@ -486,9 +485,7 @@ class TestConfig(unittest.TestCase):
                     '0.0.0.0', 'US', 'United States', 'CA', 'California',
                     'San Diego', '92122', 'America/Los_Angeles', 32.8594,
                     -117.2073, True))
-    @mock.patch('homeassistant.util.location.elevation',
-                autospec=True, return_value=101)
-    def test_discovering_configuration(self, mock_detect, mock_elevation):
+    def test_discovering_configuration(self, mock_detect):
         """Test auto discovery for missing core configs."""
         self.hass.config.latitude = None
         self.hass.config.longitude = None
@@ -503,7 +500,6 @@ class TestConfig(unittest.TestCase):
 
         assert self.hass.config.latitude == 32.8594
         assert self.hass.config.longitude == -117.2073
-        assert self.hass.config.elevation == 101
         assert self.hass.config.location_name == 'San Diego'
         assert self.hass.config.units.name == CONF_UNIT_SYSTEM_METRIC
         assert self.hass.config.units.is_metric
@@ -511,9 +507,7 @@ class TestConfig(unittest.TestCase):
 
     @mock.patch('homeassistant.util.location.detect_location_info',
                 autospec=True, return_value=None)
-    @mock.patch('homeassistant.util.location.elevation', return_value=0)
-    def test_discovering_configuration_auto_detect_fails(self, mock_detect,
-                                                         mock_elevation):
+    def test_discovering_configuration_auto_detect_fails(self, mock_detect):
         """Test config remains unchanged if discovery fails."""
         self.hass.config = Config()
         self.hass.config.config_dir = "/test/config"
@@ -526,7 +520,6 @@ class TestConfig(unittest.TestCase):
         blankConfig = Config()
         assert self.hass.config.latitude == blankConfig.latitude
         assert self.hass.config.longitude == blankConfig.longitude
-        assert self.hass.config.elevation == blankConfig.elevation
         assert self.hass.config.location_name == blankConfig.location_name
         assert self.hass.config.units == blankConfig.units
         assert self.hass.config.time_zone == blankConfig.time_zone

--- a/tests/util/test_location.py
+++ b/tests/util/test_location.py
@@ -99,11 +99,10 @@ class TestLocationUtil(TestCase):
         assert info.longitude == -117.2073
         assert not info.use_metric
 
-    @patch('homeassistant.util.location.elevation', return_value=0)
     @patch('homeassistant.util.location._get_ipapi', return_value=None)
     @patch('homeassistant.util.location._get_ip_api', return_value=None)
     def test_detect_location_info_both_queries_fail(
-            self, mock_ipapi, mock_ip_api, mock_elevation):
+            self, mock_ipapi, mock_ip_api):
         """Ensure we return None if both queries fail."""
         info = location_util.detect_location_info(_test_real=True)
         assert info is None
@@ -121,24 +120,3 @@ class TestLocationUtil(TestCase):
         """Test ip api query when the request to API fails."""
         info = location_util._get_ip_api()
         assert info is None
-
-    @patch('homeassistant.util.location.requests.get',
-           side_effect=requests.RequestException)
-    def test_elevation_query_raises(self, mock_get):
-        """Test elevation when the request to API fails."""
-        elevation = location_util.elevation(10, 10, _test_real=True)
-        assert elevation == 0
-
-    @requests_mock.Mocker()
-    def test_elevation_query_fails(self, mock_req):
-        """Test elevation when the request to API fails."""
-        mock_req.get(location_util.ELEVATION_URL, text='{}', status_code=401)
-        elevation = location_util.elevation(10, 10, _test_real=True)
-        assert elevation == 0
-
-    @requests_mock.Mocker()
-    def test_elevation_query_nonjson(self, mock_req):
-        """Test if elevation API returns a non JSON value."""
-        mock_req.get(location_util.ELEVATION_URL, text='{ I am not JSON }')
-        elevation = location_util.elevation(10, 10, _test_real=True)
-        assert elevation == 0


### PR DESCRIPTION
## Description:

Google Maps API requires a API key now to access elevation data.

**Related issue (if applicable):** fixes #19860, related: https://github.com/home-assistant/architecture/issues/176

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
