### PR TITLE
Empty parm

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -1,6 +1,7 @@
 """Support for Climate devices of (EMEA/EU-based) Honeywell evohome systems."""
 from datetime import datetime, timedelta
 import logging
+import requests.exceptions
 
 from requests.exceptions import HTTPError
 
@@ -346,10 +347,11 @@ class EvoZone(EvoClimateDevice):
     def _set_operation_mode(self, operation_mode):
         if operation_mode == EVO_FOLLOW:
             try:
-              #  self._obj.cancel_temp_override(self._obj)
-                self._obj.cancel_temp_override()
-            except HTTPError as err:
-                self._handle_exception("HTTPError", str(err))  # noqa: E501; pylint: disable=no-member
+                import evohomeclient2
+                self._obj.cancel_temp_override(operation_mode)
+            except (requests.exceptions.RequestException,
+                    evohomeclient2.AuthenticationError) as err:
+                self._handle_exception(err)
 
         elif operation_mode == EVO_TEMPOVER:
             _LOGGER.error(

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -346,7 +346,8 @@ class EvoZone(EvoClimateDevice):
     def _set_operation_mode(self, operation_mode):
         if operation_mode == EVO_FOLLOW:
             try:
-                self._obj.cancel_temp_override(self._obj)
+              #  self._obj.cancel_temp_override(self._obj)
+                self._obj.cancel_temp_override()
             except HTTPError as err:
                 self._handle_exception("HTTPError", str(err))  # noqa: E501; pylint: disable=no-member
 


### PR DESCRIPTION
Home Assistant release with the issue: All

Last working Home Assistant release (if known): None/never

Operating environment (Hass.io/Docker/Windows/etc.): All

Component/platform: evohome

Description of problem: There is a bug in evohome/climate.py

Problem-relevant configuration.yaml entries and (fill out even if it seems unimportant): N/A

Traceback (if applicable):

Failed to call service climate/turn_on. cancel_temp_override() takes one positional argument, but two were given.

At line 347 def _set_operation_mode(self, operation_mode):

The operation_mode has not been used