### PR TITLE
Support cover.stop service for HomeKit Window Covers

### DIFF
--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.cover import (
     ATTR_POSITION, ATTR_TILT_POSITION, SUPPORT_CLOSE, SUPPORT_CLOSE_TILT,
-    SUPPORT_OPEN, SUPPORT_OPEN_TILT, SUPPORT_SET_POSITION,
+    SUPPORT_OPEN, SUPPORT_OPEN_TILT, SUPPORT_SET_POSITION, SUPPORT_STOP,
     SUPPORT_SET_TILT_POSITION, CoverDevice)
 from homeassistant.const import (
     STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING)
@@ -137,9 +137,10 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
         self._state = None
         self._position = None
         self._tilt_position = None
-        self._hold = None
         self._obstruction_detected = None
         self.lock_state = None
+        self._features = (
+            SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION)
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
@@ -157,14 +158,24 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
             CharacteristicsTypes.OBSTRUCTION_DETECTED,
         ]
 
+    def _setup_position_hold(self, char):
+        self._features |= SUPPORT_STOP
+
+    def _setup_vertical_tilt_current(self, char):
+        self._features |= (
+            SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT |
+            SUPPORT_SET_TILT_POSITION)
+
+    def _setup_horizontal_tilt_current(self, char):
+        self._features |= (
+            SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT |
+            SUPPORT_SET_TILT_POSITION)
+
     def _update_position_state(self, value):
         self._state = CURRENT_WINDOW_STATE_MAP[value]
 
     def _update_position_current(self, value):
         self._position = value
-
-    def _update_position_hold(self, value):
-        self._hold = value
 
     def _update_vertical_tilt_current(self, value):
         self._tilt_position = value
@@ -175,21 +186,10 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
     def _update_obstruction_detected(self, value):
         self._obstruction_detected = value
 
-    def _update_name(self, value):
-        self._hold = value
-
     @property
     def supported_features(self):
         """Flag supported features."""
-        supported_features = (
-            SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION)
-
-        if self._tilt_position is not None:
-            supported_features |= (
-                SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT |
-                SUPPORT_SET_TILT_POSITION)
-
-        return supported_features
+        return self._features
 
     @property
     def current_cover_position(self):
@@ -210,6 +210,13 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
     def is_opening(self):
         """Return if the cover is opening or not."""
         return self._state == STATE_OPENING
+
+    async def async_stop_cover(self, **kwargs):
+        """Send hold command."""
+        characteristics = [{'aid': self._aid,
+                            'iid': self._chars['position.hold'],
+                            'value': 1}]
+        await self._accessory.put_characteristics(characteristics)
 
     async def async_open_cover(self, **kwargs):
         """Send open command."""
@@ -254,9 +261,5 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
         if self._obstruction_detected is not None:
             state_attributes['obstruction-detected'] = \
                 self._obstruction_detected
-
-        if self._hold is not None:
-            state_attributes['hold-position'] = \
-                self._hold
 
         return state_attributes

--- a/tests/components/homekit_controller/test_cover.py
+++ b/tests/components/homekit_controller/test_cover.py
@@ -5,6 +5,7 @@ from tests.components.homekit_controller.common import (
 POSITION_STATE = ('window-covering', 'position.state')
 POSITION_CURRENT = ('window-covering', 'position.current')
 POSITION_TARGET = ('window-covering', 'position.target')
+POSITION_HOLD = ('window-covering', 'position.hold')
 
 H_TILT_CURRENT = ('window-covering', 'horizontal-tilt.current')
 H_TILT_TARGET = ('window-covering', 'horizontal-tilt.target')
@@ -164,6 +165,17 @@ async def test_write_window_cover_tilt_vertical(hass, utcnow):
         'tilt_position': 90
     }, blocking=True)
     assert helper.characteristics[V_TILT_TARGET].value == 90
+
+
+async def test_window_cover_stop(hass, utcnow):
+    """Test that vertical tilt is written correctly."""
+    window_cover = create_window_covering_service_with_v_tilt()
+    helper = await setup_test_component(hass, [window_cover])
+
+    await hass.services.async_call('cover', 'stop_cover', {
+        'entity_id': helper.entity_id,
+    }, blocking=True)
+    assert helper.characteristics[POSITION_HOLD].value == 1
 
 
 def create_garage_door_opener_service():


### PR DESCRIPTION
## Description:

As part of #21775 I added support for `cover.stop` for HomeKit powered window covers by supporting writes to the `position.hold` characteristic. Unfortunately this isn't actually supported by the device mentioned in the ticket, but is valid for other HomeKit window covers.

This also removes support for reading `position.hold`. It looks like that code was broken already, but also it turns out (according to HomeKit spec) this is a write-only characteristic and shouldn't be read.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.