### PR TITLE
Add TTL support and custom headers support.

### DIFF
--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -76,8 +76,9 @@ ATTR_ACTIONS = 'actions'
 ATTR_TYPE = 'type'
 ATTR_URL = 'url'
 ATTR_DISMISS = 'dismiss'
+ATTR_PRIORITY = "priority"
+DEFAULT_PRIORITY = "normal"
 ATTR_TTL = "ttl"
-
 DEFAULT_TTL = 86400
 
 ATTR_JWT = 'jwt'
@@ -465,7 +466,9 @@ class HTML5NotificationService(BaseNotificationService):
 
         timestamp = int(time.time())
         ttl = int(kwargs.get(ATTR_TTL, DEFAULT_TTL))
-
+        priority = kwargs.get(ATTR_PRIORITY, DEFAULT_PRIORITY)
+        if priority not in ['normal', 'high']:
+            priority = DEFAULT_PRIORITY
         payload['timestamp'] = (timestamp*1000)  # Javascript ms since epoch
         targets = kwargs.get(ATTR_TARGET)
 
@@ -496,8 +499,8 @@ class HTML5NotificationService(BaseNotificationService):
                     self._vapid_email, info[ATTR_SUBSCRIPTION],
                     self._vapid_prv)
                 vapid_headers.update({
-                    'urgency': 'high',
-                    'priority': 'high'
+                    'urgency': priority,
+                    'priority': priority
                 })
                 response = webpusher.send(
                     data=json.dumps(payload),

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -76,9 +76,9 @@ ATTR_ACTIONS = 'actions'
 ATTR_TYPE = 'type'
 ATTR_URL = 'url'
 ATTR_DISMISS = 'dismiss'
-ATTR_PRIORITY = "priority"
-DEFAULT_PRIORITY = "normal"
-ATTR_TTL = "ttl"
+ATTR_PRIORITY = 'priority'
+DEFAULT_PRIORITY = 'normal'
+ATTR_TTL = 'ttl'
 DEFAULT_TTL = 86400
 
 ATTR_JWT = 'jwt'
@@ -477,7 +477,9 @@ class HTML5NotificationService(BaseNotificationService):
 
         for target in list(targets):
             info = self.registrations.get(target)
-            if info is None:
+            if (info is None or
+                    ATTR_SUBSCRIPTION not in info or
+                    ATTR_ENDPOINT not in info[ATTR_SUBSCRIPTION]):
                 _LOGGER.error("%s is not a valid HTML5 push notification"
                               " target", target)
                 continue
@@ -547,8 +549,9 @@ def create_vapid_headers(vapid_email, subscription_info, vapid_private_key):
         from urllib.parse import urlparse
     except ImportError:  # pragma nocover
         from urlparse import urlparse
-    if vapid_email and vapid_private_key:
-        url = urlparse(subscription_info.get('endpoint'))
+    if (vapid_email and vapid_private_key and
+            ATTR_ENDPOINT in subscription_info):
+        url = urlparse(subscription_info.get(ATTR_ENDPOINT))
         vapid_claims = {
             'sub': 'mailto:{}'.format(vapid_email),
             'aud': "{}://{}".format(url.scheme, url.netloc)

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -1,9 +1,4 @@
-"""
-HTML5 Push Messaging notification service.
-
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/notify.html5/
-"""
+"""HTML5 Push Messaging notification service."""
 from datetime import datetime, timedelta
 
 from functools import partial

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -477,9 +477,9 @@ class HTML5NotificationService(BaseNotificationService):
 
         for target in list(targets):
             info = self.registrations.get(target)
-            if (info is None or
-                    ATTR_SUBSCRIPTION not in info or
-                    ATTR_ENDPOINT not in info[ATTR_SUBSCRIPTION]):
+            try:
+                info = REGISTER_SCHEMA(info)
+            except vol.Invalid:
                 _LOGGER.error("%s is not a valid HTML5 push notification"
                               " target", target)
                 continue

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -40,14 +40,12 @@ ATTR_VAPID_EMAIL = 'vapid_email'
 
 def gcm_api_deprecated(value):
     """Warn user that GCM API config is deprecated."""
-    if not value:
-        return value
-
-    _LOGGER.warning(
-        "Configuring html5_push_notifications via the GCM api"
-        " has been deprecated and will stop working after April 11,"
-        " 2019. Use the VAPID configuration instead. For instructions,"
-        " see https://www.home-assistant.io/components/notify.html5/")
+    if value:
+        _LOGGER.warning(
+            "Configuring html5_push_notifications via the GCM api"
+            " has been deprecated and will stop working after April 11,"
+            " 2019. Use the VAPID configuration instead. For instructions,"
+            " see https://www.home-assistant.io/components/notify.html5/")
     return value
 
 
@@ -547,7 +545,7 @@ def create_vapid_headers(vapid_email, subscription_info, vapid_private_key):
     from py_vapid import Vapid
     try:
         from urllib.parse import urlparse
-    except ImportError:  # pragma nocover
+    except ImportError:  # pragma: no cover
         from urlparse import urlparse
     if (vapid_email and vapid_private_key and
             ATTR_ENDPOINT in subscription_info):

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -518,7 +518,7 @@ class HTML5NotificationService(BaseNotificationService):
 
 
 def add_jwt(timestamp, target, tag, jwt_secret):
-    """ Create JWT json to put into payload. """
+    """Create JWT json to put into payload."""
     import jwt
     jwt_exp = (datetime.fromtimestamp(timestamp) +
                timedelta(days=JWT_VALID_DAYS))
@@ -529,7 +529,7 @@ def add_jwt(timestamp, target, tag, jwt_secret):
 
 
 def create_vapid_headers(vapid_email, subscription_info, vapid_private_key):
-    """ Create encrypted headers to send to WebPusher. """
+    """Create encrypted headers to send to WebPusher."""
     from py_vapid import Vapid
     try:
         from urllib.parse import urlparse


### PR DESCRIPTION
Related issue: https://github.com/home-assistant/home-assistant/issues/22249#issuecomment-481280570
Added TTL support in service and changed default TTL from 0 to 86400.

Creating headers manually (before webpush lib did it for us) to allow us add custom FCM headers like urgency, priority and maybe we find better priority header in the future.


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
I will update docs if you agree with these changes.