### PR TITLE
Fix for stateless covers

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util, temperature as temp_util
-from .const import ERR_VALUE_OUT_OF_RANGE
+from .const import ERR_VALUE_OUT_OF_RANGE, ERR_FUNCTION_NOT_SUPPORTED
 from .helpers import SmartHomeError
 
 _LOGGER = logging.getLogger(__name__)
@@ -1050,9 +1050,9 @@ class OpenCloseTrait(_Trait):
             # Google will not issue an open command if the assumed state is
             # open, even if that is currently incorrect.
             if self.state.attributes.get(ATTR_ASSUMED_STATE):
-                response['willReportState'] = False
+                response['openPercent'] = 50
             elif self.state.state == STATE_UNKNOWN:
-                response['willReportState'] = False
+                response['openPercent'] = 50
             else:
                 position = self.state.attributes.get(
                     cover.ATTR_CURRENT_POSITION
@@ -1096,13 +1096,6 @@ class OpenCloseTrait(_Trait):
                         cover.ATTR_POSITION: params['openPercent']
                     }, blocking=True, context=data.context)
             else:
-                if params['openPercent'] < 100:
-                    await self.hass.services.async_call(
-                        cover.DOMAIN, cover.SERVICE_CLOSE_COVER, {
-                            ATTR_ENTITY_ID: self.state.entity_id
-                        }, blocking=True, context=data.context)
-                elif params['openPercent'] > 0:
-                    await self.hass.services.async_call(
-                        cover.DOMAIN, cover.SERVICE_OPEN_COVER, {
-                            ATTR_ENTITY_ID: self.state.entity_id
-                        }, blocking=True, context=data.context)
+                raise SmartHomeError(
+                    ERR_FUNCTION_NOT_SUPPORTED,
+                    'Setting a position is not supported')

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -33,7 +33,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util, temperature as temp_util
-from .const import ERR_VALUE_OUT_OF_RANGE, ERR_FUNCTION_NOT_SUPPORTED
+from .const import (
+    ERR_VALUE_OUT_OF_RANGE,
+    ERR_NOT_SUPPORTED,
+    ERR_FUNCTION_NOT_SUPPORTED,
+)
 from .helpers import SmartHomeError
 
 _LOGGER = logging.getLogger(__name__)
@@ -1050,9 +1054,13 @@ class OpenCloseTrait(_Trait):
             # Google will not issue an open command if the assumed state is
             # open, even if that is currently incorrect.
             if self.state.attributes.get(ATTR_ASSUMED_STATE):
-                response['openPercent'] = 50
+                raise SmartHomeError(
+                    ERR_NOT_SUPPORTED,
+                    'Querying state is not supported')
             elif self.state.state == STATE_UNKNOWN:
-                response['openPercent'] = 50
+                raise SmartHomeError(
+                    ERR_NOT_SUPPORTED,
+                    'Querying state is not supported')
             else:
                 position = self.state.attributes.get(
                     cover.ATTR_CURRENT_POSITION

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1057,21 +1057,22 @@ class OpenCloseTrait(_Trait):
                 raise SmartHomeError(
                     ERR_NOT_SUPPORTED,
                     'Querying state is not supported')
-            elif self.state.state == STATE_UNKNOWN:
+
+            if self.state.state == STATE_UNKNOWN:
                 raise SmartHomeError(
                     ERR_NOT_SUPPORTED,
                     'Querying state is not supported')
-            else:
-                position = self.state.attributes.get(
-                    cover.ATTR_CURRENT_POSITION
-                )
 
-                if position is not None:
-                    response['openPercent'] = position
-                elif self.state.state != cover.STATE_CLOSED:
-                    response['openPercent'] = 100
-                else:
-                    response['openPercent'] = 0
+            position = self.state.attributes.get(
+                cover.ATTR_CURRENT_POSITION
+            )
+
+            if position is not None:
+                response['openPercent'] = position
+            elif self.state.state != cover.STATE_CLOSED:
+                response['openPercent'] = 100
+            else:
+                response['openPercent'] = 0
 
         elif domain == binary_sensor.DOMAIN:
             if self.state.state == STATE_ON:

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     ATTR_ASSUMED_STATE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util, temperature as temp_util
@@ -1049,7 +1050,9 @@ class OpenCloseTrait(_Trait):
             # Google will not issue an open command if the assumed state is
             # open, even if that is currently incorrect.
             if self.state.attributes.get(ATTR_ASSUMED_STATE):
-                response['openPercent'] = 50
+                response['willReportState'] = False
+            elif self.state.state == STATE_UNKNOWN:
+                response['willReportState'] = False
             else:
                 position = self.state.attributes.get(
                     cover.ATTR_CURRENT_POSITION
@@ -1076,22 +1079,30 @@ class OpenCloseTrait(_Trait):
 
         if domain == cover.DOMAIN:
             position = self.state.attributes.get(cover.ATTR_CURRENT_POSITION)
-            if position is not None:
+            if params['openPercent'] == 0:
+                await self.hass.services.async_call(
+                    cover.DOMAIN, cover.SERVICE_CLOSE_COVER, {
+                        ATTR_ENTITY_ID: self.state.entity_id
+                    }, blocking=True, context=data.context)
+            elif params['openPercent'] == 100:
+                await self.hass.services.async_call(
+                    cover.DOMAIN, cover.SERVICE_OPEN_COVER, {
+                        ATTR_ENTITY_ID: self.state.entity_id
+                    }, blocking=True, context=data.context)
+            elif position is not None:
                 await self.hass.services.async_call(
                     cover.DOMAIN, cover.SERVICE_SET_COVER_POSITION, {
                         ATTR_ENTITY_ID: self.state.entity_id,
                         cover.ATTR_POSITION: params['openPercent']
                     }, blocking=True, context=data.context)
             else:
-                if self.state.state != cover.STATE_CLOSED:
-                    if params['openPercent'] < 100:
-                        await self.hass.services.async_call(
-                            cover.DOMAIN, cover.SERVICE_CLOSE_COVER, {
-                                ATTR_ENTITY_ID: self.state.entity_id
-                            }, blocking=True, context=data.context)
-                else:
-                    if params['openPercent'] > 0:
-                        await self.hass.services.async_call(
-                            cover.DOMAIN, cover.SERVICE_OPEN_COVER, {
-                                ATTR_ENTITY_ID: self.state.entity_id
-                            }, blocking=True, context=data.context)
+                if params['openPercent'] < 100:
+                    await self.hass.services.async_call(
+                        cover.DOMAIN, cover.SERVICE_CLOSE_COVER, {
+                            ATTR_ENTITY_ID: self.state.entity_id
+                        }, blocking=True, context=data.context)
+                elif params['openPercent'] > 0:
+                    await self.hass.services.async_call(
+                        cover.DOMAIN, cover.SERVICE_OPEN_COVER, {
+                            ATTR_ENTITY_ID: self.state.entity_id
+                        }, blocking=True, context=data.context)

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -23,7 +23,7 @@ from homeassistant.components.google_assistant import trait, helpers, const
 from homeassistant.const import (
     STATE_ON, STATE_OFF, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
     TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_SUPPORTED_FEATURES, ATTR_TEMPERATURE,
-    ATTR_DEVICE_CLASS, ATTR_ASSUMED_STATE)
+    ATTR_DEVICE_CLASS, ATTR_ASSUMED_STATE, STATE_UNKNOWN)
 from homeassistant.core import State, DOMAIN as HA_DOMAIN, EVENT_CALL_SERVICE
 from homeassistant.util import color
 from tests.common import async_mock_service, mock_coro
@@ -1065,6 +1065,15 @@ async def test_openclose_cover(hass):
         'openPercent': 100
     }
 
