### PR TITLE
Refactor yeelight code

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -178,14 +178,12 @@ class YeelightDevice:
 
     def __init__(self, hass, ipaddr, config):
         """Initialize device."""
-        import yeelight
-
         self._hass = hass
         self._config = config
         self._ipaddr = ipaddr
         self._name = config.get(CONF_NAME)
         self._model = config.get(CONF_MODEL)
-        self._bulb_device = yeelight.Bulb(self.ipaddr, model=self._model)
+        self._bulb_device = Bulb(self.ipaddr, model=self._model)
         self._device_type = None
         self._available = False
         self._initialized = False

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -233,8 +233,8 @@ class YeelightDevice:
         """Return true / false if nightlight is supported."""
         if self.model:
             return self.bulb.get_model_specs().get('night_light', False)
-        else:
-            return self._active_mode is not None
+
+        return self._active_mode is not None
 
     @property
     def _active_mode(self):

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -170,7 +170,7 @@ def _setup_device(hass, _, ipaddr, device_config):
     device = YeelightDevice(hass, ipaddr, device_config)
 
     devices[ipaddr] = device
-    hass.add_job(device.update)
+    hass.add_job(device.setup)
 
 
 class YeelightDevice:
@@ -186,6 +186,7 @@ class YeelightDevice:
         self._name = config.get(CONF_NAME)
         self._model = config.get(CONF_MODEL)
         self._bulb_device = yeelight.Bulb(self.ipaddr, model=self._model)
+        self._device_type = None
         self._available = False
         self._initialized = False
 
@@ -215,6 +216,11 @@ class YeelightDevice:
         return self._available
 
     @property
+    def model(self):
+        """Return configured device model."""
+        return self._model
+
+    @property
     def is_nightlight_enabled(self) -> bool:
         """Return true / false if nightlight is currently enabled."""
         if self.bulb is None:
@@ -225,7 +231,10 @@ class YeelightDevice:
     @property
     def is_nightlight_supported(self) -> bool:
         """Return true / false if nightlight is supported."""
-        return self._active_mode is not None
+        if self.model:
+            return self.bulb.get_model_specs().get('night_light', False)
+        else:
+            return self._active_mode is not None
 
     @property
     def _active_mode(self):
@@ -234,7 +243,10 @@ class YeelightDevice:
     @property
     def type(self):
         """Return bulb type."""
-        return self.bulb.bulb_type
+        if not self._device_type:
+            self._device_type = self.bulb.bulb_type
+
+        return self._device_type
 
     def turn_on(self, duration=DEFAULT_TRANSITION, light_type=None):
         """Turn on device."""
@@ -251,7 +263,7 @@ class YeelightDevice:
             _LOGGER.error("Unable to turn the bulb off: %s, %s: %s",
                           self.ipaddr, self.name, ex)
 
-    def update(self):
+    def _update_properties(self):
         """Read new properties from the device."""
         if not self.bulb:
             return
@@ -259,13 +271,30 @@ class YeelightDevice:
         try:
             self.bulb.get_properties(UPDATE_REQUEST_PROPERTIES)
             self._available = True
-            if not self._initialized:
-                self._initialized = True
-                dispatcher_send(self._hass, DEVICE_INITIALIZED, self.ipaddr)
         except BulbException as ex:
             if self._available:  # just inform once
                 _LOGGER.error("Unable to update device %s, %s: %s",
                               self.ipaddr, self.name, ex)
             self._available = False
 
+        return self._available
+
+    def _initialize_if_not_already(self):
+        if self._initialized:
+            return
+
+        self._initialized = True
+        dispatcher_send(self._hass, DEVICE_INITIALIZED, self.ipaddr)
+
+    def update(self):
+        """Update device properties and send data updated signal."""
+        if self._update_properties():
+            self._initialize_if_not_already()
+
         dispatcher_send(self._hass, DATA_UPDATED.format(self._ipaddr))
+
+    def setup(self):
+        """Initialize device and send initialized signal."""
+
+        if self._update_properties() or self.model:
+            self._initialize_if_not_already()

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -295,6 +295,5 @@ class YeelightDevice:
 
     def setup(self):
         """Initialize device and send initialized signal."""
