### PR TITLE
Remove pycryptodome requirement for Android TV

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.14"
+    "androidtv==0.0.15"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 ANDROIDTV_DOMAIN = 'androidtv'
 
-REQUIREMENTS = ['androidtv==0.0.14']
+REQUIREMENTS = ['androidtv==0.0.15']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -294,12 +294,12 @@ class ADBDevice(MediaPlayerDevice):
     @adb_decorator()
     def media_previous_track(self):
         """Send previous track command (results in rewind)."""
-        self.aftv.media_previous()
+        self.aftv.media_previous_track()
 
     @adb_decorator()
     def media_next_track(self):
         """Send next track command (results in fast-forward)."""
-        self.aftv.media_next()
+        self.aftv.media_next_track()
 
     @adb_decorator()
     def adb_command(self, cmd):
@@ -324,11 +324,11 @@ class AndroidTVDevice(ADBDevice):
                          turn_off_command)
 
         self._device = None
-        self._muted = None
         self._device_properties = self.aftv.device_properties
+        self._is_volume_muted = None
         self._unique_id = 'androidtv-{}-{}'.format(
             name, self._device_properties['serialno'])
-        self._volume = None
+        self._volume_level = None
 
     @adb_decorator(override_available=True)
     def update(self):
@@ -345,16 +345,16 @@ class AndroidTVDevice(ADBDevice):
         if not self._available:
             return
 
-        # Get the `state`, `current_app`, and `running_apps`.
-        state, self._current_app, self._device, self._muted, self._volume = \
-            self.aftv.update()
+        # Get the updated state and attributes.
+        state, self._current_app, self._device, self._is_volume_muted, \
+            self._volume_level = self.aftv.update()
 
         self._state = ANDROIDTV_STATES[state]
 
     @property
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
-        return self._muted
+        return self._is_volume_muted
 
     @property
     def source(self):
@@ -374,7 +374,7 @@ class AndroidTVDevice(ADBDevice):
     @property
     def volume_level(self):
         """Return the volume level."""
-        return self._volume
+        return self._volume_level
 
     @adb_decorator()
     def media_stop(self):
@@ -389,12 +389,12 @@ class AndroidTVDevice(ADBDevice):
     @adb_decorator()
     def volume_down(self):
         """Send volume down command."""
-        self.aftv.volume_down()
+        self._volume_level = self.aftv.volume_down(self._volume_level)
 
     @adb_decorator()
     def volume_up(self):
         """Send volume up command."""
-        self.aftv.volume_up()
+        self._volume_level = self.aftv.volume_up(self._volume_level)
 
 
 class FireTVDevice(ADBDevice):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -158,7 +158,7 @@ alpha_vantage==2.1.0
 amcrest==1.3.0
 
 # homeassistant.components.androidtv
-androidtv==0.0.14
+androidtv==0.0.15
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:

This removes the `pycryptodome` requirement from `androidtv`. 

Originally, I wanted to implement the `set_volume_method`, but this proved to be more difficult than expected, so I changed the focus of this pull request. 

**Fixes issue:** https://github.com/home-assistant/home-assistant/issues/22726, #22769

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.