### PR TITLE
More Mobile app sensor fixes

### DIFF
--- a/homeassistant/components/mobile_app/binary_sensor.py
+++ b/homeassistant/components/mobile_app/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (ATTR_SENSOR_STATE,
                     ATTR_SENSOR_TYPE_BINARY_SENSOR as ENTITY_TYPE,
+                    ATTR_SENSOR_UNIQUE_ID,
                     DATA_DEVICES, DOMAIN)
 
 from .entity import MobileAppEntity
@@ -35,6 +36,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     def handle_sensor_registration(webhook_id, data):
         if data[CONF_WEBHOOK_ID] != webhook_id:
             return
+
+        unique_id = "{}_{}".format(data[CONF_WEBHOOK_ID],
+                                   data[ATTR_SENSOR_UNIQUE_ID])
+
+        entity = hass.data[DOMAIN][ENTITY_TYPE][unique_id]
+
+        if 'added' in entity:
+            return
+
+        entity['added'] = True
 
         device = hass.data[DOMAIN][DATA_DEVICES][data[CONF_WEBHOOK_ID]]
 

--- a/homeassistant/components/mobile_app/binary_sensor.py
+++ b/homeassistant/components/mobile_app/binary_sensor.py
@@ -11,7 +11,7 @@ from .const import (ATTR_SENSOR_STATE,
                     ATTR_SENSOR_UNIQUE_ID,
                     DATA_DEVICES, DOMAIN)
 
-from .entity import MobileAppEntity
+from .entity import MobileAppEntity, sensor_id
 
 DEPENDENCIES = ['mobile_app']
 
@@ -37,8 +37,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if data[CONF_WEBHOOK_ID] != webhook_id:
             return
 
-        unique_id = "{}_{}".format(data[CONF_WEBHOOK_ID],
-                                   data[ATTR_SENSOR_UNIQUE_ID])
+        unique_id = sensor_id(data[CONF_WEBHOOK_ID],
+                              data[ATTR_SENSOR_UNIQUE_ID])
 
         entity = hass.data[DOMAIN][ENTITY_TYPE][unique_id]
 

--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -13,6 +13,11 @@ from .const import (ATTR_DEVICE_ID, ATTR_DEVICE_NAME, ATTR_MANUFACTURER,
                     DOMAIN, SIGNAL_SENSOR_UPDATE)
 
 
+def sensor_id(webhook_id, unique_id):
+    """Return a unique sensor ID."""
+    return "{}_{}".format(webhook_id, unique_id)
+
+
 class MobileAppEntity(Entity):
     """Representation of an mobile app entity."""
 
@@ -22,8 +27,8 @@ class MobileAppEntity(Entity):
         self._device = device
         self._entry = entry
         self._registration = entry.data
-        self._sensor_id = "{}_{}".format(self._registration[CONF_WEBHOOK_ID],
-                                         config[ATTR_SENSOR_UNIQUE_ID])
+        self._sensor_id = sensor_id(self._registration[CONF_WEBHOOK_ID],
+                                    config[ATTR_SENSOR_UNIQUE_ID])
         self._entity_type = config[ATTR_SENSOR_TYPE]
         self.unsub_dispatcher = None
 
@@ -94,5 +99,10 @@ class MobileAppEntity(Entity):
     @callback
     def _handle_update(self, data):
         """Handle async event updates."""
+        incoming_id = sensor_id(data[CONF_WEBHOOK_ID],
+                                data[ATTR_SENSOR_UNIQUE_ID])
+        if incoming_id != self._sensor_id:
+            return
+
         self._config = data
         self.async_schedule_update_ha_state()

--- a/homeassistant/components/mobile_app/sensor.py
+++ b/homeassistant/components/mobile_app/sensor.py
@@ -10,7 +10,7 @@ from .const import (ATTR_SENSOR_STATE,
                     ATTR_SENSOR_UNIQUE_ID, ATTR_SENSOR_UOM, DATA_DEVICES,
                     DOMAIN)
 
-from .entity import MobileAppEntity
+from .entity import MobileAppEntity, sensor_id
 
 DEPENDENCIES = ['mobile_app']
 
@@ -36,8 +36,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if data[CONF_WEBHOOK_ID] != webhook_id:
             return
 
-        unique_id = "{}_{}".format(data[CONF_WEBHOOK_ID],
-                                   data[ATTR_SENSOR_UNIQUE_ID])
+        unique_id = sensor_id(data[CONF_WEBHOOK_ID],
+                              data[ATTR_SENSOR_UNIQUE_ID])
 
         entity = hass.data[DOMAIN][ENTITY_TYPE][unique_id]
 

--- a/homeassistant/components/mobile_app/sensor.py
+++ b/homeassistant/components/mobile_app/sensor.py
@@ -7,7 +7,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (ATTR_SENSOR_STATE,
                     ATTR_SENSOR_TYPE_SENSOR as ENTITY_TYPE,
-                    ATTR_SENSOR_UOM, DATA_DEVICES, DOMAIN)
+                    ATTR_SENSOR_UNIQUE_ID, ATTR_SENSOR_UOM, DATA_DEVICES,
+                    DOMAIN)
 
 from .entity import MobileAppEntity
 
@@ -34,6 +35,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     def handle_sensor_registration(webhook_id, data):
         if data[CONF_WEBHOOK_ID] != webhook_id:
             return
+
+        unique_id = "{}_{}".format(data[CONF_WEBHOOK_ID],
+                                   data[ATTR_SENSOR_UNIQUE_ID])
+
+        entity = hass.data[DOMAIN][ENTITY_TYPE][unique_id]
+
+        if 'added' in entity:
+            return
+
+        entity['added'] = True
 
         device = hass.data[DOMAIN][DATA_DEVICES][data[CONF_WEBHOOK_ID]]
 

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -1,5 +1,6 @@
 """Webhook handlers for mobile_app."""
 import logging
+import json
 
 from aiohttp.web import HTTPBadRequest, Response, Request
 import voluptuous as vol
@@ -95,6 +96,9 @@ async def handle_webhook(hass: HomeAssistantType, webhook_id: str,
         return empty_okay_response()
 
     data = webhook_payload
+
+    _LOGGER.debug("Received webhook payload for type %s: %s", webhook_type,
+                  json.dumps(data))
 
     if webhook_type in WEBHOOK_SCHEMAS:
         try:

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -1,6 +1,5 @@
 """Webhook handlers for mobile_app."""
 import logging
-import json
 
 from aiohttp.web import HTTPBadRequest, Response, Request
 import voluptuous as vol
@@ -98,7 +97,7 @@ async def handle_webhook(hass: HomeAssistantType, webhook_id: str,
     data = webhook_payload
 
     _LOGGER.debug("Received webhook payload for type %s: %s", webhook_type,
-                  json.dumps(data))
+                  data)
 
     if webhook_type in WEBHOOK_SCHEMAS:
         try:


### PR DESCRIPTION
## Description:

Discovered an issue where we weren't limiting what previously loaded entities would do with new sensor registrations or sensor updates. This limits things so that only the entity matching the unique ID of the sensor handles its own updates. It also ensures that only one entity handles registering new sensors. Finally, it includes some debug logging to ease development of apps.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.