### PR TITLE
Centralize all usages of `host` as a configuration param to the constant CONF_HOST

### DIFF
--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_HOST
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.util import dt as dt_util
 from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
@@ -20,7 +20,6 @@ DATA_AD = 'alarmdecoder'
 
 CONF_DEVICE = 'device'
 CONF_DEVICE_BAUD = 'baudrate'
-CONF_DEVICE_HOST = 'host'
 CONF_DEVICE_PATH = 'path'
 CONF_DEVICE_PORT = 'port'
 CONF_DEVICE_TYPE = 'type'
@@ -55,7 +54,7 @@ SIGNAL_REL_MESSAGE = 'alarmdecoder.rel_message'
 
 DEVICE_SOCKET_SCHEMA = vol.Schema({
     vol.Required(CONF_DEVICE_TYPE): 'socket',
-    vol.Optional(CONF_DEVICE_HOST, default=DEFAULT_DEVICE_HOST): cv.string,
+    vol.Optional(CONF_HOST, default=DEFAULT_DEVICE_HOST): cv.string,
     vol.Optional(CONF_DEVICE_PORT, default=DEFAULT_DEVICE_PORT): cv.port})
 
 DEVICE_SERIAL_SCHEMA = vol.Schema({
@@ -165,7 +164,7 @@ def setup(hass, config):
 
     controller = False
     if device_type == 'socket':
-        host = device.get(CONF_DEVICE_HOST)
+        host = device.get(CONF_HOST)
         port = device.get(CONF_DEVICE_PORT)
         controller = AlarmDecoder(SocketDevice(interface=(host, port)))
     elif device_type == 'serial':

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -8,14 +8,13 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_HOSTS
+from homeassistant.const import CONF_HOSTS, CONF_HOST
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import Throttle
 
 from . import config_flow  # noqa  pylint_disable=unused-import
-from .const import KEY_HOST
 
 REQUIREMENTS = ['pydaikin==1.2.0']
 
@@ -53,7 +52,7 @@ async def async_setup(hass, config):
                 DOMAIN,
                 context={'source': SOURCE_IMPORT},
                 data={
-                    KEY_HOST: host,
+                    CONF_HOST: host,
                 }))
     return True
 
