### PR TITLE
Trend binary sensor check for state unavailable

### DIFF
--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, CONF_DEVICE_CLASS, CONF_ENTITY_ID,
-    CONF_FRIENDLY_NAME, STATE_UNKNOWN, CONF_SENSORS)
+    CONF_FRIENDLY_NAME, STATE_UNKNOWN, STATE_UNAVAILABLE, CONF_SENSORS)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
@@ -140,7 +140,7 @@ class SensorTrend(BinarySensorDevice):
                     state = new_state.attributes.get(self._attribute)
                 else:
                     state = new_state.state
-                if state != STATE_UNKNOWN:
+                if state != STATE_UNKNOWN and state != STATE_UNAVAILABLE:
                     sample = (utcnow().timestamp(), float(state))
                     self.samples.append(sample)
                     self.async_schedule_update_ha_state(True)

--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -140,7 +140,7 @@ class SensorTrend(BinarySensorDevice):
                     state = new_state.attributes.get(self._attribute)
                 else:
                     state = new_state.state
-                if state != STATE_UNKNOWN and state != STATE_UNAVAILABLE:
+                if state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                     sample = (utcnow().timestamp(), float(state))
                     self.samples.append(sample)
                     self.async_schedule_update_ha_state(True)


### PR DESCRIPTION
My very first PR!
Hope i did nothing wrong.

## Description:

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/20210

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
