### PR TITLE
Added features to Concord232 Alarm Panel

### DIFF
--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -100,8 +100,6 @@ class Concord232Alarm(alarm.AlarmControlPanel):
             self._state = STATE_ALARM_DISARMED
         elif 'Home' in part['arming_level']:
             self._state = STATE_ALARM_ARMED_HOME
-        elif 'Silent' in part['arming_level']:
-            self._state = STATE_ALARM_ARMED_HOME
         else:
             self._state = STATE_ALARM_ARMED_AWAY
 

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -14,7 +14,7 @@ import homeassistant.components.alarm_control_panel as alarm
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, CONF_CODE, CONF_MODE, 
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_CODE, CONF_MODE,
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 
 REQUIREMENTS = ['concord232==0.15']

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -14,7 +14,7 @@ import homeassistant.components.alarm_control_panel as alarm
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, STATE_ALARM_ARMED_AWAY,
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_CODE, CONF_MODE, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 
 REQUIREMENTS = ['concord232==0.15']
@@ -24,12 +24,15 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_HOST = 'localhost'
 DEFAULT_NAME = 'CONCORD232'
 DEFAULT_PORT = 5007
+DEFAULT_MODE = 'audible'
 
 SCAN_INTERVAL = datetime.timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_CODE, 'code validation'): cv.string,
+    vol.Optional(CONF_MODE, default=DEFAULT_MODE): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })
 
@@ -37,13 +40,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Concord232 alarm control panel platform."""
     name = config.get(CONF_NAME)
+    code = config.get(CONF_CODE)
+    mode = config.get(CONF_MODE)
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
 
     url = 'http://{}:{}'.format(host, port)
 
     try:
-        add_entities([Concord232Alarm(url, name)], True)
+        add_entities([Concord232Alarm(url, name, code, mode)], True)
     except requests.exceptions.ConnectionError as ex:
         _LOGGER.error("Unable to connect to Concord232: %s", str(ex))
 
@@ -51,12 +56,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class Concord232Alarm(alarm.AlarmControlPanel):
     """Representation of the Concord232-based alarm panel."""
 
-    def __init__(self, url, name):
+    def __init__(self, url, name, code, mode):
         """Initialize the Concord232 alarm panel."""
         from concord232 import client as concord232_client
 
         self._state = None
         self._name = name
+        self._code = code or None
+        self._mode = mode
         self._url = url
         self._alarm = concord232_client.Client(self._url)
         self._alarm.partitions = self._alarm.list_partitions()
@@ -91,19 +98,42 @@ class Concord232Alarm(alarm.AlarmControlPanel):
 
         if part['arming_level'] == 'Off':
             self._state = STATE_ALARM_DISARMED
-        elif 'Home' in part['arming_level']:
+        elif 'Home' in part['arming_level'] or 'Silent' in part['arming_level']:
             self._state = STATE_ALARM_ARMED_HOME
         else:
             self._state = STATE_ALARM_ARMED_AWAY
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""
+        if not self._validate_code(code, STATE_ALARM_DISARMED):
+            return
         self._alarm.disarm(code)
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
-        self._alarm.arm('stay')
+        if not self._validate_code(code, STATE_ALARM_ARMED_HOME):
+            return
+        if self._mode == 'silent':
+            self._alarm.arm('stay', 'silent')
+        else:
+            self._alarm.arm('stay')
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
+        if not self._validate_code(code, STATE_ALARM_ARMED_AWAY):
+            return
         self._alarm.arm('away')
+
+    def _validate_code(self, code, state):
+        """Validate given code."""
+        if self._code is None:
+            return True
+        if isinstance(self._code, str):
+            alarm_code = self._code
+        else:
+            alarm_code = self._code.render(from_state=self._state,
+                                           to_state=state)
+        check = not alarm_code or code == alarm_code
+        if not check:
+            _LOGGER.warning("Invalid code given for %s", state)
+        return check

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -14,8 +14,8 @@ import homeassistant.components.alarm_control_panel as alarm
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, CONF_CODE, CONF_MODE, STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_CODE, CONF_MODE, 
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 
 REQUIREMENTS = ['concord232==0.15']
 
@@ -98,7 +98,9 @@ class Concord232Alarm(alarm.AlarmControlPanel):
 
         if part['arming_level'] == 'Off':
             self._state = STATE_ALARM_DISARMED
-        elif 'Home' in part['arming_level'] or 'Silent' in part['arming_level']:
+        elif 'Home' in part['arming_level']:
+            self._state = STATE_ALARM_ARMED_HOME
+        elif 'Silent' in part['arming_level']:
             self._state = STATE_ALARM_ARMED_HOME
         else:
             self._state = STATE_ALARM_ARMED_AWAY

--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -79,7 +79,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 )
             )
 
-        add_entities(sensors, True)
+    add_entities(sensors, True)
 
 
 def get_opening_type(zone):


### PR DESCRIPTION
## Description: Adds functionality to Concord232 Alarm Panel. 2 additional attributes can be defined in configuration.yaml. 'code' which allows for defining a code and 'mode' which allows for silent activation of the ARM HOME option

Currently Concord232 Server can Arm/Disarm without providing code or by providing wrong code. Updated code adds functionality to define a code in configuration.yaml.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9039

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: concord232
     host: 192.168.1.172
     code: 1234
     mode: silent
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
