### PR TITLE
Fix HomeKit fan speed conversion

### DIFF
--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -148,6 +148,8 @@ class HomeKitSpeedMapping:
 
     def speed_to_homekit(self, speed):
         """Map Home Assistant speed state to HomeKit speed."""
+        if speed is None:
+            return None
         speed_range = self.speed_ranges[speed]
         return speed_range.target
 

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -191,6 +191,7 @@ def test_homekit_speed_mapping():
 def test_speed_to_homekit():
     """Test speed conversion from HA to Homekit."""
     speed_mapping = HomeKitSpeedMapping(['off', 'low', 'high'])
+    assert speed_mapping.speed_to_homekit(None) is None
     assert speed_mapping.speed_to_homekit('off') == 0
     assert speed_mapping.speed_to_homekit('low') == 50
     assert speed_mapping.speed_to_homekit('high') == 100
@@ -199,6 +200,7 @@ def test_speed_to_homekit():
 def test_speed_to_states():
     """Test speed conversion from Homekit to HA."""
     speed_mapping = HomeKitSpeedMapping(['off', 'low', 'high'])
+    assert speed_mapping.speed_to_states(-1) == 'off'
     assert speed_mapping.speed_to_states(0) == 'off'
     assert speed_mapping.speed_to_states(33) == 'off'
     assert speed_mapping.speed_to_states(34) == 'low'


### PR DESCRIPTION
## Description:
* Check that speed value from state is not `None`
* Added tests

**Related issue:** fixes #22760

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Tests have been added to verify that the new code works.