### PR TITLE
Test for circular dependencies using manifests

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -402,7 +402,7 @@ def _get_domains(hass: core.HomeAssistant, config: Dict[str, Any]) -> Set[str]:
     """Get domains of components to set up."""
     # Filter out the repeating and common config section [homeassistant]
     domains = set(key.split(' ')[0] for key in config.keys()
-                     if key != core.DOMAIN)
+                  if key != core.DOMAIN)
 
     # Add config entry domains
     domains.update(hass.config_entries.async_domains())  # type: ignore

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -132,7 +132,8 @@ async def async_from_config_dict(config: Dict[str, Any],
 
     # Resolve all dependencies of all components.
     for dep_domains in await asyncio.gather(*[
-        loader.async_component_dependencies(hass, domain) for domain in domains
+            loader.async_component_dependencies(hass, domain)
+            for domain in domains
     ], return_exceptions=True):
         # Result is either a set or an exception. We ignore exceptions
         # It will be properly handled during setup of the domain.

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -10,7 +10,6 @@ call get_component(hass, 'switch.your_platform'). In both cases the config
 directory is checked to see if it contains a user provided version. If not
 available it will check the built-in components and platforms.
 """
-import asyncio
 import functools as ft
 import importlib
 import json

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -68,8 +68,8 @@ def manifest_from_legacy_module(module: Any) -> Dict:
 class Integration:
     """An integration in Home Assistant."""
 
-    @staticmethod
-    def resolve_from_root(hass: 'HomeAssistant', root_module: Any,
+    @classmethod
+    def resolve_from_root(cls, hass: 'HomeAssistant', root_module: Any,
                           domain: str) -> 'Optional[Integration]':
         """Resolve an integration from a root module."""
         for base in root_module.__path__:
@@ -93,8 +93,8 @@ class Integration:
 
         return None
 
-    @staticmethod
-    def resolve_legacy(hass: 'HomeAssistant', domain: str) \
+    @classmethod
+    def resolve_legacy(cls, hass: 'HomeAssistant', domain: str) \
             -> 'Optional[Integration]':
         """Resolve legacy component.
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -87,7 +87,7 @@ class Integration:
                               manifest_path, err)
                 continue
 
