### PR TITLE
Improve Nuki lock

### DIFF
--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -1,10 +1,12 @@
 """Nuki.io lock platform."""
 from datetime import timedelta
 import logging
+import requests
 
 import voluptuous as vol
 
-from homeassistant.components.lock import DOMAIN, PLATFORM_SCHEMA, LockDevice
+from homeassistant.components.lock import (
+    DOMAIN, PLATFORM_SCHEMA, LockDevice, SUPPORT_OPEN)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, CONF_TOKEN)
 import homeassistant.helpers.config_validation as cv
@@ -13,6 +15,7 @@ from homeassistant.helpers.service import extract_entity_ids
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 8080
+DEFAULT_TIMEOUT = 20
 
 ATTR_BATTERY_CRITICAL = 'battery_critical'
 ATTR_NUKI_ID = 'nuki_id'
@@ -23,8 +26,8 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
 
 NUKI_DATA = 'nuki'
 
-SERVICE_LOCK_N_GO = 'nuki_lock_n_go'
-SERVICE_UNLATCH = 'nuki_unlatch'
+SERVICE_LOCK_N_GO = 'lock_n_go'
+SERVICE_CHECK_CONNECTION = "check_connection"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -37,7 +40,7 @@ LOCK_N_GO_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_UNLATCH, default=False): cv.boolean
 })
 
-UNLATCH_SERVICE_SCHEMA = vol.Schema({
+CHECK_CONNECTION_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
 })
 
@@ -45,8 +48,10 @@ UNLATCH_SERVICE_SCHEMA = vol.Schema({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Nuki lock platform."""
     from pynuki import NukiBridge
-    bridge = NukiBridge(config.get(CONF_HOST), config.get(CONF_TOKEN))
-    add_entities([NukiLock(lock) for lock in bridge.locks])
+    bridge = NukiBridge(config[CONF_HOST], config[CONF_TOKEN],
+                        config[CONF_PORT], DEFAULT_TIMEOUT)
+    add_entities([NukiLock(lock)
+                  for lock in bridge.locks])
 
     def service_handler(service):
         """Service handler for nuki services."""
@@ -63,15 +68,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             if service.service == SERVICE_LOCK_N_GO:
                 unlatch = service.data[ATTR_UNLATCH]
                 lock.lock_n_go(unlatch=unlatch)
-            elif service.service == SERVICE_UNLATCH:
-                lock.unlatch()
+            elif service.service == SERVICE_CHECK_CONNECTION:
+                lock.check_connection()
 
     hass.services.register(
-        DOMAIN, SERVICE_LOCK_N_GO, service_handler,
+        'nuki', SERVICE_LOCK_N_GO, service_handler,
         schema=LOCK_N_GO_SERVICE_SCHEMA)
     hass.services.register(
-        DOMAIN, SERVICE_UNLATCH, service_handler,
-        schema=UNLATCH_SERVICE_SCHEMA)
+        'nuki', SERVICE_CHECK_CONNECTION, service_handler,
+        schema=CHECK_CONNECTION_SERVICE_SCHEMA)
 
 
 class NukiLock(LockDevice):
@@ -83,6 +88,7 @@ class NukiLock(LockDevice):
         self._locked = nuki_lock.is_locked
         self._name = nuki_lock.name
         self._battery_critical = nuki_lock.battery_critical
+        self._available = nuki_lock.state != 255
 
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
@@ -110,12 +116,26 @@ class NukiLock(LockDevice):
             ATTR_NUKI_ID: self._nuki_lock.nuki_id}
         return data
 
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
+
     def update(self):
         """Update the nuki lock properties."""
-        self._nuki_lock.update(aggressive=False)
-        self._name = self._nuki_lock.name
-        self._locked = self._nuki_lock.is_locked
-        self._battery_critical = self._nuki_lock.battery_critical
+        try:
+            self._nuki_lock.update(aggressive=False)
+        except requests.exceptions.RequestException:
+            self._available = False
+        else:
+            self._name = self._nuki_lock.name
+            self._locked = self._nuki_lock.is_locked
+            self._battery_critical = self._nuki_lock.battery_critical
 
     def lock(self, **kwargs):
         """Lock the device."""
@@ -125,6 +145,10 @@ class NukiLock(LockDevice):
         """Unlock the device."""
         self._nuki_lock.unlock()
 
+    def open(self, **kwargs):
+        """Open the door latch."""
+        self._nuki_lock.unlatch()
+
     def lock_n_go(self, unlatch=False, **kwargs):
         """Lock and go.
 
@@ -133,6 +157,11 @@ class NukiLock(LockDevice):
         """
         self._nuki_lock.lock_n_go(unlatch, kwargs)
 
-    def unlatch(self, **kwargs):
-        """Unlatch door."""
-        self._nuki_lock.unlatch()
+    def check_connection(self, **kwargs):
+        """Update the nuki lock properties."""
+        try:
+            self._nuki_lock.update(aggressive=True)
+        except requests.exceptions.RequestException:
+            self._available = False
+        else:
+            self._available = self._nuki_lock.state != 255

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nuki",
   "documentation": "https://www.home-assistant.io/components/nuki",
   "requirements": [
-    "pynuki==1.3.2"
+    "pynuki==1.3.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1277,7 +1277,7 @@ pynetgear==0.6.1
 pynetio==0.1.9.1
 
 # homeassistant.components.nuki
-pynuki==1.3.2
+pynuki==1.3.3
 
 # homeassistant.components.nut
 pynut2==2.1.2


### PR DESCRIPTION
## Breaking Change:
The `lock.nuki_unlatch` service has been removed. It has been replaced by the `lock.open` service. The `lock.nuki_lock_n_go` service has been renamed to `nuki.lock_n_go`. Users that are using the removed or renamed services in automations need to replace them with the new services.

## Description:
Nuki lock component improvements:
 - Bride port: The port parameter was not forwarded on bridge component initialization. 
 - The default timeout has been changed from 5s to 20s.
 - available attribute: Implemented entity available attribute. It checks if the communication HA <-> bridge and bridge <-> lock is fine.
 - Check connection service: If, by any reason, the connection between the bridge and the lock was lost, there was no way to detect it. There is now a new service to force the communication between the bridge and the lock, instead of retrieving the last know state. If that communication fails, the attribute lock_reachable will become false. 
 - Open service implemented (previous nuki_unlatch)

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/9841

## Example entry for `configuration.yaml`:
```yaml
lock:
  - platform: nuki
    host: 192.168.0.85
    port: 8080
    token: [token]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)(waiting to be approved this PR to change the documentation)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
