### PR TITLE
Convert translation helper to use async_get_integration

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -1,6 +1,5 @@
 """Translation string lookup helpers."""
 import logging
-import pathlib
 from typing import Any, Dict, Iterable
 
 from homeassistant import config_entries

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -1,6 +1,6 @@
 """Translation string lookup helpers."""
 import logging
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterablem, Optional
 
 from homeassistant import config_entries
 from homeassistant.loader import async_get_integration, bind_hass
@@ -30,7 +30,7 @@ def flatten(data: Dict) -> Dict[str, Any]:
 
 
 async def component_translation_file(hass: HomeAssistantType, component: str,
-                                     language: str) -> str:
+                                     language: str) -> Optional[str]:
     """Return the translation json file location for a component.
 
     For component:

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -1,6 +1,6 @@
 """Translation string lookup helpers."""
 import logging
-from typing import Any, Dict, Iterablem, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from homeassistant import config_entries
 from homeassistant.loader import async_get_integration, bind_hass

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant import config_entries
 import homeassistant.helpers.translation as translation
 from homeassistant.setup import async_setup_component
+from tests.common import mock_coro
 
 
 @pytest.fixture
@@ -52,20 +53,20 @@ async def test_component_translation_file(hass):
         'test_package'
     })
 
-    assert path.normpath(translation.component_translation_file(
+    assert path.normpath(await translation.component_translation_file(
         hass, 'switch.test', 'en')) == path.normpath(hass.config.path(
             'custom_components', 'test', '.translations', 'switch.en.json'))
 
-    assert path.normpath(translation.component_translation_file(
+    assert path.normpath(await translation.component_translation_file(
         hass, 'switch.test_embedded', 'en')) == path.normpath(hass.config.path(
             'custom_components', 'test_embedded', '.translations',
             'switch.en.json'))
 
-    assert path.normpath(translation.component_translation_file(
+    assert path.normpath(await translation.component_translation_file(
         hass, 'test_standalone', 'en')) == path.normpath(hass.config.path(
             'custom_components', '.translations', 'test_standalone.en.json'))
 
-    assert path.normpath(translation.component_translation_file(
+    assert path.normpath(await translation.component_translation_file(
         hass, 'test_package', 'en')) == path.normpath(hass.config.path(
             'custom_components', 'test_package', '.translations', 'en.json'))
 
@@ -133,7 +134,7 @@ async def test_get_translations_loads_config_flows(hass, mock_config_flows):
     mock_config_flows.append('component1')
 
     with patch.object(translation, 'component_translation_file',
-                      return_value='bla.json'), \
+                      return_value=mock_coro('bla.json')), \
             patch.object(translation, 'load_translations_files', return_value={
                 'component1': {'hello': 'world'}}):
         translations = await translation.async_get_translations(hass, 'en')

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -62,9 +62,9 @@ async def test_component_translation_file(hass):
             'custom_components', 'test_embedded', '.translations',
             'switch.en.json'))
 
-    assert path.normpath(await translation.component_translation_file(
-        hass, 'test_standalone', 'en')) == path.normpath(hass.config.path(
-            'custom_components', '.translations', 'test_standalone.en.json'))
+    assert await translation.component_translation_file(
+        hass, 'test_standalone', 'en'
+    ) is None
 
     assert path.normpath(await translation.component_translation_file(
         hass, 'test_package', 'en')) == path.normpath(hass.config.path(


### PR DESCRIPTION
## Description:
Use `async_get_integration` inside the translation helper.

**Related issue (if applicable):** fixes #23007

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
