### PR TITLE
Fibaro hub integration - Changed scene unique ID generation

### DIFF
--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -222,9 +222,9 @@ class FibaroController():
                 room_name = self._room_map[device.roomID].name
             device.room_name = room_name
             device.friendly_name = '{} {}'.format(room_name, device.name)
-            device.ha_id = '{}_{}_{}'.format(
+            device.ha_id = 'scene_{}_{}_{}'.format(
                 slugify(room_name), slugify(device.name), device.id)
-            device.unique_id_str = "{}.{}".format(
+            device.unique_id_str = "{}.scene.{}".format(
                 self.hub_serial, device.id)
             self._scene_map[device.id] = device
             self.fibaro_devices['scene'].append(device)


### PR DESCRIPTION
There was a potential unique ID collission which caused problems for some users, as scenes and devices are enumerated separately, so the same ID could be assigned to in they are unnamed.
So I changed the unique ID generation for scenes to avoid this, which is a breaking change wrt scenes.

## Breaking Change:

Scene unique IDs change, which could break scripts/automations referring to them.

## Description:
Scene unique ID naming is changed.

**Related issue (if applicable):** 
fixes #20151
fixes https://github.com/home-assistant/home-assistant/issues/20151

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
