### PR TITLE
Add discovery support to HEOS component

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -35,6 +35,7 @@ SERVICE_FREEBOX = 'freebox'
 SERVICE_HASS_IOS_APP = 'hass_ios'
 SERVICE_HASSIO = 'hassio'
 SERVICE_HOMEKIT = 'homekit'
+SERVICE_HEOS = 'heos'
 SERVICE_HUE = 'philips_hue'
 SERVICE_IGD = 'igd'
 SERVICE_IKEA_TRADFRI = 'ikea_tradfri'
@@ -57,6 +58,7 @@ CONFIG_ENTRY_HANDLERS = {
     SERVICE_DECONZ: 'deconz',
     'esphome': 'esphome',
     'google_cast': 'cast',
+    SERVICE_HEOS: 'heos',
     SERVICE_HUE: 'hue',
     SERVICE_TELLDUSLIVE: 'tellduslive',
     SERVICE_IKEA_TRADFRI: 'tradfri',

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==2.5.0']
+REQUIREMENTS = ['netdisco==2.6.0']
 
 DOMAIN = 'discovery'
 

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -21,6 +21,11 @@ class HeosFlowHandler(config_entries.ConfigFlow):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
+    async def async_step_discovery(self, discovery_info):
+        """Handle a discovered Heos device."""
+        return await self.async_step_user(
+            {CONF_HOST: discovery_info[CONF_HOST]})
+
     async def async_step_import(self, user_input=None):
         """Occurs when an entry is setup through config."""
         host = user_input[CONF_HOST]
@@ -32,7 +37,7 @@ class HeosFlowHandler(config_entries.ConfigFlow):
         """Obtain host and validate connection."""
         from pyheos import Heos
 
-        # Only a single entry is supported
+        # Only a single entry is needed for all devices
         entries = self.hass.config_entries.async_entries(DOMAIN)
         if entries:
             return self.async_abort(reason='already_setup')

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -741,7 +741,7 @@ nessclient==0.9.15
 netdata==0.1.2
 
 # homeassistant.components.discovery
-netdisco==2.5.0
+netdisco==2.6.0
 
 # homeassistant.components.neurio_energy.sensor
 neurio==0.3.1

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -77,6 +77,6 @@ async def test_create_entry_with_discovery(hass, controller):
     result = await flow.async_step_user(data)
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['title'] == 'Controller (127.0.0.1)'
-    assert result['data'] == data
+    assert result['data'] == {'host': '127.0.0.1'}
     assert controller.connect.call_count == 1
     assert controller.disconnect.call_count == 1

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -55,3 +55,28 @@ async def test_create_entry_when_host_valid(hass, controller):
     assert result['data'] == data
     assert controller.connect.call_count == 1
     assert controller.disconnect.call_count == 1
+
+
+async def test_create_entry_with_discovery(hass, controller):
+    """Test result type is create entry when valid through discovery."""
+    flow = HeosFlowHandler()
+    flow.hass = hass
+    data = {
+        'host': '127.0.0.1',
+        'manufacturer': 'Denon',
+        'model_name': 'HEOS Drive',
+        'model_number': 'DWSA-10 4.0',
+        'name': 'Office',
+        'port': 60006,
+        'serial': None,
+        'ssdp_description':
+            'http://127.0.0.1:60006/upnp/desc/aios_device/aios_device.xml',
+        'udn': 'uuid:e61de70c-2250-1c22-0080-0005cdf512be',
+        'upnp_device_type': 'urn:schemas-denon-com:device:AiosDevice:1'
+    }
+    result = await flow.async_step_user(data)
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['title'] == 'Controller (127.0.0.1)'
+    assert result['data'] == data
+    assert controller.connect.call_count == 1
+    assert controller.disconnect.call_count == 1

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -74,7 +74,7 @@ async def test_create_entry_with_discovery(hass, controller):
         'udn': 'uuid:e61de70c-2250-1c22-0080-0005cdf512be',
         'upnp_device_type': 'urn:schemas-denon-com:device:AiosDevice:1'
     }
-    result = await flow.async_step_user(data)
+    result = await flow.async_step_discovery(data)
     assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result['title'] == 'Controller (127.0.0.1)'
     assert result['data'] == {'host': '127.0.0.1'}


### PR DESCRIPTION
## Description:
Adds the config entry point for discovery of HEOS devices.  A single connection controls all HEOS devices on the network, therefore only a single entry is needed.  Additional discovered devices are aborted.

**Pull request in [netdisco](https://github.com/home-assistant/netdisco):** home-assistant/netdisco#250

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#9098

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.