### PR TITLE
Add netgear_lte connection sensors

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from . import sensor_types
 
-REQUIREMENTS = ['eternalegypt==0.0.5']
+REQUIREMENTS = ['eternalegypt==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/netgear_lte/sensor.py
+++ b/homeassistant/components/netgear_lte/sensor.py
@@ -36,6 +36,8 @@ async def async_setup_platform(
             sensors.append(SMSSensor(modem_data, sensor_type))
         elif sensor_type == SENSOR_USAGE:
             sensors.append(UsageSensor(modem_data, sensor_type))
+        else:
+            sensors.append(GenericSensor(modem_data, sensor_type))
 
     async_add_entities(sensors)
 
@@ -106,3 +108,12 @@ class UsageSensor(LTESensor):
     def state(self):
         """Return the state of the sensor."""
         return round(self.modem_data.data.usage / 1024**2, 1)
+
+
+class GenericSensor(LTESensor):
+    """Sensor entity with raw state."""
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return getattr(self.modem_data.data, self.sensor_type)

--- a/homeassistant/components/netgear_lte/sensor_types.py
+++ b/homeassistant/components/netgear_lte/sensor_types.py
@@ -6,6 +6,19 @@ SENSOR_USAGE = 'usage'
 SENSOR_UNITS = {
     SENSOR_SMS: 'unread',
     SENSOR_USAGE: 'MiB',
+    'radio_quality': '%',
+    'rx_level': 'dBm',
+    'tx_level': 'dBm',
+    'upstream': None,
+    'wire_connected': None,
+    'mobile_connected': None,
+    'connection_text': None,
+    'connection_type': None,
+    'current_ps_service_type': None,
+    'register_network_display': None,
+    'roaming': None,
+    'current_band': None,
+    'cell_id': None,
 }
 
 ALL = list(SENSOR_UNITS)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -407,7 +407,7 @@ ephem==3.7.6.0
 epson-projector==0.1.3
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.5
+eternalegypt==0.0.6
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1


### PR DESCRIPTION
## Description:

This adds several sensors with information about the current connection.

(Introduced upstream in amelchio/eternalegypt#3)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9076

## Example entry for `configuration.yaml` (if applicable):
```yaml
netgear_lte:
  - host: !secret lb2120_hostname
    password: !secret lb2120_password
    sensor:
      monitored_conditions:
        - radio_quality
        - rx_level
        - tx_level
        - upstream
        - connection
        - connection_text
        - connection_type
        - current_ps_service_type
        - register_network_display
        - roaming
        - current_band
        - cell_id
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
