### PR TITLE
Change URL handling for ingress

### DIFF
--- a/tests/components/hassio/test_ingress.py
+++ b/tests/components/hassio/test_ingress.py
@@ -13,7 +13,7 @@ import pytest
 async def test_ingress_request_get(
         hassio_client, build_type, aioclient_mock):
     """Test no auth needed for ."""
-    aioclient_mock.get("http://127.0.0.1/addons/{}/web/{}".format(
+    aioclient_mock.get("http://127.0.0.1/ingress/{}/{}".format(
         build_type[0], build_type[1]), text="test")
 
     resp = await hassio_client.get(
@@ -45,7 +45,7 @@ async def test_ingress_request_get(
 async def test_ingress_request_post(
         hassio_client, build_type, aioclient_mock):
     """Test no auth needed for ."""
-    aioclient_mock.post("http://127.0.0.1/addons/{}/web/{}".format(
+    aioclient_mock.post("http://127.0.0.1/ingress/{}/{}".format(
         build_type[0], build_type[1]), text="test")
 
     resp = await hassio_client.post(
@@ -77,7 +77,7 @@ async def test_ingress_request_post(
 async def test_ingress_request_put(
         hassio_client, build_type, aioclient_mock):
     """Test no auth needed for ."""
-    aioclient_mock.put("http://127.0.0.1/addons/{}/web/{}".format(
+    aioclient_mock.put("http://127.0.0.1/ingress/{}/{}".format(
         build_type[0], build_type[1]), text="test")
 
     resp = await hassio_client.put(
@@ -109,7 +109,7 @@ async def test_ingress_request_put(
 async def test_ingress_request_delete(
         hassio_client, build_type, aioclient_mock):
     """Test no auth needed for ."""
-    aioclient_mock.delete("http://127.0.0.1/addons/{}/web/{}".format(
+    aioclient_mock.delete("http://127.0.0.1/ingress/{}/{}".format(
         build_type[0], build_type[1]), text="test")
 
     resp = await hassio_client.delete(
@@ -142,7 +142,7 @@ async def test_ingress_request_delete(
 async def test_ingress_websocket(
         hassio_client, build_type, aioclient_mock):
     """Test no auth needed for ."""
-    aioclient_mock.get("http://127.0.0.1/addons/{}/web/{}".format(
+    aioclient_mock.get("http://127.0.0.1/ingress/{}/{}".format(
         build_type[0], build_type[1]))
 
     # Ignore error because we can setup a full IO infrastructure


### PR DESCRIPTION
## Description:

Instead of an add-on name, we use a token for ingress routing.