### PR TITLE
Use dict[key] for required config keys and keys with default values MQTT cover

### DIFF
--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -84,38 +84,36 @@ def validate_options(value):
 
 PLATFORM_SCHEMA = vol.All(mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_SET_POSITION_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_SET_POSITION_TEMPLATE): cv.template,
-    vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
-    vol.Optional(CONF_GET_POSITION_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_PAYLOAD_OPEN, default=DEFAULT_PAYLOAD_OPEN): cv.string,
-    vol.Optional(CONF_PAYLOAD_CLOSE, default=DEFAULT_PAYLOAD_CLOSE): cv.string,
-    vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): cv.string,
-    vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): cv.string,
-    vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): cv.string,
-    vol.Optional(CONF_POSITION_OPEN,
-                 default=DEFAULT_POSITION_OPEN): int,
-    vol.Optional(CONF_POSITION_CLOSED,
-                 default=DEFAULT_POSITION_CLOSED): int,
-    vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
-    vol.Optional(CONF_TILT_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_TILT_STATUS_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_TILT_CLOSED_POSITION,
-                 default=DEFAULT_TILT_CLOSED_POSITION): int,
-    vol.Optional(CONF_TILT_OPEN_POSITION,
-                 default=DEFAULT_TILT_OPEN_POSITION): int,
-    vol.Optional(CONF_TILT_MIN, default=DEFAULT_TILT_MIN): int,
-    vol.Optional(CONF_TILT_MAX, default=DEFAULT_TILT_MAX): int,
-    vol.Optional(CONF_TILT_STATE_OPTIMISTIC,
-                 default=DEFAULT_TILT_OPTIMISTIC): cv.boolean,
-    vol.Optional(CONF_TILT_INVERT_STATE,
-                 default=DEFAULT_TILT_INVERT_STATE): cv.boolean,
-    vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+    vol.Optional(CONF_GET_POSITION_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
+    vol.Optional(CONF_PAYLOAD_CLOSE, default=DEFAULT_PAYLOAD_CLOSE): cv.string,
+    vol.Optional(CONF_PAYLOAD_OPEN, default=DEFAULT_PAYLOAD_OPEN): cv.string,
+    vol.Optional(CONF_PAYLOAD_STOP, default=DEFAULT_PAYLOAD_STOP): cv.string,
+    vol.Optional(CONF_POSITION_CLOSED, default=DEFAULT_POSITION_CLOSED): int,
+    vol.Optional(CONF_POSITION_OPEN, default=DEFAULT_POSITION_OPEN): int,
+    vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
+    vol.Optional(CONF_SET_POSITION_TEMPLATE): cv.template,
+    vol.Optional(CONF_SET_POSITION_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_STATE_CLOSED, default=STATE_CLOSED): cv.string,
+    vol.Optional(CONF_STATE_OPEN, default=STATE_OPEN): cv.string,
+    vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_TILT_CLOSED_POSITION,
+                 default=DEFAULT_TILT_CLOSED_POSITION): int,
+    vol.Optional(CONF_TILT_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_TILT_INVERT_STATE,
+                 default=DEFAULT_TILT_INVERT_STATE): cv.boolean,
+    vol.Optional(CONF_TILT_MAX, default=DEFAULT_TILT_MAX): int,
+    vol.Optional(CONF_TILT_MIN, default=DEFAULT_TILT_MIN): int,
+    vol.Optional(CONF_TILT_OPEN_POSITION,
+                 default=DEFAULT_TILT_OPEN_POSITION): int,
+    vol.Optional(CONF_TILT_STATE_OPTIMISTIC,
+                 default=DEFAULT_TILT_OPTIMISTIC): cv.boolean,
+    vol.Optional(CONF_TILT_STATUS_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema).extend(
     mqtt.MQTT_JSON_ATTRS_SCHEMA.schema), validate_options)
 
@@ -194,10 +192,10 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
     def _setup_from_config(self, config):
         self._config = config
-        self._optimistic = (config.get(CONF_OPTIMISTIC) or
+        self._optimistic = (config[CONF_OPTIMISTIC] or
                             (config.get(CONF_STATE_TOPIC) is None and
                              config.get(CONF_GET_POSITION_TOPIC) is None))
-        self._tilt_optimistic = config.get(CONF_TILT_STATE_OPTIMISTIC)
+        self._tilt_optimistic = config[CONF_TILT_STATE_OPTIMISTIC]
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -214,8 +212,8 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         def tilt_updated(msg):
             """Handle tilt updates."""
             if (msg.payload.isnumeric() and
-                    (self._config.get(CONF_TILT_MIN) <= int(msg.payload) <=
-                     self._config.get(CONF_TILT_MAX))):
+                    (self._config[CONF_TILT_MIN] <= int(msg.payload) <=
+                     self._config[CONF_TILT_MAX])):
 
                 level = self.find_percentage_in_range(float(msg.payload))
                 self._tilt_value = level
