### PR TITLE
Update Z-Wave to use async_get_integration

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -1,7 +1,7 @@
 """Support for Z-Wave."""
 import asyncio
 import copy
-import importlib
+from importlib import import_module
 import logging
 from pprint import pprint
 
@@ -908,8 +908,8 @@ class ZWaveDeviceEntityValues():
         if polling_intensity:
             self.primary.enable_poll(polling_intensity)
 
-        platform = importlib.import_module('.{}'.format(component),
-                                           __name__)
+        platform = import_module('.{}'.format(component),
+                                 __name__)
 
         device = platform.get_device(
             node=self._node, values=self,

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -1,6 +1,7 @@
 """Support for Z-Wave."""
 import asyncio
 import copy
+import importlib
 import logging
 from pprint import pprint
 
@@ -8,7 +9,6 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import callback, CoreState
-from homeassistant.loader import async_get_integration
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
@@ -908,10 +908,8 @@ class ZWaveDeviceEntityValues():
         if polling_intensity:
             self.primary.enable_poll(polling_intensity)
 
-        integration = asyncio.run_coroutine_threadsafe(
-            async_get_integration(self._hass, DOMAIN),
-            self._hass.loop).result()
-        platform = integration.get_platform(component)
+        platform = importlib.import_module('.{}'.format(component),
+                                           __name__)
 
         device = platform.get_device(
             node=self._node, values=self,

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import callback, CoreState
-from homeassistant.loader import get_platform
+from homeassistant.loader import async_get_integration
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
@@ -908,7 +908,11 @@ class ZWaveDeviceEntityValues():
         if polling_intensity:
             self.primary.enable_poll(polling_intensity)
 
-        platform = get_platform(self._hass, component, DOMAIN)
+        integration = asyncio.run_coroutine_threadsafe(
+            async_get_integration(self._hass, DOMAIN),
+            self._hass.loop).result()
+        platform = integration.get_platform(component)
+
         device = platform.get_device(
             node=self._node, values=self,
             node_config=node_config, hass=self._hass)

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -558,13 +558,13 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_entity_discovery(self, discovery, get_platform):
+    def test_entity_discovery(self, discovery, import_module):
         """Test the creation of a new entity."""
         discovery.async_load_platform.return_value = mock_coro()
         mock_platform = MagicMock()
-        get_platform.return_value = mock_platform
+        import_module.return_value = mock_platform
         mock_device = MagicMock()
         mock_device.name = 'test_device'
         mock_platform.get_device.return_value = mock_device
@@ -618,13 +618,13 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         assert values._entity.value_changed.called
         assert len(values._entity.value_changed.mock_calls) == 1
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_entity_existing_values(self, discovery, get_platform):
+    def test_entity_existing_values(self, discovery, import_module):
         """Test the loading of already discovered values."""
         discovery.async_load_platform.return_value = mock_coro()
         mock_platform = MagicMock()
-        get_platform.return_value = mock_platform
+        import_module.return_value = mock_platform
         mock_device = MagicMock()
         mock_device.name = 'test_device'
         mock_platform.get_device.return_value = mock_device
@@ -663,9 +663,9 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         assert args[4] == self.zwave_config
         assert not self.primary.enable_poll.called
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_node_schema_mismatch(self, discovery, get_platform):
+    def test_node_schema_mismatch(self, discovery, import_module):
         """Test node schema mismatch."""
         self.node.generic = 'no_match'
         self.node.values = {
@@ -686,13 +686,13 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
 
         assert not discovery.async_load_platform.called
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_entity_workaround_component(self, discovery, get_platform):
+    def test_entity_workaround_component(self, discovery, import_module):
         """Test component workaround."""
         discovery.async_load_platform.return_value = mock_coro()
         mock_platform = MagicMock()
-        get_platform.return_value = mock_platform
+        import_module.return_value = mock_platform
         mock_device = MagicMock()
         mock_device.name = 'test_device'
         mock_platform.get_device.return_value = mock_device
@@ -729,9 +729,9 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             args = mock_dispatch_send.mock_calls[0][1]
             assert args[1] == 'zwave_new_binary_sensor'
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_entity_workaround_ignore(self, discovery, get_platform):
+    def test_entity_workaround_ignore(self, discovery, import_module):
         """Test ignore workaround."""
         self.node.manufacturer_id = '010f'
         self.node.product_type = '0301'
@@ -758,9 +758,9 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
 
         assert not discovery.async_load_platform.called
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_entity_config_ignore(self, discovery, get_platform):
+    def test_entity_config_ignore(self, discovery, import_module):
         """Test ignore config."""
         self.node.values = {
             self.primary.value_id: self.primary,
@@ -782,9 +782,10 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
 
         assert not discovery.async_load_platform.called
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_entity_config_ignore_with_registry(self, discovery, get_platform):
+    def test_entity_config_ignore_with_registry(self, discovery,
+                                                import_module):
         """Test ignore config.
 
         The case when the device is in entity registry.
@@ -813,16 +814,16 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
 
         assert not discovery.async_load_platform.called
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_entity_platform_ignore(self, discovery, get_platform):
+    def test_entity_platform_ignore(self, discovery, import_module):
         """Test platform ignore device."""
         self.node.values = {
             self.primary.value_id: self.primary,
             self.secondary.value_id: self.secondary,
         }
         platform = MagicMock()
-        get_platform.return_value = platform
+        import_module.return_value = platform
         platform.get_device.return_value = None
         zwave.ZWaveDeviceEntityValues(
             hass=self.hass,
@@ -836,12 +837,12 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
 
         assert not discovery.async_load_platform.called
 
-    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'import_module')
     @patch.object(zwave, 'discovery')
-    def test_config_polling_intensity(self, discovery, get_platform):
+    def test_config_polling_intensity(self, discovery, import_module):
         """Test polling intensity."""
         mock_platform = MagicMock()
-        get_platform.return_value = mock_platform
+        import_module.return_value = mock_platform
         mock_device = MagicMock()
         mock_device.name = 'test_device'
         mock_platform.get_device.return_value = mock_device


### PR DESCRIPTION
## Description:
Update Z-Wave component to use `async_get_integration` instead of `get_platform`

**Related issue (if applicable):** fixes #23009

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
