### PR TITLE
Add mobile_app notify platform

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -52,7 +52,8 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
         except ValueError:
             pass
 
-    discovery.load_platform(hass, 'notify', DOMAIN, {}, config)
+    hass.async_create_task(discovery.async_load_platform(
+        hass, 'notify', DOMAIN, {}, config))
 
     return True
 

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -5,11 +5,10 @@ from homeassistant.components.webhook import async_register as webhook_register
 from homeassistant.helpers import device_registry as dr, discovery
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .const import (ATTR_APP_DATA, ATTR_DEVICE_ID, ATTR_DEVICE_NAME,
-                    ATTR_MANUFACTURER, ATTR_MODEL, ATTR_PUSH_TOKEN,
-                    ATTR_PUSH_URL, ATTR_OS_VERSION, DATA_BINARY_SENSOR,
-                    DATA_CONFIG_ENTRIES, DATA_DELETED_IDS, DATA_DEVICES,
-                    DATA_SENSOR, DATA_STORE, DOMAIN, STORAGE_KEY,
+from .const import (ATTR_DEVICE_ID, ATTR_DEVICE_NAME,
+                    ATTR_MANUFACTURER, ATTR_MODEL, ATTR_OS_VERSION,
+                    DATA_BINARY_SENSOR, DATA_CONFIG_ENTRIES, DATA_DELETED_IDS,
+                    DATA_DEVICES, DATA_SENSOR, DATA_STORE, DOMAIN, STORAGE_KEY,
                     STORAGE_VERSION)
 
 from .http_api import RegistrationsView
@@ -118,15 +117,3 @@ class MobileAppFlowHandler(config_entries.ConfigFlow):
         """Handle a flow initialized during registration."""
         return self.async_create_entry(title=user_input[ATTR_DEVICE_NAME],
                                        data=user_input)
-
-
-def push_registrations(hass):
-    """Return a dictionary of push enabled registrations."""
-    targets = {}
-    for webhook_id, entry in hass.data[DOMAIN][DATA_CONFIG_ENTRIES].items():
-        data = entry.data
-        app_data = data[ATTR_APP_DATA]
-        if ATTR_PUSH_TOKEN in app_data and ATTR_PUSH_URL in app_data:
-            device_name = data[ATTR_DEVICE_NAME]
-            targets[device_name] = webhook_id
-    return targets

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -40,6 +40,8 @@ ATTR_MANUFACTURER = 'manufacturer'
 ATTR_MODEL = 'model'
 ATTR_OS_NAME = 'os_name'
 ATTR_OS_VERSION = 'os_version'
+ATTR_PUSH_TOKEN = 'push_token'
+ATTR_PUSH_URL = 'push_url'
 ATTR_SUPPORTS_ENCRYPTION = 'supports_encryption'
 
 ATTR_EVENT_DATA = 'event_data'

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -9,7 +9,6 @@ from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.components.notify import (
     ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT,
     BaseNotificationService)
-from homeassistant.components.mobile_app import push_registrations
 from homeassistant.components.mobile_app.const import (
     ATTR_APP_DATA, ATTR_APP_ID, ATTR_APP_NAME, ATTR_APP_VERSION,
     ATTR_DEVICE_NAME, ATTR_MANUFACTURER, ATTR_MODEL, ATTR_OS_NAME,
@@ -21,6 +20,18 @@ import homeassistant.util.dt as dt_util
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["mobile_app"]
+
+
+def push_registrations(hass):
+    """Return a dictionary of push enabled registrations."""
+    targets = {}
+    for webhook_id, entry in hass.data[DOMAIN][DATA_CONFIG_ENTRIES].items():
+        data = entry.data
+        app_data = data[ATTR_APP_DATA]
+        if ATTR_PUSH_TOKEN in app_data and ATTR_PUSH_URL in app_data:
+            device_name = data[ATTR_DEVICE_NAME]
+            targets[device_name] = webhook_id
+    return targets
 
 
 # pylint: disable=invalid-name

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -5,13 +5,11 @@ import logging
 
 import async_timeout
 
-from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.components.notify import (
     ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT,
     BaseNotificationService)
 from homeassistant.components.mobile_app.const import (
-    ATTR_APP_DATA, ATTR_APP_ID, ATTR_APP_NAME, ATTR_APP_VERSION,
-    ATTR_DEVICE_NAME, ATTR_MANUFACTURER, ATTR_MODEL, ATTR_OS_NAME,
+    ATTR_APP_DATA, ATTR_APP_ID, ATTR_APP_VERSION, ATTR_DEVICE_NAME,
     ATTR_OS_VERSION, ATTR_PUSH_TOKEN, ATTR_PUSH_URL, DATA_CONFIG_ENTRIES,
     DOMAIN)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -97,15 +95,8 @@ class MobileAppNotificationService(BaseNotificationService):
             data[ATTR_PUSH_TOKEN] = push_token
 
             reg_info = {
-                ATTR_APP_DATA: app_data,
                 ATTR_APP_ID: entry_data[ATTR_APP_ID],
-                ATTR_APP_NAME: entry_data[ATTR_APP_NAME],
                 ATTR_APP_VERSION: entry_data[ATTR_APP_VERSION],
-                ATTR_DEVICE_NAME: entry_data[ATTR_DEVICE_NAME],
-                ATTR_MANUFACTURER: entry_data[ATTR_MANUFACTURER],
-                ATTR_MODEL: entry_data[ATTR_MODEL],
-                ATTR_OS_NAME: entry_data[ATTR_OS_NAME],
-                CONF_WEBHOOK_ID: entry_data[CONF_WEBHOOK_ID],
             }
             if ATTR_OS_VERSION in entry_data:
                 reg_info[ATTR_OS_VERSION] = entry_data[ATTR_OS_VERSION]

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -117,7 +117,7 @@ class MobileAppNotificationService(BaseNotificationService):
                                     "please try again later: "
                                     "{}").format(fallback_error)
                 message = result.get("message", fallback_message)
-                if response.status_code == 429:
+                if response.status == 429:
                     _LOGGER.warning(message)
                     log_rate_limits(self.hass,
                                     entry_data[ATTR_DEVICE_NAME],

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -51,7 +51,7 @@ def log_rate_limits(hass, device_name, resp, level=logging.INFO):
                 str(resetsAtTime).split(".")[0])
 
 
-async def get_service(hass, config, discovery_info=None):
+async def async_get_service(hass, config, discovery_info=None):
     """Get the mobile_app notification service."""
     session = async_get_clientsession(hass)
     return MobileAppNotificationService(session)

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -17,7 +17,7 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ["mobile_app"]
+DEPENDENCIES = ['mobile_app']
 
 
 def push_registrations(hass):
@@ -35,16 +35,16 @@ def push_registrations(hass):
 # pylint: disable=invalid-name
 def log_rate_limits(hass, device_name, resp, level=logging.INFO):
     """Output rate limit log line at given level."""
-    rate_limits = resp["rateLimits"]
-    resetsAt = dt_util.parse_datetime(rate_limits["resetsAt"])
+    rate_limits = resp['rateLimits']
+    resetsAt = dt_util.parse_datetime(rate_limits['resetsAt'])
     resetsAtTime = resetsAt - datetime.now(timezone.utc)
     rate_limit_msg = ("mobile_app push notification rate limits for %s: "
                       "%d sent, %d allowed, %d errors, "
                       "resets in %s")
     _LOGGER.log(level, rate_limit_msg,
                 device_name,
-                rate_limits["successful"],
-                rate_limits["maximum"], rate_limits["errors"],
+                rate_limits['successful'],
+                rate_limits['maximum'], rate_limits['errors'],
                 str(resetsAtTime).split(".")[0])
 
 

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -1,0 +1,117 @@
+"""Support for mobile_app push notifications."""
+from datetime import datetime, timezone
+import logging
+
+import requests
+
+from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.components.notify import (
+    ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT,
+    BaseNotificationService)
+from homeassistant.components.mobile_app import push_registrations
+from homeassistant.components.mobile_app.const import (
+    ATTR_APP_DATA, ATTR_APP_ID, ATTR_APP_NAME, ATTR_APP_VERSION,
+    ATTR_DEVICE_NAME, ATTR_MANUFACTURER, ATTR_MODEL, ATTR_OS_NAME,
+    ATTR_OS_VERSION, ATTR_PUSH_TOKEN, ATTR_PUSH_URL, DATA_CONFIG_ENTRIES,
+    DOMAIN)
+import homeassistant.util.dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ["mobile_app"]
+
+
+# pylint: disable=invalid-name
+def log_rate_limits(hass, device_name, resp, level=20):
+    """Output rate limit log line at given level."""
+    rate_limits = resp["rateLimits"]
+    resetsAt = dt_util.parse_datetime(rate_limits["resetsAt"])
+    resetsAtTime = resetsAt - datetime.now(timezone.utc)
+    rate_limit_msg = ("mobile_app push notification rate limits for %s: "
+                      "%d sent, %d allowed, %d errors, "
+                      "resets in %s")
+    _LOGGER.log(level, rate_limit_msg,
+                device_name,
+                rate_limits["successful"],
+                rate_limits["maximum"], rate_limits["errors"],
+                str(resetsAtTime).split(".")[0])
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the mobile_app notification service."""
+    return MobileAppNotificationService()
+
+
+class MobileAppNotificationService(BaseNotificationService):
+    """Implement the notification service for mobile_app."""
+
+    def __init__(self):
+        """Initialize the service."""
+
+    @property
+    def targets(self):
+        """Return a dictionary of registered targets."""
+        return push_registrations(self.hass)
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to the Lambda APNS gateway."""
+        data = {ATTR_MESSAGE: message}
+
+        if kwargs.get(ATTR_TITLE) is not None:
+            # Remove default title from notifications.
+            if kwargs.get(ATTR_TITLE) != ATTR_TITLE_DEFAULT:
+                data[ATTR_TITLE] = kwargs.get(ATTR_TITLE)
+
+        targets = kwargs.get(ATTR_TARGET)
+
+        if not targets:
+            targets = push_registrations(self.hass)
+
+        if kwargs.get(ATTR_DATA) is not None:
+            data[ATTR_DATA] = kwargs.get(ATTR_DATA)
+
+        for target in targets:
+
+            entry = self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES][target]
+            entry_data = entry.data
+
+            app_data = entry_data[ATTR_APP_DATA]
+            push_token = app_data[ATTR_PUSH_TOKEN]
+            push_url = app_data[ATTR_PUSH_URL]
+
+            data[ATTR_PUSH_TOKEN] = push_token
+
+            reg_info = {
+                ATTR_APP_DATA: app_data,
+                ATTR_APP_ID: entry_data[ATTR_APP_ID],
+                ATTR_APP_NAME: entry_data[ATTR_APP_NAME],
+                ATTR_APP_VERSION: entry_data[ATTR_APP_VERSION],
+                ATTR_DEVICE_NAME: entry_data[ATTR_DEVICE_NAME],
+                ATTR_MANUFACTURER: entry_data[ATTR_MANUFACTURER],
+                ATTR_MODEL: entry_data[ATTR_MODEL],
+                ATTR_OS_NAME: entry_data[ATTR_OS_NAME],
+                CONF_WEBHOOK_ID: entry_data[CONF_WEBHOOK_ID],
+            }
+            if ATTR_OS_VERSION in entry_data:
+                reg_info[ATTR_OS_VERSION] = entry_data[ATTR_OS_VERSION]
+
+            data['registration_info'] = reg_info
+
+            req = requests.post(push_url, json=data, timeout=10)
+
+            if req.status_code != 201:
+                fallback_error = req.json().get("errorMessage",
+                                                "Unknown error")
+                fallback_message = ("Internal server error, "
+                                    "please try again later: "
+                                    "{}").format(fallback_error)
+                message = req.json().get("message", fallback_message)
+                if req.status_code == 429:
+                    _LOGGER.warning(message)
+                    log_rate_limits(self.hass, entry_data[ATTR_DEVICE_NAME],
+                                    req.json(), 30)
+                else:
+                    _LOGGER.error(message)
+            else:
+                log_rate_limits(self.hass, entry_data[ATTR_DEVICE_NAME],
+                                req.json())

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -28,6 +28,9 @@ def push_registrations(hass):
         app_data = data[ATTR_APP_DATA]
         if ATTR_PUSH_TOKEN in app_data and ATTR_PUSH_URL in app_data:
             device_name = data[ATTR_DEVICE_NAME]
