### PR TITLE
Print error instead of warning for custom platforms in legacy format

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -99,10 +99,10 @@ def get_platform(hass,  # type: HomeAssistant
     if platform is not None:
         return platform
 
-    # Legacy platform check: light/hue.py
+    # Legacy platform check for custom: custom_components/light/hue.py
     platform = _load_file(
         hass, PLATFORM_FORMAT.format(domain=platform_name, platform=domain),
-        base_paths)
+        [PACKAGE_CUSTOM_COMPONENTS])
 
     if platform is None:
         if component is None:
@@ -113,11 +113,10 @@ def get_platform(hass,  # type: HomeAssistant
         _LOGGER.error("Unable to find platform %s.%s", platform_name, extra)
         return None
 
-    if platform.__name__.startswith(PACKAGE_CUSTOM_COMPONENTS):
-        _LOGGER.warning(
-            "Integrations need to be in their own folder. Change %s/%s.py to "
-            "%s/%s.py. This will stop working soon.",
-            domain, platform_name, platform_name, domain)
+    _LOGGER.error(
+        "Integrations need to be in their own folder. Change %s/%s.py to "
+        "%s/%s.py. This will stop working soon.",
+        domain, platform_name, platform_name, domain)
 
     return platform
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -100,9 +100,13 @@ def get_platform(hass,  # type: HomeAssistant
         return platform
 
     # Legacy platform check for custom: custom_components/light/hue.py
-    platform = _load_file(
-        hass, PLATFORM_FORMAT.format(domain=platform_name, platform=domain),
-        [PACKAGE_CUSTOM_COMPONENTS])
+    # Only check if the component was also in custom components.
+    if component is None or base_paths[0] == PACKAGE_CUSTOM_COMPONENTS:
+        platform = _load_file(
+            hass,
+            PLATFORM_FORMAT.format(domain=platform_name, platform=domain),
+            [PACKAGE_CUSTOM_COMPONENTS]
+        )
 
     if platform is None:
         if component is None:


### PR DESCRIPTION
## Description:
Next level of deprecation, instead of warning, it's an error.
Also no longer looks for built-in platforms in legacy format as they don't exist ! 

**Related issue (if applicable):** fixes #22309
