### PR TITLE
Remove unused homekit_controller constant

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -28,7 +28,6 @@ HOMEKIT_IGNORE = [
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUEST_TIMEOUT = 5  # seconds
 RETRY_INTERVAL = 60  # seconds
 
 PAIRING_FILE = "pairing.json"


### PR DESCRIPTION
## Description:

As discussed in #17672, the `REQUEST_TIMEOUT` value is no longer used, but was never removed from the code. Users keep finding reference to it in old forum and bug posts and changing it anyway. So we should remove it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.