### PR TITLE
Fix effects on HUE integration for Osram bulbs

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -362,26 +362,27 @@ class HueLight(Light):
         if ATTR_BRIGHTNESS in kwargs:
             command['bri'] = kwargs[ATTR_BRIGHTNESS]
 
-        flash = kwargs.get(ATTR_FLASH)
+        if ATTR_FLASH in kwargs:
+            flash = kwargs[ATTR_FLASH]
 
-        if flash == FLASH_LONG:
-            command['alert'] = 'lselect'
-            del command['on']
-        elif flash == FLASH_SHORT:
-            command['alert'] = 'select'
-            del command['on']
-        else:
-            command['alert'] = 'none'
+            if flash == FLASH_LONG:
+                command['alert'] = 'lselect'
+                del command['on']
+            elif flash == FLASH_SHORT:
+                command['alert'] = 'select'
+                del command['on']
+            else:
+                command['alert'] = 'none'
 
-        effect = kwargs.get(ATTR_EFFECT)
-
-        if effect == EFFECT_COLORLOOP:
-            command['effect'] = 'colorloop'
-        elif effect == EFFECT_RANDOM:
-            command['hue'] = random.randrange(0, 65535)
-            command['sat'] = random.randrange(150, 254)
-        elif self.is_philips or effect == '':
-            command['effect'] = 'none'
+        if ATTR_EFFECT in kwargs:
+            effect = kwargs[ATTR_EFFECT]
+            if effect == EFFECT_COLORLOOP:
+                command['effect'] = 'colorloop'
+            elif effect == EFFECT_RANDOM:
+                command['hue'] = random.randrange(0, 65535)
+                command['sat'] = random.randrange(150, 254)
+            else:
+                command['effect'] = 'none'
 
         if self.is_group:
             await self.light.set_action(**command)
@@ -395,16 +396,16 @@ class HueLight(Light):
         if ATTR_TRANSITION in kwargs:
             command['transitiontime'] = int(kwargs[ATTR_TRANSITION] * 10)
 
-        flash = kwargs.get(ATTR_FLASH)
-
-        if flash == FLASH_LONG:
-            command['alert'] = 'lselect'
-            del command['on']
-        elif flash == FLASH_SHORT:
-            command['alert'] = 'select'
-            del command['on']
-        else:
-            command['alert'] = 'none'
+        if ATTR_FLASH in kwargs:
+            flash = kwargs[ATTR_FLASH]
+            if flash == FLASH_LONG:
+                command['alert'] = 'lselect'
+                del command['on']
+            elif flash == FLASH_SHORT:
+                command['alert'] = 'select'
+                del command['on']
+            else:
+                command['alert'] = 'none'
 
         if self.is_group:
             await self.light.set_action(**command)

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -378,7 +378,7 @@ class HueLight(Light):
         elif effect == EFFECT_RANDOM:
             command['hue'] = random.randrange(0, 65535)
             command['sat'] = random.randrange(150, 254)
-        elif self.is_philips:
+        else:
             command['effect'] = 'none'
 
         if self.is_group:

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -312,7 +312,9 @@ class HueLight(Light):
     @property
     def effect_list(self):
         """Return the list of supported effects."""
-        return [EFFECT_COLORLOOP, EFFECT_RANDOM]
+        if self.is_philips:
+            return [EFFECT_COLORLOOP, EFFECT_RANDOM]
+        return [EFFECT_RANDOM]
 
     @property
     def device_info(self):
@@ -378,7 +380,7 @@ class HueLight(Light):
         elif effect == EFFECT_RANDOM:
             command['hue'] = random.randrange(0, 65535)
             command['sat'] = random.randrange(150, 254)
-        else:
+        elif self.is_philips or effect == '':
             command['effect'] = 'none'
 
         if self.is_group:

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -312,9 +312,9 @@ class HueLight(Light):
     @property
     def effect_list(self):
         """Return the list of supported effects."""
-        if self.is_philips:
-            return [EFFECT_COLORLOOP, EFFECT_RANDOM]
-        return [EFFECT_RANDOM]
+        if self.is_osram:
+            return [EFFECT_RANDOM]
+        return [EFFECT_COLORLOOP, EFFECT_RANDOM]
 
     @property
     def device_info(self):

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -362,17 +362,16 @@ class HueLight(Light):
         if ATTR_BRIGHTNESS in kwargs:
             command['bri'] = kwargs[ATTR_BRIGHTNESS]
 
-        if ATTR_FLASH in kwargs:
-            flash = kwargs[ATTR_FLASH]
+        flash = kwargs.get(ATTR_FLASH)
 
-            if flash == FLASH_LONG:
-                command['alert'] = 'lselect'
-                del command['on']
-            elif flash == FLASH_SHORT:
-                command['alert'] = 'select'
-                del command['on']
-            else:
-                command['alert'] = 'none'
+        if flash == FLASH_LONG:
+            command['alert'] = 'lselect'
+            del command['on']
+        elif flash == FLASH_SHORT:
+            command['alert'] = 'select'
+            del command['on']
+        else:
+            command['alert'] = 'none'
 
         if ATTR_EFFECT in kwargs:
             effect = kwargs[ATTR_EFFECT]
@@ -396,16 +395,16 @@ class HueLight(Light):
         if ATTR_TRANSITION in kwargs:
             command['transitiontime'] = int(kwargs[ATTR_TRANSITION] * 10)
 
-        if ATTR_FLASH in kwargs:
-            flash = kwargs[ATTR_FLASH]
-            if flash == FLASH_LONG:
-                command['alert'] = 'lselect'
-                del command['on']
-            elif flash == FLASH_SHORT:
-                command['alert'] = 'select'
-                del command['on']
-            else:
-                command['alert'] = 'none'
+        flash = kwargs.get(ATTR_FLASH)
+
+        if flash == FLASH_LONG:
+            command['alert'] = 'lselect'
+            del command['on']
+        elif flash == FLASH_SHORT:
+            command['alert'] = 'select'
+            del command['on']
+        else:
+            command['alert'] = 'none'
 
         if self.is_group:
             await self.light.set_action(**command)

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -640,7 +640,6 @@ async def test_light_turn_on_service(hass, mock_bridge):
         'bri': 100,
         'on': True,
         'ct': 300,
-        'effect': 'none',
         'alert': 'none',
     }
 
@@ -661,7 +660,6 @@ async def test_light_turn_on_service(hass, mock_bridge):
     assert mock_bridge.mock_requests[3]['json'] == {
         'on': True,
         'xy': (0.138, 0.08),
-        'effect': 'none',
         'alert': 'none',
     }
 


### PR DESCRIPTION
## Description:
It's not possible to get rid off effects if your bulb is not from philips.
This is tested with OSRAM bulbs.

I don't now why the current code checks for is_philips.
With this PR the implementation is comparable to deconz.

**Related issue (if applicable):** fixes #22356

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. 
  - [x] There is no commented out code in this PR.


[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
