### PR TITLE
Fix for homekit_controller #22368

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -102,6 +102,7 @@ class HKDevice():
                 if component is not None:
                     discovery.load_platform(self.hass, component, DOMAIN,
                                             service_info, self.config)
+                    self.entities.append((aid, iid))
 
     def device_config_callback(self, callback_data):
         """Handle initial pairing."""


### PR DESCRIPTION
## Description:

Fix for review comment by @MartinHjelmare. Error backporting change from a long running config entry branch.

(When #22194 is merged I already have a test for this code path I can submit, but atm its blocked by #22194).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.