### PR TITLE
Add traccar events

### DIFF
--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -147,7 +147,7 @@ class TraccarScanner:
                 attr[ATTR_TRACCAR_ID] = device['traccar_id']
             for custom_attr in self._custom_attributes:
                 if device.get(custom_attr) is not None:
-                    attr[custom_attr] = device[custom_attr] 
+                    attr[custom_attr] = device[custom_attr]
             await self._async_see(
                 dev_id=slugify(device['device_id']),
                 gps=(device.get('latitude'), device.get('longitude')),
@@ -158,15 +158,14 @@ class TraccarScanner:
         device_ids = [device['id'] for device in self._api.devices]
         end_interval = datetime.utcnow()
         start_interval = end_interval - self._scan_interval
-        events = await self._api.get_events(device_ids=device_ids, 
+        events = await self._api.get_events(device_ids=device_ids,
                                             from_time=start_interval,
                                             to_time=end_interval,
                                             event_types=self._event_types)
         if events is not None:
             for event in events:
-                device_name = list(filter(lambda dev: dev.get('id') == event['deviceId'], 
-                                          self._api._devices)
-                                  )[0].get('name')
+                device_name = list(filter(lambda dev: dev.get(
+                    'id') == event['deviceId'], self._api._devices))[0].get('name')
                 self._hass.bus.fire('traccar_' + event["type"], {
                     'device_traccar_id': event['deviceId'],
                     'device_name': device_name,

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -169,10 +169,11 @@ class TraccarScanner:
         device_ids = [device['id'] for device in self._api.devices]
         end_interval = datetime.utcnow()
         start_interval = end_interval - self._scan_interval
-        events = await self._api.get_events(device_ids=device_ids,
-                                            from_time=start_interval,
-                                            to_time=end_interval,
-                                            event_types=self._event_types.keys())
+        events = await self._api.get_events(
+            device_ids=device_ids,
+            from_time=start_interval,
+            to_time=end_interval,
+            event_types=self._event_types.keys())
         if events is not None:
             for event in events:
                 try:

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -174,8 +174,10 @@ class TraccarScanner:
                                             event_types=self._event_types)
         if events is not None:
             for event in events:
-                device_name = list(filter(lambda dev: dev.get(
-                    'id') == event['deviceId'], self._api._devices))[0].get('name')
+                device_name = list(filter(lambda dev:
+                                          dev.get('id') == event['deviceId'],
+                                          self._api._devices)
+                                   )[0].get('name')
                 self._hass.bus.fire('traccar_' + event["type"], {
                     'device_traccar_id': event['deviceId'],
                     'device_name': device_name,

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -176,12 +176,9 @@ class TraccarScanner:
             event_types=self._event_types.keys())
         if events is not None:
             for event in events:
-                try:
-                    device_name = next((
-                        dev.get('name') for dev in self._api._devices
-                        if dev.get('id') == event['deviceId']))
-                except StopIteration:
-                    device_name = None
+                device_name = next((
+                    dev.get('name') for dev in self._api.devices()
+                    if dev.get('id') == event['deviceId']), None)
                 self._hass.bus.async_fire(
                     'traccar_' + self._event_types.get(event["type"]), {
                         'device_traccar_id': event['deviceId'],

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -64,16 +64,24 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_CONDITIONS,
                  default=[]): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_EVENT,
-                 default=[]): vol.All(cv.ensure_list, 
-                 [vol.Any(EVENT_DEVICE_MOVING, EVENT_COMMAND_RESULT,
-                          EVENT_DEVICE_FUEL_DROP, EVENT_GEOFENCE_ENTER,
-                          EVENT_DEVICE_OFFLINE, EVENT_DRIVER_CHANGED,
-                          EVENT_GEOFENCE_EXIT, EVENT_DEVICE_OVERSPEED,
-                          EVENT_DEVICE_ONLINE, EVENT_DEVICE_STOPPED,
-                          EVENT_MAINTENANCE, EVENT_ALARM,
-                          EVENT_TEXT_MESSAGE, EVENT_DEVICE_UNKNOWN,
-                          EVENT_IGNITION_OFF, EVENT_IGNITION_ON,
-                          EVENT_ALL_EVENTS)]),
+                 default=[]): vol.All(cv.ensure_list,
+                                      [vol.Any(EVENT_DEVICE_MOVING,
+                                               EVENT_COMMAND_RESULT,
+                                               EVENT_DEVICE_FUEL_DROP,
+                                               EVENT_GEOFENCE_ENTER,
+                                               EVENT_DEVICE_OFFLINE,
+                                               EVENT_DRIVER_CHANGED,
+                                               EVENT_GEOFENCE_EXIT,
+                                               EVENT_DEVICE_OVERSPEED,
+                                               EVENT_DEVICE_ONLINE,
+                                               EVENT_DEVICE_STOPPED,
+                                               EVENT_MAINTENANCE,
+                                               EVENT_ALARM,
+                                               EVENT_TEXT_MESSAGE,
+                                               EVENT_DEVICE_UNKNOWN,
+                                               EVENT_IGNITION_OFF,
+                                               EVENT_IGNITION_ON,
+                                               EVENT_ALL_EVENTS)]),
 })
 
 
@@ -97,7 +105,9 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
 class TraccarScanner:
     """Define an object to retrieve Traccar data."""
 
-    def __init__(self, api, hass, async_see, scan_interval, custom_attributes, event_types):
+    def __init__(self, api, hass, async_see, scan_interval,
+                 custom_attributes,
+                 event_types):
         """Initialize."""
         self._event_types = event_types
         self._custom_attributes = custom_attributes

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1428,6 +1428,7 @@ pytouchline==0.7
 
 # homeassistant.components.traccar.device_tracker
 pytraccar==0.5.0
+stringcase==1.2.0
 
 # homeassistant.components.trackr.device_tracker
 pytrackr==0.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1427,7 +1427,7 @@ pytile==2.0.6
 pytouchline==0.7
 
 # homeassistant.components.traccar.device_tracker
-pytraccar==0.3.0
+pytraccar==0.5.0
 
 # homeassistant.components.trackr.device_tracker
 pytrackr==0.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1428,7 +1428,6 @@ pytouchline==0.7
 
 # homeassistant.components.traccar.device_tracker
 pytraccar==0.5.0
-stringcase==1.2.0
 
 # homeassistant.components.trackr.device_tracker
 pytrackr==0.0.5
@@ -1648,6 +1647,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.thermoworks_smoke.sensor
+# homeassistant.components.traccar.device_tracker
 stringcase==1.2.0
 
 # homeassistant.components.ecovacs


### PR DESCRIPTION
## Description:

I isolated the code that imports traccar's tracking data and added a new function that imports traccar's events (and subsequently fires them in Home Assistant) to make them run in parallel and reduce delay. The events that are imported in Home Assistant, are fired with the prefix "traccar_". Furthermore a traccar_id is now imported in the Home Assistant entities, useful for matching the traccar entities with the traccar events in the most accurate way.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9035
## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
   - platform: traccar
     host: 127.0.0.1
     port: 8072
     username: admin
     password: !secret traccar_password
     event: ['alarm']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
