### PR TITLE
Kill bluetooth LE scanning gracefully when asked to shut down.

### DIFF
--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -22,7 +22,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
     new_devices = {}
     adapter = None
 
-    async def async_stop():
+    async def async_stop(event):
         if adapter is not None:
             adapter.kill()
 

--- a/homeassistant/components/bluetooth_le_tracker/manifest.json
+++ b/homeassistant/components/bluetooth_le_tracker/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bluetooth le tracker",
   "documentation": "https://www.home-assistant.io/components/bluetooth_le_tracker",
   "requirements": [
-    "pygatt[GATTTOOL]==3.2.0"
+    "pygatt[GATTTOOL]==4.0.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/skybeacon/manifest.json
+++ b/homeassistant/components/skybeacon/manifest.json
@@ -3,7 +3,7 @@
   "name": "Skybeacon",
   "documentation": "https://www.home-assistant.io/components/skybeacon",
   "requirements": [
-    "pygatt[GATTTOOL]==3.2.0"
+    "pygatt[GATTTOOL]==4.0.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/skybeacon/sensor.py
+++ b/homeassistant/components/skybeacon/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_DEVICE = 'device'

--- a/homeassistant/components/skybeacon/sensor.py
+++ b/homeassistant/components/skybeacon/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_DEVICE = 'device'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1054,7 +1054,7 @@ pyfritzhome==0.4.0
 pyfttt==0.3
 
 # homeassistant.components.bluetooth_le_tracker
-# homeassistant.components.skybeacon.
+# homeassistant.components.skybeacon
 pygatt[GATTTOOL]==4.0.1
 
 # homeassistant.components.gogogate2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1054,8 +1054,8 @@ pyfritzhome==0.4.0
 pyfttt==0.3
 
 # homeassistant.components.bluetooth_le_tracker
-# homeassistant.components.skybeacon
-pygatt[GATTTOOL]==3.2.0
+# homeassistant.components.skybeacon.
+pygatt[GATTTOOL]==4.0.1
 
 # homeassistant.components.gogogate2
 pygogogate2==0.1.1


### PR DESCRIPTION
## Description:
When systemd (or anything else) asks hass to stop, it can now also ask pygatt to stop gracefully with SIGINT, avoiding leaving orphan processes and the bluetooth adapter in a bad state. The new version of pygatt also includes many other fixes.

**Related issue (if applicable):** fixes #19760, #19592, #17118; may relate to #16698

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
