### PR TITLE
Switch from using Google Maps API for elevation to Open Elevation API

### DIFF
--- a/homeassistant/util/location.py
+++ b/homeassistant/util/location.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Tuple, Dict
 
 import requests
 
-ELEVATION_URL = 'http://maps.googleapis.com/maps/api/elevation/json'
+ELEVATION_URL = 'https://api.open-elevation.com/api/v1/lookup'
 IP_API = 'http://ip-api.com/json'
 IPAPI = 'https://ipapi.co/json/'
 
@@ -70,7 +70,6 @@ def elevation(latitude: float, longitude: float) -> int:
             ELEVATION_URL,
             params={
                 'locations': '{},{}'.format(latitude, longitude),
-                'sensor': 'false',
             },
             timeout=10)
     except requests.RequestException:


### PR DESCRIPTION
## Description:

Switches elevation helper to use [Open Elevation](https://open-elevation.com/) instead of Google Maps API which now requires a API key. It's a drop in replacement for Google Maps too!

**Related issue (if applicable):** fixes #19860

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
