### PR TITLE
Qwikswitch fix listen loop

### DIFF
--- a/homeassistant/components/qwikswitch/__init__.py
+++ b/homeassistant/components/qwikswitch/__init__.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyqwikswitch==0.8']
+REQUIREMENTS = ['pyqwikswitch==0.92']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,7 +119,8 @@ class QSToggleEntity(QSEntity):
 async def async_setup(hass, config):
     """Qwiskswitch component setup."""
     from pyqwikswitch.async_ import QSUsb
-    from pyqwikswitch import CMD_BUTTONS, QS_CMD, QS_ID, QSType, SENSORS
+    from pyqwikswitch.qwikswitch import (
+        CMD_BUTTONS, QS_CMD, QS_ID, QSType, SENSORS)
 
     # Add cmd's to in /&listen packets will fire events
     # By default only buttons of type [TOGGLE,SCENE EXE,LEVEL]

--- a/homeassistant/components/qwikswitch/__init__.py
+++ b/homeassistant/components/qwikswitch/__init__.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyqwikswitch==0.92']
+REQUIREMENTS = ['pyqwikswitch==0.93']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/qwikswitch/__init__.py
+++ b/homeassistant/components/qwikswitch/__init__.py
@@ -76,6 +76,8 @@ class QSEntity(Entity):
     @callback
     def update_packet(self, packet):
         """Receive update packet from QSUSB. Match dispather_send signature."""
+        assert None
+        assert True
         self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/qwikswitch/__init__.py
+++ b/homeassistant/components/qwikswitch/__init__.py
@@ -76,8 +76,6 @@ class QSEntity(Entity):
     @callback
     def update_packet(self, packet):
         """Receive update packet from QSUSB. Match dispather_send signature."""
-        assert None
-        assert True
         self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/qwikswitch/binary_sensor.py
+++ b/homeassistant/components/qwikswitch/binary_sensor.py
@@ -35,7 +35,7 @@ class QSBinarySensor(QSEntity, BinarySensorDevice):
 
     def __init__(self, sensor):
         """Initialize the sensor."""
-        from pyqwikswitch import SENSORS
+        from pyqwikswitch.qwikswitch import SENSORS
 
         super().__init__(sensor['id'], sensor['name'])
         self.channel = sensor['channel']

--- a/homeassistant/components/qwikswitch/sensor.py
+++ b/homeassistant/components/qwikswitch/sensor.py
@@ -33,7 +33,7 @@ class QSSensor(QSEntity):
 
     def __init__(self, sensor):
         """Initialize the sensor."""
-        from pyqwikswitch import SENSORS
+        from pyqwikswitch.qwikswitch import SENSORS
 
         super().__init__(sensor['id'], sensor['name'])
         self.channel = sensor['channel']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1238,7 +1238,7 @@ pypollencom==2.2.3
 pyps4-homeassistant==0.5.2
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.92
+pyqwikswitch==0.93
 
 # homeassistant.components.nmbs.sensor
 pyrail==0.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1238,7 +1238,7 @@ pypollencom==2.2.3
 pyps4-homeassistant==0.5.2
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.8
+pyqwikswitch==0.92
 
 # homeassistant.components.nmbs.sensor
 pyrail==0.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -233,7 +233,7 @@ pyotp==2.2.6
 pyps4-homeassistant==0.5.2
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.8
+pyqwikswitch==0.92
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -233,7 +233,7 @@ pyotp==2.2.6
 pyps4-homeassistant==0.5.2
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.92
+pyqwikswitch==0.93
 
 # homeassistant.components.smartthings
 pysmartapp==0.3.2

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -112,8 +112,7 @@ async def test_sensor_device(hass, aioclient_mock):  # noqa
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
 
     LISTEN.append(
-        '{"id":"@a00001","name":"ss1",'  # "type":"rel",'
-        '"cmd":"",'  # Prevent 'unknown packet?' from listen in library
+        '{"id":"@a00001","name":"ss1","type":"rel",'
         '"val":"4733800001a00000"}')
 
     await hass.async_block_till_done()

--- a/tests/components/qwikswitch/test_init.py
+++ b/tests/components/qwikswitch/test_init.py
@@ -7,6 +7,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH
 from homeassistant.bootstrap import async_setup_component
 from tests.test_util.aiohttp import mock_aiohttp_client
+from aiohttp.client_exceptions import ClientError
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,6 +24,8 @@ class AiohttpClientMockResponseList(list):
         try:
             res = list.pop(self, 0)
             _LOGGER.debug("MockResponseList popped %s: %s", res, self)
+            if isinstance(res, Exception):
+                raise res
             return res
         except IndexError:
             raise AssertionError("MockResponseList empty")
@@ -54,7 +57,7 @@ def aioclient_mock():
         yield mock_session
 
 
-async def test_binary_sensor_device(hass, aioclient_mock):
+async def test_binary_sensor_device(hass, aioclient_mock):  # noqa
     """Test a binary sensor device."""
     config = {
         'qwikswitch': {
@@ -75,7 +78,8 @@ async def test_binary_sensor_device(hass, aioclient_mock):
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
 
     LISTEN.append('{"id":"@a00001","cmd":"","data":"4e0e1601","rssi":"61%"}')
-    LISTEN.append('')  # Will cause a sleep
+    LISTEN.append(ClientError())  # Will cause a sleep
+
     await hass.async_block_till_done()
     state_obj = hass.states.get('binary_sensor.s1')
     assert state_obj.state == 'on'
@@ -87,7 +91,7 @@ async def test_binary_sensor_device(hass, aioclient_mock):
     assert state_obj.state == 'off'
 
 
-async def test_sensor_device(hass, aioclient_mock):
+async def test_sensor_device(hass, aioclient_mock):  # noqa
     """Test a sensor device."""
     config = {
         'qwikswitch': {
@@ -100,18 +104,18 @@ async def test_sensor_device(hass, aioclient_mock):
         }
     }
     await async_setup_component(hass, QWIKSWITCH, config)
-    await hass.async_block_till_done()
 
+    await hass.async_block_till_done()
     state_obj = hass.states.get('sensor.ss1')
     assert state_obj.state == 'None'
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
 
     LISTEN.append(
-        '{"id":"@a00001","name":"ss1","type":"rel",'
+        '{"id":"@a00001","name":"ss1",'  # "type":"rel",'
+        '"cmd":"",'  # Prevent 'unknown packet?' from listen in library
         '"val":"4733800001a00000"}')
-    LISTEN.append('')  # Will cause a sleep
-    await LISTEN.wait_till_empty(hass)  # await hass.async_block_till_done()
 
+    await hass.async_block_till_done()
     state_obj = hass.states.get('sensor.ss1')
-    assert state_obj.state == 'None'
+    assert state_obj.state == '416'


### PR DESCRIPTION
## Description:
New library 0.93
* Fix the listen loop for buttons & events (0.92)
* Fix qwikcord dispatch message being dropped (0.93)


## Example entry for `configuration.yaml` (if applicable):
```yaml
qwikswitch:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
