### PR TITLE
Use relative imports in yeelight

### DIFF
--- a/homeassistant/components/yeelight/binary_sensor.py
+++ b/homeassistant/components/yeelight/binary_sensor.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.yeelight import DATA_YEELIGHT, DATA_UPDATED
+from . import DATA_YEELIGHT, DATA_UPDATED
 
 DEPENDENCIES = ['yeelight']
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -15,7 +15,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR, SUPPORT_TRANSITION, SUPPORT_COLOR_TEMP, SUPPORT_FLASH,
     SUPPORT_EFFECT, Light)
 import homeassistant.util.color as color_util
-from homeassistant.components.yeelight import (
+from . import (
     CONF_TRANSITION, DATA_YEELIGHT, CONF_MODE_MUSIC,
     CONF_SAVE_ON_CHANGE, CONF_CUSTOM_EFFECTS, DATA_UPDATED,
     YEELIGHT_SERVICE_SCHEMA, DOMAIN, ATTR_TRANSITIONS,


### PR DESCRIPTION
## Description:
Yeelight wasn't component when doing auto import change https://github.com/home-assistant/home-assistant/pull/22235

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.