### PR TITLE
Add permission checking to all RainMachine services

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -157,7 +157,6 @@ def _check_valid_user(hass):
                 entity.entity_id for entity in en_reg.entities.values()
                 if entity.platform == DOMAIN
             ]
-
             for entity_id in rainmachine_entities:
                 if user.permissions.check_entity(entity_id, POLICY_CONTROL):
                     return await service(call)

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -162,6 +162,7 @@ async def _check_service_permissions(hass, service_call):
                     permission=POLICY_CONTROL,
                 )
 
+
 async def async_setup(hass, config):
     """Set up the RainMachine component."""
     hass.data[DOMAIN] = {}

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -1,0 +1,23 @@
+"""Configuration for HEOS tests."""
+import pytest
+
+from homeassistant.components.rainmachine.const import DOMAIN
+from homeassistant.const import (
+    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL, CONF_SSL)
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="config_entry")
+def config_entry_fixture():
+    """Create a mock RainMachine config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title='192.168.1.101',
+        data={
+            CONF_IP_ADDRESS: '192.168.1.101',
+            CONF_PASSWORD: '12345',
+            CONF_PORT: 8080,
+            CONF_SSL: True,
+            CONF_SCAN_INTERVAL: 60,
+        })

--- a/tests/components/rainmachine/conftest.py
+++ b/tests/components/rainmachine/conftest.py
@@ -1,4 +1,4 @@
-"""Configuration for HEOS tests."""
+"""Configuration for Rainmachine tests."""
 import pytest
 
 from homeassistant.components.rainmachine.const import DOMAIN

--- a/tests/components/rainmachine/test_service_permissions.py
+++ b/tests/components/rainmachine/test_service_permissions.py
@@ -1,0 +1,42 @@
+"""Define tests for permissions on RainMachine service calls."""
+import asynctest
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.rainmachine.const import DOMAIN
+from homeassistant.core import Context
+from homeassistant.exceptions import Unauthorized, UnknownUser
+from homeassistant.setup import async_setup_component
+
+from tests.common import mock_coro
+
+
+async def setup_platform(hass, config_entry):
+    """Set up the media player platform for testing."""
+    with asynctest.mock.patch('regenmaschine.login') as mock_login:
+        mock_client = mock_login.return_value
+        mock_client.restrictions.current.return_value = mock_coro()
+        mock_client.restrictions.universal.return_value = mock_coro()
+        config_entry.add_to_hass(hass)
+        assert await async_setup_component(hass, DOMAIN)
+        await hass.async_block_till_done()
+
+
+async def test_services_authorization(
+        hass, config_entry, hass_read_only_user):
+    """Test that a RainMachine service is halted on incorrect permissions."""
+    await setup_platform(hass, config_entry)
+
+    with pytest.raises(UnknownUser):
+        await hass.services.async_call(
+            'rainmachine',
+            'unpause_watering', {},
+            blocking=True,
+            context=Context(user_id='fake_user_id'))
+
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            'rainmachine',
+            'unpause_watering', {},
+            blocking=True,
+            context=Context(user_id=hass_read_only_user.id))

--- a/tests/components/rainmachine/test_service_permissions.py
+++ b/tests/components/rainmachine/test_service_permissions.py
@@ -1,7 +1,6 @@
 """Define tests for permissions on RainMachine service calls."""
 import asynctest
 import pytest
-import voluptuous as vol
 
 from homeassistant.components.rainmachine.const import DOMAIN
 from homeassistant.core import Context


### PR DESCRIPTION
## Description:

This PR implements user permission checking on all RainMachine services (per the ["Can I Have User Permissions?"](https://developers.home-assistant.io/blog/2019/03/11/user-permissions.html) blog post).

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
