### PR TITLE
Cloudhooks for webhook config flows

### DIFF
--- a/homeassistant/components/dialogflow/__init__.py
+++ b/homeassistant/components/dialogflow/__init__.py
@@ -79,6 +79,11 @@ async def async_unload_entry(hass, entry):
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
     return True
 
+
+# pylint: disable=invalid-name
+async_remove_entry = config_entry_flow.webhook_async_remove_entry
+
+
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     'Dialogflow Webhook',

--- a/homeassistant/components/geofency/__init__.py
+++ b/homeassistant/components/geofency/__init__.py
@@ -133,6 +133,11 @@ async def async_unload_entry(hass, entry):
     await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
     return True
 
+
+# pylint: disable=invalid-name
+async_remove_entry = config_entry_flow.webhook_async_remove_entry
+
+
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     'Geofency Webhook',

--- a/homeassistant/components/gpslogger/__init__.py
+++ b/homeassistant/components/gpslogger/__init__.py
@@ -104,6 +104,11 @@ async def async_unload_entry(hass, entry):
     await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
     return True
 
+
+# pylint: disable=invalid-name
+async_remove_entry = config_entry_flow.webhook_async_remove_entry
+
+
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     'GPSLogger Webhook',

--- a/homeassistant/components/ifttt/__init__.py
+++ b/homeassistant/components/ifttt/__init__.py
@@ -108,6 +108,11 @@ async def async_unload_entry(hass, entry):
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
     return True
 
+
+# pylint: disable=invalid-name
+async_remove_entry = config_entry_flow.webhook_async_remove_entry
+
+
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     'IFTTT Webhook',

--- a/homeassistant/components/locative/__init__.py
+++ b/homeassistant/components/locative/__init__.py
@@ -141,9 +141,13 @@ async def async_setup_entry(hass, entry):
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
-
     await hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
     return True
+
+
+# pylint: disable=invalid-name
+async_remove_entry = config_entry_flow.webhook_async_remove_entry
+
 
 config_entry_flow.register_webhook_flow(
     DOMAIN,

--- a/homeassistant/components/mailgun/__init__.py
+++ b/homeassistant/components/mailgun/__init__.py
@@ -88,6 +88,11 @@ async def async_unload_entry(hass, entry):
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
     return True
 
+
+# pylint: disable=invalid-name
+async_remove_entry = config_entry_flow.webhook_async_remove_entry
+
+
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     'Mailgun Webhook',

--- a/homeassistant/components/twilio/__init__.py
+++ b/homeassistant/components/twilio/__init__.py
@@ -60,6 +60,11 @@ async def async_unload_entry(hass, entry):
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
     return True
 
+
+# pylint: disable=invalid-name
+async_remove_entry = config_entry_flow.webhook_async_remove_entry
+
+
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     'Twilio Webhook',

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -118,15 +118,35 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
             )
 
         webhook_id = self.hass.components.webhook.async_generate_id()
-        webhook_url = \
-            self.hass.components.webhook.async_generate_url(webhook_id)
+
+        if self.hass.components.cloud.async_active_subscription():
+            webhook_url = \
+                await self.hass.components.cloud.async_create_cloudhook(
+                    webhook_id
+                )
+            cloudhook = True
+        else:
+            webhook_url = \
+                self.hass.components.webhook.async_generate_url(webhook_id)
+            cloudhook = False
 
         self._description_placeholder['webhook_url'] = webhook_url
 
         return self.async_create_entry(
             title=self._title,
             data={
-                'webhook_id': webhook_id
+                'webhook_id': webhook_id,
+                'cloudhook': cloudhook,
             },
             description_placeholders=self._description_placeholder
         )
+
+
+async def webhook_async_remove_entry(hass, entry) -> None:
+    """Remove a webhook config entry."""
+    if (not entry.data.get('cloudhook') or
+            'cloud' not in hass.config.components):
+        return
+
+    await hass.components.cloud.async_delete_cloudhook(
+        entry.data['webhook_id'])

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -3,9 +3,9 @@ from unittest.mock import patch, Mock
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, loader
+from homeassistant import config_entries, data_entry_flow, loader, setup
 from homeassistant.helpers import config_entry_flow
-from tests.common import MockConfigEntry, MockModule
+from tests.common import MockConfigEntry, MockModule, mock_coro
 
 
 @pytest.fixture
@@ -193,3 +193,51 @@ async def test_webhook_config_flow_registers_webhook(hass, webhook_flow_conf):
 
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['data']['webhook_id'] is not None
+
+
+async def test_webhook_create_cloudhook(hass, webhook_flow_conf):
+    """Test only a single entry is allowed."""
+    assert await setup.async_setup_component(hass, 'cloud', {})
+
+    async_setup_entry = Mock(return_value=mock_coro(True))
+    async_unload_entry = Mock(return_value=mock_coro(True))
+
+    loader.set_component(hass, 'test_single', MockModule(
+        'test_single',
+        async_setup_entry=async_setup_entry,
+        async_unload_entry=async_unload_entry,
+        async_remove_entry=config_entry_flow.webhook_async_remove_entry,
+    ))
+
+    result = await hass.config_entries.flow.async_init(
+        'test_single', context={'source': config_entries.SOURCE_USER})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+
+    coro = mock_coro({
+        'cloudhook_url': 'https://example.com'
+    })
+
+    with patch('hass_nabucasa.cloudhooks.Cloudhooks.async_create',
+               return_value=coro) as mock_create, \
+            patch('homeassistant.components.cloud.async_active_subscription',
+                  return_value=True), \
+            patch('homeassistant.components.cloud.async_is_logged_in',
+                  return_value=True):
+
+        result = await hass.config_entries.flow.async_configure(
+            result['flow_id'], {})
+
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['description_placeholders']['webhook_url'] == \
+        'https://example.com'
+    assert len(mock_create.mock_calls) == 1
+    assert len(async_setup_entry.mock_calls) == 1
+
+    with patch('hass_nabucasa.cloudhooks.Cloudhooks.async_delete',
+               return_value=coro) as mock_delete:
+
+        result = \
+            await hass.config_entries.async_remove(result['result'].entry_id)
+
+    assert len(mock_delete.mock_calls) == 1
+    assert result['require_restart'] is False


### PR DESCRIPTION
## Description:
Update the webhook config entry helper to automatically use cloudhooks when available.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
