### PR TITLE
Add connection control for netgear_lte

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -37,11 +37,18 @@ DATA_KEY = 'netgear_lte'
 EVENT_SMS = 'netgear_lte_sms'
 
 SERVICE_DELETE_SMS = 'delete_sms'
+SERVICE_SET_OPTION = 'set_option'
+SERVICE_CONNECT_LTE = 'connect_lte'
 
 ATTR_HOST = 'host'
 ATTR_SMS_ID = 'sms_id'
 ATTR_FROM = 'from'
 ATTR_MESSAGE = 'message'
+ATTR_FAILOVER = 'failover'
+ATTR_AUTOCONNECT = 'autoconnect'
+
+FAILOVER_MODES = ['auto', 'wire', 'mobile']
+AUTOCONNECT_MODES = ['never', 'home', 'always']
 
 
 NOTIFY_SCHEMA = vol.Schema({
@@ -76,8 +83,20 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 DELETE_SMS_SCHEMA = vol.Schema({
-    vol.Required(ATTR_HOST): cv.string,
+    vol.Optional(ATTR_HOST): cv.string,
     vol.Required(ATTR_SMS_ID): vol.All(cv.ensure_list, [cv.positive_int]),
+})
+
+SET_OPTION_SCHEMA = vol.Schema(
+    vol.All(cv.has_at_least_one_key(ATTR_FAILOVER, ATTR_AUTOCONNECT), {
+        vol.Optional(ATTR_HOST): cv.string,
+        vol.Optional(ATTR_FAILOVER): vol.In(FAILOVER_MODES),
+        vol.Optional(ATTR_AUTOCONNECT): vol.In(AUTOCONNECT_MODES),
+    })
+)
+
+CONNECT_LTE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_HOST): cv.string,
 })
 
 
@@ -118,7 +137,11 @@ class LTEData:
 
     def get_modem_data(self, config):
         """Get modem_data for the host in config."""
-        return self.modem_data.get(config[CONF_HOST])
+        if config[CONF_HOST] is not None:
+            return self.modem_data.get(config[CONF_HOST])
+        if len(self.modem_data) != 1:
+            return None
+        return next(iter(self.modem_data.values()))
 
 
 async def async_setup(hass, config):
@@ -128,23 +151,42 @@ async def async_setup(hass, config):
             hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
         hass.data[DATA_KEY] = LTEData(websession)
 
-        async def delete_sms_handler(service):
+        async def service_handler(service):
             """Apply a service."""
-            host = service.data[ATTR_HOST]
+            host = service.data.get(ATTR_HOST)
             conf = {CONF_HOST: host}
             modem_data = hass.data[DATA_KEY].get_modem_data(conf)
 
             if not modem_data:
                 _LOGGER.error(
-                    "%s: host %s unavailable", SERVICE_DELETE_SMS, host)
+                    "%s: host %s unavailable", service.service, host)
                 return
 
-            for sms_id in service.data[ATTR_SMS_ID]:
-                await modem_data.modem.delete_sms(sms_id)
+            if service.service == SERVICE_DELETE_SMS:
+                for sms_id in service.data[ATTR_SMS_ID]:
+                    await modem_data.modem.delete_sms(sms_id)
+            elif service.service == SERVICE_SET_OPTION:
+                failover = service.data.get(ATTR_FAILOVER)
+                if failover:
+                    await modem_data.modem.set_failover_mode(failover)
+
+                autoconnect = service.data.get(ATTR_AUTOCONNECT)
+                if autoconnect:
+                    await modem_data.modem.set_autoconnect_mode(autoconnect)
+            elif service.service == SERVICE_CONNECT_LTE:
+                await modem_data.modem.connect_lte()
 
         hass.services.async_register(
-            DOMAIN, SERVICE_DELETE_SMS, delete_sms_handler,
+            DOMAIN, SERVICE_DELETE_SMS, service_handler,
             schema=DELETE_SMS_SCHEMA)
+
+        hass.services.async_register(
+            DOMAIN, SERVICE_SET_OPTION, service_handler,
+            schema=SET_OPTION_SCHEMA)
+
+        hass.services.async_register(
+            DOMAIN, SERVICE_CONNECT_LTE, service_handler,
+            schema=CONNECT_LTE_SCHEMA)
 
     netgear_lte_config = config[DOMAIN]
 

--- a/homeassistant/components/netgear_lte/services.yaml
+++ b/homeassistant/components/netgear_lte/services.yaml
@@ -7,3 +7,23 @@ delete_sms:
     sms_id:
       description: Integer or list of integers with inbox IDs of messages to delete.
       example: 7
+
+set_option:
+  description: Set options on the modem.
+  fields:
+    host:
+      description: The modem to set options on.
+      example: 192.168.5.1
+    failover:
+      description: Failover mode, auto/wire/mobile.
+      example: auto
+    autoconnect:
+      description: Auto-connect mode, never/home/always.
+      example: home
+
+connect_lte:
+  description: Ask the modem to establish the LTE connection.
+  fields:
+    host:
+      description: The modem that should connect.
+      example: 192.168.5.1


### PR DESCRIPTION
## Description:

This adds two Netgear LTE services, [a feature requested in the forum](https://community.home-assistant.io/t/netgear-lte-could-be-extended-to-allow-lte-connection-management/108520).

Also makes the `host` argument optional for the existing service in the common situation where only one device is configured.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9179

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
