### PR TITLE
WIP: Manual entry of watched entity_id for scripts with templates.

### DIFF
--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -4,7 +4,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM
+from homeassistant.const import (
+    CONF_VALUE_TEMPLATE, CONF_PLATFORM, CONF_ENTITY_ID)
 from homeassistant.helpers.event import async_track_template
 import homeassistant.helpers.config_validation as cv
 
@@ -13,6 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 TRIGGER_SCHEMA = IF_ACTION_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'template',
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_ENTITY_ID): cv.comp_entity_ids,
 })
 
 
@@ -20,6 +22,7 @@ async def async_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
     value_template.hass = hass
+    entity_ids = config.get(CONF_ENTITY_ID)
 
     @callback
     def template_listener(entity_id, from_s, to_s):
@@ -33,4 +36,5 @@ async def async_trigger(hass, config, action, automation_info):
             },
         }, context=to_s.context))
 
-    return async_track_template(hass, value_template, template_listener)
+    return async_track_template(hass, value_template, template_listener,
+                                entity_ids=entity_ids)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -89,7 +89,8 @@ track_state_change = threaded_listener_factory(async_track_state_change)
 
 @callback
 @bind_hass
-def async_track_template(hass, template, action, variables=None):
+def async_track_template(hass, template, action, variables=None,
+                         entity_ids=None):
     """Add a listener that track state changes with template condition."""
     from . import condition
 
@@ -109,8 +110,10 @@ def async_track_template(hass, template, action, variables=None):
         elif not template_result:
             already_triggered = False
 
+    if not entity_ids:
+        entity_ids = template.extract_entities(variables)
     return async_track_state_change(
-        hass, template.extract_entities(variables),
+        hass, entity_ids,
         template_condition_listener)
 
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -8,7 +8,7 @@ from typing import Optional, Sequence
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, Context, callback
-from homeassistant.const import CONF_CONDITION, CONF_TIMEOUT
+from homeassistant.const import CONF_CONDITION, CONF_TIMEOUT, CONF_ENTITY_ID
 from homeassistant import exceptions
 from homeassistant.helpers import (
     service, condition, template as template,
@@ -258,6 +258,7 @@ class Script():
         # Call ourselves in the future to continue work
         wait_template = action[CONF_WAIT_TEMPLATE]
         wait_template.hass = self.hass
+        entity_ids = action.get(CONF_ENTITY_ID)
 
         self.last_action = action.get(CONF_ALIAS, 'wait template')
         self._log("Executing step %s" % self.last_action)
@@ -275,7 +276,8 @@ class Script():
                 self.async_run(variables, context))
 
         self._async_listener.append(async_track_template(
-            self.hass, wait_template, async_script_wait, variables))
+            self.hass, wait_template, async_script_wait, variables,
+            entity_ids))
 
         if CONF_TIMEOUT in action:
             self._async_set_timeout(


### PR DESCRIPTION
## Description:

I have fixed an old issue I found with wait templates. The same issue is present in template triggers for automatons. The details are in the related issue:

**Related issue (if applicable):** fixes #6342

This is still WIP since it needs some questions discussed before proceeding further.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#todo

## Example entry for `configuration.yaml`:
```yaml
example_script:
  alias: 'Example'
  sequence:
  - wait_template: "{{ is_state('sensor' + '.season', 'winter') }}"
    timeout: '00:00:30'
    entity_id: sensor.season
```

The new part is the `entity_id`, which allows you to specify manually the entity IDs to watch if the script dynamically looks up entity IDs and it's not possible to use the existing code to figure out what to watch.

I'm not entirely happy with this however, I'm not sure `entity_id` is the right key to use, possibly `entities` or `watch_entities` would be a more descriptive key since it's potentially a list and can have `all` as an option. 

I don't think it's possible to create a perfect piece of code that extracts entity IDs and gracefully falls-back to `all` here in a general sense either. Some kind of manual override is desirable.

I've found a bunch of other places where this still will still be an issue and isn't handled, it would be good to have something consistent: 

- [ ] baysian.binary_sensor
- [ ] template.binary_sensor - this does use the `entity_id` parameter already.
- [ ] template.cover
- [ ] template.fan - uses `entity_id` parameter
- [ ] template.light
- [ ] template.lock - warns if it can't extract entity IDs (which can still be wrong)
- [ ] template.sensor - warns
- [ ] template.switch - uses `entity_id`
- [ ] universal.media_player

## Questions:

* Is `entity_id` really an appropriate key? (I think `watch_entities` is better, and deprecate `entity_id` where used.)
* Should we *never* fall back to `all` and display an error in the log? (Yeh probably)
* Would it be worth improving the templates developer tool to show what entity IDs can be extracted from a script? (Yeh, but outside the scope of this PR)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
