### PR TITLE
Remove all config deprecations invalidated in 0.91

### DIFF
--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -1,19 +1,18 @@
 """Support for the Broadlink RM2 Pro (only temperature) and A1 devices."""
-from datetime import timedelta
 import binascii
 import logging
 import socket
+from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_MAC, CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_CELSIUS,
-    CONF_TIMEOUT, CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL,
-    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
+    CONF_TIMEOUT, CONF_SCAN_INTERVAL)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['broadlink==0.9.0']
 
@@ -31,24 +30,14 @@ SENSOR_TYPES = {
     'noise': ['Noise', ' '],
 }
 
-PLATFORM_SCHEMA = vol.All(
-    PLATFORM_SCHEMA.extend({
-        vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): vol.Coerce(str),
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
-            vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
-        vol.Optional(CONF_UPDATE_INTERVAL):
-            vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_MAC): cv.string,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
-    }),
-    cv.deprecated(
-        CONF_UPDATE_INTERVAL,
-        replacement_key=CONF_SCAN_INTERVAL,
-        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=SCAN_INTERVAL
-    )
-)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): vol.Coerce(str),
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_MAC): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/darksky/sensor.py
+++ b/homeassistant/components/darksky/sensor.py
@@ -1,17 +1,16 @@
 """Support for Dark Sky weather service."""
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
+import voluptuous as vol
 from requests.exceptions import (
     ConnectionError as ConnectError, HTTPError, Timeout)
-import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE,
-    CONF_MONITORED_CONDITIONS, CONF_NAME, UNIT_UV_INDEX, CONF_UPDATE_INTERVAL,
-    CONF_SCAN_INTERVAL, CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
-import homeassistant.helpers.config_validation as cv
+    CONF_MONITORED_CONDITIONS, CONF_NAME, UNIT_UV_INDEX, CONF_SCAN_INTERVAL)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -166,39 +165,29 @@ LANGUAGE_CODES = [
 
 ALLOWED_UNITS = ['auto', 'si', 'us', 'ca', 'uk', 'uk2']
 
-PLATFORM_SCHEMA = vol.All(
-    PLATFORM_SCHEMA.extend({
-        vol.Required(CONF_MONITORED_CONDITIONS):
-            vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
-        vol.Required(CONF_API_KEY): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_UNITS): vol.In(ALLOWED_UNITS),
-        vol.Optional(CONF_LANGUAGE,
-                     default=DEFAULT_LANGUAGE): vol.In(LANGUAGE_CODES),
-        vol.Inclusive(
-            CONF_LATITUDE,
-            'coordinates',
-            'Latitude and longitude must exist together'
-        ): cv.latitude,
-        vol.Inclusive(
-            CONF_LONGITUDE,
-            'coordinates',
-            'Latitude and longitude must exist together'
-        ): cv.longitude,
-        vol.Optional(CONF_UPDATE_INTERVAL):
-            vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_FORECAST):
-            vol.All(cv.ensure_list, [vol.Range(min=0, max=7)]),
-        vol.Optional(CONF_HOURLY_FORECAST):
-            vol.All(cv.ensure_list, [vol.Range(min=0, max=48)]),
-    }),
-    cv.deprecated(
-        CONF_UPDATE_INTERVAL,
-        replacement_key=CONF_SCAN_INTERVAL,
-        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=SCAN_INTERVAL
-    )
-)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_UNITS): vol.In(ALLOWED_UNITS),
+    vol.Optional(CONF_LANGUAGE,
+                 default=DEFAULT_LANGUAGE): vol.In(LANGUAGE_CODES),
+    vol.Inclusive(
+        CONF_LATITUDE,
+        'coordinates',
+        'Latitude and longitude must exist together'
+    ): cv.latitude,
+    vol.Inclusive(
+        CONF_LONGITUDE,
+        'coordinates',
+        'Latitude and longitude must exist together'
+    ): cv.longitude,
+    vol.Optional(CONF_FORECAST):
+        vol.All(cv.ensure_list, [vol.Range(min=0, max=7)]),
+    vol.Optional(CONF_HOURLY_FORECAST):
+        vol.All(cv.ensure_list, [vol.Range(min=0, max=48)]),
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -5,8 +5,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL, \
-    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION
+from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
@@ -23,21 +22,11 @@ CONF_MANUAL = 'manual'
 DEFAULT_INTERVAL = timedelta(hours=1)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(
-        vol.Schema({
-            vol.Optional(CONF_UPDATE_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_MANUAL, default=False): cv.boolean,
-        }),
-        cv.deprecated(
-            CONF_UPDATE_INTERVAL,
-            replacement_key=CONF_SCAN_INTERVAL,
-            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-            default=DEFAULT_INTERVAL
-        )
-    )
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_MANUAL, default=False): cv.boolean,
+    })
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/fedex/sensor.py
+++ b/homeassistant/components/fedex/sensor.py
@@ -1,20 +1,18 @@
 """Sensor for Fedex packages."""
