### PR TITLE
Fix Sonos handling of unsupported favorites

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.helpers import config_entry_flow
 
 
 DOMAIN = 'sonos'
-REQUIREMENTS = ['pysonos==0.0.8']
+REQUIREMENTS = ['pysonos==0.0.9']
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.8"
+    "pysonos==0.0.9"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -454,18 +454,7 @@ class SonosEntity(MediaPlayerDevice):
 
     def _set_favorites(self):
         """Set available favorites."""
-        # SoCo 0.16 raises a generic Exception on invalid xml in favorites.
-        # Filter those out now so our list is safe to use.
-        try:
-            self._favorites = []
-            for fav in self.soco.music_library.get_sonos_favorites():
-                try:
-                    if fav.reference.get_uri():
-                        self._favorites.append(fav)
-                except Exception:  # pylint: disable=broad-except
-                    _LOGGER.debug("Ignoring invalid favorite '%s'", fav.title)
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.debug("Ignoring invalid favorite list")
+        self._favorites = self.soco.music_library.get_sonos_favorites()
 
     def _radio_artwork(self, url):
         """Return the private URL with artwork for a radio stream."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1270,7 +1270,7 @@ pysmartthings==0.6.7
 pysnmp==4.4.8
 
 # homeassistant.components.sonos
-pysonos==0.0.8
+pysonos==0.0.9
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -239,7 +239,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.7
 
 # homeassistant.components.sonos
-pysonos==0.0.8
+pysonos==0.0.9
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

Any invalid XML should be handled by pysonos by now and if it isn't, I want to see the backtrace so I can fix it.

**Related issue (if applicable):** fixes #22714

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
