### PR TITLE
Bump raincloud dependency to fix broken integration: Fixes #22422

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -162,6 +162,7 @@ homeassistant/components/pvoutput/* @fabaff
 homeassistant/components/qnap/* @colinodell
 homeassistant/components/quantum_gateway/* @cisasteelersfan
 homeassistant/components/qwikswitch/* @kellerza
+homeassistant/components/raincloud/* @tchellomello @vanstinator
 homeassistant/components/rainmachine/* @bachya
 homeassistant/components/random/* @fabaff
 homeassistant/components/rfxtrx/* @danielhiversen

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -162,7 +162,7 @@ homeassistant/components/pvoutput/* @fabaff
 homeassistant/components/qnap/* @colinodell
 homeassistant/components/quantum_gateway/* @cisasteelersfan
 homeassistant/components/qwikswitch/* @kellerza
-homeassistant/components/raincloud/* @tchellomello @vanstinator
+homeassistant/components/raincloud/* @vanstinator
 homeassistant/components/rainmachine/* @bachya
 homeassistant/components/random/* @fabaff
 homeassistant/components/rfxtrx/* @danielhiversen

--- a/homeassistant/components/raincloud/__init__.py
+++ b/homeassistant/components/raincloud/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 
-REQUIREMENTS = ['raincloudy==0.0.5']
+REQUIREMENTS = ['raincloudy==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/raincloud/manifest.json
+++ b/homeassistant/components/raincloud/manifest.json
@@ -6,5 +6,5 @@
     "raincloudy==0.0.6"
   ],
   "dependencies": [],
-  "codeowners": ["@tchellomello", "@vanstinator"]
+  "codeowners": ["@vanstinator"]
 }

--- a/homeassistant/components/raincloud/manifest.json
+++ b/homeassistant/components/raincloud/manifest.json
@@ -3,8 +3,8 @@
   "name": "Raincloud",
   "documentation": "https://www.home-assistant.io/components/raincloud",
   "requirements": [
-    "raincloudy==0.0.5"
+    "raincloudy==0.0.6"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@tchellomello", "@vanstinator"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1471,7 +1471,7 @@ rachiopy==0.1.3
 radiotherm==2.0.0
 
 # homeassistant.components.raincloud
-raincloudy==0.0.5
+raincloudy==0.0.6
 
 # homeassistant.components.raspihats
 # raspihats==2.2.3


### PR DESCRIPTION
## Description:

Melnor (the manufacturer of the Raincloud hardware) pushed a fairly significant change to their web portal last week which broke the python module that powered this integration. I fixed the python module and now we need to bump the dependency version in HA to get the integration working again.

**Related issue (if applicable):** fixes #22422

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
