### PR TITLE
Correctly load Mopar's config

### DIFF
--- a/homeassistant/components/mopar/__init__.py
+++ b/homeassistant/components/mopar/__init__.py
@@ -53,12 +53,13 @@ def setup(hass, config):
     """Set up the Mopar component."""
     import motorparts
 
+    conf = config[DOMAIN]
     cookie = hass.config.path(COOKIE_FILE)
     try:
         session = motorparts.get_session(
-            config[CONF_USERNAME],
-            config[CONF_PASSWORD],
-            config[CONF_PIN],
+            conf[CONF_USERNAME],
+            conf[CONF_PASSWORD],
+            conf[CONF_PIN],
             cookie_path=cookie
         )
     except motorparts.MoparError:
@@ -69,7 +70,7 @@ def setup(hass, config):
     data.update(now=None)
 
     track_time_interval(
-        hass, data.update, config[CONF_SCAN_INTERVAL]
+        hass, data.update, conf[CONF_SCAN_INTERVAL]
     )
 
     def handle_horn(call):


### PR DESCRIPTION
## Description:
Mopar's config was not getting extracted from the main Home Assistant config in the refactor in https://github.com/home-assistant/home-assistant/pull/21526

**Related issue (if applicable):** fixes #22770

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
