### PR TITLE
Change library to georss_generic_client

### DIFF
--- a/homeassistant/components/geo_rss_events/sensor.py
+++ b/homeassistant/components/geo_rss_events/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS, CONF_URL)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['georss_client==0.5']
+REQUIREMENTS = ['georss_generic_client==0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -473,7 +473,7 @@ geizhals==0.0.9
 geojson_client==0.3
 
 # homeassistant.components.geo_rss_events.sensor
-georss_client==0.5
+georss_generic_client==0.2
 
 # homeassistant.components.gitter.sensor
 gitterpy==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -108,7 +108,7 @@ gTTS-token==1.1.3
 geojson_client==0.3
 
 # homeassistant.components.geo_rss_events.sensor
-georss_client==0.5
+georss_generic_client==0.2
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==2.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -59,7 +59,7 @@ TEST_REQUIREMENTS = (
     'feedparser-homeassistant',
     'foobot_async',
     'geojson_client',
-    'georss_client',
+    'georss_generic_client',
     'gTTS-token',
     'ha-ffmpeg',
     'hangups',


### PR DESCRIPTION
## Description:
This change replaces the third-party library from `georss_client` to `georss_generic_client`. The interface to HA has not changed.

I am the maintainer of both libraries and decided to refactor the structure of the libraries in a way to make the GeoRSS feed access framework independent of the concrete implementations. This approach will hopefully make it easier to implement multiple separate GeoRSS integrations while keeping the common code in a separate library.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: geo_rss_events
    name: NSW Fire Service
    url: http://www.rfs.nsw.gov.au/feeds/majorIncidents.xml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
