### PR TITLE
Automation component to not use platform logic

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -711,7 +711,6 @@ def async_process_component_config(
     This method must be run in the event loop.
     """
     component = get_component(hass, domain)
-
     if hasattr(component, 'CONFIG_SCHEMA'):
         try:
             config = component.CONFIG_SCHEMA(config)  # type: ignore

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -22,7 +22,8 @@ from homeassistant.const import (
     ENTITY_MATCH_ALL, CONF_ENTITY_NAMESPACE, __version__)
 from homeassistant.core import valid_entity_id, split_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper
+from homeassistant.helpers import (
+    template as template_helper, config_per_platform, extract_domain_configs)
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 
@@ -635,6 +636,20 @@ def deprecated(key: str,
         return has_at_most_one_key(key, replacement_key)(config)
 
     return validator
+
+
+def gather_domain_platforms(domain):
+    """Return a function that will organize a domain in a HA config."""
+    def gather_domain_validator(config):
+        """Gather domain validator."""
+        filter_keys = extract_domain_configs(config, domain)
+        result = {key: value for key, value in config.items()
+                  if key not in filter_keys}
+        result[domain] = [conf[1] for conf
+                          in config_per_platform(config, domain)]
+        return result
+
+    return gather_domain_validator
 
 
 # Validator helpers


### PR DESCRIPTION
## Description:
This is a WIP.

Migrate automation integration away from abusing the PLATFORM_SCHEMA, as it doesn't actually use platforms. This has a downside that I did not initially consider: for platforms, if a single platform is invalid, we still set up the component with the other platform logic present. To mimic this in the automation component, we have two choices:

1. Add the automation validation logic in `CONFIG_SCHEMA`. This means that `check_config` will pick it up and config validation will report the invalid config correctly. However, it means that no automations will load when a single automation contains invalid config.
2. Do the validation logic in `_async_process_config` (as is this PR). Downside is that `check_config` no longer works.

I think that we should consider adding a new type of schema, to indicate that an integration is platform like, but that we should not load platforms. But then, maybe we just end up at what we have now? 🤷‍♂️ 

**Related issue (if applicable):** fixes #23080

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
