### PR TITLE
Shutdown ZHAGateway on hass closing.

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -16,15 +16,14 @@ from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from . import config_flow  # noqa  # pylint: disable=unused-import
 from . import api
 from .core import ZHAGateway
+from .core.channels.registry import populate_channel_registry
 from .core.const import (
     COMPONENTS, CONF_BAUDRATE, CONF_DATABASE, CONF_DEVICE_CONFIG,
-    CONF_RADIO_TYPE, CONF_USB_PATH, DATA_ZHA,
-    DATA_ZHA_CONFIG, DATA_ZHA_CORE_COMPONENT, DATA_ZHA_DISPATCHERS,
-    DATA_ZHA_RADIO, DEFAULT_BAUDRATE, DATA_ZHA_GATEWAY,
-    DEFAULT_RADIO_TYPE, DOMAIN, RadioType, DATA_ZHA_CORE_EVENTS, ENABLE_QUIRKS)
-from .core.registries import establish_device_mappings
-from .core.channels.registry import populate_channel_registry
+    CONF_RADIO_TYPE, CONF_USB_PATH, DATA_ZHA, DATA_ZHA_CONFIG,
+    DATA_ZHA_CORE_COMPONENT, DATA_ZHA_DISPATCHERS, DATA_ZHA_GATEWAY,
+    DEFAULT_BAUDRATE, DEFAULT_RADIO_TYPE, DOMAIN, ENABLE_QUIRKS, RadioType)
 from .core.patches import apply_cluster_listener_patch
+from .core.registries import establish_device_mappings
 
 REQUIREMENTS = [
     'bellows-homeassistant==0.7.2',
@@ -143,9 +142,9 @@ async def async_setup_entry(hass, config_entry):
 
     async def async_zha_shutdown(event):
         """Handle shutdown tasks."""
+        await hass.data[DATA_ZHA][DATA_ZHA_GATEWAY].shutdown()
         await hass.data[DATA_ZHA][
             DATA_ZHA_GATEWAY].async_update_device_storage()
-        hass.data[DATA_ZHA][DATA_ZHA_RADIO].close()
 
     hass.bus.async_listen_once(
         ha_const.EVENT_HOMEASSISTANT_STOP, async_zha_shutdown)
@@ -154,6 +153,8 @@ async def async_setup_entry(hass, config_entry):
 
 async def async_unload_entry(hass, config_entry):
     """Unload ZHA config entry."""
+    await hass.data[DATA_ZHA][DATA_ZHA_GATEWAY].shutdown()
+
     api.async_unload_api(hass)
 
     dispatchers = hass.data[DATA_ZHA].get(DATA_ZHA_DISPATCHERS, [])
@@ -172,9 +173,6 @@ async def async_unload_entry(hass, config_entry):
 
     # clean up events
     hass.data[DATA_ZHA][DATA_ZHA_CORE_EVENTS].clear()
-
-    _LOGGER.debug("Closing zha radio")
-    hass.data[DATA_ZHA][DATA_ZHA_RADIO].close()
 
     del hass.data[DATA_ZHA]
     return True

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -171,8 +171,5 @@ async def async_unload_entry(hass, config_entry):
     for entity_id in entity_ids:
         await component.async_remove_entity(entity_id)
 
-    # clean up events
-    hass.data[DATA_ZHA][DATA_ZHA_CORE_EVENTS].clear()
-
     del hass.data[DATA_ZHA]
     return True

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -17,7 +17,6 @@ BAUD_RATES = [
 DATA_ZHA = 'zha'
 DATA_ZHA_CONFIG = 'config'
 DATA_ZHA_BRIDGE_ID = 'zha_bridge_id'
-DATA_ZHA_RADIO = 'zha_radio'
 DATA_ZHA_DISPATCHERS = 'zha_dispatchers'
 DATA_ZHA_CORE_COMPONENT = 'zha_core_component'
 DATA_ZHA_CORE_EVENTS = 'zha_core_events'

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -23,11 +23,11 @@ from .const import (
     ADD_DEVICE_RELAY_LOGGERS, ATTR_MANUFACTURER, BELLOWS, CONF_BAUDRATE,
     CONF_DATABASE, CONF_RADIO_TYPE, CONF_USB_PATH, CONTROLLER, CURRENT,
     DATA_ZHA, DATA_ZHA_BRIDGE_ID, DATA_ZHA_CORE_COMPONENT, DATA_ZHA_GATEWAY,
-    DATA_ZHA_RADIO, DEBUG_LEVELS, DEFAULT_BAUDRATE, DEFAULT_DATABASE_NAME,
-    DEVICE_FULL_INIT, DEVICE_INFO, DEVICE_JOINED, DEVICE_REMOVED, DOMAIN, IEEE,
-    LOG_ENTRY, LOG_OUTPUT, MODEL, NWK, ORIGINAL, RADIO, RADIO_DESCRIPTION,
-    RAW_INIT, SIGNAL_REMOVE, SIGNATURE, TYPE, ZHA, ZHA_GW_MSG, ZIGPY,
-    ZIGPY_DECONZ, ZIGPY_XBEE)
+    DEBUG_LEVELS, DEFAULT_BAUDRATE, DEFAULT_DATABASE_NAME, DEVICE_FULL_INIT,
+    DEVICE_INFO, DEVICE_JOINED, DEVICE_REMOVED, DOMAIN, IEEE, LOG_ENTRY,
+    LOG_OUTPUT, MODEL, NWK, ORIGINAL, RADIO, RADIO_DESCRIPTION, RAW_INIT,
+    SIGNAL_REMOVE, SIGNATURE, TYPE, ZHA, ZHA_GW_MSG, ZIGPY, ZIGPY_DECONZ,
+    ZIGPY_XBEE)
 from .device import DeviceStatus, ZHADevice
 from .discovery import (
     async_create_device_entity, async_dispatch_discovery_info,
@@ -76,7 +76,6 @@ class ZHAGateway:
         radio = radio_details[RADIO]
         self.radio_description = RADIO_TYPES[radio_type][RADIO_DESCRIPTION]
         await radio.connect(usb_path, baudrate)
-        self._hass.data[DATA_ZHA][DATA_ZHA_RADIO] = radio
 
         if CONF_DATABASE in self._config:
             database = self._config[CONF_DATABASE]
@@ -311,6 +310,11 @@ class ZHAGateway:
                     DEVICE_INFO: device_info
                 }
             )
+
+    async def shutdown(self):
+        """Stop ZHA Controller Application."""
+        _LOGGER.debug("Shutting down ZHA ControllerApplication")
+        await self.application_controller.shutdown()
 
 
 @callback

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -139,7 +139,7 @@ async def check_zigpy_connection(usb_path, radio_type, database_path):
         await radio.connect(usb_path, DEFAULT_BAUDRATE)
         controller = ControllerApplication(radio, database_path)
         await asyncio.wait_for(controller.startup(auto_form=True), timeout=30)
-        radio.close()
+        await controller.shutdown()
     except Exception:  # pylint: disable=broad-except
         return False
     return True


### PR DESCRIPTION
## Description:
Refactor ZHA component unloading/shutdown.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
