### PR TITLE
Fix tts Great Migration issue

### DIFF
--- a/homeassistant/components/amazon_polly/__init__.py
+++ b/homeassistant/components/amazon_polly/__init__.py
@@ -1,0 +1,1 @@
+"""Support for Amazon Polly integration."""

--- a/homeassistant/components/amazon_polly/tts.py
+++ b/homeassistant/components/amazon_polly/tts.py
@@ -8,9 +8,8 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.tts import PLATFORM_SCHEMA, Provider
 import homeassistant.helpers.config_validation as cv
-
-from . import PLATFORM_SCHEMA, Provider
 
 REQUIREMENTS = ['boto3==1.9.16']
 

--- a/homeassistant/components/baidu/__init__.py
+++ b/homeassistant/components/baidu/__init__.py
@@ -1,0 +1,1 @@
+"""Support for Baidu integration."""

--- a/homeassistant/components/baidu/tts.py
+++ b/homeassistant/components/baidu/tts.py
@@ -9,10 +9,9 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
-
-from . import CONF_LANG, PLATFORM_SCHEMA, Provider
 
 REQUIREMENTS = ["baidu-aip==1.6.6"]
 

--- a/homeassistant/components/marytts/__init__.py
+++ b/homeassistant/components/marytts/__init__.py
@@ -1,0 +1,1 @@
+"""Support for MaryTTS integration."""

--- a/homeassistant/components/marytts/tts.py
+++ b/homeassistant/components/marytts/tts.py
@@ -12,11 +12,10 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
+from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/microsoft/__init__.py
+++ b/homeassistant/components/microsoft/__init__.py
@@ -1,0 +1,1 @@
+"""Support for Microsoft integration."""

--- a/homeassistant/components/microsoft/tts.py
+++ b/homeassistant/components/microsoft/tts.py
@@ -9,10 +9,9 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 from homeassistant.const import CONF_API_KEY, CONF_TYPE
 import homeassistant.helpers.config_validation as cv
-
-from . import CONF_LANG, PLATFORM_SCHEMA, Provider
 
 CONF_GENDER = 'gender'
 CONF_OUTPUT = 'output'

--- a/homeassistant/components/picotts/__init__.py
+++ b/homeassistant/components/picotts/__init__.py
@@ -1,0 +1,1 @@
+"""Support for pico integration."""

--- a/homeassistant/components/picotts/tts.py
+++ b/homeassistant/components/picotts/tts.py
@@ -12,7 +12,7 @@ import tempfile
 
 import voluptuous as vol
 
-from . import CONF_LANG, PLATFORM_SCHEMA, Provider
+from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/voicerss/__init__.py
+++ b/homeassistant/components/voicerss/__init__.py
@@ -1,0 +1,1 @@
+"""Support for VoiceRSS integration."""

--- a/homeassistant/components/voicerss/tts.py
+++ b/homeassistant/components/voicerss/tts.py
@@ -11,11 +11,10 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
+from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/yandextts/__init__.py
+++ b/homeassistant/components/yandextts/__init__.py
@@ -1,0 +1,1 @@
+"""Support for the yandex speechkit tts integration."""

--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -11,11 +11,10 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
+from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-
-from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -194,6 +194,9 @@ av==6.1.2
 # homeassistant.components.axis
 axis==19
 
+# homeassistant.components.baidu.tts
+baidu-aip==1.6.6
+
 # homeassistant.components.modem_callerid.sensor
 basicmodem==0.7
 
@@ -233,6 +236,7 @@ blockchain==1.4.4
 # bme680==1.0.5
 
 # homeassistant.components.route53
+# homeassistant.components.amazon_polly.tts
 # homeassistant.components.aws_lambda.notify
 # homeassistant.components.aws_sns.notify
 # homeassistant.components.aws_sqs.notify
@@ -986,6 +990,9 @@ pycomfoconnect==0.3
 
 # homeassistant.components.coolmaster.climate
 pycoolmasternet==0.0.4
+
+# homeassistant.components.microsoft.tts
+pycsspeechtts==1.0.2
 
 # homeassistant.components.cups.sensor
 # pycups==1.9.73


### PR DESCRIPTION
## Description:

Add `__init__.py` to several tts integrations


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