-from collections import defaultdict
 import logging
+from collections import defaultdict
 from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
-                                 ATTR_ATTRIBUTION, CONF_UPDATE_INTERVAL,
-                                 CONF_SCAN_INTERVAL,
-                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
+                                 ATTR_ATTRIBUTION, CONF_SCAN_INTERVAL)
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import slugify
 from homeassistant.util import Throttle
+from homeassistant.util import slugify
 from homeassistant.util.dt import now, parse_date
-import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['fedexdeliverymanager==1.0.6']
 
@@ -30,21 +28,11 @@ STATUS_DELIVERED = 'delivered'
 
 SCAN_INTERVAL = timedelta(seconds=1800)
 
-PLATFORM_SCHEMA = vol.All(
-    PLATFORM_SCHEMA.extend({
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_UPDATE_INTERVAL):
-            vol.All(cv.time_period, cv.positive_timedelta),
-    }),
-    cv.deprecated(
-        CONF_UPDATE_INTERVAL,
-        replacement_key=CONF_SCAN_INTERVAL,
-        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=SCAN_INTERVAL
-    )
-)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/freedns/__init__.py
+++ b/homeassistant/components/freedns/__init__.py
@@ -1,16 +1,16 @@
 """Integrate with FreeDNS Dynamic DNS service at freedns.afraid.org."""
 import asyncio
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import (CONF_URL, CONF_ACCESS_TOKEN,
-                                 CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL,
-                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN, CONF_SCAN_INTERVAL, CONF_URL
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,22 +22,12 @@ TIMEOUT = 10
 UPDATE_URL = 'https://freedns.afraid.org/dynamic/update.php'
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(
-        vol.Schema({
-            vol.Exclusive(CONF_URL, DOMAIN): cv.string,
-            vol.Exclusive(CONF_ACCESS_TOKEN, DOMAIN): cv.string,
-            vol.Optional(CONF_UPDATE_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-        }),
-        cv.deprecated(
-            CONF_UPDATE_INTERVAL,
-            replacement_key=CONF_SCAN_INTERVAL,
-            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-            default=DEFAULT_INTERVAL
-        )
-    )
+    DOMAIN: vol.Schema({
+        vol.Exclusive(CONF_URL, DOMAIN): cv.string,
+        vol.Exclusive(CONF_ACCESS_TOKEN, DOMAIN): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+    }),
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/mythicbeastsdns/__init__.py
+++ b/homeassistant/components/mythicbeastsdns/__init__.py
@@ -23,7 +23,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_DOMAIN): cv.string,
         vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string
+        vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
     })

--- a/homeassistant/components/mythicbeastsdns/__init__.py
+++ b/homeassistant/components/mythicbeastsdns/__init__.py
@@ -1,15 +1,14 @@
 """Support for Mythic Beasts Dynamic DNS service."""
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_HOST, CONF_DOMAIN, CONF_PASSWORD, CONF_UPDATE_INTERVAL,
-    CONF_SCAN_INTERVAL, CONF_UPDATE_INTERVAL_INVALIDATION_VERSION
+    CONF_DOMAIN, CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 
 REQUIREMENTS = ['mbddns==0.1.2']
@@ -21,23 +20,13 @@ DOMAIN = 'mythicbeastsdns'
 DEFAULT_INTERVAL = timedelta(minutes=10)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(
-        vol.Schema({
-            vol.Required(CONF_DOMAIN): cv.string,
-            vol.Required(CONF_HOST): cv.string,
-            vol.Required(CONF_PASSWORD): cv.string,
-            vol.Optional(CONF_UPDATE_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-        }),
-        cv.deprecated(
-            CONF_UPDATE_INTERVAL,
-            replacement_key=CONF_SCAN_INTERVAL,
-            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-            default=DEFAULT_INTERVAL
-        )
-    )
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DOMAIN): cv.string,
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+    })
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -1,18 +1,17 @@
 """Support for testing internet speed via Speedtest.net."""
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS, CONF_SCAN_INTERVAL, CONF_UPDATE_INTERVAL,
-    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
-import homeassistant.helpers.config_validation as cv
+    CONF_MONITORED_CONDITIONS, CONF_SCAN_INTERVAL
+)
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
-
 from .const import DATA_UPDATED, DOMAIN, SENSOR_TYPES
 
 REQUIREMENTS = ['speedtest-cli==2.1.1']
