### PR TITLE
Upgrade python-slugify to 3.0.2

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -8,7 +8,7 @@ jinja2>=2.10
 PyJWT==1.7.1
 cryptography==2.6.1
 pip>=8.0.3
-python-slugify==1.2.6
+python-slugify==3.0.2
 pytz>=2019.01
 pyyaml>=3.13,<4
 requests==2.21.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -9,7 +9,7 @@ jinja2>=2.10
 PyJWT==1.7.1
 cryptography==2.6.1
 pip>=8.0.3
-python-slugify==1.2.6
+python-slugify==3.0.2
 pytz>=2019.01
 pyyaml>=3.13,<4
 requests==2.21.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ REQUIRES = [
     # PyJWT has loose dependency. We want the latest one.
     'cryptography==2.6.1',
     'pip>=8.0.3',
-    'python-slugify==1.2.6',
+    'python-slugify==3.0.2',
     'pytz>=2019.01',
     'pyyaml>=3.13,<4',
     'requests==2.21.0',


### PR DESCRIPTION
## Description:

Devs from python-slugify these days released a few versions recently. The latest version is 3.0.2 from 31st March 2019. HA has a requirement for version 1.2.6 from 2nd September 2018.

Changelog: https://github.com/un33k/python-slugify/blob/master/CHANGELOG.md

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
