### PR TITLE
Prevent toogle to false at restart of ADS platforms

### DIFF
--- a/homeassistant/components/ads/binary_sensor.py
+++ b/homeassistant/components/ads/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for ADS binary sensors."""
 import logging
+import asyncio
+import async_timeout
 
 import voluptuous as vol
 
@@ -7,6 +9,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA, BinarySensorDevice)
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from . import CONF_ADS_VAR, DATA_ADS
 
@@ -41,10 +44,11 @@ class AdsBinarySensor(BinarySensorDevice):
         """Initialize ADS binary sensor."""
         self._name = name
         self._unique_id = ads_var
-        self._state = False
+        self._state = None
         self._device_class = device_class or 'moving'
         self._ads_hub = ads_hub
         self.ads_var = ads_var
+        self._event = None
 
     async def async_added_to_hass(self):
         """Register device notification."""
@@ -52,11 +56,24 @@ class AdsBinarySensor(BinarySensorDevice):
             """Handle device notifications."""
             _LOGGER.debug('Variable %s changed its value to %d', name, value)
             self._state = value
+            run_coroutine_threadsafe(async_event_set(), self.hass.loop)
             self.schedule_update_ha_state()
 
-        self.hass.async_add_job(
+        async def async_event_set():
+            """Set event in async context."""
+            self._event.set()
+
+        self._event = asyncio.Event()
+
+        await self.hass.async_add_executor_job(
             self._ads_hub.add_device_notification,
             self.ads_var, self._ads_hub.PLCTYPE_BOOL, update)
+        try:
+            with async_timeout.timeout(30):
+                await self._event.wait()
+        except asyncio.TimeoutError:
+            _LOGGER.debug('Variable %s: Timeout during first update',
+                          self.ads_var)
 
     @property
     def name(self):
@@ -82,3 +99,8 @@ class AdsBinarySensor(BinarySensorDevice):
     def should_poll(self):
         """Return False because entity pushes its state to HA."""
         return False
+
+    @property
+    def available(self):
+        """Return False if state has not been updated yet."""
+        return self._state is not None

--- a/homeassistant/components/ads/binary_sensor.py
+++ b/homeassistant/components/ads/binary_sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA, BinarySensorDevice)
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from . import CONF_ADS_VAR, DATA_ADS
 
@@ -56,7 +55,7 @@ class AdsBinarySensor(BinarySensorDevice):
             """Handle device notifications."""
             _LOGGER.debug('Variable %s changed its value to %d', name, value)
             self._state = value
-            run_coroutine_threadsafe(async_event_set(), self.hass.loop)
+            asyncio.run_coroutine_threadsafe(async_event_set(), self.hass.loop)
             self.schedule_update_ha_state()
 
         async def async_event_set():
@@ -69,7 +68,7 @@ class AdsBinarySensor(BinarySensorDevice):
             self._ads_hub.add_device_notification,
             self.ads_var, self._ads_hub.PLCTYPE_BOOL, update)
         try:
-            with async_timeout.timeout(30):
+            with async_timeout.timeout(10):
                 await self._event.wait()
         except asyncio.TimeoutError:
             _LOGGER.debug('Variable %s: Timeout during first update',

--- a/homeassistant/components/ads/light.py
+++ b/homeassistant/components/ads/light.py
@@ -9,7 +9,6 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from . import CONF_ADS_VAR, CONF_ADS_VAR_BRIGHTNESS, DATA_ADS
 
@@ -56,7 +55,7 @@ class AdsLight(Light):
             """Handle device notifications for state."""
             _LOGGER.debug('Variable %s changed its value to %d', name, value)
             self._on_state = value
-            run_coroutine_threadsafe(async_event_set(), self.hass.loop)
+            asyncio.run_coroutine_threadsafe(async_event_set(), self.hass.loop)
             self.schedule_update_ha_state()
 
         async def async_event_set():
@@ -82,7 +81,7 @@ class AdsLight(Light):
                 update_brightness
             )
         try:
-            with async_timeout.timeout(30):
+            with async_timeout.timeout(10):
                 await self._event.wait()
         except asyncio.TimeoutError:
             _LOGGER.debug('Variable %s: Timeout during first update',

--- a/homeassistant/components/ads/light.py
+++ b/homeassistant/components/ads/light.py
@@ -1,5 +1,7 @@
 """Support for ADS light sources."""
 import logging
+import asyncio
+import async_timeout
 
 import voluptuous as vol
 
@@ -7,6 +9,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from . import CONF_ADS_VAR, CONF_ADS_VAR_BRIGHTNESS, DATA_ADS
 
@@ -30,7 +33,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
 
     add_entities([AdsLight(ads_hub, ads_var_enable, ads_var_brightness,
-                           name)], True)
+                           name)])
 
 
 class AdsLight(Light):
@@ -39,12 +42,13 @@ class AdsLight(Light):
     def __init__(self, ads_hub, ads_var_enable, ads_var_brightness, name):
         """Initialize AdsLight entity."""
         self._ads_hub = ads_hub
-        self._on_state = False
+        self._on_state = None
         self._brightness = None
         self._name = name
         self._unique_id = ads_var_enable
         self.ads_var_enable = ads_var_enable
         self.ads_var_brightness = ads_var_brightness
+        self._event = None
 
     async def async_added_to_hass(self):
         """Register device notification."""
@@ -52,7 +56,12 @@ class AdsLight(Light):
             """Handle device notifications for state."""
             _LOGGER.debug('Variable %s changed its value to %d', name, value)
             self._on_state = value
+            run_coroutine_threadsafe(async_event_set(), self.hass.loop)
             self.schedule_update_ha_state()
+
+        async def async_event_set():
+            """Set event in async context."""
+            self._event.set()
 
         def update_brightness(name, value):
             """Handle device notification for brightness."""
@@ -60,16 +69,24 @@ class AdsLight(Light):
             self._brightness = value
             self.schedule_update_ha_state()
 
-        self.hass.async_add_executor_job(
+        self._event = asyncio.Event()
+
+        await self.hass.async_add_executor_job(
             self._ads_hub.add_device_notification,
             self.ads_var_enable, self._ads_hub.PLCTYPE_BOOL, update_on_state
         )
         if self.ads_var_brightness is not None:
-            self.hass.async_add_executor_job(
+            await self.hass.async_add_executor_job(
                 self._ads_hub.add_device_notification,
                 self.ads_var_brightness, self._ads_hub.PLCTYPE_INT,
                 update_brightness
             )
+        try:
+            with async_timeout.timeout(30):
+                await self._event.wait()
+        except asyncio.TimeoutError:
+            _LOGGER.debug('Variable %s: Timeout during first update',
+                          self.ads_var_enable)
 
     @property
     def name(self):
@@ -103,6 +120,11 @@ class AdsLight(Light):
         if self.ads_var_brightness is not None:
             support = SUPPORT_BRIGHTNESS
         return support
+
+    @property
+    def available(self):
+        """Return False if state has not been updated yet."""
+        return self._on_state is not None
 
     def turn_on(self, **kwargs):
         """Turn the light on or set a specific dimmer value."""

--- a/homeassistant/components/ads/switch.py
+++ b/homeassistant/components/ads/switch.py
@@ -1,5 +1,7 @@
 """Support for ADS switch platform."""
 import logging
+import asyncio
+import async_timeout
 
 import voluptuous as vol
 
@@ -7,6 +9,7 @@ from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from . import CONF_ADS_VAR, DATA_ADS
 
@@ -29,7 +32,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
     ads_var = config.get(CONF_ADS_VAR)
 
-    add_entities([AdsSwitch(ads_hub, name, ads_var)], True)
+    add_entities([AdsSwitch(ads_hub, name, ads_var)])
 
 
 class AdsSwitch(ToggleEntity):
@@ -38,10 +41,11 @@ class AdsSwitch(ToggleEntity):
     def __init__(self, ads_hub, name, ads_var):
         """Initialize the AdsSwitch entity."""
         self._ads_hub = ads_hub
-        self._on_state = False
+        self._on_state = None
         self._name = name
         self._unique_id = ads_var
         self.ads_var = ads_var
+        self._event = None
 
     async def async_added_to_hass(self):
         """Register device notification."""
@@ -49,11 +53,24 @@ class AdsSwitch(ToggleEntity):
             """Handle device notification."""
             _LOGGER.debug("Variable %s changed its value to %d", name, value)
             self._on_state = value
+            run_coroutine_threadsafe(async_event_set(), self.hass.loop)
             self.schedule_update_ha_state()
 
-        self.hass.async_add_job(
+        async def async_event_set():
+            """Set event in async context."""
+            self._event.set()
+
+        self._event = asyncio.Event()
+
+        await self.hass.async_add_executor_job(
             self._ads_hub.add_device_notification,
             self.ads_var, self._ads_hub.PLCTYPE_BOOL, update)
+        try:
+            with async_timeout.timeout(30):
+                await self._event.wait()
+        except asyncio.TimeoutError:
+            _LOGGER.debug('Variable %s: Timeout during first update',
+                          self.ads_var)
 
     @property
     def is_on(self):
@@ -74,6 +91,11 @@ class AdsSwitch(ToggleEntity):
     def should_poll(self):
         """Return False because entity pushes its state to HA."""
         return False
+
+    @property
+    def available(self):
+        """Return False if state has not been updated yet."""
+        return self._on_state is not None
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/homeassistant/components/ads/switch.py
+++ b/homeassistant/components/ads/switch.py
@@ -9,7 +9,6 @@ from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from . import CONF_ADS_VAR, DATA_ADS
 
@@ -53,7 +52,7 @@ class AdsSwitch(ToggleEntity):
             """Handle device notification."""
             _LOGGER.debug("Variable %s changed its value to %d", name, value)
             self._on_state = value
-            run_coroutine_threadsafe(async_event_set(), self.hass.loop)
+            asyncio.run_coroutine_threadsafe(async_event_set(), self.hass.loop)
             self.schedule_update_ha_state()
 
         async def async_event_set():
@@ -66,7 +65,7 @@ class AdsSwitch(ToggleEntity):
             self._ads_hub.add_device_notification,
             self.ads_var, self._ads_hub.PLCTYPE_BOOL, update)
         try:
-            with async_timeout.timeout(30):
+            with async_timeout.timeout(10):
                 await self._event.wait()
         except asyncio.TimeoutError:
             _LOGGER.debug('Variable %s: Timeout during first update',


### PR DESCRIPTION
## Description:
Fixes behavior of ADS binary_sensor, light and switch entities to toggle to false at HA restart, while the underlying device's state kept being true.

**Related issue (if applicable):** fixes #21893

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23