### PR TITLE
Use dict[key] for required config keys and keys with default values MQTT camera

### DIFF
--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -26,9 +26,9 @@ DEFAULT_NAME = 'MQTT Camera'
 DEPENDENCIES = ['mqtt']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_UNIQUE_ID): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
 })
 
 
@@ -103,7 +103,7 @@ class MqttCamera(MqttDiscoveryUpdate, Camera):
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,
-            {'state_topic': {'topic': self._config.get(CONF_TOPIC),
+            {'state_topic': {'topic': self._config[CONF_TOPIC],
                              'msg_callback': message_received,
                              'qos': self._qos,
                              'encoding': None}})
@@ -121,7 +121,7 @@ class MqttCamera(MqttDiscoveryUpdate, Camera):
     @property
     def name(self):
         """Return the name of this camera."""
-        return self._config.get(CONF_NAME)
+        return self._config[CONF_NAME]
 
     @property
     def unique_id(self):


### PR DESCRIPTION
## Description:
Use dict[key] for required config keys and keys with default values.
Sort configuration schema.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
