### PR TITLE
Prevent the projector to toogle on/off

### DIFF
--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -137,12 +137,14 @@ class EpsonProjector(MediaPlayerDevice):
     async def async_turn_on(self):
         """Turn on epson."""
         from epson_projector.const import TURN_ON
-        await self._projector.send_command(TURN_ON)
+        if self._state == STATE_OFF:
+            await self._projector.send_command(TURN_ON)
 
     async def async_turn_off(self):
         """Turn off epson."""
         from epson_projector.const import TURN_OFF
-        await self._projector.send_command(TURN_OFF)
+        if self._state == STATE_ON:
+            await self._projector.send_command(TURN_OFF)
 
     @property
     def source_list(self):


### PR DESCRIPTION
Prevents the projector to toogle on/off.

## Description:
The Epson Projector EH-TW7300 turns on and off with the same command. This minor change fix it.

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ x] Local tests pass with `tox`.
  - [ x] There is no commented out code in this PR.