### PR TITLE
Add multi-board and initial_state support for PiFace Digital2 board

### DIFF
--- a/homeassistant/components/rpi_pfio/__init__.py
+++ b/homeassistant/components/rpi_pfio/__init__.py
@@ -12,13 +12,19 @@ DOMAIN = 'rpi_pfio'
 
 DATA_PFIO_LISTENER = 'pfio_listener'
 
+BOARD_ADDRESSES = [0,1,2,3]
 
 def setup(hass, config):
     """Set up the Raspberry PI PFIO component."""
     import pifacedigitalio as PFIO
-
-    pifacedigital = PFIO.PiFaceDigital()
-    hass.data[DATA_PFIO_LISTENER] = PFIO.InputEventListener(chip=pifacedigital)
+    pifacedigital={}
+    hass.data[DATA_PFIO_LISTENER]={}
+    for address in BOARD_ADDRESSES:
+        try:
+            pifacedigital[address] = PFIO.PiFaceDigital(address)
+            hass.data[DATA_PFIO_LISTENER][address] = PFIO.InputEventListener(chip=pifacedigital[address])
+        except:
+            pass
 
     def cleanup_pfio(event):
         """Stuff to do before stopping."""
@@ -34,25 +40,26 @@ def setup(hass, config):
     return True
 
 
-def write_output(port, value):
+def write_output(port, value, hardware_addr=0):
     """Write a value to a PFIO."""
     import pifacedigitalio as PFIO
-    PFIO.digital_write(port, value)
+    PFIO.digital_write(port, value, hardware_addr)
 
 
-def read_input(port):
+def read_input(port, hardware_addr=0):
     """Read a value from a PFIO."""
     import pifacedigitalio as PFIO
-    return PFIO.digital_read(port)
+    return PFIO.digital_read(port, hardware_addr)
 
 
-def edge_detect(hass, port, event_callback, settle):
+def edge_detect(hass, port, event_callback, settle, hardware_addr=0):
     """Add detection for RISING and FALLING events."""
     import pifacedigitalio as PFIO
-    hass.data[DATA_PFIO_LISTENER].register(
+    hass.data[DATA_PFIO_LISTENER][hardware_addr].register(
         port, PFIO.IODIR_BOTH, event_callback, settle_time=settle)
 
 
 def activate_listener(hass):
     """Activate the registered listener events."""
-    hass.data[DATA_PFIO_LISTENER].activate()
+    for address in hass.data[DATA_PFIO_LISTENER]:
+        hass.data[DATA_PFIO_LISTENER][address].activate()

--- a/homeassistant/components/rpi_pfio/__init__.py
+++ b/homeassistant/components/rpi_pfio/__init__.py
@@ -12,18 +12,20 @@ DOMAIN = 'rpi_pfio'
 
 DATA_PFIO_LISTENER = 'pfio_listener'
 
-BOARD_ADDRESSES = [0,1,2,3]
+BOARD_ADDRESSES = [0, 1, 2, 3]
+
 
 def setup(hass, config):
     """Set up the Raspberry PI PFIO component."""
     import pifacedigitalio as PFIO
-    pifacedigital={}
-    hass.data[DATA_PFIO_LISTENER]={}
+    pifacedigital = {}
+    hass.data[DATA_PFIO_LISTENER] = {}
     for address in BOARD_ADDRESSES:
         try:
             pifacedigital[address] = PFIO.PiFaceDigital(address)
-            hass.data[DATA_PFIO_LISTENER][address] = PFIO.InputEventListener(chip=pifacedigital[address])
-        except:
+            hass.data[DATA_PFIO_LISTENER][address] = PFIO.InputEventListener(
+                    chip=pifacedigital[address])
+        except PFIO.core.NoPiFaceDigitalDetectedError:
             pass
 
     def cleanup_pfio(event):

--- a/homeassistant/components/rpi_pfio/__init__.py
+++ b/homeassistant/components/rpi_pfio/__init__.py
@@ -24,7 +24,7 @@ def setup(hass, config):
         try:
             pifacedigital[address] = PFIO.PiFaceDigital(address)
             hass.data[DATA_PFIO_LISTENER][address] = PFIO.InputEventListener(
-                    chip=pifacedigital[address])
+                chip=pifacedigital[address])
         except PFIO.core.NoPiFaceDigitalDetectedError:
             pass
 

