### PR TITLE
Google Assistant: Migrate light setting trait to use HSV color spectrum

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -305,12 +305,14 @@ class ColorSettingTrait(_Trait):
         if features & light.SUPPORT_COLOR_TEMP:
             # Max Kelvin is Min Mireds K = 1000000 / mireds
             # Min Kevin is Max Mireds K = 1000000 / mireds
-            response['temperatureMaxK'] = \
+            response['colorTemperatureRange'] = {
+                'temperatureMaxK':
                 color_util.color_temperature_mired_to_kelvin(
-                    attrs.get(light.ATTR_MIN_MIREDS))
-            response['temperatureMinK'] = \
+                    attrs.get(light.ATTR_MIN_MIREDS)),
+                'temperatureMinK':
                 color_util.color_temperature_mired_to_kelvin(
-                    attrs.get(light.ATTR_MAX_MIREDS))
+                    attrs.get(light.ATTR_MAX_MIREDS)),
+            }
 
         return response
 
@@ -323,14 +325,7 @@ class ColorSettingTrait(_Trait):
             color_hs = self.state.attributes.get(light.ATTR_HS_COLOR)
             brightness = self.state.attributes.get(light.ATTR_BRIGHTNESS, 1)
             if color_hs is not None:
-                # Backwards compatible for users. Won't be needed when users
-                # sync their devices over.
-                color['spectrumRGB'] = int(
-                    color_util.color_rgb_to_hex(
-                        *color_util.color_hs_to_RGB(*color_hs)),
-                    16
-                )
-                color['spectrumHSV'] = {
+                color['spectrumHsv'] = {
                     'hue': color_hs[0],
                     'saturation': color_hs[1]/100,
                     'value': brightness/255,
@@ -343,7 +338,7 @@ class ColorSettingTrait(_Trait):
                 _LOGGER.warning('Entity %s has incorrect color temperature %s',
                                 self.state.entity_id, temp)
             elif temp is not None:
-                color['temperature'] = \
+                color['temperatureK'] = \
                     color_util.color_temperature_mired_to_kelvin(temp)
 
         response = {}

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -174,8 +174,12 @@ def test_query_request(hass_fixture, assistant_client, auth_header):
     assert devices['light.bed_light']['on'] is False
     assert devices['light.ceiling_lights']['on'] is True
     assert devices['light.ceiling_lights']['brightness'] == 70
-    assert devices['light.kitchen_lights']['color']['spectrumRGB'] == 16727919
-    assert devices['light.kitchen_lights']['color']['temperature'] == 4166
+    assert devices['light.kitchen_lights']['color']['spectrumHsv'] == {
+        'hue': 345,
+        'saturation': 0.75,
+        'value': 0.7058823529411765,
+    }
+    assert devices['light.kitchen_lights']['color']['temperatureK'] == 4166
     assert devices['media_player.lounge_room']['on'] is True
 
 

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -98,7 +98,7 @@ async def test_sync_message(hass):
                 'type': sh.TYPE_LIGHT,
                 'willReportState': False,
                 'attributes': {
-                    'colorModel': 'rgb',
+                    'colorModel': 'hsv',
                     'temperatureMinK': 2000,
                     'temperatureMaxK': 6535,
                 },
@@ -176,7 +176,7 @@ async def test_sync_in_area(hass, registries):
                 'type': sh.TYPE_LIGHT,
                 'willReportState': False,
                 'attributes': {
-                    'colorModel': 'rgb',
+                    'colorModel': 'hsv',
                     'temperatureMinK': 2000,
                     'temperatureMaxK': 6535,
                 },
@@ -253,6 +253,11 @@ async def test_query_message(hass):
                     'brightness': 30,
                     'color': {
                         'spectrumRGB': 4194303,
+                        'spectrumHSV': {
+                            'hue': 180,
+                            'saturation': 0.75,
+                            'value': 0.3058823529411765,
+                        },
                         'temperature': 2500,
                     }
                 },
@@ -339,6 +344,11 @@ async def test_execute(hass):
                     'brightness': 20,
                     'color': {
                         'spectrumRGB': 16773155,
+                        'spectrumHSV': {
+                            'hue': 56,
+                            'saturation': 0.86,
+                            'value': 0.2,
+                        },
                         'temperature': 2631,
                     },
                 }

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -99,8 +99,10 @@ async def test_sync_message(hass):
                 'willReportState': False,
                 'attributes': {
                     'colorModel': 'hsv',
-                    'temperatureMinK': 2000,
-                    'temperatureMaxK': 6535,
+                    'colorTemperatureRange': {
+                        'temperatureMinK': 2000,
+                        'temperatureMaxK': 6535,
+                    }
                 },
                 'roomHint': 'Living Room'
             }]
