### PR TITLE
Update ZHA component codeowners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -284,6 +284,7 @@ homeassistant/components/yi/camera.py @bachya
 
 # Z
 homeassistant/components/zeroconf/* @robbiet480
+homeassistant/components/zha/* @dmulcahey @adminiuga
 homeassistant/components/zoneminder/* @rohankapoorcom
 
 # Other code


### PR DESCRIPTION
## Description:
Update codeowners for ZHA component.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
