### PR TITLE
Allow setting an alternate base url for streams

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -644,7 +644,7 @@ async def async_handle_play_stream_service(camera, service_call):
                          keepalive=camera_prefs.preload_stream)
     data = {
         ATTR_ENTITY_ID: entity_ids,
-        ATTR_MEDIA_CONTENT_ID: "{}{}".format(hass.config.api.base_url, url),
+        ATTR_MEDIA_CONTENT_ID: url,
         ATTR_MEDIA_CONTENT_TYPE: FORMAT_CONTENT_TYPE[fmt]
     }
 

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -218,7 +218,7 @@ class CameraStreamTrait(_Trait):
         url = await self.hass.components.camera.async_request_stream(
             self.state.entity_id, 'hls')
         self.stream_info = {
-            'cameraStreamAccessUrl': self.hass.config.api.base_url + url
+            'cameraStreamAccessUrl': url
         }
 
 

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.loader import bind_hass
 
 from .const import (
     DOMAIN, ATTR_STREAMS, ATTR_ENDPOINTS, CONF_STREAM_SOURCE,
-    CONF_DURATION, CONF_LOOKBACK, SERVICE_RECORD)
+    CONF_BASE_URL, CONF_DURATION, CONF_LOOKBACK, SERVICE_RECORD)
 from .core import PROVIDERS
 from .worker import stream_worker
 from .hls import async_setup_hls
@@ -31,7 +31,9 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['http']
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({}),
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_BASE_URL): cv.string,
+    }),
 }, extra=vol.ALLOW_EXTRA)
 
 STREAM_SERVICE_SCHEMA = vol.Schema({
@@ -92,8 +94,11 @@ async def async_setup(hass, config):
     hass.data[DOMAIN][ATTR_ENDPOINTS] = {}
     hass.data[DOMAIN][ATTR_STREAMS] = {}
 
+    conf = config.get(DOMAIN)
+    base_url = conf.get(CONF_BASE_URL) or hass.config.api.base_url
+
     # Setup HLS
-    hls_endpoint = async_setup_hls(hass)
+    hls_endpoint = async_setup_hls(hass, base_url)
     hass.data[DOMAIN][ATTR_ENDPOINTS]['hls'] = hls_endpoint
 
     # Setup Recorder

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -4,6 +4,7 @@ DOMAIN = 'stream'
 CONF_STREAM_SOURCE = 'stream_source'
 CONF_LOOKBACK = 'lookback'
 CONF_DURATION = 'duration'
+CONF_BASE_URL = 'base_url'
 
 ATTR_ENDPOINTS = 'endpoints'
 ATTR_STREAMS = 'streams'

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -14,11 +14,11 @@ from .core import StreamView, StreamOutput, PROVIDERS
 
 
 @callback
-def async_setup_hls(hass):
+def async_setup_hls(hass, base_url):
     """Set up api endpoints."""
     hass.http.register_view(HlsPlaylistView())
     hass.http.register_view(HlsSegmentView())
-    return '/api/hls/{}/playlist.m3u8'
+    return "{}{}".format(base_url, '/api/hls/{}/playlist.m3u8')
 
 
 class HlsPlaylistView(StreamView):

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -569,7 +569,7 @@ async def test_trait_execute_adding_query_data(hass):
     })
 
     with patch('homeassistant.components.camera.async_request_stream',
-               return_value=mock_coro('/api/streams/bla')):
+               return_value=mock_coro('http://1.1.1.1:8123/api/streams/bla')):
         result = await sh.async_handle_message(
             hass, BASIC_CONFIG, None,
             {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -132,7 +132,7 @@ async def test_camera_stream(hass):
     assert trt.query_attributes() == {}
 
     with patch('homeassistant.components.camera.async_request_stream',
-               return_value=mock_coro('/api/streams/bla')):
+               return_value=mock_coro('http://1.1.1.1:8123/api/streams/bla')):
         await trt.execute(trait.COMMAND_GET_CAMERA_STREAM, BASIC_DATA, {})
 
     assert trt.query_attributes() == {


### PR DESCRIPTION
## Description:
Add a config option to allow setting an alternate base_url for stream urls, much like the existing one for the `tts` component. This allows users with weird setups to continue doing weird stuff. For example... I run hass with nginx in front of it, presenting a nice tidy SSL certificate. This certificate doesn't validate on Chromecast though, so I need a different base URL to pass to Chromecast, which doesn't use SSL.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9079

## Example entry for `configuration.yaml` (if applicable):
```yaml
stream:
  base_url: http://home.assistant
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** - tests don't run on Darwin
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)