### PR TITLE
Fix stream unsub event on timeout

### DIFF
--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -128,6 +128,7 @@ class StreamOutput:
     @callback
     def _timeout(self, _now=None):
         """Handle stream timeout."""
+        self._unsub = None
         if self._stream.keepalive:
             self.idle = True
             self._stream.check_idle()


### PR DESCRIPTION
## Description:

This resets unsub to `None` once timeout is called, so that if keepalive is set on the stream, it prevents the below error:

`WARNING (MainThread) [homeassistant.core] Unable to remove unknown listener <function async_track_point_in_utc_time.<locals>.point_in_time_listener at 0x10c23a598>`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.