### PR TITLE
Fix typo in light/__init__.py

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -447,7 +447,7 @@ class Light(ToggleEntity):
             if supported_features & SUPPORT_COLOR_TEMP:
                 data[ATTR_COLOR_TEMP] = self.color_temp
 
-            if self.supported_features & SUPPORT_COLOR and self.hs_color:
+            if supported_features & SUPPORT_COLOR and self.hs_color:
                 # pylint: disable=unsubscriptable-object,not-an-iterable
                 hs_color = self.hs_color
                 data[ATTR_HS_COLOR] = (


### PR DESCRIPTION
## Description:

Just fix a typo.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
