### PR TITLE
Improve exception handling in ADS integration

### DIFF
--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -185,6 +185,9 @@ class AdsHub:
             try:
                 hnotify, huser = self._client.add_device_notification(
                     name, attr, self._device_notification_callback)
+            except pyads.ADSError as err:
+                _LOGGER.error("Error subscribing to %s: %s", name, err)
+            else:
                 hnotify = int(hnotify)
                 self._notification_items[hnotify] = NotificationItem(
                     hnotify, huser, name, plc_datatype, callback)
@@ -192,8 +195,6 @@ class AdsHub:
                 _LOGGER.debug(
                     "Added device notification %d for variable %s",
                     hnotify, name)
-            except pyads.ADSError as err:
-                _LOGGER.error("Error subscribing to %s: %s", name, err)
 
     def _device_notification_callback(self, notification, name):
         """Handle device notifications."""

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -192,7 +192,8 @@ class AdsHub:
                     hnotify, huser, name, plc_datatype, callback)
 
                 _LOGGER.debug(
-                    "Added device notification %d for variable %s", hnotify, name)
+                    "Added device notification %d for variable %s",
+                    hnotify, name)
             except pyads.ADSError as err:
                 _LOGGER.error(err)
                 _LOGGER.error("ADS variable: %s", name)

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -193,7 +193,7 @@ class AdsHub:
                     "Added device notification %d for variable %s",
                     hnotify, name)
             except pyads.ADSError as err:
-                _LOGGER.error("Error reading %s: %s", name, err)
+                _LOGGER.error("Error subscribing to %s: %s", name, err)
 
     def _device_notification_callback(self, notification, name):
         """Handle device notifications."""

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -165,8 +165,7 @@ class AdsHub:
             try:
                 return self._client.write_by_name(name, value, plc_datatype)
             except pyads.ADSError as err:
-                _LOGGER.error(err)
-                _LOGGER.error("ADS variable: %s", name)
+                _LOGGER.error("Error writing %s: %s", name, err)
 
     def read_by_name(self, name, plc_datatype):
         """Read a value from the device."""
@@ -175,8 +174,7 @@ class AdsHub:
             try:
                 return self._client.read_by_name(name, plc_datatype)
             except pyads.ADSError as err:
-                _LOGGER.error(err)
-                _LOGGER.error("ADS variable: %s", name)
+                _LOGGER.error("Error reading %s: %s", name, err)
 
     def add_device_notification(self, name, plc_datatype, callback):
         """Add a notification to the ADS devices."""
@@ -195,8 +193,7 @@ class AdsHub:
                     "Added device notification %d for variable %s",
                     hnotify, name)
             except pyads.ADSError as err:
-                _LOGGER.error(err)
-                _LOGGER.error("ADS variable: %s", name)
+                _LOGGER.error("Error reading %s: %s", name, err)
 
     def _device_notification_callback(self, notification, name):
         """Handle device notifications."""


### PR DESCRIPTION
## Description:
Just add some exception handling to the ADS hub class. No change in functionality.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
