### PR TITLE
Fix TpLink Device Tracker initialize error

### DIFF
--- a/homeassistant/components/tplink/device_tracker.py
+++ b/homeassistant/components/tplink/device_tracker.py
@@ -77,8 +77,8 @@ class TplinkDeviceScanner(DeviceScanner):
             self.last_results = {}
 
             self.success_init = self._update_info()
-        except requests.exceptions.ConnectionError:
-            _LOGGER.debug("ConnectionError in TplinkDeviceScanner")
+        except requests.exceptions.RequestException:
+            _LOGGER.debug("RequestException in %s", __class__.__name__)
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
@@ -123,8 +123,8 @@ class Tplink1DeviceScanner(DeviceScanner):
         self.success_init = False
         try:
             self.success_init = self._update_info()
-        except requests.exceptions.ConnectionError:
-            _LOGGER.debug("ConnectionError in Tplink1DeviceScanner")
+        except requests.exceptions.RequestException:
+            _LOGGER.debug("RequestException in %s", __class__.__name__)
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""


### PR DESCRIPTION
## Description:
I have a TP-Link EAP245 AP and HA configured to use TpLink platform for device tracking.   
On OrangePi with Armbian everything works fine. 
On Intel architecture (Docker Ubuntu 18.04LTS server) with the same config I've got an error: "requests.exceptions.ChunkedEncodingError: ("Connection broken: ... 'Connection reset by peer'...)" similar like in #13991 .
This happend in block "try ... except ConnectionException" so it should be replaced with "RequestException".

**Related issue (if applicable):** fixes #13991, #9120


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

