### PR TITLE
Enable hass.io panel without ping

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -145,8 +145,7 @@ async def async_setup(hass, config):
     hass.data[DOMAIN] = hassio = HassIO(hass.loop, websession, host)
 
     if not await hassio.is_connected():
-        _LOGGER.error("Not connected with Hass.io")
-        return False
+        _LOGGER.warning("Not connected with Hass.io / system to busy")
 
     store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
     data = await store.async_load()

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -145,7 +145,7 @@ async def async_setup(hass, config):
     hass.data[DOMAIN] = hassio = HassIO(hass.loop, websession, host)
 
     if not await hassio.is_connected():
-        _LOGGER.warning("Not connected with Hass.io / system to busy")
+        _LOGGER.warning("Not connected with Hass.io / system to busy!")
 
     store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
     data = await store.async_load()

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -62,7 +62,7 @@ class HassIO:
 
         This method return a coroutine.
         """
-        return self.send_command("/supervisor/ping", method="get")
+        return self.send_command("/supervisor/ping", method="get", timeout=15)
 
     @_api_data
     def get_homeassistant_info(self):

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -196,15 +196,16 @@ def test_fail_setup_without_environ_var(hass):
 
 
 @asyncio.coroutine
-def test_fail_setup_cannot_connect(hass):
+def test_fail_setup_cannot_connect(hass, caplog):
     """Fail setup if cannot connect."""
     with patch.dict(os.environ, MOCK_ENVIRON), \
             patch('homeassistant.components.hassio.HassIO.is_connected',
                   Mock(return_value=mock_coro(None))):
         result = yield from async_setup_component(hass, 'hassio', {})
-        assert not result
+        assert result
 
-    assert not hass.components.hassio.is_hassio()
+    assert hass.components.hassio.is_hassio()
+    assert "Not connected with Hass.io / system to busy!" in caplog.text
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:

Allow Hass.io panel also with a false ping to the supervisor. Some device has to low power and the ping fails on to the busy system. I add a warning, so the user known that they should look for a faster device.

Look like that are mostly device they use the internal Bluetooth for device detection. On RPi3 they slow done the CPU.

I extend also the timeout and hope that the supervisor is in response after 15sec.

Fix: #22260
https://github.com/home-assistant/hassio/issues/972