-
         if self._update_properties() or self.model:
             self._initialize_if_not_already()

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -43,6 +43,8 @@ ACTION_RECOVER = 'recover'
 ACTION_STAY = 'stay'
 ACTION_OFF = 'off'
 
+ACTIVE_MODE_NIGHTLIGHT = '1'
+
 SCAN_INTERVAL = timedelta(seconds=30)
 
 YEELIGHT_RGB_TRANSITION = 'RGBTransition'
@@ -224,7 +226,7 @@ class YeelightDevice:
         if self.bulb is None:
             return False
 
-        return self._active_mode == '1'
+        return self._active_mode == ACTIVE_MODE_NIGHTLIGHT
 
     @property
     def is_nightlight_supported(self) -> bool:

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -294,6 +294,6 @@ class YeelightDevice:
         """Fetch initial device properties."""
         initial_update = self._update_properties()
 
+        # We can build correct class anyway.
         if not initial_update and self.model:
-            """We can build correct class anyway."""
             self._initialize_device()

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -137,11 +137,23 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     custom_effects = _parse_custom_effects(discovery_info[CONF_CUSTOM_EFFECTS])
 
-    lights = [YeelightLight(device, custom_effects=custom_effects)]
+    lights = []
 
-    if device.is_ambilight_supported:
-        lights.append(
-            YeelightAmbientLight(device, custom_effects=custom_effects))
+    def _lights_setup_helper(klass):
+        lights.append(klass(device, custom_effects=custom_effects))
+
+    if device.type == BulbType.White:
+        _lights_setup_helper(YeelightGenericLight)
+    elif device.type == BulbType.Color:
+        _lights_setup_helper(YeelightColorLight)
+    elif device.type == BulbType.WhiteTemp:
+        _lights_setup_helper(YeelightWhiteTempLight)
+    elif device.type == BulbType.WhiteTempMood:
+        _lights_setup_helper(YeelightWithAmbientLight)
+        _lights_setup_helper(YeelightAmbientLight)
+    else:
+        _LOGGER.error("Cannot determinate device type for %s, %s",
+                      device.ipaddr, device.name)
 
     hass.data[data_key] += lights
     add_entities(lights, True)
@@ -179,23 +191,22 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         schema=service_schema_start_flow)
 
 
-class YeelightLight(Light):
-    """Representation of a Yeelight light."""
+class YeelightGenericLight(Light):
+    """Representation of a Yeelight generic light."""
 
     def __init__(self, device, custom_effects=None):
         """Initialize the Yeelight light."""
         self.config = device.config
         self._device = device
 
-        self._supported_features = SUPPORT_YEELIGHT
-
         self._brightness = None
         self._color_temp = None
         self._is_on = None
         self._hs = None
 
-        self._min_mireds = None
-        self._max_mireds = None
+        model_specs = self._bulb.get_model_specs()
+        self._min_mireds = kelvin_to_mired(model_specs['color_temp']['max'])
+        self._max_mireds = kelvin_to_mired(model_specs['color_temp']['min'])
 
         self._light_type = LightType.Main
 
@@ -229,7 +240,7 @@ class YeelightLight(Light):
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
-        return self._supported_features
+        return SUPPORT_YEELIGHT
 
     @property
     def effect_list(self):
@@ -239,7 +250,10 @@ class YeelightLight(Light):
     @property
     def color_temp(self) -> int:
         """Return the color temperature."""
-        return self._color_temp
+        temp = self._get_property('ct')
+        if temp:
+            self._color_temp = temp
+        return kelvin_to_mired(int(self._color_temp))
 
     @property
     def name(self) -> str:
@@ -249,12 +263,15 @@ class YeelightLight(Light):
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return self._is_on
+        return self._get_property('power') == 'on'
 
     @property
     def brightness(self) -> int:
         """Return the brightness of this light between 1..255."""
-        return self._brightness
+        temp = self._get_property(self._brightness_property)
+        if temp:
+            self._brightness = temp
+        return round(255 * (int(self._brightness) / 100))
 
     @property
     def min_mireds(self):
