### PR TITLE
Update cryptography to 2.6.1 and PyJWT to 1.7.1

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,8 +5,8 @@ attrs==18.2.0
 bcrypt==3.1.6
 certifi>=2018.04.16
 jinja2>=2.10
-PyJWT==1.6.4
-cryptography==2.5
+PyJWT==1.7.1
+cryptography==2.6.1
 pip>=8.0.3
 python-slugify==1.2.6
 pytz>=2018.07

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,8 +6,8 @@ attrs==18.2.0
 bcrypt==3.1.6
 certifi>=2018.04.16
 jinja2>=2.10
-PyJWT==1.6.4
-cryptography==2.5
+PyJWT==1.7.1
+cryptography==2.6.1
 pip>=8.0.3
 python-slugify==1.2.6
 pytz>=2018.07

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ REQUIRES = [
     'bcrypt==3.1.6',
     'certifi>=2018.04.16',
     'jinja2>=2.10',
-    'PyJWT==1.6.4',
+    'PyJWT==1.7.1',
     # PyJWT has loose dependency. We want the latest one.
-    'cryptography==2.5',
+    'cryptography==2.6.1',
     'pip>=8.0.3',
     'python-slugify==1.2.6',
     'pytz>=2018.07',


### PR DESCRIPTION
## Description

Update cryptography to 2.6.1, changelogs: http://cryptography.io/en/latest/changelog/
Update PyJWT to 1.7.1, changelogs: https://github.com/jpadilla/pyjwt/blob/1.7.1/CHANGELOG.md

I'm a little on deep water here.
These are added in setup.py so I just edited them there.

I ran the gen_requirements, but `requirements_test_all.txt` did not get updated.

Are there any manifest that need to be changed?

Related PR
https://github.com/home-assistant/home-assistant/pull/22737
@robbiet480 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
