### PR TITLE
Fix name conflict in tests

### DIFF
--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -45,7 +45,7 @@ class Comp1ConfigFlow:
 @HANDLERS.register('comp2')
 class Comp2ConfigFlow:
     """Config flow without options flow."""
-    
+
     def __init__(self):
         """Init."""
         pass

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -34,16 +34,20 @@ def client(hass, hass_client):
 @HANDLERS.register('comp1')
 class Comp1ConfigFlow:
     """Config flow with options flow."""
+
     @staticmethod
     @callback
     def async_get_options_flow(config, options):
+        """Get options flow."""
         pass
 
 
 @HANDLERS.register('comp2')
 class Comp2ConfigFlow:
     """Config flow without options flow."""
+    
     def __init__(self):
+        """Init."""
         pass
 
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -31,10 +31,26 @@ def client(hass, hass_client):
     yield hass.loop.run_until_complete(hass_client())
 
 
+@HANDLERS.register('comp1')
+class Comp1ConfigFlow:
+    """Config flow with options flow."""
+    @staticmethod
+    @callback
+    def async_get_options_flow(config, options):
+        pass
+
+
+@HANDLERS.register('comp2')
+class Comp2ConfigFlow:
+    """Config flow without options flow."""
+    def __init__(self):
+        pass
+
+
 async def test_get_entries(hass, client):
     """Test get entries."""
     MockConfigEntry(
-        domain='comp',
+        domain='comp1',
         title='Test 1',
         source='bla',
         connection_class=core_ce.CONN_CLASS_LOCAL_POLL,
@@ -47,18 +63,6 @@ async def test_get_entries(hass, client):
         connection_class=core_ce.CONN_CLASS_ASSUMED,
     ).add_to_hass(hass)
 
-    class CompConfigFlow:
-        @staticmethod
-        @callback
-        def async_get_options_flow(config, options):
-            pass
-    HANDLERS['comp'] = CompConfigFlow()
-
-    class Comp2ConfigFlow:
-        def __init__(self):
-            pass
-    HANDLERS['comp2'] = Comp2ConfigFlow()
-
     resp = await client.get('/api/config/config_entries/entry')
     assert resp.status == 200
     data = await resp.json()
@@ -66,7 +70,7 @@ async def test_get_entries(hass, client):
         entry.pop('entry_id')
     assert data == [
         {
-            'domain': 'comp',
+            'domain': 'comp1',
             'title': 'Test 1',
             'source': 'bla',
             'state': 'not_loaded',


### PR DESCRIPTION
## Description:

Fix failing tests in circleci. config_entries.HANDLERS is a global variable. To ensure the isolation of tests, we need to make sure each test config flow has unique names.

It failed in circleci but not travis because we changed the execution order of tests. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
