### PR TITLE
Add yeelight nightlight support via separate light entity

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -192,13 +192,13 @@ class YeelightDevice:
         import yeelight
         if self._bulb_device is None:
             try:
-                self._bulb_device = yeelight.Bulb(self._ipaddr,
+                self._bulb_device = yeelight.Bulb(self.ipaddr,
                                                   model=self._model)
                 self._available = True
             except yeelight.BulbException as ex:
                 self._available = False
                 _LOGGER.error("Failed to connect to bulb %s, %s: %s",
-                              self._ipaddr, self._name, ex)
+                              self.ipaddr, self.name, ex)
                 self._available = False
 
         return self._bulb_device

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -13,7 +13,8 @@ from homeassistant.components.binary_sensor import DOMAIN as \
 from homeassistant.helpers import discovery
 from homeassistant.helpers.discovery import load_platform
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import dispatcher_send, dispatcher_connect
+from homeassistant.helpers.dispatcher import dispatcher_send, \
+    dispatcher_connect
 from homeassistant.helpers.event import track_time_interval
 
 REQUIREMENTS = ['yeelight==0.4.4']

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -35,6 +35,7 @@ CONF_SAVE_ON_CHANGE = 'save_on_change'
 CONF_MODE_MUSIC = 'use_music_mode'
 CONF_FLOW_PARAMS = 'flow_params'
 CONF_CUSTOM_EFFECTS = 'custom_effects'
+CONF_NIGHTLIGHT_SWITCH_TYPE = 'nightlight_switch_type'
 
 ATTR_COUNT = 'count'
 ATTR_ACTION = 'action'
@@ -43,6 +44,8 @@ ATTR_TRANSITIONS = 'transitions'
 ACTION_RECOVER = 'recover'
 ACTION_STAY = 'stay'
 ACTION_OFF = 'off'
