### PR TITLE
Fix racy homekit_controller platform setup caused by #22368

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -191,8 +191,7 @@ def setup(hass, config):
             return
 
         _LOGGER.debug('Discovered unique device %s', hkid)
-        device = HKDevice(hass, host, port, model, hkid, config_num, config)
-        hass.data[KNOWN_DEVICES][hkid] = device
+        HKDevice(hass, host, port, model, hkid, config_num, config)
 
     hass.data[KNOWN_DEVICES] = {}
     discovery.listen(hass, SERVICE_HOMEKIT, discovery_dispatch)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -7,7 +7,8 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.event import call_later
 
 from .const import (
-    CONTROLLER, DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, PAIRING_FILE, HOMEKIT_DIR
+    CONTROLLER, DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, KNOWN_DEVICES,
+    PAIRING_FILE, HOMEKIT_DIR
 )
 
 
@@ -75,6 +76,8 @@ class HKDevice():
         self.pairing_lock = asyncio.Lock(loop=hass.loop)
 
         self.pairing = self.controller.pairings.get(hkid)
+
+        hass.data[KNOWN_DEVICES][hkid] = self
 
         if self.pairing is not None:
             self.accessory_setup()


### PR DESCRIPTION
## Description:

#22194 introduced some new homekit_controller tests and @balloob and @awarecan pointed out at least one of them was flaky. This doesn't happen in my config entry branch and i've now traced its root cause to #22368.

Essentially, `HKDevice.__init__` on dev has for some time triggered the `setup_platform` for its sub-domains like light/climate/etc. But there is a race where this code hasn't run yet:

```
hass.data[KNOWN_DEVICES][hkid] = device
```

If the setup_platform runs before that happens you get the error in the test. This fix moves where we store the current HKDevice into hass.data so that it is always set before any further `setup_platform` is called.

This race is probably a real bug, not just a flaky test. So if #22368 is already in a tag or in an rc branch it might be worth applying the fix there too.

This is something of a temporary band aid - the buggy code is actually removed in my config entry branch and doesn't have this problem. The config entry branch won't trigger side effects in `HKDevice.__init__` any more. So the config entry work will be the 'real' fix, but this will do until then.


**Related issue (if applicable): #22650

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