+            if device_name in targets:
+                _LOGGER.warning("Found duplicate device name %s", device_name)
+                continue
             targets[device_name] = webhook_id
     return targets
 

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -64,7 +64,6 @@ async def setup_push_receiver(hass, aioclient_mock):
 
 async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
     """Return two new registrations."""
-    print("services", hass.services.async_services())
     assert hass.services.has_service('notify', 'mobile_app_test') is True
     assert await hass.services.async_call('notify', 'mobile_app_test',
                                           {'message': 'Hello world'},

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -63,7 +63,7 @@ async def setup_push_receiver(hass, aioclient_mock):
 
 
 async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
-    """Return two new registrations."""
+    """Test notify works."""
     assert hass.services.has_service('notify', 'mobile_app_test') is True
     assert await hass.services.async_call('notify', 'mobile_app_test',
                                           {'message': 'Hello world'},

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -1,0 +1,82 @@
+"""Notify platform tests for mobile_app."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from homeassistant.setup import async_setup_component
+
+from homeassistant.components.mobile_app.const import DOMAIN
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+async def setup_push_receiver(hass, aioclient_mock):
+    """Fixture that sets up a mocked push receiver."""
+    push_url = 'https://mobile-push.home-assistant.dev/push'
+
+    from datetime import datetime, timedelta
+    now = (datetime.now() + timedelta(hours=24))
+    iso_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    aioclient_mock.post(push_url, json={
+        'rateLimits': {
+            'attempts': 1,
+            'successful': 1,
+            'errors': 0,
+            'total': 1,
+            'maximum': 150,
+            'remaining': 149,
+            'resetsAt': iso_time
+        }
+    })
+
+    entry = MockConfigEntry(
+        connection_class="cloud_push",
+        data={
+            "app_data": {
+                "push_token": "PUSH_TOKEN",
+                "push_url": push_url
+            },
+            "app_id": "io.homeassistant.mobile_app",
+            "app_name": "mobile_app tests",
+            "app_version": "1.0",
+            "device_id": "4d5e6f",
+            "device_name": "Test",
+            "manufacturer": "Home Assistant",
+            "model": "mobile_app",
+            "os_name": "Linux",
+            "os_version": "5.0.6",
+            "secret": "123abc",
+            "supports_encryption": False,
+            "user_id": "1a2b3c",
+            "webhook_id": "webhook_id"
+        },
+        domain=DOMAIN,
+        source="registration",
+        title="mobile_app test entry",
+        version=1
+    )
+    entry.add_to_hass(hass)
+
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+
+
+async def test_notify_works(hass, aioclient_mock, setup_push_receiver):
+    """Return two new registrations."""
+    print("services", hass.services.async_services())
+    assert hass.services.has_service('notify', 'mobile_app_test') is True
+    assert await hass.services.async_call('notify', 'mobile_app_test',
+                                          {'message': 'Hello world'},
+                                          blocking=True)
+
+    assert len(aioclient_mock.mock_calls) == 1
+    call = aioclient_mock.mock_calls
+
+    call_json = call[0][2]
+
+    assert call_json["push_token"] == "PUSH_TOKEN"
+    assert call_json["message"] == "Hello world"
+    assert call_json["registration_info"]["app_id"] == \
+        "io.homeassistant.mobile_app"
+    assert call_json["registration_info"]["app_version"] == "1.0"


### PR DESCRIPTION
## Description:

Adds a generic `mobile_app` notification platform. `push_url` and `push_token` must be set in the app data dictionary to enable the platform for a registration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.