### PR TITLE
FamilyHub Camera import fix

### DIFF
--- a/homeassistant/components/familyhub/camera.py
+++ b/homeassistant/components/familyhub/camera.py
@@ -8,8 +8,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.camera import Camera
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv


### PR DESCRIPTION
## Description:

PLATFORM_SCHEMA was being accessed from sensor instead of camera in this camera platform.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