--- a/homeassistant/components/rpi_pfio/binary_sensor.py
+++ b/homeassistant/components/rpi_pfio/binary_sensor.py
@@ -55,9 +55,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
             binary_sensors.append(RPiPFIOBinarySensor(
                 hass, port, name, settle_time, invert_logic, board))
-        add_entities(binary_sensors, True)
 
-        rpi_pfio.activate_listener(hass)
+    add_entities(binary_sensors, True)
+    rpi_pfio.activate_listener(hass)
 
 
 class RPiPFIOBinarySensor(BinarySensorDevice):

--- a/homeassistant/components/rpi_pfio/binary_sensor.py
+++ b/homeassistant/components/rpi_pfio/binary_sensor.py
@@ -63,7 +63,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class RPiPFIOBinarySensor(BinarySensorDevice):
     """Represent a binary sensor that a PiFace Digital Input."""
 
-    def __init__(self, hass, port, name, settle_time, invert_logic, hardware_addr=0):
+    def __init__(self, hass, port, name, settle_time, invert_logic,
+            hardware_addr=0):
         """Initialize the RPi binary sensor."""
         self._port = port
         self._name = name or DEVICE_DEFAULT_NAME
@@ -75,7 +76,8 @@ class RPiPFIOBinarySensor(BinarySensorDevice):
             """Read state from PFIO."""
             self._state = rpi_pfio.read_input(self._port, self._hardware_addr)
             self.schedule_update_ha_state()
-        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time, self._hardware_addr)
+        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time,
+                self._hardware_addr)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/rpi_pfio/binary_sensor.py
+++ b/homeassistant/components/rpi_pfio/binary_sensor.py
@@ -64,7 +64,7 @@ class RPiPFIOBinarySensor(BinarySensorDevice):
     """Represent a binary sensor that a PiFace Digital Input."""
 
     def __init__(self, hass, port, name, settle_time, invert_logic,
-            hardware_addr=0):
+                 hardware_addr=0):
         """Initialize the RPi binary sensor."""
         self._port = port
         self._name = name or DEVICE_DEFAULT_NAME
@@ -77,7 +77,7 @@ class RPiPFIOBinarySensor(BinarySensorDevice):
             self._state = rpi_pfio.read_input(self._port, self._hardware_addr)
             self.schedule_update_ha_state()
         rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time,
-                self._hardware_addr)
+                             self._hardware_addr)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/rpi_pfio/binary_sensor.py
+++ b/homeassistant/components/rpi_pfio/binary_sensor.py
@@ -15,6 +15,8 @@ CONF_INVERT_LOGIC = 'invert_logic'
 CONF_PORTS = 'ports'
 CONF_SETTLE_TIME = 'settle_time'
 
+CONF_BOARDS = 'boards'
+
 DEFAULT_INVERT_LOGIC = False
 DEFAULT_SETTLE_TIME = 20
 
@@ -27,9 +29,15 @@ PORT_SCHEMA = vol.Schema({
     vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
 })
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+BOARD_SCHEMA = vol.Schema({
     vol.Optional(CONF_PORTS, default={}): vol.Schema({
         cv.positive_int: PORT_SCHEMA,
+    })
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_BOARDS, default={}): vol.Schema({
+        cv.positive_int: BOARD_SCHEMA,
     })
 })
 
