### PR TITLE
Load dependencies from manifests. Fallback to current `DEPENDENCIES`.

### DIFF
--- a/homeassistant/components/automation/manifest.json
+++ b/homeassistant/components/automation/manifest.json
@@ -4,7 +4,8 @@
   "documentation": "https://www.home-assistant.io/components/automation",
   "requirements": [],
   "dependencies": [
-    "group"
+    "group",
+    "webhook"
   ],
   "codeowners": [
     "@home-assistant/core"

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -247,7 +247,10 @@ async def async_process_deps_reqs(
         os.path.join(os.path.dirname(module.__file__), 'manifest.json')
     )
 
-    deps = (manifest['dependencies'] if manifest else getattr(module, 'DEPENDENCIES', []))  # type: ignore # noqa: line-to-long # pylint: disable=line-too-long
+    if manifest:
+        deps = manifest['dependencies']  # type: ignore
+    else:
+        deps = getattr(module, 'DEPENDENCIES', [])
 
     if deps and not await _async_process_dependencies(
             hass,

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -1,5 +1,6 @@
 """All methods needed to bootstrap a Home Assistant instance."""
 import asyncio
+import collections
 import logging.handlers
 import os
 from timeit import default_timer as timer
@@ -247,9 +248,10 @@ async def async_process_deps_reqs(
         os.path.join(os.path.dirname(module.__file__), 'manifest.json')
     )
 
-    if manifest.get('dependencies'):
+    if (isinstance(manifest, collections.Mapping)
+            and manifest.get('dependencies')):
         dep_success = await _async_process_dependencies(
-            hass, config, name, manifest['dependencies'])  # type: ignore
+            hass, config, name, manifest['dependencies'])
 
         if not dep_success:
             raise HomeAssistantError("Could not set up all dependencies.")

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -1,6 +1,5 @@
 """All methods needed to bootstrap a Home Assistant instance."""
 import asyncio
-import collections
 import logging.handlers
 import os
 from timeit import default_timer as timer
@@ -248,10 +247,9 @@ async def async_process_deps_reqs(
         os.path.join(os.path.dirname(module.__file__), 'manifest.json')
     )
 
-    if (isinstance(manifest, collections.Mapping)
-            and manifest.get('dependencies')):
+    if manifest.get('dependencies'):  # type: ignore
         dep_success = await _async_process_dependencies(
-            hass, config, name, manifest['dependencies'])
+            hass, config, name, manifest['dependencies'])  # type: ignore
 
         if not dep_success:
             raise HomeAssistantError("Could not set up all dependencies.")

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -260,11 +260,10 @@ async def async_process_deps_reqs(
 
     manifest = await hass.async_add_executor_job(
         json_util.load_json,
-        os.path.join(os.path.dirname(module.__file__), 'manifest.json'),
-        None
+        os.path.join(os.path.dirname(module.__file__), 'manifest.json')
     )
 
-    if manifest:
+    if manifest and manifest['dependencies']:
         await _async_process_deps(
             hass,
             config,

--- a/tests/common.py
+++ b/tests/common.py
@@ -696,13 +696,15 @@ def assert_setup_component(count, domain=None):
     config = {}
 
     @ha.callback
-    def mock_psc(hass, config_input, domain):
+    def mock_psc(hass, config_input, domain_input):
         """Mock the prepare_setup_component to capture config."""
         res = async_process_component_config(
-            hass, config_input, domain)
-        config[domain] = None if res is None else res.get(domain)
+            hass, config_input, domain_input)
+        config[domain_input] = None if res is None else res.get(domain_input)
         _LOGGER.debug("Configuration for %s, Validated: %s, Original %s",
-                      domain, config[domain], config_input.get(domain))
+                      domain_input,
+                      config[domain_input],
+                      config_input.get(domain_input))
         return res
 
     assert isinstance(config, dict)

--- a/tests/common.py
+++ b/tests/common.py
@@ -713,7 +713,7 @@ def assert_setup_component(count, domain=None):
         yield config
 
     if domain is None:
