### PR TITLE
Add LCN climate platform

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -3,20 +3,22 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.climate import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP
 from homeassistant.const import (
     CONF_ADDRESS, CONF_BINARY_SENSORS, CONF_COVERS, CONF_HOST, CONF_LIGHTS,
     CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_SENSORS, CONF_SWITCHES,
-    CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME)
+    CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
 
 from .const import (
-    BINSENSOR_PORTS, CONF_CONNECTIONS, CONF_DIM_MODE, CONF_DIMMABLE,
-    CONF_MOTOR, CONF_OUTPUT, CONF_SK_NUM_TRIES, CONF_SOURCE, CONF_TRANSITION,
-    DATA_LCN, DEFAULT_NAME, DIM_MODES, DOMAIN, KEYS, LED_PORTS, LOGICOP_PORTS,
-    MOTOR_PORTS, OUTPUT_PORTS, PATTERN_ADDRESS, RELAY_PORTS, S0_INPUTS,
-    SETPOINTS, THRESHOLDS, VAR_UNITS, VARIABLES)
+    BINSENSOR_PORTS, CONF_CLIMATES, CONF_CONNECTIONS, CONF_DIM_MODE,
+    CONF_DIMMABLE, CONF_LOCKABLE, CONF_MAX_TEMP, CONF_MIN_TEMP, CONF_MOTOR,
+    CONF_OUTPUT, CONF_SETPOINT, CONF_SK_NUM_TRIES, CONF_SOURCE,
+    CONF_TRANSITION, DATA_LCN, DEFAULT_NAME, DIM_MODES, DOMAIN, KEYS,
+    LED_PORTS, LOGICOP_PORTS, MOTOR_PORTS, OUTPUT_PORTS, PATTERN_ADDRESS,
+    RELAY_PORTS, S0_INPUTS, SETPOINTS, THRESHOLDS, VAR_UNITS, VARIABLES)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,6 +72,19 @@ BINARY_SENSORS_SCHEMA = vol.Schema({
                                                          BINSENSOR_PORTS))
     })
 
+CLIMATES_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_ADDRESS): is_address,
+    vol.Required(CONF_SOURCE): vol.All(vol.Upper, vol.In(VARIABLES)),
+    vol.Required(CONF_SETPOINT): vol.All(vol.Upper,
+                                         vol.In(VARIABLES + SETPOINTS)),
+    vol.Optional(CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
+    vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
+    vol.Optional(CONF_LOCKABLE, default=False): vol.Coerce(bool),
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT, default=TEMP_CELSIUS):
+        vol.In(TEMP_CELSIUS, TEMP_FAHRENHEIT)
+})
+
 COVERS_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_ADDRESS): is_address,
