### PR TITLE
Add multi-board and initial_state support for PiFace Digital2

### DIFF
--- a/homeassistant/components/rpi_pfio/__init__.py
+++ b/homeassistant/components/rpi_pfio/__init__.py
@@ -12,13 +12,19 @@ DOMAIN = 'rpi_pfio'
 
 DATA_PFIO_LISTENER = 'pfio_listener'
 
+BOARD_ADDRESSES = [0,1,2,3]
 
 def setup(hass, config):
     """Set up the Raspberry PI PFIO component."""
     import pifacedigitalio as PFIO
-
-    pifacedigital = PFIO.PiFaceDigital()
-    hass.data[DATA_PFIO_LISTENER] = PFIO.InputEventListener(chip=pifacedigital)
+    pifacedigital={}
+    hass.data[DATA_PFIO_LISTENER]={}
+    for address in BOARD_ADDRESSES:
+        try:
+            pifacedigital[address] = PFIO.PiFaceDigital(address)
+            hass.data[DATA_PFIO_LISTENER][address] = PFIO.InputEventListener(chip=pifacedigital[address])
+        except:
+            pass
 
     def cleanup_pfio(event):
         """Stuff to do before stopping."""
@@ -34,25 +40,26 @@ def setup(hass, config):
     return True
 
 
-def write_output(port, value):
+def write_output(port, value, hardware_addr=0):
     """Write a value to a PFIO."""
     import pifacedigitalio as PFIO
-    PFIO.digital_write(port, value)
+    PFIO.digital_write(port, value, hardware_addr)
 
 
-def read_input(port):
+def read_input(port, hardware_addr=0):
     """Read a value from a PFIO."""
     import pifacedigitalio as PFIO
-    return PFIO.digital_read(port)
+    return PFIO.digital_read(port, hardware_addr)
 
 
-def edge_detect(hass, port, event_callback, settle):
+def edge_detect(hass, port, event_callback, settle, hardware_addr=0):
     """Add detection for RISING and FALLING events."""
     import pifacedigitalio as PFIO
-    hass.data[DATA_PFIO_LISTENER].register(
+    hass.data[DATA_PFIO_LISTENER][hardware_addr].register(
         port, PFIO.IODIR_BOTH, event_callback, settle_time=settle)
 
 
 def activate_listener(hass):
     """Activate the registered listener events."""
-    hass.data[DATA_PFIO_LISTENER].activate()
+    for address in hass.data[DATA_PFIO_LISTENER]:
+        hass.data[DATA_PFIO_LISTENER][address].activate()

--- a/homeassistant/components/rpi_pfio/binary_sensor.py
+++ b/homeassistant/components/rpi_pfio/binary_sensor.py
@@ -15,6 +15,8 @@ CONF_INVERT_LOGIC = 'invert_logic'
 CONF_PORTS = 'ports'
 CONF_SETTLE_TIME = 'settle_time'
 
+CONF_BOARDS = 'boards'
+
 DEFAULT_INVERT_LOGIC = False
 DEFAULT_SETTLE_TIME = 20
 
@@ -27,9 +29,15 @@ PORT_SCHEMA = vol.Schema({
     vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
 })
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+BOARD_SCHEMA = vol.Schema({
     vol.Optional(CONF_PORTS, default={}): vol.Schema({
         cv.positive_int: PORT_SCHEMA,
+    })
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_BOARDS, default={}): vol.Schema({
+        cv.positive_int: BOARD_SCHEMA,
     })
 })
 
@@ -37,35 +45,37 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the PiFace Digital Input devices."""
     binary_sensors = []
-    ports = config.get(CONF_PORTS)
-    for port, port_entity in ports.items():
-        name = port_entity.get(CONF_NAME)
-        settle_time = port_entity[CONF_SETTLE_TIME] / 1000
-        invert_logic = port_entity[CONF_INVERT_LOGIC]
+    boards = config.get(CONF_BOARDS)
+    for board, board_entity in boards.items():
+        ports = board_entity.get(CONF_PORTS)
+        for port, port_entity in ports.items():
+            name = port_entity.get(CONF_NAME)
+            settle_time = port_entity[CONF_SETTLE_TIME] / 1000
+            invert_logic = port_entity[CONF_INVERT_LOGIC]
 
-        binary_sensors.append(RPiPFIOBinarySensor(
-            hass, port, name, settle_time, invert_logic))
-    add_entities(binary_sensors, True)
+            binary_sensors.append(RPiPFIOBinarySensor(
+                hass, port, name, settle_time, invert_logic, board))
+        add_entities(binary_sensors, True)
 
-    rpi_pfio.activate_listener(hass)
+        rpi_pfio.activate_listener(hass)
 
 
 class RPiPFIOBinarySensor(BinarySensorDevice):
     """Represent a binary sensor that a PiFace Digital Input."""
 
-    def __init__(self, hass, port, name, settle_time, invert_logic):
+    def __init__(self, hass, port, name, settle_time, invert_logic, hardware_addr=0):
         """Initialize the RPi binary sensor."""
         self._port = port
         self._name = name or DEVICE_DEFAULT_NAME
         self._invert_logic = invert_logic
+        self._hardware_addr = hardware_addr
         self._state = None
 
-        def read_pfio(port):
+        def read_pfio(port, hardware_addr=0):
             """Read state from PFIO."""
-            self._state = rpi_pfio.read_input(self._port)
+            self._state = rpi_pfio.read_input(self._port, self._hardware_addr)
             self.schedule_update_ha_state()
-
-        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time)
+        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time, self._hardware_addr)
 
     @property
     def should_poll(self):
@@ -82,6 +92,11 @@ class RPiPFIOBinarySensor(BinarySensorDevice):
         """Return the state of the entity."""
         return self._state != self._invert_logic
 
+    @property
+    def hardware_addr(self):
+        """Return the hardware address."""
+        return self._hardware_addr
+
     def update(self):
         """Update the PFIO state."""
-        self._state = rpi_pfio.read_input(self._port)
+        self._state = rpi_pfio.read_input(self._port, self._hardware_addr)


### PR DESCRIPTION
## Breaking Change:
Because of a multi-board support the structure of piface switch's and binary_sensor's configuration is changing from:
```
  - platform: rpi_pfio                                                                                                                                                                                                                                                         
    ports:                                                                                                                                                                                                                                                                 
      0:
```
to:
```
  - platform: rpi_pfio                                                                                                                                                                                                                                                         
    boards:                                                                                                                                                                                                                                                                    
      0:                                                                                                                                                                                                                                                                       
        ports:                                                                                                                                                                                                                                                                 
          0:
```
## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9160

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
 - platform: rpi_pfio
    boards:
      0:
        ports:
          0:
            name: Garage door
            invert_logic: true
            initial_state: off

binary_sensor:
  - platform: rpi_pfio
    boards:
      0:
        ports:
          7:
            name: Garage door
            settle_time: 63
            invert_logic: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
