### PR TITLE
Better algorithm for computing unique_id

### DIFF
--- a/homeassistant/components/konnected/switch.py
+++ b/homeassistant/components/konnected/switch.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.entity import ToggleEntity
 
 from . import (
     CONF_ACTIVATION, CONF_MOMENTARY, CONF_PAUSE, CONF_REPEAT,
-    DOMAIN as KONNECTED_DOMAIN, PIN_TO_ZONE, STATE_HIGH, STATE_LOW)
+    DOMAIN as KONNECTED_DOMAIN, STATE_HIGH, STATE_LOW)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +41,8 @@ class KonnectedSwitch(ToggleEntity):
         self._pause = self._data.get(CONF_PAUSE)
         self._repeat = self._data.get(CONF_REPEAT)
         self._state = self._boolean_state(self._data.get(ATTR_STATE))
-        self._unique_id = '{}-{}'.format(device_id, PIN_TO_ZONE[pin_num])
+        self._unique_id = '{}-{}'.format(device_id, hash(frozenset(
+            {self._pin_num, self._momentary, self._pause, self._repeat})))
         self._name = self._data.get(CONF_NAME)
 
     @property


### PR DESCRIPTION
## Breaking Change:

This will change the internal `unique_id` for Konnected switches (i.e. siren, buzzer, generic switch). Users will need to manually remove the orphaned switch entities from the entity registry after updating and re-configure any changes stored in the entity registry (i.e. name and entity_id), as their unique IDs will change.

## Description:

Improve computation of `unique_id` for Konnected switches.

**Related issue (if applicable):** fixes #22257

**Pull request in home-assistant.io with documentation**: home-assistant/home-assistant.io#9053

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


@MartinHjelmare do you mind taking a quick look?