### PR TITLE
Fix myq increasing number of network connections

### DIFF
--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -1,6 +1,12 @@
-"""Support for MyQ-Enabled Garage Doors."""
-import logging
+"""
+Support for MyQ-Enabled Garage Doors.
 
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/cover.myq/
+"""
+import aiohttp
+import logging
+import socket
 import voluptuous as vol
 
 from homeassistant.components.cover import (
@@ -10,7 +16,8 @@ from homeassistant.const import (
     STATE_OPEN, STATE_OPENING)
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-REQUIREMENTS = ['pymyq==1.1.0']
+REQUIREMENTS = ['aiohttp',
+                'pymyq==1.1.0']
 _LOGGER = logging.getLogger(__name__)
 
 MYQ_TO_HASS = {
@@ -33,7 +40,17 @@ async def async_setup_platform(
     from pymyq import login
     from pymyq.errors import MyQError, UnsupportedBrandError
 
-    websession = aiohttp_client.async_get_clientsession(hass)
+    # websession = aiohttp_client.async_get_clientsession(hass)
+
+    # Specify socket
+    conn = aiohttp.TCPConnector(
+        family=socket.AF_INET,
+        verify_ssl=True,
+    )
+
+    session_timeout = aiohttp.ClientTimeout(connect=10)
+    websession = aiohttp.ClientSession(connector=conn,
+                                       timeout=session_timeout)
 
     username = config[CONF_USERNAME]
     password = config[CONF_PASSWORD]

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -1,9 +1,4 @@
-"""
-Support for MyQ-Enabled Garage Doors.
-
-For more details about this platform, please refer to the documentation
-https://home-assistant.io/components/cover.myq/
-"""
+"""Support for MyQ-Enabled Garage Doors."""
 import logging
 import voluptuous as vol
 

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -45,7 +45,8 @@ async def async_setup_platform(
     # Specify socket
     conn = aiohttp.TCPConnector(
         family=socket.AF_INET,
-        verify_ssl=True,
+        limit_per_host=5,
+        enable_cleanup_closed=True,
     )
 
     session_timeout = aiohttp.ClientTimeout(connect=10)

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -70,6 +70,7 @@ class MyQDevice(CoverDevice):
             _LOGGER.debug("%s: Closing MyQ device", self.name)
             await self._device.close_connection()
 
+        # Register callback with HA
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
 
     @property

--- a/homeassistant/components/myq/manifest.json
+++ b/homeassistant/components/myq/manifest.json
@@ -3,7 +3,7 @@
   "name": "Myq",
   "documentation": "https://www.home-assistant.io/components/myq",
   "requirements": [
-    "pymyq==1.1.0"
+    "pymyq==1.2.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -168,7 +168,10 @@ def _async_get_connector(hass: HomeAssistantType,
     else:
         ssl_context = False
 
-    connector = aiohttp.TCPConnector(loop=hass.loop, ssl=ssl_context)
+    connector = aiohttp.TCPConnector(loop=hass.loop,
+                                     enable_cleanup_closed=True,
+                                     ssl=ssl_context,
+                                     )
     hass.data[key] = connector
 
     async def _async_close_connector(event: Event) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1156,8 +1156,8 @@ pymonoprice==0.3
 # homeassistant.components.yamaha_musiccast
 pymusiccast==0.1.6
 
-# homeassistant.components.myq
-pymyq==1.1.0
+# homeassistant.components.myq.cover
+pymyq==1.2.0
 
 # homeassistant.components.mysensors
 pymysensors==0.18.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1156,7 +1156,7 @@ pymonoprice==0.3
 # homeassistant.components.yamaha_musiccast
 pymusiccast==0.1.6
 
-# homeassistant.components.myq.cover
+# homeassistant.components.myq
 pymyq==1.2.0
 
 # homeassistant.components.mysensors


### PR DESCRIPTION
## Description:
Updated pymyq version to 1.2.0. The aiohttp client session is now setup within the pymyq library instead with tested socket options to prevent continuous increase in sockets on certain platforms.

**Related issue (if applicable):** fixes #9193

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
