### PR TITLE
Add 'Assumed State' property to Somfy MyLink covers

### DIFF
--- a/homeassistant/components/somfy_mylink/cover.py
+++ b/homeassistant/components/somfy_mylink/cover.py
@@ -59,7 +59,7 @@ class SomfyShade(CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        pass
+        return None
 
     @property
     def device_class(self):

--- a/homeassistant/components/somfy_mylink/cover.py
+++ b/homeassistant/components/somfy_mylink/cover.py
@@ -62,6 +62,11 @@ class SomfyShade(CoverDevice):
         return None
 
     @property
+    def assumed_state(self):
+        """Let HA know the integration is assumed state"""
+        return True
+
+    @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
         return self._device_class

--- a/homeassistant/components/somfy_mylink/cover.py
+++ b/homeassistant/components/somfy_mylink/cover.py
@@ -63,7 +63,7 @@ class SomfyShade(CoverDevice):
 
     @property
     def assumed_state(self):
-        """Let HA know the integration is assumed state"""
+        """Let HA know the integration is assumed state."""
         return True
 
     @property


### PR DESCRIPTION
## Description:

Adds `assumed_state` property for Somfy MyLink covers, was accidently left out of previous PR home-assistant/home-assistant#22514

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9063



## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

ATTN: @MartinHjelmare 