### PR TITLE
Remove botocore dependency from credstash script

### DIFF
--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -4,7 +4,7 @@ import getpass
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['credstash==1.15.0', 'botocore==1.7.34']
+REQUIREMENTS = ['credstash==1.15.0']
 
 
 def run(args):
@@ -24,16 +24,14 @@ def run(args):
         'value', help="The value to save when putting a secret",
         nargs='?', default=None)
 
-    # pylint: disable=import-error, no-member
     import credstash
-    import botocore
 
     args = parser.parse_args(args)
     table = _SECRET_NAMESPACE
 
     try:
         credstash.listSecrets(table=table)
-    except botocore.errorfactory.ClientError:
+    except Exception:  # pylint: disable=broad-except
         credstash.createDdbTable(table=table)
 
     if args.action == 'list':

--- a/homeassistant/scripts/credstash.py
+++ b/homeassistant/scripts/credstash.py
@@ -24,6 +24,7 @@ def run(args):
         'value', help="The value to save when putting a secret",
         nargs='?', default=None)
 
+    # pylint: disable=no-member
     import credstash
 
     args = parser.parse_args(args)

--- a/pylintrc
+++ b/pylintrc
@@ -42,7 +42,6 @@ reports=no
 [TYPECHECK]
 # For attrs
 ignored-classes=_CountingAttr
-generated-members=botocore.errorfactory
 
 [FORMAT]
 expected-line-ending-format=LF

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -235,9 +235,6 @@ blockchain==1.4.4
 # homeassistant.components.aws_sqs.notify
 boto3==1.9.16
 
-# homeassistant.scripts.credstash
-botocore==1.7.34
-
 # homeassistant.components.braviatv.media_player
 braviarc-homeassistant==0.3.7.dev0
 


### PR DESCRIPTION
## Description:

`credstash` script pinned `botocore` version just for exception catching. It is unnecessary. 

This caused pip warning
```
aiobotocore 0.10.2 has requirement botocore<1.12.92,>=1.12.91, but you'll have botocore 1.7.34 which is incompatible.
boto3 1.9.16 has requirement botocore<1.13.0,>=1.12.16, but you'll have botocore 1.7.34 which is incompatible.
```


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
