### PR TITLE
Fix regression of the xiaomi_aqara config validation

### DIFF
--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -70,7 +70,7 @@ GATEWAY_CONFIG = vol.Schema({
 })
 
 GATEWAY_CONFIG_MAC_OPTIONAL = GATEWAY_CONFIG.extend({
-    vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None)
+    vol.Optional(CONF_MAC): GW_MAC,
 })
 
 GATEWAY_CONFIG_MAC_REQUIRED = GATEWAY_CONFIG.extend({

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -62,6 +62,7 @@ SERVICE_SCHEMA_REMOVE_DEVICE = vol.Schema({
 
 
 GATEWAY_CONFIG_MAC_OPT = vol.Schema({
+    vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None),
     vol.Optional(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,
@@ -70,6 +71,7 @@ GATEWAY_CONFIG_MAC_OPT = vol.Schema({
 })
 
 GATEWAY_CONFIG_MAC_REQ = vol.Schema({
+    vol.Required(CONF_MAC): GW_MAC,
     vol.Required(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -61,7 +61,7 @@ SERVICE_SCHEMA_REMOVE_DEVICE = vol.Schema({
 })
 
 
-GATEWAY_CONFIG_MAC_OPT = vol.Schema({
+GATEWAY_CONFIG_MAC_OPTIONAL = vol.Schema({
     vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None),
     vol.Optional(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
@@ -70,9 +70,9 @@ GATEWAY_CONFIG_MAC_OPT = vol.Schema({
     vol.Optional(CONF_DISABLE, default=False): cv.boolean,
 })
 
-GATEWAY_CONFIG_MAC_REQ = vol.Schema({
+GATEWAY_CONFIG_MAC_REQUIRED = vol.Schema({
     vol.Required(CONF_MAC): GW_MAC,
-    vol.Required(CONF_KEY):
+    vol.Optional(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=9898): cv.port,
@@ -99,8 +99,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_GATEWAYS, default={}):
             vol.All(cv.ensure_list, vol.Any(
-                vol.All([GATEWAY_CONFIG_MAC_OPT], vol.Length(max=1)),
-                vol.All([GATEWAY_CONFIG_MAC_REQ], vol.Length(min=2))
+                vol.All([GATEWAY_CONFIG_MAC_OPTIONAL], vol.Length(max=1)),
+                vol.All([GATEWAY_CONFIG_MAC_REQUIRED], vol.Length(min=2))
             ), [_fix_conf_defaults]),
         vol.Optional(CONF_INTERFACE, default='any'): cv.string,
         vol.Optional(CONF_DISCOVERY_RETRY, default=3): cv.positive_int

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -61,8 +61,7 @@ SERVICE_SCHEMA_REMOVE_DEVICE = vol.Schema({
 })
 
 
-GATEWAY_CONFIG_MAC_OPTIONAL = vol.Schema({
-    vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None),
+GATEWAY_CONFIG = vol.Schema({
     vol.Optional(CONF_KEY):
         vol.All(cv.string, vol.Length(min=16, max=16)),
     vol.Optional(CONF_HOST): cv.string,
@@ -70,13 +69,12 @@ GATEWAY_CONFIG_MAC_OPTIONAL = vol.Schema({
     vol.Optional(CONF_DISABLE, default=False): cv.boolean,
 })
 
-GATEWAY_CONFIG_MAC_REQUIRED = vol.Schema({
+GATEWAY_CONFIG_MAC_OPTIONAL = GATEWAY_CONFIG.extend({
+    vol.Optional(CONF_MAC, default=None): vol.Any(GW_MAC, None)
+})
+
+GATEWAY_CONFIG_MAC_REQUIRED = GATEWAY_CONFIG.extend({
     vol.Required(CONF_MAC): GW_MAC,
-    vol.Optional(CONF_KEY):
-        vol.All(cv.string, vol.Length(min=16, max=16)),
-    vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_PORT, default=9898): cv.port,
-    vol.Optional(CONF_DISABLE, default=False): cv.boolean,
 })
 
 


### PR DESCRIPTION
## Breaking Change:

The option key `mac` isn't allowed to be empty now. Please remove the key if it's empty.

```yaml
# not allowed anymore
xiaomi_aqara:
    gateways:
        - key: gkdaptzfdjl48ds9
          mac:

# valid
xiaomi_aqara:
    gateways:
        - key: gkdaptzfdjl48ds9

# valid
xiaomi_aqara:
    gateways:
        - key: gkdaptzfdjl48ds9
          mac: 0242cba9b678
```

## Description:

Fixes a regression introduces by #21834:

> 2019-03-26 17:53:25 ERROR (MainThread) [homeassistant.config] Invalid config for [xiaomi_aqara]:
[mac] is an invalid option for [xiaomi_aqara]. Check: xiaomi_aqara->xiaomi_aqara->gateways->0->mac. (See /home/homeassistant/.homeassistant/configuration.yaml, line 1025). Please check the docs at https://home-assistant.io/components/xiaomi_aqara/

@karlkar Could you review/test this fix?

## Allowed configurations are
```yaml
# Valid
xiaomi_aqara:
    gateways:
        - key: gkdaptzfdjl48ds9

# Valid
xiaomi_aqara:
    gateways:
        - mac: 0242cba9b678
          key: gkdaptzfdjl48ds9

# Valid
xiaomi_aqara:
    gateways:
        - mac: 0242cba9b678
          key: gkdaptzfdjl48ds9
        - mac: 9242cba9b679
          key: vfdaptzfdjl48d3j

# Invalid
xiaomi_aqara:
    gateways:
        - key: gkdaptzfdjl48ds9
        - mac: 9242cba9b679
          key: vfdaptzfdjl48d3j

# Invalid
xiaomi_aqara:
    gateways:
        - key: gkdaptzfdjl48ds9
        - key: vfdaptzfdjl48d3j
```
