### PR TITLE
Validate data packet format on config validation

### DIFF
--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -1,5 +1,4 @@
 """Support for Broadlink RM devices."""
-from base64 import b64decode
 import binascii
 from datetime import timedelta
 import logging
@@ -15,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, slugify
 
-from . import async_setup_service
+from . import async_setup_service, data_packet
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,8 +34,8 @@ MP1_TYPES = ['mp1']
 SWITCH_TYPES = RM_TYPES + SP1_TYPES + SP2_TYPES + MP1_TYPES
 
 SWITCH_SCHEMA = vol.Schema({
-    vol.Optional(CONF_COMMAND_OFF): cv.string,
-    vol.Optional(CONF_COMMAND_ON): cv.string,
+    vol.Optional(CONF_COMMAND_OFF): data_packet,
+    vol.Optional(CONF_COMMAND_ON): data_packet,
     vol.Optional(CONF_FRIENDLY_NAME): cv.string,
 })
 
@@ -124,8 +123,8 @@ class BroadlinkRMSwitch(SwitchDevice):
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(name))
         self._name = friendly_name
         self._state = False
-        self._command_on = b64decode(command_on) if command_on else None
-        self._command_off = b64decode(command_off) if command_off else None
+        self._command_on = command_on
+        self._command_off = command_off
         self._device = device
 
     @property


### PR DESCRIPTION
## Description:
Validate and decode data packet on config validation 

## Example entry for `configuration.yaml` (if applicable):
```yaml

switch:
  - platform: broadlink
    host: 192.168.16.22
    mac: 'xx:xx:xx:xx:xx:xx'
    type: rm2
    switches:
     arcam:
       command_on    : JgAVADodHTo6HR0dHR0dOh0dHR06Oh0dHQ0FAA==
       command_off   : JgAWADodHTo6HR0dHR0dOh0dHR0dHTodHR0NBQAAAAAAAAAAAAAAAAAAAAA=

     arcam_volume:
       command_on: JgAWAB0dOjo6HR0dHR0dHR06Oh0dHR0dHR0NBQAAAAAAAAAAAAAAAAAAAAA=
       command_off: JgAVAB0dOjo6HR0dHR0dHR06Oh0dHR06HQ0FAA==

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - ~[ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~

If the code communicates with devices, web services, or third-party tools:
  - ~[ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).~
  - ~[ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).~
  - ~[ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - ~[ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - ~[ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - ~[ ] Tests have been added to verify that the new code works.~

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
