### PR TITLE
Fix unavailable state for homekit locks and covers

### DIFF
--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -83,11 +83,6 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverDevice):
         self._obstruction_detected = value
 
     @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._state is not None
-
-    @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_OPEN | SUPPORT_CLOSE
@@ -145,11 +140,6 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
         self._hold = None
         self._obstruction_detected = None
         self.lock_state = None
-
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._state is not None
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -64,11 +64,6 @@ class HomeKitLock(HomeKitEntity, LockDevice):
         """Return true if device is locked."""
         return self._state == STATE_LOCKED
 
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._state is not None
-
     async def async_lock(self, **kwargs):
         """Lock the device."""
         await self._set_lock_state(STATE_LOCKED)


### PR DESCRIPTION
## Description:

Back in #21901 I added code that meant a homekit device would correctly enter and leave the `unavailable` state. Unfortunately locks and covers override `available` so don't benefit from that fix. This fixes that and normalizes handling of the available state for all homekit entities.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
