### PR TITLE
Stream Timestamp Fixes

### DIFF
--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -85,7 +85,7 @@ class M3U8Renderer:
         for sequence in segments:
             segment = track.get_segment(sequence)
             playlist.extend([
-                "#EXTINF:{:.04},".format(float(segment.duration)),
+                "#EXTINF:{:.04f},".format(float(segment.duration)),
                 "./segment/{}.ts".format(segment.sequence),
             ])
 

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -55,11 +55,16 @@ def stream_worker(hass, stream, quit_event):
 
     audio_frame = generate_audio_frame()
 
-    outputs = {}
     first_packet = True
+    # Holds the buffers for each stream provider
+    outputs = {}
+    # Keep track of the number of segments we've processed
     sequence = 1
+    # Holds the generated silence that needs to be muxed into the output
     audio_packets = {}
+    # The presentation timestamp of the first video packet we recieve
     first_pts = 0
+    # The decoder timestamp of the latest packet we processed
     last_dts = None
 
     while not quit_event.is_set():
@@ -83,14 +88,18 @@ def stream_worker(hass, stream, quit_event):
             continue
         last_dts = packet.dts
 
-        # Reset timestamps for this stream
+        # Reset timestamps from a 0 time base for this stream
         packet.dts -= first_pts
         packet.pts -= first_pts
 
         # Reset segment on every keyframe
         if packet.is_keyframe:
-            # Save segment to outputs
+            # Calculate the segment duration by multiplying the presentation
+            # timestamp by the time base, which gets us total seconds.
+            # By then dividing by the seqence, we can calculate how long
+            # each segment is, assuming the stream starts from 0.
             segment_duration = (packet.pts * packet.time_base) / sequence
+            # Save segment to outputs
             for fmt, buffer in outputs.items():
                 buffer.output.close()
                 del audio_packets[buffer.astream]
@@ -118,7 +127,9 @@ def stream_worker(hass, stream, quit_event):
         # First video packet tends to have a weird dts/pts
         if first_packet:
             # If we are attaching to a live stream that does not reset
-            # timestamps for us, we need to do it ourselves.
+            # timestamps for us, we need to do it ourselves by recording
+            # the first presentation timestamp and subtracting it from
+            # subsequent packets we recieve.
             if (packet.pts * packet.time_base) > 1:
                 first_pts = packet.pts
             packet.dts = 0


### PR DESCRIPTION
## Description:

@cgtobi PMed me via Discord today regarding his attempts to integrate the Netatmo Welcome camera.  This camera provides an HLS feed directly from the camera.  It was found that the HLS feed was not on-demand, and the camera did not reset the video decode/presentation timestamps for us like many other cameras do.

Because of this, the `stream` component was incorrectly calculating the duration of a segment to the tune of 8000+ seconds per segment.  To correct this, if the presentation timestamp of the first packet received by the stream worker is greater than 1 second, we will record that as the base, and subtract it from all future packets.  This effectively resets the timestamps to start at 0, and fixes the stream.

While this has been tested and confirmed working on @cgtobi's Netatmo camera along with my HikVision cameras, I recommend **not** tagging this for 0.91.3 in order for it to go through the full beta cycle during 0.92 so we can get confirmation from other configurations that are already working.

**Related issue (if applicable):** @cgtobi via Discord PM

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.