### PR TITLE
Use device ID provided in registration instead of random UUID

### DIFF
--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -85,21 +85,6 @@ WEBHOOK_TYPES = [WEBHOOK_TYPE_CALL_SERVICE, WEBHOOK_TYPE_FIRE_EVENT,
                  WEBHOOK_TYPE_UPDATE_REGISTRATION,
                  WEBHOOK_TYPE_UPDATE_SENSOR_STATES]
 
-
-REGISTRATION_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_APP_DATA, default={}): dict,
-    vol.Required(ATTR_APP_ID): cv.string,
-    vol.Required(ATTR_APP_NAME): cv.string,
-    vol.Required(ATTR_APP_VERSION): cv.string,
-    vol.Required(ATTR_DEVICE_ID): cv.string,
-    vol.Required(ATTR_DEVICE_NAME): cv.string,
-    vol.Required(ATTR_MANUFACTURER): cv.string,
-    vol.Required(ATTR_MODEL): cv.string,
-    vol.Required(ATTR_OS_NAME): cv.string,
-    vol.Optional(ATTR_OS_VERSION): cv.string,
-    vol.Required(ATTR_SUPPORTS_ENCRYPTION, default=False): cv.boolean,
-})
-
 UPDATE_REGISTRATION_SCHEMA = vol.Schema({
     vol.Optional(ATTR_APP_DATA, default={}): dict,
     vol.Required(ATTR_APP_VERSION): cv.string,
@@ -108,6 +93,13 @@ UPDATE_REGISTRATION_SCHEMA = vol.Schema({
     vol.Required(ATTR_MANUFACTURER): cv.string,
     vol.Required(ATTR_MODEL): cv.string,
     vol.Optional(ATTR_OS_VERSION): cv.string,
+})
+
+REGISTRATION_SCHEMA = UPDATE_REGISTRATION_SCHEMA.extend({
+    vol.Required(ATTR_APP_ID): cv.string,
+    vol.Required(ATTR_APP_NAME): cv.string,
+    vol.Required(ATTR_OS_NAME): cv.string,
+    vol.Required(ATTR_SUPPORTS_ENCRYPTION, default=False): cv.boolean,
 })
 
 WEBHOOK_PAYLOAD_SCHEMA = vol.Schema({

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -91,6 +91,7 @@ REGISTRATION_SCHEMA = vol.Schema({
     vol.Required(ATTR_APP_ID): cv.string,
     vol.Required(ATTR_APP_NAME): cv.string,
     vol.Required(ATTR_APP_VERSION): cv.string,
+    vol.Required(ATTR_DEVICE_ID): cv.string,
     vol.Required(ATTR_DEVICE_NAME): cv.string,
     vol.Required(ATTR_MANUFACTURER): cv.string,
     vol.Required(ATTR_MODEL): cv.string,
@@ -102,6 +103,7 @@ REGISTRATION_SCHEMA = vol.Schema({
 UPDATE_REGISTRATION_SCHEMA = vol.Schema({
     vol.Optional(ATTR_APP_DATA, default={}): dict,
     vol.Required(ATTR_APP_VERSION): cv.string,
+    vol.Required(ATTR_DEVICE_ID): cv.string,
     vol.Required(ATTR_DEVICE_NAME): cv.string,
     vol.Required(ATTR_MANUFACTURER): cv.string,
     vol.Required(ATTR_MODEL): cv.string,

--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -31,6 +31,9 @@ class MobileAppEntity(Entity):
                                     config[ATTR_SENSOR_UNIQUE_ID])
         self._entity_type = config[ATTR_SENSOR_TYPE]
         self.unsub_dispatcher = None
+        self.entity_id = "{}.{}_{}_{}".format(self._entity_type, DOMAIN,
+                                              config[ATTR_DEVICE_ID],
+                                              config[ATTR_SENSOR_UNIQUE_ID])
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/mobile_app/entity.py
+++ b/homeassistant/components/mobile_app/entity.py
@@ -31,8 +31,9 @@ class MobileAppEntity(Entity):
                                     config[ATTR_SENSOR_UNIQUE_ID])
         self._entity_type = config[ATTR_SENSOR_TYPE]
         self.unsub_dispatcher = None
+        device_id = self._registration[ATTR_DEVICE_ID]
         self.entity_id = "{}.{}_{}_{}".format(self._entity_type, DOMAIN,
-                                              config[ATTR_DEVICE_ID],
+                                              device_id,
                                               config[ATTR_SENSOR_UNIQUE_ID])
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/mobile_app/helpers.py
+++ b/homeassistant/components/mobile_app/helpers.py
@@ -10,10 +10,10 @@ from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import (ATTR_APP_DATA, ATTR_APP_ID, ATTR_APP_NAME,
-                    ATTR_APP_VERSION, ATTR_DEVICE_NAME, ATTR_MANUFACTURER,
-                    ATTR_MODEL, ATTR_OS_VERSION, ATTR_SUPPORTS_ENCRYPTION,
-                    CONF_SECRET, CONF_USER_ID, DATA_BINARY_SENSOR,
-                    DATA_DELETED_IDS, DATA_SENSOR, DOMAIN)
+                    ATTR_APP_VERSION, ATTR_DEVICE_ID, ATTR_DEVICE_NAME,
+                    ATTR_MANUFACTURER, ATTR_MODEL, ATTR_OS_VERSION,
+                    ATTR_SUPPORTS_ENCRYPTION, CONF_SECRET, CONF_USER_ID,
+                    DATA_BINARY_SENSOR, DATA_DELETED_IDS, DATA_SENSOR, DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,6 +114,7 @@ def safe_registration(registration: Dict) -> Dict:
         ATTR_APP_ID: registration[ATTR_APP_ID],
         ATTR_APP_NAME: registration[ATTR_APP_NAME],
         ATTR_APP_VERSION: registration[ATTR_APP_VERSION],
+        ATTR_DEVICE_ID: registration[ATTR_DEVICE_ID],
         ATTR_DEVICE_NAME: registration[ATTR_DEVICE_NAME],
         ATTR_MANUFACTURER: registration[ATTR_MANUFACTURER],
         ATTR_MODEL: registration[ATTR_MODEL],

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -1,5 +1,4 @@
 """Provides an HTTP API for mobile_app."""
-import uuid
 from typing import Dict
 
 from aiohttp.web import Response, Request
@@ -12,9 +11,9 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.const import (HTTP_CREATED, CONF_WEBHOOK_ID)
 
-from .const import (ATTR_DEVICE_ID, ATTR_SUPPORTS_ENCRYPTION,
-                    CONF_CLOUDHOOK_URL, CONF_REMOTE_UI_URL, CONF_SECRET,
-                    CONF_USER_ID, DOMAIN, REGISTRATION_SCHEMA)
+from .const import (ATTR_SUPPORTS_ENCRYPTION, CONF_CLOUDHOOK_URL,
+                    CONF_REMOTE_UI_URL, CONF_SECRET, CONF_USER_ID, DOMAIN,
+                    REGISTRATION_SCHEMA)
 
 from .helpers import supports_encryption
 

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -36,8 +36,6 @@ class RegistrationsView(HomeAssistantView):
             data[CONF_CLOUDHOOK_URL] = \
                 await async_create_cloudhook(hass, webhook_id)
 
-        data[ATTR_DEVICE_ID] = str(uuid.uuid4()).replace("-", "")
-
         data[CONF_WEBHOOK_ID] = webhook_id
 
         if data[ATTR_SUPPORTS_ENCRYPTION] and supports_encryption():

--- a/tests/components/mobile_app/const.py
+++ b/tests/components/mobile_app/const.py
@@ -25,6 +25,7 @@ REGISTER = {
     'app_id': 'io.homeassistant.mobile_app_test',
     'app_name': 'Mobile App Tests',
     'app_version': '1.0.0',
+    'device_id': 'test_1',
     'device_name': 'Test 1',
     'manufacturer': 'mobile_app',
     'model': 'Test',
@@ -38,6 +39,7 @@ REGISTER_CLEARTEXT = {
     'app_id': 'io.homeassistant.mobile_app_test',
     'app_name': 'Mobile App Tests',
     'app_version': '1.0.0',
+    'device_id': 'test_1',
     'device_name': 'Test 1',
     'manufacturer': 'mobile_app',
     'model': 'Test',
@@ -58,7 +60,8 @@ RENDER_TEMPLATE = {
 UPDATE = {
     'app_data': {'foo': 'bar'},
     'app_version': '2.0.0',
-    'device_name': 'Test 1',
+    'device_id': 'test_2',
+    'device_name': 'Test 2',
     'manufacturer': 'mobile_app',
     'model': 'Test',
     'os_version': '1.0'

--- a/tests/components/mobile_app/test_entity.py
+++ b/tests/components/mobile_app/test_entity.py
@@ -38,7 +38,7 @@ async def test_sensor(hass, create_registrations, webhook_client):  # noqa: F401
     assert json == {'success': True}
     await hass.async_block_till_done()
 
-    entity = hass.states.get('sensor.battery_state')
+    entity = hass.states.get('sensor.mobile_app_test_1_battery_state')
     assert entity is not None
 
     assert entity.attributes['device_class'] == 'battery'
@@ -66,7 +66,7 @@ async def test_sensor(hass, create_registrations, webhook_client):  # noqa: F401
 
     assert update_resp.status == 200
 
-    updated_entity = hass.states.get('sensor.battery_state')
+    updated_entity = hass.states.get('sensor.mobile_app_test_1_battery_state')
     assert updated_entity.state == '123'
 
 

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -97,6 +97,8 @@ async def test_webhook_update_registration(webhook_client, hass_client):  # noqa
 
     assert update_resp.status == 200
     update_json = await update_resp.json()
+    assert update_json['device_id'] == 'test_2'
+    assert update_json['device_name'] == 'Test 2'
     assert update_json['app_version'] == '2.0.0'
     assert CONF_WEBHOOK_ID not in update_json
     assert CONF_SECRET not in update_json


### PR DESCRIPTION
## Breaking Change:

Device Tracker and Entity IDs will change (only affects beta users of the Home Assistant Companion iOS app so you can probably leave this out of the notes).

## Description:

Previous to this PR, we generated a random UUID and used it as the device ID in the device tracker. This caused much consternation amongst iOS beta users because it made the device tracker unwieldy to find and use. This PR changes the behavior to require a `device_id` be set in the registration and uses it in place of the random UUID.

Furthermore, it also changes entity IDs generated by `mobile_app` to be of the format `<binary_sensor or sensor>.mobile_app_device_id_sensor_name` instead of the previous format `<binary_sensor or sensor>.sensor_name`. This will ensure that conflicts will not happen for `mobile_app` entities. The entities already had a `unique_id` set and that has not changed. **Changing the device ID in the registration will change the entity IDs of the sensors**.

**Related issue (if applicable):** fixes home-assistant/home-assistant-iOS#262

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
