### PR TITLE
Stream support for Netatmo cameras

### DIFF
--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -38,7 +38,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     netatmo = hass.components.netatmo
     home = config.get(CONF_HOME)
     verify_ssl = config.get(CONF_VERIFY_SSL, True)
-    quality = config.get(CONF_QUALITY)
+    quality = config.get(CONF_QUALITY, DEFAULT_QUALITY)
     import pyatmo
     try:
         data = CameraData(hass, netatmo.NETATMO_AUTH, home)

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -125,7 +125,7 @@ class NetatmoCamera(Camera):
     @property
     def stream_source(self):
         """Return the stream source."""
-        url = '{0}live/files/{1}/index.m3u8'
+        url = '{0}/live/files/{1}/index.m3u8'
         if self._localurl:
             return url.format(self._localurl, self._quality)
         return url.format(self._vpnurl, self._quality)

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -4,7 +4,8 @@ import logging
 import requests
 import voluptuous as vol
 
-from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
+from homeassistant.components.camera import (
+    PLATFORM_SCHEMA, Camera, SUPPORT_STREAM)
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.helpers import config_validation as cv
 
@@ -16,12 +17,19 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_HOME = 'home'
 CONF_CAMERAS = 'cameras'
+CONF_QUALITY = 'quality'
+
+DEFAULT_QUALITY = 'high'
+
+VALID_QUALITIES = ['high', 'medium', 'low', 'poor']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     vol.Optional(CONF_HOME): cv.string,
     vol.Optional(CONF_CAMERAS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_QUALITY, default=DEFAULT_QUALITY):
+        vol.All(cv.string, vol.In(VALID_QUALITIES)),
 })
 
 
@@ -30,6 +38,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     netatmo = hass.components.netatmo
     home = config.get(CONF_HOME)
     verify_ssl = config.get(CONF_VERIFY_SSL, True)
+    quality = config[CONF_QUALITY]
     import pyatmo
     try:
         data = CameraData(hass, netatmo.NETATMO_AUTH, home)
@@ -40,7 +49,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                    camera_name not in config[CONF_CAMERAS]:
                     continue
             add_entities([NetatmoCamera(data, camera_name, home,
-                                        camera_type, verify_ssl)])
+                                        camera_type, verify_ssl, quality)])
         data.get_persons()
     except pyatmo.NoDevice:
         return None
@@ -49,12 +58,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class NetatmoCamera(Camera):
     """Representation of the images published from a Netatmo camera."""
 
-    def __init__(self, data, camera_name, home, camera_type, verify_ssl):
+    def __init__(self, data, camera_name, home, camera_type, verify_ssl,
+                 quality):
         """Set up for access to the Netatmo camera images."""
         super(NetatmoCamera, self).__init__()
         self._data = data
         self._camera_name = camera_name
         self._verify_ssl = verify_ssl
+        self._quality = quality
         if home:
             self._name = home + ' / ' + camera_name
         else:
@@ -105,3 +116,16 @@ class NetatmoCamera(Camera):
         if self._cameratype == "NACamera":
             return "Welcome"
         return None
+
+    @property
+    def supported_features(self):
+        """Return supported features."""
+        return SUPPORT_STREAM
+
+    @property
+    def stream_source(self):
+        """Return the stream source."""
+        url = '{0}live/files/{1}/index.m3u8'
+        if self._localurl:
+            return url.format(self._localurl, self._quality)
+        return url.format(self._vpnurl, self._quality)

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -38,7 +38,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     netatmo = hass.components.netatmo
     home = config.get(CONF_HOME)
     verify_ssl = config.get(CONF_VERIFY_SSL, True)
-    quality = config[CONF_QUALITY]
+    quality = config.get(CONF_QUALITY)
     import pyatmo
     try:
         data = CameraData(hass, netatmo.NETATMO_AUTH, home)


### PR DESCRIPTION
## Breaking Change:
Should not break anything.

## Description:
This will add stream support for Netatmo cameras.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9182

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: netatmo
    quality: high
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_