### PR TITLE
Added check for ebusd monitored conditions validity 

### DIFF
--- a/homeassistant/components/ebusd/__init__.py
+++ b/homeassistant/components/ebusd/__init__.py
@@ -25,15 +25,29 @@ SERVICE_EBUSD_WRITE = 'ebusd_write'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=15)
 
+
+def verify_ebusd_config(config):
+    """Verify eBusd config."""
+    circuit = config[CONF_CIRCUIT]
+    for condition in config[CONF_MONITORED_CONDITIONS]:
+        if condition not in SENSOR_TYPES[circuit]:
+            raise vol.Invalid(
+                "Condition '" + condition + "' not in '" + circuit + "'.")
+    return config
+
+
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_CIRCUIT): cv.string,
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=[]): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES['700'])])
-    })
+    DOMAIN: vol.Schema(
+        vol.All({
+            vol.Required(CONF_CIRCUIT): cv.string,
+            vol.Required(CONF_HOST): cv.string,
+            vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
+                cv.ensure_list,
+        },
+                verify_ebusd_config)
+    )
 }, extra=vol.ALLOW_EXTRA)
 
 


### PR DESCRIPTION
ebusd: added check for monitored conditions validity within correct circuit

## Description:
This changes condition check to use list from correct circuit. Before this was statically defined for one circuit and throw error for conditions from other circuits

**Related issue (if applicable):** fixes #21370

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
