### PR TITLE
Deal with cover assumed state

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
+    ATTR_ASSUMED_STATE,
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util, temperature as temp_util
@@ -1055,11 +1056,16 @@ class OpenCloseTrait(_Trait):
         response = {}
 
         if domain == cover.DOMAIN:
-            position = self.state.attributes.get(cover.ATTR_CURRENT_POSITION)
-            if position is not None:
-                response['openPercent'] = position
+            if self.state.attributes.get(ATTR_ASSUMED_STATE):
+                response['openPercent'] = 50
             else:
-                if self.state.state != cover.STATE_CLOSED:
+                position = self.state.attributes.get(
+                    cover.ATTR_CURRENT_POSITION
+                )
+
+                if position is not None:
+                    response['openPercent'] = position
+                elif self.state.state != cover.STATE_CLOSED:
                     response['openPercent'] = 100
                 else:
                     response['openPercent'] = 0

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1056,6 +1056,9 @@ class OpenCloseTrait(_Trait):
         response = {}
 
         if domain == cover.DOMAIN:
+            # When it's an assumed state, we will always report it as 50%
+            # Google will not issue an open command if the assumed state is
+            # open, even if that is currently incorrect.
             if self.state.attributes.get(ATTR_ASSUMED_STATE):
                 response['openPercent'] = 50
             else:

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -21,7 +21,8 @@ from homeassistant.components.climate import const as climate
 from homeassistant.components.google_assistant import trait, helpers, const
 from homeassistant.const import (
     STATE_ON, STATE_OFF, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
-    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_SUPPORTED_FEATURES, ATTR_TEMPERATURE)
+    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_SUPPORTED_FEATURES, ATTR_TEMPERATURE,
+    ATTR_ASSUMED_STATE)
 from homeassistant.core import State, DOMAIN as HA_DOMAIN, EVENT_CALL_SERVICE
 from homeassistant.util import color
 from tests.common import async_mock_service, mock_coro
@@ -1059,12 +1060,30 @@ async def test_openclose_cover(hass):
     assert trait.OpenCloseTrait.supported(cover.DOMAIN,
                                           cover.SUPPORT_SET_POSITION)
 
+    # No position
+    trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
+    }), BASIC_CONFIG)
+
+    assert trt.sync_attributes() == {}
+    assert trt.query_attributes() == {
+        'openPercent': 100
+    }
+
+    # Assumed state
+    trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
+        ATTR_ASSUMED_STATE: True,
+    }), BASIC_CONFIG)
+
+    assert trt.sync_attributes() == {}
+    assert trt.query_attributes() == {
+        'openPercent': 50
+    }
+
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
         cover.ATTR_CURRENT_POSITION: 75
     }), BASIC_CONFIG)
 
     assert trt.sync_attributes() == {}
-
     assert trt.query_attributes() == {
         'openPercent': 75
     }


### PR DESCRIPTION
## Description:
When a cover has an assumed state, we will always report the state as "50%" open. That way both commands can always be issued.

I've reached out to Google to ask if they can add support for `commandOnlyOnOff` to the OpenClose trait, like they have for the `OnOff` trait.

**Related issue (if applicable):** fixes #22672

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
