### PR TITLE
throw `PlatformNotReady` if unable to connect

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     ATTR_COMMAND, ATTR_ENTITY_ID, CONF_DEVICE_CLASS, CONF_HOST, CONF_NAME,
     CONF_PORT, STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING,
     STATE_STANDBY)
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 ANDROIDTV_DOMAIN = 'androidtv'
@@ -125,7 +126,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         _LOGGER.warning("Could not connect to %s at %s%s",
                         device_name, host, adb_log)
-        return
+        raise PlatformNotReady
 
     if host in hass.data[ANDROIDTV_DOMAIN]:
         _LOGGER.warning("Platform already setup on %s, skipping", host)


### PR DESCRIPTION
Throw `PlatformNotReady` for when the device disconnects, or when the Home Assistant is booting and the ADB server is not ready yet.

## Description:

When HA is ready before my ADB server in my docker container, or if my device disconnects from the network temporarily, HA loses connection and requires a restart. Instead, I think it should throw a `PlatformNotReady` so it will retry it, and do it in a back-off manner.

I tested this on my own network and it fixed my problem. I think others should benefit from this too.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
