### PR TITLE
Remove expired 17track.net packages from entity registry

### DIFF
--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -248,8 +248,8 @@ class SeventeenTrackPackageSensor(Entity):
                     self._tracking_number))
 
             reg = self.hass.helpers.entity_registry.async_get_registry()
-            self.hass.async_create_task(self.async_remove())
             self.hass.async_create_task(reg.async_remove(self.entity_id))
+            self.hass.async_create_task(self.async_remove())
             return
 
         self._attrs.update({

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -232,7 +232,8 @@ class SeventeenTrackPackageSensor(Entity):
             return
 
         # If the user has elected to not see delivered packages and one gets
-        # delivered, post a notification and delete the entity:
+        # delivered, post a notification, remove the entity from the UI, and
+        # delete it from the entity registry:
         if package.status == VALUE_DELIVERED and not self._data.show_delivered:
             _LOGGER.info('Package delivered: %s', self._tracking_number)
             self.hass.components.persistent_notification.create(
@@ -245,7 +246,10 @@ class SeventeenTrackPackageSensor(Entity):
                 title=NOTIFICATION_DELIVERED_TITLE,
                 notification_id=NOTIFICATION_DELIVERED_ID_SCAFFOLD.format(
                     self._tracking_number))
+
+            reg = self.hass.helpers.entity_registry.async_get_registry()
             self.hass.async_create_task(self.async_remove())
+            self.hass.async_create_task(reg.async_remove(self.entity_id))
             return
 
         self._attrs.update({


### PR DESCRIPTION
## Description:

This PR ensures that when a package is delivered, its corresponding sensor is removed from the UI _and_ the entity registry.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/22994

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: seventeentrack 
    username: !secret 17track_username
    password: !secret 17track_password    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
