### PR TITLE
Fix demo

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -11,9 +11,6 @@ from typing import Any, Optional, Dict, Set
 import voluptuous as vol
 
 from homeassistant import core, config as conf_util, config_entries, loader
-from homeassistant.components import (
-    persistent_notification, homeassistant as core_component
-)
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
 from homeassistant.setup import async_setup_component
 from homeassistant.util.logging import AsyncHandler
@@ -139,17 +136,18 @@ async def async_from_config_dict(config: Dict[str, Any],
         if isinstance(dep_domains, set):
             domains.update(dep_domains)
 
-    # setup components
-    res = await core_component.async_setup(hass, config)
-    if not res:
+    # Set up core.
+    if not all(await asyncio.gather(
+            async_setup_component(hass, 'homeassistant', config),
+            async_setup_component(hass, 'persistent_notification', config),
+    )):
         _LOGGER.error("Home Assistant core failed to initialize. "
                       "Further initialization aborted")
         return hass
 
-    await persistent_notification.async_setup(hass, config)
+    _LOGGER.debug("Home Assistant core initialized")
 
-    _LOGGER.info("Home Assistant core initialized")
-
+    # setup components
     # stage 0, load logging components
     for domain in domains:
         if domain in LOGGING_COMPONENT:

--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -1,14 +1,14 @@
 """Set up the demo environment that mimics interaction with devices."""
 import asyncio
+import logging
 import time
-import sys
 
 from homeassistant import bootstrap
 import homeassistant.core as ha
-from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
+from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
 
 DOMAIN = 'demo'
-
+_LOGGER = logging.getLogger(__name__)
 COMPONENTS_WITH_DEMO_PLATFORM = [
     'air_quality',
     'alarm_control_panel',
@@ -31,19 +31,21 @@ COMPONENTS_WITH_DEMO_PLATFORM = [
 ]
 
 
-async def _async_setup(hass, config):
+async def async_setup(hass, config):
     """Set up the demo environment."""
-    group = hass.components.group
-    configurator = hass.components.configurator
-    persistent_notification = hass.components.persistent_notification
+    if DOMAIN not in config:
+        return True
 
     config.setdefault(ha.DOMAIN, {})
     config.setdefault(DOMAIN, {})
 
-    if config[DOMAIN].get('hide_demo_state') != 1:
-        hass.states.async_set('a.Demo_Mode', 'Enabled')
+    # Set up demo platforms
+    for component in COMPONENTS_WITH_DEMO_PLATFORM:
+        hass.async_create_task(hass.helpers.discovery.async_load_platform(
+            component, DOMAIN, {}, config,
+        ))
 
-    # Setup sun
+    # Set up sun
     if not hass.config.latitude:
         hass.config.latitude = 32.87336
 
@@ -51,15 +53,8 @@ async def _async_setup(hass, config):
         hass.config.longitude = 117.22743
 
     tasks = [
-        bootstrap.async_setup_component(hass, 'sun')
+        bootstrap.async_setup_component(hass, 'sun', config)
     ]
-
-    # Set up demo platforms
-    demo_config = config.copy()
-    for component in COMPONENTS_WITH_DEMO_PLATFORM:
-        demo_config[component] = {CONF_PLATFORM: 'demo'}
-        tasks.append(
-            bootstrap.async_setup_component(hass, component, demo_config))
 
     # Set up input select
     tasks.append(bootstrap.async_setup_component(
@@ -72,6 +67,7 @@ async def _async_setup(hass, config):
                         'initial': 'Anne Therese',
                         'name': 'Cook today',
                         'options': ['Paulus', 'Anne Therese']}}}))
+
     # Set up input boolean
     tasks.append(bootstrap.async_setup_component(
         hass, 'input_boolean',
@@ -96,25 +92,60 @@ async def _async_setup(hass, config):
         {'weblink': {'entities': [{'name': 'Router',
                                    'url': 'http://192.168.1.1'}]}}))
 
-    results = await asyncio.gather(*tasks, loop=hass.loop)
+    results = await asyncio.gather(*tasks)
 
     if any(not result for result in results):
         return False
 
     # Set up example persistent notification
