### PR TITLE
Fix stream for some cameras

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -29,11 +29,7 @@ def create_stream_buffer(stream_output, video_stream, audio_frame):
     segment = io.BytesIO()
     output = av.open(
         segment, mode='w', format=stream_output.format)
-    vstream = output.add_stream(
-        stream_output.video_codec, video_stream.rate)
-    # Fix format
-    vstream.codec_context.format = \
-        video_stream.codec_context.format
+    vstream = output.add_stream(template=video_stream)
     # Check if audio is requested
     astream = None
     if stream_output.audio_codec:


### PR DESCRIPTION
## Description:

This was tested against the doorbird camera of olbjan on discord, as well as my HikVisions that were previously already working.  Hopefully it will work for the Axis cameras @Kane610 is working on as well - please confirm.

The issue appears to be that the previous method would create a libx264 encoder codec when passed h264.  I then copied over the video format from the input stream so that it would match and I could properly remux the stream.  The reason for doing it this way was to be able to eventually drop in transcoding support without many changes as to how the output stream got created.

Unfortunately, for some feeds, that does not appear to work correctly, and since we only support remuxing streams at this point, it is much easier to pass in the input video stream as a template to the new output stream, and fixes the problems for the Doorbird without breaking my HikVisions.

See [here](https://github.com/mikeboers/PyAV/blob/develop/av/container/output.pyx#L46-L55) for the differences on how the codec gets created.

**Related issue (if applicable):** #22593

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.