### PR TITLE
Add Netgear LTE sms_total sensor

### DIFF
--- a/homeassistant/components/netgear_lte/sensor.py
+++ b/homeassistant/components/netgear_lte/sensor.py
@@ -5,7 +5,8 @@ from homeassistant.components.sensor import DOMAIN
 from homeassistant.exceptions import PlatformNotReady
 
 from . import CONF_MONITORED_CONDITIONS, DATA_KEY, LTEEntity
-from .sensor_types import SENSOR_SMS, SENSOR_USAGE, SENSOR_UNITS
+from .sensor_types import (
+    SENSOR_SMS, SENSOR_SMS_TOTAL, SENSOR_USAGE, SENSOR_UNITS)
 
 DEPENDENCIES = ['netgear_lte']
 
@@ -29,7 +30,9 @@ async def async_setup_platform(
     sensors = []
     for sensor_type in monitored_conditions:
         if sensor_type == SENSOR_SMS:
-            sensors.append(SMSSensor(modem_data, sensor_type))
+            sensors.append(SMSUnreadSensor(modem_data, sensor_type))
+        elif sensor_type == SENSOR_SMS_TOTAL:
+            sensors.append(SMSTotalSensor(modem_data, sensor_type))
         elif sensor_type == SENSOR_USAGE:
             sensors.append(UsageSensor(modem_data, sensor_type))
         else:
@@ -47,13 +50,22 @@ class LTESensor(LTEEntity):
         return SENSOR_UNITS[self.sensor_type]
 
 
-class SMSSensor(LTESensor):
+class SMSUnreadSensor(LTESensor):
     """Unread SMS sensor entity."""
 
     @property
     def state(self):
         """Return the state of the sensor."""
         return sum(1 for x in self.modem_data.data.sms if x.unread)
+
+
+class SMSTotalSensor(LTESensor):
+    """Total SMS sensor entity."""
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return len(self.modem_data.data.sms)
 
 
 class UsageSensor(LTESensor):

--- a/homeassistant/components/netgear_lte/sensor_types.py
+++ b/homeassistant/components/netgear_lte/sensor_types.py
@@ -3,10 +3,12 @@
 from homeassistant.components.binary_sensor import DEVICE_CLASS_CONNECTIVITY
 
 SENSOR_SMS = 'sms'
+SENSOR_SMS_TOTAL = 'sms_total'
 SENSOR_USAGE = 'usage'
 
 SENSOR_UNITS = {
     SENSOR_SMS: 'unread',
+    SENSOR_SMS_TOTAL: 'messages',
     SENSOR_USAGE: 'MiB',
     'radio_quality': '%',
     'rx_level': 'dBm',


### PR DESCRIPTION
## Description:

Add a sensor with the total number of SMS messages in the modem inbox. This is in addition to the current "sms" sensor that has the number of unread messages.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9076

## Example entry for `configuration.yaml` (if applicable):
```yaml
netgear_lte:
  - host: !secret lb2120_hostname
    password: !secret lb2120_password
    sensor:
      monitored_conditions:
        - sms_total
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_