@@ -281,6 +298,38 @@ class YeelightLight(Light):
         """Return light type."""
         return self._light_type
 
+    @property
+    def hs_color(self) -> tuple:
+        """Return the color property."""
+        return self._hs
+
+    # F821: https://github.com/PyCQA/pyflakes/issues/373
+    @property
+    def _bulb(self) -> 'yeelight.Bulb':  # noqa: F821
+        return self.device.bulb
+
+    @property
+    def _properties(self) -> dict:
+        if self._bulb is None:
+            return {}
+        return self._bulb.last_properties
+
+    def _get_property(self, prop, default=None):
+        return self._properties.get(prop, default)
+
+    @property
+    def _brightness_property(self):
+        return 'bright'
+
+    @property
+    def device(self):
+        """Return yeelight device."""
+        return self._device
+
+    def update(self):
+        """Update light properties."""
+        self._hs = self._get_hs_from_properties()
+
     def _get_hs_from_properties(self):
         rgb = self._get_property('rgb')
         color_mode = self._get_property('color_mode')
@@ -290,7 +339,7 @@ class YeelightLight(Light):
 
         color_mode = int(color_mode)
         if color_mode == 2:  # color temperature
-            temp_in_k = mired_to_kelvin(self._color_temp)
+            temp_in_k = mired_to_kelvin(self.color_temp)
             return color_util.color_temperature_to_hs(temp_in_k)
         if color_mode == 3:  # hsv
             hue = int(self._get_property('hue'))
@@ -305,81 +354,12 @@ class YeelightLight(Light):
 
         return color_util.color_RGB_to_hs(red, green, blue)
 
-    @property
-    def hs_color(self) -> tuple:
-        """Return the color property."""
-        return self._hs
-
-    @property
-    def _properties(self) -> dict:
-        if self._bulb is None:
-            return {}
-        return self._bulb.last_properties
-
-    def _get_property(self, prop, default=None):
-        return self._properties.get(prop, default)
-
-    @property
-    def device(self):
-        """Return yeelight device."""
-        return self._device
-
-    @property
-    def _is_nightlight_enabled(self):
-        return self.device.is_nightlight_enabled
-
-    # F821: https://github.com/PyCQA/pyflakes/issues/373
-    @property
-    def _bulb(self) -> 'yeelight.Bulb':  # noqa: F821
-        return self.device.bulb
-
     def set_music_mode(self, mode) -> None:
         """Set the music mode on or off."""
         if mode:
             self._bulb.start_music()
         else:
             self._bulb.stop_music()
-
-    def update(self) -> None:
-        """Update properties from the bulb."""
-        bulb_type = self._bulb.bulb_type
-
-        if bulb_type == BulbType.Color:
-            self._supported_features = SUPPORT_YEELIGHT_RGB
-        elif self.light_type == LightType.Ambient:
-            self._supported_features = SUPPORT_YEELIGHT_RGB
-        elif bulb_type in (BulbType.WhiteTemp, BulbType.WhiteTempMood):
-            if self._is_nightlight_enabled:
-                self._supported_features = SUPPORT_YEELIGHT
-            else:
-                self._supported_features = SUPPORT_YEELIGHT_WHITE_TEMP
-
-        if self.min_mireds is None:
-            model_specs = self._bulb.get_model_specs()
-            self._min_mireds = \
-                kelvin_to_mired(model_specs['color_temp']['max'])
-            self._max_mireds = \
-                kelvin_to_mired(model_specs['color_temp']['min'])
-
-        if bulb_type == BulbType.WhiteTempMood:
-            self._is_on = self._get_property('main_power') == 'on'
-        else:
-            self._is_on = self._get_property('power') == 'on'
-
-        if self._is_nightlight_enabled:
-            bright = self._get_property('nl_br')
-        else:
-            bright = self._get_property('bright')
-
-        if bright:
-            self._brightness = round(255 * (int(bright) / 100))
-
-        temp_in_k = self._get_property('ct')
-
-        if temp_in_k:
-            self._color_temp = kelvin_to_mired(int(temp_in_k))
-
-        self._hs = self._get_hs_from_properties()
 
     @_cmd
     def set_brightness(self, brightness, duration) -> None:
