### PR TITLE
Admin service to automatically add empty schema

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -187,11 +187,10 @@ async def async_setup(hass, config):
             await cloud.remote.disconnect()
             await prefs.async_update(remote_enabled=False)
 
-    empty_schema = vol.Schema({})
     hass.helpers.service.async_register_admin_service(
-        DOMAIN, SERVICE_REMOTE_CONNECT, _service_handler, empty_schema)
+        DOMAIN, SERVICE_REMOTE_CONNECT, _service_handler)
     hass.helpers.service.async_register_admin_service(
-        DOMAIN, SERVICE_REMOTE_DISCONNECT, _service_handler, empty_schema)
+        DOMAIN, SERVICE_REMOTE_DISCONNECT, _service_handler)
 
     await http_api.async_setup(hass)
     hass.async_create_task(hass.helpers.discovery.async_load_platform(

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -335,7 +335,7 @@ async def _handle_service_platform_call(func, data, entities, context):
 @ha.callback
 def async_register_admin_service(hass: typing.HomeAssistantType, domain: str,
                                  service: str, service_func: Callable,
-                                 schema: vol.Schema) -> None:
+                                 schema: vol.Schema = vol.Schema({}, extra=vol.PREVENT_EXTRA)) -> None:
     """Register a service that requires admin access."""
     @wraps(service_func)
     async def admin_handler(call):

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -333,9 +333,10 @@ async def _handle_service_platform_call(func, data, entities, context):
 
 @bind_hass
 @ha.callback
-def async_register_admin_service(hass: typing.HomeAssistantType, domain: str,
-                                 service: str, service_func: Callable,
-                                 schema: vol.Schema = vol.Schema({}, extra=vol.PREVENT_EXTRA)) -> None:
+def async_register_admin_service(
+        hass: typing.HomeAssistantType, domain: str,
+        service: str, service_func: Callable,
+        schema: vol.Schema = vol.Schema({}, extra=vol.PREVENT_EXTRA)) -> None:
     """Register a service that requires admin access."""
     @wraps(service_func)
     async def admin_handler(call):


### PR DESCRIPTION
## Description:
Don't require services without a schema to define one, instead just add a schema.

Per discussion https://github.com/home-assistant/home-assistant/pull/22609#discussion_r270759045

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
