### PR TITLE
Specify configurator as dependency

### DIFF
--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "pyatv==0.3.12"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "py-august==0.7.0"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/automatic/manifest.json
+++ b/homeassistant/components/automatic/manifest.json
@@ -6,6 +6,7 @@
     "aioautomatic==0.6.5"
   ],
   "dependencies": [
+    "configurator",
     "http"
   ],
   "codeowners": [

--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -5,7 +5,9 @@
   "requirements": [
     "braviarc-homeassistant==0.3.7.dev0"
   ],
-  "dependencies": [],
+  "dependencies": [
+    "configurator"
+  ],
   "codeowners": [
     "@robbiet480"
   ]

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "python-ecobee-api==0.0.18"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/fitbit/manifest.json
+++ b/homeassistant/components/fitbit/manifest.json
@@ -6,6 +6,7 @@
     "fitbit==0.3.0"
   ],
   "dependencies": [
+    "configurator",
     "http"
   ],
   "codeowners": [

--- a/homeassistant/components/gpmdp/manifest.json
+++ b/homeassistant/components/gpmdp/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "websocket-client==0.54.0"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "homekit[IP]==0.13.0"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/icloud/manifest.json
+++ b/homeassistant/components/icloud/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "pyicloud==0.9.1"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "plexapi==3.0.6"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/remember_the_milk/manifest.json
+++ b/homeassistant/components/remember_the_milk/manifest.json
@@ -6,6 +6,6 @@
     "RtmAPI==0.7.0",
     "httplib2==0.10.3"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/sabnzbd/manifest.json
+++ b/homeassistant/components/sabnzbd/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "pysabnzbd==1.1.0"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -6,6 +6,7 @@
     "spotipy-homeassistant==2.4.4.dev1"
   ],
   "dependencies": [
+    "configurator",
     "http"
   ],
   "codeowners": []

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -6,6 +6,6 @@
     "pylgtv==0.1.9",
     "websockets==6.0"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }

--- a/homeassistant/components/wink/manifest.json
+++ b/homeassistant/components/wink/manifest.json
@@ -6,6 +6,6 @@
     "pubnubsub-handler==1.0.3",
     "python-wink==1.10.3"
   ],
-  "dependencies": [],
+  "dependencies": ["configurator"],
   "codeowners": []
 }


### PR DESCRIPTION
## Description:
An integration should only use `hass.components.` if it has that integration specified in dependencies.

This requirement is a work in progress, related to #23004