### PR TITLE
Speed up status updating in SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -126,7 +126,8 @@ async def async_setup_entry(hass, config_entry):
 
     hass.data[DOMAIN][DATA_LISTENER][
         config_entry.entry_id] = async_track_time_interval(
-            hass, refresh,
+            hass,
+            refresh,
             timedelta(seconds=config_entry.data[CONF_SCAN_INTERVAL]))
 
     return True

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -115,14 +115,15 @@ async def async_setup_entry(hass, config_entry):
                 _LOGGER.error(
                     'There was error updating "%s": %s', system.address,
                     result)
-            else:
-                _LOGGER.debug('Updated status of "%s"', system.address)
-                async_dispatcher_send(
-                    hass, TOPIC_UPDATE.format(system.system_id))
+                continue
 
-                if system.api.refresh_token_dirty:
-                    _async_save_refresh_token(
-                        hass, config_entry, system.api.refresh_token)
+            _LOGGER.debug('Updated status of "%s"', system.address)
+            async_dispatcher_send(
+                hass, TOPIC_UPDATE.format(system.system_id))
+
+            if system.api.refresh_token_dirty:
+                _async_save_refresh_token(
+                    hass, config_entry, system.api.refresh_token)
 
     hass.data[DOMAIN][DATA_LISTENER][
         config_entry.entry_id] = async_track_time_interval(


### PR DESCRIPTION
## Description:

Following up on https://github.com/home-assistant/home-assistant/pull/22466, this PR speeds up the process by which multiple SimpliSafe systems get updates.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
