### PR TITLE
Fire event on rflink sensor update

### DIFF
--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -50,6 +50,7 @@ DEFAULT_SIGNAL_REPETITIONS = 1
 CONNECTION_TIMEOUT = 10
 
 EVENT_BUTTON_PRESSED = 'button_pressed'
+EVENT_SENSOR_READINGS = 'sensor_readings'
 EVENT_KEY_COMMAND = 'command'
 EVENT_KEY_ID = 'id'
 EVENT_KEY_SENSOR = 'sensor'
@@ -292,14 +293,23 @@ class RflinkDevice(Entity):
         self.async_schedule_update_ha_state()
 
         # Put command onto bus for user to subscribe to
-        if self._should_fire_event and identify_event_type(
-                event) == EVENT_KEY_COMMAND:
-            self.hass.bus.async_fire(EVENT_BUTTON_PRESSED, {
-                ATTR_ENTITY_ID: self.entity_id,
-                ATTR_STATE: event[EVENT_KEY_COMMAND],
-            })
-            _LOGGER.debug("Fired bus event for %s: %s",
-                          self.entity_id, event[EVENT_KEY_COMMAND])
+        if self._should_fire_event:
+            if identify_event_type(
+                    event) == EVENT_KEY_COMMAND:
+                self.hass.bus.async_fire(EVENT_BUTTON_PRESSED, {
+                    ATTR_ENTITY_ID: self.entity_id,
+                    ATTR_STATE: event[EVENT_KEY_COMMAND],
+                })
+                _LOGGER.debug("Fired bus event for %s: %s",
+                            self.entity_id, event[EVENT_KEY_COMMAND])
+            elif identify_event_type(
+                    event) == EVENT_KEY_SENSOR:
+                self.hass.bus.async_fire(EVENT_SENSOR_READINGS, {
+                    ATTR_ENTITY_ID: self.entity_id,
+                    ATTR_STATE: self._state,
+                })
+                _LOGGER.debug("Fired bus event for %s: %s",
+                            self.entity_id, self._state)
 
     def _handle_event(self, event):
         """Platform specific event handler."""

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -10,12 +10,12 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_UNIT_OF_MEASUREMENT)
+    ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_UNIT_OF_MEASUREMENT)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
-    CONF_ALIASES, CONF_ALIASSES, CONF_AUTOMATIC_ADD, CONF_DEVICES,
+    ATTR_STATE, CONF_FIRE_EVENT, CONF_ALIASES, CONF_ALIASSES, CONF_AUTOMATIC_ADD, CONF_DEVICES,
     DATA_DEVICE_REGISTER, DATA_ENTITY_LOOKUP, EVENT_KEY_ID, EVENT_KEY_SENSOR,
     EVENT_KEY_UNIT, SIGNAL_AVAILABILITY, SIGNAL_HANDLE_EVENT, TMP_ENTITY,
     RflinkDevice, remove_deprecated)
@@ -38,6 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.string: vol.Schema({
             vol.Optional(CONF_NAME): cv.string,
             vol.Required(CONF_SENSOR_TYPE): cv.string,
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
             vol.Optional(CONF_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -10,15 +10,16 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_UNIT_OF_MEASUREMENT)
+    ATTR_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_UNIT_OF_MEASUREMENT,
+    ATTR_ENTITY_ID)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
-    ATTR_STATE, CONF_FIRE_EVENT, CONF_ALIASES, CONF_ALIASSES, CONF_AUTOMATIC_ADD, CONF_DEVICES,
+    CONF_ALIASES, CONF_ALIASSES, CONF_AUTOMATIC_ADD, CONF_DEVICES,
     DATA_DEVICE_REGISTER, DATA_ENTITY_LOOKUP, EVENT_KEY_ID, EVENT_KEY_SENSOR,
     EVENT_KEY_UNIT, SIGNAL_AVAILABILITY, SIGNAL_HANDLE_EVENT, TMP_ENTITY,
-    RflinkDevice, remove_deprecated)
+    ATTR_STATE, CONF_FIRE_EVENT, RflinkDevice, remove_deprecated)
 
 DEPENDENCIES = ['rflink']
 


### PR DESCRIPTION
## Description:
For long time I wanted to have a way to tell whether a sensor sends its readings or it's just broke/run out of batteries.
There was no way to find out when the last reading was received by rflink component and without that it was impossible to tell whether the sensor sends the same value over a long period of time OR it's out of order and is sending nothing at all (because in both cases HA does not update its state).

That's why I thought it would be useful to have a fire_event option (exactly as in `rflink.switch`) for sensors so it can be used as a heartbeat.

I'm currently use customised rflink  component in my local Hass.io environment and it does the job.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23