### PR TITLE
Make ZHA light get color and temp on init and polls

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -33,6 +33,10 @@ class ColorChannel(ZigbeeChannel):
     async def async_initialize(self, from_cache):
         """Initialize channel."""
         await self.fetch_color_capabilities(True)
+        await self.get_attribute_value(
+            'color_temperature', from_cache=from_cache)
+        await self.get_attribute_value('current_x', from_cache=from_cache)
+        await self.get_attribute_value('current_y', from_cache=from_cache)
 
     async def fetch_color_capabilities(self, from_cache):
         """Get the color configuration."""

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -253,6 +253,20 @@ class Light(ZhaEntity, light.Light):
         if self._level_channel:
             self._brightness = await self._level_channel.get_attribute_value(
                 'current_level', from_cache=from_cache)
+        if self._color_channel:
+            color_capabilities = self._color_channel.get_color_capabilities()
+            if color_capabilities is not None and\
+                    color_capabilities & CAPABILITIES_COLOR_TEMP:
+                self._color_temp = await\
+                    self._color_channel.get_attribute_value(
+                        'color_temperature', from_cache=from_cache)
+            if color_capabilities is not None and\
+                    color_capabilities & CAPABILITIES_COLOR_XY:
+                color_x = await self._color_channel.get_attribute_value(
+                    'current_x', from_cache=from_cache)
+                color_y = await self._color_channel.get_attribute_value(
+                    'current_y', from_cache=from_cache)
+                self._hs_color = color_util.color_xy_to_hs(color_x, color_y)
 
     async def refresh(self, time):
         """Call async_get_state at an interval."""


### PR DESCRIPTION
## Description:

Update ZHA to get color temp and color when we init a light and when we poll for state.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.