### PR TITLE
Update version of python_awair to 0.0.4

### DIFF
--- a/homeassistant/components/awair/manifest.json
+++ b/homeassistant/components/awair/manifest.json
@@ -3,7 +3,7 @@
   "name": "Awair",
   "documentation": "https://www.home-assistant.io/components/awair",
   "requirements": [
-    "python_awair==0.0.3"
+    "python_awair==0.0.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, dt
 
-REQUIREMENTS = ['python_awair==0.0.3']
+REQUIREMENTS = ['python_awair==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ python-whois==0.7.1
 python-wink==1.10.3
 
 # homeassistant.components.awair
-python_awair==0.0.3
+python_awair==0.0.4
 
 # homeassistant.components.swiss_public_transport
 python_opendata_transport==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -251,7 +251,7 @@ python-forecastio==1.4.0
 python-nest==4.1.0
 
 # homeassistant.components.awair
-python_awair==0.0.3
+python_awair==0.0.4
 
 # homeassistant.components.tradfri
 pytradfri[async]==6.0.1


### PR DESCRIPTION
## Description:

The awair API has changed again, this time substituting 'lat' and 'lon' for 'latitude' and 'longitude'. See related [PR on ahayworth/python_awair](https://github.com/ahayworth/python_awair/pull/1/files)

**Related issue (if applicable):** fixes #22735 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

