### PR TITLE
Improve logging of exceptions in async_create_task

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -528,7 +528,7 @@ class CastDevice(MediaPlayerDevice):
             if _is_matching_dynamic_group(self._cast_info, discover):
                 _LOGGER.debug("Discovered matching dynamic group: %s",
                               discover)
-                self.hass.async_create_task(
+                self.hass.async_catching_create_task(
                     self.async_set_dynamic_group(discover))
                 return
 
@@ -542,7 +542,7 @@ class CastDevice(MediaPlayerDevice):
                     self._cast_info.host, self._cast_info.port)
                 return
             _LOGGER.debug("Discovered chromecast with same UUID: %s", discover)
-            self.hass.async_create_task(self.async_set_cast_info(discover))
+            self.hass.async_catching_create_task(self.async_set_cast_info(discover))
 
         def async_cast_removed(discover: ChromecastInfo):
             """Handle removal of Chromecast."""
@@ -552,13 +552,13 @@ class CastDevice(MediaPlayerDevice):
             if (self._dynamic_group_cast_info is not None and
                     self._dynamic_group_cast_info.uuid == discover.uuid):
                 _LOGGER.debug("Removed matching dynamic group: %s", discover)
-                self.hass.async_create_task(self.async_del_dynamic_group())
+                self.hass.async_catching_create_task(self.async_del_dynamic_group())
                 return
             if self._cast_info.uuid != discover.uuid:
                 # Removed is not our device.
                 return
             _LOGGER.debug("Removed chromecast with same UUID: %s", discover)
-            self.hass.async_create_task(self.async_del_cast_info(discover))
+            self.hass.async_catching_create_task(self.async_del_cast_info(discover))
 
         async def async_stop(event):
             """Disconnect socket on Home Assistant stop."""
@@ -571,13 +571,13 @@ class CastDevice(MediaPlayerDevice):
             self.hass, SIGNAL_CAST_REMOVED,
             async_cast_removed)
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop)
-        self.hass.async_create_task(self.async_set_cast_info(self._cast_info))
+        self.hass.async_catching_create_task(self.async_set_cast_info(self._cast_info))
         for info in self.hass.data[KNOWN_CHROMECAST_INFO_KEY]:
             if _is_matching_dynamic_group(self._cast_info, info):
                 _LOGGER.debug("[%s %s (%s:%s)] Found dynamic group: %s",
                               self.entity_id, self._cast_info.friendly_name,
                               self._cast_info.host, self._cast_info.port, info)
-                self.hass.async_create_task(
+                self.hass.async_catching_create_task(
                     self.async_set_dynamic_group(info))
                 break
 

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, dispatcher_send)
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 import homeassistant.util.dt as dt_util
+from homeassistant.util.logging import async_create_catching_coro
 
 from . import DOMAIN as CAST_DOMAIN
 
@@ -528,8 +529,8 @@ class CastDevice(MediaPlayerDevice):
             if _is_matching_dynamic_group(self._cast_info, discover):
                 _LOGGER.debug("Discovered matching dynamic group: %s",
                               discover)
-                self.hass.async_catching_create_task(
-                    self.async_set_dynamic_group(discover))
+                self.hass.async_create_task(async_create_catching_coro(
+                    self.async_set_dynamic_group(discover)))
                 return
 
             if self._cast_info.uuid != discover.uuid:
@@ -542,7 +543,8 @@ class CastDevice(MediaPlayerDevice):
                     self._cast_info.host, self._cast_info.port)
                 return
             _LOGGER.debug("Discovered chromecast with same UUID: %s", discover)
-            self.hass.async_catching_create_task(self.async_set_cast_info(discover))
+            self.hass.async_create_task(async_create_catching_coro(
+                self.async_set_cast_info(discover)))
 
         def async_cast_removed(discover: ChromecastInfo):
             """Handle removal of Chromecast."""
@@ -552,13 +554,15 @@ class CastDevice(MediaPlayerDevice):
             if (self._dynamic_group_cast_info is not None and
                     self._dynamic_group_cast_info.uuid == discover.uuid):
                 _LOGGER.debug("Removed matching dynamic group: %s", discover)
-                self.hass.async_catching_create_task(self.async_del_dynamic_group())
+                self.hass.async_create_task(async_create_catching_coro(
+                    self.async_del_dynamic_group()))
                 return
             if self._cast_info.uuid != discover.uuid:
                 # Removed is not our device.
                 return
             _LOGGER.debug("Removed chromecast with same UUID: %s", discover)
-            self.hass.async_catching_create_task(self.async_del_cast_info(discover))
+            self.hass.async_create_task(async_create_catching_coro(
+                self.async_del_cast_info(discover)))
 
         async def async_stop(event):
             """Disconnect socket on Home Assistant stop."""
