### PR TITLE
Fix cover position reporting in SmartThings cover platform

### DIFF
--- a/homeassistant/components/smartthings/cover.py
+++ b/homeassistant/components/smartthings/cover.py
@@ -135,6 +135,8 @@ class SmartThingsCover(SmartThingsEntity, CoverDevice):
     @property
     def current_cover_position(self):
         """Return current position of cover."""
+        if not self._supported_features & SUPPORT_SET_POSITION:
+            return None
         return self._device.status.level
 
     @property

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -142,7 +142,10 @@ async def test_set_cover_position_unsupported(hass, device_factory):
         COVER_DOMAIN, SERVICE_SET_COVER_POSITION,
         {ATTR_POSITION: 50}, blocking=True)
 
-    # Ensure API was notcalled
+    state = hass.states.get('cover.shade')
+    assert ATTR_CURRENT_POSITION not in state.attributes
+
+    # Ensure API was not called
     # pylint: disable=protected-access
     assert device._api.post_device_command.call_count == 0  # type: ignore
 


### PR DESCRIPTION
## Description:
Updates the cover platform to not return a value for `current_cover_position` when it is not supported by the device.  Previously it was returning `0`.

**Related issue (if applicable):** fixes #22465

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
