### PR TITLE
Add support for params in send_command

### DIFF
--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -1,5 +1,6 @@
 """Support for a generic MQTT vacuum."""
 import logging
+import json
 
 import voluptuous as vol
 
@@ -512,8 +513,13 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         """Send a command to a vacuum cleaner."""
         if self.supported_features & SUPPORT_SEND_COMMAND == 0:
             return
-
+        if params:
+            message = {"command": command}
+            message.update(params)
+            message = json.dumps(message)
+        else:
+            message = command
         mqtt.async_publish(self.hass, self._send_command_topic,
-                           command, self._qos, self._retain)
-        self._status = "Sending command {}...".format(command)
+                           message, self._qos, self._retain)
+        self._status = "Sending command {}...".format(message)
         self.async_write_ha_state()

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -130,6 +130,15 @@ async def test_all_commands(hass, mock_publish):
     await hass.async_block_till_done()
     mock_publish.async_publish.assert_called_once_with(
         'vacuum/send_command', '44 FE 93', 0, False)
+    mock_publish.async_publish.reset_mock()
+
+    common.send_command(hass, '44 FE 93', {"key": "value"},
+                        entity_id='vacuum.mqtttest')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    mock_publish.async_publish.assert_called_once_with(
+        'vacuum/send_command', '{"command": "44 FE 93", "key": "value"}',
+        0, False)
 
 
 async def test_status(hass, mock_publish):


### PR DESCRIPTION
## Description:

HA currently doesn't support params in send_command for Vacuum component.
Added this functionality. If params are not provided it is working in old way.
If params are provided we are creating json such as
```
{
  'command': command
  'param1': 'param1'
}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.