### PR TITLE
Only load stream when av package available

### DIFF
--- a/homeassistant/components/default_config/__init__.py
+++ b/homeassistant/components/default_config/__init__.py
@@ -4,9 +4,14 @@ try:
 except ImportError:
     av = None
 
+from homeassistant.setup import async_setup_component
+
 DOMAIN = 'default_config'
 
 
 async def async_setup(hass, config):
     """Initialize default configuration."""
-    return True
+    if av is None:
+        return True
+
+    return await async_setup_component(hass, 'stream', config)

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -15,7 +15,6 @@
     "mobile_app",
     "person",
     "script",
-    "stream",
     "sun",
     "system_health",
     "updater",


### PR DESCRIPTION
## Description:
Remove `strream` from default config dependencies and set it up inside async_setup when the package is installed. This restores the behavior like it was before the migration to `manifest.json`.

**Related issue (if applicable):** fixes #23013
