### PR TITLE
Cast: Fix next/previous track

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -2,7 +2,7 @@
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
 
-REQUIREMENTS = ['pychromecast==3.1.0']
+REQUIREMENTS = ['pychromecast==3.2.0']
 
 DOMAIN = 'cast'
 

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -12,8 +12,8 @@ from homeassistant.components.media_player import (
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW, SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE,
-    SUPPORT_VOLUME_SET)
+    SUPPORT_SEEK, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET)
 from homeassistant.const import (
     CONF_HOST, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF, STATE_PAUSED,
     STATE_PLAYING)
@@ -36,9 +36,9 @@ CAST_SPLASH = 'https://home-assistant.io/images/cast/splash.png'
 
 DEFAULT_PORT = 8009
 
-SUPPORT_CAST = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PREVIOUS_TRACK | \
-    SUPPORT_NEXT_TRACK | SUPPORT_PLAY_MEDIA | SUPPORT_STOP | SUPPORT_PLAY
+SUPPORT_CAST = SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_PLAY_MEDIA | \
+               SUPPORT_STOP | SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
+               SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET
 
 # Stores a threading.Lock that is held by the internal pychromecast discovery.
 INTERNAL_DISCOVERY_RUNNING_KEY = 'cast_discovery_running'
@@ -931,12 +931,12 @@ class CastDevice(MediaPlayerDevice):
     def media_previous_track(self):
         """Send previous track command."""
         media_controller = self._media_controller()
-        media_controller.rewind()
+        media_controller.queue_next()
 
     def media_next_track(self):
         """Send next track command."""
         media_controller = self._media_controller()
-        media_controller.skip()
+        media_controller.queue_next()
 
     def media_seek(self, position):
         """Seek the media to a specific location."""
@@ -1130,7 +1130,18 @@ class CastDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        return SUPPORT_CAST
+        support = SUPPORT_CAST
+        media_status, _ = self._media_status()
+
+        if media_status:
+            if media_status.supports_queue_next:
+                support |= SUPPORT_PREVIOUS_TRACK
+            if media_status.supports_queue_next:
+                support |= SUPPORT_NEXT_TRACK
+            if media_status.supports_seek:
+                support |= SUPPORT_SEEK
+
+        return support
 
     @property
     def media_position(self):

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -931,7 +931,7 @@ class CastDevice(MediaPlayerDevice):
     def media_previous_track(self):
         """Send previous track command."""
         media_controller = self._media_controller()
-        media_controller.queue_next()
+        media_controller.queue_prev()
 
     def media_next_track(self):
         """Send next track command."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -980,7 +980,7 @@ pycfdns==0.0.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==3.1.0
+pychromecast==3.2.0
 
 # homeassistant.components.cmus.media_player
 pycmus==0.1.1

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -479,16 +479,16 @@ async def test_dynamic_group_media_control(hass: HomeAssistantType):
     group_media_status.player_is_playing = True
     entity.new_dynamic_group_media_status(group_media_status)
     entity.media_previous_track()
-    assert entity._dynamic_group_cast.media_controller.rewind.called
-    assert not chromecast.media_controller.rewind.called
+    assert entity._dynamic_group_cast.media_controller.queue_prev.called
+    assert not chromecast.media_controller.queue_prev.called
 
     # Player is paused, dynamic group is playing -> Should not forward
     player_media_status.player_is_playing = False
     player_media_status.player_is_paused = True
     entity.new_media_status(player_media_status)
     entity.media_next_track()
-    assert not entity._dynamic_group_cast.media_controller.skip.called
-    assert chromecast.media_controller.skip.called
+    assert not entity._dynamic_group_cast.media_controller.queue_next.called
+    assert chromecast.media_controller.queue_next.called
 
     # Player is in unknown state, dynamic group is playing -> Should forward
     player_media_status.player_state = "UNKNOWN"


### PR DESCRIPTION
## Description:

Use `queue_next` / `queue_prev` instead of seeking to end/beginning of track
Also only show next / previous UI controls if the currently playing playlist allows it.

Note: Depends on balloob/pychromecast#286

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
