### PR TITLE
Mobile App: Remove component loading support

### DIFF
--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -28,7 +28,6 @@ DATA_DEVICES = 'devices'
 DATA_SENSOR = 'sensor'
 DATA_STORE = 'store'
 
-ATTR_APP_COMPONENT = 'app_component'
 ATTR_APP_DATA = 'app_data'
 ATTR_APP_ID = 'app_id'
 ATTR_APP_NAME = 'app_name'
@@ -66,7 +65,6 @@ ATTR_WEBHOOK_ENCRYPTED_DATA = 'encrypted_data'
 ATTR_WEBHOOK_TYPE = 'type'
 
 ERR_ENCRYPTION_REQUIRED = 'encryption_required'
-ERR_INVALID_COMPONENT = 'invalid_component'
 ERR_SENSOR_NOT_REGISTERED = 'not_registered'
 ERR_SENSOR_DUPLICATE_UNIQUE_ID = 'duplicate_unique_id'
 
@@ -89,7 +87,6 @@ WEBHOOK_TYPES = [WEBHOOK_TYPE_CALL_SERVICE, WEBHOOK_TYPE_FIRE_EVENT,
 
 
 REGISTRATION_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_APP_COMPONENT): cv.string,
     vol.Optional(ATTR_APP_DATA, default={}): dict,
     vol.Required(ATTR_APP_ID): cv.string,
     vol.Required(ATTR_APP_NAME): cv.string,

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -12,15 +12,11 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.const import (HTTP_CREATED, CONF_WEBHOOK_ID)
 
-from homeassistant.loader import get_component
+from .const import (ATTR_DEVICE_ID, ATTR_SUPPORTS_ENCRYPTION,
+                    CONF_CLOUDHOOK_URL, CONF_REMOTE_UI_URL, CONF_SECRET,
+                    CONF_USER_ID, DOMAIN, REGISTRATION_SCHEMA)
 
-from .const import (ATTR_APP_COMPONENT, ATTR_DEVICE_ID,
-                    ATTR_SUPPORTS_ENCRYPTION, CONF_CLOUDHOOK_URL,
-                    CONF_REMOTE_UI_URL, CONF_SECRET,
-                    CONF_USER_ID, DOMAIN, ERR_INVALID_COMPONENT,
-                    REGISTRATION_SCHEMA)
-
-from .helpers import error_response, supports_encryption
+from .helpers import supports_encryption
 
 
 class RegistrationsView(HomeAssistantView):
@@ -33,20 +29,6 @@ class RegistrationsView(HomeAssistantView):
     async def post(self, request: Request, data: Dict) -> Response:
         """Handle the POST request for registration."""
         hass = request.app['hass']
-
-        if ATTR_APP_COMPONENT in data:
-            component = get_component(hass, data[ATTR_APP_COMPONENT])
-            if component is None:
-                fmt_str = "{} is not a valid component."
-                msg = fmt_str.format(data[ATTR_APP_COMPONENT])
-                return error_response(ERR_INVALID_COMPONENT, msg)
-
-            if (hasattr(component, 'DEPENDENCIES') is False or
-                    (hasattr(component, 'DEPENDENCIES') and
-                     DOMAIN not in component.DEPENDENCIES)):
-                fmt_str = "{} is not compatible with mobile_app."
-                msg = fmt_str.format(data[ATTR_APP_COMPONENT])
-                return error_response(ERR_INVALID_COMPONENT, msg)
 
         webhook_id = generate_secret()
 

--- a/tests/components/mobile_app/test_http_api.py
+++ b/tests/components/mobile_app/test_http_api.py
@@ -80,28 +80,3 @@ async def test_registration(hass, hass_client):  # noqa: F811
     decrypted_data = decrypted_data.decode("utf-8")
 
     assert json.loads(decrypted_data) == {'one': 'Hello world'}
-
-
-async def test_register_invalid_component(authed_api_client):  # noqa: F811
-    """Test that registration with invalid component fails."""
-    resp = await authed_api_client.post(
-        '/api/mobile_app/registrations', json={
-            'app_component': 'will_never_be_valid',
-            'app_data': {'foo': 'bar'},
-            'app_id': 'io.homeassistant.mobile_app_test',
-            'app_name': 'Mobile App Tests',
-            'app_version': '1.0.0',
-            'device_name': 'Test 1',
-            'manufacturer': 'mobile_app',
-            'model': 'Test',
-            'os_name': 'Linux',
-            'os_version': '1.0',
-            'supports_encryption': True
-        }
-    )
-
-    assert resp.status == 400
-    register_json = await resp.json()
-    assert 'error' in register_json
-    assert register_json['success'] is False
-    assert register_json['error']['code'] == 'invalid_component'


### PR DESCRIPTION
Loading a component defined in a registration didn't actually work and was undocumented, so let's just remove it instead of fixing #23005.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
