### PR TITLE
Incoming SMS handling for netgear_lte

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -30,6 +30,8 @@ DATA_KEY = 'netgear_lte'
 
 EVENT_SMS = 'netgear_lte_sms'
 
+SERVICE_DELETE_SMS = 'delete_sms'
+
 ATTR_HOST = 'host'
 ATTR_SMS_ID = 'sms_id'
 ATTR_FROM = 'from'
@@ -57,6 +59,11 @@ CONFIG_SCHEMA = vol.Schema({
             SENSOR_SCHEMA,
     })])
 }, extra=vol.ALLOW_EXTRA)
+
+DELETE_SMS_SCHEMA = vol.Schema({
+    vol.Required(ATTR_HOST): cv.string,
+    vol.Required(ATTR_SMS_ID): vol.All(cv.ensure_list, [cv.positive_int]),
+})
 
 
 @attr.s
@@ -109,6 +116,24 @@ async def async_setup(hass, config):
         websession = async_create_clientsession(
             hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
         hass.data[DATA_KEY] = LTEData(websession)
+
+        async def delete_sms_handler(service):
+            """Apply a service."""
+            host = service.data[ATTR_HOST]
+            conf = {CONF_HOST: host}
+            modem_data = hass.data[DATA_KEY].get_modem_data(conf)
+
+            if not modem_data:
+                _LOGGER.error(
+                    "%s: host  '%s' unavailable", SERVICE_DELETE_SMS, host)
+                return
+
+            for sms_id in service.data[ATTR_SMS_ID]:
+                await modem_data.modem.delete_sms(sms_id)
+
+        hass.services.async_register(
+            DOMAIN, SERVICE_DELETE_SMS, delete_sms_handler,
+            schema=DELETE_SMS_SCHEMA)
 
     netgear_lte_config = config[DOMAIN]
 

--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -125,7 +125,7 @@ async def async_setup(hass, config):
 
             if not modem_data:
                 _LOGGER.error(
-                    "%s: host  '%s' unavailable", SERVICE_DELETE_SMS, host)
+                    "%s: host %s unavailable", SERVICE_DELETE_SMS, host)
                 return
 
             for sms_id in service.data[ATTR_SMS_ID]:

--- a/homeassistant/components/netgear_lte/services.yaml
+++ b/homeassistant/components/netgear_lte/services.yaml
@@ -1,0 +1,9 @@
+delete_sms:
+  description: Delete messages from the modem inbox.
+  fields:
+    host:
+      description: The modem that should have a message deleted.
+      example: 192.168.5.1
+    sms_id:
+      description: Integer or list of integers with inbox IDs of messages to delete.
+      example: 7


### PR DESCRIPTION
## Description:

This enables incoming SMS handling for netgear_lte:
1) Fire incoming SMS messages as events
2) Add a service call to delete SMS messages from the modem inbox

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9047

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  - alias: SMS conversation
    trigger:
      - platform: event
        event_type: netgear_lte_sms
    action:
      - service: netgear_lte.delete_sms
        data_template:
          host: '{{ trigger.event.data.host }}'
          sms_id: '{{ trigger.event.data.sms_id }}'
      - service: conversation.process
        data_template:
          text: '{{ trigger.event.data.message }}'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
