### PR TITLE
Ignore secrets.yaml when using include_dir_named

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -157,6 +157,8 @@ def _include_dir_named_yaml(loader: SafeLineLoader,
     loc = os.path.join(os.path.dirname(loader.name), node.value)
     for fname in _find_files(loc, '*.yaml'):
         filename = os.path.splitext(os.path.basename(fname))[0]
+        if os.path.basename(fname) == SECRET_YAML:
+            continue
         mapping[filename] = load_yaml(fname)
     return _add_reference(mapping, loader, node)
 

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -134,7 +134,7 @@ class TestYaml(unittest.TestCase):
     def test_include_dir_named(self, mock_walk):
         """Test include dir named yaml."""
         mock_walk.return_value = [
-            ['/tmp', [], ['first.yaml', 'second.yaml']]
+            ['/tmp', [], ['first.yaml', 'second.yaml', 'secrets.yaml']]
         ]
 
         with patch_yaml_files({


### PR DESCRIPTION
## Description:
Fixes the inclusion of secrets.yml when using the "include_dir_named" directive. 

**Related issue (if applicable):** fixes #22926

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**  n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

