### PR TITLE
Add stream to the default config

### DIFF
--- a/homeassistant/components/default_config/__init__.py
+++ b/homeassistant/components/default_config/__init__.py
@@ -1,7 +1,11 @@
 """Component providing default configuration for new users."""
+try:
+    import av
+except ImportError:
+    av = None
 
 DOMAIN = 'default_config'
-DEPENDENCIES = (
+DEPENDENCIES = [
     'automation',
     'cloud',
     'config',
@@ -17,7 +21,10 @@ DEPENDENCIES = (
     'system_health',
     'updater',
     'zeroconf',
-)
+]
+# Only automatically set up the stream component when dependency installed
+if av is not None:
+    DEPENDENCIES.append('stream')
 
 
 async def async_setup(hass, config):


### PR DESCRIPTION
## Description:
Make the stream component part of the default config if the requirements of the stream component are satisfied. This means that on both hass.io and Docker, the user won't need to do anything extra to get it working.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

