### PR TITLE
Ring camera improvements

### DIFF
--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -166,11 +166,11 @@ class RingCam(Camera):
         video_status = last_event['recording']['status']
 
         if video_status == 'ready' and \
-            (self._last_video_id != last_recording_id or \
-            self._utcnow >= self._expires_at):
+            (self._last_video_id != last_recording_id or
+             self._utcnow >= self._expires_at):
 
             video_url = self._camera.recording_url(last_recording_id)
-            if video_url != False:
+            if video_url:
                 _LOGGER.info("Ring DoorBell properties refreshed")
 
                 # update attributes if new video or if URL has expired

--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -157,14 +157,23 @@ class RingCam(Camera):
         self._camera.update()
         self._utcnow = dt_util.utcnow()
 
-        last_recording_id = self._camera.last_recording_id
+        try:
+            last_event = self._camera.history(limit=1)[0]
+        except (IndexError, TypeError):
+            return
 
-        if self._last_video_id != last_recording_id or \
-           self._utcnow >= self._expires_at:
+        last_recording_id = last_event['id']
+        video_status = last_event['recording']['status']
 
-            _LOGGER.info("Ring DoorBell properties refreshed")
+        if video_status == 'ready' and \
+            (self._last_video_id != last_recording_id or \
+            self._utcnow >= self._expires_at):
 
-            # update attributes if new video or if URL has expired
-            self._last_video_id = self._camera.last_recording_id
-            self._video_url = self._camera.recording_url(self._last_video_id)
-            self._expires_at = FORCE_REFRESH_INTERVAL + self._utcnow
+            video_url = self._camera.recording_url(last_recording_id)
+            if video_url != False:
+                _LOGGER.info("Ring DoorBell properties refreshed")
+
+                # update attributes if new video or if URL has expired
+                self._last_video_id = last_recording_id
+                self._video_url = video_url
+                self._expires_at = FORCE_REFRESH_INTERVAL + self._utcnow


### PR DESCRIPTION
## Breaking Change:

No breaking changes

## Description:

There are a few issues with current ring camera implementation:
  - Currently, there is no way to check if `video_url` was already seen or not.
  - Sometimes `video_url` is set to false (usually after new motion/ding event)
  - Due to the current implementation, some videos may not show up in HA at all (if `last_video_id` is already updated but URL is not yet ready)

This PR:
  - Exposes attribute `last_video_id`, which can be used in automation to check if the video was changed or not.
  - Only updates `last_video_id` and `video_url` when video is ready. (Usually, it's not yet ready, while Ring is still recording, right after the motion).
  - Only updates `last_video_id` and `video_url` together, so `video_url` always corresponds to last_video_id`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

No new configuration variables are added/changed.