@@ -37,35 +45,37 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the PiFace Digital Input devices."""
     binary_sensors = []
-    ports = config.get(CONF_PORTS)
-    for port, port_entity in ports.items():
-        name = port_entity.get(CONF_NAME)
-        settle_time = port_entity[CONF_SETTLE_TIME] / 1000
-        invert_logic = port_entity[CONF_INVERT_LOGIC]
+    boards = config.get(CONF_BOARDS)
+    for board, board_entity in boards.items():
+        ports = board_entity.get(CONF_PORTS)
+        for port, port_entity in ports.items():
+            name = port_entity.get(CONF_NAME)
+            settle_time = port_entity[CONF_SETTLE_TIME] / 1000
+            invert_logic = port_entity[CONF_INVERT_LOGIC]
 
-        binary_sensors.append(RPiPFIOBinarySensor(
-            hass, port, name, settle_time, invert_logic))
-    add_entities(binary_sensors, True)
+            binary_sensors.append(RPiPFIOBinarySensor(
+                hass, port, name, settle_time, invert_logic, board))
+        add_entities(binary_sensors, True)
 
-    rpi_pfio.activate_listener(hass)
+        rpi_pfio.activate_listener(hass)
 
 
 class RPiPFIOBinarySensor(BinarySensorDevice):
     """Represent a binary sensor that a PiFace Digital Input."""
 
-    def __init__(self, hass, port, name, settle_time, invert_logic):
+    def __init__(self, hass, port, name, settle_time, invert_logic, hardware_addr=0):
         """Initialize the RPi binary sensor."""
         self._port = port
         self._name = name or DEVICE_DEFAULT_NAME
         self._invert_logic = invert_logic
+        self._hardware_addr = hardware_addr
         self._state = None
 
-        def read_pfio(port):
+        def read_pfio(port, hardware_addr=0):
             """Read state from PFIO."""
-            self._state = rpi_pfio.read_input(self._port)
+            self._state = rpi_pfio.read_input(self._port, self._hardware_addr)
             self.schedule_update_ha_state()
-
-        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time)
+        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time, self._hardware_addr)
 
     @property
     def should_poll(self):
@@ -82,6 +92,11 @@ class RPiPFIOBinarySensor(BinarySensorDevice):
         """Return the state of the entity."""
         return self._state != self._invert_logic
 
+    @property
+    def hardware_addr(self):
+        """Return the hardware address."""
+        return self._hardware_addr
+
     def update(self):
         """Update the PFIO state."""
-        self._state = rpi_pfio.read_input(self._port)
+        self._state = rpi_pfio.read_input(self._port, self._hardware_addr)

--- a/homeassistant/components/rpi_pfio/switch.py
+++ b/homeassistant/components/rpi_pfio/switch.py
@@ -55,7 +55,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             initial_state = port_entity[ATTR_INITIAL_STATE]
             switches.append(RPiPFIOSwitch(port, name, invert_logic,
                                           initial_state, board))
-        add_entities(switches)
+    add_entities(switches)
 
 
 class RPiPFIOSwitch(ToggleEntity):

--- a/homeassistant/components/rpi_pfio/switch.py
+++ b/homeassistant/components/rpi_pfio/switch.py
@@ -26,7 +26,7 @@ DEFAULT_INITIAL_STATE = False
 PORT_SCHEMA = vol.Schema({
     vol.Optional(ATTR_NAME): cv.string,
     vol.Optional(ATTR_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
-    vol.Optional(ATTR_INITIAL_STATE, default=DEFAULT_INITIAL_STATE): 
+    vol.Optional(ATTR_INITIAL_STATE, default=DEFAULT_INITIAL_STATE):
         cv.boolean,
 })
 
@@ -53,8 +53,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             name = port_entity.get(ATTR_NAME)
             invert_logic = port_entity[ATTR_INVERT_LOGIC]
             initial_state = port_entity[ATTR_INITIAL_STATE]
-            switches.append(RPiPFIOSwitch(port, name, invert_logic, 
-                initial_state, board))
+            switches.append(RPiPFIOSwitch(port, name, invert_logic,
+                            initial_state, board))
         add_entities(switches)
 
 
@@ -62,7 +62,7 @@ class RPiPFIOSwitch(ToggleEntity):
     """Representation of a PiFace Digital Output."""
 
     def __init__(self, port, name, invert_logic, initial_state,
-            hardware_addr=0):
+                 hardware_addr=0):
         """Initialize the pin."""
         self._port = port
         self._name = name or DEVICE_DEFAULT_NAME
@@ -99,13 +99,13 @@ class RPiPFIOSwitch(ToggleEntity):
     def turn_on(self, **kwargs):
         """Turn the device on."""
         rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1,
-                self._hardware_addr)
+                              self._hardware_addr)
         self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0,
-                self._hardware_addr)
+                              self._hardware_addr)
         self._state = False
         self.schedule_update_ha_state()

--- a/homeassistant/components/rpi_pfio/switch.py
+++ b/homeassistant/components/rpi_pfio/switch.py
@@ -54,7 +54,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             invert_logic = port_entity[ATTR_INVERT_LOGIC]
             initial_state = port_entity[ATTR_INITIAL_STATE]
             switches.append(RPiPFIOSwitch(port, name, invert_logic,
-                            initial_state, board))
+                                          initial_state, board))
         add_entities(switches)
 
 

--- a/homeassistant/components/rpi_pfio/switch.py
+++ b/homeassistant/components/rpi_pfio/switch.py
@@ -26,7 +26,8 @@ DEFAULT_INITIAL_STATE = False
 PORT_SCHEMA = vol.Schema({
     vol.Optional(ATTR_NAME): cv.string,
     vol.Optional(ATTR_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
-    vol.Optional(ATTR_INITIAL_STATE, default=DEFAULT_INITIAL_STATE): cv.boolean,
+    vol.Optional(ATTR_INITIAL_STATE, default=DEFAULT_INITIAL_STATE): 
+        cv.boolean,
 })
 
 BOARD_SCHEMA = vol.Schema({
@@ -52,14 +53,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             name = port_entity.get(ATTR_NAME)
             invert_logic = port_entity[ATTR_INVERT_LOGIC]
             initial_state = port_entity[ATTR_INITIAL_STATE]
-            switches.append(RPiPFIOSwitch(port, name, invert_logic, initial_state, board))
+            switches.append(RPiPFIOSwitch(port, name, invert_logic, 
+                initial_state, board))
         add_entities(switches)
 
 
 class RPiPFIOSwitch(ToggleEntity):
     """Representation of a PiFace Digital Output."""
 
-    def __init__(self, port, name, invert_logic, initial_state, hardware_addr=0):
+    def __init__(self, port, name, invert_logic, initial_state,
+            hardware_addr=0):
         """Initialize the pin."""
         self._port = port
         self._name = name or DEVICE_DEFAULT_NAME
@@ -71,7 +74,7 @@ class RPiPFIOSwitch(ToggleEntity):
             state_to_set = 0
         else:
             state_to_set = 1
-        rpi_pfio.write_output(self._port, state_to_set , self._hardware_addr)
+        rpi_pfio.write_output(self._port, state_to_set, self._hardware_addr)
 
     @property
     def name(self):
@@ -95,12 +98,14 @@ class RPiPFIOSwitch(ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1, self._hardware_addr)
+        rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1,
+                self._hardware_addr)
         self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0, self._hardware_addr)
+        rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0,
+                self._hardware_addr)
         self._state = False
         self.schedule_update_ha_state()

--- a/homeassistant/components/rpi_pfio/switch.py
+++ b/homeassistant/components/rpi_pfio/switch.py
@@ -14,19 +14,30 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['rpi_pfio']
 
 ATTR_INVERT_LOGIC = 'invert_logic'
+ATTR_INITIAL_STATE = "initial_state"
 
 CONF_PORTS = 'ports'
 
+CONF_BOARDS = 'boards'
+
 DEFAULT_INVERT_LOGIC = False
+DEFAULT_INITIAL_STATE = False
 
 PORT_SCHEMA = vol.Schema({
     vol.Optional(ATTR_NAME): cv.string,
     vol.Optional(ATTR_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+    vol.Optional(ATTR_INITIAL_STATE, default=DEFAULT_INITIAL_STATE): cv.boolean,
+})
+
+BOARD_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PORTS, default={}): vol.Schema({
+        cv.positive_int: PORT_SCHEMA,
+    })
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_PORTS, default={}): vol.Schema({
-        cv.positive_int: PORT_SCHEMA,
+    vol.Optional(CONF_BOARDS, default={}): vol.Schema({
+        cv.positive_int: BOARD_SCHEMA,
     })
 })
 
@@ -34,25 +45,33 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the PiFace Digital Output devices."""
     switches = []
