### PR TITLE
Run PyLint under Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.7-stretch
+          python: 3.5.5-stretch
           all: true
           test: true
       - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     parameters:
       tag:
         type: string
-        default: latest  
+        default: latest
     docker:
       - image: circleci/python:<< parameters.tag >>
       - image: circleci/buildpack-deps:stretch
@@ -107,20 +107,20 @@ jobs:
   pre-install-all-requirements:
     executor:
       name: python
-      tag: 3.7-stretch
+      tag: 3.5.5-stretch
 
     steps:
       - checkout
       - docker-prereqs
       - install-requirements:
-          python: 3.7-stretch
+          python: 3.5.5-stretch
           all: true
           test: true
 
   pylint:
     executor:
       name: python
-      tag: 3.7-stretch
+      tag: 3.5.5-stretch
     parallelism: 2
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,9 @@ commands:
             python3 -m venv venv
             . venv/bin/activate
             pip install -q -U pip
-            <<# parameters.all >>pip install -q --progress-bar off -r requirements_all.txt -c homeassistant/package_constraints.txt<</ parameters.all>>
-            <<# parameters.test >>pip install -q --progress-bar off -r requirements_test.txt -c homeassistant/package_constraints.txt<</ parameters.test>>
-            <<# parameters.test_all >>pip install -q --progress-bar off -r requirements_test_all.txt -c homeassistant/package_constraints.txt<</ parameters.test_all>>
+            <<# parameters.all >>pip install --progress-bar off -r requirements_all.txt -c homeassistant/package_constraints.txt<</ parameters.all>>
+            <<# parameters.test >>pip install --progress-bar off -r requirements_test.txt -c homeassistant/package_constraints.txt<</ parameters.test>>
+            <<# parameters.test_all >>pip install --progress-bar off -r requirements_test_all.txt -c homeassistant/package_constraints.txt<</ parameters.test_all>>
       - save_cache:
           paths:
             - ./venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,10 @@ commands:
             python3 -m venv venv
             . venv/bin/activate
             pip install -q -U pip
-            <<# parameters.all >>pip install --progress-bar off -r requirements_all.txt -c homeassistant/package_constraints.txt<</ parameters.all>>
-            <<# parameters.test >>pip install --progress-bar off -r requirements_test.txt -c homeassistant/package_constraints.txt<</ parameters.test>>
-            <<# parameters.test_all >>pip install --progress-bar off -r requirements_test_all.txt -c homeassistant/package_constraints.txt<</ parameters.test_all>>
+            pip install -q -U setuptools
+            <<# parameters.all >>pip install -q --progress-bar off -r requirements_all.txt -c homeassistant/package_constraints.txt<</ parameters.all>>
+            <<# parameters.test >>pip install -q --progress-bar off -r requirements_test.txt -c homeassistant/package_constraints.txt<</ parameters.test>>
+            <<# parameters.test_all >>pip install -q --progress-bar off -r requirements_test_all.txt -c homeassistant/package_constraints.txt<</ parameters.test_all>>
       - save_cache:
           paths:
             - ./venv


### PR DESCRIPTION
## Description:
Run PyLint under Python 3.5, so we don't allow merging any Python 3.6+ syntax.
