### PR TITLE
Don't use room setpoint override in climate.opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -154,6 +154,8 @@ class OpenThermGateway(ClimateDevice):
         """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs:
             temp = float(kwargs[ATTR_TEMPERATURE])
+            if temp == self.target_temperature:
+                return
             self._new_target_temperature = await self._gateway.set_target_temp(
                 temp)
             self.async_schedule_update_ha_state()

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -39,6 +39,7 @@ class OpenThermGateway(ClimateDevice):
         self.temp_precision = config.get(CONF_PRECISION)
         self._current_operation = STATE_IDLE
         self._current_temperature = None
+        self._new_target_temperature = None
         self._target_temperature = None
         self._away_mode_a = None
         self._away_mode_b = None
@@ -63,7 +64,10 @@ class OpenThermGateway(ClimateDevice):
         else:
             self._current_operation = STATE_IDLE
         self._current_temperature = status.get(self._gw_vars.DATA_ROOM_TEMP)
-        self._target_temperature = status.get(self._gw_vars.DATA_ROOM_SETPOINT)
+        temp_upd = status.get(self._gw_vars.DATA_ROOM_SETPOINT)
+        if self._target_temperature != temp_upd:
+            self._new_target_temperature = None
+        self._target_temperature = temp_upd
 
         # GPIO mode 5: 0 == Away
         # GPIO mode 6: 1 == Away
@@ -134,7 +138,7 @@ class OpenThermGateway(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._target_temperature
+        return self._new_target_temperature or self._target_temperature
 
     @property
     def target_temperature_step(self):
@@ -150,7 +154,7 @@ class OpenThermGateway(ClimateDevice):
         """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs:
             temp = float(kwargs[ATTR_TEMPERATURE])
-            self._target_temperature = await self._gateway.set_target_temp(
+            self._new_target_temperature = await self._gateway.set_target_temp(
                 temp)
             self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -63,11 +63,7 @@ class OpenThermGateway(ClimateDevice):
         else:
             self._current_operation = STATE_IDLE
         self._current_temperature = status.get(self._gw_vars.DATA_ROOM_TEMP)
-
-        temp = status.get(self._gw_vars.DATA_ROOM_SETPOINT_OVRD)
-        if temp is None:
-            temp = status.get(self._gw_vars.DATA_ROOM_SETPOINT)
-        self._target_temperature = temp
+        self._target_temperature = status.get(self._gw_vars.DATA_ROOM_SETPOINT)
 
         # GPIO mode 5: 0 == Away
         # GPIO mode 6: 1 == Away


### PR DESCRIPTION
## Description:
While troubleshooting some issues in the pyotgw library, it was noted that the room setpoint override (DATA_ROOM_SETP_OVRD) does not always provide reliable data with some thermostats. To fix this, we only use the actual current setpoint as reported by the thermostat. When setting an override (changing the target temperature through HA), the thermostat takes some time to update its setpoint. To bridge this gap, we assume the override value as target temperature until the thermostat changes the setpoint.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - N/A

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