@@ -566,12 +546,38 @@ class YeelightLight(Light):
             _LOGGER.error("Unable to set effect: %s", ex)
 
 
-class YeelightAmbientLight(YeelightLight):
+class YeelightColorLight(YeelightGenericLight):
+    """Representation of a Color Yeelight light."""
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_YEELIGHT_RGB
+
+
+class YeelightWhiteTempLight(YeelightGenericLight):
+    """Representation of a Color Yeelight light."""
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_YEELIGHT_WHITE_TEMP
+
+
+class YeelightWithAmbientLight(YeelightWhiteTempLight):
+    """Representation of a Yeelight which has ambilight support."""
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return self._get_property('main_power') == 'on'
+
+
+class YeelightAmbientLight(YeelightColorLight):
     """Representation of a Yeelight ambient light."""
 
     PROPERTIES_MAPPING = {
         "color_mode": "bg_lmode",
-        "main_power": "bg_power",
     }
 
     def __init__(self, *args, **kwargs):
@@ -587,14 +593,10 @@ class YeelightAmbientLight(YeelightLight):
         """Return the name of the device if any."""
         return "{} ambilight".format(self.device.name)
 
-    @property
-    def _is_nightlight_enabled(self):
-        return False
-
     def _get_property(self, prop, default=None):
         bg_prop = self.PROPERTIES_MAPPING.get(prop)
 
         if not bg_prop:
             bg_prop = "bg_" + prop
 
-        return self._properties.get(bg_prop, default)
+        return super()._get_property(bg_prop, default)

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -565,6 +565,10 @@ class YeelightWhiteTempLight(YeelightGenericLight):
         """Flag supported features."""
         return SUPPORT_YEELIGHT_WHITE_TEMP
 
+    @property
+    def _brightness_property(self):
+        return 'current_brightness'
+
 
 class YeelightWithAmbientLight(YeelightWhiteTempLight):
     """Representation of a Yeelight which has ambilight support."""

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -201,7 +201,6 @@ class YeelightGenericLight(Light):
 
         self._brightness = None
         self._color_temp = None
-        self._is_on = None
         self._hs = None
 
         model_specs = self._bulb.get_model_specs()

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -135,6 +135,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     device = hass.data[DATA_YEELIGHT][discovery_info[CONF_HOST]]
     _LOGGER.debug("Adding %s", device.name)
 
+    model = device.model
     custom_effects = _parse_custom_effects(discovery_info[CONF_CUSTOM_EFFECTS])
 
     lights = []
@@ -142,13 +143,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     def _lights_setup_helper(klass):
         lights.append(klass(device, custom_effects=custom_effects))
 
-    if device.type == BulbType.White:
+    if model in ('mono', 'mono1') or device.type == BulbType.White:
         _lights_setup_helper(YeelightGenericLight)
-    elif device.type == BulbType.Color:
+    elif model in ('color', 'color1', 'color2', 'strip1', 'bslamp1') or \
+            device.type == BulbType.Color:
         _lights_setup_helper(YeelightColorLight)
-    elif device.type == BulbType.WhiteTemp:
+    elif model in ('ceiling1', 'ceiling2', 'ceiling3') or \
+            device.type == BulbType.WhiteTemp:
         _lights_setup_helper(YeelightWhiteTempLight)
-    elif device.type == BulbType.WhiteTempMood:
+    elif model == 'ceiling4' or device.type == BulbType.WhiteTempMood:
         _lights_setup_helper(YeelightWithAmbientLight)
         _lights_setup_helper(YeelightAmbientLight)
     else:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -265,7 +265,7 @@ class YeelightGenericLight(Light):
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return self._get_property('power') == 'on'
+        return self._get_property(self._power_property) == 'on'
 
     @property
     def brightness(self) -> int:
@@ -322,6 +322,10 @@ class YeelightGenericLight(Light):
     @property
     def _brightness_property(self):
         return 'bright'
