### PR TITLE
Add functionality to the version sensor

### DIFF
--- a/homeassistant/components/version/manifest.json
+++ b/homeassistant/components/version/manifest.json
@@ -3,7 +3,7 @@
   "name": "Version",
   "documentation": "https://www.home-assistant.io/components/version",
   "requirements": [
-    "pyhaversion==2.0.3"
+    "pyhaversion==2.2.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_NAME, CONF_SOURCE
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyhaversion==2.0.3']
+REQUIREMENTS = ['pyhaversion==2.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1061,7 +1061,7 @@ pygtfs==0.1.5
 pygtt==1.1.2
 
 # homeassistant.components.version
-pyhaversion==2.0.3
+pyhaversion==2.2.0
 
 # homeassistant.components.heos
 pyheos==0.3.0


### PR DESCRIPTION
## Description:
This PR adds more functionality to the existing version sensor platform.

Now, (thank only to @ludeeus work) the sensor can get Dockerhub versions for all platforms.
The only change is in the requirements version.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9175

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