-    ports = config.get(CONF_PORTS)
-    for port, port_entity in ports.items():
-        name = port_entity.get(ATTR_NAME)
-        invert_logic = port_entity[ATTR_INVERT_LOGIC]
-
-        switches.append(RPiPFIOSwitch(port, name, invert_logic))
-    add_entities(switches)
+    boards = config.get(CONF_BOARDS)
+    for board, board_entity in boards.items():
+        ports = board_entity.get(CONF_PORTS)
+        for port, port_entity in ports.items():
+            name = port_entity.get(ATTR_NAME)
+            invert_logic = port_entity[ATTR_INVERT_LOGIC]
+            initial_state = port_entity[ATTR_INITIAL_STATE]
+            switches.append(RPiPFIOSwitch(port, name, invert_logic, initial_state, board))
+        add_entities(switches)
 
 
 class RPiPFIOSwitch(ToggleEntity):
     """Representation of a PiFace Digital Output."""
 
-    def __init__(self, port, name, invert_logic):
+    def __init__(self, port, name, invert_logic, initial_state, hardware_addr=0):
         """Initialize the pin."""
         self._port = port
         self._name = name or DEVICE_DEFAULT_NAME
         self._invert_logic = invert_logic
-        self._state = False
-        rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0)
+        self._initial_state = initial_state
+        self._hardware_addr = hardware_addr
+        self._state = initial_state
+        if self._invert_logic == self._initial_state:
+            state_to_set = 0
+        else:
+            state_to_set = 1
+        rpi_pfio.write_output(self._port, state_to_set , self._hardware_addr)
 
     @property
     def name(self):