+    # No state
+    trt = trait.OpenCloseTrait(hass, State('cover.bla', STATE_UNKNOWN, {
+    }), BASIC_CONFIG)
+
+    assert trt.sync_attributes() == {}
+    assert trt.query_attributes() == {
+        'willReportState': False
+    }
+
     # Assumed state
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
         ATTR_ASSUMED_STATE: True,
@@ -1072,7 +1081,7 @@ async def test_openclose_cover(hass):
 
     assert trt.sync_attributes() == {}
     assert trt.query_attributes() == {
-        'openPercent': 50
+        'willReportState': False
     }
 
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1071,7 +1071,7 @@ async def test_openclose_cover(hass):
 
     assert trt.sync_attributes() == {}
     assert trt.query_attributes() == {
-        'willReportState': False
+        'openPercent': 50
     }
 
     # Assumed state
@@ -1081,7 +1081,7 @@ async def test_openclose_cover(hass):
 
     assert trt.sync_attributes() == {}
     assert trt.query_attributes() == {
-        'willReportState': False
+        'openPercent': 50
     }
 
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1071,12 +1071,18 @@ async def test_openclose_cover(hass):
 
     assert trt.sync_attributes() == {}
 
+    with pytest.raises(helpers.SmartHomeError):
+        trt.query_attributes()
+
     # Assumed state
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
         ATTR_ASSUMED_STATE: True,
     }), BASIC_CONFIG)
 
     assert trt.sync_attributes() == {}
+
+    with pytest.raises(helpers.SmartHomeError):
+        trt.query_attributes()
 
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
         cover.ATTR_CURRENT_POSITION: 75
@@ -1134,3 +1140,4 @@ async def test_openclose_binary_sensor(hass, device_class):
     assert trt.query_attributes() == {
         'openPercent': 0
     }
+

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1140,4 +1140,3 @@ async def test_openclose_binary_sensor(hass, device_class):
     assert trt.query_attributes() == {
         'openPercent': 0
     }
-

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1070,9 +1070,6 @@ async def test_openclose_cover(hass):
     }), BASIC_CONFIG)
 
     assert trt.sync_attributes() == {}
-    assert trt.query_attributes() == {
-        'openPercent': 50
-    }
 
     # Assumed state
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
@@ -1080,9 +1077,6 @@ async def test_openclose_cover(hass):
     }), BASIC_CONFIG)
 
     assert trt.sync_attributes() == {}
-    assert trt.query_attributes() == {
-        'openPercent': 50
-    }
 
     trt = trait.OpenCloseTrait(hass, State('cover.bla', cover.STATE_OPEN, {
         cover.ATTR_CURRENT_POSITION: 75


### PR DESCRIPTION
## Description:
Stateless covers didn't work with previous trait

**Related issue (if applicable):** fixes #22740

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

