### PR TITLE
Initial part of #22587 - API changes, wait_template, and bayesian.binary_sensor

### DIFF
--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -24,6 +24,7 @@ async def async_trigger(hass, config, action, automation_info):
     @callback
     def template_listener(entity_id, from_s, to_s):
         """Listen for state changes and calls action."""
+        context = to_s.context if to_s else None
         hass.async_run_job(action({
             'trigger': {
                 'platform': 'template',
@@ -31,6 +32,6 @@ async def async_trigger(hass, config, action, automation_info):
                 'from_state': from_s,
                 'to_state': to_s,
             },
-        }, context=to_s.context))
+        }, context=context))
 
     return async_track_template(hass, value_template, template_listener)

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -156,9 +156,6 @@ class BayesianBinarySensor(BinarySensorDevice):
         async_track_state_change(
             self.hass, self.entity_obs, async_threshold_sensor_state_listener)
 
-        self._register_template_callbacks()
-
-    def _register_template_callbacks(self):
         @callback
         def async_template_result_changed(
                 event, template, old_result, new_result):
@@ -175,10 +172,10 @@ class BayesianBinarySensor(BinarySensorDevice):
 
         for template in self.template_obs:
             template.hass = self.hass
-            (cancel, result) = async_track_template_result(
+            info = async_track_template_result(
                 self.hass, template, async_template_result_changed)
-            async_template_result_changed(None, template, None, result)
-            self._callbacks.append(cancel)
+
+            self._callbacks.append(info)
 
     def _update_current_obs(self, entity_observation, should_trigger):
         """Update current observation."""
@@ -258,9 +255,7 @@ class BayesianBinarySensor(BinarySensorDevice):
 
     async def async_update(self):
         """Get the latest data and update the states."""
-        # Just recalculate the templates, the direct states
-        # get updated in the listeners.
+        # Force recalc of the templates. The states will
+        # update automatically.
         for call in self._callbacks:
-            call()
-        self._callbacks.clear()
-        self._register_template_callbacks()
+            call.async_refresh()

--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -155,7 +155,8 @@ class BayesianBinarySensor(BinarySensorDevice):
             self.hass, self.entity_obs, async_threshold_sensor_state_listener)
 
         @callback
-        def async_template_result_changed(template, old_result, new_result):
+        def async_template_result_changed(
+                event, template, old_result, new_result):
             template_obs_list = self.template_obs[template]
             result = str_to_bool(new_result)
 

--- a/homeassistant/components/rest/binary_sensor.py
+++ b/homeassistant/components/rest/binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_USERNAME, CONF_VALUE_TEMPLATE, CONF_VERIFY_SSL,
     HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.util import str_to_bool
 import homeassistant.helpers.config_validation as cv
 
 from .sensor import RestData
@@ -121,11 +122,7 @@ class RestBinarySensor(BinarySensorDevice):
             response = self._value_template.\
                 async_render_with_possible_json_value(self.rest.data, False)
 
-        try:
-            return bool(int(response))
-        except ValueError:
-            return {'true': True, 'on': True, 'open': True,
-                    'yes': True}.get(response.lower(), False)
+        return str_to_bool(response)
 
     def update(self):
         """Get the latest data from REST API and updates the state."""

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -98,26 +98,31 @@ async def async_setup_platform(hass, config, async_add_entities,
             continue
         template_entity_ids = set()
         if state_template is not None:
+            state_template.hass = hass
             temp_ids = state_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)
 
         if position_template is not None:
+            position_template.hass = hass
             temp_ids = position_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)
 
         if tilt_template is not None:
+            tilt_template.hass = hass
             temp_ids = tilt_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)
 
         if icon_template is not None:
+            icon_template.hass = hass
             temp_ids = icon_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)
 
         if entity_picture_template is not None:
