### PR TITLE
Update PR template requirements to point to the manifest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,6 @@ If the code communicates with devices, web services, or third-party tools:
 If the code does not interact with devices:
   - [ ] Tests have been added to verify that the new code works.
 
-[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/manifest.json
-[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/manifest.json#L6
+[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
+[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
 [ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,8 @@ If user exposed functionality or configuration variables are added/changed:
   - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
 
 If the code communicates with devices, web services, or third-party tools:
-  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
+  - [ ] There is a manifest with all fields filled out correctly ([example][ex-manifest]).
+  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
   - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
   - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
   - [ ] New files were added to `.coveragerc`.
@@ -31,5 +32,6 @@ If the code communicates with devices, web services, or third-party tools:
 If the code does not interact with devices:
   - [ ] Tests have been added to verify that the new code works.
 
-[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
+[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/manifest.json
+[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/manifest.json#L6
 [ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23


### PR DESCRIPTION
## Description:
Update the PR template to point requirements to the new manifest requirements.

**Related issue (if applicable):** relates to #22700

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/developers.home-assistant/pull/214

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
