### PR TITLE
PS4 bump to 0.5.2

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -14,7 +14,7 @@ from .const import DOMAIN  # noqa: pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyps4-homeassistant==0.5.0']
+REQUIREMENTS = ['pyps4-homeassistant==0.5.2']
 
 
 async def async_setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1225,7 +1225,7 @@ pypoint==1.1.1
 pypollencom==2.2.3
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.5.0
+pyps4-homeassistant==0.5.2
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -227,7 +227,7 @@ pyopenuv==1.0.9
 pyotp==2.2.6
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.5.0
+pyps4-homeassistant==0.5.2
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8


### PR DESCRIPTION
## Description:
Bump pyps4 lib to 0.5.2. Media art bug fixes. Connection improvements. Prevent spamming of remote control commands. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
