### PR TITLE
Two small improvements to `caldav` component

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -81,7 +81,7 @@ def setup_platform(hass, config, add_entities, disc_info=None):
                     cust_calendar.get(CONF_NAME)),
             }
 
-            include_all_day = cust_calendar.get(CONF_INCLUDE_ALL_DAY)
+            include_all_day = cust_calendar[CONF_INCLUDE_ALL_DAY]
 
             calendar_devices.append(
                 WebDavCalendarEventDevice(
@@ -95,7 +95,7 @@ def setup_platform(hass, config, add_entities, disc_info=None):
                 CONF_DEVICE_ID: calendar.name,
             }
 
-            include_all_day = config.get(CONF_INCLUDE_ALL_DAY)
+            include_all_day = config[CONF_INCLUDE_ALL_DAY]
 
             calendar_devices.append(
                 WebDavCalendarEventDevice(hass, device_data, calendar,

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -173,7 +173,7 @@ class WebDavCalendarData:
         # won't return events that have already started
         results = self.calendar.date_search(
             dt.start_of_local_day(),
-            dt.start_of_local_day() + timedelta(days=1)
+            dt.start_of_local_day() + timedelta(days=2)
         )
 
         # dtstart can be a date or datetime depending if the event lasts a
@@ -265,6 +265,6 @@ class WebDavCalendarData:
             enddate = obj.dtstart.value + obj.duration.value
 
         else:
-            enddate = obj.dtstart.value + timedelta(days=2)
+            enddate = obj.dtstart.value + timedelta(days=1)
 
         return enddate

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -169,7 +169,8 @@ def mock_private_cal():
 
 def _local_datetime(hours, minutes, days=0):
     """Build a datetime object for testing in the correct timezone."""
-    return dt.as_local(datetime.datetime(2017, 11, 27 + days, hours, minutes, 0))
+    return dt.as_local(datetime.datetime(2017, 11, 27 + days,
+                                         hours, minutes, 0))
 
 
 def _mocked_dav_client(*names, calendars=None):
@@ -194,8 +195,9 @@ def _mock_calendar(name):
         start_dt = WebDavCalendarData.to_datetime(start)
         end_dt = WebDavCalendarData.to_datetime(end)
         for e in events:
-            e_start = WebDavCalendarData.to_datetime(e.instance.vevent.dtstart.value)
-            e_end = WebDavCalendarData.get_end_date(e.instance.vevent)
+            event = e.instance.vevent
+            e_start = WebDavCalendarData.to_datetime(event.dtstart.value)
+            e_end = WebDavCalendarData.get_end_date(event)
             e_end = WebDavCalendarData.to_datetime(e_end)
             if e_end <= start_dt or e_start >= end_dt:
                 continue
@@ -478,7 +480,8 @@ async def test_all_day_event_returned(mock_now, hass, calendar):
     }
 
 
-@patch('homeassistant.util.dt.now', return_value=_local_datetime(12, 00, days=1))
+@patch('homeassistant.util.dt.now', return_value=_local_datetime(12, 00,
+                                                                 days=1))
 async def test_all_day_event_tomorrow(mock_now, hass, calendar):
     """Test that the event lasting tomorrow's whole day is returned."""
     config = dict(CALDAV_CONFIG)


### PR DESCRIPTION
This component includes the data of the currently running event (if the binary sensor is on) or the next upcoming event (if it is off) in the attributes of the binary sensor. However, it only looks for events that take place *today*. The rationale is, I guess, that the python-caldav library does not admit to look for the next upcoming event but only allows a date search. However, I can think of many use cases where one would need the first event *tomorrow*, like trigger automation X if I have an appointment in the morning. So increasing the date search range to today + tomorrow seems like a reasonable compromise to me.

The other change concerns the inclusion of all-day events. Currently, all-day events are *not* included on the default calendars (i.e. if there are no custom calendars), while they *are* included for all custom calendars. I don't quite understand the motivation for this, but in any case I believe it would be useful to customize it. So I added the options `include_all_day` both to the default calendars and to the custom calendars. The default values are such that the current behaviour is reproduced, so there is no breaking change.

## Description:


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9156

## Example entry for `configuration.yaml` (if applicable):
```yaml
calendar:
  - platform: caldav
    username: MYUSER
    password: MYPW
    url: https://<MYNEXTCLOUD>/remote.php/dav/
    calendars:
      - Birthdays
    include_all_day: true
```

```yaml
calendar:
  - platform: caldav
    username: MYUSER
    password: MYPW
    url: https://<MYNEXTCLOUD>/remote.php/dav/
    custom_calendars:
        - name: custom
          calendar: Personal
          search: 'Test.*'
          include_all_day: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
