### PR TITLE
Update RainMachine sensors in parallel

### DIFF
--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
     BINARY_SENSORS, DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN,
+    OPERATION_RESTRICTIONS_CURRENT, OPERATION_RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC, TYPE_FREEZE, TYPE_FREEZE_PROTECTION, TYPE_HOT_DAYS,
     TYPE_HOURLY, TYPE_MONTH, TYPE_RAINDELAY, TYPE_RAINSENSOR, TYPE_WEEKDAY,
     RainMachineEntity)
@@ -79,21 +80,26 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
     async def async_update(self):
         """Update the state."""
         if self._sensor_type == TYPE_FREEZE:
-            self._state = self.rainmachine.restrictions['current']['freeze']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_CURRENT]['freeze']
         elif self._sensor_type == TYPE_FREEZE_PROTECTION:
-            self._state = self.rainmachine.restrictions['global'][
-                'freezeProtectEnabled']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_UNIVERSAL]['freezeProtectEnabled']
         elif self._sensor_type == TYPE_HOT_DAYS:
-            self._state = self.rainmachine.restrictions['global'][
-                'hotDaysExtraWatering']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_UNIVERSAL]['hotDaysExtraWatering']
         elif self._sensor_type == TYPE_HOURLY:
-            self._state = self.rainmachine.restrictions['current']['hourly']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_CURRENT]['hourly']
         elif self._sensor_type == TYPE_MONTH:
-            self._state = self.rainmachine.restrictions['current']['month']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_CURRENT]['month']
         elif self._sensor_type == TYPE_RAINDELAY:
-            self._state = self.rainmachine.restrictions['current']['rainDelay']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_CURRENT]['rainDelay']
         elif self._sensor_type == TYPE_RAINSENSOR:
-            self._state = self.rainmachine.restrictions['current'][
-                'rainSensor']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_CURRENT]['rainSensor']
         elif self._sensor_type == TYPE_WEEKDAY:
-            self._state = self.rainmachine.restrictions['current']['weekDay']
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_CURRENT]['weekDay']

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -12,4 +12,7 @@ DEFAULT_PORT = 8080
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 DEFAULT_SSL = True
 
+OPERATION_RESTRICTIONS_CURRENT = 'restrictions.current'
+OPERATION_RESTRICTIONS_UNIVERSAL = 'restrictions.universal'
+
 TOPIC_UPDATE = 'update_{0}'

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -5,7 +5,8 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
-    DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN, SENSOR_UPDATE_TOPIC, SENSORS,
+    DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN,
+    OPERATION_RESTRICTIONS_UNIVERSAL, SENSOR_UPDATE_TOPIC, SENSORS,
     RainMachineEntity)
 
 _LOGGER = logging.getLogger(__name__)
@@ -81,5 +82,5 @@ class RainMachineSensor(RainMachineEntity):
 
     async def async_update(self):
         """Update the sensor's state."""
-        self._state = self.rainmachine.restrictions['global'][
+        self._state = self.rainmachine.data[OPERATION_RESTRICTIONS_UNIVERSAL][
             'freezeProtectTemp']


### PR DESCRIPTION
## Description:

This PR forces the `rainmachine` integration to update data for all sensors in parallel.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_ip
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
