### PR TITLE
Bugfix binary_sensor.py

### DIFF
--- a/homeassistant/components/concord232/binary_sensor.py
+++ b/homeassistant/components/concord232/binary_sensor.py
@@ -74,7 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 )
             )
 
-        add_entities(sensors, True)
+    add_entities(sensors, True)
 
 
 def get_opening_type(zone):


### PR DESCRIPTION
Description: Add_entities is wrongly placed inside loop, so it ads the same sensor multiple times creating errors during HA restart.

Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
