### PR TITLE
Fix ZHA Light color conversion.

### DIFF
--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -29,6 +29,7 @@ class ColorChannel(ZigbeeChannel):
     async def async_configure(self):
         """Configure channel."""
         await self.fetch_color_capabilities(False)
+        await super().async_configure()
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -266,7 +266,9 @@ class Light(ZhaEntity, light.Light):
                     'current_x', from_cache=from_cache)
                 color_y = await self._color_channel.get_attribute_value(
                     'current_y', from_cache=from_cache)
-                self._hs_color = color_util.color_xy_to_hs(color_x, color_y)
+                if color_x is not None and color_y is not None:
+                    self._hs_color = color_util.color_xy_to_hs(
+                        float(color_x / 65535), float(color_y / 65535))
 
     async def refresh(self, time):
         """Call async_get_state at an interval."""


### PR DESCRIPTION
## Description:
Correctly convert Zigbee `color_x` and `color_y` to hs colorspace
Fix Zigbee attribute reporting for color channel.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
