### PR TITLE
Use dict[key] for required config keys and keys with default values MQTT climate

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -66,11 +66,11 @@ CONF_PAYLOAD_OFF = 'payload_off'
 CONF_FAN_MODE_LIST = 'fan_modes'
 CONF_MODE_LIST = 'modes'
 CONF_SWING_MODE_LIST = 'swing_modes'
-CONF_INITIAL = 'initial'
 CONF_SEND_IF_OFF = 'send_if_off'
 
-CONF_MIN_TEMP = 'min_temp'
-CONF_MAX_TEMP = 'max_temp'
+CONF_TEMP_INITIAL = 'initial'
+CONF_TEMP_MIN = 'min_temp'
+CONF_TEMP_MAX = 'max_temp'
 CONF_TEMP_STEP = 'temp_step'
 
 TEMPLATE_KEYS = (
@@ -87,57 +87,53 @@ TEMPLATE_KEYS = (
 
 SCHEMA_BASE = CLIMATE_PLATFORM_SCHEMA.extend(MQTT_BASE_PLATFORM_SCHEMA.schema)
 PLATFORM_SCHEMA = SCHEMA_BASE.extend({
-    vol.Optional(CONF_RETAIN, default=mqtt.DEFAULT_RETAIN): cv.boolean,
-    vol.Optional(CONF_POWER_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_TEMPERATURE_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_FAN_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_SWING_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_AWAY_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_HOLD_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_AUX_COMMAND_TOPIC): mqtt.valid_publish_topic,
-
-    vol.Optional(CONF_POWER_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_TEMPERATURE_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_FAN_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_SWING_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_AWAY_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_HOLD_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_AUX_STATE_TOPIC): mqtt.valid_subscribe_topic,
-
-    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_POWER_STATE_TEMPLATE): cv.template,
-    vol.Optional(CONF_MODE_STATE_TEMPLATE): cv.template,
-    vol.Optional(CONF_TEMPERATURE_STATE_TEMPLATE): cv.template,
-    vol.Optional(CONF_FAN_MODE_STATE_TEMPLATE): cv.template,
-    vol.Optional(CONF_SWING_MODE_STATE_TEMPLATE): cv.template,
-    vol.Optional(CONF_AWAY_MODE_STATE_TEMPLATE): cv.template,
-    vol.Optional(CONF_HOLD_STATE_TEMPLATE): cv.template,
     vol.Optional(CONF_AUX_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_AUX_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_AWAY_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_AWAY_MODE_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_AWAY_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_CURRENT_TEMPERATURE_TEMPLATE): cv.template,
-
     vol.Optional(CONF_CURRENT_TEMPERATURE_TOPIC):
         mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
+    vol.Optional(CONF_FAN_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_FAN_MODE_LIST,
                  default=[STATE_AUTO, SPEED_LOW,
                           SPEED_MEDIUM, SPEED_HIGH]): cv.ensure_list,
-    vol.Optional(CONF_SWING_MODE_LIST,
-                 default=[STATE_ON, STATE_OFF]): cv.ensure_list,
+    vol.Optional(CONF_FAN_MODE_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_FAN_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_HOLD_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_HOLD_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_HOLD_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_MODE_LIST,
                  default=[STATE_AUTO, STATE_OFF, STATE_COOL, STATE_HEAT,
                           STATE_DRY, STATE_FAN_ONLY]): cv.ensure_list,
+    vol.Optional(CONF_MODE_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_INITIAL, default=21): cv.positive_int,
-    vol.Optional(CONF_SEND_IF_OFF, default=True): cv.boolean,
     vol.Optional(CONF_PAYLOAD_ON, default="ON"): cv.string,
     vol.Optional(CONF_PAYLOAD_OFF, default="OFF"): cv.string,
-
-    vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
-    vol.Optional(CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
+    vol.Optional(CONF_POWER_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_POWER_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_POWER_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_RETAIN, default=mqtt.DEFAULT_RETAIN): cv.boolean,
+    vol.Optional(CONF_SEND_IF_OFF, default=True): cv.boolean,
+    vol.Optional(CONF_SWING_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_SWING_MODE_LIST,
+                 default=[STATE_ON, STATE_OFF]): cv.ensure_list,
+    vol.Optional(CONF_SWING_MODE_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_SWING_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_TEMP_INITIAL, default=21): cv.positive_int,
+    vol.Optional(CONF_TEMP_MIN, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
+    vol.Optional(CONF_TEMP_MAX, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
     vol.Optional(CONF_TEMP_STEP, default=1.0): vol.Coerce(float),
+    vol.Optional(CONF_TEMPERATURE_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_TEMPERATURE_STATE_TEMPLATE): cv.template,
+    vol.Optional(CONF_TEMPERATURE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_UNIQUE_ID): cv.string,
-    vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema).extend(
     mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 
@@ -255,7 +251,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         self._target_temperature = self._current_fan_mode = \
             self._current_operation = self._current_swing_mode = None
         if self._topic[CONF_TEMPERATURE_STATE_TOPIC] is None:
-            self._target_temperature = config.get(CONF_INITIAL)
+            self._target_temperature = config[CONF_TEMP_INITIAL]
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
             self._current_fan_mode = SPEED_LOW
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
@@ -279,7 +275,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
-        qos = self._config.get(CONF_QOS)
+        qos = self._config[CONF_QOS]
 
         @callback
         def handle_current_temp_received(msg):
@@ -310,7 +306,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 payload = self._value_templates[CONF_MODE_STATE_TEMPLATE].\
                   async_render_with_possible_json_value(payload)
 
-            if payload not in self._config.get(CONF_MODE_LIST):
+            if payload not in self._config[CONF_MODE_LIST]:
                 _LOGGER.error("Invalid mode: %s", payload)
             else:
                 self._current_operation = payload
@@ -352,7 +348,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                   self._value_templates[CONF_FAN_MODE_STATE_TEMPLATE].\
                   async_render_with_possible_json_value(payload)
 
-            if payload not in self._config.get(CONF_FAN_MODE_LIST):
+            if payload not in self._config[CONF_FAN_MODE_LIST]:
                 _LOGGER.error("Invalid fan mode: %s", payload)
             else:
                 self._current_fan_mode = payload
@@ -373,7 +369,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                   self._value_templates[CONF_SWING_MODE_STATE_TEMPLATE].\
                   async_render_with_possible_json_value(payload)
 
-            if payload not in self._config.get(CONF_SWING_MODE_LIST):
+            if payload not in self._config[CONF_SWING_MODE_LIST]:
                 _LOGGER.error("Invalid swing mode: %s", payload)
             else:
                 self._current_swing_mode = payload
@@ -389,8 +385,8 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         def handle_away_mode_received(msg):
             """Handle receiving away mode via MQTT."""
             payload = msg.payload
-            payload_on = self._config.get(CONF_PAYLOAD_ON)
-            payload_off = self._config.get(CONF_PAYLOAD_OFF)
+            payload_on = self._config[CONF_PAYLOAD_ON]
+            payload_off = self._config[CONF_PAYLOAD_OFF]
             if CONF_AWAY_MODE_STATE_TEMPLATE in self._value_templates:
                 payload = \
                   self._value_templates[CONF_AWAY_MODE_STATE_TEMPLATE].\
@@ -419,8 +415,8 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         def handle_aux_mode_received(msg):
             """Handle receiving aux mode via MQTT."""
             payload = msg.payload
-            payload_on = self._config.get(CONF_PAYLOAD_ON)
-            payload_off = self._config.get(CONF_PAYLOAD_OFF)
+            payload_on = self._config[CONF_PAYLOAD_ON]
+            payload_off = self._config[CONF_PAYLOAD_OFF]
             if CONF_AUX_STATE_TEMPLATE in self._value_templates:
                 payload = self._value_templates[CONF_AUX_STATE_TEMPLATE].\
                   async_render_with_possible_json_value(payload)
@@ -480,7 +476,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def name(self):
         """Return the name of the climate device."""
-        return self._config.get(CONF_NAME)
+        return self._config[CONF_NAME]
 
     @property
     def unique_id(self):
@@ -510,12 +506,12 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def operation_list(self):
         """Return the list of available operation modes."""
-        return self._config.get(CONF_MODE_LIST)
+        return self._config[CONF_MODE_LIST]
 
     @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
-        return self._config.get(CONF_TEMP_STEP)
+        return self._config[CONF_TEMP_STEP]
 
     @property
     def is_away_mode_on(self):
@@ -540,7 +536,7 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def fan_list(self):
         """Return the list of available fan modes."""
-        return self._config.get(CONF_FAN_MODE_LIST)
+        return self._config[CONF_FAN_MODE_LIST]
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
@@ -553,24 +549,24 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 # optimistic mode
                 self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
 
-            if (self._config.get(CONF_SEND_IF_OFF) or
+            if (self._config[CONF_SEND_IF_OFF] or
                     self._current_operation != STATE_OFF):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_TEMPERATURE_COMMAND_TOPIC],
-                    kwargs.get(ATTR_TEMPERATURE), self._config.get(CONF_QOS),
-                    self._config.get(CONF_RETAIN))
+                    kwargs.get(ATTR_TEMPERATURE), self._config[CONF_QOS],
+                    self._config[CONF_RETAIN])
 
         # Always optimistic?
         self.async_write_ha_state()
 
     async def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""
-        if (self._config.get(CONF_SEND_IF_OFF) or
+        if (self._config[CONF_SEND_IF_OFF] or
                 self._current_operation != STATE_OFF):
             mqtt.async_publish(
                 self.hass, self._topic[CONF_SWING_MODE_COMMAND_TOPIC],
-                swing_mode, self._config.get(CONF_QOS),
-                self._config.get(CONF_RETAIN))
+                swing_mode, self._config[CONF_QOS],
+                self._config[CONF_RETAIN])
 
         if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
             self._current_swing_mode = swing_mode
@@ -578,12 +574,12 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
     async def async_set_fan_mode(self, fan_mode):
         """Set new target temperature."""
-        if (self._config.get(CONF_SEND_IF_OFF) or
+        if (self._config[CONF_SEND_IF_OFF] or
                 self._current_operation != STATE_OFF):
             mqtt.async_publish(
                 self.hass, self._topic[CONF_FAN_MODE_COMMAND_TOPIC],
-                fan_mode, self._config.get(CONF_QOS),
-                self._config.get(CONF_RETAIN))
+                fan_mode, self._config[CONF_QOS],
+                self._config[CONF_RETAIN])
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
             self._current_fan_mode = fan_mode
@@ -591,19 +587,19 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
     async def async_set_operation_mode(self, operation_mode) -> None:
         """Set new operation mode."""
-        qos = self._config.get(CONF_QOS)
-        retain = self._config.get(CONF_RETAIN)
+        qos = self._config[CONF_QOS]
+        retain = self._config[CONF_RETAIN]
         if self._topic[CONF_POWER_COMMAND_TOPIC] is not None:
             if (self._current_operation == STATE_OFF and
                     operation_mode != STATE_OFF):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
-                    self._config.get(CONF_PAYLOAD_ON), qos, retain)
+                    self._config[CONF_PAYLOAD_ON], qos, retain)
             elif (self._current_operation != STATE_OFF and
                   operation_mode == STATE_OFF):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_POWER_COMMAND_TOPIC],
-                    self._config.get(CONF_PAYLOAD_OFF), qos, retain)
+                    self._config[CONF_PAYLOAD_OFF], qos, retain)
 
         if self._topic[CONF_MODE_COMMAND_TOPIC] is not None:
             mqtt.async_publish(
@@ -622,16 +618,16 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def swing_list(self):
         """List of available swing modes."""
-        return self._config.get(CONF_SWING_MODE_LIST)
+        return self._config[CONF_SWING_MODE_LIST]
 
     async def async_turn_away_mode_on(self):
         """Turn away mode on."""
         if self._topic[CONF_AWAY_MODE_COMMAND_TOPIC] is not None:
             mqtt.async_publish(self.hass,
                                self._topic[CONF_AWAY_MODE_COMMAND_TOPIC],
-                               self._config.get(CONF_PAYLOAD_ON),
-                               self._config.get(CONF_QOS),
-                               self._config.get(CONF_RETAIN))
+                               self._config[CONF_PAYLOAD_ON],
+                               self._config[CONF_QOS],
+                               self._config[CONF_RETAIN])
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is None:
             self._away = True
