### PR TITLE
Allow users to set encoding of mikrotik connection

### DIFF
--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -18,13 +18,17 @@ _LOGGER = logging.getLogger(__name__)
 MTK_DEFAULT_API_PORT = '8728'
 MTK_DEFAULT_API_SSL_PORT = '8729'
 
+CONF_ENCODING = 'encoding'
+DEFAULT_ENCODING = 'utf-8'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_METHOD): cv.string,
     vol.Optional(CONF_PORT): cv.port,
-    vol.Optional(CONF_SSL, default=False): cv.boolean
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
 })
 
 
@@ -59,6 +63,7 @@ class MikrotikScanner(DeviceScanner):
         self.client = None
         self.wireless_exist = None
         self.success_init = self.connect_to_device()
+        self.encoding = config[CONF_ENCODING]
 
         if self.success_init:
             _LOGGER.info("Start polling Mikrotik (%s) router...", self.host)
@@ -72,7 +77,7 @@ class MikrotikScanner(DeviceScanner):
         try:
             kwargs = {
                 'port': self.port,
-                'encoding': 'utf-8'
+                'encoding': self.encoding
             }
             if self.ssl:
                 ssl_context = ssl.create_default_context()


### PR DESCRIPTION
## Description:

Mikrotik does some stupid stuff with character encoding that can screw up the DHCP responses. See #15257 for more detail. 

**Related issue (if applicable):** fixes #15257

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
