### PR TITLE
Add switches to control Daikin Airbase zones

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -26,7 +26,7 @@ DOMAIN = 'daikin'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
-COMPONENT_TYPES = ['climate', 'sensor']
+COMPONENT_TYPES = ['climate', 'sensor', 'switch']
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -17,13 +17,13 @@ from homeassistant.util import Throttle
 from . import config_flow  # noqa  pylint_disable=unused-import
 from .const import KEY_HOST
 
-REQUIREMENTS = ['pydaikin==1.2.0']
+REQUIREMENTS = ['pydaikin==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'daikin'
 
-
+PARALLEL_UPDATES = 0
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 COMPONENT_TYPES = ['climate', 'sensor', 'switch']

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -51,7 +51,8 @@ class DaikinZoneSwitch(ToggleEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._api.device.zones[self._zone_id][0]
+        return "{} {}".format(self._api.name,
+                              self._api.device.zones[self._zone_id][0])
 
     @property
     def is_on(self):

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -1,0 +1,76 @@
+"""Support for Daikin AirBase zones."""
+import logging
+
+from homeassistant.helpers.entity import ToggleEntity
+
+from . import DOMAIN as DAIKIN_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+ZONE_ICON = 'mdi:home-circle'
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Old way of setting up the platform.
+
+    Can only be called when a user accidentally mentions the platform in their
+    config. But even in that case it would have been ignored.
+    """
+    pass
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Daikin climate based on config_entry."""
+    daikin_api = hass.data[DAIKIN_DOMAIN].get(entry.entry_id)
+    zones = daikin_api.device.zones
+    if zones:
+        async_add_entities([
+            DaikinZoneSwitch(daikin_api, zone_id)
+            for zone_id in range(len(zones))
+        ])
+
+
+class DaikinZoneSwitch(ToggleEntity):
+    """Representation of a zone."""
+
+    def __init__(self, daikin_api, zone_id):
+        """Initialize the zone."""
+        self._api = daikin_api
+        self._zone_id = zone_id
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return "{}-zone{}".format(self._api.mac, self._zone_id)
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return ZONE_ICON
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._api.device.zones[self._zone_id][0]
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        return self._api.device.zones[self._zone_id][1] == '1'
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return self._api.device_info
+
+    async def async_update(self):
+        """Retrieve latest state."""
+        await self._api.async_update()
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the zone on."""
+        await self._api.device.set_zone(self._zone_id, '1')
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the zone off."""
+        await self._api.device.set_zone(self._zone_id, '0')

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -21,7 +21,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
-    daikin_api = hass.data[DAIKIN_DOMAIN].get(entry.entry_id)
+    daikin_api = hass.data[DAIKIN_DOMAIN][entry.entry_id]
     zones = daikin_api.device.zones
     if zones:
         async_add_entities([

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -998,7 +998,7 @@ pycsspeechtts==1.0.2
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-pydaikin==1.2.0
+pydaikin==1.3.1
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.0.7


### PR DESCRIPTION
## Description:

This adds support for controlling zones with the Daikin AirBase units

**Related issue (if applicable):** fixes #22376

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9040

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