@@ -229,9 +227,9 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 payload = template.async_render_with_possible_json_value(
                     payload)
 
-            if payload == self._config.get(CONF_STATE_OPEN):
+            if payload == self._config[CONF_STATE_OPEN]:
                 self._state = False
-            elif payload == self._config.get(CONF_STATE_CLOSED):
+            elif payload == self._config[CONF_STATE_CLOSED]:
                 self._state = True
             else:
                 _LOGGER.warning("Payload is not True or False: %s", payload)
@@ -262,12 +260,12 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             topics['get_position_topic'] = {
                 'topic': self._config.get(CONF_GET_POSITION_TOPIC),
                 'msg_callback': position_message_received,
-                'qos': self._config.get(CONF_QOS)}
+                'qos': self._config[CONF_QOS]}
         elif self._config.get(CONF_STATE_TOPIC):
             topics['state_topic'] = {
                 'topic': self._config.get(CONF_STATE_TOPIC),
                 'msg_callback': state_message_received,
-                'qos': self._config.get(CONF_QOS)}
+                'qos': self._config[CONF_QOS]}
         else:
             # Force into optimistic mode.
             self._optimistic = True
@@ -280,7 +278,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             topics['tilt_status_topic'] = {
                 'topic': self._config.get(CONF_TILT_STATUS_TOPIC),
                 'msg_callback': tilt_updated,
-                'qos': self._config.get(CONF_QOS)}
+                'qos': self._config[CONF_QOS]}
 
         self._sub_state = await subscription.async_subscribe_topics(
             self.hass, self._sub_state,
@@ -306,7 +304,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def name(self):
         """Return the name of the cover."""
-        return self._config.get(CONF_NAME)
+        return self._config[CONF_NAME]
 
     @property
     def is_closed(self):
@@ -353,14 +351,14 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_OPEN), self._config.get(CONF_QOS),
-            self._config.get(CONF_RETAIN))
+            self._config[CONF_PAYLOAD_OPEN], self._config[CONF_QOS],
+            self._config[CONF_RETAIN])
         if self._optimistic:
             # Optimistically assume that cover has changed state.
             self._state = False
             if self._config.get(CONF_GET_POSITION_TOPIC):
                 self._position = self.find_percentage_in_range(
-                    self._config.get(CONF_POSITION_OPEN), COVER_PAYLOAD)
+                    self._config[CONF_POSITION_OPEN], COVER_PAYLOAD)
             self.async_write_ha_state()
 
     async def async_close_cover(self, **kwargs):
@@ -370,14 +368,14 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_CLOSE), self._config.get(CONF_QOS),
-            self._config.get(CONF_RETAIN))
+            self._config[CONF_PAYLOAD_CLOSE], self._config[CONF_QOS],
+            self._config[CONF_RETAIN])
         if self._optimistic:
             # Optimistically assume that cover has changed state.
             self._state = True
             if self._config.get(CONF_GET_POSITION_TOPIC):
                 self._position = self.find_percentage_in_range(
-                    self._config.get(CONF_POSITION_CLOSED), COVER_PAYLOAD)
+                    self._config[CONF_POSITION_CLOSED], COVER_PAYLOAD)
             self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs):
@@ -387,29 +385,29 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
-            self._config.get(CONF_PAYLOAD_STOP), self._config.get(CONF_QOS),
-            self._config.get(CONF_RETAIN))
+            self._config[CONF_PAYLOAD_STOP], self._config[CONF_QOS],
+            self._config[CONF_RETAIN])
 
     async def async_open_cover_tilt(self, **kwargs):
         """Tilt the cover open."""
         mqtt.async_publish(self.hass,
                            self._config.get(CONF_TILT_COMMAND_TOPIC),
-                           self._config.get(CONF_TILT_OPEN_POSITION),
-                           self._config.get(CONF_QOS),
-                           self._config.get(CONF_RETAIN))
+                           self._config[CONF_TILT_OPEN_POSITION],
+                           self._config[CONF_QOS],
+                           self._config[CONF_RETAIN])
         if self._tilt_optimistic:
