### PR TITLE
Add LCN binary sensor component

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -4,19 +4,19 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_ADDRESS, CONF_COVERS, CONF_HOST, CONF_LIGHTS, CONF_NAME,
-    CONF_PASSWORD, CONF_PORT, CONF_SENSORS, CONF_SWITCHES,
+    CONF_ADDRESS, CONF_BINARY_SENSORS, CONF_COVERS, CONF_HOST, CONF_LIGHTS,
+    CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_SENSORS, CONF_SWITCHES,
     CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
 
 from .const import (
-    CONF_CONNECTIONS, CONF_DIM_MODE, CONF_DIMMABLE, CONF_MOTOR, CONF_OUTPUT,
-    CONF_SK_NUM_TRIES, CONF_SOURCE, CONF_TRANSITION, DATA_LCN, DEFAULT_NAME,
-    DIM_MODES, DOMAIN, LED_PORTS, LOGICOP_PORTS, MOTOR_PORTS, OUTPUT_PORTS,
-    PATTERN_ADDRESS, RELAY_PORTS, S0_INPUTS, SETPOINTS, THRESHOLDS, VAR_UNITS,
-    VARIABLES)
+    BINSENSOR_PORTS, CONF_CONNECTIONS, CONF_DIM_MODE, CONF_DIMMABLE,
+    CONF_MOTOR, CONF_OUTPUT, CONF_SK_NUM_TRIES, CONF_SOURCE, CONF_TRANSITION,
+    DATA_LCN, DEFAULT_NAME, DIM_MODES, DOMAIN, KEYS, LED_PORTS, LOGICOP_PORTS,
+    MOTOR_PORTS, OUTPUT_PORTS, PATTERN_ADDRESS, RELAY_PORTS, S0_INPUTS,
+    SETPOINTS, THRESHOLDS, VAR_UNITS, VARIABLES)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,6 +64,13 @@ def is_address(value):
         return addr, conn_id
     raise vol.error.Invalid('Not a valid address string.')
 
+
+BINARY_SENSORS_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_ADDRESS): is_address,
+    vol.Required(CONF_SOURCE): vol.All(vol.Upper, vol.In(SETPOINTS + KEYS +
+                                                         BINSENSOR_PORTS))
+    })
 
 COVERS_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
@@ -115,6 +122,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_CONNECTIONS): vol.All(
             cv.ensure_list, has_unique_connection_names, [CONNECTION_SCHEMA]),
