### PR TITLE
Add configuration options for DDWRT device_tracker

### DIFF
--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -8,7 +8,8 @@ import voluptuous as vol
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_SSL, CONF_USERNAME, CONF_VERIFY_SSL)
+    CONF_HOST, CONF_PASSWORD, CONF_SSL, CONF_TYPE, CONF_USERNAME,
+    CONF_VERIFY_SSL, CONF_MONITORED_CONDITIONS)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,18 +19,28 @@ _MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
 
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
+DEFAULT_TYPE = 'lan'
+
+AVAILABLE_ATTRS = [
+    'interface', 'tx_rate', 'rx_rate', 'info', 'signal_db', 'signal',
+    'noise_db', 'snr'
+]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(AVAILABLE_ATTRS)]),
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): cv.string,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
 
 
 def get_scanner(hass, config):
     """Validate the configuration and return a DD-WRT scanner."""
+
     try:
         return DdWrtDeviceScanner(config[DOMAIN])
     except ConnectionError:
@@ -46,6 +57,8 @@ class DdWrtDeviceScanner(DeviceScanner):
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
+        self.type = config[CONF_TYPE]
+        self.monitored_conditions = config[CONF_MONITORED_CONDITIONS]
 
         self.last_results = {}
         self.mac2name = {}
@@ -64,35 +77,55 @@ class DdWrtDeviceScanner(DeviceScanner):
         return self.last_results
 
     def get_device_name(self, device):
+        if device not in self.mac2name:
+            return self.scan_table(device)
+
+    def scan_table(self, device, table='dhcp_leases'):
         """Return the name of the given device or None if we don't know."""
         # If not initialised and not already scanned and not found.
-        if device not in self.mac2name:
-            url = '{}://{}/Status_Lan.live.asp'.format(
-                self.protocol, self.host)
-            data = self.get_ddwrt_data(url)
+        url = '{}://{}/Status_Lan.live.asp'.format(
+            self.protocol, self.host)
+        data = self.get_ddwrt_data(url)
 
-            if not data:
-                return None
+        if not data:
+            return None
 
-            dhcp_leases = data.get('dhcp_leases', None)
+        dhcp_leases = data.get(table, None)
 
-            if not dhcp_leases:
-                return None
+        if not dhcp_leases:
+            return None
 
-            # Remove leading and trailing quotes and spaces
-            cleaned_str = dhcp_leases.replace(
-                "\"", "").replace("\'", "").replace(" ", "")
-            elements = cleaned_str.split(',')
-            num_clients = int(len(elements) / 5)
-            self.mac2name = {}
-            for idx in range(0, num_clients):
-                # The data is a single array
-                # every 5 elements represents one host, the MAC
-                # is the third element and the name is the first.
-                mac_index = (idx * 5) + 2
-                if mac_index < len(elements):
-                    mac = elements[mac_index]
-                    self.mac2name[mac] = elements[idx * 5]
+        # Remove leading and trailing quotes and spaces
+        cleaned_str = dhcp_leases.replace(
+            "\"", "").replace("\'", "").replace(" ", "")
+        elements = cleaned_str.split(',')
+        num_clients = int(len(elements) / 5)
+        self.mac2name = {}
+
+        # The data is a single array
+        # For 'dhcp_leases', every 5 elements represents one host,
+        # the MAC is the third element and the name is the first.
+        if table == 'dhcp_leases':
+            set_columns = 5
+
+        # For 'arp_table', every 4 elements represents one host,
+        # The position of the MAC and the name remains the same.
+        else:
+            set_columns = 4
+
+        for idx in range(0, num_clients):
+            mac_index = (idx * set_columns) + 2
+            # Make sure the index is not out of scope.
+            if _verify_out_of_scope(mac_index, elements):
+                mac = elements[mac_index]
+                if mac in self.mac2name:
+                    # Make sure the index is not out of scope.
+                    if _verify_out_of_scope(idx * set_columns, elements):
+                        self.mac2name[mac] = elements[idx * set_columns]
+                        # If the name is a *, it means the name wasn't found in the
+                        # dhcp_lease table. Check on the arp_table instead.
+                        if elements[idx * set_columns] == '*' and table != 'arp_table':
+                            self.scan_table(device, 'arp_table')
 
         return self.mac2name.get(device)
 