-            self._tilt_value = self._config.get(CONF_TILT_OPEN_POSITION)
+            self._tilt_value = self._config[CONF_TILT_OPEN_POSITION]
             self.async_write_ha_state()
 
     async def async_close_cover_tilt(self, **kwargs):
         """Tilt the cover closed."""
         mqtt.async_publish(self.hass,
                            self._config.get(CONF_TILT_COMMAND_TOPIC),
-                           self._config.get(CONF_TILT_CLOSED_POSITION),
-                           self._config.get(CONF_QOS),
-                           self._config.get(CONF_RETAIN))
+                           self._config[CONF_TILT_CLOSED_POSITION],
+                           self._config[CONF_QOS],
+                           self._config[CONF_RETAIN])
         if self._tilt_optimistic:
-            self._tilt_value = self._config.get(CONF_TILT_CLOSED_POSITION)
+            self._tilt_value = self._config[CONF_TILT_CLOSED_POSITION]
             self.async_write_ha_state()
 
     async def async_set_cover_tilt_position(self, **kwargs):
@@ -425,8 +423,8 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         mqtt.async_publish(self.hass,
                            self._config.get(CONF_TILT_COMMAND_TOPIC),
                            level,
-                           self._config.get(CONF_QOS),
-                           self._config.get(CONF_RETAIN))
+                           self._config[CONF_QOS],
+                           self._config[CONF_RETAIN])
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
@@ -441,19 +439,19 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 except TemplateError as ex:
                     _LOGGER.error(ex)
                     self._state = None
-            elif (self._config.get(CONF_POSITION_OPEN) != 100 and
-                  self._config.get(CONF_POSITION_CLOSED) != 0):
+            elif (self._config[CONF_POSITION_OPEN] != 100 and
+                  self._config[CONF_POSITION_CLOSED] != 0):
                 position = self.find_in_range_from_percent(
                     position, COVER_PAYLOAD)
 
             mqtt.async_publish(self.hass,
                                self._config.get(CONF_SET_POSITION_TOPIC),
                                position,
-                               self._config.get(CONF_QOS),
-                               self._config.get(CONF_RETAIN))
+                               self._config[CONF_QOS],
+                               self._config[CONF_RETAIN])
             if self._optimistic:
                 self._state = percentage_position == \
-                    self._config.get(CONF_POSITION_CLOSED)
+                    self._config[CONF_POSITION_CLOSED]
                 self._position = percentage_position
                 self.async_write_ha_state()
 
@@ -461,11 +459,11 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """Find the 0-100% value within the specified range."""
         # the range of motion as defined by the min max values
         if range_type == COVER_PAYLOAD:
-            max_range = self._config.get(CONF_POSITION_OPEN)
-            min_range = self._config.get(CONF_POSITION_CLOSED)
+            max_range = self._config[CONF_POSITION_OPEN]
+            min_range = self._config[CONF_POSITION_CLOSED]
         else:
-            max_range = self._config.get(CONF_TILT_MAX)
-            min_range = self._config.get(CONF_TILT_MIN)
+            max_range = self._config[CONF_TILT_MAX]
+            min_range = self._config[CONF_TILT_MIN]
         current_range = max_range - min_range
         # offset to be zero based
         offset_position = position - min_range
@@ -477,7 +475,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         position_percentage = min(max(position_percentage, min_percent),
                                   max_percent)
         if range_type == TILT_PAYLOAD and \
-                self._config.get(CONF_TILT_INVERT_STATE):
+                self._config[CONF_TILT_INVERT_STATE]:
             return 100 - position_percentage
         return position_percentage
 
@@ -491,18 +489,18 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         returning the offset
         """
         if range_type == COVER_PAYLOAD:
-            max_range = self._config.get(CONF_POSITION_OPEN)
-            min_range = self._config.get(CONF_POSITION_CLOSED)
+            max_range = self._config[CONF_POSITION_OPEN]
+            min_range = self._config[CONF_POSITION_CLOSED]
         else:
-            max_range = self._config.get(CONF_TILT_MAX)
-            min_range = self._config.get(CONF_TILT_MIN)
+            max_range = self._config[CONF_TILT_MAX]
+            min_range = self._config[CONF_TILT_MIN]
         offset = min_range
         current_range = max_range - min_range
         position = round(current_range * (percentage / 100.0))
         position += offset
 
         if range_type == TILT_PAYLOAD and \
-                self._config.get(CONF_TILT_INVERT_STATE):
+                self._config[CONF_TILT_INVERT_STATE]:
             position = max_range - position + offset
         return position
 


### PR DESCRIPTION
## Description:
Use dict[key] for required config keys and keys with default values.
Sort configuration schema.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
