### PR TITLE
Fix platform warnings

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -37,6 +37,7 @@ DATA_KEY = 'components'
 PACKAGE_CUSTOM_COMPONENTS = 'custom_components'
 PACKAGE_BUILTIN = 'homeassistant.components'
 LOOKUP_PATHS = [PACKAGE_CUSTOM_COMPONENTS, PACKAGE_BUILTIN]
+COMPONENTS_WITH_BAD_PLATFORMS = ['automation', 'mqtt', 'telegram_bot']
 
 
 class LoaderError(Exception):
@@ -83,7 +84,7 @@ def get_platform(hass,  # type: HomeAssistant
     """
     # If the platform has a component, we will limit the platform loading path
     # to be the same source (custom/built-in).
-    if domain not in ['automation', 'mqtt', 'telegram_bot']:
+    if domain not in COMPONENTS_WITH_BAD_PLATFORMS:
         component = _load_file(hass, platform_name, LOOKUP_PATHS)
     else:
         # avoid load component for legacy platform
@@ -104,7 +105,7 @@ def get_platform(hass,  # type: HomeAssistant
         return platform
 
     # Legacy platform check for automation: components/automation/event.py
-    if component is None and domain in ['automation', 'mqtt', 'telegram_bot']:
+    if component is None and domain in COMPONENTS_WITH_BAD_PLATFORMS:
         platform = _load_file(
             hass,
             PLATFORM_FORMAT.format(domain=platform_name, platform=domain),
@@ -129,10 +130,11 @@ def get_platform(hass,  # type: HomeAssistant
         _LOGGER.error("Unable to find platform %s.%s", platform_name, extra)
         return None
 
-    _LOGGER.error(
-        "Integrations need to be in their own folder. Change %s/%s.py to "
-        "%s/%s.py. This will stop working soon.",
-        domain, platform_name, platform_name, domain)
+    if domain not in COMPONENTS_WITH_BAD_PLATFORMS:
+        _LOGGER.error(
+            "Integrations need to be in their own folder. Change %s/%s.py to "
+            "%s/%s.py. This will stop working soon.",
+            domain, platform_name, platform_name, domain)
 
     return platform
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Fix Home Assistant printing warnings when loading MQTT, telegram_bot or automation integration platforms. These platforms should be fixed, but not today.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