+            entity_picture_template.hass = hass
             temp_ids = entity_picture_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -102,6 +102,7 @@ async def async_setup_platform(
             if entity_ids == MATCH_ALL or manual_entity_ids is not None:
                 continue
 
+            template.hass = hass
             template_entity_ids = template.extract_entities()
             if template_entity_ids == MATCH_ALL:
                 entity_ids = MATCH_ALL

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -67,21 +67,25 @@ async def async_setup_platform(hass, config, async_add_entities,
         template_entity_ids = set()
 
         if state_template is not None:
+            state_template.hass = hass
             temp_ids = state_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)
 
         if level_template is not None:
+            level_template.hass = hass
             temp_ids = level_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)
 
         if icon_template is not None:
+            icon_template.hass = hass
             temp_ids = icon_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)
 
         if entity_picture_template is not None:
+            entity_picture_template.hass = hass
             temp_ids = entity_picture_template.extract_entities()
             if str(temp_ids) != MATCH_ALL:
                 template_entity_ids |= set(temp_ids)

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -55,6 +55,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             CONF_ENTITY_PICTURE_TEMPLATE)
         on_action = device_config[ON_ACTION]
         off_action = device_config[OFF_ACTION]
+        state_template.hass = hass
         entity_ids = (device_config.get(ATTR_ENTITY_ID) or
                       state_template.extract_entities())
 

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -21,6 +21,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
 from homeassistant.util.async_ import run_callback_threadsafe
+from homeassistant.util import str_to_bool
 
 FROM_CONFIG_FORMAT = '{}_from_config'
 ASYNC_FROM_CONFIG_FORMAT = 'async_{}_from_config'
