### PR TITLE
Fix unnecessary hass.components interaction

### DIFF
--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -8,6 +8,8 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 import homeassistant.helpers.config_validation as cv
 
+from . import BLOOMSKY
+
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['bloomsky']
@@ -25,14 +27,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather binary sensors."""
-    bloomsky = hass.components.bloomsky
     # Default needed in case of discovery
     sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
 
-    for device in bloomsky.BLOOMSKY.devices.values():
+    for device in BLOOMSKY.devices.values():
         for variable in sensors:
             add_entities(
-                [BloomSkySensor(bloomsky.BLOOMSKY, device, variable)], True)
+                [BloomSkySensor(BLOOMSKY, device, variable)], True)
 
 
 class BloomSkySensor(BinarySensorDevice):

--- a/homeassistant/components/bloomsky/camera.py
+++ b/homeassistant/components/bloomsky/camera.py
@@ -5,14 +5,15 @@ import requests
 
 from homeassistant.components.camera import Camera
 
+from . import BLOOMSKY
+
 DEPENDENCIES = ['bloomsky']
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up access to BloomSky cameras."""
-    bloomsky = hass.components.bloomsky
-    for device in bloomsky.BLOOMSKY.devices.values():
-        add_entities([BloomSkyCamera(bloomsky.BLOOMSKY, device)])
+    for device in BLOOMSKY.devices.values():
+        add_entities([BloomSkyCamera(BLOOMSKY, device)])
 
 
 class BloomSkyCamera(Camera):

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -8,7 +8,9 @@ from homeassistant.const import (TEMP_FAHRENHEIT, CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-_LOGGER = logging.getLogger(__name__)
+from . import BLOOMSKY
+
+LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['bloomsky']
 
@@ -38,14 +40,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather sensors."""
-    bloomsky = hass.components.bloomsky
     # Default needed in case of discovery
     sensors = config.get(CONF_MONITORED_CONDITIONS, SENSOR_TYPES)
 
-    for device in bloomsky.BLOOMSKY.devices.values():
+    for device in BLOOMSKY.devices.values():
         for variable in sensors:
             add_entities(
-                [BloomSkySensor(bloomsky.BLOOMSKY, device, variable)], True)
+                [BloomSkySensor(BLOOMSKY, device, variable)], True)
 
 
 class BloomSkySensor(Entity):

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import CONF_TIMEOUT
 from homeassistant.helpers import config_validation as cv
 
-from . import CameraData
+from . import CameraData, NETATMO_AUTH
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +53,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the access to Netatmo binary sensor."""
-    netatmo = hass.components.netatmo
     home = config.get(CONF_HOME)
     timeout = config.get(CONF_TIMEOUT)
     if timeout is None:
@@ -63,7 +62,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     import pyatmo
     try:
-        data = CameraData(hass, netatmo.NETATMO_AUTH, home)
+        data = CameraData(hass, NETATMO_AUTH, home)
         if not data.get_camera_names():
             return None
     except pyatmo.NoDevice:

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -9,7 +9,7 @@ from homeassistant.components.camera import (
 from homeassistant.const import CONF_VERIFY_SSL
 from homeassistant.helpers import config_validation as cv
 
-from . import CameraData
+from . import CameraData, NETATMO_AUTH
 
 DEPENDENCIES = ['netatmo']
 
@@ -35,13 +35,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up access to Netatmo cameras."""
-    netatmo = hass.components.netatmo
     home = config.get(CONF_HOME)
     verify_ssl = config.get(CONF_VERIFY_SSL, True)
     quality = config.get(CONF_QUALITY, DEFAULT_QUALITY)
     import pyatmo
     try:
-        data = CameraData(hass, netatmo.NETATMO_AUTH, home)
+        data = CameraData(hass, NETATMO_AUTH, home)
         for camera_name in data.get_camera_names():
             camera_type = data.get_camera_type(camera=camera_name, home=home)
             if CONF_CAMERAS in config:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -14,6 +14,8 @@ from homeassistant.const import (
     STATE_OFF, TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_NAME)
 from homeassistant.util import Throttle
 
+from . import NETATMO_AUTH
+
 DEPENDENCIES = ['netatmo']
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,12 +68,10 @@ NA_VALVE = 'NRV'
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NetAtmo Thermostat."""
-    netatmo = hass.components.netatmo
-
     import pyatmo
     homes_conf = config.get(CONF_HOMES)
     try:
-        home_data = HomeData(netatmo.NETATMO_AUTH)
+        home_data = HomeData(NETATMO_AUTH)
     except pyatmo.NoDevice:
         return
 

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -90,7 +90,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for home in homes:
         _LOGGER.debug("Setting up %s ...", home)
         try:
-            room_data = ThermostatData(netatmo.NETATMO_AUTH, home)
+            room_data = ThermostatData(NETATMO_AUTH, home)
         except pyatmo.NoDevice:
             continue
         for room_id in room_data.get_room_ids():

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -12,6 +12,8 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
+from . import NETATMO_AUTH
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_MODULES = 'modules'
@@ -67,26 +69,24 @@ MODULE_TYPE_INDOOR = 'NAModule4'
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available Netatmo weather sensors."""
-    netatmo = hass.components.netatmo
-
     dev = []
     if CONF_MODULES in config:
-        manual_config(netatmo, config, dev)
+        manual_config(config, dev)
     else:
-        auto_config(netatmo, config, dev)
+        auto_config(config, dev)
 
     if dev:
         add_entities(dev, True)
 
 
-def manual_config(netatmo, config, dev):
+def manual_config(config, dev):
     """Handle manual configuration."""
     import pyatmo
 
     all_classes = all_product_classes()
     not_handled = {}
     for data_class in all_classes:
-        data = NetAtmoData(netatmo.NETATMO_AUTH, data_class,
+        data = NetAtmoData(NETATMO_AUTH, data_class,
                            config.get(CONF_STATION))
         try:
             # Iterate each module
@@ -109,13 +109,12 @@ def manual_config(netatmo, config, dev):
             _LOGGER.error('Module name: "%s" not found', module_name)
 
 
-def auto_config(netatmo, config, dev):
+def auto_config(config, dev):
     """Handle auto configuration."""
     import pyatmo
 
     for data_class in all_product_classes():
-        data = NetAtmoData(netatmo.NETATMO_AUTH, data_class,
-                           config.get(CONF_STATION))
+        data = NetAtmoData(NETATMO_AUTH, data_class, config.get(CONF_STATION))
         try:
             for module_name in data.get_module_names():
                 for variable in \

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -8,6 +8,8 @@ import requests
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.exceptions import PlatformNotReady
 
+from . import SUBSCRIPTION_REGISTRY
+
 DEPENDENCIES = ['wemo']
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,7 +68,7 @@ class WemoBinarySensor(BinarySensorDevice):
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
-        registry = self.hass.components.wemo.SUBSCRIPTION_REGISTRY
+        registry = SUBSCRIPTION_REGISTRY
         await self.hass.async_add_executor_job(registry.register, self.wemo)
         registry.on(self.wemo, None, self._subscription_callback)
 

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -14,6 +14,8 @@ from homeassistant.components.fan import (
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.const import ATTR_ENTITY_ID
 
+from . import SUBSCRIPTION_REGISTRY
+
 DEPENDENCIES = ['wemo']
 SCAN_INTERVAL = timedelta(seconds=10)
 DATA_KEY = 'fan.wemo'
@@ -229,7 +231,7 @@ class WemoHumidifier(FanEntity):
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
-        registry = self.hass.components.wemo.SUBSCRIPTION_REGISTRY
+        registry = SUBSCRIPTION_REGISTRY
         await self.hass.async_add_executor_job(registry.register, self.wemo)
         registry.on(self.wemo, None, self._subscription_callback)
 

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -13,6 +13,8 @@ from homeassistant.components.light import (
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.util.color as color_util
 
+from . import SUBSCRIPTION_REGISTRY
+
 DEPENDENCIES = ['wemo']
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
@@ -226,7 +228,7 @@ class WemoDimmer(Light):
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
-        registry = self.hass.components.wemo.SUBSCRIPTION_REGISTRY
+        registry = SUBSCRIPTION_REGISTRY
         await self.hass.async_add_executor_job(registry.register, self.wemo)
         registry.on(self.wemo, None, self._subscription_callback)
 

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -12,6 +12,8 @@ from homeassistant.util import convert
 from homeassistant.const import (
     STATE_OFF, STATE_ON, STATE_STANDBY, STATE_UNKNOWN)
 
+from . import SUBSCRIPTION_REGISTRY
+
 DEPENDENCIES = ['wemo']
 SCAN_INTERVAL = timedelta(seconds=10)
 
@@ -198,7 +200,7 @@ class WemoSwitch(SwitchDevice):
         # Define inside async context so we know our event loop
         self._update_lock = asyncio.Lock()
 
-        registry = self.hass.components.wemo.SUBSCRIPTION_REGISTRY
+        registry = SUBSCRIPTION_REGISTRY
         await self.hass.async_add_job(registry.register, self.wemo)
         registry.on(self.wemo, None, self._subscription_callback)
 


### PR DESCRIPTION
## Description:
These integrations were using `hass.components` instead of importing from their own integration. And yes, they should have used `hass.data`  but I don't want to do a refactor of these integrations now.

Related to #23004