@@ -642,9 +638,9 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         if self._topic[CONF_AWAY_MODE_COMMAND_TOPIC] is not None:
             mqtt.async_publish(self.hass,
                                self._topic[CONF_AWAY_MODE_COMMAND_TOPIC],
-                               self._config.get(CONF_PAYLOAD_OFF),
-                               self._config.get(CONF_QOS),
-                               self._config.get(CONF_RETAIN))
+                               self._config[CONF_PAYLOAD_OFF],
+                               self._config[CONF_QOS],
+                               self._config[CONF_RETAIN])
 
         if self._topic[CONF_AWAY_MODE_STATE_TOPIC] is None:
             self._away = False
@@ -655,8 +651,8 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         if self._topic[CONF_HOLD_COMMAND_TOPIC] is not None:
             mqtt.async_publish(self.hass,
                                self._topic[CONF_HOLD_COMMAND_TOPIC],
-                               hold_mode, self._config.get(CONF_QOS),
-                               self._config.get(CONF_RETAIN))
+                               hold_mode, self._config[CONF_QOS],
+                               self._config[CONF_RETAIN])
 
         if self._topic[CONF_HOLD_STATE_TOPIC] is None:
             self._hold = hold_mode
@@ -666,9 +662,9 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """Turn auxiliary heater on."""
         if self._topic[CONF_AUX_COMMAND_TOPIC] is not None:
             mqtt.async_publish(self.hass, self._topic[CONF_AUX_COMMAND_TOPIC],
-                               self._config.get(CONF_PAYLOAD_ON),
-                               self._config.get(CONF_QOS),
-                               self._config.get(CONF_RETAIN))
+                               self._config[CONF_PAYLOAD_ON],
+                               self._config[CONF_QOS],
+                               self._config[CONF_RETAIN])
 
         if self._topic[CONF_AUX_STATE_TOPIC] is None:
             self._aux = True
@@ -678,9 +674,9 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """Turn auxiliary heater off."""
         if self._topic[CONF_AUX_COMMAND_TOPIC] is not None:
             mqtt.async_publish(self.hass, self._topic[CONF_AUX_COMMAND_TOPIC],
-                               self._config.get(CONF_PAYLOAD_OFF),
-                               self._config.get(CONF_QOS),
-                               self._config.get(CONF_RETAIN))
+                               self._config[CONF_PAYLOAD_OFF],
+                               self._config[CONF_QOS],
+                               self._config[CONF_RETAIN])
 
         if self._topic[CONF_AUX_STATE_TOPIC] is None:
             self._aux = False
@@ -724,9 +720,9 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return self._config.get(CONF_MIN_TEMP)
+        return self._config[CONF_TEMP_MIN]
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return self._config.get(CONF_MAX_TEMP)
+        return self._config[CONF_TEMP_MAX]


### PR DESCRIPTION
## Description:
Use dict[key] for required config keys and keys with default values.
Sort configuration schema.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