@@ -101,10 +134,21 @@ class DdWrtDeviceScanner(DeviceScanner):
 
         Return boolean if scanning successful.
         """
-        _LOGGER.info("Checking ARP")
+        if self.type.lower() == 'wireless':
+            _LOGGER.info("Checking Wireless ARP")
+            url = 'http://{}/Status_Wireless.live.asp'.format(self.host)
+            extract_key = 'active_wireless'
 
-        url = '{}://{}/Status_Wireless.live.asp'.format(
-            self.protocol, self.host)
+        elif self.type.lower() == 'dhcp':
+            _LOGGER.info("Checking DHCP leases")
+            #url = 'http://{}/Info.live.htm'.format(self.host)
+            url = 'http://{}/Status_Lan.live.asp'.format(self.host)
+            extract_key = 'dhcp_leases'
+        else:
+            _LOGGER.info("Checking Lan ARP")
+            url = 'http://{}/Status_Lan.live.asp'.format(self.host)
+            extract_key = 'arp_table'
+
         data = self.get_ddwrt_data(url)
 
         if not data:
@@ -112,7 +156,8 @@ class DdWrtDeviceScanner(DeviceScanner):
 
         self.last_results = []
 
-        active_clients = data.get('active_wireless', None)
+        active_clients = data.get(extract_key, None)
+
         if not active_clients:
             return False
 
@@ -145,8 +190,70 @@ class DdWrtDeviceScanner(DeviceScanner):
             return
         _LOGGER.error("Invalid response from DD-WRT: %s", response)
 
+    def get_extra_attributes(self, device):
+        """Return the extra attributes of the devices wireless connections."""
+        if not self.monitored_conditions:
+            return {}
+
+        url = '{}://{}/Status_Wireless.live.asp'.format(
+            self.protocol, self.host)
+        data = self.get_ddwrt_data(url)
+
+        if not data:
+            return None
+
+        active_wireless = data.get('active_wireless', None)
+
+        # Remove leading and trailing quotes and spaces
+        cleaned_str = active_wireless.replace(
+            "\"", "").replace("\'", "").replace(" ", "")
+        elements = cleaned_str.split(',')
+
+        # The data is a single array
+        # For 'active_wireless', every 10 elements represents one host,
+        num_clients = int(len(elements) / 10)
+
+        attributes = {}
+        # This loops through each wireless client and
+        # then assign a variable to each 'column'.
+        for idx in range(0, num_clients):
+            column_indexes = {
+                'mac': 0,
+                'interface': 1,
+                'tx_rate': 3,
+                'rx_rate': 4,
+                'info': 5,
+                'signal_db': 6,
+                'noise_db': 7,
+                'snr': 8,
+                'signal': 9,
+            }
+
+            # The loop stops when the proper MAC address is found.
+            current_mac_lookup = idx * 10 + column_indexes['mac']
+
+            if elements[current_mac_lookup] == device:
+                # Looping through the requested monitoring conditions and get the data.
+                for monitored_value in self.monitored_conditions: 
+                    column_index = column_indexes[monitored_value]
+                    attributes[monitored_value] = elements[idx * 10 + column_index]
+                    # TX and RX rate have a M at the end of the string,
+                    # here we remove it for convenience.
+                    if monitored_value in ['tx_rate', 'rx_rate']:
+                        attributes[monitored_value] = attributes[monitored_value][:-1]
+
+        _LOGGER.debug("Device MAC %s attributes %s", device, attributes)
+        return attributes
+
 
 def _parse_ddwrt_response(data_str):
     """Parse the DD-WRT data format."""
     return {
         key: val for key, val in _DDWRT_DATA_REGEX.findall(data_str)}
+
+def _verify_out_of_scope(index, elements):
+    """Check if an index is out of scope.
+
+    Return boolean reflecting the result.
+    """
+    return bool(index < len(elements))

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -19,7 +19,7 @@ _MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
 
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
-DEFAULT_TYPE = 'lan'
+DEFAULT_TYPE = 'wireless'
 
 AVAILABLE_ATTRS = [
     'interface', 'tx_rate', 'rx_rate', 'info', 'signal_db', 'signal',

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -19,6 +19,7 @@ _MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
 
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
+DEFAULT_TYPE = 'lan'
 
 AVAILABLE_ATTRS = [
     'interface', 'tx_rate', 'rx_rate', 'info', 'signal_db', 'signal',

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -19,7 +19,6 @@ _MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
 
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
-DEFAULT_TYPE = 'lan'
 
 AVAILABLE_ATTRS = [
     'interface', 'tx_rate', 'rx_rate', 'info', 'signal_db', 'signal',


### PR DESCRIPTION
(This is my first ever public pull request, if I made a mistake or can easily optimize the code below or made a rookie mistake, I'll be happy to fix it)
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
By default the device tracker also tracks wired connections and the end user may need to set it to `wireless` to expect the same behavior as before.

**EDIT**
Revert back to current behavior as default.

## Description:
Add a `type` configuration option to allow the user to either pool:

- lan: pool all connected devices, wired and wireless
- wireless: pool only wireless devices, like before
- dhcp: get all devices in the dhcp leases table. this may include devices not connected to the router anymore as the lease may not have expired yet

Add a `monitored_condition` configuration option to gather states about wireless devices including:

- Interface name
- Transmission and reception rate
- Information about the type of the connection
- Signal strengh in dB and the noise in dB
- Signal-to-Noise ratio
- The signal quality expressed between 0 and 1000


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here> https://github.com/home-assistant/home-assistant.io/pull/9146

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: ddwrt
    host: 192.168.1.1
    username: master
    password: Ttl-8aghast-spiro-Wars2-bungee8-8chomp
    type: wireless
    monitored_conditions:
      - interface
      - tx_rate
      - rx_rate
      - info
      - signal_db
      - signal
      - noise_db
      - snr
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