@@ -333,7 +334,7 @@ def async_template(hass: HomeAssistant, value_template: Template,
         _LOGGER.error("Error during template condition: %s", ex)
         return False
 
-    return value.lower() == 'true'
+    return str_to_bool(value)
 
 
 def async_template_from_config(config: ConfigType,

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
     ENTITY_MATCH_ALL, CONF_ENTITY_NAMESPACE, __version__)
 from homeassistant.core import valid_entity_id, split_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 
@@ -439,6 +438,8 @@ unit_system = vol.All(vol.Lower, vol.Any(CONF_UNIT_SYSTEM_METRIC,
 
 def template(value):
     """Validate a jinja2 template."""
+    from homeassistant.helpers import template as template_helper
+
     if value is None:
         raise vol.Invalid('template value is None')
     if isinstance(value, (list, dict, template_helper.Template)):

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,5 +1,5 @@
 """Helper class to implement include/exclude of entities and domains."""
-from typing import Callable, Dict, Iterable, Any
+from typing import Callable, Dict, Iterable, Any, Optional
 
 import voluptuous as vol
 
@@ -112,11 +112,11 @@ def generate_filter(include_domains: Iterable[str],
 class FilterBuilder:
     """Builder class for entity filters."""
 
-    def __init__(self, include_all=False,
-                 include_domains: Iterable[str] = None,
-                 include_entities: Iterable[str] = None,
-                 exclude_domains: Iterable[str] = None,
-                 exclude_entities: Iterable[str] = None):
+    def __init__(self, include_all: bool = False,
+                 include_domains: Optional[Iterable[str]] = None,
+                 include_entities: Optional[Iterable[str]] = None,
+                 exclude_domains: Optional[Iterable[str]] = None,
+                 exclude_entities: Optional[Iterable[str]] = None):
         """Initialiser."""
         self.include_all = include_all
         self.include_domains = set(include_domains or [])

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,5 +1,5 @@
 """Helper class to implement include/exclude of entities and domains."""
-from typing import Callable, Dict, Iterable, Any, Optional
+from typing import Callable, Dict, Iterable, Any, Optional, Set
 
 import voluptuous as vol
 
@@ -39,78 +39,19 @@ def generate_filter(include_domains: Iterable[str],
                     exclude_domains: Iterable[str],
                     exclude_entities: Iterable[str]) -> Callable[[str], bool]:
     """Return a function that will filter entities based on the args."""
-    include_d = set(include_domains)
-    include_e = set(include_entities)
-    exclude_d = set(exclude_domains)
-    exclude_e = set(exclude_entities)
-
-    have_exclude = bool(exclude_e or exclude_d)
-    have_include = bool(include_e or include_d)
-
     # Case 1 - no includes or excludes - pass all entities
-    if not have_include and not have_exclude:
-        return lambda entity_id: True
+    if (not include_domains and not include_entities
+            and not exclude_domains and not exclude_entities):
+        return EntityFilter(include_all=True)
 
-    # Case 2 - includes, no excludes - only include specified entities
-    if have_include and not have_exclude:
-        def entity_filter_2(entity_id: str) -> bool:
-            """Return filter function for case 2."""
-            domain = split_entity_id(entity_id)[0]
-            return (entity_id in include_e or
-                    domain in include_d)
-
-        return entity_filter_2
-
-    # Case 3 - excludes, no includes - only exclude specified entities
-    if not have_include and have_exclude:
-        def entity_filter_3(entity_id: str) -> bool:
-            """Return filter function for case 3."""
-            domain = split_entity_id(entity_id)[0]
-            return (entity_id not in exclude_e and
-                    domain not in exclude_d)
-
-        return entity_filter_3
-
-    # Case 4 - both includes and excludes specified
-    # Case 4a - include domain specified
-    #  - if domain is included, pass if entity not excluded
-    #  - if domain is not included, pass if entity is included
-    # note: if both include and exclude domains specified,
-    #   the exclude domains are ignored
-    if include_d:
-        def entity_filter_4a(entity_id: str) -> bool:
-            """Return filter function for case 4a."""
-            domain = split_entity_id(entity_id)[0]
-            if domain in include_d:
-                return entity_id not in exclude_e
-            return entity_id in include_e
-
-        return entity_filter_4a
-
-    # Case 4b - exclude domain specified
-    #  - if domain is excluded, pass if entity is included
-    #  - if domain is not excluded, pass if entity not excluded
-    if exclude_d:
-        def entity_filter_4b(entity_id: str) -> bool:
-            """Return filter function for case 4b."""
-            domain = split_entity_id(entity_id)[0]
-            if domain in exclude_d:
-                return entity_id in include_e
-            return entity_id not in exclude_e
-
-        return entity_filter_4b
-
-    # Case 4c - neither include or exclude domain specified
-    #  - Only pass if entity is included.  Ignore entity excludes.
-    def entity_filter_4c(entity_id: str) -> bool:
-        """Return filter function for case 4c."""
-        return entity_id in include_e
-
-    return entity_filter_4c
+    return EntityFilter(include_domains=include_domains,
+                        include_entities=include_entities,
+                        exclude_domains=exclude_domains,
+                        exclude_entities=exclude_entities)
 
 
-class FilterBuilder:
-    """Builder class for entity filters."""
+class EntityFilter:
+    """Filter for entitity IDs."""
 
     def __init__(self, include_all: bool = False,
                  include_domains: Optional[Iterable[str]] = None,
@@ -119,52 +60,101 @@ class FilterBuilder:
                  exclude_entities: Optional[Iterable[str]] = None):
         """Initialiser."""
         self.include_all = include_all
-        self.include_domains = set(include_domains or [])
-        self.include_entities = set(include_entities or [])
-        self.exclude_domains = set(exclude_domains or [])
-        self.exclude_entities = set(exclude_entities or [])
+        self._include_domains = set(include_domains or [])
+        self._include_entities = set(include_entities or [])
+        self._exclude_domains = set(exclude_domains or [])
+        self._exclude_entities = set(exclude_entities or [])
 
-    def build(self) -> Callable[[str], bool]:
-        """Build a callable entity filter based on current settings."""
-        if self.include_all:
-            return lambda _: True
-        if (not self.include_domains
-                and not self.include_entities
-                and not self.exclude_entities
-                and not self.exclude_entities):
-            return lambda _: False
+    @property
+    def include_domains(self) -> Set[str]:
+        """Domains included in the filter."""
+        return self._include_domains
 
-        return generate_filter(
-            self.include_domains,
-            self.include_entities,
-            self.exclude_domains,
-            self.exclude_entities)
+    @property
+    def include_entities(self) -> Set[str]:
+        """Entities included in the filter."""
+        return self._include_entities
 
-    def __call__(self, entity_id: str) -> bool:
-        """Build filter and evaluate for given entity_id."""
-        return self.build()(entity_id)
+    @property
+    def exclude_domains(self) -> Set[str]:
+        """Domains excluded from the filter."""
+        return self._exclude_domains
+
+    @property
+    def exclude_entities(self) -> Set[str]:
+        """Entities excluded from the filter."""
+        return self._exclude_entities
 
     def __eq__(self, other: Any) -> bool:
-        """Test equivalence of two filter builders, or list of entities."""
-        if isinstance(other, FilterBuilder):
+        """Test equivalence of two filters."""
+        if isinstance(other, EntityFilter):
             return (
                 self.include_all == other.include_all and
-                self.include_domains == other.include_domains and
-                self.include_entities == other.include_entities and
-                self.exclude_domains == other.exclude_domains and
-                self.exclude_entities == other.exclude_entities)
+                self._include_domains == other.include_domains and
+                self._include_entities == other.include_entities and
+                self._exclude_domains == other.exclude_domains and
+                self._exclude_entities == other.exclude_entities)
         return False
 
     def __repr__(self) -> str:
         """Convert to string."""
         return (
-            "FilterBuilder(" +
+            "EntityFilter(" +
             ("include_all=True " if self.include_all else "") +
-            (("include_domains=" + str(self.include_domains) + " ")
-             if self.include_domains else "") +
-            (("include_entities=" + str(self.include_entities) + " ")
-             if self.include_entities else "") +
-            (("exclude_domains=" + str(self.exclude_domains) + " ")
-             if self.exclude_domains else "") +
-            (("exclude_entities=" + str(self.exclude_entities) + " ")
-             if self.exclude_entities else ""))
+            (("include_domains=" + str(self._include_domains) + " ")
+             if self._include_domains else "") +
+            (("include_entities=" + str(self._include_entities) + " ")
+             if self._include_entities else "") +
+            (("exclude_domains=" + str(self._exclude_domains) + " ")
+             if self._exclude_domains else "") +
+            (("exclude_entities=" + str(self._exclude_entities) + " ")
+             if self._exclude_entities else "") +
+            ")")
+
+    def __call__(self, entity_id: str) -> bool:
+        """Filter entities based on the filter."""
+        # Case 1 - pass all entities
+        if self.include_all:
+            return True
+
+        have_exclude = bool(self._exclude_entities or self._exclude_domains)
+        have_include = bool(self._include_entities or self._include_domains)
+
+        # Case 1a - fail all entities
+        if not have_exclude and not have_include:
+            return False
+
+        # Case 2 - includes, no excludes - only include specified entities
+        if have_include and not have_exclude:
+            return (entity_id in self._include_entities or
+                    split_entity_id(entity_id)[0] in self._include_domains)
+
+        # Case 3 - excludes, no includes - only exclude specified entities
+        if not have_include and have_exclude:
+            return (entity_id not in self._exclude_entities and
+                    split_entity_id(entity_id)[0] not in self._exclude_domains)
+
+        # Case 4 - both includes and excludes specified
+        # Case 4a - include domain specified
+        #  - if domain is included, pass if entity not excluded
+        #  - if domain is not included, pass if entity is included
+        # note: if both include and exclude domains specified,
+        #   the exclude domains are ignored
+        if self._include_domains:
+            domain = split_entity_id(entity_id)[0]
+            if domain in self._include_domains:
+                return entity_id not in self._exclude_entities
+            return entity_id in self._include_entities
+
+        # Case 4b - exclude domain specified
+        #  - if domain is excluded, pass if entity is included
+        #  - if domain is not excluded, pass if entity not excluded
+        if self._exclude_domains:
+            domain = split_entity_id(entity_id)[0]
+            if domain in self._exclude_domains:
+                return entity_id in self._include_entities
+            return entity_id not in self._exclude_entities
+
+        # Case 4c - neither include or exclude domain specified
+        #  - Only pass if entity is included.  Ignore entity excludes.
+        return entity_id in self._include_entities

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -302,7 +302,7 @@ def track_template_result(
     """Add a listener that fires whenever a template changes."""
     (async_remove, result) = run_callback_threadsafe(
         hass.loop, ft.partial(
-            async_track_template_result, hass, template, 
+            async_track_template_result, hass, template,
             action, variables)).result()
 
     def remove():
@@ -310,6 +310,7 @@ def track_template_result(
         run_callback_threadsafe(hass.loop, async_remove).result()
 
     return (remove, result)
+
 
 @callback
 @bind_hass

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -283,7 +283,7 @@ class TemplateState(State):
     @property
     def state_with_unit(self):
         """Return the state concatenated with the unit if available."""
-        state = self._access_state()
+        state = object.__getattribute__(self, '_access_state')()
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         if unit is None:
             return state.state
@@ -294,17 +294,17 @@ class TemplateState(State):
         # This one doesn't count as an access of the state
         # since we either found it by looking direct for the ID
         # or got it off an iterator.
-        if name == 'entity_id':
+        if name == 'entity_id' or name in object.__dict__:
             state = object.__getattribute__(self, '_state')
             return getattr(state, name)
         if name in TemplateState.__dict__:
             return object.__getattribute__(self, name)
-        state = self._access_state()
+        state = object.__getattribute__(self, '_access_state')()
         return getattr(state, name)
 
     def __repr__(self):
         """Representation of Template State."""
-        state = self._access_state()
+        state = object.__getattribute__(self, '_access_state')()
         rep = state.__repr__()
         return '<template ' + rep[1:]
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -5,7 +5,6 @@ import logging
 import math
 import random
 import re
-from contextlib import AbstractContextManager
 from datetime import datetime
 from typing import Callable
 
@@ -36,7 +35,7 @@ _ENTITY_COLLECT = None
 # pylint: disable=invalid-name
 
 
-class async_generate_filter(AbstractContextManager, FilterBuilder):
+class async_generate_filter(FilterBuilder):
     """
     Filter function generator for entities touched in template.
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -231,6 +231,9 @@ class AllStates:
 
     def __len__(self):
         """Return number of states."""
+        entity_collect = self._hass.data.get(_COLLECT_KEY)
+        if entity_collect is not None:
+            entity_collect.include_all = True
         return len(self._hass.states.async_entity_ids())
 
     def __call__(self, entity_id):
@@ -271,6 +274,9 @@ class DomainStates:
 
     def __len__(self):
         """Return number of states."""
+        entity_collect = self._hass.data.get(_COLLECT_KEY)
+        if entity_collect is not None:
+            entity_collect.include_domains.add(self._domain)
         return len(self._hass.states.async_entity_ids(self._domain))
 
     def __repr__(self):

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -63,6 +63,15 @@ def convert(value: T, to_type: Callable[[T], U],
         return default
 
 
+def str_to_bool(value: str) -> bool:
+    """Convert a string to a boolean value."""
+    try:
+        return bool(int(value))
+    except ValueError:
+        return {'true': True, 'on': True, 'open': True,
+                'yes': True}.get(value.lower(), False)
+
+
 def ensure_unique_string(preferred_string: str, current_strings:
                          Union[Iterable[str], KeysView[str]]) -> str:
     """Return a string that is not present in current_strings.

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -106,7 +106,7 @@ async def test_if_not_fires_on_change_bool(hass, calls):
     assert 0 == len(calls)
 
 
-async def test_if_not_fires_on_change_str(hass, calls):
+async def test_if_fires_on_change_bare_str(hass, calls):
     """Test for not firing on string change."""
     assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
@@ -122,7 +122,7 @@ async def test_if_not_fires_on_change_str(hass, calls):
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert 0 == len(calls)
+    assert 1 == len(calls)
 
 
 async def test_if_not_fires_on_change_str_crazy(hass, calls):
@@ -225,10 +225,11 @@ async def test_if_not_fires_on_change_with_template(hass, calls):
     })
 
     await hass.async_block_till_done()
+    assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_fires_on_change_with_template_advanced(hass, calls):
@@ -307,21 +308,6 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     })
 
     await hass.async_block_till_done()
