### PR TITLE
Fix homekit_controller handling new devices added to a bridge at runtime

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -184,7 +184,7 @@ def setup(hass, config):
         if hkid in hass.data[KNOWN_DEVICES]:
             device = hass.data[KNOWN_DEVICES][hkid]
             if config_num > device.config_num and \
-               device.pairing_info is not None:
+               device.pairing is not None:
                 device.accessory_setup()
             return
 

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -11,7 +11,7 @@ from homekit.model import Accessory, get_id
 from homekit.exceptions import AccessoryNotFoundError
 from homeassistant.components.homekit_controller import SERVICE_HOMEKIT
 from homeassistant.components.homekit_controller.const import (
-    DOMAIN, HOMEKIT_ACCESSORY_DISPATCH)
+    CONTROLLER, DOMAIN, HOMEKIT_ACCESSORY_DISPATCH)
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from tests.common import (
@@ -225,6 +225,30 @@ async def setup_test_accessories(hass, accessories, capitalize=False):
     await hass.async_block_till_done()
 
     return pairing
+
+
+async def device_config_changed(hass, accessories):
+    """Discover new devices added to HomeAssistant at runtime."""
+    # Update the accessories our FakePairing knows about
+    controller = hass.data[CONTROLLER]
+    pairing = controller.pairings['00:00:00:00:00:00']
+    pairing.accessories = accessories
+
+    discovery_info = {
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TestDevice',
+            'id': '00:00:00:00:00:00',
+            'c#': '2',
+            'sf': '0',
+        }
+    }
+
+    fire_service_discovered(hass, SERVICE_HOMEKIT, discovery_info)
+
+    # Wait for services to reconfigure
+    await hass.async_block_till_done()
 
 
 async def setup_test_component(hass, services, capitalize=False, suffix=None):

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -7,7 +7,8 @@ https://github.com/home-assistant/home-assistant/issues/15336
 from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
 from tests.components.homekit_controller.common import (
-    setup_accessories_from_file, setup_test_accessories, Helper
+    device_config_changed, setup_accessories_from_file, setup_test_accessories,
+    Helper
 )
 
 
@@ -35,6 +36,43 @@ async def test_ecobee3_setup(hass):
         hass, 'binary_sensor.kitchen', pairing, accessories[0])
     occ1_state = await occ1_helper.poll_and_get_state()
     assert occ1_state.attributes['friendly_name'] == 'Kitchen'
+
+    occ2 = entity_registry.async_get('binary_sensor.porch')
+    assert occ2.unique_id == 'homekit-AB2C-56'
+
+    occ3 = entity_registry.async_get('binary_sensor.basement')
+    assert occ3.unique_id == 'homekit-AB3C-56'
+
+
+async def test_ecobee3_add_sensors_at_runtime(hass):
+    """Test that new sensors are automatically added."""
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    # Set up a base Ecobee 3 with no additional sensors.
+    # There shouldn't be any entities but climate visible.
+    accessories = await setup_accessories_from_file(
+        hass, 'ecobee3_no_sensors.json')
+    await setup_test_accessories(hass, accessories)
+
+    climate = entity_registry.async_get('climate.homew')
+    assert climate.unique_id == 'homekit-123456789012-16'
+
+    occ1 = entity_registry.async_get('binary_sensor.kitchen')
+    assert occ1 is None
+
+    occ2 = entity_registry.async_get('binary_sensor.porch')
+    assert occ2 is None
+
+    occ3 = entity_registry.async_get('binary_sensor.basement')
+    assert occ3 is None
+
+    # Now added 3 new sensors at runtime - sensors should appear and climate
+    # shouldn't be duplicated.
+    accessories = await setup_accessories_from_file(hass, 'ecobee3.json')
+    await device_config_changed(hass, accessories)
+
+    occ1 = entity_registry.async_get('binary_sensor.kitchen')
+    assert occ1.unique_id == 'homekit-AB1C-56'
 
     occ2 = entity_registry.async_get('binary_sensor.porch')
     assert occ2.unique_id == 'homekit-AB2C-56'


### PR DESCRIPTION
## Description:

A HomeKit device exposes a property called `c#` via Bonjour. When this changes we need to re-run accessory setup to see if there are new entities available.

The code to handle this already exists but is hobbled by a typo in the old discovery code. The PR fixes it and adds a test to stop it happening again.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
