### PR TITLE
Add image field and bump python-join-api version

### DIFF
--- a/homeassistant/components/joaoapps_join/notify.py
+++ b/homeassistant/components/joaoapps_join/notify.py
@@ -7,7 +7,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-join-api==0.0.2']
+REQUIREMENTS = ['python-join-api==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,5 +60,5 @@ class JoinNotificationService(BaseNotificationService):
         send_notification(
             device_id=self._device_id, device_ids=self._device_ids,
             device_names=self._device_names, text=message, title=title,
-            icon=data.get('icon'), smallicon=data.get('smallicon'),
-            vibration=data.get('vibration'), api_key=self._api_key)
+            image=data.get('image'), vibration=data.get('vibration'),
+            api_key=self._api_key)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Bump python-join-api version to 0.0.3 and add image field for notification data.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9055

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