@@ -122,6 +137,8 @@ CONFIG_SCHEMA = vol.Schema({
             cv.ensure_list, has_unique_connection_names, [CONNECTION_SCHEMA]),
         vol.Optional(CONF_BINARY_SENSORS): vol.All(
             cv.ensure_list, [BINARY_SENSORS_SCHEMA]),
+        vol.Optional(CONF_CLIMATES): vol.All(
+            cv.ensure_list, [CLIMATES_SCHEMA]),
         vol.Optional(CONF_COVERS): vol.All(
             cv.ensure_list, [COVERS_SCHEMA]),
         vol.Optional(CONF_LIGHTS): vol.All(
@@ -185,6 +202,7 @@ async def async_setup(hass, config):
 
     # load platforms
     for component, conf_key in (('binary_sensor', CONF_BINARY_SENSORS),
+                                ('climate', CONF_CLIMATES),
                                 ('cover', CONF_COVERS),
                                 ('light', CONF_LIGHTS),
                                 ('sensor', CONF_SENSORS),

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -1,0 +1,139 @@
+"""Support for LCN climate control."""
+
+from homeassistant.components.climate import ClimateDevice, const
+from homeassistant.const import (
+    ATTR_TEMPERATURE, CONF_ADDRESS, CONF_UNIT_OF_MEASUREMENT)
+
+from . import LcnDevice, get_connection
+from .const import (
+    CONF_CONNECTIONS, CONF_LOCKABLE, CONF_MAX_TEMP, CONF_MIN_TEMP,
+    CONF_SETPOINT, CONF_SOURCE, DATA_LCN)
+
+DEPENDENCIES = ['lcn']
+
+
+async def async_setup_platform(hass, hass_config, async_add_entities,
+                               discovery_info=None):
+    """Set up the LCN climate platform."""
+    if discovery_info is None:
+        return
+
+    import pypck
+
+    devices = []
+    for config in discovery_info:
+        address, connection_id = config[CONF_ADDRESS]
+        addr = pypck.lcn_addr.LcnAddr(*address)
+        connections = hass.data[DATA_LCN][CONF_CONNECTIONS]
+        connection = get_connection(connections, connection_id)
+        address_connection = connection.get_address_conn(addr)
+
+        devices.append(LcnClimate(config, address_connection))
+
+    async_add_entities(devices)
+
+
+class LcnClimate(LcnDevice, ClimateDevice):
+    """Representation of a LCN climate device."""
+
+    def __init__(self, config, address_connection):
+        """Initialize of a LCN climate device."""
+        super().__init__(config, address_connection)
+
+        self.variable = self.pypck.lcn_defs.Var[config[CONF_SOURCE]]
+        self.setpoint = self.pypck.lcn_defs.Var[config[CONF_SETPOINT]]
+        self.unit = self.pypck.lcn_defs.VarUnit.parse(
+            config[CONF_UNIT_OF_MEASUREMENT])
+
+        self.regulator_id = \
+            self.pypck.lcn_defs.Var.to_set_point_id(self.setpoint)
+        self.is_lockable = config[CONF_LOCKABLE]
+        self._max_temp = config[CONF_MAX_TEMP]
+        self._min_temp = config[CONF_MIN_TEMP]
+
+        self._current_temperature = None
+        self._target_temperature = None
+        self._is_on = True
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.variable))
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.setpoint))
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        support = const.SUPPORT_TARGET_TEMPERATURE
+        if self.is_lockable:
+            support |= const.SUPPORT_ON_OFF
+        return support
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return self.unit.value
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    @property
+    def is_on(self):
+        """Return true if the device is on."""
+        return self._is_on
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return self._max_temp
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return self._min_temp
+
+    async def async_turn_on(self):
+        """Turn on."""
+        self._is_on = True
+        self.address_connection.lock_regulator(self.regulator_id, False)
+        self.schedule_update_ha_state()
+
+    async def async_turn_off(self):
+        """Turn off."""
+        self._is_on = False
+        self.address_connection.lock_regulator(self.regulator_id, True)
+        self._target_temperature = None
+        self.schedule_update_ha_state()
+
+    async def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        if kwargs.get(ATTR_TEMPERATURE) is not None:
+            self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
+            self.address_connection.var_abs(
+                self.setpoint, self._target_temperature, self.unit)
+            await self.async_update_ha_state()
+
+    def input_received(self, input_obj):
+        """Set temperature value when LCN input object is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusVar):
+            return
+
+        if input_obj.get_var() == self.variable:
+            self._current_temperature = (
+                input_obj.get_value().to_var_unit(self.unit))
+        elif self._is_on and input_obj.get_var() == self.setpoint:
+            self._target_temperature = (
+                input_obj.get_value().to_var_unit(self.unit))
+
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -107,14 +107,14 @@ class LcnClimate(LcnDevice, ClimateDevice):
         """Turn on."""
         self._is_on = True
         self.address_connection.lock_regulator(self.regulator_id, False)
-        self.schedule_update_ha_state()
+        await self.async_update_ha_state()
 
     async def async_turn_off(self):
         """Turn off."""
         self._is_on = False
         self.address_connection.lock_regulator(self.regulator_id, True)
         self._target_temperature = None
-        self.schedule_update_ha_state()
+        await self.async_update_ha_state()
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -21,6 +21,11 @@ CONF_DIMMABLE = 'dimmable'
 CONF_TRANSITION = 'transition'
 CONF_MOTOR = 'motor'
 CONF_SOURCE = 'source'
+CONF_SETPOINT = 'setpoint'
+CONF_LOCKABLE = 'lockable'
+CONF_CLIMATES = 'climates'
+CONF_MAX_TEMP = 'max_temp'
+CONF_MIN_TEMP = 'min_temp'
 
 DIM_MODES = ['STEPS50', 'STEPS200']
 


### PR DESCRIPTION
## Description:
This adds the LCN climate platform. The implementation allows the control of LCN hardware modules which have been properly configured as a heater.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9073

## Example entry for `configuration.yaml` (if applicable):
```yaml
lcn:
  connections:
    - name: myhome
      host: 192.168.2.41
      port: 4114
      username: !secret lcn_username
      password: !secret lcn_password

  climates:
    - name: Temperature bedroom
      address: myhome.s0.m7
      source: var1
      setpoint: r1varsetpoint
      min_temp: 17.
      max_temp: 30.
      lockable: true
      unit_of_measurement: °C
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
