### PR TITLE
Add deprecation warning to embedded MQTT broker

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -174,6 +174,16 @@ MQTT_WILL_BIRTH_SCHEMA = vol.Schema({
     vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
 }, required=True)
 
+
+def embedded_broker_deprecated(value):
+    """Warn user that embedded MQTT broker is deprecated."""
+    _LOGGER.warning(
+        "The embedded MQTT broker has been deprecated and will stop working"
+        "after June 5th, 2019. Use an external broker instead. For"
+        "instructions, see https://www.home-assistant.io/docs/mqtt/broker")
+    return value
+
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_CLIENT_ID): cv.string,
@@ -193,7 +203,8 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Any('auto', '1.0', '1.1', '1.2'),
         vol.Optional(CONF_PROTOCOL, default=DEFAULT_PROTOCOL):
             vol.All(cv.string, vol.In([PROTOCOL_31, PROTOCOL_311])),
-        vol.Optional(CONF_EMBEDDED): HBMQTT_CONFIG_SCHEMA,
+        vol.Optional(CONF_EMBEDDED):
+            vol.All(HBMQTT_CONFIG_SCHEMA, embedded_broker_deprecated),
         vol.Optional(CONF_WILL_MESSAGE): MQTT_WILL_BIRTH_SCHEMA,
         vol.Optional(CONF_BIRTH_MESSAGE): MQTT_WILL_BIRTH_SCHEMA,
         vol.Optional(CONF_DISCOVERY, default=DEFAULT_DISCOVERY): cv.boolean,


### PR DESCRIPTION
## Description:

Add deprecation warning if embedded broker is configured, background in home-assistant/architecture#186

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#TODO

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)