### PR TITLE
Ensure Z-Wave Bool Configuration values are handled correctly

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -523,10 +523,16 @@ async def async_setup_entry(hass, config_entry):
                 .values()):
             if value.index != param:
                 continue
-            if value.type in [const.TYPE_LIST, const.TYPE_BOOL]:
+            if value.type == const.TYPE_BOOL:
+                value.data = int(selection == 'True')
+                _LOGGER.info("Setting config parameter %s on Node %s "
+                             "with bool selection %s", param, node_id,
+                             str(selection))
+                return
+            if value.type == const.TYPE_LIST:
                 value.data = str(selection)
                 _LOGGER.info("Setting config parameter %s on Node %s "
-                             "with list/bool selection %s", param, node_id,
+                             "with list selection %s", param, node_id,
                              str(selection))
                 return
             if value.type == const.TYPE_BUTTON:

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1083,7 +1083,7 @@ class TestZWaveServices(unittest.TestCase):
 
     def test_set_config_parameter(self):
         """Test zwave set_config_parameter service."""
-        value = MockValue(
+        value_byte = MockValue(
             index=12,
             command_class=const.COMMAND_CLASS_CONFIGURATION,
             type=const.TYPE_BYTE,
@@ -1094,23 +1094,43 @@ class TestZWaveServices(unittest.TestCase):
             type=const.TYPE_LIST,
             data_items=['item1', 'item2', 'item3'],
         )
+        value_button = MockValue(
+            index=14,
+            command_class=const.COMMAND_CLASS_CONFIGURATION,
+            type=const.TYPE_BUTTON,
+        )
         value_list_int = MockValue(
             index=15,
             command_class=const.COMMAND_CLASS_CONFIGURATION,
             type=const.TYPE_LIST,
             data_items=['1', '2', '3'],
         )
-        value_button = MockValue(
-            index=14,
+        value_bool = MockValue(
+            index=16,
             command_class=const.COMMAND_CLASS_CONFIGURATION,
-            type=const.TYPE_BUTTON,
+            type=const.TYPE_BOOL,
         )
         node = MockNode(node_id=14)
-        node.get_values.return_value = {12: value, 13: value_list,
-                                        14: value_button,
-                                        15: value_list_int}
+        node.get_values.return_value = {
+            12: value_byte,
+            13: value_list,
+            14: value_button,
+            15: value_list_int,
+            16: value_bool
+        }
         self.zwave_network.nodes = {14: node}
 
+        # Byte
+        self.hass.services.call('zwave', 'set_config_parameter', {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 12,
+            const.ATTR_CONFIG_VALUE: 7,
+        })
+        self.hass.block_till_done()
+
+        assert value_byte.data == 7
+
+        # List
         self.hass.services.call('zwave', 'set_config_parameter', {
             const.ATTR_NODE_ID: 14,
             const.ATTR_CONFIG_PARAMETER: 13,
@@ -1120,24 +1140,7 @@ class TestZWaveServices(unittest.TestCase):
 
         assert value_list.data == 'item3'
 
-        self.hass.services.call('zwave', 'set_config_parameter', {
-            const.ATTR_NODE_ID: 14,
-            const.ATTR_CONFIG_PARAMETER: 15,
-            const.ATTR_CONFIG_VALUE: 3,
-        })
-        self.hass.block_till_done()
-
-        assert value_list_int.data == '3'
-
-        self.hass.services.call('zwave', 'set_config_parameter', {
-            const.ATTR_NODE_ID: 14,
-            const.ATTR_CONFIG_PARAMETER: 12,
-            const.ATTR_CONFIG_VALUE: 7,
-        })
-        self.hass.block_till_done()
-
-        assert value.data == 7
-
+        # Button
         self.hass.services.call('zwave', 'set_config_parameter', {
             const.ATTR_NODE_ID: 14,
             const.ATTR_CONFIG_PARAMETER: 14,
@@ -1148,6 +1151,37 @@ class TestZWaveServices(unittest.TestCase):
         assert self.zwave_network.manager.pressButton.called
         assert self.zwave_network.manager.releaseButton.called
 
+        # List of Ints
+        self.hass.services.call('zwave', 'set_config_parameter', {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 15,
+            const.ATTR_CONFIG_VALUE: 3,
+        })
+        self.hass.block_till_done()
+
+        assert value_list_int.data == '3'
+
+        # Boolean Truthy
+        self.hass.services.call('zwave', 'set_config_parameter', {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 16,
+            const.ATTR_CONFIG_VALUE: 'True',
+        })
+        self.hass.block_till_done()
+
+        assert value_bool.data == 1
+
+        # Boolean Falsy
+        self.hass.services.call('zwave', 'set_config_parameter', {
+            const.ATTR_NODE_ID: 14,
+            const.ATTR_CONFIG_PARAMETER: 16,
+            const.ATTR_CONFIG_VALUE: 'False',
+        })
+        self.hass.block_till_done()
+
+        assert value_bool.data == 0
+
+        # Different Parameter Size
         self.hass.services.call('zwave', 'set_config_parameter', {
             const.ATTR_NODE_ID: 14,
             const.ATTR_CONFIG_PARAMETER: 19,


### PR DESCRIPTION
## Description:
On configuration parameters of type "Bool" it is impossible to turn them off once turned on as `str(False)` is ultimately Truthy.

## With `zwcfg.xml`:
```xml
	<Node id="4" name="" location="" basic="4" generic="17" specific="1" roletype="5" devicetype="1536" nodetype="0" type="Multilevel Power Switch" listening="true" frequentListening="false" beaming="true" routing="true" max_baud_rate="40000" version="4" refreshonnodeinfoframe="false" query_stage="Complete">
		<Manufacturer id="86" name="Aeotec">
			<Product type="103" id="63" name="ZW099 Smart Dimmer 6" />
		</Manufacturer>
		<CommandClasses>
			<CommandClass id="32" name="COMMAND_CLASS_BASIC" version="1" request_flags="5" mapping="38">
				<Instance index="1" endpoint="1" />
				<Instance index="2" endpoint="2" />
			</CommandClass>
			<CommandClass id="38" name="COMMAND_CLASS_SWITCH_MULTILEVEL" version="2" request_flags="1" innif="true">
				<Instance index="1" endpoint="1" />
				<Instance index="2" endpoint="2" />
				<Value type="byte" genre="user" instance="1" index="0" label="Level" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="34" />
				<Value type="button" genre="user" instance="1" index="1" label="Bright" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
				<Value type="button" genre="user" instance="1" index="2" label="Dim" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
				<Value type="bool" genre="system" instance="1" index="3" label="Ignore Start Level" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="True" />
				<Value type="byte" genre="system" instance="1" index="4" label="Start Level" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="0" />
				<Value type="byte" genre="system" instance="1" index="5" label="Dimming Duration" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="255" />
				<Value type="byte" genre="user" instance="2" index="0" label="Level" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="0" />
				<Value type="button" genre="user" instance="2" index="1" label="Bright" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
				<Value type="button" genre="user" instance="2" index="2" label="Dim" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
				<Value type="bool" genre="system" instance="2" index="3" label="Ignore Start Level" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="True" />
				<Value type="byte" genre="system" instance="2" index="4" label="Start Level" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="0" />
				<Value type="byte" genre="system" instance="2" index="5" label="Dimming Duration" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="255" />
			</CommandClass>
			<CommandClass id="39" name="COMMAND_CLASS_SWITCH_ALL" version="1" request_flags="5" innif="true">
				<Instance index="1" endpoint="1" />
				<Value type="list" genre="system" instance="1" index="0" label="Switch All" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" vindex="3" size="1">
					<Item label="Disabled" value="0" />
					<Item label="Off Enabled" value="1" />
					<Item label="On Enabled" value="2" />
					<Item label="On and Off Enabled" value="255" />
				</Value>
			</CommandClass>
			<CommandClass id="50" name="COMMAND_CLASS_METER" version="3" request_flags="3" innif="true">
				<Instance index="1" endpoint="1" />
				<Value type="decimal" genre="user" instance="1" index="0" label="Energy" units="kWh" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="4.094" />
				<Value type="decimal" genre="user" instance="1" index="1" label="Previous Reading" units="kWh" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="4.089" />
				<Value type="int" genre="user" instance="1" index="2" label="Interval" units="seconds" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="1271" />
				<Value type="decimal" genre="user" instance="1" index="8" label="Power" units="W" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="13.121" />
				<Value type="decimal" genre="user" instance="1" index="16" label="Voltage" units="V" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="122.559" />
				<Value type="decimal" genre="user" instance="1" index="20" label="Current" units="A" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0.232" />
				<Value type="bool" genre="user" instance="1" index="32" label="Exporting" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="False" />
				<Value type="button" genre="system" instance="1" index="33" label="Reset" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
			</CommandClass>
			<CommandClass id="51" name="COMMAND_CLASS_COLOR" version="1" request_flags="3" innif="true" colorchannels="28">
				<Instance index="1" endpoint="2" />
				<Value type="string" genre="user" instance="1" index="0" label="Color" units="#RRGGBB" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="#FFFFFF" />
				<Value type="list" genre="user" instance="1" index="1" label="Color Index" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" vindex="1" size="0">
					<Item label="Off" value="0" />
					<Item label="Cool White" value="1" />
					<Item label="Warm White" value="2" />
					<Item label="Red" value="3" />
					<Item label="Lime" value="4" />
					<Item label="Blue" value="5" />
					<Item label="Yellow" value="6" />
					<Item label="Cyan" value="7" />
					<Item label="Magenta" value="8" />
					<Item label="Silver" value="9" />
					<Item label="Gray" value="10" />
					<Item label="Maroon" value="11" />
					<Item label="Olive" value="12" />
					<Item label="Green" value="13" />
					<Item label="Purple" value="14" />
					<Item label="Teal" value="15" />
					<Item label="Navy" value="16" />
					<Item label="Custom" value="17" />
				</Value>
				<Value type="int" genre="system" instance="1" index="2" label="Color Channels" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="28" />
			</CommandClass>
			<CommandClass id="90" name="COMMAND_CLASS_DEVICE_RESET_LOCALLY" version="1" request_flags="5" after_mark="true" innif="true">
				<Instance index="1" />
			</CommandClass>
			<CommandClass id="94" name="COMMAND_CLASS_ZWAVEPLUS_INFO" version="1" request_flags="5" innif="true">
				<Instance index="1" endpoint="1" />
				<Instance index="2" endpoint="2" />
				<Value type="byte" genre="system" instance="1" index="0" label="ZWave+ Version" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="1" />
				<Value type="short" genre="system" instance="1" index="1" label="InstallerIcon" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-32768" max="32767" value="1536" />
				<Value type="short" genre="system" instance="1" index="2" label="UserIcon" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-32768" max="32767" value="1536" />
				<Value type="byte" genre="system" instance="2" index="0" label="ZWave+ Version" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="0" />
				<Value type="short" genre="system" instance="2" index="1" label="InstallerIcon" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-32768" max="32767" value="0" />
				<Value type="short" genre="system" instance="2" index="2" label="UserIcon" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-32768" max="32767" value="0" />
			</CommandClass>
			<CommandClass id="96" name="COMMAND_CLASS_MULTI_INSTANCE/CHANNEL" version="4" request_flags="1" innif="true" mapping="endpoints" forceUniqueEndpoints="true">
				<Instance index="1" />
			</CommandClass>
			<CommandClass id="112" name="COMMAND_CLASS_CONFIGURATION" version="1" request_flags="5" innif="true">
				<Instance index="1" endpoint="1" />
				<Value type="list" genre="config" instance="1" index="3" label="Current Overload Protection" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
					<Help>Load will be closed when the Current overruns (US 15.5A, Others 16.2) for more than 2 minutes</Help>
					<Item label="Deactivate Overload Protection (Default)" value="0" />
					<Item label="Active Overload Protection" value="1" />
				</Value>
				<Value type="list" genre="config" instance="1" index="20" label="Output Load Status" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="0" size="1">
					<Help>Configure the output load status after re-power on.</Help>
					<Item label="Last status (Default)" value="0" />
					<Item label="Always on" value="1" />
					<Item label="Always off" value="2" />
				</Value>
				<Value type="list" genre="config" instance="1" index="80" label="Notification status" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="2" vindex="2" size="1">
					<Help>Defines the automated status notification of an associated device when status changes</Help>
					<Item label="Nothing" value="0" />
					<Item label="Hail" value="1" />
					<Item label="Basic" value="2" />
				</Value>
				<Value type="list" genre="config" instance="1" index="81" label="Configure the state of the LED" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="1" size="1">
					<Help>Configure what the LED Ring displays during operations</Help>
					<Item label="The LED will follow the status (on/off) of its load. (Default)" value="0" />
					<Item label="When the state of the Switch changes, the LED will follow the status (on/off) of its load, but the LED will turn off after 5 seconds." value="1" />
					<Item label="Night Light Mode" value="2" />
				</Value>
				<Value type="int" genre="config" instance="1" index="83" label="Night Light Color" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="16777215" value="14524637">
					<Help>Configure the RGB Value when in Night Light Mode. Byte 1: Red Color Byte 2: Green Color Byte 3: Blue Color</Help>
				</Value>
				<Value type="int" genre="config" instance="1" index="84" label="RGB Brightness in Energy Mode" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="16777215" value="5263440">
					<Help>Configure the brightness level of RGB LED (0%-100%) when it is in Energy Mode/momentary indicate mode. Byte 1: Red Color Byte 2: Green Color Byte 3: Blue Color</Help>
				</Value>
				<Value type="byte" genre="config" instance="1" index="85" label="Parameter #85" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="5" />
				<Value type="short" genre="config" instance="1" index="90" label="Enables/disables parameter 91/92" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="0">
					<Help>Enable/disable Wattage threshold and percent.</Help>
				</Value>
				<Value type="short" genre="config" instance="1" index="91" label="Minimum Change to send Report (Watt)" units="watts" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="32000" value="50">
					<Help>The value represents the minimum change in wattage for a Report to be sent (default 25 W)</Help>
				</Value>
				<Value type="byte" genre="config" instance="1" index="92" label="Minimum Change to send Report (%)" units="%" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="100" value="100">
					<Help>The value represents the minimum percentage change in wattage for a Report to be sent (Default 5)</Help>
				</Value>
				<Value type="button" genre="config" instance="1" index="100" label="Default Group Reports" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" affects="101,102,103">
					<Help>Set report types for groups 1, 2 and 3 to default.</Help>
				</Value>
				<Value type="int" genre="config" instance="1" index="101" label="Report type sent in Reporting Group 1" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0">
					<Help>Defines the type of report sent for reporting group 1. 2 is multisensor report. 4 is meter report for watts. 8 is meter report for kilowatts. Value 1 (msb) Reserved Value 2 Reserved Value 3 Reserved Value 4 (lsb) bits 7-4 reserved bit 3 KWH bit 2 Watt bit 1 Current bit 0 Voltage</Help>
				</Value>
				<Value type="int" genre="config" instance="1" index="102" label="Report type sent in Reporting Group 2" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0">
					<Help>Defines the type of report sent for reporting group 1. 2 is multisensor report. 4 is meter report for watts. 8 is meter report for kilowatts. Value 1 (msb) Reserved Value 2 Reserved Value 3 Reserved Value 4 (lsb) bits 7-4 reserved bit 3 KWH bit 2 Watt bit 1 Current bit 0 Voltage</Help>
				</Value>
				<Value type="int" genre="config" instance="1" index="103" label="Report type sent in Reporting Group 3" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-2147483648" max="2147483647" value="0">
					<Help>Defines the type of report sent for reporting group 1. 2 is multisensor report. 4 is meter report for watts. 8 is meter report for kilowatts. Value 1 (msb) Reserved Value 2 Reserved Value 3 Reserved Value 4 (lsb) bits 7-4 reserved bit 3 KWH bit 2 Watt bit 1 Current bit 0 Voltage</Help>
				</Value>
				<Value type="button" genre="config" instance="1" index="110" label="Set 111 to 113 to default" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" affects="111,112,113">
					<Help>Set time interval for sending reports for groups 1, 2 and 3 to default.</Help>
				</Value>
				<Value type="int" genre="config" instance="1" index="111" label="Send Interval for Reporting Group 1" units="seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="-1" value="3">
					<Help>Defines the time interval when the defined report for group 1 is sent.</Help>
				</Value>
				<Value type="int" genre="config" instance="1" index="112" label="Send Interval for Reporting Group 2" units="seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="-1" value="600">
					<Help>Defines the time interval when the defined report for group 2 is sent.</Help>
				</Value>
				<Value type="int" genre="config" instance="1" index="113" label="Send Interval for Reporting Group 3" units="seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="-1" value="600">
					<Help>Defines the time interval when the defined report for group 3 is sent.</Help>
				</Value>
				<Value type="list" genre="config" instance="1" index="200" label="Partner ID" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
					<Help>Partner ID</Help>
					<Item label="Aeon Labs Standard (Default)" value="0" />
					<Item label="Others" value="1" />
				</Value>
				<Value type="list" genre="config" instance="1" index="252" label="Configuration Locked" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="1" vindex="0" size="1">
					<Help>Enable/disable Configuration Locked</Help>
					<Item label="Disable" value="0" />
					<Item label="Enable" value="1" />
				</Value>
				<Value type="short" genre="config" instance="1" index="254" label="Device tag" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="65535" value="0">
					<Help>Device tag.</Help>
				</Value>
				<Value type="button" genre="config" instance="1" index="255" label="Reset device" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0">
					<Help>Reset to the default configuration.</Help>
				</Value>
			</CommandClass>
			<CommandClass id="114" name="COMMAND_CLASS_MANUFACTURER_SPECIFIC" version="1" request_flags="5" innif="true">
				<Instance index="1" />
			</CommandClass>
			<CommandClass id="115" name="COMMAND_CLASS_POWERLEVEL" version="1" request_flags="5" innif="true">
				<Instance index="1" />
				<Value type="list" genre="system" instance="1" index="0" label="Powerlevel" units="dB" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" vindex="0" size="1">
					<Item label="Normal" value="0" />
					<Item label="-1dB" value="1" />
					<Item label="-2dB" value="2" />
					<Item label="-3dB" value="3" />
					<Item label="-4dB" value="4" />
					<Item label="-5dB" value="5" />
					<Item label="-6dB" value="6" />
					<Item label="-7dB" value="7" />
					<Item label="-8dB" value="8" />
					<Item label="-9dB" value="9" />
				</Value>
				<Value type="byte" genre="system" instance="1" index="1" label="Timeout" units="seconds" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="0" />
				<Value type="button" genre="system" instance="1" index="2" label="Set Powerlevel" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
				<Value type="byte" genre="system" instance="1" index="3" label="Test Node" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="0" />
				<Value type="list" genre="system" instance="1" index="4" label="Test Powerlevel" units="dB" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" vindex="0" size="1">
					<Item label="Normal" value="0" />
					<Item label="-1dB" value="1" />
					<Item label="-2dB" value="2" />
					<Item label="-3dB" value="3" />
					<Item label="-4dB" value="4" />
					<Item label="-5dB" value="5" />
					<Item label="-6dB" value="6" />
					<Item label="-7dB" value="7" />
					<Item label="-8dB" value="8" />
					<Item label="-9dB" value="9" />
				</Value>
				<Value type="short" genre="system" instance="1" index="5" label="Frame Count" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="-32768" max="32767" value="0" />
				<Value type="button" genre="system" instance="1" index="6" label="Test" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
				<Value type="button" genre="system" instance="1" index="7" label="Report" units="" read_only="false" write_only="true" verify_changes="false" poll_intensity="0" min="0" max="0" />
				<Value type="list" genre="system" instance="1" index="8" label="Test Status" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" vindex="0" size="1">
					<Item label="Failed" value="0" />
					<Item label="Success" value="1" />
					<Item label="In Progress" value="2" />
				</Value>
				<Value type="short" genre="system" instance="1" index="9" label="Acked Frames" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="-32768" max="32767" value="0" />
			</CommandClass>
			<CommandClass id="129" name="COMMAND_CLASS_CLOCK" version="1" request_flags="5" innif="true">
				<Instance index="1" endpoint="1" />
				<Value type="list" genre="user" instance="1" index="0" label="Day" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" vindex="0" size="1">
					<Item label="Monday" value="1" />
					<Item label="Tuesday" value="2" />
					<Item label="Wednesday" value="3" />
					<Item label="Thursday" value="4" />
					<Item label="Friday" value="5" />
					<Item label="Saturday" value="6" />
					<Item label="Sunday" value="7" />
				</Value>
				<Value type="byte" genre="user" instance="1" index="1" label="Hour" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="20" />
				<Value type="byte" genre="user" instance="1" index="2" label="Minute" units="" read_only="false" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="255" value="19" />
			</CommandClass>
			<CommandClass id="130" name="COMMAND_CLASS_HAIL" version="1" request_flags="5" after_mark="true" innif="true">
				<Instance index="1" />
			</CommandClass>
			<CommandClass id="133" name="COMMAND_CLASS_ASSOCIATION" version="1" request_flags="5" innif="true">
				<Instance index="1" endpoint="1" />
				<Instance index="2" endpoint="2" />
				<Associations num_groups="2">
					<Group index="1" max_associations="5" label="LifeLine" auto="true" multiInstance="true">
						<Node id="1" />
					</Group>
					<Group index="2" max_associations="5" label="Retransmit Switch CC" auto="false" multiInstance="true" />
				</Associations>
			</CommandClass>
			<CommandClass id="134" name="COMMAND_CLASS_VERSION" version="1" request_flags="5" innif="true">
				<Instance index="1" endpoint="1" />
				<Value type="string" genre="system" instance="1" index="0" label="Library Version" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="3" />
				<Value type="string" genre="system" instance="1" index="1" label="Protocol Version" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="4.05" />
				<Value type="string" genre="system" instance="1" index="2" label="Application Version" units="" read_only="true" write_only="false" verify_changes="false" poll_intensity="0" min="0" max="0" value="1.02" />
			</CommandClass>
			<CommandClass id="142" name="COMMAND_CLASS_MULTI_CHANNEL_ASSOCIATION" version="1" request_flags="5" innif="true">
				<Instance index="1" endpoint="1" />
				<Associations num_groups="2">
					<Group index="1" max_associations="5" label="LifeLine" auto="true" multiInstance="true">
						<Node id="1" />
					</Group>
					<Group index="2" max_associations="5" label="Retransmit Switch CC" auto="false" multiInstance="true" />
				</Associations>
			</CommandClass>
		</CommandClasses>
	</Node>
```

## Debug Logging from homeassistant.components.zwave and python-openzwave:
```
2019-04-06 14:05:32 INFO (SyncWorker_7) [homeassistant.components.zwave] Setting config parameter 90 on Node 5 with list/bool selection False
2019-04-06 14:05:32 DEBUG (Dummy-3) [openzwave] zwcallback args=[{'notificationType': 'ValueChanged', 'homeId': 4275901172, 'nodeId': 5, 'valueId': {'homeId': 4275901172, 'nodeId': 5, 'commandClass': 'COMMAND_CLASS_CONFIGURATION', 'instance': 1, 'index': 90, 'id': 72057594132039072, 'genre': 'Config', 'type': 'Bool', 'value': True, 'label': 'Enables/disables parameter 91/92', 'units': '', 'readOnly': False}}]
2019-04-06 14:05:32 DEBUG (Dummy-3) [openzwave] Z-Wave Notification ValueChanged : {'notificationType': 'ValueChanged', 'homeId': 4275901172, 'nodeId': 5, 'valueId': {'homeId': 4275901172, 'nodeId': 5, 'commandClass': 'COMMAND_CLASS_CONFIGURATION', 'instance': 1, 'index': 90, 'id': 72057594132039072, 'genre': 'Config', 'type': 'Bool', 'value': True, 'label': 'Enables/disables parameter 91/92', 'units': '', 'readOnly': False}}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
