### PR TITLE
Add json_attributes_template

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -71,6 +71,7 @@ CONF_AVAILABILITY_TOPIC = 'availability_topic'
 CONF_PAYLOAD_AVAILABLE = 'payload_available'
 CONF_PAYLOAD_NOT_AVAILABLE = 'payload_not_available'
 CONF_JSON_ATTRS_TOPIC = 'json_attributes_topic'
+CONF_JSON_ATTRS_TEMPLATE = 'json_attributes_template'
 CONF_QOS = 'qos'
 CONF_RETAIN = 'retain'
 
@@ -244,6 +245,7 @@ MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(vol.Schema({
 
 MQTT_JSON_ATTRS_SCHEMA = vol.Schema({
     vol.Optional(CONF_JSON_ATTRS_TOPIC): valid_subscribe_topic,
+    vol.Optional(CONF_JSON_ATTRS_TEMPLATE): cv.template,
 })
 
 MQTT_BASE_PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(SCHEMA_BASE)
@@ -910,10 +912,18 @@ class MqttAttributes(Entity):
         """(Re)Subscribe to topics."""
         from .subscription import async_subscribe_topics
 
+        attr_tpl = self._attributes_config.get(CONF_JSON_ATTRS_TEMPLATE)
+        if attr_tpl is not None:
+            attr_tpl.hass = self.hass
+
         @callback
         def attributes_message_received(msg: Message) -> None:
             try:
-                json_dict = json.loads(msg.payload)
+                payload = msg.payload
+                if attr_tpl is not None:
+                    payload = attr_tpl.async_render_with_possible_json_value(
+                        payload)
+                json_dict = json.loads(payload)
                 if isinstance(json_dict, dict):
                     self._attributes = json_dict
                     self.async_write_ha_state()
@@ -921,7 +931,7 @@ class MqttAttributes(Entity):
                     _LOGGER.warning("JSON result was not a dictionary")
                     self._attributes = None
             except ValueError:
-                _LOGGER.warning("Erroneous JSON: %s", msg.payload)
+                _LOGGER.warning("Erroneous JSON: %s", payload)
                 self._attributes = None
 
         self._attributes_sub_state = await async_subscribe_topics(


### PR DESCRIPTION
## Description:
Add `json_attributes_template` to give a little bit of flexibility to `json_attributes_topic`, which has been requested several times, most recently in #22924.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9332

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: mqtt
    name: "Timer 1"
    state_topic: "tele/sonoff/sensor"
    value_template: "{{ value_json.Timer1.Arm }}"
    json_attributes_topic: "tele/sonoff/sensor"
    json_attributes_template: "{{ value_json.Timer1 | tojson }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) TODO

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