+
+NIGHTLIGHT_SWITCH_TYPE_LIGHT = 'light'
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
@@ -78,6 +81,8 @@ DEVICE_SCHEMA = vol.Schema({
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+        vol.Optional(CONF_NIGHTLIGHT_SWITCH_TYPE):
+            vol.Any(NIGHTLIGHT_SWITCH_TYPE_LIGHT),
         vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
             cv.time_period,
         vol.Optional(CONF_CUSTOM_EFFECTS): [{
@@ -146,6 +151,8 @@ def setup(hass, config):
     def load_platforms(ipaddr):
         platform_config = hass.data[DATA_YEELIGHT][ipaddr].config.copy()
         platform_config[CONF_HOST] = ipaddr
+        platform_config[CONF_NIGHTLIGHT_SWITCH_TYPE] = \
+            config.get(DOMAIN, {}).get(CONF_NIGHTLIGHT_SWITCH_TYPE, None)
         platform_config[CONF_CUSTOM_EFFECTS] = \
             config.get(DOMAIN, {}).get(CONF_CUSTOM_EFFECTS, {})
         load_platform(hass, LIGHT_DOMAIN, DOMAIN, platform_config, config)
@@ -239,6 +246,7 @@ class YeelightDevice:
 
     @property
     def type(self):
+        """Return bulb type."""
         return self.bulb.bulb_type
 
     def turn_on(self, duration=DEFAULT_TRANSITION, light_type=None,

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -158,14 +158,13 @@ def _setup_device(hass, hass_config, ipaddr, device_config):
     device = YeelightDevice(hass, ipaddr, device_config)
 
     devices[ipaddr] = device
-
     platform_config = device_config.copy()
     platform_config[CONF_HOST] = ipaddr
     platform_config[CONF_CUSTOM_EFFECTS] = \
         hass_config.get(DOMAIN, {}).get(CONF_CUSTOM_EFFECTS, {})
 
     def setup_platforms():
-        device.update()
+        device.setup()
         load_platform(hass, LIGHT_DOMAIN, DOMAIN, platform_config, hass_config)
         load_platform(hass, BINARY_SENSOR_DOMAIN, DOMAIN, platform_config,
                       hass_config)
@@ -189,19 +188,18 @@ class YeelightDevice:
     @property
     def bulb(self):
         """Return bulb device."""
-        import yeelight
-        if self._bulb_device is None:
-            try:
-                self._bulb_device = yeelight.Bulb(self.ipaddr,
-                                                  model=self._model)
-                self._available = True
-            except yeelight.BulbException as ex:
-                self._available = False
-                _LOGGER.error("Failed to connect to bulb %s, %s: %s",
-                              self.ipaddr, self.name, ex)
-                self._available = False
-
         return self._bulb_device
+
+    def setup(self):
+        import yeelight
+        try:
+            self._bulb_device = yeelight.Bulb(self.ipaddr, model=self._model)
+            self._bulb_device.get_properties(UPDATE_REQUEST_PROPERTIES)
+            self._available = True
+        except yeelight.BulbException as ex:
+            self._available = False
+            _LOGGER.error("Failed to connect to bulb %s, %s: %s",
+                          self.ipaddr, self.name, ex)
 
     @property
     def name(self):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -224,7 +224,7 @@ class YeelightGenericLight(Light):
     @callback
     def _schedule_immediate_update(self, ipaddr):
         if ipaddr == self.device.ipaddr:
-            self.async_schedule_update_ha_state(True)
+            self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -124,6 +124,7 @@ def _cmd(func):
 
     return _wrap
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Yeelight bulbs."""
     from yeelight.enums import PowerMode, BulbType
@@ -142,6 +143,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     custom_effects = _parse_custom_effects(discovery_info[CONF_CUSTOM_EFFECTS])
 
     lights = []
+
     def _klass_setup_helper(klass):
         lights.append(klass(device, custom_effects=custom_effects))
 
@@ -631,6 +633,7 @@ class YeelightGenericLight(Light):
         except yeelight.BulbException as ex:
             _LOGGER.error("Unable to set effect: %s", ex)
 
+
 class YeelightColorLight(YeelightGenericLight):
     """Representation of a Color Yeelight light."""
 
@@ -638,6 +641,7 @@ class YeelightColorLight(YeelightGenericLight):
     def supported_features(self) -> int:
         """Flag supported features."""
         return SUPPORT_YEELIGHT_RGB
+
 
 class YeelightWhiteTempLight(YeelightGenericLight):
     """Representation of a Color Yeelight light."""

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -115,6 +115,7 @@ def _parse_custom_effects(effects_config):
 
 def _cmd(func):
     """Define a wrapper to catch exceptions from the bulb."""
+
     def _wrap(self, *args, **kwargs):
         import yeelight
         try:
@@ -142,6 +143,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     _LOGGER.debug("Adding %s", device.name)
 
     custom_effects = _parse_custom_effects(discovery_info[CONF_CUSTOM_EFFECTS])
+    nl_switch_light = discovery_info[CONF_NIGHTLIGHT_SWITCH_TYPE] == \
+        NIGHTLIGHT_SWITCH_TYPE_LIGHT
 
     lights = []
 
@@ -153,15 +156,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     elif device.type == BulbType.Color:
         _lights_setup_helper(YeelightColorLight)
     elif device.type == BulbType.WhiteTemp:
-        if discovery_info[CONF_NIGHTLIGHT_SWITCH_TYPE] == \
-                NIGHTLIGHT_SWITCH_TYPE_LIGHT and device.is_nightlight_supported:
+        if nl_switch_light and device.is_nightlight_supported:
             _lights_setup_helper(YeelightWithNightLight)
             _lights_setup_helper(YeelightNightLightMode)
         else:
             _lights_setup_helper(YeelightWhiteTempLight)
     elif device.type == BulbType.WhiteTempMood:
-        if discovery_info[CONF_NIGHTLIGHT_SWITCH_TYPE] == \
-                NIGHTLIGHT_SWITCH_TYPE_LIGHT:
+        if nl_switch_light:
             _lights_setup_helper(YeelightNightLightMode)
             _lights_setup_helper(YeelightWithAmbientAndNightlight)
         else:
@@ -651,7 +652,7 @@ class YeelightWithAmbientWithoutNightlight(YeelightWithAmbientLightSupport,
                                            YeelightWhiteTempLight):
     """
     Representation of a Yeelight which has ambilight support but no
-    nightlight support. Its used when nightlight switch type is none
+    nightlight support. Its used when nightlight switch type is none.
     """
 
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -315,7 +315,7 @@ class YeelightGenericLight(Light):
         return self._properties.get(prop, default)
 
     @property
-    def _bright_property(self):
+    def _brightness_property(self):
         return 'bright'
 
     @property
@@ -652,7 +652,7 @@ class YeelightWithNightLight(YeelightWhiteTempLight):
         return self.device.is_nightlight_enabled
 
     def update(self) -> None:
-        bright = self._get_property(self._bright_property)
+        bright = self._get_property(self._brightness_property)
         if bright:
             self._brightness = round(255 * (int(bright) / 100))
 
@@ -683,7 +683,7 @@ class YeelightNightLightMode(YeelightGenericLight):
         return super().is_on and self.device.is_nightlight_enabled
 
     @property
-    def _bright_property(self):
+    def _brightness_property(self):
         return 'nl_br'
 
     @property

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -124,7 +124,6 @@ def _cmd(func):
 
     return _wrap
 
-
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Yeelight bulbs."""
     from yeelight.enums import PowerMode, BulbType
@@ -143,20 +142,23 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     custom_effects = _parse_custom_effects(discovery_info[CONF_CUSTOM_EFFECTS])
 
     lights = []
+    def _klass_setup_helper(klass):
+        lights.append(klass(device, custom_effects=custom_effects))
+
     if device.type == BulbType.White:
-        lights.append(YeelightGenericLight(device, custom_effects=custom_effects))
+        _klass_setup_helper(YeelightGenericLight)
     elif device.type == BulbType.Color:
-        lights.append(YeelightColorLight(device, custom_effects=custom_effects))
+        _klass_setup_helper(YeelightColorLight)
     elif device.type == BulbType.WhiteTemp:
         if device.is_nightlight_supported:
-            lights.append(YeelightWithNightLight(device, custom_effects=custom_effects))
-            lights.append(YeelightNightLightMode(device, custom_effects=custom_effects))
+            _klass_setup_helper(YeelightWithNightLight)
+            _klass_setup_helper(YeelightNightLightMode)
         else:
-            lights.append(YeelightWhiteTempLight(device, custom_effects=custom_effects))
+            _klass_setup_helper(YeelightWhiteTempLight)
     elif device.type == BulbType.WhiteTempMood:
-        lights.append(YeelightWithAmbientLight(device, custom_effects=custom_effects))
-        lights.append(YeelightNightLightMode(device, custom_effects=custom_effects))
-        lights.append(YeelightAmbientLight(device, custom_effects=custom_effects))
+        _klass_setup_helper(YeelightWithAmbientLight)
+        _klass_setup_helper(YeelightNightLightMode)
+        _klass_setup_helper(YeelightAmbientLight)
     else:
         _LOGGER.error("Cannot determinate device type for %s, %s",
                       device.ipaddr, device._name)

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -163,7 +163,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _klass_setup_helper(YeelightAmbientLight)
     else:
         _LOGGER.error("Cannot determinate device type for %s, %s",
-                      device.ipaddr, device._name)
+                      device.ipaddr, device.name)
 
     hass.data[data_key] += lights
     add_entities(lights, True)

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -115,7 +115,6 @@ def _parse_custom_effects(effects_config):
 
 def _cmd(func):
     """Define a wrapper to catch exceptions from the bulb."""
-
     def _wrap(self, *args, **kwargs):
         import yeelight
         try:
@@ -650,16 +649,15 @@ class YeelightWithAmbientLightSupport(YeelightGenericLight):
 
 class YeelightWithAmbientWithoutNightlight(YeelightWithAmbientLightSupport,
                                            YeelightWhiteTempLight):
-    """
-    Representation of a Yeelight which has ambilight support but no
+    """Representation of a Yeelight which has ambilight support but no
     nightlight support. Its used when nightlight switch type is none.
+
     """
 
 
 class YeelightWithAmbientAndNightlight(YeelightWithAmbientLightSupport,
                                        YeelightWithNightLight):
-    """
-    Representation of a Yeelight which has ambilight support and nightlight
+    """Representation of a Yeelight which has ambilight support and nightlight
     switch type is set to light.
     """
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -31,8 +31,7 @@ SUPPORT_YEELIGHT = (SUPPORT_BRIGHTNESS |
                     SUPPORT_FLASH)
 
 SUPPORT_YEELIGHT_WHITE_TEMP = (SUPPORT_YEELIGHT |
-                               SUPPORT_COLOR_TEMP |
-                               SUPPORT_EFFECT)
+                               SUPPORT_COLOR_TEMP)
 
 SUPPORT_YEELIGHT_RGB = (SUPPORT_YEELIGHT |
                         SUPPORT_COLOR |

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -31,7 +31,8 @@ SUPPORT_YEELIGHT = (SUPPORT_BRIGHTNESS |
                     SUPPORT_FLASH)
 
 SUPPORT_YEELIGHT_WHITE_TEMP = (SUPPORT_YEELIGHT |
-                               SUPPORT_COLOR_TEMP)
+                               SUPPORT_COLOR_TEMP |
+                               SUPPORT_EFFECT)
 
 SUPPORT_YEELIGHT_RGB = (SUPPORT_YEELIGHT |
                         SUPPORT_COLOR |
@@ -144,23 +145,23 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     lights = []
 
-    def _klass_setup_helper(klass):
+    def _lights_setup_helper(klass):
         lights.append(klass(device, custom_effects=custom_effects))
 
     if device.type == BulbType.White:
-        _klass_setup_helper(YeelightGenericLight)
+        _lights_setup_helper(YeelightGenericLight)
     elif device.type == BulbType.Color:
-        _klass_setup_helper(YeelightColorLight)
+        _lights_setup_helper(YeelightColorLight)
     elif device.type == BulbType.WhiteTemp:
         if device.is_nightlight_supported:
-            _klass_setup_helper(YeelightWithNightLight)
-            _klass_setup_helper(YeelightNightLightMode)
+            _lights_setup_helper(YeelightWithNightLight)
+            _lights_setup_helper(YeelightNightLightMode)
         else:
-            _klass_setup_helper(YeelightWhiteTempLight)
+            _lights_setup_helper(YeelightWhiteTempLight)
     elif device.type == BulbType.WhiteTempMood:
-        _klass_setup_helper(YeelightWithAmbientLight)
-        _klass_setup_helper(YeelightNightLightMode)
-        _klass_setup_helper(YeelightAmbientLight)
+        _lights_setup_helper(YeelightWithAmbientLight)
+        _lights_setup_helper(YeelightNightLightMode)
+        _lights_setup_helper(YeelightAmbientLight)
     else:
         _LOGGER.error("Cannot determinate device type for %s, %s",
                       device.ipaddr, device.name)


### PR DESCRIPTION
## Description:
Added option to create separate light entity, for better nightlight mode switch UX. By default option is off, so its opt in.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
yeelight:
  devices:
    192.168.1.132:
      name: Wall light bedroom
  nightlight_switch_type: light
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)