### PR TITLE
Warn user about HTML5 GCM deprecation

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -58,6 +58,7 @@ def gcm_api_deprecated(value):
         " see https://www.home-assistant.io/components/notify.html5/")
     return value
 
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(ATTR_GCM_SENDER_ID):
         vol.All(cv.string, gcm_api_deprecated),

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -52,7 +52,7 @@ def gcm_api_deprecated(value):
         return value
 
     _LOGGER.warning(
-        "Configuring hmtl5_push_notifications via the GCM api"
+        "Configuring html5_push_notifications via the GCM api"
         " has been deprecated and will stop working after April 11,"
         " 2019. Use the VAPID configuration instead. For instructions,"
         " see https://www.home-assistant.io/components/notify.html5/")

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -45,6 +45,7 @@ ATTR_VAPID_PUB_KEY = 'vapid_pub_key'
 ATTR_VAPID_PRV_KEY = 'vapid_prv_key'
 ATTR_VAPID_EMAIL = 'vapid_email'
 
+
 def gcm_api_deprecated(value):
     """Warn user that GCM API config is deprecated."""
     if not value:
@@ -58,7 +59,7 @@ def gcm_api_deprecated(value):
     return value
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(ATTR_GCM_SENDER_ID): 
+    vol.Optional(ATTR_GCM_SENDER_ID):
         vol.All(cv.string, gcm_api_deprecated),
     vol.Optional(ATTR_GCM_API_KEY): cv.string,
     vol.Optional(ATTR_VAPID_PUB_KEY): cv.string,

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -45,8 +45,21 @@ ATTR_VAPID_PUB_KEY = 'vapid_pub_key'
 ATTR_VAPID_PRV_KEY = 'vapid_prv_key'
 ATTR_VAPID_EMAIL = 'vapid_email'
 
+def gcm_api_deprecated(value):
+    """Warn user that GCM API config is deprecated."""
+    if not value:
+        return value
+
+    _LOGGER.warning(
+        "Configuring hmtl5_push_notifications via the GCM api"
+        " has been deprecated and will stop working after April 11,"
+        " 2019. Use the VAPID configuration instead. For instructions,"
+        " see https://www.home-assistant.io/components/notify.html5/")
+    return value
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(ATTR_GCM_SENDER_ID): cv.string,
+    vol.Optional(ATTR_GCM_SENDER_ID): 
+        vol.All(cv.string, gcm_api_deprecated),
     vol.Optional(ATTR_GCM_API_KEY): cv.string,
     vol.Optional(ATTR_VAPID_PUB_KEY): cv.string,
     vol.Optional(ATTR_VAPID_PRV_KEY): cv.string,


### PR DESCRIPTION
## Description:
> As of April 10, 2018, Google has deprecated GCM. The GCM server and client APIs are deprecated and will be removed as soon as **April 11, 2019**. Migrate GCM apps to Firebase Cloud Messaging (FCM), which inherits the reliable and scalable GCM infrastructure, plus many new features. See the migration guide to learn more.

This PR will print a warning to users still using the HTML5 push GCM configuration method that is going to be deprecated soon.

**Related issue (if applicable):** 
Continues the work started in https://github.com/home-assistant/home-assistant/pull/20415

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9019

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
