### PR TITLE
Turn light off if brightness is 0

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -284,8 +284,9 @@ async def async_setup(hass, config):
                 preprocess_turn_on_alternatives(pars)
             if ATTR_BRIGHTNESS in pars and pars[ATTR_BRIGHTNESS] == 0:
                 # Zero brightness: Turn the light off
-                [pars.pop(k) for k in list(pars.keys()) if k not in \
-                    [ATTR_TRANSITION, ATTR_FLASH]]
+                for k in list(pars.keys()):
+                    if k not in [ATTR_TRANSITION, ATTR_FLASH]:
+                        pars.pop(k)
                 await light.async_turn_off(**pars)
             else:
                 await light.async_turn_on(**pars)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -155,8 +155,8 @@ def preprocess_turn_on_alternatives(params):
     if ATTR_BRIGHTNESS in params and params[ATTR_BRIGHTNESS] == 0:
         # Zero brightness: Light will be turned off
         for k in list(params.keys()):
-            params = {k: v for k,v in params.items() if k in [ATTR_TRANSITION,
-                                                              ATTR_FLASH]}
+            params = {k: v for k, v in params.items() if k in [ATTR_TRANSITION,
+                                                               ATTR_FLASH]}
 
     color_name = params.pop(ATTR_COLOR_NAME, None)
     if color_name is not None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -282,7 +282,13 @@ async def async_setup(hass, config):
                 pars = params.copy()
                 pars[ATTR_PROFILE] = Profiles.get_default(light.entity_id)
                 preprocess_turn_on_alternatives(pars)
-            await light.async_turn_on(**pars)
+            if ATTR_BRIGHTNESS in pars and pars[ATTR_BRIGHTNESS] == 0:
+                # Zero brightness: Turn the light off
+                [pars.pop(k) for k in list(pars.keys()) if k not in \
+                    [ATTR_TRANSITION, ATTR_FLASH]]
+                await light.async_turn_off(**pars)
+            else:
+                await light.async_turn_on(**pars)
 
             if not light.should_poll:
                 continue

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -148,6 +148,16 @@ def preprocess_turn_on_alternatives(params):
         params.setdefault(ATTR_XY_COLOR, profile[:2])
         params.setdefault(ATTR_BRIGHTNESS, profile[2])
 
+    brightness_pct = params.pop(ATTR_BRIGHTNESS_PCT, None)
+    if brightness_pct is not None:
+        params[ATTR_BRIGHTNESS] = int(255 * brightness_pct/100)
+
+    if ATTR_BRIGHTNESS in params and params[ATTR_BRIGHTNESS] == 0:
+        # Zero brightness: Light will be turned off
+        for k in list(params.keys()):
+            params = {k: v for k,v in params.items() if k in [ATTR_TRANSITION,
+                                                              ATTR_FLASH]}
+
     color_name = params.pop(ATTR_COLOR_NAME, None)
     if color_name is not None:
         try:
@@ -161,10 +171,6 @@ def preprocess_turn_on_alternatives(params):
     if kelvin is not None:
         mired = color_util.color_temperature_kelvin_to_mired(kelvin)
         params[ATTR_COLOR_TEMP] = int(mired)
-
-    brightness_pct = params.pop(ATTR_BRIGHTNESS_PCT, None)
-    if brightness_pct is not None:
-        params[ATTR_BRIGHTNESS] = int(255 * brightness_pct/100)
 
     xy_color = params.pop(ATTR_XY_COLOR, None)
     if xy_color is not None:
@@ -284,9 +290,6 @@ async def async_setup(hass, config):
                 preprocess_turn_on_alternatives(pars)
             if ATTR_BRIGHTNESS in pars and pars[ATTR_BRIGHTNESS] == 0:
                 # Zero brightness: Turn the light off
-                for k in list(pars.keys()):
-                    if k not in [ATTR_TRANSITION, ATTR_FLASH]:
-                        pars.pop(k)
                 await light.async_turn_off(**pars)
             else:
                 await light.async_turn_on(**pars)

--- a/homeassistant/components/tradfri/light.py
+++ b/homeassistant/components/tradfri/light.py
@@ -266,8 +266,6 @@ class TradfriLight(Light):
             brightness = kwargs[ATTR_BRIGHTNESS]
             if brightness > 254:
                 brightness = 254
-            elif brightness < 0:
-                brightness = 0
             dimmer_data = {ATTR_DIMMER: brightness, ATTR_TRANSITION_TIME:
                            transition_time}
             dimmer_command = self._light_control.set_dimmer(**dimmer_data)

--- a/tests/components/light/test_tradfri.py
+++ b/tests/components/light/test_tradfri.py
@@ -35,20 +35,12 @@ TURN_ON_TEST_CASES = [
             'brightness': 100
         }
     ],
-    # Brightness == 0
+    # Brightness == 1
     [
         {'can_set_dimmer': True},
-        {'brightness': 0},
+        {'brightness': 1},
         {
-            'brightness': 0
-        }
-    ],
-    # Brightness < 0
-    [
-        {'can_set_dimmer': True},
-        {'brightness': -1},
-        {
-            'brightness': 0
+            'brightness': 1
         }
     ],
     # Brightness > 254


### PR DESCRIPTION
## Breaking Change:
Lights will now be turned off when brightness is set to 0

## Description:
Turn light off if when brightness is set to 0 as discussed in home-assistant/architecture#119

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8967

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
