### PR TITLE
Fix trend binary sensor and tests

### DIFF
--- a/homeassistant/components/trend/binary_sensor.py
+++ b/homeassistant/components/trend/binary_sensor.py
@@ -141,7 +141,7 @@ class SensorTrend(BinarySensorDevice):
                 else:
                     state = new_state.state
                 if state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                    sample = (utcnow().timestamp(), float(state))
+                    sample = (new_state.last_updated.timestamp(), float(state))
                     self.samples.append(sample)
                     self.async_schedule_update_ha_state(True)
             except (ValueError, TypeError) as ex:


### PR DESCRIPTION
## Description:

Trend binary sensor has the capability to calculate the state base one trend line. It is time-sensitive calculation,  so the sample time should be the update_time of the entity's state, not the time trend sensor received sample.

Also, the test also time-sensitive, it may become flaky since everytime I run I got different numbers. This PR changed test to control the timing. Now I get more stable result.

One flaky test result I spotted at here: https://circleci.com/gh/home-assistant/home-assistant/3728#tests/containers/1  


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
