### PR TITLE
Clean up homematicip cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -12,9 +12,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['homematicip_cloud']
 
-HMIP_ZONE_AWAY = 'EXTERNAL'
-HMIP_ZONE_HOME = 'INTERNAL'
-
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -219,19 +219,6 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
         return True
 
     @property
-    def icon(self):
-        """Return the icon to use in the frontend, if any."""
-        if super().icon:
-            return super().icon
-        if self._device.motionDetected or self._device.presenceDetected:
-            return 'mdi:motion-sensor'
-        from homematicip.base.enums import WindowState
-        if self._device.windowState is not None and \
-                self._device.windowState != WindowState.CLOSED:
-            return 'mdi:door-open'
-        return None
-
-    @property
     def device_state_attributes(self):
         """Return the state attributes of the security zone group."""
         attr = super().device_state_attributes
@@ -270,22 +257,6 @@ class HomematicipSecuritySensorGroup(HomematicipSecurityZoneSensorGroup,
     def __init__(self, home, device):
         """Initialize security group."""
         super().__init__(home, device, 'Sensors')
-
-    @property
-    def icon(self):
-        """Return the icon to use in the frontend, if any."""
-        if super().icon:
-            return super().icon
-        if self._device.powerMainsFailure:
-            return 'mdi:power-plug-off'
-        if self._device.moistureDetected or self._device.waterlevelDetected:
-            return 'mdi:water'
-        from homematicip.base.enums import SmokeDetectorAlarmType
-        if self._device.smokeDetectorAlarmType is not None and \
-                self._device.smokeDetectorAlarmType != \
-                SmokeDetectorAlarmType.IDLE_OFF:
-            return 'mdi:fire'
-        return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -219,6 +219,19 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice,
         return True
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        if super().icon:
+            return super().icon
+        if self._device.motionDetected or self._device.presenceDetected:
+            return 'mdi:motion-sensor'
+        from homematicip.base.enums import WindowState
+        if self._device.windowState is not None and \
+                self._device.windowState != WindowState.CLOSED:
+            return 'mdi:door-open'
+        return None
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes of the security zone group."""
         attr = super().device_state_attributes
@@ -257,6 +270,22 @@ class HomematicipSecuritySensorGroup(HomematicipSecurityZoneSensorGroup,
     def __init__(self, home, device):
         """Initialize security group."""
         super().__init__(home, device, 'Sensors')
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        if super().icon:
+            return super().icon
+        if self._device.powerMainsFailure:
+            return 'mdi:power-plug-off'
+        if self._device.moistureDetected or self._device.waterlevelDetected:
+            return 'mdi:water'
+        from homematicip.base.enums import SmokeDetectorAlarmType
+        if self._device.smokeDetectorAlarmType is not None and \
+                self._device.smokeDetectorAlarmType != \
+                SmokeDetectorAlarmType.IDLE_OFF:
+            return 'mdi:fire'
+        return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -10,8 +10,6 @@ from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-STATE_BOOST = 'Boost'
-
 HA_STATE_TO_HMIP = {
     STATE_AUTO: 'AUTOMATIC',
     STATE_MANUAL: 'MANUAL',

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -13,7 +13,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_ENERGY_COUNTER = 'energy_counter_kwh'
 ATTR_POWER_CONSUMPTION = 'power_consumption'
-ATTR_PROFILE_MODE = 'profile_mode'
 
 
 async def async_setup_platform(
@@ -77,13 +76,9 @@ class HomematicipLightMeasuring(HomematicipLight):
         """Return the state attributes of the generic device."""
         attr = super().device_state_attributes
         if self._device.currentPowerConsumption > 0.05:
-            attr.update({
-                ATTR_POWER_CONSUMPTION:
-                    round(self._device.currentPowerConsumption, 2)
-            })
-        attr.update({
-            ATTR_ENERGY_COUNTER: round(self._device.energyCounter, 2)
-        })
+            attr[ATTR_POWER_CONSUMPTION] = \
+                round(self._device.currentPowerConsumption, 2)
+        attr[ATTR_ENERGY_COUNTER] = round(self._device.energyCounter, 2)
         return attr
 
 
@@ -168,10 +163,7 @@ class HomematicipNotificationLight(HomematicipGenericDevice, Light):
         """Return the state attributes of the generic device."""
         attr = super().device_state_attributes
         if self.is_on:
-            attr.update({
-                ATTR_COLOR_NAME:
-                    self._channel.simpleRGBColorState
-            })
+            attr[ATTR_COLOR_NAME] = self._channel.simpleRGBColorState
         return attr
 
     @property

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -12,8 +12,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['homematicip_cloud']
 
 ATTR_TEMPERATURE_OFFSET = 'temperature_offset'
-ATTR_VALVE_STATE = 'valve_state'
-ATTR_VALVE_POSITION = 'valve_position'
 ATTR_WIND_DIRECTION = 'wind_direction'
 ATTR_WIND_DIRECTION_VARIATION = 'wind_direction_variation_in_degree'
 

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -10,10 +10,6 @@ DEPENDENCIES = ['homematicip_cloud']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_POWER_CONSUMPTION = 'power_consumption'
-ATTR_ENERGIE_COUNTER = 'energie_counter'
-ATTR_PROFILE_MODE = 'profile_mode'
-
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):

--- a/homeassistant/components/homematicip_cloud/weather.py
+++ b/homeassistant/components/homematicip_cloud/weather.py
@@ -3,6 +3,7 @@
 import logging
 
 from homeassistant.components.weather import WeatherEntity
+from homeassistant.const import TEMP_CELSIUS
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 
@@ -55,7 +56,7 @@ class HomematicipWeatherSensor(HomematicipGenericDevice, WeatherEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return self.hass.config.units.temperature_unit
+        return TEMP_CELSIUS
 
     @property
     def humidity(self):


### PR DESCRIPTION
## Description:

This PR cleans up the code for HomematicIP Cloud 
- removed unused constants
- aligned  code for device_state_attributes
- fixed temperature unit origin for weather

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
