### PR TITLE
Migrate check-config to use get_integration

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -336,8 +336,9 @@ def check_ha_config_file(hass):
             result.add_error("Integration not found: {}".format(domain))
             continue
 
-        component = integration.get_component()
-        if not component:
+        try:
+            component = integration.get_component()
+        except ImportError:
             result.add_error("Component not found: {}".format(domain))
             continue
 

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -90,7 +90,7 @@ class TestCheckConfig(unittest.TestCase):
             res = check_config.check(get_test_config_dir())
             assert res['components'].keys() == {'homeassistant'}
             assert res['except'] == {
-                check_config.ERROR_STR: ['Component not found: beer']}
+                check_config.ERROR_STR: ['Integration not found: beer']}
             assert res['secret_cache'] == {}
             assert res['secrets'] == {}
             assert len(res['yaml_files']) == 1
@@ -104,7 +104,8 @@ class TestCheckConfig(unittest.TestCase):
             assert res['components']['light'] == []
             assert res['except'] == {
                 check_config.ERROR_STR: [
-                    'Platform not found: light.beer',
+                    'Integration beer not found when trying to verify its '
+                    'light platform.',
                 ]}
             assert res['secret_cache'] == {}
             assert res['secrets'] == {}


### PR DESCRIPTION
## Description:
Converts the check config script to use `async_get_integration`.

**Related issue (if applicable):** fixes #23008

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
