### PR TITLE
Do not warn when creating an empty database

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -19,6 +19,11 @@ def migrate_schema(instance):
             SchemaChanges.change_id.desc()).first()
         current_version = getattr(res, 'schema_version', None)
 
+        if current_version is None:
+            current_version = _inspect_schema_version(instance.engine, session)
+            _LOGGER.debug("No schema version found. Inspected version: %s",
+                          current_version)
+
         if current_version == SCHEMA_VERSION:
             # Clean up if old migration left file
             if os.path.isfile(progress_path):
@@ -31,11 +36,6 @@ def migrate_schema(instance):
 
         _LOGGER.warning("Database is about to upgrade. Schema version: %s",
                         current_version)
-
-        if current_version is None:
-            current_version = _inspect_schema_version(instance.engine, session)
-            _LOGGER.debug("No schema version found. Inspected version: %s",
-                          current_version)
 
         try:
             for version in range(current_version, SCHEMA_VERSION):


### PR DESCRIPTION
## Description:

This is to avoid the following warning when creating a new database:
```
Database is about to upgrade. Schema version: None
```

The issue is that `_inspect_schema_version()` will decide between a new database with the correct schema version and a very old database with no version. However, that decision was made _after_ the warning is printed.

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