-        assert len(config) >= 1, ('assert_setup_component requires DOMAIN: {}'
+        assert len(config) == 1, ('assert_setup_component requires DOMAIN: {}'
                                   .format(list(config.keys())))
         domain = list(config.keys())[0]
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -485,7 +485,7 @@ class MockPlatform:
     """Provide a fake platform."""
 
     __name__ = 'homeassistant.components.light.bla'
-    __file__ = 'homeassistant/components/light/bla'
+    __file__ = 'homeassistant/components/blah/light'
 
     # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,

--- a/tests/common.py
+++ b/tests/common.py
@@ -444,6 +444,7 @@ class MockModule:
                  async_migrate_entry=None, async_remove_entry=None):
         """Initialize the mock module."""
         self.__name__ = 'homeassistant.components.{}'.format(domain)
+        self.__file__ = 'homeassistant/components/{}'.format(domain)
         self.DOMAIN = domain
         self.DEPENDENCIES = dependencies or []
         self.REQUIREMENTS = requirements or []
@@ -483,7 +484,8 @@ class MockModule:
 class MockPlatform:
     """Provide a fake platform."""
 
-    __name__ = "homeassistant.components.light.bla"
+    __name__ = 'homeassistant.components.light.bla'
+    __file__ = 'homeassistant/components/light/bla'
 
     # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -703,7 +703,7 @@ async def test_if_action(hass, calls):
 
 async def test_if_fails_setup_bad_for(hass, calls):
     """Test for setup failure for bad for."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -723,7 +723,7 @@ async def test_if_fails_setup_bad_for(hass, calls):
 
 async def test_if_fails_setup_for_without_above_below(hass, calls):
     """Test for setup failures for missing above or below."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -51,6 +51,7 @@ async def test_if_fires_on_entity_change(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world', context=context)
     await hass.async_block_till_done()
@@ -80,6 +81,7 @@ async def test_if_fires_on_entity_change_with_from_filter(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
@@ -100,6 +102,7 @@ async def test_if_fires_on_entity_change_with_to_filter(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
@@ -120,6 +123,7 @@ async def test_if_fires_on_attribute_change_with_to_filter(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world', {'test_attribute': 11})
     hass.states.async_set('test.entity', 'world', {'test_attribute': 12})
@@ -142,6 +146,7 @@ async def test_if_fires_on_entity_change_with_both_filters(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
@@ -163,6 +168,7 @@ async def test_if_not_fires_if_to_filter_not_match(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'moon')
     await hass.async_block_till_done()
@@ -186,6 +192,7 @@ async def test_if_not_fires_if_from_filter_not_match(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
@@ -205,6 +212,7 @@ async def test_if_not_fires_if_entity_not_match(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
@@ -231,6 +239,7 @@ async def test_if_action(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set(entity_id, test_state)
     hass.bus.async_fire('test_event')
@@ -247,7 +256,7 @@ async def test_if_action(hass, calls):
 
 async def test_if_fails_setup_if_to_boolean_value(hass, calls):
     """Test for setup failure for boolean to."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -263,7 +272,7 @@ async def test_if_fails_setup_if_to_boolean_value(hass, calls):
 
 async def test_if_fails_setup_if_from_boolean_value(hass, calls):
     """Test for setup failure for boolean from."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -279,7 +288,7 @@ async def test_if_fails_setup_if_from_boolean_value(hass, calls):
 
 async def test_if_fails_setup_bad_for(hass, calls):
     """Test for setup failure for bad for."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -298,7 +307,7 @@ async def test_if_fails_setup_bad_for(hass, calls):
 
 async def test_if_fails_setup_for_without_to(hass, calls):
     """Test for setup failures for missing to."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -331,6 +340,7 @@ async def test_if_not_fires_on_entity_change_with_for(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
@@ -362,6 +372,7 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(hass,
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity_1', 'world')
     hass.states.async_set('test.entity_2', 'world')
@@ -402,6 +413,7 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(hass,
             }
         }
     })
+    await hass.async_block_till_done()
 
     utcnow = dt_util.utcnow()
     with patch('homeassistant.core.dt_util.utcnow') as mock_utcnow:
@@ -438,6 +450,7 @@ async def test_if_fires_on_entity_change_with_for_multiple_force_update(hass,
             }
         }
     })
+    await hass.async_block_till_done()
 
     utcnow = dt_util.utcnow()
     with patch('homeassistant.core.dt_util.utcnow') as mock_utcnow:
@@ -473,6 +486,7 @@ async def test_if_fires_on_entity_change_with_for(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
@@ -505,6 +519,7 @@ async def test_if_fires_on_for_condition(hass, calls):
                 'action': {'service': 'test.automation'},
             }
         })
+        await hass.async_block_till_done()
 
         # not enough time has passed
         hass.bus.async_fire('test_event')
