### PR TITLE
Use ConfigEntryNotReady when setting up Daikin

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -93,13 +93,13 @@ async def daikin_api_setup(hass, host):
             device = Appliance(host, session)
             await device.init()
     except asyncio.TimeoutError:
-        _LOGGER.error("Connection to Daikin timeout")
+        _LOGGER.debug("Connection to %s timed out", host)
         raise ConfigEntryNotReady
     except ClientConnectionError:
-        _LOGGER.error("ServerDisconected")
+        _LOGGER.debug("ClientConnectionError to %s", host)
         raise ConfigEntryNotReady
     except Exception:  # pylint: disable=broad-except
-        _LOGGER.error("Unexpected error creating device")
+        _LOGGER.error("Unexpected error creating device %s", host)
         return None
 
     api = DaikinApi(device)

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_HOSTS
+from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.typing import HomeAssistantType
@@ -88,15 +89,15 @@ async def daikin_api_setup(hass, host):
     from pydaikin.appliance import Appliance
     session = hass.helpers.aiohttp_client.async_get_clientsession()
     try:
-        with timeout(10, loop=hass.loop):
+        with timeout(10):
             device = Appliance(host, session)
             await device.init()
     except asyncio.TimeoutError:
         _LOGGER.error("Connection to Daikin timeout")
-        return None
+        raise ConfigEntryNotReady
     except ClientConnectionError:
         _LOGGER.error("ServerDisconected")
-        return None
+        raise ConfigEntryNotReady
     except Exception:  # pylint: disable=broad-except
         _LOGGER.error("Unexpected error creating device")
         return None


### PR DESCRIPTION
## Description:

It seems like a 10s timeout for setting up the component is not enough when sharing aiohttp socket, the component will now raise a ConfigEntryNotReady during setup if the timeout is reached.

**Related issue (if applicable):** fixes #22821


## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
