### PR TITLE
Add game and app media types

### DIFF
--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -38,6 +38,8 @@ MEDIA_TYPE_CHANNEL = 'channel'
 MEDIA_TYPE_PLAYLIST = 'playlist'
 MEDIA_TYPE_IMAGE = 'image'
 MEDIA_TYPE_URL = 'url'
+MEDIA_TYPE_GAME = 'game'
+MEDIA_TYPE_APP = 'app'
 
 SERVICE_CLEAR_PLAYLIST = 'clear_playlist'
 SERVICE_PLAY_MEDIA = 'play_media'

--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -39,7 +39,6 @@ MEDIA_TYPE_PLAYLIST = 'playlist'
 MEDIA_TYPE_IMAGE = 'image'
 MEDIA_TYPE_URL = 'url'
 MEDIA_TYPE_GAME = 'game'
-MEDIA_TYPE_APP = 'app'
 
 SERVICE_CLEAR_PLAYLIST = 'clear_playlist'
 SERVICE_PLAY_MEDIA = 'play_media'

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     ENTITY_IMAGE_URL, MediaPlayerDevice)
 from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_MUSIC, SUPPORT_SELECT_SOURCE, SUPPORT_STOP, SUPPORT_TURN_OFF,
+    MEDIA_TYPE_GAME, SUPPORT_SELECT_SOURCE, SUPPORT_STOP, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON)
 from homeassistant.const import (
     ATTR_COMMAND, ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_REGION,
@@ -328,8 +328,7 @@ class PS4Device(MediaPlayerDevice):
     @property
     def media_content_type(self):
         """Content type of current playing media."""
-        # No MEDIA_TYPE_GAME attr as of 0.90.
-        return MEDIA_TYPE_MUSIC
+        return MEDIA_TYPE_GAME
 
     @property
     def media_image_url(self):


### PR DESCRIPTION
## Breaking Change:
media_content_type changed to game from music
Makes more sense that it is a game playing on the PS4

## Description:
Changed default media type for PS4 to game instead of music

**Related issue:** fixes #21896

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
