### PR TITLE
Fix .coveragerc from merge/rebase

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -235,15 +235,12 @@ omit =
     homeassistant/components/harmony/remote.py
     homeassistant/components/haveibeenpwned/sensor.py
     homeassistant/components/hdmi_cec/*
-<<<<<<< HEAD
     homeassistant/components/heatmiser/climate.py
     homeassistant/components/hikvision/binary_sensor.py
     homeassistant/components/hikvisioncam/switch.py
     homeassistant/components/hipchat/notify.py
     homeassistant/components/hitron_coda/device_tracker.py
-=======
-    homeassistant/components/heos/*
->>>>>>> Update HEOS to support multiple speaker and conformance.
+    homeassistant/components/heos/
     homeassistant/components/hive/*
     homeassistant/components/hlk_sw16/*
     homeassistant/components/homekit_controller/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -240,7 +240,7 @@ omit =
     homeassistant/components/hikvisioncam/switch.py
     homeassistant/components/hipchat/notify.py
     homeassistant/components/hitron_coda/device_tracker.py
-    homeassistant/components/heos/
+    homeassistant/components/heos/*
     homeassistant/components/hive/*
     homeassistant/components/hlk_sw16/*
     homeassistant/components/homekit_controller/*


### PR DESCRIPTION
Removes merge/rebase comments from .coveragerc.  Blame #21721 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.