### PR TITLE
remove config sections from hass.config.components

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -46,7 +46,6 @@ async def async_setup(hass, config):
         if success:
             key = '{}.{}'.format(DOMAIN, panel_name)
             hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: key})
-            hass.config.components.add(key)
 
     @callback
     def component_loaded(event):

--- a/tests/components/config/test_init.py
+++ b/tests/components/config/test_init.py
@@ -29,7 +29,6 @@ def test_load_on_demand_already_loaded(hass, aiohttp_client):
         yield from async_setup_component(hass, 'config', {})
 
     yield from hass.async_block_till_done()
-    assert 'config.zwave' in hass.config.components
     assert stp.called
 
 
@@ -47,5 +46,4 @@ def test_load_on_demand_on_load(hass, aiohttp_client):
         hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: 'zwave'})
         yield from hass.async_block_till_done()
 
-    assert 'config.zwave' in hass.config.components
     assert stp.called


### PR DESCRIPTION
## Description:

Remove config sections from `hass.config.components`

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/21579#issuecomment-475931352

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
