### PR TITLE
Add missing attribution

### DIFF
--- a/homeassistant/components/london_underground/sensor.py
+++ b/homeassistant/components/london_underground/sensor.py
@@ -1,11 +1,12 @@
 """Sensor for checking the status of London Underground tube lines."""
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import ATTR_ATTRIBUTION
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['london-tube-status==0.2']
@@ -15,6 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Powered by TfL Open Data"
 
 CONF_LINE = 'line'
+
+ICON = 'mdi:subway'
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
@@ -54,16 +57,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class LondonTubeSensor(Entity):
-    """Sensor that reads the status of a line from TubeData."""
-
-    ICON = 'mdi:subway'
+    """Sensor that reads the status of a line from Tube Data."""
 
     def __init__(self, name, data):
-        """Initialize the sensor."""
-        self._name = name
+        """Initialize the London Underground sensor."""
         self._data = data
-        self._state = None
         self._description = None
+        self._name = name
+        self._state = None
+        self.attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
 
     @property
     def name(self):
@@ -78,14 +80,13 @@ class LondonTubeSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        return self.ICON
+        return ICON
 
     @property
     def device_state_attributes(self):
         """Return other details about the sensor state."""
-        attrs = {}
-        attrs['Description'] = self._description
-        return attrs
+        self.attrs['Description'] = self._description
+        return self.attrs
 
     def update(self):
         """Update the sensor."""


### PR DESCRIPTION
## Description:
- Add missing attribution
- Fix ordering of imports

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: london_underground
    line:
      - Bakerloo
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
