### PR TITLE
Add device HmIP-MIOB to Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -15,7 +15,7 @@ from .const import (
 from .device import HomematicipGenericDevice  # noqa: F401
 from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
-REQUIREMENTS = ['homematicip==0.10.6']
+REQUIREMENTS = ['homematicip==0.10.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "Homematicip cloud",
   "documentation": "https://www.home-assistant.io/components/homematicip_cloud",
   "requirements": [
-    "homematicip==0.10.6"
+    "homematicip==0.10.7"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -25,6 +25,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         AsyncBrandSwitchMeasuring,
         AsyncFullFlushSwitchMeasuring,
         AsyncOpenCollector8Module,
+        AsyncMultiIOBox,
     )
 
     from homematicip.aio.group import AsyncSwitchingGroup
@@ -44,6 +45,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             devices.append(HomematicipSwitch(home, device))
         elif isinstance(device, AsyncOpenCollector8Module):
             for channel in range(1, 9):
+                devices.append(HomematicipMultiSwitch(home, device, channel))
+        elif isinstance(device, AsyncMultiIOBox):
+            for channel in range(1, 3):
                 devices.append(HomematicipMultiSwitch(home, device, channel))
 
     for group in home.groups:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -551,7 +551,7 @@ homeassistant-pyozw==0.1.4
 homekit[IP]==0.13.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.6
+homematicip==0.10.7
 
 # homeassistant.components.horizon
 horimote==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -136,7 +136,7 @@ home-assistant-frontend==20190331.0
 homekit[IP]==0.13.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.6
+homematicip==0.10.7
 
 # homeassistant.components.influxdb
 influxdb==5.2.0


### PR DESCRIPTION
## Description:
- update upstream library to 0.10.7
- adds HmIP-MIOB
  * the two main switches can be controlled (implemented)
  * the two digital Input channels cannot be read due to missing value in upstream lib
  * the analog output can not be controlled (range of 0-10V) (not implemented, could be implemented in a follow up PR)


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9190

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running 

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
