### PR TITLE
Add infer_arming_state option to ness alarm

### DIFF
--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['nessclient==0.9.14']
+REQUIREMENTS = ['nessclient==0.9.15']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +22,7 @@ DATA_NESS = 'ness_alarm'
 
 CONF_DEVICE_HOST = 'host'
 CONF_DEVICE_PORT = 'port'
+CONF_INFER_ARMING_STATE = 'infer_arming_state'
 CONF_ZONES = 'zones'
 CONF_ZONE_NAME = 'name'
 CONF_ZONE_TYPE = 'type'
@@ -29,6 +30,7 @@ CONF_ZONE_ID = 'id'
 ATTR_OUTPUT_ID = 'output_id'
 DEFAULT_ZONES = []
 DEFAULT_SCAN_INTERVAL = datetime.timedelta(minutes=1)
+DEFAULT_INFER_ARMING_STATE = False
 
 SIGNAL_ZONE_CHANGED = 'ness_alarm.zone_changed'
 SIGNAL_ARMING_STATE_CHANGED = 'ness_alarm.arming_state_changed'
@@ -50,6 +52,9 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(cv.time_period, cv.positive_timedelta),
         vol.Optional(CONF_ZONES, default=DEFAULT_ZONES):
             vol.All(cv.ensure_list, [ZONE_SCHEMA]),
+        vol.Optional(CONF_INFER_ARMING_STATE,
+                     default=DEFAULT_INFER_ARMING_STATE):
+            cv.boolean
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -79,9 +79,11 @@ async def async_setup(hass, config):
     host = conf[CONF_DEVICE_HOST]
     port = conf[CONF_DEVICE_PORT]
     scan_interval = conf[CONF_SCAN_INTERVAL]
+    infer_arming_state = conf[CONF_INFER_ARMING_STATE]
 
     client = Client(host=host, port=port, loop=hass.loop,
-                    update_interval=scan_interval.total_seconds())
+                    update_interval=scan_interval.total_seconds()
+                    infer_arming_state=infer_arming_state)
     hass.data[DATA_NESS] = client
 
     async def _close(event):

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -82,7 +82,7 @@ async def async_setup(hass, config):
     infer_arming_state = conf[CONF_INFER_ARMING_STATE]
 
     client = Client(host=host, port=port, loop=hass.loop,
-                    update_interval=scan_interval.total_seconds()
+                    update_interval=scan_interval.total_seconds(),
                     infer_arming_state=infer_arming_state)
     hass.data[DATA_NESS] = client
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -735,7 +735,7 @@ nad_receiver==0.0.11
 ndms2_client==0.0.6
 
 # homeassistant.components.ness_alarm
-nessclient==0.9.14
+nessclient==0.9.15
 
 # homeassistant.components.netdata.sensor
 netdata==0.1.2


### PR DESCRIPTION
## Description:
Introduce a new configuration option `infer_arming_state` which is passed down into the `nessclient` client library which attempts to fix an issue where the arming state is incorrectly reported shortly after the panel has been armed.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9031

## Example entry for `configuration.yaml` (if applicable):
```yaml
ness_alarm:
  host: alarm.local
  port: 2401
  infer_arming_state: true
  zones:
    - name: Garage
      id: 1
    - name: Storeroom
      id: 2
    - name: Kitchen
      id: 3
    - name: Front Entrance
      id: 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] ~New dependencies are only imported inside functions that use them ([example][ex-import])~.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] ~New files were added to `.coveragerc`~.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
