### PR TITLE
Bootstrap to start registry loading early

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -1,4 +1,5 @@
 """Provide methods to bootstrap a Home Assistant instance."""
+import asyncio
 import logging
 import logging.handlers
 import os
@@ -156,6 +157,12 @@ async def async_from_config_dict(config: Dict[str, Any],
                 async_setup_component(hass, component, config))
 
     await hass.async_block_till_done()
+
+    # Kick off loading the registries. They don't need to be awaited.
+    asyncio.gather(
+        hass.helpers.device_registry.async_get_registry(),
+        hass.helpers.entity_registry.async_get_registry(),
+        hass.helpers.area_registry.async_get_registry())
 
     # stage 1
     for component in components:

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -1,6 +1,7 @@
 """Provide a way to connect devices to one physical location."""
 import logging
 import uuid
+from asyncio import Event
 from collections import OrderedDict
 from typing import MutableMapping  # noqa: F401
 from typing import Iterable, Optional, cast
@@ -9,6 +10,7 @@ import attr
 
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
+
 from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
@@ -133,14 +135,23 @@ class AreaRegistry:
 @bind_hass
 async def async_get_registry(hass: HomeAssistantType) -> AreaRegistry:
     """Return area registry instance."""
-    task = hass.data.get(DATA_REGISTRY)
+    reg_or_evt = hass.data.get(DATA_REGISTRY)
 
-    if task is None:
-        async def _load_reg() -> AreaRegistry:
-            registry = AreaRegistry(hass)
-            await registry.async_load()
-            return registry
+    if not reg_or_evt:
+        evt = hass.data[DATA_REGISTRY] = Event()
 
-        task = hass.data[DATA_REGISTRY] = hass.async_create_task(_load_reg())
+        reg = AreaRegistry(hass)
+        await reg.async_load()
 
-    return cast(AreaRegistry, await task)
+        hass.data[DATA_REGISTRY] = reg
+        evt.set()
+        return reg
+
+    if isinstance(reg_or_evt, Event):
+        # This shouldn't be possible in production (has been tested)
+        # It's here soley for testing purposes.
+        evt = reg_or_evt
+        await evt.wait()
+        return cast(AreaRegistry, hass.data.get(DATA_REGISTRY))
+
+    return cast(AreaRegistry, reg_or_evt)

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -148,8 +148,6 @@ async def async_get_registry(hass: HomeAssistantType) -> AreaRegistry:
         return reg
 
     if isinstance(reg_or_evt, Event):
-        # This shouldn't be possible in production (has been tested)
-        # It's here soley for testing purposes.
         evt = reg_or_evt
         await evt.wait()
         return cast(AreaRegistry, hass.data.get(DATA_REGISTRY))

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -290,8 +290,6 @@ async def async_get_registry(hass: HomeAssistantType) -> DeviceRegistry:
         return reg
 
     if isinstance(reg_or_evt, Event):
-        # This shouldn't be possible in production (has been tested)
-        # It's here soley for testing purposes.
         evt = reg_or_evt
         await evt.wait()
         return cast(DeviceRegistry, hass.data.get(DATA_REGISTRY))

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1,14 +1,16 @@
 """Provide a way to connect entities belonging to one device."""
 import logging
 import uuid
-from typing import List, Optional
-
+from asyncio import Event
 from collections import OrderedDict
+from typing import List, Optional, cast
 
 import attr
 
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
+
+from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 _UNDEF = object()
@@ -273,19 +275,28 @@ class DeviceRegistry:
 
 
 @bind_hass
-async def async_get_registry(hass) -> DeviceRegistry:
+async def async_get_registry(hass: HomeAssistantType) -> DeviceRegistry:
     """Return device registry instance."""
-    task = hass.data.get(DATA_REGISTRY)
+    reg_or_evt = hass.data.get(DATA_REGISTRY)
 
-    if task is None:
-        async def _load_reg():
-            registry = DeviceRegistry(hass)
-            await registry.async_load()
-            return registry
+    if not reg_or_evt:
+        evt = hass.data[DATA_REGISTRY] = Event()
 
-        task = hass.data[DATA_REGISTRY] = hass.async_create_task(_load_reg())
+        reg = DeviceRegistry(hass)
+        await reg.async_load()
 
