### PR TITLE
Add new data fields and bump python-join-api

### DIFF
--- a/homeassistant/components/joaoapps_join/__init__.py
+++ b/homeassistant/components/joaoapps_join/__init__.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, CONF_API_KEY
 
-REQUIREMENTS = ['python-join-api==0.0.2']
+REQUIREMENTS = ['python-join-api==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/joaoapps_join/notify.py
+++ b/homeassistant/components/joaoapps_join/notify.py
@@ -7,7 +7,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-join-api==0.0.2']
+REQUIREMENTS = ['python-join-api==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,4 +61,7 @@ class JoinNotificationService(BaseNotificationService):
             device_id=self._device_id, device_ids=self._device_ids,
             device_names=self._device_names, text=message, title=title,
             icon=data.get('icon'), smallicon=data.get('smallicon'),
+            image=data.get('image'), sound=data.get('sound'),
+            notification_id=data.get('notification_id'), url=data.get('url'),
+            tts=data.get('tts'), tts_language=data.get('tts_language'),
             vibration=data.get('vibration'), api_key=self._api_key)


### PR DESCRIPTION
## Description:
Bump python-join-api version to 0.0.4 and add image, sound, notification_id, url, tts and tts_language fields for notification data.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9055

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
