### PR TITLE
Bugfix ZHA device_removed() handler.

### DIFF
--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -145,14 +145,14 @@ class ZHAGateway:
 
     def device_removed(self, device):
         """Handle device being removed from the network."""
-        device = self._devices.pop(device.ieee, None)
+        zha_device = self._devices.pop(device.ieee, None)
         self._device_registry.pop(device.ieee, None)
-        if device is not None:
-            device_info = async_get_device_info(self._hass, device)
-            self._hass.async_create_task(device.async_unsub_dispatcher())
+        if zha_device is not None:
+            device_info = async_get_device_info(self._hass, zha_device)
+            self._hass.async_create_task(zha_device.async_unsub_dispatcher())
             async_dispatcher_send(
                 self._hass,
-                "{}_{}".format(SIGNAL_REMOVE, str(device.ieee))
+                "{}_{}".format(SIGNAL_REMOVE, str(zha_device.ieee))
             )
             if device_info is not None:
                 async_dispatcher_send(


### PR DESCRIPTION
## Description:
Bugfix ZHA `device_removed()` handler.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