@@ -177,8 +179,10 @@ async def test_sync_in_area(hass, registries):
                 'willReportState': False,
                 'attributes': {
                     'colorModel': 'hsv',
-                    'temperatureMinK': 2000,
-                    'temperatureMaxK': 6535,
+                    'colorTemperatureRange': {
+                        'temperatureMinK': 2000,
+                        'temperatureMaxK': 6535,
+                    }
                 },
                 'roomHint': 'Living Room'
             }]
@@ -252,13 +256,12 @@ async def test_query_message(hass):
                     'online': True,
                     'brightness': 30,
                     'color': {
-                        'spectrumRGB': 4194303,
-                        'spectrumHSV': {
+                        'spectrumHsv': {
                             'hue': 180,
                             'saturation': 0.75,
                             'value': 0.3058823529411765,
                         },
-                        'temperature': 2500,
+                        'temperatureK': 2500,
                     }
                 },
             }
@@ -343,13 +346,12 @@ async def test_execute(hass):
                     "online": True,
                     'brightness': 20,
                     'color': {
-                        'spectrumRGB': 16773155,
-                        'spectrumHSV': {
+                        'spectrumHsv': {
                             'hue': 56,
                             'saturation': 0.86,
                             'value': 0.2,
                         },
-                        'temperature': 2631,
+                        'temperatureK': 2631,
                     },
                 }
             }]

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -470,8 +470,7 @@ async def test_color_setting_color_light(hass):
 
     assert trt.query_attributes() == {
         'color': {
-            'spectrumRGB': 16736015,
-            'spectrumHSV': {
+            'spectrumHsv': {
                 'hue': 20,
                 'saturation': 0.94,
                 'value': 200 / 255,
@@ -528,13 +527,15 @@ async def test_color_setting_temperature_light(hass):
     }), BASIC_CONFIG)
 
     assert trt.sync_attributes() == {
-        'temperatureMinK': 2000,
-        'temperatureMaxK': 5000,
+        'colorTemperatureRange': {
+            'temperatureMinK': 2000,
+            'temperatureMaxK': 5000,
+        }
     }
 
     assert trt.query_attributes() == {
         'color': {
-            'temperature': 3333
+            'temperatureK': 3333
         }
     }
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -459,17 +459,23 @@ async def test_color_setting_color_light(hass):
                                              light.SUPPORT_COLOR, None)
 
     trt = trait.ColorSettingTrait(hass, State('light.bla', STATE_ON, {
-        light.ATTR_HS_COLOR: (0, 94),
+        light.ATTR_HS_COLOR: (20, 94),
+        light.ATTR_BRIGHTNESS: 200,
         ATTR_SUPPORTED_FEATURES: light.SUPPORT_COLOR,
     }), BASIC_CONFIG)
 
     assert trt.sync_attributes() == {
-        'colorModel': 'rgb'
+        'colorModel': 'hsv'
     }
 
     assert trt.query_attributes() == {
         'color': {
-            'spectrumRGB': 16715535
+            'spectrumRGB': 16736015,
+            'spectrumHSV': {
+                'hue': 20,
+                'saturation': 0.94,
+                'value': 200 / 255,
+            }
         }
     }
 
@@ -489,6 +495,22 @@ async def test_color_setting_color_light(hass):
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'light.bla',
         light.ATTR_HS_COLOR: (240, 93.725),
+    }
+
+    await trt.execute(trait.COMMAND_COLOR_ABSOLUTE, BASIC_DATA, {
+        'color': {
+            'spectrumHSV': {
+                'hue': 100,
+                'saturation': .50,
+                'value': .20,
+            }
+        }
+    })
+    assert len(calls) == 2
+    assert calls[1].data == {
+        ATTR_ENTITY_ID: 'light.bla',
+        light.ATTR_HS_COLOR: [100, 50],
+        light.ATTR_BRIGHTNESS: .2 * 255,
     }
 
 


### PR DESCRIPTION
## Description:
Migrate light setting trait to use HSV. Now it's HSV all the way. Also fixed some bugs that got introduced in #22894, namely that for query, some values are differently capitalized now 🤦‍♂️ 

Breaking Change: If you have lights with colors, please run a Google Assistant SYNC after you update to this version. It will get you improved color representation.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
