### PR TITLE
Bump androidtv to 0.0.13

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 
 ANDROIDTV_DOMAIN = 'androidtv'
 
-REQUIREMENTS = ['androidtv==0.0.12']
+REQUIREMENTS = ['androidtv==0.0.13']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -155,7 +155,7 @@ alpha_vantage==2.1.0
 amcrest==1.2.7
 
 # homeassistant.components.androidtv.media_player
-androidtv==0.0.12
+androidtv==0.0.13
 
 # homeassistant.components.anel_pwrctrl.switch
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/22239

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
