### PR TITLE
Remove occupancy from NMBS sensor as it is not available in the iRail API

### DIFF
--- a/homeassistant/components/nmbs/sensor.py
+++ b/homeassistant/components/nmbs/sensor.py
@@ -124,7 +124,6 @@ class NMBSLiveBoard(Entity):
         attrs = {
             'departure': "In {} minutes".format(departure),
             'extra_train': int(self._attrs['isExtra']) > 0,
-            'occupancy': self._attrs['occupancy']['name'],
             'vehicle_id': self._attrs['vehicle'],
             'monitored_station': self._station,
             ATTR_ATTRIBUTION: "https://api.irail.be/",


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** #21810 #20744 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
