### PR TITLE
Fix incorrect "Unavailable" Ambient sensors

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -419,7 +419,7 @@ class AmbientWeatherEntity(Entity):
         """Return True if entity is available."""
         return bool(
             self._ambient.stations[self._mac_address][ATTR_LAST_DATA].get(
-                self._sensor_type))
+                self._sensor_type) is not None)
 
     @property
     def device_info(self):

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -417,9 +417,8 @@ class AmbientWeatherEntity(Entity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return bool(
-            self._ambient.stations[self._mac_address][ATTR_LAST_DATA].get(
-                self._sensor_type) is not None)
+        return self._ambient.stations[self._mac_address][ATTR_LAST_DATA].get(
+            self._sensor_type) is not None
 
     @property
     def device_info(self):


### PR DESCRIPTION
## Description:

In situations where an Ambient sensor would have a value of `0`, the component would interpret that as a falsey value, thus rendering `Unavailable`. This PR fixes that.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/22733

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
