### PR TITLE
Fix too-abrubt SimpliSafe data refresh termination on error

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -113,8 +113,9 @@ async def async_setup_entry(hass, config_entry):
             try:
                 await system.update()
             except SimplipyError as err:
-                _LOGGER.error('There was an error while updating: %s', err)
-                return
+                _LOGGER.error(
+                    'There was error updating "%s": %s', system.address, err)
+                continue
 
             async_dispatcher_send(hass, TOPIC_UPDATE.format(system.system_id))
 


### PR DESCRIPTION
## Description:

This PR fixes an issue where a failed data update for one system would terminate updates for any other system.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
