### PR TITLE
Catch connection reset

### DIFF
--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -53,7 +53,8 @@ class WebSocketHandler:
     async def _writer(self):
         """Write outgoing messages."""
         # Exceptions if Socket disconnected or cancelled by connection handler
-        with suppress(RuntimeError, *CANCELLATION_ERRORS):
+        with suppress(RuntimeError, ConnectionResetError,
+                      *CANCELLATION_ERRORS):
             while not self.wsock.closed:
                 message = await self._to_write.get()
                 if message is None:


### PR DESCRIPTION
## Description:
With https://github.com/aio-libs/aiohttp/pull/2989 a `ConnectionResetError` will be raised when writing to closed stream. Let's add it to the errors we catch.


Fixes #22765