### PR TITLE
Add code_arm_required to manual alarm

### DIFF
--- a/homeassistant/components/demo/alarm_control_panel.py
+++ b/homeassistant/components/demo/alarm_control_panel.py
@@ -17,7 +17,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Demo alarm control panel platform."""
     async_add_entities([
-        ManualAlarm(hass, 'Alarm', '1234', None, False, {
+        ManualAlarm(hass, 'Alarm', '1234', None, True, False, {
             STATE_ALARM_ARMED_AWAY: {
                 CONF_DELAY_TIME: datetime.timedelta(seconds=0),
                 CONF_PENDING_TIME: datetime.timedelta(seconds=5),

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -214,6 +214,11 @@ class ManualAlarm(alarm.AlarmControlPanel, RestoreEntity):
             return alarm.FORMAT_NUMBER
         return alarm.FORMAT_TEXT
 
+    @property
+    def code_arm_required(self):
+        """Whether the code is required for arm actions."""
+        return self._code_arm_required
+
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         if not self._validate_code(code, STATE_ALARM_DISARMED):

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -49,6 +49,31 @@ async def test_arm_home_no_pending(hass):
         hass.states.get(entity_id).state
 
 
+async def test_arm_home_no_pending_when_code_not_req(hass):
+    """Test arm home method."""
+    assert await async_setup_component(
+        hass, alarm_control_panel.DOMAIN,
+        {'alarm_control_panel': {
+            'platform': 'manual',
+            'name': 'test',
+            'code': CODE,
+            'code_arm_required': False,
+            'pending_time': 0,
+            'disarm_after_trigger': False
+        }})
+
+    entity_id = 'alarm_control_panel.test'
+
+    assert STATE_ALARM_DISARMED == \
+        hass.states.get(entity_id).state
+
+    common.async_alarm_arm_home(hass, 0)
+    await hass.async_block_till_done()
+
+    assert STATE_ALARM_ARMED_HOME == \
+        hass.states.get(entity_id).state
+
+
 async def test_arm_home_with_pending(hass):
     """Test arm home method."""
     assert await async_setup_component(
@@ -127,6 +152,31 @@ async def test_arm_away_no_pending(hass):
         hass.states.get(entity_id).state
 
     common.async_alarm_arm_away(hass, CODE, entity_id)
+    await hass.async_block_till_done()
+
+    assert STATE_ALARM_ARMED_AWAY == \
+        hass.states.get(entity_id).state
+
+
+async def test_arm_away_no_pending_when_code_not_req(hass):
+    """Test arm home method."""
+    assert await async_setup_component(
+        hass, alarm_control_panel.DOMAIN,
+        {'alarm_control_panel': {
+            'platform': 'manual',
+            'name': 'test',
+            'code': CODE,
+            'code_arm_required': False,
+            'pending_time': 0,
+            'disarm_after_trigger': False
+        }})
+
+    entity_id = 'alarm_control_panel.test'
+
+    assert STATE_ALARM_DISARMED == \
+        hass.states.get(entity_id).state
+
+    common.async_alarm_arm_away(hass, 0, entity_id)
     await hass.async_block_till_done()
 
     assert STATE_ALARM_ARMED_AWAY == \
@@ -235,6 +285,31 @@ async def test_arm_night_no_pending(hass):
         hass.states.get(entity_id).state
 
     common.async_alarm_arm_night(hass, CODE)
+    await hass.async_block_till_done()
+
+    assert STATE_ALARM_ARMED_NIGHT == \
+        hass.states.get(entity_id).state
+
+
+async def test_arm_night_no_pending_when_code_not_req(hass):
+    """Test arm night method."""
+    assert await async_setup_component(
+        hass, alarm_control_panel.DOMAIN,
+        {'alarm_control_panel': {
+            'platform': 'manual',
+            'name': 'test',
+            'code': CODE,
+            'code_arm_required': False,
+            'pending_time': 0,
+            'disarm_after_trigger': False
+        }})
+
+    entity_id = 'alarm_control_panel.test'
+
+    assert STATE_ALARM_DISARMED == \
+        hass.states.get(entity_id).state
+
+    common.async_alarm_arm_night(hass, 0)
     await hass.async_block_till_done()
 
     assert STATE_ALARM_ARMED_NIGHT == \
@@ -1168,6 +1243,31 @@ async def test_arm_custom_bypass_no_pending(hass):
         hass.states.get(entity_id).state
 
     common.async_alarm_arm_custom_bypass(hass, CODE)
+    await hass.async_block_till_done()
+
+    assert STATE_ALARM_ARMED_CUSTOM_BYPASS == \
+        hass.states.get(entity_id).state
+
+
+async def test_arm_custom_bypass_no_pending_when_code_not_req(hass):
+    """Test arm custom bypass method."""
+    assert await async_setup_component(
+        hass, alarm_control_panel.DOMAIN,
+        {'alarm_control_panel': {
+            'platform': 'manual',
+            'name': 'test',
+            'code': CODE,
+            'code_arm_required': False,
+            'pending_time': 0,
+            'disarm_after_trigger': False
+        }})
+
+    entity_id = 'alarm_control_panel.test'
+
+    assert STATE_ALARM_DISARMED == \
+        hass.states.get(entity_id).state
+
+    common.async_alarm_arm_custom_bypass(hass, 0)
     await hass.async_block_till_done()
 
     assert STATE_ALARM_ARMED_CUSTOM_BYPASS == \


### PR DESCRIPTION
## Description:
Add code_arm_required to the manual alarm as per the mqtt alarm. This option bypasses the code check if code_arm_required is false.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9088

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: manual
    code: 1234
    code_arm_required: False
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
