### PR TITLE
More homekit_controller clean up before config entry lands

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -11,8 +11,7 @@ from homeassistant.helpers.event import call_later
 
 from .connection import get_accessory_information
 from .const import (
-    CONTROLLER, DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, KNOWN_ACCESSORIES,
-    KNOWN_DEVICES
+    CONTROLLER, DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, KNOWN_DEVICES
 )
 
 
@@ -32,25 +31,6 @@ REQUEST_TIMEOUT = 5  # seconds
 RETRY_INTERVAL = 60  # seconds
 
 PAIRING_FILE = "pairing.json"
-
-
-def get_serial(accessory):
-    """Obtain the serial number of a HomeKit device."""
-    # pylint: disable=import-error
-    from homekit.model.services import ServicesTypes
-    from homekit.model.characteristics import CharacteristicsTypes
-
-    for service in accessory['services']:
-        if ServicesTypes.get_short(service['type']) != \
-           'accessory-information':
-            continue
-        for characteristic in service['characteristics']:
-            ctype = CharacteristicsTypes.get_short(
-                characteristic['type'])
-            if ctype != 'serial-number':
-                continue
-            return characteristic['value']
-    return None
 
 
 def escape_characteristic_name(char_name):
@@ -75,6 +55,10 @@ class HKDevice():
         self.config = config
         self.configurator = hass.components.configurator
         self._connection_warning_logged = False
+
+        # This just tracks aid/iid pairs so we know if a HK service has been
+        # mapped to a HA entity.
+        self.entities = []
 
         self.pairing_lock = asyncio.Lock(loop=hass.loop)
 
@@ -101,15 +85,16 @@ class HKDevice():
                 self.hass, RETRY_INTERVAL, lambda _: self.accessory_setup())
             return
         for accessory in data:
-            serial = get_serial(accessory)
-            if serial in self.hass.data[KNOWN_ACCESSORIES]:
-                continue
-            self.hass.data[KNOWN_ACCESSORIES][serial] = self
             aid = accessory['aid']
             for service in accessory['services']:
+                iid = service['iid']
+                if (aid, iid) in self.entities:
+                    # Don't add the same entity again
+                    continue
+
                 devtype = ServicesTypes.get_short(service['type'])
                 _LOGGER.debug("Found %s", devtype)
-                service_info = {'serial': serial,
+                service_info = {'serial': self.hkid,
                                 'aid': aid,
                                 'iid': service['iid'],
                                 'model': self.model,
@@ -382,7 +367,6 @@ def setup(hass, config):
         device = HKDevice(hass, host, port, model, hkid, config_num, config)
         hass.data[KNOWN_DEVICES][hkid] = device
 
-    hass.data[KNOWN_ACCESSORIES] = {}
     hass.data[KNOWN_DEVICES] = {}
     discovery.listen(hass, SERVICE_HOMEKIT, discovery_dispatch)
     return True

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -6,7 +6,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT, STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED)
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 DEPENDENCIES = ['homekit_controller']
 
@@ -34,7 +34,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Homekit Alarm Control Panel support."""
     if discovery_info is None:
         return
-    accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+    accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
     add_entities([HomeKitAlarmControlPanel(accessory, discovery_info)],
                  True)
 

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 DEPENDENCIES = ['homekit_controller']
 
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Homekit motion sensor support."""
     if discovery_info is not None:
-        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
         add_entities([HomeKitMotionSensor(accessory, discovery_info)], True)
 
 

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -7,7 +7,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, TEMP_CELSIUS
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 DEPENDENCIES = ['homekit_controller']
 
@@ -29,7 +29,7 @@ DEFAULT_VALID_MODES = list(MODE_HOMEKIT_TO_HASS)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Homekit climate."""
     if discovery_info is not None:
-        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
         add_entities([HomeKitClimateDevice(accessory, discovery_info)], True)
 
 

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -1,7 +1,6 @@
 """Constants for the homekit_controller component."""
 DOMAIN = 'homekit_controller'
 
-KNOWN_ACCESSORIES = "{}-accessories".format(DOMAIN)
 KNOWN_DEVICES = "{}-devices".format(DOMAIN)
 CONTROLLER = "{}-controller".format(DOMAIN)
 

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -8,7 +8,7 @@ from homeassistant.components.cover import (
 from homeassistant.const import (
     STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING)
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 STATE_STOPPED = 'stopped'
 
@@ -41,7 +41,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up HomeKit Cover support."""
     if discovery_info is None:
         return
-    accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+    accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
 
     if discovery_info['device-type'] == 'garage-door-opener':
         add_entities([HomeKitGarageDoorCover(accessory, discovery_info)],

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -5,7 +5,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR, SUPPORT_COLOR_TEMP, Light)
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 DEPENDENCIES = ['homekit_controller']
 
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Homekit lighting."""
     if discovery_info is not None:
-        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
         add_entities([HomeKitLight(accessory, discovery_info)], True)
 
 

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -5,7 +5,7 @@ from homeassistant.components.lock import LockDevice
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, STATE_LOCKED, STATE_UNLOCKED)
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 DEPENDENCIES = ['homekit_controller']
 
@@ -30,7 +30,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Homekit Lock support."""
     if discovery_info is None:
         return
-    accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+    accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
     add_entities([HomeKitLock(accessory, discovery_info)], True)
 
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -1,7 +1,7 @@
 """Support for Homekit sensors."""
 from homeassistant.const import TEMP_CELSIUS
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 DEPENDENCIES = ['homekit_controller']
 
@@ -16,7 +16,7 @@ UNIT_LUX = "lux"
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Homekit sensor support."""
     if discovery_info is not None:
-        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
         devtype = discovery_info['device-type']
 
         if devtype == 'humidity':

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.switch import SwitchDevice
 
-from . import KNOWN_ACCESSORIES, HomeKitEntity
+from . import KNOWN_DEVICES, HomeKitEntity
 
 DEPENDENCIES = ['homekit_controller']
 
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Homekit switch support."""
     if discovery_info is not None:
-        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        accessory = hass.data[KNOWN_DEVICES][discovery_info['serial']]
         add_entities([HomeKitSwitch(accessory, discovery_info)], True)
 
 


### PR DESCRIPTION
## Description:

I have been working on migrating homekit_controller to config entries for a while now, and it is just about done. But it's quite a large change set. Even when #22194 is finally merged my config entry branch is still quite large so i'm trying to send in multiple the smaller intermediary bits.

This removes `KNOWN_ACCESSORIES` and `get_serial` from the homekit_controller code which are no longer needed.

`KNOWN_ACCESSORIES` was only storing a reference to the same `HKDevice` object already stored in `KNOWN_DEVICES` - this just simplifies the code a bit to not need both. When `KNOWN_ACCESSORIES` is gone, nothing uses `get_serial` any more.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.