### PR TITLE
Add support for 'image' media type

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -17,6 +17,9 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_CHANNEL, MEDIA_TYPE_EPISODE, MEDIA_TYPE_IMAGE,
+    MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_PLAYLIST,
+    MEDIA_TYPE_TVSHOW, MEDIA_TYPE_VIDEO,
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK, SUPPORT_STOP,
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET)
@@ -51,20 +54,25 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 HOME_ASSISTANT_UPNP_CLASS_MAPPING = {
-    'music': 'object.item.audioItem',
-    'tvshow': 'object.item.videoItem',
-    'video': 'object.item.videoItem',
-    'episode': 'object.item.videoItem',
-    'channel': 'object.item.videoItem',
-    'playlist': 'object.item.playlist',
+    MEDIA_TYPE_MUSIC: 'object.item.audioItem',
+    MEDIA_TYPE_TVSHOW: 'object.item.videoItem',
+    MEDIA_TYPE_MOVIE: 'object.item.videoItem',
+    MEDIA_TYPE_VIDEO: 'object.item.videoItem',
+    MEDIA_TYPE_EPISODE: 'object.item.videoItem',
+    MEDIA_TYPE_CHANNEL: 'object.item.videoItem',
+    MEDIA_TYPE_IMAGE: 'object.item.imageItem',
+    MEDIA_TYPE_PLAYLIST: 'object.item.playlist',
 }
+UPNP_CLASS_DEFAULT = 'object.item'
 HOME_ASSISTANT_UPNP_MIME_TYPE_MAPPING = {
-    'music': 'audio/*',
-    'tvshow': 'video/*',
-    'video': 'video/*',
-    'episode': 'video/*',
-    'channel': 'video/*',
-    'playlist': 'playlist/*',
+    MEDIA_TYPE_MUSIC: 'audio/*',
+    MEDIA_TYPE_TVSHOW: 'video/*',
+    MEDIA_TYPE_MOVIE: 'video/*',
+    MEDIA_TYPE_VIDEO: 'video/*',
+    MEDIA_TYPE_EPISODE: 'video/*',
+    MEDIA_TYPE_CHANNEL: 'video/*',
+    MEDIA_TYPE_IMAGE: 'image/*',
+    MEDIA_TYPE_PLAYLIST: 'playlist/*',
 }
 
 
@@ -319,8 +327,10 @@ class DlnaDmrDevice(MediaPlayerDevice):
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
         title = "Home Assistant"
-        mime_type = HOME_ASSISTANT_UPNP_MIME_TYPE_MAPPING[media_type]
-        upnp_class = HOME_ASSISTANT_UPNP_CLASS_MAPPING[media_type]
+        mime_type = HOME_ASSISTANT_UPNP_MIME_TYPE_MAPPING.get(media_type,
+                                                              media_type)
+        upnp_class = HOME_ASSISTANT_UPNP_CLASS_MAPPING.get(media_type,
+                                                           UPNP_CLASS_DEFAULT)
 
         # Stop current playing media
         if self._device.can_stop:

--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -36,6 +36,7 @@ MEDIA_TYPE_VIDEO = 'video'
 MEDIA_TYPE_EPISODE = 'episode'
 MEDIA_TYPE_CHANNEL = 'channel'
 MEDIA_TYPE_PLAYLIST = 'playlist'
+MEDIA_TYPE_IMAGE = 'image'
 MEDIA_TYPE_URL = 'url'
 
 SERVICE_CLEAR_PLAYLIST = 'clear_playlist'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -131,7 +131,7 @@ play_media:
       description: The ID of the content to play. Platform dependent.
       example: 'https://home-assistant.io/images/cast/splash.png'
     media_content_type:
-      description: The type of the content to play. Must be one of music, tvshow, video, episode, channel or playlist
+      description: The type of the content to play. Must be one of image, music, tvshow, video, episode, channel or playlist
       example: 'music'
 
 select_source:


### PR DESCRIPTION
## Breaking Change:

This pull request adds a new media type: image.
I doubt this directly impacts other media_players, but other media_player platforms might need to add support for it.

## Description:

Add support for `image` media type.

**Related issue (if applicable):** fixes https://github.com/StevenLooman/async_upnp_client/issues/35

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
