### PR TITLE
Fix GTFS variable type mismatch

### DIFF
--- a/homeassistant/components/gtfs/sensor.py
+++ b/homeassistant/components/gtfs/sensor.py
@@ -268,9 +268,8 @@ def get_next_departure(schedule: Any, start_station_id: Any,
                 timetable[idx] = {**row, **extras}
 
     # Flag last departures.
-    for idx in [yesterday_last, today_last]:
-        if idx is not None:
-            timetable[idx]['last'] = True
+    for idx in filter(None, [yesterday_last, today_last]):
+        timetable[idx]['last'] = True
 
     _LOGGER.debug("Timetable: %s", sorted(timetable.keys()))
 


### PR DESCRIPTION
## Description:

My latest [GTFS typing PR](https://github.com/home-assistant/home-assistant/pull/22572) introduced a basic type mismatch (checking `''` against `None`), this simple fix aims to correct that mistake.

**Related issue (if applicable):** complements #22572

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
