### PR TITLE
Uprade asynctest to 0.12.3

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 # linters such as flake8 and pylint should be pinned, as new releases
 # make new things fail. Manually update these pins when pulling in a
 # new version
-asynctest==0.12.2
+asynctest==0.12.3
 codecov==2.0.15
 coveralls==1.2.0
 flake8-docstrings==1.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2,7 +2,7 @@
 # linters such as flake8 and pylint should be pinned, as new releases
 # make new things fail. Manually update these pins when pulling in a
 # new version
-asynctest==0.12.2
+asynctest==0.12.3
 codecov==2.0.15
 coveralls==1.2.0
 flake8-docstrings==1.3.0


### PR DESCRIPTION
## Description:

SSIA. No upstream changelog available that I'm aware, commit log between 0.12.2 and .3: https://github.com/Martiusweb/asynctest/commits/master

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
