### PR TITLE
Fix xiaomi vacuum resume functionality

### DIFF
--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -303,7 +303,7 @@ class MiroboVacuum(StateVacuumDevice):
     async def async_start(self):
         """Start or resume the cleaning task."""
         await self._try_command(
-            "Unable to start the vacuum: %s", self._vacuum.start)
+            "Unable to start the vacuum: %s", self._vacuum.resume_or_start)
 
     async def async_pause(self):
         """Pause the cleaning task."""


### PR DESCRIPTION
## Description:

This small fix makes use of resume_or_start helper method that was introduced in 0.4.5 version of python-miio.

**Previous behavior:**
1. Start zoned cleaning
2. Press pause button
3. Press start button
4. Vacuum starts global cleaning from scratch 👎

**New behavior:**
1. Start zoned cleaning
2. Press pause button
3. Press start button
4. Vacuum continues zoned cleaning 👍

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
