### PR TITLE
Fix websocket connection sensor

### DIFF
--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -24,3 +24,6 @@ CANCELLATION_ERRORS = (asyncio.CancelledError, futures.CancelledError)
 # Event types
 SIGNAL_WEBSOCKET_CONNECTED = 'websocket_connected'
 SIGNAL_WEBSOCKET_DISCONNECTED = 'websocket_disconnected'
+
+# Data used to store the current connection list
+DATA_CONNECTIONS = DOMAIN + '.connections'

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -50,8 +50,6 @@ class WebSocketHandler:
         self._writer_task = None
         self._logger = logging.getLogger(
             "{}.connection.{}".format(__name__, id(self)))
-        self._connections = set()
-        hass.data[DATA_CONNECTIONS] = self._connections
 
     async def _writer(self):
         """Write outgoing messages."""
@@ -147,7 +145,8 @@ class WebSocketHandler:
 
             self._logger.debug("Received %s", msg)
             connection = await auth.async_handle(msg)
-            self._connections.add(connection)
+            self.hass.data[DATA_CONNECTIONS] = \
+                self.hass.data.get(DATA_CONNECTIONS, 0) + 1
             self.hass.helpers.dispatcher.async_dispatcher_send(
                 SIGNAL_WEBSOCKET_CONNECTED)
 
@@ -200,7 +199,7 @@ class WebSocketHandler:
             else:
                 self._logger.warning("Disconnected: %s", disconnect_warn)
 
-            self._connections.remove(connection)
+            self.hass.data[DATA_CONNECTIONS] -= 1
             self.hass.helpers.dispatcher.async_dispatcher_send(
                 SIGNAL_WEBSOCKET_DISCONNECTED)
 

--- a/homeassistant/components/websocket_api/sensor.py
+++ b/homeassistant/components/websocket_api/sensor.py
@@ -3,19 +3,15 @@
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 
-from .const import SIGNAL_WEBSOCKET_CONNECTED, SIGNAL_WEBSOCKET_DISCONNECTED
+from .const import (
+    SIGNAL_WEBSOCKET_CONNECTED, SIGNAL_WEBSOCKET_DISCONNECTED,
+    DATA_CONNECTIONS)
 
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the API streams platform."""
     entity = APICount()
-
-    # pylint: disable=protected-access
-    hass.helpers.dispatcher.async_dispatcher_connect(
-        SIGNAL_WEBSOCKET_CONNECTED, entity._increment)
-    hass.helpers.dispatcher.async_dispatcher_connect(
-        SIGNAL_WEBSOCKET_DISCONNECTED, entity._decrement)
 
     async_add_entities([entity])
 
@@ -25,7 +21,15 @@ class APICount(Entity):
 
     def __init__(self):
         """Initialize the API count."""
-        self.count = 0
+        self.count = None
+
+    async def async_added_to_hass(self):
+        """Added to hass."""
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            SIGNAL_WEBSOCKET_CONNECTED, self._update_count)
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            SIGNAL_WEBSOCKET_DISCONNECTED, self._update_count)
+        self._update_count()
 
     @property
     def name(self):
@@ -43,11 +47,7 @@ class APICount(Entity):
         return "clients"
 
     @callback
-    def _increment(self):
-        self.count += 1
-        self.async_schedule_update_ha_state()
-
-    @callback
-    def _decrement(self):
-        self.count -= 1
+    def _update_count(self):
+        connections = self.hass.data.get(DATA_CONNECTIONS)
+        self.count = len(connections) if connections else 0
         self.async_schedule_update_ha_state()

--- a/homeassistant/components/websocket_api/sensor.py
+++ b/homeassistant/components/websocket_api/sensor.py
@@ -48,6 +48,5 @@ class APICount(Entity):
 
     @callback
     def _update_count(self):
-        connections = self.hass.data.get(DATA_CONNECTIONS)
-        self.count = len(connections) if connections else 0
+        self.count = self.hass.data.get(DATA_CONNECTIONS, 0)
         self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:

Bug shows that websocket sensor gets out of sync and shows negative numbers. I suspect this is because there's connections made before the websocket sensor is started up.

Fixed by:

* Keeping a set of connections in `hass.data`
* Reading the size of the set directly

The set approach has the advantage that it we can look at the list of connections somewhere else, for example to display the list of current connections somewhere in the API if we choose to at some stage. 

**Related issue (if applicable):** fixes #22890

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
