### PR TITLE
Adjust manifest codeowners script

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,13 +45,13 @@ homeassistant/components/configurator/* @home-assistant/core
 homeassistant/components/conversation/* @home-assistant/core
 homeassistant/components/coolmaster/* @OnFreund
 homeassistant/components/counter/* @fabaff
-homeassistant/components/cover/* @cdce8p
+homeassistant/components/cover/* @home-assistant/core
 homeassistant/components/cpuspeed/* @fabaff
 homeassistant/components/cups/* @fabaff
 homeassistant/components/daikin/* @fredrike @rofrantz
 homeassistant/components/darksky/* @fabaff
 homeassistant/components/deconz/* @kane610
-homeassistant/components/demo/* @fabaff
+homeassistant/components/demo/* @home-assistant/core
 homeassistant/components/digital_ocean/* @fabaff
 homeassistant/components/discogs/* @thibmaek
 homeassistant/components/doorbird/* @oblogic7
@@ -243,3 +243,7 @@ homeassistant/components/zha/* @dmulcahey @adminiuga
 homeassistant/components/zone/* @home-assistant/core
 homeassistant/components/zoneminder/* @rohankapoorcom
 homeassistant/components/zwave/* @home-assistant/z-wave
+
+# Individual files
+homeassistant/components/group/cover @cdce8p
+homeassistant/components/demo/weather @fabaff

--- a/homeassistant/components/cover/manifest.json
+++ b/homeassistant/components/cover/manifest.json
@@ -7,6 +7,6 @@
     "group"
   ],
   "codeowners": [
-    "@cdce8p"
+    "@home-assistant/core"
   ]
 }

--- a/homeassistant/components/demo/manifest.json
+++ b/homeassistant/components/demo/manifest.json
@@ -9,6 +9,6 @@
     "zone"
   ],
   "codeowners": [
-    "@fabaff"
+    "@home-assistant/core"
   ]
 }

--- a/script/manifest/codeowners.py
+++ b/script/manifest/codeowners.py
@@ -27,6 +27,12 @@ homeassistant/scripts/check_config.py @kellerza
 # Integrations
 """
 
+INDIVIDUAL_FILES = """
+# Individual files
+homeassistant/components/group/cover @cdce8p
+homeassistant/components/demo/weather @fabaff
+"""
+
 
 def generate():
     """Generate CODEOWNERS."""
@@ -38,6 +44,8 @@ def generate():
 
         parts.append("homeassistant/components/{}/* {}".format(
             manifest['domain'], ' '.join(manifest['codeowners'])))
+
+    parts.append('\n' + INDIVIDUAL_FILES.strip())
 
     return '\n'.join(parts)
 


### PR DESCRIPTION
## Description:
I noticed that the conversion script for the old codeowners file didn't properly account for cases where only a single platform has a domain. I though of three options to solve this:
1. Drop the original codeowner and just assign `home-assistant/core`
2. Change the manifest schema to allow for details (e.g. codeowners on individual files)
3. Add the 'problem' cases to the codeowners script. This works, since Github only matches the `last` one that fits.

As far as I can tell it seems to only be an issue in two cases. Thus option `3` might be the best one.

**Related:** #22699

## Checklist:
  - [x] The code change is tested and works locally.