### PR TITLE
Improve yeelight signal handling

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "yeelight"
 DATA_YEELIGHT = DOMAIN
-DATA_UPDATED = '{}_data_updated'.format(DOMAIN)
+DATA_UPDATED = 'yeelight_{}_data_updated'
 
 DEFAULT_NAME = 'Yeelight'
 DEFAULT_TRANSITION = 350
@@ -280,4 +280,4 @@ class YeelightDevice:
                 _LOGGER.error("Unable to update bulb status: %s", ex)
             self._available = False
 
-        dispatcher_send(self._hass, DATA_UPDATED, self._ipaddr)
+        dispatcher_send(self._hass, DATA_UPDATED.format(self._ipaddr))

--- a/homeassistant/components/yeelight/binary_sensor.py
+++ b/homeassistant/components/yeelight/binary_sensor.py
@@ -31,14 +31,15 @@ class YeelightNightlightModeSensor(BinarySensorDevice):
         self._device = device
 
     @callback
-    def _schedule_immediate_update(self, ipaddr):
-        if ipaddr == self._device.ipaddr:
-            self.async_schedule_update_ha_state()
+    def _schedule_immediate_update(self):
+        self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         async_dispatcher_connect(
-            self.hass, DATA_UPDATED, self._schedule_immediate_update
+            self.hass,
+            DATA_UPDATED.format(self._device.ipaddr),
+            self._schedule_immediate_update
         )
 
     @property

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -208,14 +208,15 @@ class YeelightLight(Light):
             self._custom_effects = {}
 
     @callback
-    def _schedule_immediate_update(self, ipaddr):
-        if ipaddr == self.device.ipaddr:
-            self.async_schedule_update_ha_state(True)
+    def _schedule_immediate_update(self):
+        self.async_schedule_update_ha_state(True)
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         async_dispatcher_connect(
-            self.hass, DATA_UPDATED, self._schedule_immediate_update
+            self.hass,
+            DATA_UPDATED.format(self._device.ipaddr),
+            self._schedule_immediate_update
         )
 
     @property


### PR DESCRIPTION
## Description:
Optimize signal handling. Each entity now only listens to signal for its device, not for all yeelights, as before.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
