### PR TITLE
Fix #22648 - Utility_meter would try to cancel a non existing task

### DIFF
--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -118,7 +118,8 @@ class UtilityMeterSensor(RestoreEntity):
             self._collecting = async_track_state_change(
                 self.hass, self._sensor_source_id, self.async_reading)
         else:
-            self._collecting()
+            if self._collecting:
+                self._collecting()
             self._collecting = None
 
         _LOGGER.debug("%s - %s - source <%s>", self._name,


### PR DESCRIPTION
## Description:

This is a bug fix for utility_meters with more than 2 tariffs. 

**Related issue (if applicable):** fixes #22648 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
utility_meter:
  sonoff_1000384783_daily_energy_consumption:
    source: sensor.sonoff_1000384783_energy
    cycle: daily
    tariffs:
      - onpeak
      - midpeak
      - offpeak
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23