### PR TITLE
Fix konnected unique_id computation for switches

### DIFF
--- a/homeassistant/components/konnected/switch.py
+++ b/homeassistant/components/konnected/switch.py
@@ -41,9 +41,10 @@ class KonnectedSwitch(ToggleEntity):
         self._pause = self._data.get(CONF_PAUSE)
         self._repeat = self._data.get(CONF_REPEAT)
         self._state = self._boolean_state(self._data.get(ATTR_STATE))
-        self._unique_id = '{}-{}'.format(device_id, hash(frozenset(
-            {self._pin_num, self._momentary, self._pause, self._repeat})))
         self._name = self._data.get(CONF_NAME)
+        self._unique_id = '{}-{}-{}-{}-{}'.format(
+            device_id, self._pin_num, self._momentary,
+            self._pause, self._repeat)
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
## Breaking Change:

This will change the internal `unique_id` for Konnected switches (i.e. siren, buzzer, generic switch). Users will need to manually remove the orphaned switch entities from the entity registry after updating and re-configure any changes stored in the entity registry (i.e. name and entity_id), as their unique IDs will change.
## Description:

Previous fix for #22389 used a flawed hashing algorithm to generate unique_id. This simplifies and ensures that unique_id is unique and deterministic.

**Related issue (if applicable):** fixes #22746 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