-            return Integration(
+            return cls(
                 hass, "{}.{}".format(root_module.__name__, domain), manifest
             )
 
@@ -105,7 +105,7 @@ class Integration:
         if comp is None:
             return None
 
-        return Integration(
+        return cls(
             hass, comp.__name__, manifest_from_legacy_module(comp)
         )
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -108,8 +108,8 @@ async def _async_setup_component(hass: core.HomeAssistant,
 
     # Validate all dependencies exist and there are no circular dependencies
     try:
-        loader.component_dependencies(hass, domain)
-    except loader.ComponentNotFound as err:
+        await loader.async_component_dependencies(hass, domain)
+    except loader.IntegrationNotFound as err:
         _LOGGER.error(
             "Not setting up %s because we are unable to resolve "
             "(sub)dependency %s", domain, err.domain)

--- a/tests/common.py
+++ b/tests/common.py
@@ -902,6 +902,10 @@ def mock_integration(hass, module):
     integration = loader.Integration(
         hass, 'homeassisant.components.{}'.format(module.DOMAIN),
         loader.manifest_from_legacy_module(module))
+    integration.get_component = lambda: module
+
+    # Backwards compat
+    loader.set_component(hass, module.DOMAIN, module)
 
     hass.data.setdefault(
         loader.DATA_INTEGRATIONS, {}

--- a/tests/common.py
+++ b/tests/common.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, Mock, patch
 import homeassistant.util.dt as date_util
 import homeassistant.util.yaml as yaml
 
-from homeassistant import auth, config_entries, core as ha
+from homeassistant import auth, config_entries, core as ha, loader
 from homeassistant.auth import (
     models as auth_models, auth_store, providers as auth_providers,
     permissions as auth_permissions)
@@ -34,6 +34,7 @@ from homeassistant.setup import async_setup_component, setup_component
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.util.async_ import (
     run_callback_threadsafe, run_coroutine_threadsafe)
+
 
 _TEST_INSTANCE_PORT = SERVER_PORT
 _LOGGER = logging.getLogger(__name__)
@@ -894,3 +895,14 @@ async def flush_store(store):
 async def get_system_health_info(hass, domain):
     """Get system health info."""
     return await hass.data['system_health']['info'][domain](hass)
+
+
+def mock_integration(hass, module):
+    """Mock an integration."""
+    integration = loader.Integration(
+        hass, 'homeassisant.components.{}'.format(module.DOMAIN),
+        loader.manifest_from_legacy_module(module))
+
+    hass.data.setdefault(
+        loader.DATA_INTEGRATIONS, {}
+    )[module.DOMAIN] = integration

--- a/tests/components/mobile_app/__init__.py
+++ b/tests/components/mobile_app/__init__.py
@@ -55,7 +55,7 @@ async def webhook_client(hass, aiohttp_client, hass_storage, hass_admin_user):
     }
 
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
-
+    await hass.async_block_till_done()
     return await aiohttp_client(hass.http.app)
 
 
@@ -63,6 +63,7 @@ async def webhook_client(hass, aiohttp_client, hass_storage, hass_admin_user):
 async def authed_api_client(hass, hass_client):
     """Provide an authenticated client for mobile_app to use."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
     return await hass_client()
 
 
@@ -70,3 +71,4 @@ async def authed_api_client(hass, hass_client):
 async def setup_ws(hass):
     """Configure the websocket_api component."""
     assert await async_setup_component(hass, 'websocket_api', {})
+    await hass.async_block_till_done()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -108,7 +108,7 @@ async def test_async_from_config_file_not_mount_deps_folder(loop):
 async def test_load_hassio(hass):
     """Test that we load Hass.io component."""
     with patch.dict(os.environ, {}, clear=True):
-        assert bootstrap._get_components(hass, {}) == set()
+        assert bootstrap._get_domains(hass, {}) == set()
 
     with patch.dict(os.environ, {'HASSIO': '1'}):
-        assert bootstrap._get_components(hass, {}) == {'hassio'}
+        assert bootstrap._get_domains(hass, {}) == {'hassio'}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -158,6 +158,14 @@ async def test_get_integration_legacy(hass):
     assert integration.get_platform('switch') is not None
 
 
+async def test_get_integration_custom_component(hass):
+    """Test resolving integration."""
+    integration = await loader.async_get_integration(hass, 'test_package')
+    print(integration)
+    assert integration.get_component().DOMAIN == 'test_package'
+    assert integration.name == 'Test Package'
+
+
 def test_integration_properties(hass):
     """Test integration properties."""
     integration = loader.Integration(hass, 'homeassistant.components.hue', {

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import discovery
 
 from tests.common import \
     get_test_home_assistant, MockModule, MockPlatform, \
-    assert_setup_component, get_test_config_dir
+    assert_setup_component, get_test_config_dir, mock_integration
 
 ORIG_TIMEZONE = dt_util.DEFAULT_TIME_ZONE
 VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
@@ -378,18 +378,18 @@ class TestSetup:
 
     def test_component_not_setup_missing_dependencies(self):
         """Test we do not set up a component if not all dependencies loaded."""
-        deps = ['non_existing']
-        loader.set_component(
-            self.hass, 'comp', MockModule('comp', dependencies=deps))
+        deps = ['maybe_existing']
+        mock_integration(self.hass, MockModule('comp', dependencies=deps))
 
         assert not setup.setup_component(self.hass, 'comp', {})
         assert 'comp' not in self.hass.config.components
 
         self.hass.data.pop(setup.DATA_SETUP)
 
-        loader.set_component(
-            self.hass, 'non_existing', MockModule('non_existing'))
-        assert setup.setup_component(self.hass, 'comp', {})
+        mock_integration(self.hass, MockModule('comp2', dependencies=deps))
+        mock_integration(self.hass, MockModule('maybe_existing'))
+
+        assert setup.setup_component(self.hass, 'comp2', {})
 
     def test_component_failing_setup(self):
         """Test component that fails setup."""

--- a/tests/testing_config/custom_components/test_embedded/__init__.py
+++ b/tests/testing_config/custom_components/test_embedded/__init__.py
@@ -1,4 +1,5 @@
 """Component with embedded platforms."""
+DOMAIN = 'test_embedded'
 
 
 async def async_setup(hass, config):

--- a/tests/testing_config/custom_components/test_package/manifest.json
+++ b/tests/testing_config/custom_components/test_package/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "test_package",
+  "name": "Test Package",
+  "documentation": "http://test-package.io",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": []
+}


### PR DESCRIPTION
## Description:
This tests for circular dependencies based on the dependencies specified in the manifest, falling back to the legacy format if not available.

This PR introduces a new format to hold integration metadata, based off the manifest.json, falling back to the legacy format if no manifest found.

Started out as an exploration to help @rohankapoorcom with #22717 #22716 . If this gets merged before, we should rebase and use `async_get_integration` there too to see if it helps with fixing tests.

**Related issue (if applicable):** #22700

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