-    persistent_notification.async_create(
+    hass.components.persistent_notification.async_create(
         'This is an example of a persistent notification.',
         title='Example Notification')
 
-    # Set up room groups
+    # Set up configurator
+    configurator_ids = []
+    configurator = hass.components.configurator
+
+    def hue_configuration_callback(data):
+        """Fake callback, mark config as done."""
+        time.sleep(2)
+
+        # First time it is called, pretend it failed.
+        if len(configurator_ids) == 1:
+            configurator.notify_errors(
+                configurator_ids[0],
+                "Failed to register, please try again.")
+
+            configurator_ids.append(0)
+        else:
+            configurator.request_done(configurator_ids[0])
+
+    request_id = configurator.async_request_config(
+        "Philips Hue", hue_configuration_callback,
+        description=("Press the button on the bridge to register Philips "
+                     "Hue with Home Assistant."),
+        description_image="/static/images/config_philips_hue.jpg",
+        fields=[{'id': 'username', 'name': 'Username'}],
+        submit_caption="I have pressed the button"
+    )
+    configurator_ids.append(request_id)
+
+    async def demo_start_listener(_event):
+        """Finish set up."""
+        await finish_setup(hass, config)
+
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_START, demo_start_listener)
+
+    return True
+
+
+async def finish_setup(hass, config):
+    """Finish set up once demo platforms are set up."""
     lights = sorted(hass.states.async_entity_ids('light'))
     switches = sorted(hass.states.async_entity_ids('switch'))
-    media_players = sorted(hass.states.async_entity_ids('media_player'))
-
-    tasks2 = []
 
     # Set up history graph
-    tasks2.append(bootstrap.async_setup_component(
+    await bootstrap.async_setup_component(
         hass, 'history_graph',
         {'history_graph': {'switches': {
             'name': 'Recent Switches',
@@ -122,10 +153,10 @@ async def _async_setup(hass, config):
             'hours_to_show': 1,
             'refresh': 60
         }}}
-    ))
+    )
 
     # Set up scripts
-    tasks2.append(bootstrap.async_setup_component(
+    await bootstrap.async_setup_component(
         hass, 'script',
         {'script': {
             'demo': {
@@ -144,10 +175,10 @@ async def _async_setup(hass, config):
                     'service': 'light.turn_off',
                     'data': {ATTR_ENTITY_ID: lights[0]}
                 }]
-            }}}))
+            }}})
 
     # Set up scenes
-    tasks2.append(bootstrap.async_setup_component(
+    await bootstrap.async_setup_component(
         hass, 'scene',
         {'scene': [
             {'name': 'Romantic lights',
@@ -161,70 +192,4 @@ async def _async_setup(hass, config):
                  switches[0]: True,
                  switches[1]: False,
              }},
-            ]}))
-
-    tasks2.append(group.Group.async_create_group(hass, 'Living Room', [
-        lights[1], switches[0], 'input_select.living_room_preset',
-        'cover.living_room_window', media_players[1],
-        'scene.romantic_lights']))
-    tasks2.append(group.Group.async_create_group(hass, 'Bedroom', [
-        lights[0], switches[1], media_players[0],
-        'input_number.noise_allowance']))
-    tasks2.append(group.Group.async_create_group(hass, 'Kitchen', [
-        lights[2], 'cover.kitchen_window', 'lock.kitchen_door']))
-    tasks2.append(group.Group.async_create_group(hass, 'Doors', [
-        'lock.front_door', 'lock.kitchen_door',
-        'garage_door.right_garage_door', 'garage_door.left_garage_door']))
-    tasks2.append(group.Group.async_create_group(hass, 'Automations', [
-        'input_select.who_cooks', 'input_boolean.notify', ]))
-    tasks2.append(group.Group.async_create_group(hass, 'People', [
-        'device_tracker.demo_anne_therese', 'device_tracker.demo_home_boy',
-        'device_tracker.demo_paulus']))
-    tasks2.append(group.Group.async_create_group(hass, 'Downstairs', [
-        'group.living_room', 'group.kitchen',
-        'scene.romantic_lights', 'cover.kitchen_window',
-        'cover.living_room_window', 'group.doors',
-        'climate.ecobee',
-    ], view=True))
-
-    results = await asyncio.gather(*tasks2, loop=hass.loop)
-
-    if any(not result for result in results):
-        return False
-
-    # Set up configurator
-    configurator_ids = []
-
-    def hue_configuration_callback(data):
-        """Fake callback, mark config as done."""
-        time.sleep(2)
-
-        # First time it is called, pretend it failed.
-        if len(configurator_ids) == 1:
-            configurator.notify_errors(
-                configurator_ids[0],
-                "Failed to register, please try again.")
-
-            configurator_ids.append(0)
-        else:
-            configurator.request_done(configurator_ids[0])
-
-    def setup_configurator():
-        """Set up a configurator."""
-        request_id = configurator.request_config(
-            "Philips Hue", hue_configuration_callback,
-            description=("Press the button on the bridge to register Philips "
-                         "Hue with Home Assistant."),
-            description_image="/static/images/config_philips_hue.jpg",
-            fields=[{'id': 'username', 'name': 'Username'}],
-            submit_caption="I have pressed the button"
-        )
-        configurator_ids.append(request_id)
-
-    hass.async_add_job(setup_configurator)
-
-    return True
-
-
-if 'pytest' not in sys.modules:
-    async_setup = _async_setup  # pylint: disable=invalid-name
+            ]})

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -164,7 +164,7 @@ def setup(hass, config):
                 'ssdp_description': url,
             }
 
