### PR TITLE
Add amcrest binary_sensors

### DIFF
--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -121,7 +121,7 @@ def setup(hass, config):
             camera.current_time
 
         except AmcrestError as ex:
-            _LOGGER.error("Unable to connect to Amcrest camera: %s", str(ex))
+            _LOGGER.error("Unable to connect to %s camera: %s", name, str(ex))
             hass.components.persistent_notification.create(
                 'Error: {}<br />'
                 'You will need to restart hass after fixing.'

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -1,0 +1,73 @@
+"""Suppoort for Amcrest IP camera binary sensors."""
+import asyncio
+from datetime import timedelta
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import CONF_NAME, CONF_BINARY_SENSORS
+from . import DATA_AMCREST, BINARY_SENSORS
+
+DEPENDENCIES = ['amcrest']
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=5)
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up a binary sensor for an Amcrest IP Camera."""
+    if discovery_info is None:
+        return
+
+    device_name = discovery_info[CONF_NAME]
+    binary_sensors = discovery_info[CONF_BINARY_SENSORS]
+    amcrest = hass.data[DATA_AMCREST][device_name]
+
+    amcrest_binary_sensors = []
+    for sensor_type in binary_sensors:
+        amcrest_binary_sensors.append(
+            AmcrestBinarySensor(amcrest.name, amcrest.device, sensor_type))
+
+    async_add_devices(amcrest_binary_sensors, True)
+    return True
+
+
+class AmcrestBinarySensor(BinarySensorDevice):
+    """Binary sensor for Amcrest camera."""
+
+    def __init__(self, name, camera, sensor_type):
+        """Initialize entity."""
+        self._name = '{} {}'.format(name, BINARY_SENSORS[sensor_type])
+        self._camera = camera
+        self._sensor_type = sensor_type
+        self._state = None
+
+    @property
+    def name(self):
+        """Return entity name."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return if entity is on."""
+        return self._state
+
+    @property
+    def device_class(self):
+        """Return device class."""
+        return 'motion'
+
+    def update(self):
+        """Update entity."""
+        from amcrest import AmcrestError
+
+        _LOGGER.debug('Pulling data from %s binary sensor', self._name)
+
+        if self._sensor_type == 'motion_detected':
+            try:
+                self._state = self._camera.is_motion_detected
+            except AmcrestError as error:
+                _LOGGER.error(
+                    'Could not update %s binary sensor due to error: %s',
+                    self.name, error)

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -1,9 +1,9 @@
 """Suppoort for Amcrest IP camera binary sensors."""
-import asyncio
 from datetime import timedelta
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, DEVICE_CLASS_MOTION)
 from homeassistant.const import CONF_NAME, CONF_BINARY_SENSORS
 from . import DATA_AMCREST, BINARY_SENSORS
 
@@ -14,8 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=5)
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Set up a binary sensor for an Amcrest IP Camera."""
     if discovery_info is None:
         return
@@ -56,7 +56,7 @@ class AmcrestBinarySensor(BinarySensorDevice):
     @property
     def device_class(self):
         """Return device class."""
-        return 'motion'
+        return DEVICE_CLASS_MOTION
 
     def update(self):
         """Update entity."""

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -30,7 +30,6 @@ async def async_setup_platform(hass, config, async_add_devices,
             AmcrestBinarySensor(amcrest.name, amcrest.device, sensor_type))
 
     async_add_devices(amcrest_binary_sensors, True)
-    return True
 
 
 class AmcrestBinarySensor(BinarySensorDevice):

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -63,10 +63,9 @@ class AmcrestBinarySensor(BinarySensorDevice):
 
         _LOGGER.debug('Pulling data from %s binary sensor', self._name)
 
-        if self._sensor_type == 'motion_detected':
-            try:
-                self._state = self._camera.is_motion_detected
-            except AmcrestError as error:
-                _LOGGER.error(
-                    'Could not update %s binary sensor due to error: %s',
-                    self.name, error)
+        try:
+            self._state = self._camera.is_motion_detected
+        except AmcrestError as error:
+            _LOGGER.error(
+                'Could not update %s binary sensor due to error: %s',
+                self.name, error)

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -28,8 +28,6 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     async_add_entities([AmcrestCam(hass, amcrest)], True)
 
-    return True
-
 
 class AmcrestCam(Camera):
     """An implementation of an Amcrest IP camera."""

--- a/homeassistant/components/amcrest/sensor.py
+++ b/homeassistant/components/amcrest/sensor.py
@@ -30,7 +30,6 @@ async def async_setup_platform(
             AmcrestSensor(amcrest.name, amcrest.device, sensor_type))
 
     async_add_entities(amcrest_sensors, True)
-    return True
 
 
 class AmcrestSensor(Entity):


### PR DESCRIPTION
## Description:
Add a binary sensor for motion detection to replace the corresponding sensor (which should have been a binary_sensor originally.) Make the default scan interval 5 seconds (rather than the default of 10 seconds for the sensor.) Add a deprecation warning to the motion detection sensor.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9130

## Example entry for `configuration.yaml` (if applicable):
```yaml
amcrest:
  host: !secret amcrest_host
  username: !secret amcrest_username
  password: !secret amcrest_password
  binary_sensors:
    - motion_detected
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
