### PR TITLE
Coerce Record Service to int

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -83,8 +83,8 @@ CAMERA_SERVICE_PLAY_STREAM = CAMERA_SERVICE_SCHEMA.extend({
 
 CAMERA_SERVICE_RECORD = CAMERA_SERVICE_SCHEMA.extend({
     vol.Required(CONF_FILENAME): cv.template,
-    vol.Optional(CONF_DURATION, default=30): int,
-    vol.Optional(CONF_LOOKBACK, default=0): int,
+    vol.Optional(CONF_DURATION, default=30): vol.Coerce(int),
+    vol.Optional(CONF_LOOKBACK, default=0): vol.Coerce(int),
 })
 
 WS_TYPE_CAMERA_THUMBNAIL = 'camera_thumbnail'


### PR DESCRIPTION
## Description:

Needed so that it can be called inside a template automation.

## Example entry for `automation.yaml`:
```yaml
  action:
    - service: camera.record
      data_template:
        entity_id: "camera.{{ trigger.entity_id.split('.')[1].split('_')[1] }}"
        filename: "/share/videos/{{ trigger.entity_id.split('.')[1].split('_')[1] }}_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4"
        duration: 20
        lookback: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.