### PR TITLE
Freebox sensor use shared object

### DIFF
--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -1,4 +1,5 @@
 """Support for Freebox devices (Freebox v6 and Freebox mini 4K)."""
+from datetime import timedelta
 import logging
 import socket
 
@@ -8,14 +9,16 @@ from homeassistant.components.discovery import SERVICE_FREEBOX
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.event import async_track_time_interval
 
 REQUIREMENTS = ['aiofreepybox==0.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "freebox"
+DOMAIN = 'freebox'
 DATA_FREEBOX = DOMAIN
-
+DATA_FREEBOX_SENSOR = 'freebox_sensor'
+UPDATE_INTERVAL = timedelta(seconds=30)
 FREEBOX_CONFIG_FILE = 'freebox.conf'
 
 CONFIG_SCHEMA = vol.Schema({
@@ -28,6 +31,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the Freebox component."""
+
     conf = config.get(DOMAIN)
 
     async def discovery_dispatch(service, discovery_info):
@@ -35,20 +39,22 @@ async def async_setup(hass, config):
             host = discovery_info.get('properties', {}).get('api_domain')
             port = discovery_info.get('properties', {}).get('https_port')
             _LOGGER.info("Discovered Freebox server: %s:%s", host, port)
-            await async_setup_freebox(hass, config, host, port)
+            fbx = await get_freebox_connection(hass, config, host, port)
+            await async_setup_freebox(hass, config, fbx)
 
     discovery.async_listen(hass, SERVICE_FREEBOX, discovery_dispatch)
 
     if conf is not None:
         host = conf.get(CONF_HOST)
         port = conf.get(CONF_PORT)
-        await async_setup_freebox(hass, config, host, port)
+        fbx = await get_freebox_connection(hass, config, host, port)
+        await async_setup_freebox(hass, config, fbx)
 
     return True
 
 
-async def async_setup_freebox(hass, config, host, port):
-    """Start up the Freebox component platforms."""
+async def get_freebox_connection(hass, config, host, port):
+    """Connect to the router and return connection object."""
     from aiofreepybox import Freepybox
     from aiofreepybox.exceptions import HttpRequestError
 
@@ -71,18 +77,35 @@ async def async_setup_freebox(hass, config, host, port):
         await fbx.open(host, port)
     except HttpRequestError:
         _LOGGER.exception('Failed to connect to Freebox')
-    else:
-        hass.data[DATA_FREEBOX] = fbx
+    return fbx
 
-        hass.async_create_task(async_load_platform(
-            hass, 'sensor', DOMAIN, {}, config))
-        hass.async_create_task(async_load_platform(
-            hass, 'device_tracker', DOMAIN, {}, config))
-        hass.async_create_task(async_load_platform(
-            hass, 'switch', DOMAIN, {}, config))
 
-        async def close_fbx(event):
-            """Close Freebox connection on HA Stop."""
-            await fbx.close()
+async def async_setup_freebox(hass, config, fbx):
+    """Start up the Freebox component platforms."""
 
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_fbx)
+    await async_update_sensor_data(hass, fbx)
+
+    async def close_fbx(event):
+        """Close Freebox connection on HA Stop."""
+        await fbx.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_fbx)
+
+    async def async_update_freebox(now):
+        """Call update of datas on time interval."""
+        await async_update_sensor_data(hass, fbx)
+
+    hass.data[DATA_FREEBOX] = fbx
+
+    async_track_time_interval(hass, async_update_freebox, UPDATE_INTERVAL)
+
+    hass.async_create_task(discovery.async_load_platform(
+        hass, 'sensor', DOMAIN, {}, config))
+    hass.async_create_task(discovery.async_load_platform(
+        hass, 'switch', DOMAIN, {}, config))
+    hass.async_create_task(discovery.async_load_platform(
+        hass, 'device_tracker', DOMAIN, {}, config))
+
+async def async_update_sensor_data(hass, fbx):
+    """Update sensors datas shared object."""
+    hass.data[DATA_FREEBOX_SENSOR] = await fbx.connection.get_status()

--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 from homeassistant.components.discovery import SERVICE_FREEBOX
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import config_validation as cv, discovery
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.event import async_track_time_interval
 
 REQUIREMENTS = ['aiofreepybox==0.0.8']
@@ -31,7 +30,6 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the Freebox component."""
-
     conf = config.get(DOMAIN)
 
     async def discovery_dispatch(service, discovery_info):
@@ -82,7 +80,6 @@ async def get_freebox_connection(hass, config, host, port):
 
 async def async_setup_freebox(hass, config, fbx):
     """Start up the Freebox component platforms."""
-
     await async_update_sensor_data(hass, fbx)
 
     async def close_fbx(event):
@@ -105,6 +102,7 @@ async def async_setup_freebox(hass, config, fbx):
         hass, 'switch', DOMAIN, {}, config))
     hass.async_create_task(discovery.async_load_platform(
         hass, 'device_tracker', DOMAIN, {}, config))
+
 
 async def async_update_sensor_data(hass, fbx):
     """Update sensors datas shared object."""

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -13,7 +13,6 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the sensors."""
-    datas = hass.data[DATA_FREEBOX_SENSOR]
     async_add_entities([FbxRXSensor(hass), FbxTXSensor(hass)], True)
 
 

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.helpers.entity import Entity
 
-from . import DATA_FREEBOX
+from . import DATA_FREEBOX_SENSOR
 
 DEPENDENCIES = ['freebox']
 
@@ -13,20 +13,20 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the sensors."""
-    fbx = hass.data[DATA_FREEBOX]
-    async_add_entities([FbxRXSensor(fbx), FbxTXSensor(fbx)], True)
+    datas = hass.data[DATA_FREEBOX_SENSOR]
+    async_add_entities([FbxRXSensor(hass), FbxTXSensor(hass)], True)
 
 
-class FbxSensor(Entity):
-    """Representation of a freebox sensor."""
-
-    _name = 'generic'
-
-    def __init__(self, fbx):
+class FbxRXSensor(Entity):
+    """Update the Freebox RxSensor."""
+    def __init__(self, hass):
         """Initialize the sensor."""
-        self._fbx = fbx
         self._state = None
-        self._datas = None
+        self._name = 'Freebox download speed'
+        self._unit = 'KB/s'
+        self._hass = hass
+        self._data = None
+        self._icon = 'mdi:download'
 
     @property
     def name(self):
@@ -38,42 +38,56 @@ class FbxSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
-    async def async_update(self):
-        """Fetch status from freebox."""
-        self._datas = await self._fbx.connection.get_status()
-
-
-class FbxRXSensor(FbxSensor):
-    """Update the Freebox RxSensor."""
-
-    _name = 'Freebox download speed'
-    _unit = 'KB/s'
-
     @property
     def unit_of_measurement(self):
         """Define the unit."""
         return self._unit
 
+    @property
+    def icon(self):
+        """Define the icon."""
+        return self._icon
+
     async def async_update(self):
         """Get the value from fetched datas."""
-        await super().async_update()
+        self._datas = self._hass.data[DATA_FREEBOX_SENSOR]
         if self._datas is not None:
             self._state = round(self._datas['rate_down'] / 1000, 2)
 
 
-class FbxTXSensor(FbxSensor):
+class FbxTXSensor(Entity):
     """Update the Freebox TxSensor."""
+    def __init__(self, hass):
+        """Initialize the sensor."""
+        self._state = None
+        self._name = 'Freebox upload speed'
+        self._unit = 'KB/s'
+        self._hass = hass
+        self._datas = None
+        self._icon = 'mdi:upload'
 
-    _name = 'Freebox upload speed'
-    _unit = 'KB/s'
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
 
     @property
     def unit_of_measurement(self):
         """Define the unit."""
         return self._unit
 
+    @property
+    def icon(self):
+        """Define the icon."""
+        return self._icon
+
     async def async_update(self):
         """Get the value from fetched datas."""
-        await super().async_update()
+        self._datas =  self._hass.data[DATA_FREEBOX_SENSOR]
         if self._datas is not None:
             self._state = round(self._datas['rate_up'] / 1000, 2)

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -19,13 +19,14 @@ async def async_setup_platform(
 
 class FbxRXSensor(Entity):
     """Update the Freebox RxSensor."""
+
     def __init__(self, hass):
         """Initialize the sensor."""
         self._state = None
         self._name = 'Freebox download speed'
         self._unit = 'KB/s'
         self._hass = hass
-        self._data = None
+        self._datas = None
         self._icon = 'mdi:download'
 
     @property
@@ -56,6 +57,7 @@ class FbxRXSensor(Entity):
 
 
 class FbxTXSensor(Entity):
+
     """Update the Freebox TxSensor."""
     def __init__(self, hass):
         """Initialize the sensor."""
@@ -88,6 +90,6 @@ class FbxTXSensor(Entity):
 
     async def async_update(self):
         """Get the value from fetched datas."""
-        self._datas =  self._hass.data[DATA_FREEBOX_SENSOR]
+        self._datas = self._hass.data[DATA_FREEBOX_SENSOR]
         if self._datas is not None:
             self._state = round(self._datas['rate_up'] / 1000, 2)

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -57,8 +57,8 @@ class FbxRXSensor(Entity):
 
 
 class FbxTXSensor(Entity):
-
     """Update the Freebox TxSensor."""
+
     def __init__(self, hass):
         """Initialize the sensor."""
         self._state = None


### PR DESCRIPTION
## Description:

- Use a shared object refreshed by the hub instead of hitting the router 2 times for 2 sensors. Should make it faster.
- Refactor of the hub.
- Small addition too : add icon property to the sensors


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.