### PR TITLE
add code_arm_required to manual alarm with mqtt

### DIFF
--- a/homeassistant/components/manual_mqtt/alarm_control_panel.py
+++ b/homeassistant/components/manual_mqtt/alarm_control_panel.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.event import track_point_in_time
 _LOGGER = logging.getLogger(__name__)
 
 CONF_CODE_TEMPLATE = 'code_template'
+CONF_CODE_ARM_REQUIRED = 'code_arm_required'
 
 CONF_PAYLOAD_DISARM = 'payload_disarm'
 CONF_PAYLOAD_ARM_HOME = 'payload_arm_home'
@@ -115,6 +116,7 @@ PLATFORM_SCHEMA = vol.Schema(vol.All(mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
         _state_schema(STATE_ALARM_TRIGGERED),
     vol.Required(mqtt.CONF_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Required(mqtt.CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
     vol.Optional(CONF_PAYLOAD_ARM_AWAY, default=DEFAULT_ARM_AWAY): cv.string,
     vol.Optional(CONF_PAYLOAD_ARM_HOME, default=DEFAULT_ARM_HOME): cv.string,
     vol.Optional(CONF_PAYLOAD_ARM_NIGHT, default=DEFAULT_ARM_NIGHT): cv.string,
@@ -133,6 +135,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         config.get(mqtt.CONF_STATE_TOPIC),
         config.get(mqtt.CONF_COMMAND_TOPIC),
         config.get(mqtt.CONF_QOS),
+        config.get(CONF_CODE_ARM_REQUIRED),
         config.get(CONF_PAYLOAD_DISARM),
         config.get(CONF_PAYLOAD_ARM_HOME),
         config.get(CONF_PAYLOAD_ARM_AWAY),
@@ -153,9 +156,9 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
     """
 
     def __init__(self, hass, name, code, code_template, disarm_after_trigger,
-                 state_topic, command_topic, qos, payload_disarm,
-                 payload_arm_home, payload_arm_away, payload_arm_night,
-                 config):
+                 state_topic, command_topic, qos, code_arm_required,
+                 payload_disarm, payload_arm_home, payload_arm_away,
+                 payload_arm_night, config):
         """Init the manual MQTT alarm panel."""
         self._state = STATE_ALARM_DISARMED
         self._hass = hass
@@ -182,6 +185,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         self._state_topic = state_topic
         self._command_topic = command_topic
         self._qos = qos
+        self._code_arm_required = code_arm_required
         self._payload_disarm = payload_disarm
         self._payload_arm_home = payload_arm_home
         self._payload_arm_away = payload_arm_away
@@ -255,21 +259,24 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
-        if not self._validate_code(code, STATE_ALARM_ARMED_HOME):
+        if self._code_arm_required and not \
+                self._validate_code(code, STATE_ALARM_ARMED_HOME):
             return
 
         self._update_state(STATE_ALARM_ARMED_HOME)
 
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
-        if not self._validate_code(code, STATE_ALARM_ARMED_AWAY):
+        if self._code_arm_required and not \
+                self._validate_code(code, STATE_ALARM_ARMED_AWAY):
             return
 
         self._update_state(STATE_ALARM_ARMED_AWAY)
 
     def alarm_arm_night(self, code=None):
         """Send arm night command."""
-        if not self._validate_code(code, STATE_ALARM_ARMED_NIGHT):
+        if self._code_arm_required and not \
+                self._validate_code(code, STATE_ALARM_ARMED_NIGHT):
             return
 
         self._update_state(STATE_ALARM_ARMED_NIGHT)

--- a/tests/components/manual_mqtt/test_alarm_control_panel.py
+++ b/tests/components/manual_mqtt/test_alarm_control_panel.py
@@ -77,6 +77,32 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
         assert STATE_ALARM_ARMED_HOME == \
             self.hass.states.get(entity_id).state
 
+    def test_arm_home_no_pending_when_code_not_req(self):
+        """Test arm home method."""
+        assert setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code': CODE,
+                'code_arm_required': False,
+                'pending_time': 0,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }})
+
+        entity_id = 'alarm_control_panel.test'
+
+        assert STATE_ALARM_DISARMED == \
+            self.hass.states.get(entity_id).state
+
+        common.alarm_arm_home(self.hass, 0)
+        self.hass.block_till_done()
+
+        assert STATE_ALARM_ARMED_HOME == \
+            self.hass.states.get(entity_id).state
+
     def test_arm_home_with_pending(self):
         """Test arm home method."""
         assert setup_component(
@@ -159,6 +185,32 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
             self.hass.states.get(entity_id).state
 
         common.alarm_arm_away(self.hass, CODE, entity_id)
+        self.hass.block_till_done()
+
+        assert STATE_ALARM_ARMED_AWAY == \
+            self.hass.states.get(entity_id).state
+
+    def test_arm_away_no_pending_when_code_not_req(self):
+        """Test arm home method."""
+        assert setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code_arm_required': False,
+                'code': CODE,
+                'pending_time': 0,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }})
+
+        entity_id = 'alarm_control_panel.test'
+
+        assert STATE_ALARM_DISARMED == \
+            self.hass.states.get(entity_id).state
+
+        common.alarm_arm_away(self.hass, 0, entity_id)
         self.hass.block_till_done()
 
         assert STATE_ALARM_ARMED_AWAY == \
@@ -274,6 +326,32 @@ class TestAlarmControlPanelManualMqtt(unittest.TestCase):
             self.hass.states.get(entity_id).state
 
         common.alarm_arm_night(self.hass, CODE, entity_id)
+        self.hass.block_till_done()
+
+        assert STATE_ALARM_ARMED_NIGHT == \
+            self.hass.states.get(entity_id).state
+
+    def test_arm_night_no_pending_when_code_not_req(self):
+        """Test arm night method."""
+        assert setup_component(
+            self.hass, alarm_control_panel.DOMAIN,
+            {'alarm_control_panel': {
+                'platform': 'manual_mqtt',
+                'name': 'test',
+                'code_arm_required': False,
+                'code': CODE,
+                'pending_time': 0,
+                'disarm_after_trigger': False,
+                'command_topic': 'alarm/command',
+                'state_topic': 'alarm/state',
+            }})
+
+        entity_id = 'alarm_control_panel.test'
+
+        assert STATE_ALARM_DISARMED == \
+            self.hass.states.get(entity_id).state
+
+        common.alarm_arm_night(self.hass, 0, entity_id)
         self.hass.block_till_done()
 
         assert STATE_ALARM_ARMED_NIGHT == \


### PR DESCRIPTION
## Description:
Add code_arm_required to the manual alarm with mqtt as per the mqtt alarm.  This option bypasses the code check if code_arm_required is false.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9087

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: manual_mqtt
    state_topic: home/alarm
    command_topic: home/alarm/set
    pending_time: 30
    delay_time: 20
    trigger_time: 4
    code_arm_required: False
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