@@ -571,14 +575,15 @@ class CastDevice(MediaPlayerDevice):
             self.hass, SIGNAL_CAST_REMOVED,
             async_cast_removed)
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop)
-        self.hass.async_catching_create_task(self.async_set_cast_info(self._cast_info))
+        self.hass.async_create_task(async_create_catching_coro(
+            self.async_set_cast_info(self._cast_info)))
         for info in self.hass.data[KNOWN_CHROMECAST_INFO_KEY]:
             if _is_matching_dynamic_group(self._cast_info, info):
                 _LOGGER.debug("[%s %s (%s:%s)] Found dynamic group: %s",
                               self.entity_id, self._cast_info.friendly_name,
                               self._cast_info.host, self._cast_info.port, info)
-                self.hass.async_catching_create_task(
-                    self.async_set_dynamic_group(info))
+                self.hass.async_create_task(async_create_catching_coro(
+                    self.async_set_dynamic_group(info)))
                 break
 
     async def async_will_remove_from_hass(self) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -14,7 +14,6 @@ import os
 import pathlib
 import sys
 import threading
-import traceback
 from time import monotonic
 import uuid
 
@@ -44,7 +43,6 @@ from homeassistant.util.async_ import (
 from homeassistant import util
 import homeassistant.util.dt as dt_util
 from homeassistant.util import location, slugify
-from homeassistant.util.logging import catch_log_exception
 from homeassistant.util.unit_system import UnitSystem, METRIC_SYSTEM  # NOQA
 
 # Typing imports that create a circular dependency
@@ -283,35 +281,14 @@ class HomeAssistant:
         return task
 
     @callback
-    def async_catching_create_task(
-            self, target: Coroutine) -> asyncio.tasks.Task:
-        """Create a task from within the eventloop and print exception.
-
-        This method must be run in the event loop.
-
-        target: target to call.
-        """
-        self.async_create_task(target, True)
-
-    @callback
-    def async_create_task(
-            self, target: Coroutine, catch=False) -> asyncio.tasks.Task:
+    def async_create_task(self, target: Coroutine) -> asyncio.tasks.Task:
         """Create a task from within the eventloop.
 
         This method must be run in the event loop.
 
         target: target to call.
         """
-        trace = traceback.extract_stack()
-        wrapped_target = target
-        if catch:
-            wrapped_target = catch_log_exception(
-                target, lambda *args:
-                "Exception in {} called from\n {}".format(
-                    target.__name__, "".join(traceback.format_list(trace))))
-
-        task = \
-            self.loop.create_task(wrapped_target)  # type: asyncio.tasks.Task
+        task = self.loop.create_task(target)  # type: asyncio.tasks.Task
 
         if self._track_task:
             self._pending_tasks.append(task)

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -167,7 +167,7 @@ def catch_log_exception(
 
 
 def catch_log_coro_exception(
-        func: Coroutine[Any, Any, Any],
+        target: Coroutine[Any, Any, Any],
         format_err: Callable[..., Any],
         *args: Any) -> Coroutine[Any, Any, Any]:
     """Decorate a coroutine to catch and log exceptions."""
@@ -179,15 +179,14 @@ def catch_log_coro_exception(
         friendly_msg = format_err(*args)
         logging.getLogger(module_name).error('%s\n%s', friendly_msg, exc_msg)
 
-    @wraps(func)  # type: ignore
     async def coro_wrapper(*args: Any) -> Any:
         """Catch and log exception."""
         try:
-            return await func
+            return await target
         except Exception:  # pylint: disable=broad-except
             log_exception(*args)
             return None
-    return coro_wrapper()  # type: ignore
+    return coro_wrapper()
 
 
 def async_create_catching_coro(
@@ -204,6 +203,6 @@ def async_create_catching_coro(
         target, lambda *args:
         "Exception in {} called from\n {}".format(
             target.__name__,  # type: ignore
-            "".join(traceback.format_list(trace))))
+            "".join(traceback.format_list(trace[:-1]))))
 
     return wrapped_target

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -171,20 +171,18 @@ def catch_log_coro_exception(
         format_err: Callable[..., Any],
         *args: Any) -> Coroutine[Any, Any, Any]:
     """Decorate a coroutine to catch and log exceptions."""
-    def log_exception(*args: Any) -> None:
-        module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
-        # Do not print the wrapper in the traceback
-        frames = len(inspect.trace()) - 1
-        exc_msg = traceback.format_exc(-frames)
-        friendly_msg = format_err(*args)
-        logging.getLogger(module_name).error('%s\n%s', friendly_msg, exc_msg)
-
     async def coro_wrapper(*args: Any) -> Any:
         """Catch and log exception."""
         try:
             return await target
         except Exception:  # pylint: disable=broad-except
-            log_exception(*args)
+            module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
+            # Do not print the wrapper in the traceback
+            frames = len(inspect.trace()) - 1
+            exc_msg = traceback.format_exc(-frames)
+            friendly_msg = format_err(*args)
+            logging.getLogger(module_name).error('%s\n%s',
+                                                 friendly_msg, exc_msg)
             return None
     return coro_wrapper()
 

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -130,7 +130,7 @@ def catch_log_exception(
         func: Callable[..., Any],
         format_err: Callable[..., Any],
         *args: Any) -> Callable[[], None]:
-    """Decorate an callback to catch and log exceptions."""
+    """Decorate a callback to catch and log exceptions."""
     def log_exception(*args: Any) -> None:
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
         # Do not print the wrapper in the traceback
@@ -154,6 +154,15 @@ def catch_log_exception(
             except Exception:  # pylint: disable=broad-except
                 log_exception(*args)
         wrapper_func = async_wrapper
+    elif inspect.iscoroutine(func):
+        @wraps(func)
+        async def async_wrapper(*args: Any) -> None:
+            """Catch and log exception."""
+            try:
+                return await func
+            except Exception:  # pylint: disable=broad-except
+                log_exception(*args)
+        wrapper_func = async_wrapper()
     else:
         @wraps(func)
         def wrapper(*args: Any) -> None:

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -6,7 +6,7 @@ import inspect
 import logging
 import threading
 import traceback
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Coroutine, Optional
 
 from .async_ import run_coroutine_threadsafe
 
@@ -173,3 +173,21 @@ def catch_log_exception(
                 log_exception(*args)
         wrapper_func = wrapper
     return wrapper_func
+
+
+def async_create_catching_coro(
+        target: Coroutine, catch=False) -> Coroutine:
+    """Wrap a coroutine to catch and log exceptions.
+
+    The exception will be logged together with a stacktrace of where the
+    coroutine was wrapped.
+
+    target: target coroutine.
+    """
+    trace = traceback.extract_stack()
+    wrapped_target = catch_log_exception(
+        target, lambda *args:
+        "Exception in {} called from\n {}".format(
+            target.__name__, "".join(traceback.format_list(trace))))
+
+    return wrapped_target

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -65,3 +65,16 @@ def test_async_handler_thread_log(loop):
 
     assert queue.get_nowait() == log_record
     assert queue.empty()
+
+
+async def test_async_create_catching_coro(hass, caplog):
+    """Test exception logging of wrapped coroutine."""
+    async def job():
+        raise Exception('This is a bad coroutine')
+        pass
+
+    hass.async_create_task(logging_util.async_create_catching_coro(job()))
+    await hass.async_block_till_done()
+    assert 'This is a bad coroutine' in caplog.text
+    assert ('hass.async_create_task('
+            'logging_util.async_create_catching_coro(job()))' in caplog.text)


### PR DESCRIPTION
## Description:
Improve logging when exceptions are thrown by the target of `async_create_task`
If accepted, this will be followed up by adding the same to `async_add_executor_job` etc.

This is currently added "opt-in" style: logging will only happen if explicitly requested by calling `async_catching_create_task` to prevent slowing down the core functionality.
Since most calls to `async_create_task` are done from integrations, it could make sense to instead "opt-out" from the logging, i.e. stable core functionality should call `async_non_catching_create_task`

Example of log before the change:
```
2019-04-03 20:12:29 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/home/erik/github/home-assistant_fork/homeassistant/components/cast/media_player.py", line 601, in async_set_cast_info
    if cast_info.blabla == None:
AttributeError: 'ChromecastInfo' object has no attribute 'blabla'
```
Example of log after the change:
```
2019-04-03 20:14:08 ERROR (MainThread) [homeassistant.components.cast.media_player] Exception in async_set_cast_info called from
   File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "homeassistant/__main__.py", line 397, in <module>
    sys.exit(main())
  File "homeassistant/__main__.py", line 389, in main
    exit_code = asyncio_run(setup_and_run_hass(config_dir, args))
  File "/home/erik/github/home-assistant_fork/homeassistant/util/async_.py", line 29, in asyncio_run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.6/asyncio/base_events.py", line 460, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.6/asyncio/base_events.py", line 427, in run_forever
    self._run_once()
  File "/usr/lib/python3.6/asyncio/base_events.py", line 1440, in _run_once
    handle._run()
  File "/usr/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/home/erik/github/home-assistant_fork/homeassistant/helpers/entity_platform.py", line 363, in _async_add_entity
    await entity.async_added_to_hass()
  File "/home/erik/github/home-assistant_fork/homeassistant/components/cast/media_player.py", line 574, in async_added_to_hass
    self.hass.async_catching_create_task(self.async_set_cast_info(self._cast_info))
  File "/home/erik/github/home-assistant_fork/homeassistant/core.py", line 294, in async_catching_create_task
    self.async_create_task(target, True)
  File "/home/erik/github/home-assistant_fork/homeassistant/core.py", line 305, in async_create_task
    trace = traceback.extract_stack()

Traceback (most recent call last):
  File "/home/erik/github/home-assistant_fork/homeassistant/components/cast/media_player.py", line 601, in async_set_cast_info
    if cast_info.blabla == None:
AttributeError: 'ChromecastInfo' object has no attribute 'blabla'
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
