### PR TITLE
Fix optimistic mode and add tests for MQTT Lock

### DIFF
--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -79,11 +79,13 @@ class MqttLock(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
     def __init__(self, config, config_entry, discovery_hash):
         """Initialize the lock."""
-        self._config = config
         self._unique_id = config.get(CONF_UNIQUE_ID)
         self._state = False
         self._sub_state = None
         self._optimistic = False
+
+        # Load config
+        self._setup_from_config(config)
 
         device_config = config.get(CONF_DEVICE)
 
@@ -101,12 +103,18 @@ class MqttLock(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     async def discovery_update(self, discovery_payload):
         """Handle updated discovery message."""
         config = PLATFORM_SCHEMA(discovery_payload)
-        self._config = config
+        self._setup_from_config(config)
         await self.attributes_discovery_update(config)
         await self.availability_discovery_update(config)
         await self.device_info_discovery_update(config)
         await self._subscribe_topics()
         self.async_write_ha_state()
+
+    def _setup_from_config(self, config):
+        """(Re)Setup the entity."""
+        self._config = config
+
+        self._optimistic = config[CONF_OPTIMISTIC]
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""

--- a/tests/components/lock/common.py
+++ b/tests/components/lock/common.py
@@ -6,6 +6,7 @@ components. Instead call the service directly.
 from homeassistant.components.lock import DOMAIN
 from homeassistant.const import (
     ATTR_CODE, ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK, SERVICE_OPEN)
+from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
 
@@ -21,6 +22,19 @@ def lock(hass, entity_id=None, code=None):
     hass.services.call(DOMAIN, SERVICE_LOCK, data)
 
 
+@callback
+@bind_hass
+def async_lock(hass, entity_id=None, code=None):
+    """Lock all or specified locks."""
+    data = {}
+    if code:
+        data[ATTR_CODE] = code
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_LOCK, data))
+
+
 @bind_hass
 def unlock(hass, entity_id=None, code=None):
     """Unlock all or specified locks."""
@@ -33,6 +47,19 @@ def unlock(hass, entity_id=None, code=None):
     hass.services.call(DOMAIN, SERVICE_UNLOCK, data)
 
 
+@callback
+@bind_hass
+def async_unlock(hass, entity_id=None, code=None):
+    """Lock all or specified locks."""
+    data = {}
+    if code:
+        data[ATTR_CODE] = code
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_UNLOCK, data))
+
+
 @bind_hass
 def open_lock(hass, entity_id=None, code=None):
     """Open all or specified locks."""
@@ -43,3 +70,16 @@ def open_lock(hass, entity_id=None, code=None):
         data[ATTR_ENTITY_ID] = entity_id
 
     hass.services.call(DOMAIN, SERVICE_OPEN, data)
+
+
+@callback
+@bind_hass
+def async_open_lock(hass, entity_id=None, code=None):
+    """Lock all or specified locks."""
+    data = {}
+    if code:
+        data[ATTR_CODE] = code
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_OPEN, data))


### PR DESCRIPTION
## Description:
Fix optimistic mode and add tests for MQTT Lock.
This is a regression from #19468

**Related issue (if applicable):** fixes #22874

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