+        vol.Optional(CONF_BINARY_SENSORS): vol.All(
+            cv.ensure_list, [BINARY_SENSORS_SCHEMA]),
         vol.Optional(CONF_COVERS): vol.All(
             cv.ensure_list, [COVERS_SCHEMA]),
         vol.Optional(CONF_LIGHTS): vol.All(
@@ -177,7 +186,8 @@ async def async_setup(hass, config):
     hass.data[DATA_LCN][CONF_CONNECTIONS] = connections
 
     # load platforms
-    for component, conf_key in (('cover', CONF_COVERS),
+    for component, conf_key in (('binary_sensor', CONF_BINARY_SENSORS),
+                                ('cover', CONF_COVERS),
                                 ('light', CONF_LIGHTS),
                                 ('sensor', CONF_SENSORS),
                                 ('switch', CONF_SWITCHES)):

--- a/homeassistant/components/lcn/binary_sensor.py
+++ b/homeassistant/components/lcn/binary_sensor.py
@@ -1,0 +1,139 @@
+"""Support for LCN binary sensors."""
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import CONF_ADDRESS
+
+from . import LcnDevice, get_connection
+from .const import (
+    BINSENSOR_PORTS, CONF_CONNECTIONS, CONF_SOURCE, DATA_LCN, SETPOINTS)
+
+DEPENDENCIES = ['lcn']
+
+
+async def async_setup_platform(hass, hass_config, async_add_entities,
+                               discovery_info=None):
+    """Set up the LCN binary sensor platform."""
+    if discovery_info is None:
+        return
+
+    import pypck
+
+    devices = []
+    for config in discovery_info:
+        address, connection_id = config[CONF_ADDRESS]
+        addr = pypck.lcn_addr.LcnAddr(*address)
+        connections = hass.data[DATA_LCN][CONF_CONNECTIONS]
+        connection = get_connection(connections, connection_id)
+        address_connection = connection.get_address_conn(addr)
+
+        if config[CONF_SOURCE] in SETPOINTS:
+            device = LcnRegulatorLockSensor(config, address_connection)
+        elif config[CONF_SOURCE] in BINSENSOR_PORTS:
+            device = LcnBinarySensor(config, address_connection)
+        else:  # in KEYS
+            device = LcnLockKeysSensor(config, address_connection)
+
+        devices.append(device)
+
+    async_add_entities(devices)
+
+
+class LcnRegulatorLockSensor(LcnDevice, BinarySensorDevice):
+    """Representation of a LCN binary sensor for regulator locks."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN binary sensor."""
+        super().__init__(config, address_connection)
+
+        self.setpoint_variable = \
+            self.pypck.lcn_defs.Var[config[CONF_SOURCE]]
+
+        self._value = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.setpoint_variable))
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._value
+
+    def input_received(self, input_obj):
+        """Set sensor value when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusVar) or \
+                input_obj.get_var() != self.setpoint_variable:
+            return
+
+        self._value = input_obj.get_value().is_locked_regulator()
+        self.async_schedule_update_ha_state()
+
+
+class LcnBinarySensor(LcnDevice, BinarySensorDevice):
+    """Representation of a LCN binary sensor for binary sensor ports."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN binary sensor."""
+        super().__init__(config, address_connection)
+
+        self.bin_sensor_port = \
+            self.pypck.lcn_defs.BinSensorPort[config[CONF_SOURCE]]
+
+        self._value = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.bin_sensor_port))
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._value
+
+    def input_received(self, input_obj):
+        """Set sensor value when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusBinSensors):
+            return
+
+        self._value = input_obj.get_state(self.bin_sensor_port.value)
+        self.async_schedule_update_ha_state()
+
+
+class LcnLockKeysSensor(LcnDevice, BinarySensorDevice):
+    """Representation of a LCN sensor for key locks."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN sensor."""
+        super().__init__(config, address_connection)
+
+        self.source = self.pypck.lcn_defs.Key[config[CONF_SOURCE]]
+        self._value = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.source))
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._value
+
+    def input_received(self, input_obj):
+        """Set sensor value when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusKeyLocks) or \
+                self.source not in self.pypck.lcn_defs.Key:
+            return
+
+        table_id = ord(self.source.name[0]) - 65
+        key_id = int(self.source.name[1]) - 1
+
+        self._value = input_obj.get_state(table_id, key_id)
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Constants for the LCN component."""
+from itertools import product
 import re
 
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
@@ -36,6 +37,12 @@ LED_PORTS = ['LED1', 'LED2', 'LED3', 'LED4', 'LED5', 'LED6',
              'LED7', 'LED8', 'LED9', 'LED10', 'LED11', 'LED12']
 
 LOGICOP_PORTS = ['LOGICOP1', 'LOGICOP2', 'LOGICOP3', 'LOGICOP4']
+
+BINSENSOR_PORTS = ['BINSENSOR1', 'BINSENSOR2', 'BINSENSOR3', 'BINSENSOR4',
+                   'BINSENSOR5', 'BINSENSOR6', 'BINSENSOR7', 'BINSENSOR8']
+
+KEYS = ['{:s}{:d}'.format(t[0], t[1]) for t in product(['A', 'B', 'C', 'D'],
+                                                       range(1, 9))]
 
 VARIABLES = ['VAR1ORTVAR', 'VAR2ORR1VAR', 'VAR3ORR2VAR',
              'TVAR', 'R1VAR', 'R2VAR',


### PR DESCRIPTION
## Description:
This adds the LCN binary sensor platform. It provides functionality to monitor various LCN hardware boolean states. With proper configured hardware modules/sensors it is possible to monitor binary hardware sensors and several lock states.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9010

## Example entry for `configuration.yaml` (if applicable):
```yaml
lcn:
  connections:
    - name: myhome
      host: 192.168.2.41
      port: 4114
      username: !secret lcn_username
      password: !secret lcn_password

  binary_sensors:
    - name: Kitchen window
      address: myhome.s0.m7
      source: binsensor1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
