### PR TITLE
Fix ps4 no creds with additional device

### DIFF
--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -79,7 +79,11 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
         # If entry exists check that devices found aren't configured.
         if self.hass.config_entries.async_entries(DOMAIN):
+            creds = {}
             for entry in self.hass.config_entries.async_entries(DOMAIN):
+                # Retrieve creds from entry
+                creds['data'] = entry.data[CONF_TOKEN]
+                # Retrieve device data from entry
                 conf_devices = entry.data['devices']
                 for c_device in conf_devices:
                     if c_device['host'] in device_list:
@@ -88,6 +92,11 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             # If list is empty then all devices are configured.
             if not device_list:
                 return self.async_abort(reason='devices_configured')
+            # Add existing creds for linking. Should be only 1.
+            if len(creds) != 1:
+                # Abort if creds is missing or more than 1.
+                return self.async_abort(reason='credential_error')
+            self.creds = creds['data']
 
         # Login to PS4 with user data.
         if user_input is not None:

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -93,8 +93,8 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             if not device_list:
                 return self.async_abort(reason='devices_configured')
             # Add existing creds for linking. Should be only 1.
-            if len(creds) != 1:
-                # Abort if creds is missing or more than 1.
+            if not creds:
+                # Abort if creds is missing.
                 return self.async_abort(reason='credential_error')
             self.creds = creds['data']
 


### PR DESCRIPTION
## Description:

Hot Fix. While adding additional device, credentials are not set and passes None to device api.


**Related issue (if applicable):** fixes #22299

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
