### PR TITLE
Add source selection to Samsung TV media player

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -15,8 +15,9 @@ from homeassistant.components.media_player import (
     MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE,
-    SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP)
+    SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP)
 from homeassistant.const import (
     CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_TIMEOUT, STATE_OFF,
     STATE_ON)
@@ -33,9 +34,13 @@ DEFAULT_TIMEOUT = 1
 
 KEY_PRESS_TIMEOUT = 1.2
 KNOWN_DEVICES_KEY = 'samsungtv_known_devices'
+SOURCES = {
+    'TV': 'KEY_DTV',
+    'HDMI': 'KEY_HDMI'
+}
 
 SUPPORT_SAMSUNGTV = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
-    SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | \
+    SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | SUPPORT_SELECT_SOURCE | \
     SUPPORT_NEXT_TRACK | SUPPORT_TURN_OFF | SUPPORT_PLAY | SUPPORT_PLAY_MEDIA
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -195,6 +200,11 @@ class SamsungTVDevice(MediaPlayerDevice):
         return self._muted
 
     @property
+    def source_list(self):
+        """List of available input sources."""
+        return SOURCES.keys()
+
+    @property
     def supported_features(self):
         """Flag media player features that are supported."""
         if self._mac:
@@ -269,6 +279,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         for digit in media_id:
             await self.hass.async_add_job(self.send_key, 'KEY_' + digit)
             await asyncio.sleep(KEY_PRESS_TIMEOUT, self.hass.loop)
+        await self.hass.async_add_job(self.send_key, 'KEY_ENTER')
 
     def turn_on(self):
         """Turn the media player on."""
@@ -276,3 +287,12 @@ class SamsungTVDevice(MediaPlayerDevice):
             self._wol.send_magic_packet(self._mac)
         else:
             self.send_key('KEY_POWERON')
+
+    async def async_select_source(self, source):
+        """Select input source."""
+        if source not in SOURCES:
+            _LOGGER.error('Unsupported source')
+            return
+
+        await self.hass.async_add_job(self.send_key, SOURCES[source])
+        await asyncio.sleep(KEY_PRESS_TIMEOUT, self.hass.loop)

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -202,7 +202,7 @@ class SamsungTVDevice(MediaPlayerDevice):
     @property
     def source_list(self):
         """List of available input sources."""
-        return list(SOURCES.keys())
+        return list(SOURCES)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -295,4 +295,3 @@ class SamsungTVDevice(MediaPlayerDevice):
             return
 
         await self.hass.async_add_job(self.send_key, SOURCES[source])
-        await asyncio.sleep(KEY_PRESS_TIMEOUT, self.hass.loop)

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -202,7 +202,7 @@ class SamsungTVDevice(MediaPlayerDevice):
     @property
     def source_list(self):
         """List of available input sources."""
-        return SOURCES.keys()
+        return list(SOURCES.keys())
 
     @property
     def supported_features(self):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -341,6 +341,14 @@ async def test_play_media_channel_as_string(hass, samsung_mock):
     assert device.send_key.call_count == 0
 
 
+async def test_play_media_channel_as_non_positive(hass, samsung_mock):
+    """Test for play_media with invalid channel as non positive integer."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.send_key = mock.Mock()
+    await device.async_play_media(MEDIA_TYPE_CHANNEL, "-4")
+    assert device.send_key.call_count == 0
+
+
 async def test_select_source(hass, samsung_mock):
     """Test for select_source."""
     device = SamsungTVDevice(**WORKING_CONFIG)
@@ -348,14 +356,6 @@ async def test_select_source(hass, samsung_mock):
     await device.async_select_source("HDMI")
     exp = [call("KEY_HDMI")]
     assert device.send_key.call_args_list == exp
-
-
-async def test_play_media_channel_as_non_positive(hass, samsung_mock):
-    """Test for play_media with invalid channel as non positive integer."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    await device.async_play_media(MEDIA_TYPE_CHANNEL, "-4")
-    assert device.send_key.call_count == 0
 
 
 async def test_select_source_invalid_source(hass, samsung_mock):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -318,7 +318,7 @@ async def test_play_media(hass, samsung_mock):
         device.send_key = mock.Mock()
         await device.async_play_media(MEDIA_TYPE_CHANNEL, "576")
 
-        exp = [call("KEY_5"), call("KEY_7"), call("KEY_6")]
+        exp = [call("KEY_5"), call("KEY_7"), call("KEY_6"), call("KEY_ENTER")]
         assert device.send_key.call_args_list == exp
         assert len(sleeps) == 3
 

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -352,6 +352,7 @@ async def test_play_media_channel_as_non_positive(hass, samsung_mock):
 async def test_select_source(hass, samsung_mock):
     """Test for select_source."""
     device = SamsungTVDevice(**WORKING_CONFIG)
+    device.hass = hass
     device.send_key = mock.Mock()
     await device.async_select_source("HDMI")
     exp = [call("KEY_HDMI")]

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -323,6 +323,15 @@ async def test_play_media(hass, samsung_mock):
         assert len(sleeps) == 3
 
 
+async def test_select_source(hass, samsung_mock):
+    """Test for select_source."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.send_key = mock.Mock()
+    await device.async_select_source("HDMI")
+    exp = [call("KEY_HDMI")]
+    assert device.send_key.call_args_list == exp
+
+
 async def test_play_media_invalid_type(hass, samsung_mock):
     """Test for play_media with invalid media type."""
     url = "https://example.com"

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -356,3 +356,11 @@ async def test_play_media_channel_as_non_positive(hass, samsung_mock):
     device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_CHANNEL, "-4")
     assert device.send_key.call_count == 0
+
+
+async def test_select_source_invalid_source(hass, samsung_mock):
+    """Test for select_source with invalid source."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.send_key = mock.Mock()
+    await device.async_select_source("INVALID")
+    assert device.send_key.call_count == 0

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -323,15 +323,6 @@ async def test_play_media(hass, samsung_mock):
         assert len(sleeps) == 3
 
 
-async def test_select_source(hass, samsung_mock):
-    """Test for select_source."""
-    device = SamsungTVDevice(**WORKING_CONFIG)
-    device.send_key = mock.Mock()
-    await device.async_select_source("HDMI")
-    exp = [call("KEY_HDMI")]
-    assert device.send_key.call_args_list == exp
-
-
 async def test_play_media_invalid_type(hass, samsung_mock):
     """Test for play_media with invalid media type."""
     url = "https://example.com"
@@ -348,6 +339,15 @@ async def test_play_media_channel_as_string(hass, samsung_mock):
     device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_CHANNEL, url)
     assert device.send_key.call_count == 0
+
+
+async def test_select_source(hass, samsung_mock):
+    """Test for select_source."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    device.send_key = mock.Mock()
+    await device.async_select_source("HDMI")
+    exp = [call("KEY_HDMI")]
+    assert device.send_key.call_args_list == exp
 
 
 async def test_play_media_channel_as_non_positive(hass, samsung_mock):


### PR DESCRIPTION
## Breaking Change:
nothing

## Description:
add select_source capabilities

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: samsungtv
    host: 192.168.0.10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - ~~[ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~~

If the code communicates with devices, web services, or third-party tools:
  - ~~[ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - ~~[ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - ~~[ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - ~~[ ] New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
