### PR TITLE
Set Onkyo reset log to debug instead of info

### DIFF
--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -179,7 +179,7 @@ class OnkyoDevice(MediaPlayerDevice):
         except (ValueError, OSError, AttributeError, AssertionError):
             if self._receiver.command_socket:
                 self._receiver.command_socket = None
-                _LOGGER.info("Resetting connection to %s", self._name)
+                _LOGGER.debug("Resetting connection to %s", self._name)
             else:
                 _LOGGER.info("%s is disconnected. Attempting to reconnect",
                              self._name)


### PR DESCRIPTION
Onkyo logs this message somewhat frequently, and its spammy, so lets make it a debug message instead of info. 

See also: #20081