### PR TITLE
Fix async configuration flow in Daikin

### DIFF
--- a/homeassistant/components/daikin/config_flow.py
+++ b/homeassistant/components/daikin/config_flow.py
@@ -38,9 +38,12 @@ class FlowHandler(config_entries.ConfigFlow):
         """Create device."""
         from pydaikin.appliance import Appliance
         try:
+            device = Appliance(
+                host,
+                self.hass.helpers.aiohttp_client.async_get_clientsession(),
+            )
             with async_timeout.timeout(10):
-                device = await self.hass.async_add_executor_job(
-                    Appliance, host)
+                await device.init()
         except asyncio.TimeoutError:
             return self.async_abort(reason='device_timeout')
         except Exception:  # pylint: disable=broad-except

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -24,9 +24,14 @@ def init_config_flow(hass):
 
 @pytest.fixture
 def mock_daikin():
-    """Mock tellduslive."""
+    """Mock pydaikin."""
+    async def mock_daikin_init():
+        """Mock the init function in pydaikin."""
+        pass
+
     with MockDependency('pydaikin.appliance') as mock_daikin_:
         mock_daikin_.Appliance().values.get.return_value = 'AABBCCDDEEFF'
+        mock_daikin_.Appliance().init = mock_daikin_init
         yield mock_daikin_
 
 


### PR DESCRIPTION
## Description:

The configuration flow in Daikin is broken after #21638, this fixes that.

**Related issue (if applicable):** fixes #22706 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
