### PR TITLE
Use dict[key] for required config keys and keys with default values MQTT fan

### DIFF
--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -50,29 +50,29 @@ OSCILLATE_OFF_PAYLOAD = 'oscillate_off'
 OSCILLATION = 'oscillation'
 
 PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_SPEED_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_SPEED_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_SPEED_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_OSCILLATION_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_OSCILLATION_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_OSCILLATION_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_OSCILLATION_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
-    vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
-    vol.Optional(CONF_PAYLOAD_OSCILLATION_ON,
-                 default=DEFAULT_PAYLOAD_ON): cv.string,
-    vol.Optional(CONF_PAYLOAD_OSCILLATION_OFF,
-                 default=DEFAULT_PAYLOAD_OFF): cv.string,
+    vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
     vol.Optional(CONF_PAYLOAD_LOW_SPEED, default=SPEED_LOW): cv.string,
     vol.Optional(CONF_PAYLOAD_MEDIUM_SPEED, default=SPEED_MEDIUM): cv.string,
-    vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
+    vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
+    vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
+    vol.Optional(CONF_PAYLOAD_OSCILLATION_OFF,
+                 default=DEFAULT_PAYLOAD_OFF): cv.string,
+    vol.Optional(CONF_PAYLOAD_OSCILLATION_ON,
+                 default=DEFAULT_PAYLOAD_ON): cv.string,
+    vol.Optional(CONF_SPEED_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_SPEED_LIST,
                  default=[SPEED_OFF, SPEED_LOW,
                           SPEED_MEDIUM, SPEED_HIGH]): cv.ensure_list,
-    vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
+    vol.Optional(CONF_SPEED_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_SPEED_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_UNIQUE_ID): cv.string,
-    vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema).extend(
     mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 
@@ -174,15 +174,15 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             OSCILLATION: config.get(CONF_OSCILLATION_VALUE_TEMPLATE)
         }
         self._payload = {
-            STATE_ON: config.get(CONF_PAYLOAD_ON),
-            STATE_OFF: config.get(CONF_PAYLOAD_OFF),
-            OSCILLATE_ON_PAYLOAD: config.get(CONF_PAYLOAD_OSCILLATION_ON),
-            OSCILLATE_OFF_PAYLOAD: config.get(CONF_PAYLOAD_OSCILLATION_OFF),
-            SPEED_LOW: config.get(CONF_PAYLOAD_LOW_SPEED),
-            SPEED_MEDIUM: config.get(CONF_PAYLOAD_MEDIUM_SPEED),
-            SPEED_HIGH: config.get(CONF_PAYLOAD_HIGH_SPEED),
+            STATE_ON: config[CONF_PAYLOAD_ON],
+            STATE_OFF: config[CONF_PAYLOAD_OFF],
+            OSCILLATE_ON_PAYLOAD: config[CONF_PAYLOAD_OSCILLATION_ON],
+            OSCILLATE_OFF_PAYLOAD: config[CONF_PAYLOAD_OSCILLATION_OFF],
+            SPEED_LOW: config[CONF_PAYLOAD_LOW_SPEED],
+            SPEED_MEDIUM: config[CONF_PAYLOAD_MEDIUM_SPEED],
+            SPEED_HIGH: config[CONF_PAYLOAD_HIGH_SPEED],
         }
-        optimistic = config.get(CONF_OPTIMISTIC)
+        optimistic = config[CONF_OPTIMISTIC]
         self._optimistic = optimistic or self._topic[CONF_STATE_TOPIC] is None
         self._optimistic_oscillation = (
             optimistic or self._topic[CONF_OSCILLATION_STATE_TOPIC] is None)
@@ -220,7 +220,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             topics[CONF_STATE_TOPIC] = {
                 'topic': self._topic[CONF_STATE_TOPIC],
                 'msg_callback': state_received,
-                'qos': self._config.get(CONF_QOS)}
+                'qos': self._config[CONF_QOS]}
 
         @callback
         def speed_received(msg):
@@ -238,7 +238,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             topics[CONF_SPEED_STATE_TOPIC] = {
                 'topic': self._topic[CONF_SPEED_STATE_TOPIC],
                 'msg_callback': speed_received,
-                'qos': self._config.get(CONF_QOS)}
+                'qos': self._config[CONF_QOS]}
             self._speed = SPEED_OFF
 
         @callback
@@ -255,7 +255,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             topics[CONF_OSCILLATION_STATE_TOPIC] = {
                 'topic': self._topic[CONF_OSCILLATION_STATE_TOPIC],
                 'msg_callback': oscillation_received,
-                'qos': self._config.get(CONF_QOS)}
+                'qos': self._config[CONF_QOS]}
             self._oscillation = False
 
         self._sub_state = await subscription.async_subscribe_topics(
@@ -287,12 +287,12 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def name(self) -> str:
         """Get entity name."""
-        return self._config.get(CONF_NAME)
+        return self._config[CONF_NAME]
 
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return self._config.get(CONF_SPEED_LIST)
+        return self._config[CONF_SPEED_LIST]
 
     @property
     def supported_features(self) -> int:
@@ -316,8 +316,8 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """
         mqtt.async_publish(
             self.hass, self._topic[CONF_COMMAND_TOPIC],
-            self._payload[STATE_ON], self._config.get(CONF_QOS),
-            self._config.get(CONF_RETAIN))
+            self._payload[STATE_ON], self._config[CONF_QOS],
+            self._config[CONF_RETAIN])
         if speed:
             await self.async_set_speed(speed)
 
@@ -328,8 +328,8 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """
         mqtt.async_publish(
             self.hass, self._topic[CONF_COMMAND_TOPIC],
-            self._payload[STATE_OFF], self._config.get(CONF_QOS),
-            self._config.get(CONF_RETAIN))
+            self._payload[STATE_OFF], self._config[CONF_QOS],
+            self._config[CONF_RETAIN])
 
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan.
@@ -350,8 +350,8 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         mqtt.async_publish(
             self.hass, self._topic[CONF_SPEED_COMMAND_TOPIC],
-            mqtt_payload, self._config.get(CONF_QOS),
-            self._config.get(CONF_RETAIN))
+            mqtt_payload, self._config[CONF_QOS],
+            self._config[CONF_RETAIN])
 
         if self._optimistic_speed:
             self._speed = speed
@@ -372,7 +372,7 @@ class MqttFan(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         mqtt.async_publish(
             self.hass, self._topic[CONF_OSCILLATION_COMMAND_TOPIC],
-            payload, self._config.get(CONF_QOS), self._config.get(CONF_RETAIN))
+            payload, self._config[CONF_QOS], self._config[CONF_RETAIN])
 
         if self._optimistic_oscillation:
             self._oscillation = oscillating


### PR DESCRIPTION
## Description:
Use dict[key] for required config keys and keys with default values.
Sort configuration schema.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
