### PR TITLE
Allow use "for" without specifying "to" for STATE TRIGGER

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -11,14 +11,14 @@ CONF_ENTITY_ID = 'entity_id'
 CONF_FROM = 'from'
 CONF_TO = 'to'
 
-TRIGGER_SCHEMA = vol.All(vol.Schema({
+TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'state',
     vol.Required(CONF_ENTITY_ID): cv.entity_ids,
     # These are str on purpose. Want to catch YAML conversions
     vol.Optional(CONF_FROM): str,
     vol.Optional(CONF_TO): str,
     vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
-}), cv.key_dependency(CONF_FOR, CONF_TO))
+})
 
 
 async def async_trigger(hass, config, action, automation_info):

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -296,24 +296,6 @@ async def test_if_fails_setup_bad_for(hass, calls):
             }})
 
 
-async def test_if_fails_setup_for_without_to(hass, calls):
-    """Test for setup failures for missing to."""
-    with assert_setup_component(0):
-        assert await async_setup_component(hass, automation.DOMAIN, {
-            automation.DOMAIN: {
-                'trigger': {
-                    'platform': 'state',
-                    'entity_id': 'test.entity',
-                    'for': {
-                        'seconds': 5
-                    },
-                },
-                'action': {
-                    'service': 'homeassistant.turn_on',
-                }
-            }})
-
-
 async def test_if_not_fires_on_entity_change_with_for(hass, calls):
     """Test for not firing on entity change with for."""
     assert await async_setup_component(hass, automation.DOMAIN, {


### PR DESCRIPTION
## Description:
Allow use `for` for any state change.

Fixes: `Invalid config for [automation]: dependency violation - key "for" requires key "to" to exist @ data['trigger'][0].
`

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**
Not ready yet.

## Example entry for `automation.yaml` (if applicable):
```yaml
- alias: test
  trigger:
    - platform: state
      entity_id: input_number.test
      for:
        seconds: 3
  action:
    - service: persistent_notification.create
      data:
        title: Test
        message: "{{ now() }}"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