@@ -25,25 +24,15 @@ CONF_MANUAL = 'manual'
 DEFAULT_INTERVAL = timedelta(hours=1)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(
-        vol.Schema({
-            vol.Optional(CONF_SERVER_ID): cv.positive_int,
-            vol.Optional(CONF_UPDATE_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
-                vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_MANUAL, default=False): cv.boolean,
-            vol.Optional(
-                CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)
-            ): vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))])
-        }),
-        cv.deprecated(
-            CONF_UPDATE_INTERVAL,
-            replacement_key=CONF_SCAN_INTERVAL,
-            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-            default=DEFAULT_INTERVAL
-        )
-    )
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_SERVER_ID): cv.positive_int,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_MANUAL, default=False): cv.boolean,
+        vol.Optional(
+            CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)
+        ): vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))])
+    })
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/tellduslive/__init__.py
+++ b/homeassistant/components/tellduslive/__init__.py
@@ -1,22 +1,21 @@
 """Support for Telldus Live."""
 import asyncio
-from functools import partial
 import logging
+from functools import partial
 
 import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.const import CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL, \
-    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION
 import homeassistant.helpers.config_validation as cv
+from homeassistant import config_entries
+from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
-
 from . import config_flow  # noqa  pylint_disable=unused-import
 from .const import (
     CONF_HOST, DOMAIN, KEY_SCAN_INTERVAL, KEY_SESSION,
     MIN_UPDATE_INTERVAL, NOT_SO_PRIVATE_KEY, PUBLIC_KEY, SCAN_INTERVAL,
-    SIGNAL_UPDATE_ENTITY, TELLDUS_DISCOVERY_NEW)
+    SIGNAL_UPDATE_ENTITY, TELLDUS_DISCOVERY_NEW
+)
 
 APPLICATION_NAME = 'Home Assistant'
 
@@ -25,21 +24,11 @@ REQUIREMENTS = ['tellduslive==0.10.10']
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(
-        vol.Schema({
-            vol.Optional(CONF_HOST, default=DOMAIN): cv.string,
-            vol.Optional(CONF_UPDATE_INTERVAL):
-                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
-            vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
-                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
-        }),
-        cv.deprecated(
-            CONF_UPDATE_INTERVAL,
-            replacement_key=CONF_SCAN_INTERVAL,
-            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-            default=SCAN_INTERVAL
-        )
-    )
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_HOST, default=DOMAIN): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
+            vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+    })
 }, extra=vol.ALLOW_EXTRA)
 
 DATA_CONFIG_ENTRY_LOCK = 'tellduslive_config_entry_lock'

--- a/homeassistant/components/tplink_lte/__init__.py
+++ b/homeassistant/components/tplink_lte/__init__.py
@@ -6,10 +6,10 @@ import aiohttp
 import attr
 import voluptuous as vol
 
-from homeassistant.components.notify import ATTR_TARGET
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP,
-    CONF_RECIPIENT)
+    CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_RECIPIENT,
+    EVENT_HOMEASSISTANT_STOP
+)
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -23,22 +23,10 @@ DATA_KEY = 'tplink_lte'
 
 CONF_NOTIFY = 'notify'
 
