### PR TITLE
Adding force_update and expire_after

### DIFF
--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -115,7 +115,6 @@ class RflinkSensor(RflinkDevice):
 
     def _handle_event(self, event):
         """Domain specific event handler."""
-
         # auto-expire enabled?
         if self._expire_after > 0:
             # Reset old trigger

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -103,7 +103,7 @@ class RflinkSensor(RflinkDevice):
     """Representation of a Rflink sensor."""
 
     def __init__(self, device_id, sensor_type, unit_of_measurement,
-                 expire_after=0, force_update=None, initial_event=None,
+                 expire_after=0, force_update=False, initial_event=None,
                  **kwargs):
         """Handle sensor specific args and super init."""
         self._sensor_type = sensor_type

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -4,7 +4,6 @@ Support for Rflink sensors.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.rflink/
 """
-from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -104,8 +103,8 @@ class RflinkSensor(RflinkDevice):
     """Representation of a Rflink sensor."""
 
     def __init__(self, device_id, sensor_type, unit_of_measurement,
-                expire_after=0, force_update=None, initial_event=None,
-                **kwargs):
+                 expire_after=0, force_update=None, initial_event=None,
+                 **kwargs):
         """Handle sensor specific args and super init."""
         self._sensor_type = sensor_type
         self._unit_of_measurement = unit_of_measurement
@@ -177,7 +176,6 @@ class RflinkSensor(RflinkDevice):
         """Return possible sensor specific icon."""
         if self._sensor_type in SENSOR_ICONS:
             return SENSOR_ICONS[self._sensor_type]
-
 
     @property
     def force_update(self):


### PR DESCRIPTION
Added support for force_update and expire_after options

## Description:
Currently according to [state object docs](https://www.home-assistant.io/docs/configuration/state_object/) on last_updated, "writing the exact same state including attributes will not result in this field being updated". That makes impossible to distinguish between "sensor is sending the same temperature for the last hour" and "sensor's batteries has died an hour ago" situations.

I propose to add force_update configuration variable as per [rflink binary sensor](https://www.home-assistant.io/components/binary_sensor.rflink/#force_update) so sensor's state (and last_updated) will be changed every time a new reading arrives even if they are the same.
That will make possible to detect if a sensor does not send readings for more than X seconds and perform necessary actions (notify user, run script etc).

I also propose to add expiry_after as per [MQTT sensor](https://www.home-assistant.io/components/sensor.mqtt/#expire_after).
It is especially useful for sensors displayed in fronted as enables effortlessly make "stale" sensor readings visible (displayed as Unknown) and makes it possible to use filter cards etc to show only failed sensors.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23