### PR TITLE
Remove archived 17track packages from the entity registry

### DIFF
--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -230,12 +230,13 @@ class SeventeenTrackPackageSensor(Entity):
             # delete this entity:
             _LOGGER.info(
                 'Deleting entity for stale package: %s', self._tracking_number)
+            reg = await self.hass.helpers.entity_registry.async_get_registry()
+            self.hass.async_create_task(reg.async_remove(self.entity_id))
             self.hass.async_create_task(self.async_remove())
             return
 
         # If the user has elected to not see delivered packages and one gets
-        # delivered, post a notification, remove the entity from the UI, and
-        # delete it from the entity registry:
+        # delivered, post a notification:
         if package.status == VALUE_DELIVERED and not self._data.show_delivered:
             _LOGGER.info('Package delivered: %s', self._tracking_number)
             self.hass.components.persistent_notification.create(
@@ -248,10 +249,6 @@ class SeventeenTrackPackageSensor(Entity):
                 title=NOTIFICATION_DELIVERED_TITLE,
                 notification_id=NOTIFICATION_DELIVERED_ID_SCAFFOLD.format(
                     self._tracking_number))
-
-            reg = self.hass.helpers.entity_registry.async_get_registry()
-            self.hass.async_create_task(reg.async_remove(self.entity_id))
-            self.hass.async_create_task(self.async_remove())
             return
 
         self._attrs.update({

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -15,8 +15,6 @@ from homeassistant.util import Throttle, slugify
 REQUIREMENTS = ['py17track==2.2.2']
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'seventeentrack'
-
 ATTR_DESTINATION_COUNTRY = 'destination_country'
 ATTR_FRIENDLY_NAME = 'friendly_name'
 ATTR_INFO_TEXT = 'info_text'
@@ -304,10 +302,11 @@ class SeventeenTrackData:
 
             # Remove archived packages from the entity registry:
             to_remove = set(self.packages) - set(packages)
-            reg = self._hass.helpers.entity_registry.async_get_registry()
+            reg = await self._hass.helpers.entity_registry.async_get_registry()
             for package in to_remove:
                 entity_id = reg.async_get_entity_id(
-                    self, DOMAIN, 'sensor', ENTITY_ID_TEMPLATE.format(
+                    self, 'sensor', 'seventeentrack',
+                    ENTITY_ID_TEMPLATE.format(
                         self.account_id, package.tracking_number))
                 if not entity_id:
                     continue

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -305,7 +305,7 @@ class SeventeenTrackData:
             reg = await self._hass.helpers.entity_registry.async_get_registry()
             for package in to_remove:
                 entity_id = reg.async_get_entity_id(
-                    self, 'sensor', 'seventeentrack',
+                    'sensor', 'seventeentrack',
                     ENTITY_ID_TEMPLATE.format(
                         self.account_id, package.tracking_number))
                 if not entity_id:

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -36,6 +36,8 @@ DATA_SUMMARY = 'summary_data'
 DEFAULT_ATTRIBUTION = 'Data provided by 17track.net'
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=10)
 
+ENTITY_ID_TEMPLATE = 'package_{0}_{1}'
+
 NOTIFICATION_DELIVERED_ID_SCAFFOLD = 'package_delivered_{0}'
 NOTIFICATION_DELIVERED_TITLE = 'Package Delivered'
 NOTIFICATION_DELIVERED_URL_SCAFFOLD = 'https://t.17track.net/track#nums={0}'
@@ -211,7 +213,7 @@ class SeventeenTrackPackageSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique, HASS-friendly identifier for this entity."""
-        return 'package_{0}_{1}'.format(
+        return ENTITY_ID_TEMPLATE.format(
             self._data.account_id, self._tracking_number)
 
     async def async_update(self):
@@ -305,7 +307,7 @@ class SeventeenTrackData:
             reg = self._hass.helpers.entity_registry.async_get_registry()
             for package in to_remove:
                 entity_id = reg.async_get_entity_id(
-                    self, DOMAIN, 'sensor', 'package_{0}_{1}'.format(
+                    self, DOMAIN, 'sensor', ENTITY_ID_TEMPLATE.format(
                         self.account_id, package.tracking_number))
                 if not entity_id:
                     continue

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -74,7 +74,7 @@ async def async_setup_platform(
     scan_interval = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
     data = SeventeenTrackData(
-        client, hass, async_add_entities, scan_interval,
+        hass, client, async_add_entities, scan_interval,
         config[CONF_SHOW_ARCHIVED], config[CONF_SHOW_DELIVERED])
     await data.async_update()
 
@@ -262,7 +262,7 @@ class SeventeenTrackData:
     """Define a data handler for 17track.net."""
 
     def __init__(
-            self, client, hass, async_add_entities, scan_interval,
+            self, hass, client, async_add_entities, scan_interval,
             show_archived, show_delivered):
         """Initialize."""
         self._async_add_entities = async_add_entities

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -265,7 +265,7 @@ class SeventeenTrackData:
     """Define a data handler for 17track.net."""
 
     def __init__(
-            self, hass, client, async_add_entities, scan_interval,
+            self, client, hass, async_add_entities, scan_interval,
             show_archived, show_delivered):
         """Initialize."""
         self._async_add_entities = async_add_entities


### PR DESCRIPTION
## Description:

Following up on https://github.com/home-assistant/home-assistant/pull/23001, this PR further adjusts the 17track.net sensor so that packages are removed from the entity registry whenever they are archived.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/22994

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: seventeentrack 
    username: !secret 17track_username
    password: !secret 17track_password    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
