### PR TITLE
Only post codecov comment if coverage changes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,3 +11,5 @@ coverage:
     slack:
       default:
         url: "secret:TgWDUM4Jw0w7wMJxuxNF/yhSOHglIo1fGwInJnRLEVPy2P2aLimkoK1mtKCowH5TFw+baUXVXT3eAqefbdvIuM8BjRR4aRji95C6CYyD0QHy4N8i7nn1SQkWDPpS8IthYTg07rUDF7s5guurkKv2RrgoCdnnqjAMSzHoExMOF7xUmblMdhBTWJgBpWEhASJy85w/xxjlsE1xoTkzeJu9Q67pTXtRcn+5kb5/vIzPSYg="
+comment:
+  require_changes: yes


### PR DESCRIPTION
## Breaking Change:
N/A

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- Make codecov comment on PRs less spammy. If everything is fine, the CI check is enough, and we don't need the extra post in the PR thread.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.