### PR TITLE
Add support for state attr in light mqtt

### DIFF
--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -55,6 +55,7 @@ CONF_EFFECT_LIST = 'effect_list'
 CONF_FLASH_TIME_LONG = 'flash_time_long'
 CONF_FLASH_TIME_SHORT = 'flash_time_short'
 CONF_HS = 'hs'
+CONF_STATE_ATTR = 'state_attr'
 
 # Stealing some of these from the base MQTT configs.
 PLATFORM_SCHEMA_JSON = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
@@ -76,6 +77,7 @@ PLATFORM_SCHEMA_JSON = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_RETAIN, default=mqtt.DEFAULT_RETAIN): cv.boolean,
     vol.Optional(CONF_RGB, default=DEFAULT_RGB): cv.boolean,
     vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_STATE_ATTR): cv.string,
     vol.Optional(CONF_WHITE_VALUE, default=DEFAULT_WHITE_VALUE): cv.boolean,
     vol.Optional(CONF_XY, default=DEFAULT_XY): cv.boolean,
     vol.Optional(CONF_HS, default=DEFAULT_HS): cv.boolean,
@@ -151,6 +153,12 @@ class MqttLightJson(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         optimistic = config.get(CONF_OPTIMISTIC)
         self._optimistic = optimistic or self._topic[CONF_STATE_TOPIC] is None
 
+        state_attr = config.get(CONF_STATE_ATTR)
+        if state_attr:
+            self._state_attr = state_attr
+        else:
+            self._state_attr = 'state'
+
         brightness = config.get(CONF_BRIGHTNESS)
         if brightness:
             self._brightness = 255
@@ -205,9 +213,9 @@ class MqttLightJson(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             """Handle new MQTT messages."""
             values = json.loads(msg.payload)
 
-            if values['state'] == 'ON':
+            if values[self._state_attr] == 'ON':
                 self._state = True
-            elif values['state'] == 'OFF':
+            elif values[self._state_attr] == 'OFF':
                 self._state = False
 
             if self._hs is not None:


### PR DESCRIPTION
usage example:
```yaml
- platform: mqtt
  schema: json
  command_topic: "zigbee2mqtt/TvLED/rgb/set"
  state_topic: "zigbee2mqtt/TvLED"
  state_attr: "state_rgb"
```

Some GLEDOPTO devices supports 2ID (it have 2 and more channels)
So when zigbee2mqtt is used, it reports multiple states in one payload.
Like: {"state_rgb":"OFF","state_white":"OFF"}

## Description:
Documentation will be added, if you will give me approve for this enhancement.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: mqtt
  schema: json
  command_topic: "zigbee2mqtt/TvLED/rgb/set"
  state_topic: "zigbee2mqtt/TvLED"
  state_attr: "state_rgb"


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [TODO] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
