### PR TITLE
Fix lightwave config validation

### DIFF
--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -14,7 +14,7 @@ DOMAIN = 'lightwave'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema(
-        cv.has_at_least_one_key(CONF_LIGHTS, CONF_SWITCHES), {
+        vol.All(cv.has_at_least_one_key(CONF_LIGHTS, CONF_SWITCHES), {
             vol.Required(CONF_HOST): cv.string,
             vol.Optional(CONF_LIGHTS, default={}): {
                 cv.string: vol.Schema({vol.Required(CONF_NAME): cv.string}),
@@ -23,6 +23,7 @@ CONFIG_SCHEMA = vol.Schema({
                 cv.string: vol.Schema({vol.Required(CONF_NAME): cv.string}),
             }
         })
+    )
 }, extra=vol.ALLOW_EXTRA)
 
 


### PR DESCRIPTION
## Breaking Change:

Lightwave configuration was not properly validated before, it is now. This can cause invalid configurations to finally be flagged as such.

## Description:

A missing `vol.All` meant that the schema would validate anything as long as `cv.has_at_least_one_key` passed.

I do not use this component so I only tested startup.

## Example entry for `configuration.yaml` (if applicable):
```yaml
lightwave:
    lights:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