@@ -61,7 +60,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Establish connection with Daikin."""
     conf = entry.data
-    daikin_api = await daikin_api_setup(hass, conf[KEY_HOST])
+    daikin_api = await daikin_api_setup(hass, conf[CONF_HOST])
     if not daikin_api:
         return False
     hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: daikin_api})

--- a/homeassistant/components/daikin/config_flow.py
+++ b/homeassistant/components/daikin/config_flow.py
@@ -6,8 +6,9 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
 
-from .const import KEY_HOST, KEY_IP, KEY_MAC
+from .const import KEY_IP, KEY_MAC
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ class FlowHandler(config_entries.ConfigFlow):
         return self.async_create_entry(
             title=host,
             data={
-                KEY_HOST: host,
+                CONF_HOST: host,
                 KEY_MAC: mac
             })
 
@@ -55,14 +56,14 @@ class FlowHandler(config_entries.ConfigFlow):
             return self.async_show_form(
                 step_id='user',
                 data_schema=vol.Schema({
-                    vol.Required(KEY_HOST): str
+                    vol.Required(CONF_HOST): str
                 })
             )
-        return await self._create_device(user_input[KEY_HOST])
+        return await self._create_device(user_input[CONF_HOST])
 
     async def async_step_import(self, user_input):
         """Import a config entry."""
-        host = user_input.get(KEY_HOST)
+        host = user_input.get(CONF_HOST)
         if not host:
             return await self.async_step_user()
         return await self._create_device(host)

--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -20,6 +20,5 @@ SENSOR_TYPES = {
     }
 }
 
-KEY_HOST = 'host'
 KEY_MAC = 'mac'
 KEY_IP = 'ip'

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -6,7 +6,8 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_TIMEOUT
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_TIMEOUT, \
+    CONF_HOST
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -20,7 +21,6 @@ DOMAIN = 'envisalink'
 DATA_EVL = 'envisalink'
 
 CONF_CODE = 'code'
-CONF_EVL_HOST = 'host'
 CONF_EVL_KEEPALIVE = 'keepalive_interval'
 CONF_EVL_PORT = 'port'
 CONF_EVL_VERSION = 'evl_version'
@@ -56,7 +56,7 @@ PARTITION_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_EVL_HOST): cv.string,
+        vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_PANEL_TYPE):
             vol.All(cv.string, vol.In(['HONEYWELL', 'DSC'])),
         vol.Required(CONF_USERNAME): cv.string,
@@ -95,7 +95,7 @@ async def async_setup(hass, config):
 
     conf = config.get(DOMAIN)
 
-    host = conf.get(CONF_EVL_HOST)
+    host = conf.get(CONF_HOST)
     port = conf.get(CONF_EVL_PORT)
     code = conf.get(CONF_CODE)
     panel_type = conf.get(CONF_PANEL_TYPE)

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP)
-from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON, CONF_HOST
 
 REQUIREMENTS = ['nad_receiver==0.0.11']
 
@@ -34,7 +34,6 @@ SUPPORT_NAD = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
 
 CONF_TYPE = 'type'
 CONF_SERIAL_PORT = 'serial_port'  # for NADReceiver
-CONF_HOST = 'host'  # for NADReceiverTelnet
 CONF_PORT = 'port'  # for NADReceiverTelnet
 CONF_MIN_VOLUME = 'min_volume'
 CONF_MAX_VOLUME = 'max_volume'

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.binary_sensor import DEVICE_CLASSES
 from homeassistant.const import (ATTR_CODE, ATTR_STATE,
                                  EVENT_HOMEASSISTANT_STOP,
-                                 CONF_SCAN_INTERVAL)
+                                 CONF_SCAN_INTERVAL, CONF_HOST)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -20,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'ness_alarm'
 DATA_NESS = 'ness_alarm'
 
-CONF_DEVICE_HOST = 'host'
 CONF_DEVICE_PORT = 'port'
 CONF_INFER_ARMING_STATE = 'infer_arming_state'
 CONF_ZONES = 'zones'
@@ -46,7 +45,7 @@ ZONE_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_DEVICE_HOST): cv.string,
+        vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_DEVICE_PORT): cv.port,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
@@ -76,7 +75,7 @@ async def async_setup(hass, config):
     conf = config[DOMAIN]
 
     zones = conf[CONF_ZONES]
-    host = conf[CONF_DEVICE_HOST]
+    host = conf[CONF_HOST]
     port = conf[CONF_DEVICE_PORT]
     scan_interval = conf[CONF_SCAN_INTERVAL]
     infer_arming_state = conf[CONF_INFER_ARMING_STATE]

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -12,7 +12,7 @@ import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 import voluptuous as vol
 
-from homeassistant.const import CONF_TIMEOUT
+from homeassistant.const import CONF_TIMEOUT, CONF_HOST
 import homeassistant.helpers.config_validation as cv
 
 from . import (
@@ -21,7 +21,6 @@ from . import (
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_IP = 'host'
 CONF_DURATION = 'duration'
 CONF_FONTSIZE = 'fontsize'
 CONF_POSITION = 'position'
@@ -95,7 +94,7 @@ COLORS = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_IP): cv.string,
+    vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_DURATION, default=DEFAULT_DURATION): vol.Coerce(int),
     vol.Optional(CONF_FONTSIZE, default=DEFAULT_FONTSIZE):
         vol.In(FONTSIZES.keys()),
@@ -112,7 +111,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_service(hass, config, discovery_info=None):
     """Get the Notifications for Android TV notification service."""
-    remoteip = config.get(CONF_IP)
+    remoteip = config.get(CONF_HOST)
     duration = config.get(CONF_DURATION)
     fontsize = config.get(CONF_FONTSIZE)
     position = config.get(CONF_POSITION)

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_HOST
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -23,7 +23,6 @@ DOMAIN = 'satel_integra'
 
 DATA_SATEL = 'satel_integra'
 
-CONF_DEVICE_HOST = 'host'
 CONF_DEVICE_PORT = 'port'
 CONF_DEVICE_PARTITION = 'partition'
 CONF_ARM_HOME_MODE = 'arm_home_mode'
@@ -48,7 +47,7 @@ ZONE_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_DEVICE_HOST): cv.string,
+        vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_DEVICE_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_DEVICE_PARTITION,
                      default=DEFAULT_DEVICE_PARTITION): cv.positive_int,
@@ -68,7 +67,7 @@ async def async_setup(hass, config):
 
     zones = conf.get(CONF_ZONES)
     outputs = conf.get(CONF_OUTPUTS)
-    host = conf.get(CONF_DEVICE_HOST)
+    host = conf.get(CONF_HOST)
     port = conf.get(CONF_DEVICE_PORT)
     partition = conf.get(CONF_DEVICE_PARTITION)
 

--- a/homeassistant/components/tellduslive/__init__.py
+++ b/homeassistant/components/tellduslive/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.event import async_call_later
 
 from . import config_flow  # noqa  pylint_disable=unused-import
 from .const import (
-    CONF_HOST, DOMAIN, KEY_HOST, KEY_SCAN_INTERVAL, KEY_SESSION,
+    CONF_HOST, DOMAIN, KEY_SCAN_INTERVAL, KEY_SESSION,
     MIN_UPDATE_INTERVAL, NOT_SO_PRIVATE_KEY, PUBLIC_KEY, SCAN_INTERVAL,
     SIGNAL_UPDATE_ENTITY, TELLDUS_DISCOVERY_NEW)
 
@@ -54,7 +54,7 @@ async def async_setup_entry(hass, entry):
     from tellduslive import Session
     conf = entry.data[KEY_SESSION]
 
-    if KEY_HOST in conf:
+    if CONF_HOST in conf:
         # Session(**conf) does blocking IO when
         # communicating with local devices.
         session = await hass.async_add_executor_job(partial(Session, **conf))
@@ -108,7 +108,7 @@ async def async_setup(hass, config):
             DOMAIN,
             context={'source': config_entries.SOURCE_IMPORT},
             data={
-                KEY_HOST: config[DOMAIN].get(CONF_HOST),
+                CONF_HOST: config[DOMAIN].get(CONF_HOST),
                 KEY_SCAN_INTERVAL: config[DOMAIN][CONF_SCAN_INTERVAL],
             }))
     return True

--- a/homeassistant/components/tellduslive/config_flow.py
+++ b/homeassistant/components/tellduslive/config_flow.py
@@ -7,10 +7,11 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
 from homeassistant.util.json import load_json
 
 from .const import (
-    APPLICATION_NAME, CLOUD_NAME, DOMAIN, KEY_HOST, KEY_SCAN_INTERVAL,
+    APPLICATION_NAME, CLOUD_NAME, DOMAIN, KEY_SCAN_INTERVAL,
     KEY_SESSION, NOT_SO_PRIVATE_KEY, PUBLIC_KEY, SCAN_INTERVAL,
     TELLDUS_CONFIG_FILE)
 
@@ -50,14 +51,14 @@ class FlowHandler(config_entries.ConfigFlow):
             return self.async_abort(reason='already_setup')
 
         if user_input is not None or len(self._hosts) == 1:
-            if user_input is not None and user_input[KEY_HOST] != CLOUD_NAME:
-                self._host = user_input[KEY_HOST]
+            if user_input is not None and user_input[CONF_HOST] != CLOUD_NAME:
+                self._host = user_input[CONF_HOST]
             return await self.async_step_auth()
 
         return self.async_show_form(
             step_id='user',
             data_schema=vol.Schema({
-                vol.Required(KEY_HOST):
+                vol.Required(CONF_HOST):
                 vol.In(list(self._hosts))
             }))
 
@@ -70,7 +71,7 @@ class FlowHandler(config_entries.ConfigFlow):
                 host = self._host or CLOUD_NAME
                 if self._host:
                     session = {
-                        KEY_HOST: host,
+                        CONF_HOST: host,
                         KEY_TOKEN: self._session.access_token
                     }
                 else:
@@ -80,7 +81,7 @@ class FlowHandler(config_entries.ConfigFlow):
                     }
                 return self.async_create_entry(
                     title=host, data={
-                        KEY_HOST: host,
+                        CONF_HOST: host,
                         KEY_SCAN_INTERVAL: self._scan_interval.seconds,
                         KEY_SESSION: session,
                     })
@@ -124,8 +125,8 @@ class FlowHandler(config_entries.ConfigFlow):
             return self.async_abort(reason='already_setup')
 
         self._scan_interval = user_input[KEY_SCAN_INTERVAL]
-        if user_input[KEY_HOST] != DOMAIN:
-            self._hosts.append(user_input[KEY_HOST])
+        if user_input[CONF_HOST] != DOMAIN:
+            self._hosts.append(user_input[CONF_HOST])
 
         if not await self.hass.async_add_executor_job(
                 os.path.isfile, self.hass.config.path(TELLDUS_CONFIG_FILE)):
@@ -135,14 +136,14 @@ class FlowHandler(config_entries.ConfigFlow):
             load_json, self.hass.config.path(TELLDUS_CONFIG_FILE))
         host = next(iter(conf))
 
-        if user_input[KEY_HOST] != host:
+        if user_input[CONF_HOST] != host:
             return await self.async_step_user()
 
         host = CLOUD_NAME if host == 'tellduslive' else host
         return self.async_create_entry(
             title=host,
             data={
-                KEY_HOST: host,
+                CONF_HOST: host,
                 KEY_SCAN_INTERVAL: self._scan_interval.seconds,
                 KEY_SESSION: next(iter(conf.values())),
             })

--- a/homeassistant/components/tellduslive/const.py
+++ b/homeassistant/components/tellduslive/const.py
@@ -13,7 +13,6 @@ KEY_CONFIG = 'tellduslive_config'
 
 SIGNAL_UPDATE_ENTITY = 'tellduslive_update'
 
-KEY_HOST = 'host'
 KEY_SESSION = 'session'
 KEY_SCAN_INTERVAL = 'scan_interval'
 

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -11,7 +11,6 @@ from homeassistant import config_entries
 from .const import (
     CONF_IMPORT_GROUPS, CONF_IDENTITY, CONF_HOST, CONF_KEY, CONF_GATEWAY_ID)
 
-KEY_HOST = 'host'
 KEY_SECURITY_CODE = 'security_code'
 KEY_IMPORT_GROUPS = 'import_groups'
 
@@ -45,7 +44,7 @@ class FlowHandler(config_entries.ConfigFlow):
         errors = {}
 
         if user_input is not None:
-            host = user_input.get(KEY_HOST, self._host)
+            host = user_input.get(CONF_HOST, self._host)
             try:
                 auth = await authenticate(
                     self.hass, host,
@@ -67,7 +66,7 @@ class FlowHandler(config_entries.ConfigFlow):
         fields = OrderedDict()
 
         if self._host is None:
-            fields[vol.Required(KEY_HOST)] = str
+            fields[vol.Required(CONF_HOST)] = str
 
         fields[vol.Required(KEY_SECURITY_CODE)] = str
 

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -6,7 +6,8 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.daikin import config_flow
-from homeassistant.components.daikin.const import KEY_HOST, KEY_IP, KEY_MAC
+from homeassistant.components.daikin.const import KEY_IP, KEY_MAC
+from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry, MockDependency
 
@@ -37,10 +38,10 @@ async def test_user(hass, mock_daikin):
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'user'
 
-    result = await flow.async_step_user({KEY_HOST: HOST})
+    result = await flow.async_step_user({CONF_HOST: HOST})
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['title'] == HOST
-    assert result['data'][KEY_HOST] == HOST
+    assert result['data'][CONF_HOST] == HOST
     assert result['data'][KEY_MAC] == MAC
 
 
@@ -49,7 +50,7 @@ async def test_abort_if_already_setup(hass, mock_daikin):
     flow = init_config_flow(hass)
     MockConfigEntry(domain='daikin', data={KEY_MAC: MAC}).add_to_hass(hass)
 
-    result = await flow.async_step_user({KEY_HOST: HOST})
+    result = await flow.async_step_user({CONF_HOST: HOST})
     assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
     assert result['reason'] == 'already_configured'
 
@@ -62,10 +63,10 @@ async def test_import(hass, mock_daikin):
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'user'
 
-    result = await flow.async_step_import({KEY_HOST: HOST})
+    result = await flow.async_step_import({CONF_HOST: HOST})
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['title'] == HOST
-    assert result['data'][KEY_HOST] == HOST
+    assert result['data'][CONF_HOST] == HOST
     assert result['data'][KEY_MAC] == MAC
 
 
@@ -76,7 +77,7 @@ async def test_discovery(hass, mock_daikin):
     result = await flow.async_step_discovery({KEY_IP: HOST, KEY_MAC: MAC})
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['title'] == HOST
-    assert result['data'][KEY_HOST] == HOST
+    assert result['data'][CONF_HOST] == HOST
     assert result['data'][KEY_MAC] == MAC
 
 
@@ -88,6 +89,6 @@ async def test_device_abort(hass, mock_daikin, s_effect, reason):
     flow = init_config_flow(hass)
     mock_daikin.Appliance.side_effect = s_effect
 
-    result = await flow.async_step_user({KEY_HOST: HOST})
+    result = await flow.async_step_user({CONF_HOST: HOST})
     assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
     assert result['reason'] == reason

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -6,20 +6,20 @@ from asynctest import patch, MagicMock
 
 from homeassistant.components import alarm_control_panel
 from homeassistant.components.ness_alarm import (
-    DOMAIN, CONF_DEVICE_PORT, CONF_DEVICE_HOST, CONF_ZONE_NAME, CONF_ZONES,
+    DOMAIN, CONF_DEVICE_PORT, CONF_ZONE_NAME, CONF_ZONES,
     CONF_ZONE_ID, SERVICE_AUX, SERVICE_PANIC,
     ATTR_CODE, ATTR_OUTPUT_ID)
 from homeassistant.const import (
     STATE_ALARM_ARMING, SERVICE_ALARM_DISARM, ATTR_ENTITY_ID,
     SERVICE_ALARM_ARM_AWAY, SERVICE_ALARM_ARM_HOME, SERVICE_ALARM_TRIGGER,
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_AWAY, STATE_ALARM_PENDING,
-    STATE_ALARM_TRIGGERED, STATE_UNKNOWN)
+    STATE_ALARM_TRIGGERED, STATE_UNKNOWN, CONF_HOST)
 from homeassistant.setup import async_setup_component
 from tests.common import MockDependency
 
 VALID_CONFIG = {
     DOMAIN: {
-        CONF_DEVICE_HOST: 'alarm.local',
+        CONF_HOST: 'alarm.local',
         CONF_DEVICE_PORT: 1234,
         CONF_ZONES: [
             {

--- a/tests/components/tellduslive/test_config_flow.py
+++ b/tests/components/tellduslive/test_config_flow.py
@@ -7,8 +7,9 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.tellduslive import (
-    APPLICATION_NAME, DOMAIN, KEY_HOST, KEY_SCAN_INTERVAL, SCAN_INTERVAL,
+    APPLICATION_NAME, DOMAIN, KEY_SCAN_INTERVAL, SCAN_INTERVAL,
     config_flow)
+from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry, MockDependency, mock_coro
 
@@ -94,7 +95,7 @@ async def test_step_import(hass, mock_tellduslive):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_import({
-        KEY_HOST: DOMAIN,
+        CONF_HOST: DOMAIN,
         KEY_SCAN_INTERVAL: 0,
     })
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
@@ -106,7 +107,7 @@ async def test_step_import_add_host(hass, mock_tellduslive):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_import({
-        KEY_HOST: 'localhost',
+        CONF_HOST: 'localhost',
         KEY_SCAN_INTERVAL: 0,
     })
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
@@ -117,7 +118,7 @@ async def test_step_import_no_config_file(hass, mock_tellduslive):
     """Test that we trigger user with no config_file configuring from import."""
     flow = init_config_flow(hass)
 
-    result = await flow.async_step_import({ KEY_HOST: 'localhost', KEY_SCAN_INTERVAL: 0, })
+    result = await flow.async_step_import({ CONF_HOST: 'localhost', KEY_SCAN_INTERVAL: 0, })
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'user'
 
@@ -129,7 +130,7 @@ async def test_step_import_load_json_matching_host(hass, mock_tellduslive):
     with patch('homeassistant.components.tellduslive.config_flow.load_json',
                return_value={'tellduslive': {}}), \
             patch('os.path.isfile'):
-        result = await flow.async_step_import({ KEY_HOST: 'Cloud API', KEY_SCAN_INTERVAL: 0, })
+        result = await flow.async_step_import({ CONF_HOST: 'Cloud API', KEY_SCAN_INTERVAL: 0, })
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'user'
 
@@ -141,7 +142,7 @@ async def test_step_import_load_json(hass, mock_tellduslive):
     with patch('homeassistant.components.tellduslive.config_flow.load_json',
                return_value={'localhost': {}}), \
             patch('os.path.isfile'):
-        result = await flow.async_step_import({ KEY_HOST: 'localhost', KEY_SCAN_INTERVAL: SCAN_INTERVAL, })
+        result = await flow.async_step_import({ CONF_HOST: 'localhost', KEY_SCAN_INTERVAL: SCAN_INTERVAL, })
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['title'] == 'localhost'
     assert result['data']['host'] == 'localhost'


### PR DESCRIPTION
## Description:
This affects where constants are defined, but does not change any of the values.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
