### PR TITLE
Amcrest: Add on/off support & attributes. Bump amcrest to 1.3.0

### DIFF
--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['amcrest==1.2.7']
+REQUIREMENTS = ['amcrest==1.3.0']
 DEPENDENCIES = ['ffmpeg']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 from homeassistant.components.camera import (
-    Camera, SUPPORT_STREAM)
+    Camera, SUPPORT_ON_OFF, SUPPORT_STREAM)
 from homeassistant.components.ffmpeg import DATA_FFMPEG
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.aiohttp_client import (
@@ -15,6 +15,13 @@ from . import DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT
 DEPENDENCIES = ['amcrest', 'ffmpeg']
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _extract_attr(resp, sep='='):
+    try:
+        return resp.split(sep)[-1].strip()
+    except AttributeError:
+        return None
 
 
 async def async_setup_platform(hass, config, async_add_entities,
@@ -39,18 +46,24 @@ class AmcrestCam(Camera):
         super(AmcrestCam, self).__init__()
         self._name = amcrest.name
         self._camera = amcrest.device
-        self._base_url = self._camera.get_base_url()
         self._ffmpeg = hass.data[DATA_FFMPEG]
         self._ffmpeg_arguments = amcrest.ffmpeg_arguments
         self._stream_source = amcrest.stream_source
         self._resolution = amcrest.resolution
         self._token = self._auth = amcrest.authentication
+        self._is_recording = False
+        self._model = None
+        self._static_attrs = {}
         self._snapshot_lock = asyncio.Lock()
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""
         from amcrest import AmcrestError
 
+        if not self.is_on:
+            _LOGGER.error(
+                'Attempt to take snaphot when %s camera is off', self.name)
+            return None
         async with self._snapshot_lock:
             try:
                 # Send the request to snap a picture and return raw jpg data
@@ -59,7 +72,8 @@ class AmcrestCam(Camera):
                 return response.data
             except AmcrestError as error:
                 _LOGGER.error(
-                    'Could not get camera image due to error %s', error)
+                    'Could not get image from %s camera due to error: %s',
+                    self.name, error)
                 return None
 
     async def handle_async_mjpeg_stream(self, request):
@@ -94,17 +108,129 @@ class AmcrestCam(Camera):
         finally:
             await stream.close()
 
+    # Entity property overrides
+
     @property
     def name(self):
         """Return the name of this camera."""
         return self._name
 
     @property
+    def device_state_attributes(self):
+        """Return the Amcrest-spectific camera state attributes."""
+        return self._static_attrs
+
+    @property
     def supported_features(self):
         """Return supported features."""
-        return SUPPORT_STREAM
+        return SUPPORT_ON_OFF | SUPPORT_STREAM
+
+    # Camera property overrides
+
+    @property
+    def is_recording(self):
+        """Return true if the device is recording."""
+        return self._is_recording
+
+    @property
+    def brand(self):
+        """Return the camera brand."""
+        return 'Amcrest'
+
+    @property
+    def model(self):
+        """Return the camera model."""
+        return self._model
 
     @property
     def stream_source(self):
         """Return the source of the stream."""
         return self._camera.rtsp_url(typeno=self._resolution)
+
+    @property
+    def is_on(self):
+        """Return true if on."""
+        return self.video_enabled
+
+    # Additional Amcrest Camera properties
+
+    @property
+    def video_enabled(self):
+        """Return the camera video streaming status."""
+        return self.is_streaming
+
+    @video_enabled.setter
+    def video_enabled(self, enable):
+        """Enable or disable camera video stream."""
+        from amcrest import AmcrestError
+
+        try:
+            self._camera.video_enabled = enable
+        except AmcrestError as error:
+            _LOGGER.error(
+                'Could not %s %s camera video stream due to error: %s',
+                'enable' if enable else 'disable', self.name, error)
+        else:
+            self.is_streaming = enable
+            self.schedule_update_ha_state()
+
+    # Other Entity method overrides
+
+    def update(self):
+        """Update entity status."""
+        from amcrest import AmcrestError
+
+        _LOGGER.debug('Pulling data from %s camera', self.name)
+        try:
+            if self._model is None:
+                self._model = _extract_attr(self._get_cam_attr('device_type'))
+            if not self._static_attrs:
+                self._update_static_attrs()
+            self.is_streaming = self._camera.video_enabled
+            self._is_recording = self._camera.record_mode == 'Manual'
+        except AmcrestError as error:
+            _LOGGER.error(
+                'Could not get %s camera attributes due to error: %s',
+                self.name, error)
+
+    # Other Camera method overrides
+
+    def turn_off(self):
+        """Turn off camera."""
+        self.video_enabled = False
+
+    def turn_on(self):
+        """Turn on camera."""
+        self.video_enabled = True
+
+    # Utility methods
+
+    def _get_cam_attr(self, attr):
+        from amcrest import AmcrestError
+
+        try:
+            return getattr(self._camera, attr)
+        except AmcrestError as error:
+            _LOGGER.error(
+                'Could not get %s camera %s due to error: %s',
+                self.name, attr, error)
+            return None
+
+    def _update_cam_attr(self, attr):
+        value = self._get_cam_attr(attr)
+        if value is not None:
+            self._static_attrs[attr] = _extract_attr(value)
+
+    def _update_static_attrs(self):
+        for attr in ('hardware_version', 'machine_name', 'serial_number'):
+            self._update_cam_attr(attr)
+        try:
+            sw_ver, sw_date = self._get_cam_attr('software_information')
+        except TypeError:
+            pass
+        except ValueError:
+            _LOGGER.error(
+                'Unexpected %s camera software_information', self.name)
+        else:
+            self._static_attrs['software_version'] = _extract_attr(sw_ver)
+            self._static_attrs['software_build'] = _extract_attr(sw_date, ':')

--- a/homeassistant/components/amcrest/sensor.py
+++ b/homeassistant/components/amcrest/sensor.py
@@ -75,19 +75,6 @@ class AmcrestSensor(Entity):
         """Get the latest data and updates the state."""
         _LOGGER.debug("Pulling data from %s sensor.", self._name)
 
-        try:
-            version, build_date = self._camera.software_information
-            self._attrs['Build Date'] = build_date.split('=')[-1]
-            self._attrs['Version'] = version.split('=')[-1]
-        except ValueError:
-            self._attrs['Build Date'] = 'Not Available'
-            self._attrs['Version'] = 'Not Available'
-
-        try:
-            self._attrs['Serial Number'] = self._camera.serial_number
-        except ValueError:
-            self._attrs['Serial Number'] = 'Not Available'
-
         if self._sensor_type == 'motion_detector':
             self._state = self._camera.is_motion_detected
             self._attrs['Record Mode'] = self._camera.record_mode

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -155,7 +155,7 @@ alarmdecoder==1.13.2
 alpha_vantage==2.1.0
 
 # homeassistant.components.amcrest
-amcrest==1.2.7
+amcrest==1.3.0
 
 # homeassistant.components.androidtv.media_player
 androidtv==0.0.14


### PR DESCRIPTION
## Breaking Change:
Remove `Build Date`, `Version` and `Serial Number` attributes from sensors. These values do not change during the life of the device and are not appropriate for state attributes. They might go into `device_info` if this was loaded via config entry.

## Description:
Add support for turn_on & turn_off services.

Add implementation of is_recording method, as well as brand and model attributes. Remove "static" attributes from sensors.

Bump amcrest package to 1.3.0 required for above changes and also handles errors in storage commands (see related issues.)

**Related issue (if applicable):** fixes #19982 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
