### PR TITLE
Allow for custom turn on/off commands

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -40,6 +40,8 @@ CONF_ADB_SERVER_IP = 'adb_server_ip'
 CONF_ADB_SERVER_PORT = 'adb_server_port'
 CONF_APPS = 'apps'
 CONF_GET_SOURCES = 'get_sources'
+CONF_TURN_ON_COMMAND = 'turn_on_command'
+CONF_TURN_OFF_COMMAND = 'turn_off_command'
 
 DEFAULT_NAME = 'Android TV'
 DEFAULT_PORT = 5555
@@ -79,7 +81,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.port,
     vol.Optional(CONF_GET_SOURCES, default=DEFAULT_GET_SOURCES): cv.boolean,
     vol.Optional(CONF_APPS, default=dict()):
-        vol.Schema({cv.string: cv.string})
+        vol.Schema({cv.string: cv.string}),
+    vol.Optional(CONF_TURN_ON_COMMAND): cv.string,
+    vol.Optional(CONF_TURN_OFF_COMMAND): cv.string
 })
 
 # Translate from `AndroidTV` / `FireTV` reported state to HA state.
@@ -136,12 +140,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     else:
         if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
             device = AndroidTVDevice(aftv, config[CONF_NAME],
-                                     config[CONF_APPS])
+                                     config[CONF_APPS],
+                                     config.get(CONF_TURN_ON_COMMAND),
+                                     config.get(CONF_TURN_OFF_COMMAND))
             device_name = config[CONF_NAME] if CONF_NAME in config \
                 else 'Android TV'
         else:
             device = FireTVDevice(aftv, config[CONF_NAME], config[CONF_APPS],
-                                  config[CONF_GET_SOURCES])
+                                  config[CONF_GET_SOURCES],
+                                  config.get(CONF_TURN_ON_COMMAND),
+                                  config.get(CONF_TURN_OFF_COMMAND))
             device_name = config[CONF_NAME] if CONF_NAME in config \
                 else 'Fire TV'
 
@@ -199,7 +207,8 @@ def adb_decorator(override_available=False):
 class ADBDevice(MediaPlayerDevice):
     """Representation of an Android TV or Fire TV device."""
 
-    def __init__(self, aftv, name, apps):
+    def __init__(self, aftv, name, apps, turn_on_command,
+                 turn_off_command):
         """Initialize the Android TV / Fire TV device."""
         from androidtv.constants import APPS, KEYS
 
@@ -208,6 +217,9 @@ class ADBDevice(MediaPlayerDevice):
         self._apps = APPS
         self._apps.update(apps)
         self._keys = KEYS
+
+        self.turn_on_command = turn_on_command
+        self.turn_off_command = turn_off_command
 
         # ADB exceptions to catch
         if not self.aftv.adb_server_ip:
@@ -278,12 +290,18 @@ class ADBDevice(MediaPlayerDevice):
     @adb_decorator()
     def turn_on(self):
         """Turn on the device."""
-        self.aftv.turn_on()
+        if self.turn_on_command:
+            self.aftv.adb_shell(self.turn_on_command)
+        else:
+            self.aftv.turn_on()
 
     @adb_decorator()
     def turn_off(self):
         """Turn off the device."""
-        self.aftv.turn_off()
+        if self.turn_off_command:
+            self.aftv.adb_shell(self.turn_off_command)
+        else:
+            self.aftv.turn_off()
 
     @adb_decorator()
     def media_previous_track(self):
@@ -311,9 +329,11 @@ class ADBDevice(MediaPlayerDevice):
 class AndroidTVDevice(ADBDevice):
     """Representation of an Android TV device."""
 
-    def __init__(self, aftv, name, apps):
+    def __init__(self, aftv, name, apps, turn_on_command,
+                 turn_off_command):
         """Initialize the Android TV device."""
-        super().__init__(aftv, name, apps)
+        super().__init__(aftv, name, apps, turn_on_command,
+                         turn_off_command)
 
         self._device = None
         self._muted = None
@@ -392,9 +412,11 @@ class AndroidTVDevice(ADBDevice):
 class FireTVDevice(ADBDevice):
     """Representation of a Fire TV device."""
 
-    def __init__(self, aftv, name, apps, get_sources):
+    def __init__(self, aftv, name, apps, get_sources,
+                 turn_on_command, turn_off_command):
         """Initialize the Fire TV device."""
-        super().__init__(aftv, name, apps)
+        super().__init__(aftv, name, apps, turn_on_command,
+                         turn_off_command)
 
         self._get_sources = get_sources
         self._running_apps = None


### PR DESCRIPTION
## Description:

Different devices respond differently to commands such as power, sleep, etc. This allows a user to override the default turn on/off commands. 

**Related issue (if applicable):** fixes https://github.com/JeffLIrion/python-androidtv/issues/18

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9018

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  # Use an ADB server to setup an Android TV device, provide
  # an app name, and override the default turn on/off commands
  - platform: androidtv
    name: Android TV
    device_class: androidtv
    host: 192.168.0.222
    adb_server_ip: 127.0.0.1
    apps:
      com.amazon.tv.launcher: "Fire TV"
    turn_on_command: "input keyevent 3"
    turn_off_command: "input keyevent 223"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)