### PR TITLE
[RFC] Optimistic yeelight update

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -348,6 +348,7 @@ class YeelightLight(Light):
             _LOGGER.debug("Setting brightness: %s", brightness)
             self._bulb.set_brightness(brightness / 255 * 100,
                                       duration=duration)
+            self._brightness = brightness
 
     @_cmd
     def set_rgb(self, rgb, duration) -> None:
@@ -355,6 +356,7 @@ class YeelightLight(Light):
         if rgb and self.supported_features & SUPPORT_COLOR:
             _LOGGER.debug("Setting RGB: %s", rgb)
             self._bulb.set_rgb(rgb[0], rgb[1], rgb[2], duration=duration)
+            self._hs = color_util.color_RGB_to_hs(rgb[0], rgb[1], rgb[2])
 
     @_cmd
     def set_colortemp(self, colortemp, duration) -> None:
@@ -364,6 +366,7 @@ class YeelightLight(Light):
             _LOGGER.debug("Setting color temp: %s K", temp_in_k)
 
             self._bulb.set_color_temp(temp_in_k, duration=duration)
+            self._color_temp = colortemp
 
     @_cmd
     def set_default(self) -> None:
@@ -466,6 +469,7 @@ class YeelightLight(Light):
             duration = int(kwargs.get(ATTR_TRANSITION) * 1000)  # kwarg in s
 
         self.device.turn_on(duration=duration)
+        self._is_on = True
 
         if self.config[CONF_MODE_MUSIC] and not self._bulb.music_mode:
             try:
@@ -503,6 +507,7 @@ class YeelightLight(Light):
             duration = int(kwargs.get(ATTR_TRANSITION) * 1000)  # kwarg in s
 
         self.device.turn_off(duration=duration)
+        self._is_on = False
         self.device.update()
 
     def set_mode(self, mode: str):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -356,7 +356,7 @@ class YeelightLight(Light):
         if rgb and self.supported_features & SUPPORT_COLOR:
             _LOGGER.debug("Setting RGB: %s", rgb)
             self._bulb.set_rgb(rgb[0], rgb[1], rgb[2], duration=duration)
-            self._hs = color_util.color_RGB_to_hs(rgb[0], rgb[1], rgb[2])
+            self._hs = color_util.color_RGB_to_hs(*rgb)
 
     @_cmd
     def set_colortemp(self, colortemp, duration) -> None:


### PR DESCRIPTION
## Description:
Improve UX by doing optimistic state update, before new values are fetched from the device

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
