### PR TITLE
Fixed brightness reducing after each light change (Zengge component)

### DIFF
--- a/homeassistant/components/zengge/light.py
+++ b/homeassistant/components/zengge/light.py
@@ -157,6 +157,6 @@ class ZenggeLight(Light):
         rgb = self._bulb.get_colour()
         hsv = color_util.color_RGB_to_hsv(*rgb)
         self._hs_color = hsv[:2]
-        self._brightness = hsv[2]
+        self._brightness = (hsv[2] / 100) * 255
         self._white = self._bulb.get_white()
         self._state = self._bulb.get_on()


### PR DESCRIPTION
## Description:
self._brightness max is 255 and hsv brightness max is 100. Assigning 255 based brightness value directly with 100 based hsv value reduces brightness eventually to zero.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

