### PR TITLE
Fix Osram bulb with Hue bridge

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -10,7 +10,7 @@ import async_timeout
 from homeassistant.components import hue
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_FLASH, ATTR_HS_COLOR,
-    ATTR_TRANSITION, EFFECT_COLORLOOP, EFFECT_NONE, EFFECT_RANDOM, FLASH_LONG,
+    ATTR_TRANSITION, EFFECT_COLORLOOP, EFFECT_RANDOM, FLASH_LONG,
     FLASH_SHORT, SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT, SUPPORT_FLASH, SUPPORT_TRANSITION, Light)
 from homeassistant.util import color
@@ -379,8 +379,7 @@ class HueLight(Light):
         elif effect == EFFECT_RANDOM:
             command['hue'] = random.randrange(0, 65535)
             command['sat'] = random.randrange(150, 254)
-        elif (self.is_philips or self.is_osram) and \
-                (effect is None or effect == EFFECT_NONE):
+        else:
             command['effect'] = 'none'
 
         if self.is_group:

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -9,11 +9,10 @@ import async_timeout
 
 from homeassistant.components import hue
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_FLASH,
-    ATTR_TRANSITION, ATTR_HS_COLOR, EFFECT_COLORLOOP, EFFECT_RANDOM,
-    FLASH_LONG, FLASH_SHORT, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP,
-    SUPPORT_EFFECT, SUPPORT_FLASH, SUPPORT_COLOR, SUPPORT_TRANSITION,
-    Light)
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_FLASH, ATTR_HS_COLOR,
+    ATTR_TRANSITION, EFFECT_COLORLOOP, EFFECT_NONE, EFFECT_RANDOM, FLASH_LONG,
+    FLASH_SHORT, SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP,
+    SUPPORT_EFFECT, SUPPORT_FLASH, SUPPORT_TRANSITION, Light)
 from homeassistant.util import color
 
 DEPENDENCIES = ['hue']
@@ -314,7 +313,7 @@ class HueLight(Light):
     @property
     def effect_list(self):
         """Return the list of supported effects."""
-        return [EFFECT_COLORLOOP, EFFECT_RANDOM]
+        return [EFFECT_COLORLOOP, EFFECT_RANDOM, EFFECT_NONE]
 
     @property
     def device_info(self):
@@ -380,7 +379,8 @@ class HueLight(Light):
         elif effect == EFFECT_RANDOM:
             command['hue'] = random.randrange(0, 65535)
             command['sat'] = random.randrange(150, 254)
-        elif self.is_philips:
+        elif (self.is_philips or self.is_osram) and \
+                (effect is None or effect == EFFECT_NONE):
             command['effect'] = 'none'
 
         if self.is_group:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -75,6 +75,7 @@ ATTR_EFFECT = "effect"
 EFFECT_COLORLOOP = "colorloop"
 EFFECT_RANDOM = "random"
 EFFECT_WHITE = "white"
+EFFECT_NONE = "none"
 
 COLOR_GROUP = "Color descriptors"
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -75,7 +75,6 @@ ATTR_EFFECT = "effect"
 EFFECT_COLORLOOP = "colorloop"
 EFFECT_RANDOM = "random"
 EFFECT_WHITE = "white"
-EFFECT_NONE = "none"
 
 COLOR_GROUP = "Color descriptors"
 


### PR DESCRIPTION
## Description:
This PR adds the ability to remove an effect from a bulb.
This has not been possible before when using osram bulbs.

This PR adds a `none` to the dropdown list to deselect effects.

Other options might be to switch line 383 (hue/light.py) 
from
` elif self.is_philips:`
to
` elif self.is_philips or self.is_osram:`
or 
` else:`

I don't now why the previous code checks for is_philips,and i tried to preserve the existing behaviour.

Personally it would say that selecting `none` is a better  UX then switching off and on.




**Related issue (if applicable):** fixes #22356

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
