### PR TITLE
Give HomeKit locks better names by default

### DIFF
--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -41,7 +41,6 @@ class HomeKitLock(HomeKitEntity, LockDevice):
         """Initialise the Lock."""
         super().__init__(accessory, discovery_info)
         self._state = None
-        self._name = discovery_info['model']
         self._battery_level = None
 
     def get_characteristic_types(self):
@@ -59,11 +58,6 @@ class HomeKitLock(HomeKitEntity, LockDevice):
 
     def _update_battery_level(self, value):
         self._battery_level = value
-
-    @property
-    def name(self):
-        """Return the name of this device."""
-        return self._name
 
     @property
     def is_locked(self):


### PR DESCRIPTION
## Description:

This is a follow up to #22171. There we set the name of an entity based on the `accessory-information` homekit service, rather than using the zeroconf/avahi name metadata. Unfortunately Lock also sets its name from zeroconf directly, rather than picking it up from the base class. This test updates it to be like the other homekit entities and use the base class.

(This is from my ongoing homekit_controller configentry branch).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.