-# Deprecated in 0.88.0, invalidated in 0.91.0, remove in 0.92.0
-ATTR_TARGET_INVALIDATION_VERSION = '0.91.0'
-
-_NOTIFY_SCHEMA = vol.All(
-    vol.Schema({
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_RECIPIENT): vol.All(cv.ensure_list, [cv.string])
-    }),
-    cv.deprecated(
-        ATTR_TARGET,
-        replacement_key=CONF_RECIPIENT,
-        invalidation_version=ATTR_TARGET_INVALIDATION_VERSION
-    ),
-    cv.has_at_least_one_key(CONF_RECIPIENT),
-)
+_NOTIFY_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_RECIPIENT): vol.All(cv.ensure_list, [cv.string])
+})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All(cv.ensure_list, [vol.Schema({

--- a/homeassistant/components/ups/sensor.py
+++ b/homeassistant/components/ups/sensor.py
@@ -1,20 +1,19 @@
 """Sensor for UPS packages."""
-from collections import defaultdict
 import logging
+from collections import defaultdict
 from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
-                                 ATTR_ATTRIBUTION, CONF_UPDATE_INTERVAL,
-                                 CONF_SCAN_INTERVAL,
-                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
-from homeassistant.helpers.entity import Entity
-from homeassistant.util import slugify
-from homeassistant.util import Throttle
-from homeassistant.util.dt import now, parse_date
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_NAME, CONF_PASSWORD, CONF_SCAN_INTERVAL,
+    CONF_USERNAME
+)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle, slugify
+from homeassistant.util.dt import now, parse_date
 
 REQUIREMENTS = ['upsmychoice==1.0.6']
 
@@ -27,21 +26,11 @@ STATUS_DELIVERED = 'delivered'
 
 SCAN_INTERVAL = timedelta(seconds=1800)
 
-PLATFORM_SCHEMA = vol.All(
-    PLATFORM_SCHEMA.extend({
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_UPDATE_INTERVAL): (
-            vol.All(cv.time_period, cv.positive_timedelta)),
-    }),
-    cv.deprecated(
-        CONF_UPDATE_INTERVAL,
-        replacement_key=CONF_SCAN_INTERVAL,
-        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=SCAN_INTERVAL
-    )
-)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -1,21 +1,20 @@
 """Support for Volvo On Call."""
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
-                                 CONF_NAME, CONF_RESOURCES,
-                                 CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL,
-                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
-from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.const import (
+    CONF_NAME, CONF_PASSWORD, CONF_RESOURCES, CONF_SCAN_INTERVAL, CONF_USERNAME
+)
+from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import (
-    async_dispatcher_send,
-    async_dispatcher_connect)
+    async_dispatcher_connect, async_dispatcher_send
+)
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
 DOMAIN = 'volvooncall'

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -84,30 +84,20 @@ RESOURCES = [
 ]
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(
-        vol.Schema({
-            vol.Required(CONF_USERNAME): cv.string,
-            vol.Required(CONF_PASSWORD): cv.string,
-            vol.Optional(CONF_UPDATE_INTERVAL):
-                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
-            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL):
-                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
-            vol.Optional(CONF_NAME, default={}):
-                cv.schema_with_slug_keys(cv.string),
-            vol.Optional(CONF_RESOURCES): vol.All(
-                cv.ensure_list, [vol.In(RESOURCES)]),
-            vol.Optional(CONF_REGION): cv.string,
-            vol.Optional(CONF_SERVICE_URL): cv.string,
-            vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
-            vol.Optional(CONF_SCANDINAVIAN_MILES, default=False): cv.boolean,
-        }),
-        cv.deprecated(
-            CONF_UPDATE_INTERVAL,
-            replacement_key=CONF_SCAN_INTERVAL,
-            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-            default=DEFAULT_UPDATE_INTERVAL
-        )
-    )
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL):
+            vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+        vol.Optional(CONF_NAME, default={}):
+            cv.schema_with_slug_keys(cv.string),
+        vol.Optional(CONF_RESOURCES): vol.All(
+            cv.ensure_list, [vol.In(RESOURCES)]),
+        vol.Optional(CONF_REGION): cv.string,
+        vol.Optional(CONF_SERVICE_URL): cv.string,
+        vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
+        vol.Optional(CONF_SCANDINAVIAN_MILES, default=False): cv.boolean,
+    })
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -147,11 +147,6 @@ CONF_TTL = 'ttl'
 CONF_TYPE = 'type'
 CONF_UNIT_OF_MEASUREMENT = 'unit_of_measurement'
 CONF_UNIT_SYSTEM = 'unit_system'
-
-# Deprecated in 0.88.0, invalidated in 0.91.0, remove in 0.92.0
-CONF_UPDATE_INTERVAL = 'update_interval'
-CONF_UPDATE_INTERVAL_INVALIDATION_VERSION = '0.91.0'
-
 CONF_URL = 'url'
 CONF_USERNAME = 'username'
 CONF_VALUE_TEMPLATE = 'value_template'


### PR DESCRIPTION
## Description:
In release 0.88, we deprecated the following items:

- `CONF_UPDATE_INTERVAL` in the configuration of all components (#20924)
- `ATTR_TARGET` in the configuration of `tplink_lte` (#20925)

Per their configuration at deprecation time, users using the old configuration would have had warning logs until 0.91 when the configuration would be invalidated. Since we release 0.91 today, we are now able to clean up and remove these from the code base.

This is **not** a breaking change because the deprecation config validator would have already broken the configurations with the release of 0.91 and we announced the breaking change as part of 0.88.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