+
+    @property
+    def _power_property(self):
+        return 'power'
 
     @property
     def device(self):
@@ -573,10 +577,9 @@ class YeelightWhiteTempLight(YeelightGenericLight):
 class YeelightWithAmbientLight(YeelightWhiteTempLight):
     """Representation of a Yeelight which has ambilight support."""
 
-    @property
-    def is_on(self) -> bool:
-        """Return true if device is on."""
-        return self._get_property('main_power') == 'on'
+    @ property
+    def _power_property(self):
+        return 'main_power'
 
 
 class YeelightAmbientLight(YeelightColorLight):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -155,7 +155,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _lights_setup_helper(YeelightWithAmbientLight)
         _lights_setup_helper(YeelightAmbientLight)
     else:
-        _LOGGER.error("Cannot determinate device type for %s, %s",
+        _LOGGER.error("Cannot determine device type for %s, %s",
                       device.ipaddr, device.name)
 
     hass.data[data_key] += lights

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -307,7 +307,7 @@ class YeelightGenericLight(Light):
 
     # F821: https://github.com/PyCQA/pyflakes/issues/373
     @property
-    def _bulb(self) -> 'yeelight.Bulb':  # noqa: F821
+    def _bulb(self) -> 'Bulb':  # noqa: F821
         return self.device.bulb
 
     @property

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -80,6 +80,19 @@ YEELIGHT_EFFECT_LIST = [
     EFFECT_TWITTER,
     EFFECT_STOP]
 
+MODEL_TO_DEVICE_TYPE = {
+    'mono': BulbType.White,
+    'mono1': BulbType.White,
+    'color': BulbType.Color,
+    'color1': BulbType.Color,
+    'color2': BulbType.Color,
+    'strip1': BulbType.Color,
+    'bslamp1': BulbType.Color,
+    'ceiling1': BulbType.WhiteTemp,
+    'ceiling2': BulbType.WhiteTemp,
+    'ceiling3': BulbType.WhiteTemp,
+    'ceiling4': BulbType.WhiteTempMood}
+
 
 def _transitions_config_parser(transitions):
     """Parse transitions config into initialized objects."""
@@ -135,23 +148,25 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     device = hass.data[DATA_YEELIGHT][discovery_info[CONF_HOST]]
     _LOGGER.debug("Adding %s", device.name)
 
-    model = device.model
     custom_effects = _parse_custom_effects(discovery_info[CONF_CUSTOM_EFFECTS])
 
     lights = []
 
+    if device.model:
+        device_type = MODEL_TO_DEVICE_TYPE.get(device.model, None)
+    else:
+        device_type = device.type
+
     def _lights_setup_helper(klass):
         lights.append(klass(device, custom_effects=custom_effects))
 
-    if model in ('mono', 'mono1') or device.type == BulbType.White:
+    if device_type == BulbType.White:
         _lights_setup_helper(YeelightGenericLight)
-    elif model in ('color', 'color1', 'color2', 'strip1', 'bslamp1') or \
-            device.type == BulbType.Color:
+    elif device_type == BulbType.Color:
         _lights_setup_helper(YeelightColorLight)
-    elif model in ('ceiling1', 'ceiling2', 'ceiling3') or \
-            device.type == BulbType.WhiteTemp:
+    elif device_type == BulbType.WhiteTemp:
         _lights_setup_helper(YeelightWhiteTempLight)
-    elif model == 'ceiling4' or device.type == BulbType.WhiteTempMood:
+    elif device_type == BulbType.WhiteTempMood:
         _lights_setup_helper(YeelightWithAmbientLight)
         _lights_setup_helper(YeelightAmbientLight)
     else:


### PR DESCRIPTION
## Breaking changes:
When starting HA, and some light is not available and doesn't have model declared. It won't be added until properties can be fetched. When model is declared in config, it will be added as before.

## Description:
Split yeelight classes, for logic simplification, some nasty nested ifs are removed. Its for easier handling future component improvements. It fixes bugs when yeelights are exported, for example to homekit, before correct supported_features are set ( on first update from device ). If it gets exported earlier, light gets marked as brightness only. It fixes #24018 and #23871.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.