### PR TITLE
Support HEOS devices not logged in to HEOS account

### DIFF
--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -141,7 +141,7 @@ class HeosMediaPlayer(MediaPlayerDevice):
 
     async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
-        await self._player.set_volume(volume * 100)
+        await self._player.set_volume(int(volume * 100))
 
     async def async_update(self):
         """Update supported features of the player."""

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -28,6 +28,8 @@ def controller_fixture(players, favorites, input_sources, dispatcher):
         mock_heos.players = players
         mock_heos.get_favorites.return_value = favorites
         mock_heos.get_input_sources.return_value = input_sources
+        mock_heos.is_signed_in = True
+        mock_heos.signed_in_username = "user@user.com"
         yield mock_heos
 
 


### PR DESCRIPTION
## Description:
Adds support for connecting to HEOS devices that are not logged in to the user's HEOS account.  All control features are still available, with the exception of loading favorites into source selection.  A warning message is printed in the log upon startup when the device is not logged in.  **Prior to this change, the HEOS config entry would fail to load.**

This PR also fixes a data-type issue in `async_set_volume_level` that resulted in a failure to set the volume level to 0.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.