-
-    hass.states.async_set('test.entity', 'world')
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-    hass.states.async_set('test.entity', 'home')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'work')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'not_home')
-    await hass.async_block_till_done()
     assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
@@ -331,6 +317,22 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     hass.states.async_set('test.entity', 'home')
     await hass.async_block_till_done()
     assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'work')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'not_home')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'world')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'home')
+    await hass.async_block_till_done()
+    assert len(calls) == 3
 
 
 async def test_if_action(hass, calls):

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -415,7 +415,7 @@ async def test_wait_template_with_trigger(hass, calls):
             },
             'action': [
                 {'wait_template':
-                    "{{ is_state(trigger.entity_id, 'hello') }}"},
+                 "{{ is_state(trigger.entity_id, 'hello') }}"},
                 {'service': 'test.automation',
                  'data_template': {
                     'some':

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -200,9 +200,9 @@ class TestBayesianBinarySensor(unittest.TestCase):
                     'prob_given_true': 0.8,
                     'prob_given_false': 0.4
                 }, {
-                    'platform': 'state',
-                    'entity_id': 'sensor.test_monitored',
-                    'to_state': 'red',
+                    'platform': 'template',
+                    'value_template': (
+                        '{{ states.sensor.test_monitored.state == "red" }}'),
                     'prob_given_true': 0.2,
                     'prob_given_false': 0.4
                 }],

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -330,9 +330,12 @@ class TestMediaPlayer(unittest.TestCase):
         config = validate_config(config)
 
         ump = universal.UniversalMediaPlayer(self.hass, **config)
