### PR TITLE
Improve yeelight imports

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -185,8 +185,8 @@ class YeelightDevice:
     @property
     def bulb(self):
         """Return bulb device."""
-        import yeelight
         if self._bulb_device is None:
+            import yeelight
             try:
                 self._bulb_device = yeelight.Bulb(self._ipaddr,
                                                   model=self._model)
@@ -241,33 +241,27 @@ class YeelightDevice:
 
     def turn_on(self, duration=DEFAULT_TRANSITION, light_type=None):
         """Turn on device."""
-        import yeelight
-
-        if not light_type:
-            light_type = yeelight.enums.LightType.Main
+        from yeelight import BulbException
 
         try:
             self.bulb.turn_on(duration=duration, light_type=light_type)
-        except yeelight.BulbException as ex:
+        except BulbException as ex:
             _LOGGER.error("Unable to turn the bulb on: %s", ex)
             return
 
     def turn_off(self, duration=DEFAULT_TRANSITION, light_type=None):
         """Turn off device."""
-        import yeelight
-
-        if not light_type:
-            light_type = yeelight.enums.LightType.Main
+        from yeelight import BulbException
 
         try:
             self.bulb.turn_off(duration=duration, light_type=light_type)
-        except yeelight.BulbException as ex:
+        except BulbException as ex:
             _LOGGER.error("Unable to turn the bulb off: %s", ex)
             return
 
     def update(self):
         """Read new properties from the device."""
-        import yeelight
+        from yeelight import BulbException
 
         if not self.bulb:
             return
@@ -275,7 +269,7 @@ class YeelightDevice:
         try:
             self.bulb.get_properties(UPDATE_REQUEST_PROPERTIES)
             self._available = True
-        except yeelight.BulbException as ex:
+        except BulbException as ex:
             if self._available:  # just inform once
                 _LOGGER.error("Unable to update bulb status: %s", ex)
             self._available = False

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -189,6 +189,8 @@ class YeelightLight(Light):
 
     def __init__(self, device, custom_effects=None):
         """Initialize the Yeelight light."""
+        from yeelight.enums import LightType
+
         self.config = device.config
         self._device = device
 
@@ -201,6 +203,8 @@ class YeelightLight(Light):
 
         self._min_mireds = None
         self._max_mireds = None
+
+        self._light_type = LightType.Main
 
         if custom_effects:
             self._custom_effects = custom_effects
@@ -281,8 +285,7 @@ class YeelightLight(Light):
     @property
     def light_type(self):
         """Return light type."""
-        import yeelight
-        return yeelight.enums.LightType.Main
+        return self._light_type
 
     def _get_hs_from_properties(self):
         rgb = self._get_property('rgb')
@@ -589,20 +592,18 @@ class YeelightAmbientLight(YeelightLight):
 
     def __init__(self, *args, **kwargs):
         """Initialize the Yeelight Ambient light."""
+        from yeelight.enums import LightType
+
         super().__init__(*args, **kwargs)
         self._min_mireds = kelvin_to_mired(6500)
         self._max_mireds = kelvin_to_mired(1700)
+
+        self._light_type = LightType.Ambient
 
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
         return "{} ambilight".format(self.device.name)
-
-    @property
-    def light_type(self):
-        """Return light type."""
-        import yeelight
-        return yeelight.enums.LightType.Ambient
 
     @property
     def _is_nightlight_enabled(self):


### PR DESCRIPTION
## Description:
Fix import in bulb method, which gets import everytime, and doesn't need that, only when _bulb_device is not set. Also skip some not needed imports in other methods.

**Related issue (if applicable):** 
https://community.home-assistant.io/t/yeelight-led-ceiling-light-compatible-with-ha/29509/319

```_frozen_importlib._DeadlockError: deadlock detected by _ModuleLock('yeelight.enums') at 140112646206184```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

