### PR TITLE
Update the MIME type for Javascript files

### DIFF
--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -8,7 +8,7 @@ from aiohttp.web_urldispatcher import StaticResource
 
 CACHE_TIME = 31 * 86400  # = 1 month
 CACHE_HEADERS = {hdrs.CACHE_CONTROL: "public, max-age={}".format(CACHE_TIME)}
-
+CONTENT_TYPE_JS = {hdrs.CONTENT_TYPE:'application/javascript'}
 
 # https://github.com/PyCQA/astroid/issues/633
 # pylint: disable=duplicate-bases
@@ -38,7 +38,12 @@ class CachingStaticResource(StaticResource):
         # on opening a dir, load its contents if allowed
         if filepath.is_dir():
             return await super()._handle(request)
+        RESPONSE_HEADER = {}
+        RESPONSE_HEADER.update(CACHE_HEADERS)
         if filepath.is_file():
+            if filepath.name.endswith(".js"):
+                RESPONSE_HEADER.update(CONTENT_TYPE_JS)
             return FileResponse(
-                filepath, chunk_size=self._chunk_size, headers=CACHE_HEADERS)
+                    filepath, chunk_size=self._chunk_size, headers=RESPONSE_HEADER)
+
         raise HTTPNotFound


### PR DESCRIPTION
## Description:
On my windows 10 machine the MIME type was wrong for javascript files. The issue was Chrome refused to execute the scripts "/frontend_es5/core-2f337d0e.js". This consequence was the page loading was aborted and i couldn't get the login form.

This issue seems to be windows related because on my raspberry pi the MIME type is correct e.g.
"content-type:application/javascript"

## Checklist:
  - [x ] The code change is tested and works locally.
