### PR TITLE
Require static-check success first for rest of workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ workflows:
   build:
     jobs:
       - static-check
-      - pre-install-all-requirements
+      - pre-install-all-requirements:
           requires:
             - static-check
       - pylint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,17 +214,25 @@ workflows:
     jobs:
       - static-check
       - pre-install-all-requirements
+          requires:
+            - static-check
       - pylint:
           requires:
             - pre-install-all-requirements
       - pre-test:
           name: pre-test 3.5.5
+          requires:
+            - static-check
           python: 3.5.5-stretch
       - pre-test:
           name: pre-test 3.6
+          requires:
+            - static-check
           python: 3.6-stretch
       - pre-test:
           name: pre-test 3.7
+          requires:
+            - static-check
           python: 3.7-stretch
       - test:
           name: test 3.5.5


### PR DESCRIPTION
## Description:

Allow fail build earlier if there was a syntax and format issue caught by our static check, e.g. flake8 and gen_requirements script

