### PR TITLE
Fix for embedded MQTT server configuration

### DIFF
--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -40,12 +40,12 @@ def async_start(hass, password, server_config):
     from hbmqtt.broker import Broker, BrokerException
 
     passwd = tempfile.NamedTemporaryFile()
+
+    gen_server_config, client_config = generate_config(hass, passwd, password)
+
     try:
         if server_config is None:
-            server_config, client_config = generate_config(
-                hass, passwd, password)
-        else:
-            client_config = None
+            server_config = gen_server_config
 
         broker = Broker(server_config, hass.loop)
         yield from broker.start()


### PR DESCRIPTION
## Description:

Passing in a configuration for the embedded MQTT server has been broken for a while. This fixes that. See related issue number for further details.

**Related issue (if applicable):** fixes #18228

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
