### PR TITLE
Prefer TCP for RTSP streams

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -44,6 +44,11 @@ def request_stream(hass, stream_source, *, fmt='hls',
     if options is None:
         options = {}
 
+    # For RTSP streams, prefer TCP
+    if isinstance(stream_source, str) \
+            and stream_source[:7] == 'rtsp://' and not options:
+        options['rtsp_flags'] = 'prefer_tcp'
+
     try:
         streams = hass.data[DOMAIN][ATTR_STREAMS]
         stream = streams.get(stream_source)


### PR DESCRIPTION
## Description:

For RTSP streams, set the `prefer_tcp` FFMPEG flag.  This should resolve some of the "green feed" issues that some users are reporting, likely due to packets being lost over UDP on their network.

Resources: [FFMPEG protocols documentation](https://ffmpeg.org/ffmpeg-protocols.html#rtsp)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.