### PR TITLE
Handle missing 'serialno' of Android TV

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -324,13 +324,7 @@ class AndroidTVDevice(ADBDevice):
         self._device = None
         self._device_properties = self.aftv.device_properties
         self._is_volume_muted = None
-
-        if 'serialno' in self._device_properties:
-            self._unique_id = 'androidtv-{}'.format(
-                self._device_properties['serialno'])
-        else:
-            self._unique_id = None
-
+        self._unique_id = self._device_properties.get('serialno')
         self._volume_level = None
 
     @adb_decorator(override_available=True)

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -324,10 +324,13 @@ class AndroidTVDevice(ADBDevice):
         self._device = None
         self._device_properties = self.aftv.device_properties
         self._is_volume_muted = None
-        self._unique_id = 'androidtv-{}-{}'.format(
-            name,
-            self._device_properties.get(
-                'serialno', aftv.host.split(':')[0].replace('.', '_')))
+
+        if 'serialno' in self._device_properties:
+            self._unique_id = 'androidtv-{}-{}'.format(
+                name, self._device_properties['serialno'])
+        else:
+            self._unique_id = None
+
         self._volume_level = None
 
     @adb_decorator(override_available=True)

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -325,7 +325,9 @@ class AndroidTVDevice(ADBDevice):
         self._device_properties = self.aftv.device_properties
         self._is_volume_muted = None
         self._unique_id = 'androidtv-{}-{}'.format(
-            name, self._device_properties['serialno'])
+            name,
+            self._device_properties.get(
+                'serialno', aftv.host.split(':')[0].replace('.', '_')))
         self._volume_level = None
 
     @adb_decorator(override_available=True)

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -326,8 +326,8 @@ class AndroidTVDevice(ADBDevice):
         self._is_volume_muted = None
 
         if 'serialno' in self._device_properties:
-            self._unique_id = 'androidtv-{}-{}'.format(
-                name, self._device_properties['serialno'])
+            self._unique_id = 'androidtv-{}'.format(
+                self._device_properties['serialno'])
         else:
             self._unique_id = None
 


### PR DESCRIPTION
## Breaking change

This will change the `unique_id` used to identify Android TV devices. As a result, users may find that the entity ID's of their `androidtv` media players have changed. This can be resolved by going to Configuration > Entity Registry and deleting those entries, then restarting HA. (Note: Fire TV devices are not affected.)

## Description:

Fixes an issue where setup fails because the `serialno` could not be determined. 

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/23035

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.