### PR TITLE
Add yeelight power mode icon

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -33,6 +33,7 @@ CONF_SAVE_ON_CHANGE = 'save_on_change'
 CONF_MODE_MUSIC = 'use_music_mode'
 CONF_FLOW_PARAMS = 'flow_params'
 CONF_CUSTOM_EFFECTS = 'custom_effects'
+CONF_POWER_MODE_ICON = 'power_mode_icon'
 
 ATTR_COUNT = 'count'
 ATTR_ACTION = 'action'
@@ -71,6 +72,7 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_MODE_MUSIC, default=False): cv.boolean,
     vol.Optional(CONF_SAVE_ON_CHANGE, default=False): cv.boolean,
     vol.Optional(CONF_MODEL): cv.string,
+    vol.Optional(CONF_POWER_MODE_ICON, default=False): cv.boolean,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -98,6 +100,7 @@ UPDATE_REQUEST_PROPERTIES = [
     "hue",
     "sat",
     "color_mode",
+    "flowing",
     "bg_power",
     "bg_lmode",
     "bg_flowing",

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -201,8 +201,10 @@ class YeelightLight(Light):
 
         if self._get_property('flowing') == '1':
             return 'mdi:waves'
-        elif self._is_nightlight_enabled:
+        if self._is_nightlight_enabled:
             return 'mdi:weather-night'
+        
+        return None
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -203,7 +203,7 @@ class YeelightLight(Light):
             return 'mdi:waves'
         if self._is_nightlight_enabled:
             return 'mdi:weather-night'
-        
+
         return None
 
     @property

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -20,7 +20,7 @@ from homeassistant.components.yeelight import (
     CONF_SAVE_ON_CHANGE, CONF_CUSTOM_EFFECTS, DATA_UPDATED,
     YEELIGHT_SERVICE_SCHEMA, DOMAIN, ATTR_TRANSITIONS,
     YEELIGHT_FLOW_TRANSITION_SCHEMA, _transitions_config_parser,
-    ACTION_RECOVER)
+    ACTION_RECOVER, CONF_POWER_MODE_ICON)
 
 DEPENDENCIES = ['yeelight']
 
@@ -192,6 +192,17 @@ class YeelightLight(Light):
     def should_poll(self):
         """No polling needed."""
         return False
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        if not self.config[CONF_POWER_MODE_ICON]:
+            return None
+
+        if self._get_property('flowing') == '1':
+            return 'mdi:waves'
+        elif self._is_nightlight_enabled:
+            return 'mdi:weather-night'
 
     @property
     def available(self) -> bool:
@@ -482,6 +493,8 @@ class YeelightLight(Light):
                 self._bulb.start_flow(flow, light_type=self.light_type)
             except BulbException as ex:
                 _LOGGER.error("Unable to set effect: %s", ex)
+
+            self.device.update()
 
     def turn_on(self, **kwargs) -> None:
         """Turn the bulb on."""


### PR DESCRIPTION
## Description:
Add option to icon change, depending of current power mode. Great for fast feedback about yeelight state. For example if bulb is flowing, its impossible to tell this from icon, or any other sensor / property. Also support nightlight mode. Based on https://github.com/home-assistant/home-assistant/pull/22346 , will rebase after merging.

![Screenshot_20190326_183252](https://user-images.githubusercontent.com/389828/55031020-f105d900-500d-11e9-914e-216de2fba5f4.png)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9043

## Example entry for `configuration.yaml` (if applicable):
```yaml
yeelight:
  devices:
    192.168.1.132:
      name: Wall light bedroom
      power_mode_icon: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)