### PR TITLE
Improved local ip

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -112,7 +112,7 @@ def get_local_ip() -> str:
         # Check eth0, eth1, eth2, en0, ...
         interfaces = [
             i + str(n) for i in ("eth", "en", "wlan") for n in range(3)
-        ]  # :(
+        ]
         for interface in interfaces:
             try:
                 ip_addr = interface_ip(interface)

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -87,7 +87,7 @@ def interface_ip(interface):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     return socket.inet_ntoa(
         fcntl.ioctl(
-            sock.fileno(), 0x8915, struct.pack('256s', interface[:15])
+            sock.fileno(), 0x8915, struct.pack('256s', interface[:15].encode('utf-8'))
         )[20:24]
     )
     # Explanation:


### PR DESCRIPTION
## Description:
I am aware this issue was closed, but the same issue does not only occur with homekit, but also when using the zeroconf component. When a VPN is running on my Mac, and I start home assistant, the zeroconf component will advertise itself on the network with my VPN's outbound IP address, not the local ip. This essentially breaks zeroconf, as the correct IP address of home assistant cannot be discovered by anyone then.

**Related issue:** fixes #14107

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.