@@ -543,6 +558,7 @@ async def test_if_fires_on_for_condition_attribute_change(hass, calls):
                 'action': {'service': 'test.automation'},
             }
         })
+        await hass.async_block_till_done()
 
         # not enough time has passed
         hass.bus.async_fire('test_event')
@@ -566,7 +582,7 @@ async def test_if_fires_on_for_condition_attribute_change(hass, calls):
 
 async def test_if_fails_setup_for_without_time(hass, calls):
     """Test for setup failure if no time is provided."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -585,7 +601,7 @@ async def test_if_fails_setup_for_without_time(hass, calls):
 
 async def test_if_fails_setup_for_without_entity(hass, calls):
     """Test for setup failure if no entity is provided."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {'event_type': 'bla'},

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -369,7 +369,7 @@ async def test_if_action(hass, calls):
 
 async def test_if_fires_on_change_with_bad_template(hass, calls):
     """Test for firing on change with bad template."""
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -56,7 +56,7 @@ async def test_if_not_fires_using_wrong_at(hass, calls):
 
     This should break the before rule.
     """
-    with assert_setup_component(0):
+    with assert_setup_component(0, automation.DOMAIN):
         assert await async_setup_component(hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {

--- a/tests/components/demo/test_geo_location.py
+++ b/tests/components/demo/test_geo_location.py
@@ -40,14 +40,13 @@ class TestDemoPlatform(unittest.TestCase):
                 assert setup_component(self.hass, geo_location.DOMAIN, CONFIG)
             self.hass.block_till_done()
 
-            # In this test, five geolocation entities have been
+            # In this test, one zone and geolocation entities have been
             # generated.
             all_states = self.hass.states.all()
-            print(all_states)
-            assert len(all_states) == NUMBER_OF_DEMO_DEVICES
+            assert len(all_states) == NUMBER_OF_DEMO_DEVICES + 1
 
             # Check a single device's attributes.
-            state_first_entry = all_states[0]
+            state_first_entry = all_states[1]  # 0 is zone
             assert abs(
                 state_first_entry.attributes['latitude'] -
                 self.hass.config.latitude
@@ -64,5 +63,5 @@ class TestDemoPlatform(unittest.TestCase):
             # Get all states again, ensure that the number of states is still
             # the same, but the lists are different.
             all_states_updated = self.hass.states.all()
-            assert len(all_states_updated) == NUMBER_OF_DEMO_DEVICES
+            assert len(all_states_updated) == NUMBER_OF_DEMO_DEVICES + 1
             assert all_states != all_states_updated

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -42,7 +42,7 @@ class TestNotifyDemo(unittest.TestCase):
         self.hass.stop()
 
     def _setup_notify(self):
-        with assert_setup_component(1) as config:
+        with assert_setup_component(1, notify.DOMAIN) as config:
             assert setup_component(self.hass, notify.DOMAIN, CONFIG)
         assert config[notify.DOMAIN]
         self.hass.block_till_done()

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -29,7 +29,7 @@ class TestNotifyGroup(unittest.TestCase):
                 return self.service1
             return self.service2
 
-        with assert_setup_component(2), \
+        with assert_setup_component(2, notify.DOMAIN), \
                 patch.object(demo, 'get_service', mock_get_service):
             setup_component(self.hass, notify.DOMAIN, {
                 'notify': [{

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -42,7 +42,9 @@ async def mock_rflink(hass, config, domain, monkeypatch, failures=None,
         'rflink.protocol.create_rflink_connection',
         mock_create)
 
+    await async_setup_component(hass, 'rflink', config)
     await async_setup_component(hass, domain, config)
+    await hass.async_block_till_done()
 
     # hook into mock config for injecting events
     event_callback = mock_create.call_args_list[0][1]['event_callback']

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -162,7 +162,7 @@ async def test_remove_entry(hass, manager):
     """Test that we can remove an entry."""
     async def mock_setup_entry(hass, entry):
         """Mock setting up entry."""
-        hass.loop.create_task(hass.config_entries.async_forward_entry_setup(
+        hass.async_create_task(hass.config_entries.async_forward_entry_setup(
             entry, 'light'))
         return True
 


### PR DESCRIPTION
## Description:
Load dependencies from manifests (if present). If not, fallback to the current approach of reading `DEPENDENCIES` from the module attribute.

**Related issue (if applicable):** relates to #22700

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
