### PR TITLE
Add homematic state_uncertain attribute for the Keylock device

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -125,7 +125,8 @@ HM_ATTRIBUTE_SUPPORT = {
     'CURRENT': ['current', {}],
     'VOLTAGE': ['voltage', {}],
     'OPERATING_VOLTAGE': ['voltage', {}],
-    'WORKING': ['working', {0: 'No', 1: 'Yes'}]
+    'WORKING': ['working', {0: 'No', 1: 'Yes'}],
+    'STATE_UNCERTAIN': ['state_uncertain', {}]
 }
 
 HM_PRESS_EVENTS = [

--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS,
+    ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_HS_COLOR, ATTR_TRANSITION, SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR, SUPPORT_EFFECT, Light)
 
 from . import ATTR_DISCOVER_DEVICES, HMDevice
@@ -77,6 +77,9 @@ class HMLight(HMDevice, Light):
 
     def turn_on(self, **kwargs):
         """Turn the light on and/or change color or color effect settings."""
+        if ATTR_TRANSITION in kwargs:
+            self._hmdevice.setValue('RAMP_TIME', kwargs[ATTR_TRANSITION])
+            
         if ATTR_BRIGHTNESS in kwargs and self._state == "LEVEL":
             percent_bright = float(kwargs[ATTR_BRIGHTNESS]) / 255
             self._hmdevice.set_level(percent_bright, self._channel)


### PR DESCRIPTION
## Description:
The Homematic Keylock Device holds an attribute to show if the status is defined or the lock was opened manually. This flag is called - STATE_UNCERTAIN
To make this attribute working, it is necassary to add the flag to the dictionary, which i have done.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

