### PR TITLE
Fix the crash due to absence of the "default_home" in HomeData

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -315,6 +315,8 @@ class HomeData:
             self.home_id = self.homedata.gethomeId(self.home)
         except TypeError:
             _LOGGER.error("Error when getting home data.")
+        except AttributeError:
+            _LOGGER.error("No default_home in HomeData.")
         except pyatmo.NoDevice:
             _LOGGER.debug("No thermostat devices available.")
 


### PR DESCRIPTION
Fix the crash due to absence of the "default_home" in HomeData from pyatmo lib (netatmo/climate)

## Description:
Fix the crash in the situation there is no thermostat or valve device of Netatmo, where `default_home` attribute is missing in the HomeData returned by `pyatmo` library.

**Related issue (if applicable):** fixes #22273

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
