### PR TITLE
Fix yeelight state update

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -259,8 +259,6 @@ class YeelightDevice:
             _LOGGER.error("Unable to turn the bulb on: %s", ex)
             return
 
-        self.update()
-
     def turn_off(self, duration=DEFAULT_TRANSITION):
         """Turn off device."""
         import yeelight
@@ -270,8 +268,6 @@ class YeelightDevice:
         except yeelight.BulbException as ex:
             _LOGGER.error("Unable to turn the bulb on: %s", ex)
             return
-
-        self.update()
 
     def update(self):
         """Read new properties from the device."""

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -494,6 +494,7 @@ class YeelightLight(Light):
             except yeelight.BulbException as ex:
                 _LOGGER.error("Unable to set the defaults: %s", ex)
                 return
+        self.device.update()
 
     def turn_off(self, **kwargs) -> None:
         """Turn off."""
@@ -502,6 +503,7 @@ class YeelightLight(Light):
             duration = int(kwargs.get(ATTR_TRANSITION) * 1000)  # kwarg in s
 
         self.device.turn_off(duration=duration)
+        self.device.update()
 
     def set_mode(self, mode: str):
         """Set a power mode."""
@@ -509,10 +511,9 @@ class YeelightLight(Light):
 
         try:
             self._bulb.set_power_mode(yeelight.enums.PowerMode[mode.upper()])
+            self.device.update()
         except yeelight.BulbException as ex:
             _LOGGER.error("Unable to set the power mode: %s", ex)
-
-        self.device.update()
 
     def start_flow(self, transitions, count=0, action=ACTION_RECOVER):
         """Start flow."""


### PR DESCRIPTION
## Description:
After moving yeelight into component, device update was done too early. For example when changing brightness, yeelight.light first calls turn_on and then set_brightness. State was updated after turn_on and before brightness change, so it was delayed.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.