@@ -69,14 +88,19 @@ class RPiPFIOSwitch(ToggleEntity):
         """Return true if device is on."""
         return self._state
 
+    @property
+    def hardware_addr(self):
+        """Return the hardware address."""
+        return self._hardware_addr
+
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1)
+        rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1, self._hardware_addr)
         self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0)
+        rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0, self._hardware_addr)
         self._state = False
         self.schedule_update_ha_state()


### PR DESCRIPTION
## Breaking Change:
Because of a multi-board support the structure of piface switch's and binary_sensor's configuration is changing from:
```
  - platform: rpi_pfio                                                                                                                                                                                                                                                         
    ports:                                                                                                                                                                                                                                                                 
      0:
```
to:
```
  - platform: rpi_pfio                                                                                                                                                                                                                                                         
    boards:                                                                                                                                                                                                                                                                    
      0:                                                                                                                                                                                                                                                                       
        ports:                                                                                                                                                                                                                                                                 
          0:
```
## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9160

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
 - platform: rpi_pfio
    boards:
      0:
        ports:
          0:
            name: Garage door
            invert_logic: true
            initial_state: off

binary_sensor:
  - platform: rpi_pfio
    boards:
      0:
        ports:
          7:
            name: Garage door
            settle_time: 63
            invert_logic: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)


[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