-            discovery.discover(hass, SERVICE_WEMO, discovery_info)
+            discovery.discover(hass, SERVICE_WEMO, discovery_info, config)
 
         _LOGGER.debug("WeMo device discovery has finished")
 

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -164,7 +164,7 @@ def setup(hass, config):
                 'ssdp_description': url,
             }
 
-            discovery.discover(hass, SERVICE_WEMO, discovery_info, config)
+            discovery_dispatch(SERVICE_WEMO, discovery_info)
 
         _LOGGER.debug("WeMo device discovery has finished")
 

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -50,15 +50,15 @@ def async_listen(hass, service, callback):
 
 
 @bind_hass
-def discover(hass, service, discovered=None, component=None, hass_config=None):
+def discover(hass, service, discovered, component, hass_config):
     """Fire discovery event. Can ensure a component is loaded."""
     hass.add_job(
         async_discover(hass, service, discovered, component, hass_config))
 
 
 @bind_hass
-async def async_discover(hass, service, discovered=None, component=None,
-                         hass_config=None):
+async def async_discover(hass, service, discovered, component,
+                         hass_config):
     """Fire discovery event. Can ensure a component is loaded."""
     if component in DEPENDENCY_BLACKLIST:
         raise HomeAssistantError(

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -124,7 +124,11 @@ class EntityComponent:
         """Set up a config entry."""
         platform_type = config_entry.domain
         platform = await async_prepare_setup_platform(
-            self.hass, self.config, self.domain, platform_type)
+            self.hass,
+            # In future PR we should make hass_config part of the constructor
+            # params.
+            self.config or {},
+            self.domain, platform_type)
 
         if platform is None:
             return False

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -132,7 +132,7 @@ class Integration:
             )
         return cache[full_name]  # type: ignore
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Text representation of class."""
         return "<Integration {}: {}>".format(self.domain, self.pkg_path)
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -132,6 +132,10 @@ class Integration:
             )
         return cache[full_name]  # type: ignore
 
+    def __repr__(self):
+        """Text representation of class."""
+        return "<Integration {}: {}>".format(self.domain, self.pkg_path)
+
 
 async def async_get_integration(hass: 'HomeAssistant', domain: str)\
          -> Integration:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -31,7 +31,7 @@ def setup_component(hass: core.HomeAssistant, domain: str,
 
 
 async def async_setup_component(hass: core.HomeAssistant, domain: str,
-                                config: Optional[Dict] = None) -> bool:
+                                config: Dict) -> bool:
     """Set up a component and all its dependencies.
 
     This method is a coroutine.
@@ -39,16 +39,10 @@ async def async_setup_component(hass: core.HomeAssistant, domain: str,
     if domain in hass.config.components:
         return True
 
-    setup_tasks = hass.data.get(DATA_SETUP)
+    setup_tasks = hass.data.setdefault(DATA_SETUP, {})
 
-    if setup_tasks is not None and domain in setup_tasks:
+    if domain in setup_tasks:
         return await setup_tasks[domain]  # type: ignore
-
-    if config is None:
-        config = {}
-
-    if setup_tasks is None:
-        setup_tasks = hass.data[DATA_SETUP] = {}
 
     task = setup_tasks[domain] = hass.async_create_task(
         _async_setup_component(hass, domain, config))

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -24,7 +24,7 @@ SLOW_SETUP_WARNING = 10
 
 
 def setup_component(hass: core.HomeAssistant, domain: str,
-                    config: Optional[Dict] = None) -> bool:
+                    config: Dict) -> bool:
     """Set up a component and all its dependencies."""
     return run_coroutine_threadsafe(  # type: ignore
         async_setup_component(hass, domain, config), loop=hass.loop).result()

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -157,7 +157,7 @@ def test_snapshot_service(hass, mock_camera):
 
 async def test_websocket_camera_thumbnail(hass, hass_ws_client, mock_camera):
     """Test camera_thumbnail websocket command."""