-
+        self.hass.add_job(ump.async_added_to_hass)
+        self.hass.block_till_done()
         assert STATE_ON == ump.master_state
+
         self.hass.states.set('input_boolean.test', STATE_ON)
+        self.hass.block_till_done()
         assert STATE_OFF == ump.master_state
 
     def test_master_state_with_bad_attrs(self):

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -368,7 +368,7 @@ class TestEventHelpers(unittest.TestCase):
 
         def syntax_error_listener(event, template, last_result, result):
             syntax_error_runs.append(
-                (event, template, last_result, result))     
+                (event, template, last_result, result))
         (_, result) = track_template_result(
             self.hass, template_syntax_error,
             syntax_error_listener)

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -253,21 +253,21 @@ class TestEventHelpers(unittest.TestCase):
 
         self.hass.states.set('sensor.test', 5)
 
-        def specific_run_callback(template, old_result, new_result):
+        def specific_run_callback(event, template, old_result, new_result):
             specific_runs.append(int(new_result))
 
         track_template_result(self.hass, template_condition,
                               specific_run_callback)
 
         @ha.callback
-        def wildcard_run_callback(template, old_result, new_result):
+        def wildcard_run_callback(event, template, old_result, new_result):
             wildcard_runs.append((int(old_result), int(new_result)))
 
         track_template_result(self.hass, template_condition,
                               wildcard_run_callback)
 
         @asyncio.coroutine
