### PR TITLE
Add optional rtsp_port for Foscam

### DIFF
--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -27,7 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_RTSP_PORT, default=None): vol.Any(None, cv.port)
+    vol.Optional(CONF_RTSP_PORT): vol.Any(None, cv.port)
 })
 
 
@@ -55,7 +55,7 @@ class FoscamCam(Camera):
         self._foscam_session = FoscamCamera(
             ip_address, port, self._username, self._password, verbose=False)
 
-        self._rtsp_port = device_info[CONF_RTSP_PORT]
+        self._rtsp_port = device_info.get(CONF_RTSP_PORT)
         if not self._rtsp_port:
             result, response = self._foscam_session.get_port_info()
             if result == 0:

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -27,7 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_RTSP_PORT): vol.Any(None, cv.port)
+    vol.Optional(CONF_RTSP_PORT): cv.port
 })
 
 

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -14,6 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 REQUIREMENTS = ['libpyfoscam==1.0']
 
 CONF_IP = 'ip'
+CONF_RTSP_PORT = 'rtsp_port'
 
 DEFAULT_NAME = 'Foscam Camera'
 DEFAULT_PORT = 88
@@ -26,6 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_RTSP_PORT, default=None): vol.Any(None, cv.port)
 })
 
 
@@ -53,11 +55,12 @@ class FoscamCam(Camera):
         self._foscam_session = FoscamCamera(
             ip_address, port, self._username, self._password, verbose=False)
 
-        self._rtsp_port = None
-        result, response = self._foscam_session.get_port_info()
-        if result == 0:
-            self._rtsp_port = response.get('rtspPort') or \
-                              response.get('mediaPort')
+        self._rtsp_port = device_info[CONF_RTSP_PORT]
+        if not self._rtsp_port:
+            result, response = self._foscam_session.get_port_info()
+            if result == 0:
+                self._rtsp_port = response.get('rtspPort') or \
+                                  response.get('mediaPort')
 
     def camera_image(self):
         """Return a still image response from the camera."""


### PR DESCRIPTION
## Description:
As laid out in #22783 there are apparently Foscam models that return `rtspPort` and use a completely different port for RTSP. Two such models are the R2 and R2C, both of which return 554 for `rtspPort` but actually use port 88, which is the media port. On other models, `rtspPort` is correctly returned.

**Related issue (if applicable):** fixes #22783

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9157

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: foscam 
  name: BabyCam 
  ip: 192.168.1.20 
  rtsp_port: 88 
  username: !secret babycam_user 
  password: !secret babycam_password 
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.