-    await async_setup_component(hass, 'camera')
+    await async_setup_component(hass, 'camera', {})
 
     client = await hass_ws_client(hass)
     await client.send_json({
@@ -179,7 +179,7 @@ async def test_websocket_camera_thumbnail(hass, hass_ws_client, mock_camera):
 async def test_websocket_stream_no_source(hass, hass_ws_client,
                                           mock_camera, mock_stream):
     """Test camera/stream websocket command."""
-    await async_setup_component(hass, 'camera')
+    await async_setup_component(hass, 'camera', {})
 
     with patch('homeassistant.components.camera.request_stream',
                return_value='http://home.assistant/playlist.m3u8') \
@@ -203,7 +203,7 @@ async def test_websocket_stream_no_source(hass, hass_ws_client,
 async def test_websocket_camera_stream(hass, hass_ws_client,
                                        mock_camera, mock_stream):
     """Test camera/stream websocket command."""
-    await async_setup_component(hass, 'camera')
+    await async_setup_component(hass, 'camera', {})
 
     with patch('homeassistant.components.camera.request_stream',
                return_value='http://home.assistant/playlist.m3u8'
@@ -231,7 +231,7 @@ async def test_websocket_camera_stream(hass, hass_ws_client,
 async def test_websocket_get_prefs(hass, hass_ws_client,
                                    mock_camera):
     """Test get camera preferences websocket command."""
-    await async_setup_component(hass, 'camera')
+    await async_setup_component(hass, 'camera', {})
 
     # Request preferences through websocket
     client = await hass_ws_client(hass)
@@ -249,7 +249,7 @@ async def test_websocket_get_prefs(hass, hass_ws_client,
 async def test_websocket_update_prefs(hass, hass_ws_client,
                                       mock_camera, setup_camera_prefs):
     """Test updating preference."""
-    await async_setup_component(hass, 'camera')
+    await async_setup_component(hass, 'camera', {})
     assert setup_camera_prefs[PREF_PRELOAD_STREAM]
     client = await hass_ws_client(hass)
     await client.send_json({
@@ -281,7 +281,7 @@ async def test_play_stream_service_no_source(hass, mock_camera, mock_stream):
 
 async def test_handle_play_stream_service(hass, mock_camera, mock_stream):
     """Test camera play_stream service."""
-    await async_setup_component(hass, 'media_player')
+    await async_setup_component(hass, 'media_player', {})
     data = {
         ATTR_ENTITY_ID: 'camera.demo_camera',
         camera.ATTR_MEDIA_PLAYER: 'media_player.test'

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -24,7 +24,7 @@ def hass_ws_client(aiohttp_client, hass_access_token):
     """Websocket client fixture connected to websocket server."""
     async def create_client(hass, access_token=hass_access_token):
         """Create a websocket client."""
-        assert await async_setup_component(hass, 'websocket_api')
+        assert await async_setup_component(hass, 'websocket_api', {})
 
         client = await aiohttp_client(hass.http.app)
 

--- a/tests/components/demo/test_geo_location.py
+++ b/tests/components/demo/test_geo_location.py
@@ -42,8 +42,9 @@ class TestDemoPlatform(unittest.TestCase):
 
             # In this test, one zone and geolocation entities have been
             # generated.
-            all_states = self.hass.states.all()
-            assert len(all_states) == NUMBER_OF_DEMO_DEVICES + 1
+            all_states = [self.hass.states.get(entity_id) for entity_id
+                          in self.hass.states.entity_ids(geo_location.DOMAIN)]
+            assert len(all_states) == NUMBER_OF_DEMO_DEVICES
 
             for state in all_states:
                 # Check a single device's attributes.
@@ -66,6 +67,8 @@ class TestDemoPlatform(unittest.TestCase):
             self.hass.block_till_done()
             # Get all states again, ensure that the number of states is still
             # the same, but the lists are different.
-            all_states_updated = self.hass.states.all()
-            assert len(all_states_updated) == NUMBER_OF_DEMO_DEVICES + 1
+            all_states_updated = [
+                self.hass.states.get(entity_id) for entity_id
+                in self.hass.states.entity_ids(geo_location.DOMAIN)]
+            assert len(all_states_updated) == NUMBER_OF_DEMO_DEVICES
             assert all_states != all_states_updated

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Demo component."""
-import asyncio
 import json
 import os
 
@@ -16,18 +15,6 @@ def mock_history(hass):
     hass.config.components.add('history')
 
 
-@pytest.fixture
-def minimize_demo_platforms(hass):
-    """Cleanup demo component for tests."""
-    orig = demo.COMPONENTS_WITH_DEMO_PLATFORM
-    demo.COMPONENTS_WITH_DEMO_PLATFORM = [
-        'switch', 'light', 'media_player']
-
-    yield
-
-    demo.COMPONENTS_WITH_DEMO_PLATFORM = orig
-
-
 @pytest.fixture(autouse=True)
 def demo_cleanup(hass):
     """Clean up device tracker demo file."""
@@ -38,32 +25,15 @@ def demo_cleanup(hass):
         pass
 
 
-@pytest.mark.skip
-@asyncio.coroutine
-def test_if_demo_state_shows_by_default(hass, minimize_demo_platforms):
-    """Test if demo state shows if we give no configuration."""
-    yield from async_setup_component(hass, demo.DOMAIN, {demo.DOMAIN: {}})
+async def test_setting_up_demo(hass):
+    """Test if we can set up the demo and dump it to JSON."""
+    assert await async_setup_component(hass, demo.DOMAIN, {
+        'demo': {}
+    })
+    await hass.async_start()
 
-    assert hass.states.get('a.Demo_Mode') is not None
-
-
-@pytest.mark.skip
-@asyncio.coroutine
-def test_hiding_demo_state(hass, minimize_demo_platforms):
-    """Test if you can hide the demo card."""
-    yield from async_setup_component(hass, demo.DOMAIN, {
-        demo.DOMAIN: {'hide_demo_state': 1}})
-
-    assert hass.states.get('a.Demo_Mode') is None
-
-
-@pytest.mark.skip
-@asyncio.coroutine
-def test_all_entities_can_be_loaded_over_json(hass):
-    """Test if you can hide the demo card."""
-    yield from async_setup_component(hass, demo.DOMAIN, {
-        demo.DOMAIN: {'hide_demo_state': 1}})
-
+    # This is done to make sure entity components don't accidentally store
+    # non-JSON-serializable data in the state machine.
     try:
         json.dumps(hass.states.async_all(), cls=JSONEncoder)
     except Exception:

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -74,7 +74,7 @@ class TestNotifyDemo(unittest.TestCase):
         self.hass.block_till_done()
         assert notify.DOMAIN in self.hass.config.components
         assert mock_demo_get_service.called
-        assert mock_demo_get_service.call_args[0] == (
+        assert mock_demo_get_service.mock_calls[0][1] == (
             self.hass, {}, {'test_key': 'test_val'})
 
     @callback

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -179,10 +179,9 @@ async def test_gravatar_and_picture(hass):
     autospec=True)
 async def test_discover_platform(mock_demo_setup_scanner, mock_see, hass):
     """Test discovery of device_tracker demo platform."""
-    assert device_tracker.DOMAIN not in hass.config.components
     await discovery.async_load_platform(
         hass, device_tracker.DOMAIN, 'demo', {'test_key': 'test_val'},
-        {'demo': {}})
+        {'bla': {}})
     await hass.async_block_till_done()
     assert device_tracker.DOMAIN in hass.config.components
     assert mock_demo_setup_scanner.called

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -210,7 +210,7 @@ async def test_themes_reload_themes(hass, hass_ws_client):
 
 async def test_missing_themes(hass, hass_ws_client):
     """Test that themes API works when themes are not defined."""
-    await async_setup_component(hass, 'frontend')
+    await async_setup_component(hass, 'frontend', {})
 
     client = await hass_ws_client(hass)
     await client.send_json({
@@ -247,7 +247,7 @@ def test_extra_urls_es5(mock_http_client_with_urls, mock_onboarded):
 
 async def test_get_panels(hass, hass_ws_client):
     """Test get_panels command."""
-    await async_setup_component(hass, 'frontend')
+    await async_setup_component(hass, 'frontend', {})
     await hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:tooltip-account', require_admin=True)
 
@@ -272,7 +272,7 @@ async def test_get_panels(hass, hass_ws_client):
 async def test_get_panels_non_admin(hass, hass_ws_client, hass_admin_user):
     """Test get_panels command."""
     hass_admin_user.groups = []
-    await async_setup_component(hass, 'frontend')
+    await async_setup_component(hass, 'frontend', {})
     await hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:tooltip-account', require_admin=True)
     await hass.components.frontend.async_register_built_in_panel(
@@ -295,7 +295,7 @@ async def test_get_panels_non_admin(hass, hass_ws_client, hass_admin_user):
 
 async def test_get_translations(hass, hass_ws_client):
     """Test get_translations command."""
-    await async_setup_component(hass, 'frontend')
+    await async_setup_component(hass, 'frontend', {})
     client = await hass_ws_client(hass)
 
     with patch('homeassistant.components.frontend.async_get_translations',

--- a/tests/components/geo_location/test_init.py
+++ b/tests/components/geo_location/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.setup import async_setup_component
 
 async def test_setup_component(hass):
     """Simple test setup of component."""
-    result = await async_setup_component(hass, geo_location.DOMAIN)
+    result = await async_setup_component(hass, geo_location.DOMAIN, {})
     assert result
 
 

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -174,7 +174,7 @@ async def test_gen_auth_url(hass, mock_logi_circle):  # pylint: disable=W0621
     flow = config_flow.LogiCircleFlowHandler()
     flow.hass = hass
     flow.flow_impl = 'test-auth-url'
-    await async_setup_component(hass, 'http')
+    await async_setup_component(hass, 'http', {})
 
     result = flow._get_authorization_url()  # pylint: disable=W0212
     assert result == 'http://authorize.url'

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -46,17 +46,17 @@ class TestHelpersDiscovery:
                                  callback_multi)
 
         helpers.discovery.discover('test service', 'discovery info',
-                                   'test_component')
+                                   'test_component', {})
         self.hass.block_till_done()
 
         assert mock_setup_component.called
         assert mock_setup_component.call_args[0] == \
-            (self.hass, 'test_component', None)
+            (self.hass, 'test_component', {})
         assert len(calls_single) == 1
         assert calls_single[0] == ('test service', 'discovery info')
 
         helpers.discovery.discover('another service', 'discovery info',
-                                   'test_component')
+                                   'test_component', {})
         self.hass.block_till_done()
 
         assert len(calls_single) == 1
@@ -171,8 +171,8 @@ class TestHelpersDiscovery:
         def component1_setup(hass, config):
             """Set up mock component."""
             print('component1 setup')
-            discovery.discover(hass, 'test_component2',
-                               component='test_component2')
+            discovery.discover(hass, 'test_component2', {},
+                               'test_component2', {})
             return True
 
         def component2_setup(hass, config):
@@ -213,4 +213,4 @@ async def test_load_platform_forbids_config():
 async def test_discover_forbids_config():
     """Test you cannot setup config component with load_platform."""
     with pytest.raises(HomeAssistantError):
-        await discovery.async_discover(None, None, None, 'config')
+        await discovery.async_discover(None, None, None, 'config', {})

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -84,7 +84,7 @@ async def test_helpers_wrapper(hass):
 
     helpers.discovery.async_listen('service_name', discovery_callback)
 
-    await helpers.discovery.async_discover('service_name', 'hello')
+    await helpers.discovery.async_discover('service_name', 'hello', None, {})
     await hass.async_block_till_done()
 
     assert result == ['hello']

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -46,7 +46,7 @@ class TestRequirements:
         loader.set_component(
             self.hass, 'comp',
             MockModule('comp', requirements=['package==0.0.1']))
-        assert setup.setup_component(self.hass, 'comp')
+        assert setup.setup_component(self.hass, 'comp', {})
         assert 'comp' in self.hass.config.components
         assert mock_install.call_args == call(
             'package==0.0.1',
@@ -63,7 +63,7 @@ class TestRequirements:
         loader.set_component(
             self.hass, 'comp',
             MockModule('comp', requirements=['package==0.0.1']))
-        assert setup.setup_component(self.hass, 'comp')
+        assert setup.setup_component(self.hass, 'comp', {})
         assert 'comp' in self.hass.config.components
         assert mock_install.call_args == call(
             'package==0.0.1', target=self.hass.config.path('deps'),

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -317,7 +317,7 @@ class TestSetup:
 
     def test_component_not_found(self):
         """setup_component should not crash if component doesn't exist."""
-        assert setup.setup_component(self.hass, 'non_existing') is False
+        assert setup.setup_component(self.hass, 'non_existing', {}) is False
 
     def test_component_not_double_initialized(self):
         """Test we do not set up a component twice."""
@@ -327,12 +327,12 @@ class TestSetup:
             self.hass,
             MockModule('comp', setup=mock_setup))
 
-        assert setup.setup_component(self.hass, 'comp')
+        assert setup.setup_component(self.hass, 'comp', {})
         assert mock_setup.called
 
         mock_setup.reset_mock()
 
-        assert setup.setup_component(self.hass, 'comp')
+        assert setup.setup_component(self.hass, 'comp', {})
         assert not mock_setup.called
 
     @mock.patch('homeassistant.util.package.install_package',
@@ -344,7 +344,7 @@ class TestSetup:
             self.hass,
             MockModule('comp', requirements=['package==0.0.1']))
 
-        assert not setup.setup_component(self.hass, 'comp')
+        assert not setup.setup_component(self.hass, 'comp', {})
         assert 'comp' not in self.hass.config.components
 
     def test_component_not_setup_twice_if_loaded_during_other_setup(self):
@@ -362,11 +362,11 @@ class TestSetup:
 
         def setup_component():
             """Set up the component."""
-            setup.setup_component(self.hass, 'comp')
+            setup.setup_component(self.hass, 'comp', {})
 
         thread = threading.Thread(target=setup_component)
         thread.start()
-        setup.setup_component(self.hass, 'comp')
+        setup.setup_component(self.hass, 'comp', {})
 
         thread.join()
 
@@ -493,7 +493,7 @@ class TestSetup:
             self.hass,
             MockModule('disabled_component', setup=lambda hass, config: None))
 
-        assert not setup.setup_component(self.hass, 'disabled_component')
+        assert not setup.setup_component(self.hass, 'disabled_component', {})
         assert loader.get_component(self.hass, 'disabled_component') is None
         assert 'disabled_component' not in self.hass.config.components
 
@@ -502,7 +502,7 @@ class TestSetup:
             self.hass,
             MockModule('disabled_component', setup=lambda hass, config: False))
 
-        assert not setup.setup_component(self.hass, 'disabled_component')
+        assert not setup.setup_component(self.hass, 'disabled_component', {})
         assert loader.get_component(
             self.hass, 'disabled_component') is not None
         assert 'disabled_component' not in self.hass.config.components
@@ -512,7 +512,7 @@ class TestSetup:
             self.hass,
             MockModule('disabled_component', setup=lambda hass, config: True))
 
-        assert setup.setup_component(self.hass, 'disabled_component')
+        assert setup.setup_component(self.hass, 'disabled_component', {})
         assert loader.get_component(
             self.hass, 'disabled_component') is not None
         assert 'disabled_component' in self.hass.config.components
@@ -523,10 +523,10 @@ class TestSetup:
 
         def component1_setup(hass, config):
             """Set up mock component."""
-            discovery.discover(hass, 'test_component2',
-                               component='test_component2')
-            discovery.discover(hass, 'test_component3',
-                               component='test_component3')
+            discovery.discover(
+                hass, 'test_component2', {}, 'test_component2', {})
+            discovery.discover(
+                hass, 'test_component3', {}, 'test_component3', {})
             return True
 
         def component_track_setup(hass, config):


### PR DESCRIPTION
## Description:
- Discovery now requires hass_config to be passed in
- async_setup_component now requires config to be passed in
- Fixes the demo tests.
- Fixes an issue where loading the scene integration would result in the integration component being set up twice.
- Demo compnent will only load when explicitly mentioned in the config, won't set itself up as part of setting up a demo platform.
- Remove groups from demo
- Loading the demo integration will no longer interfere with other integrations that are being set up, as we no longer call `async_setup_component` during our own async_setup, but use platform discovery instead.

**Related issue (if applicable):** fixes #23003

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
