### PR TITLE
Add trusted networks deprecating warning

### DIFF
--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -194,7 +194,7 @@ def setup_auth(hass, app):
                 'Access from trusted networks without auth token is going to '
                 'be removed in Home Assistant 0.96. Configure the trusted '
                 'networks auth provider or use long lived access tokens to '
-                'access %s from %s'
+                'access %s from %s',
                 request.path, request[KEY_REAL_IP])
             authenticated = True
 

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -191,9 +191,10 @@ def setup_auth(hass, app):
         elif (trusted_networks and
               await async_validate_trusted_networks(request)):
             _LOGGER.warning(
-                'Using trusted networks to bypass authentication is going to'
-                ' be removed after 0.95 release. You need to use a bearer'
-                ' token to access %s from %s',
+                'Access from trusted networks without auth token is going to '
+                'be removed in Home Assistant 0.96. Configure the trusted '
+                'networks auth provider or use long lived access tokens to '
+                'access %s from %s'
                 request.path, request[KEY_REAL_IP])
             authenticated = True
 

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -192,7 +192,7 @@ def setup_auth(hass, app):
               await async_validate_trusted_networks(request)):
             _LOGGER.warning(
                 'Using trusted networks to bypass authentication is going to'
-                ' deprecate after 0.95 release. You need to use a bearer token'
+                ' removed after 0.95 release. You need to use a bearer token'
                 ' to access %s from %s',
                 request.path, request[KEY_REAL_IP])
             authenticated = True

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -193,7 +193,7 @@ def setup_auth(hass, app):
             _LOGGER.warning(
                 'Access from trusted networks without auth token is going to '
                 'be removed in Home Assistant 0.96. Configure the trusted '
-                'networks auth provider or use long lived access tokens to '
+                'networks auth provider or use long-lived access tokens to '
                 'access %s from %s',
                 request.path, request[KEY_REAL_IP])
             authenticated = True

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -190,6 +190,11 @@ def setup_auth(hass, app):
 
         elif (trusted_networks and
               await async_validate_trusted_networks(request)):
+            _LOGGER.warning(
+                'Using trusted networks to bypass authentication is going to'
+                ' deprecate after 0.95 release. You need to use a bearer token'
+                ' to access %s from %s',
+                request.path, request[KEY_REAL_IP])
             authenticated = True
 
         elif (support_legacy and HTTP_HEADER_HA_AUTH in request.headers and

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -192,8 +192,8 @@ def setup_auth(hass, app):
               await async_validate_trusted_networks(request)):
             _LOGGER.warning(
                 'Using trusted networks to bypass authentication is going to'
-                ' removed after 0.95 release. You need to use a bearer token'
-                ' to access %s from %s',
+                ' be removed after 0.95 release. You need to use a bearer'
+                ' token to access %s from %s',
                 request.path, request[KEY_REAL_IP])
             authenticated = True
 


### PR DESCRIPTION
## Description:

Add trusted networks deprecating warning. **Trusted Network Authentication Provider IS NOT deprecating**. However using trusted networks to bypass authentication is going to deprecated after release 0.95.

All access to API have to provide an access token if that API required authentication. If your request is coming from trusted network, you can easily get an access token through login flow (via browser). If you are accessing HA API through other program, you need create a long-lived access token.


**Related issue (if applicable):** related #home-assistant/architecture#174

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)


