### PR TITLE
Speed up state change when controlling groups of lights

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -280,6 +280,7 @@ async def async_setup(hass, config):
         preprocess_turn_on_alternatives(params)
         turn_lights_off, off_params = preprocess_turn_off(params)
 
+        light_calls = []
         update_tasks = []
         for light in target_lights:
             light.async_set_context(service.context)
@@ -292,16 +293,67 @@ async def async_setup(hass, config):
                 pars[ATTR_PROFILE] = Profiles.get_default(light.entity_id)
                 preprocess_turn_on_alternatives(pars)
                 turn_light_off, off_pars = preprocess_turn_off(pars)
+
             if turn_light_off:
-                await light.async_turn_off(**off_pars)
+                light_calls.append(light.async_turn_off(**off_pars))
             else:
-                await light.async_turn_on(**pars)
+                light_calls.append(light.async_turn_on(**pars))
 
             if not light.should_poll:
                 continue
 
             update_tasks.append(
                 light.async_update_ha_state(True))
+
+        if light_calls:
+            await asyncio.gather(*light_calls, loop=hass.loop)
+
+        if update_tasks:
+            await asyncio.wait(update_tasks, loop=hass.loop)
+
+    async def async_handle_light_off_service(service):
+        """Handle a turn light off service call."""
+        # Get the validated data
+        params = service.data.copy()
+
+        # Convert the entity ids to valid light ids
+        target_lights = await component.async_extract_from_service(service)
+        params.pop(ATTR_ENTITY_ID, None)
+
+        if service.context.user_id:
+            user = await hass.auth.async_get_user(service.context.user_id)
+            if user is None:
+                raise UnknownUser(context=service.context)
+
+            entity_perms = user.permissions.check_entity
+
+            for light in target_lights:
+                if not entity_perms(light, POLICY_CONTROL):
+                    raise Unauthorized(
+                        context=service.context,
+                        entity_id=light,
+                        permission=POLICY_CONTROL
+                    )
+        light_calls = []
+        update_tasks = []
+        for light in target_lights:
+            light.async_set_context(service.context)
+
+            pars = params
+            if not pars:
+                pars = params.copy()
+                pars[ATTR_PROFILE] = Profiles.get_default(light.entity_id)
+
+            light_calls.append(light.async_turn_off(**pars))
+
+            if not light.should_poll:
+                continue
+
+            update_tasks.append(
+                light.async_update_ha_state(True))
+
+        if light_calls:
+            await asyncio.gather(*light_calls, loop=hass.loop)
 
         if update_tasks:
             await asyncio.wait(update_tasks, loop=hass.loop)
@@ -311,10 +363,9 @@ async def async_setup(hass, config):
         DOMAIN, SERVICE_TURN_ON, async_handle_light_on_service,
         schema=LIGHT_TURN_ON_SCHEMA)
 
-    component.async_register_entity_service(
-        SERVICE_TURN_OFF, LIGHT_TURN_OFF_SCHEMA,
-        'async_turn_off'
-    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_TURN_OFF, async_handle_light_off_service,
+        schema=LIGHT_TURN_OFF_SCHEMA)
 
     component.async_register_entity_service(
         SERVICE_TOGGLE, LIGHT_TOGGLE_SCHEMA,


### PR DESCRIPTION
## Description:

This PR speeds up the state change when controlling groups of lights via a single service call. It addresses an issue I had with Tuya lights which need to round-trip to the cloud for control and when controlling groups of lights there was a noticeable ~700 - 1500ms lag between each turning on/off.

The issue was caused by the light turn on/off service calling await on each light in the group when iterating through them. This change simply builds an array of on/off coroutines and then executes them concurrently instead. This greatly improves the responsiveness of lights when controlling them as a group.

Any suggestions for improvements are welcome.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
