### PR TITLE
ZHA fixes

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -310,11 +310,10 @@ async def websocket_read_zigbee_cluster_attributes(hass, connection, msg):
     cluster_id = msg[ATTR_CLUSTER_ID]
     cluster_type = msg[ATTR_CLUSTER_TYPE]
     attribute = msg[ATTR_ATTRIBUTE]
-    manufacturer = None
-    #  only use manufacturer code for manufacturer clusters
-    if cluster_id >= MFG_CLUSTER_ID_START:
-        manufacturer = msg.get(ATTR_MANUFACTURER) or None
+    manufacturer = msg.get(ATTR_MANUFACTURER) or None
     zha_device = zha_gateway.get_device(ieee)
+    if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
+        manufacturer = zha_device.manufacturer_code
     success = failure = None
     if zha_device is not None:
         cluster = zha_device.async_get_cluster(
@@ -476,11 +475,10 @@ def async_load_api(hass):
         cluster_type = service.data.get(ATTR_CLUSTER_TYPE)
         attribute = service.data.get(ATTR_ATTRIBUTE)
         value = service.data.get(ATTR_VALUE)
-        manufacturer = None
-        #  only use manufacturer code for manufacturer clusters
-        if cluster_id >= MFG_CLUSTER_ID_START:
-            manufacturer = service.data.get(ATTR_MANUFACTURER) or None
+        manufacturer = service.data.get(ATTR_MANUFACTURER) or None
         zha_device = zha_gateway.get_device(ieee)
+        if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
+            manufacturer = zha_device.manufacturer_code
         response = None
         if zha_device is not None:
             response = await zha_device.write_zigbee_attribute(
@@ -517,11 +515,10 @@ def async_load_api(hass):
         command = service.data.get(ATTR_COMMAND)
         command_type = service.data.get(ATTR_COMMAND_TYPE)
         args = service.data.get(ATTR_ARGS)
-        manufacturer = None
-        #  only use manufacturer code for manufacturer clusters
-        if cluster_id >= MFG_CLUSTER_ID_START:
-            manufacturer = service.data.get(ATTR_MANUFACTURER) or None
+        manufacturer = service.data.get(ATTR_MANUFACTURER) or None
         zha_device = zha_gateway.get_device(ieee)
+        if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
+            manufacturer = zha_device.manufacturer_code
         response = None
         if zha_device is not None:
             response = await zha_device.issue_cluster_command(

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/zha/
 import logging
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from . import ZigbeeChannel, parse_and_log_command
+from . import ZigbeeChannel, parse_and_log_command, MAINS_POWERED
 from ..helpers import get_attr_id_by_name
 from ..const import (
     SIGNAL_ATTR_UPDATED, SIGNAL_MOVE_LEVEL, SIGNAL_SET_LEVEL,
@@ -64,9 +64,14 @@ class OnOffChannel(ZigbeeChannel):
 
     async def async_update(self):
         """Initialize channel."""
-        _LOGGER.debug("Attempting to update onoff state")
+        from_cache = not self.device.power_source == MAINS_POWERED
+        _LOGGER.debug(
+            "%s is attempting to update onoff state - from cache: %s",
+            self._unique_id,
+            from_cache
+        )
         self._state = bool(
-            await self.get_attribute_value(self.ON_OFF, from_cache=False))
+            await self.get_attribute_value(self.ON_OFF, from_cache=from_cache))
         await super().async_update()
 
 


### PR DESCRIPTION
## Description:

- Change manufacturer code to be overridable from the front end and allow a user to send it even if it is not a manufacturer specific cluster. This fixes Xiaomi devices that use mfg codes on cluster 0 
- Only allow direct reads on cluster 6 when the device is mains powered

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
