### PR TITLE
show which component is causing translation errors

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -62,7 +62,7 @@ def component_translation_file(hass: HomeAssistantType, component: str,
     # It's a platform
     parts = component.split('.', 1)
     module = get_platform(hass, *parts)
-    assert module is not None
+    assert module is not None, component
 
     # Either within HA or custom_components
     # Either light/hue.py or hue/light.py


### PR DESCRIPTION
## Description:

This PR adds extra info to errors when translations fail to load for a component

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/21579#issuecomment-475925525

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
