### PR TITLE
Fix trusted networks auth provider warning message

### DIFF
--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -191,6 +191,8 @@ def setup_auth(hass, app):
         elif (trusted_networks and
               await async_validate_trusted_networks(request)):
             if request.path not in old_auth_warning:
+                # When removing this, don't forget to remove the print logic
+                # in http/view.py
                 request['deprecate_warning_message'] = \
                     'Access from trusted networks without auth token is ' \
                     'going to be removed in Home Assistant 0.96. Configure ' \

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -190,12 +190,14 @@ def setup_auth(hass, app):
 
         elif (trusted_networks and
               await async_validate_trusted_networks(request)):
-            _LOGGER.warning(
-                'Access from trusted networks without auth token is going to '
-                'be removed in Home Assistant 0.96. Configure the trusted '
-                'networks auth provider or use long-lived access tokens to '
-                'access %s from %s',
-                request.path, request[KEY_REAL_IP])
+            if request.path not in old_auth_warning:
+                request['deprecate_warning_message'] = \
+                    'Access from trusted networks without auth token is ' \
+                    'going to be removed in Home Assistant 0.96. Configure ' \
+                    'the trusted networks auth provider or use long-lived ' \
+                    'access tokens to access {} from {}'.format(
+                        request.path, request[KEY_REAL_IP])
+                old_auth_warning.add(request.path)
             authenticated = True
 
         elif (support_legacy and HTTP_HEADER_HA_AUTH in request.headers and

--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -98,6 +98,8 @@ def request_handler_factory(view, handler):
 
         if view.requires_auth:
             if authenticated:
+                if 'deprecate_warning_message' in request:
+                    _LOGGER.warning(request['deprecate_warning_message'])
                 await process_success_login(request)
             else:
                 raise HTTPUnauthorized()


### PR DESCRIPTION
## Description:

Fix spamming deprecate warning message.

We test auth before know if the path need auth. Move print the warning message to later in the HTTP View. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

