### PR TITLE
Bump pyloopenergy library to 0.1.2

### DIFF
--- a/homeassistant/components/loopenergy/sensor.py
+++ b/homeassistant/components/loopenergy/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyloopenergy==0.1.0']
+REQUIREMENTS = ['pyloopenergy==0.1.2']
 
 CONF_ELEC = 'electricity'
 CONF_GAS = 'gas'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1138,7 +1138,7 @@ pylinky==0.3.3
 pylitejet==0.1
 
 # homeassistant.components.loopenergy.sensor
-pyloopenergy==0.1.0
+pyloopenergy==0.1.2
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.5.0


### PR DESCRIPTION
## Description:

Bump pyloopenergy library.

The previous library version didn't correctly specify dependencies in setup. This might be causing the issue below.

**Related issue (if applicable):** fixes #22412

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
