### PR TITLE
Set Android HTML5 priority level to high to ensure notification delivery

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -480,6 +480,7 @@ class HTML5NotificationService(BaseNotificationService):
                           ATTR_TAG: payload[ATTR_TAG]}
             jwt_token = jwt.encode(jwt_claims, jwt_secret).decode('utf-8')
             payload[ATTR_DATA][ATTR_JWT] = jwt_token
+            payload['android'] = {'priority': 'high'}
 
             if self._vapid_prv and self._vapid_claims:
                 response = webpush(


### PR DESCRIPTION
## Description:

[Priority must be set high for HTML5 notifications to always be delivered on Android.](https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message)

**Related issue (if applicable):** fixes #22249

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