-        def wildercard_run_callback(template, old_result, new_result):
+        def wildercard_run_callback(event, template, old_result, new_result):
             wildercard_runs.append((int(old_result), int(new_result)))
 
         track_template_result(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -938,6 +938,47 @@ class TestHelpersTemplate(unittest.TestCase):
 {% endfor %}
             """) == EntityFilter(include_domains=['sensor'])
 
+    def test_generate_filter_iterators(self):
+        """Test extract entities function with none entities stuff."""
+        self.hass.states.set('sensor.test_sensor', 'off', {
+            'attr': 'value'})
+
+        # Don't need the entity because the state is not accessed
+        assert self.generate_filter("""
+{% for state in states.sensor %}
+  {{ state.entity_id }}
+{% endfor %}
+            """) == EntityFilter(include_domains=['sensor'])
+
+        assert self.generate_filter("""
+{% for state in states.sensor %}
+  {{ state.entity_id }}={{ state.state }},d
+{% endfor %}
+            """) == EntityFilter(
+                include_domains=['sensor'],
+                include_entities=['sensor.test_sensor'])
+
+        assert self.generate_filter("""
+{% for state in states.sensor %}
+  {{ state.entity_id }}={{ state.attributes.attr }},d
+{% endfor %}
+            """) == EntityFilter(
+                include_domains=['sensor'],
+                include_entities=['sensor.test_sensor'])
+
+        # Don't need the entity because the state is not accessed
+        assert self.generate_filter("""
+{% for state in states.sensor %}
+  {{ state.entity_id }}
+{% endfor %}
+            """) == EntityFilter(include_domains=['sensor'])
+
+        assert self.generate_filter("""
+{% for state in states %}
+  {{ state.entity_id }}
+{% endfor %}
+            """) == EntityFilter(include_all=True)
+
     def test_extract_entities_match_entities(self):
         """Test extract entities function with entities stuff."""
         self.hass.states.set('device_tracker.phone_1', 'home')

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -779,10 +779,17 @@ class TestHelpersTemplate(unittest.TestCase):
         group.Group.create_group(
             self.hass, 'location group', ['test_domain.object'])
 
-        assert 'test_domain.object' == \
-            template.Template(
-                '{{ closest("group.location_group").entity_id }}',
-                self.hass).render()
+        (result, filt) = template.Template(
+            '{{ closest("group.location_group").entity_id }}',
+            self.hass).render_with_collect()
+
+        assert 'test_domain.object' == result
+        assert filt == EntityFilter(
+            include_entities=[
+                'test_domain.object',
+                'group.location_group',
+            ]
+        )
 
     def test_closest_function_home_vs_group_state(self):
         """Test closest function home vs group state."""
@@ -846,10 +853,20 @@ class TestHelpersTemplate(unittest.TestCase):
             'longitude': self.hass.config.longitude + 0.3,
         })
 
-        assert 'test_domain.closest_zone' == \
-            template.Template(
+        (closest, filt) = template.Template(
                 '{{ closest("zone.far_away", '
-                'states.test_domain).entity_id }}', self.hass).render()
+                'states.test_domain).entity_id }}',
+                self.hass).render_with_collect()
+
+        assert 'test_domain.closest_zone' == closest
+        assert filt == EntityFilter(
+            include_domains=["test_domain"],
+            include_entities=[
+                'test_domain.closest_home',
+                'test_domain.closest_zone',
+                'zone.far_away',
+            ]
+        )
 
     def test_closest_function_to_state(self):
         """Test closest function to state."""


### PR DESCRIPTION
## Description:

Part of #22587

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9184

Introduces some new API functions:

##### `Template.async_render_with_collect` 

This allows accumulation of any entities touched while computing a template. The filter will return true when passed an entity ID that would (possibly) affect the result of the template.

Usage:
```python
    (result, entity_filter) = template1.async_render_with_collect(variables)
    assert entity_filter('input_boolean.test')
```

##### `helpers.events.async_track_template_result`

Register a listener that will trigger whenever the result of a template changes. 

Usage:
```python
  @callback
  def template_result_changed(event, template, old_result, result):
    pass

  info = track_template_result(template, template_result_changed)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