-    return await task
+        hass.data[DATA_REGISTRY] = reg
+        evt.set()
+        return reg
+
+    if isinstance(reg_or_evt, Event):
+        # This shouldn't be possible in production (has been tested)
+        # It's here soley for testing purposes.
+        evt = reg_or_evt
+        await evt.wait()
+        return cast(DeviceRegistry, hass.data.get(DATA_REGISTRY))
+
+    return cast(DeviceRegistry, reg_or_evt)
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -7,10 +7,11 @@ The Entity Registry will persist itself 10 seconds after a new entity is
 registered. Registering a new entity while a timer is in progress resets the
 timer.
 """
+from asyncio import Event
 from collections import OrderedDict
 from itertools import chain
 import logging
-from typing import Optional, List
+from typing import List, Optional, cast
 import weakref
 
 import attr
@@ -19,6 +20,8 @@ from homeassistant.core import callback, split_entity_id, valid_entity_id
 from homeassistant.loader import bind_hass
 from homeassistant.util import ensure_unique_string, slugify
 from homeassistant.util.yaml import load_yaml
+
+from .typing import HomeAssistantType
 
 PATH_REGISTRY = 'entity_registry.yaml'
 DATA_REGISTRY = 'entity_registry'
@@ -277,19 +280,28 @@ class EntityRegistry:
 
 
 @bind_hass
-async def async_get_registry(hass) -> EntityRegistry:
+async def async_get_registry(hass: HomeAssistantType) -> EntityRegistry:
     """Return entity registry instance."""
-    task = hass.data.get(DATA_REGISTRY)
+    reg_or_evt = hass.data.get(DATA_REGISTRY)
 
-    if task is None:
-        async def _load_reg():
-            registry = EntityRegistry(hass)
-            await registry.async_load()
-            return registry
+    if not reg_or_evt:
+        evt = hass.data[DATA_REGISTRY] = Event()
 
-        task = hass.data[DATA_REGISTRY] = hass.async_create_task(_load_reg())
+        reg = EntityRegistry(hass)
+        await reg.async_load()
 
-    return await task
+        hass.data[DATA_REGISTRY] = reg
+        evt.set()
+        return reg
+
+    if isinstance(reg_or_evt, Event):
+        # This shouldn't be possible in production (has been tested)
+        # It's here soley for testing purposes.
+        evt = reg_or_evt
+        await evt.wait()
+        return cast(EntityRegistry, hass.data.get(DATA_REGISTRY))
+
+    return cast(EntityRegistry, reg_or_evt)
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -295,8 +295,6 @@ async def async_get_registry(hass: HomeAssistantType) -> EntityRegistry:
         return reg
 
     if isinstance(reg_or_evt, Event):
-        # This shouldn't be possible in production (has been tested)
-        # It's here soley for testing purposes.
         evt = reg_or_evt
         await evt.wait()
         return cast(EntityRegistry, hass.data.get(DATA_REGISTRY))

--- a/tests/common.py
+++ b/tests/common.py
@@ -327,11 +327,7 @@ def mock_registry(hass, mock_entries=None):
     registry = entity_registry.EntityRegistry(hass)
     registry.entities = mock_entries or OrderedDict()
 
-    async def _get_reg():
-        return registry
-
-    hass.data[entity_registry.DATA_REGISTRY] = \
-        hass.loop.create_task(_get_reg())
+    hass.data[entity_registry.DATA_REGISTRY] = registry
     return registry
 
 
@@ -340,11 +336,7 @@ def mock_area_registry(hass, mock_entries=None):
     registry = area_registry.AreaRegistry(hass)
     registry.areas = mock_entries or OrderedDict()
 
-    async def _get_reg():
-        return registry
-
-    hass.data[area_registry.DATA_REGISTRY] = \
-        hass.loop.create_task(_get_reg())
+    hass.data[area_registry.DATA_REGISTRY] = registry
     return registry
 
 
@@ -353,11 +345,7 @@ def mock_device_registry(hass, mock_entries=None):
     registry = device_registry.DeviceRegistry(hass)
     registry.devices = mock_entries or OrderedDict()
 
-    async def _get_reg():
-        return registry
-
-    hass.data[device_registry.DATA_REGISTRY] = \
-        hass.loop.create_task(_get_reg())
+    hass.data[device_registry.DATA_REGISTRY] = registry
     return registry
 
 


### PR DESCRIPTION
## Description:

Kick off loading the device / area / entity registries early in the bootstrap process to allow disk IO to occur while waiting for other stuff to load. 

Also cleans up registry lookup code to avoid overhead in creating tasks.

@balloob we were talking about this in discord a little while ago.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
