### PR TITLE
Allow PLATFORM_SCHEMA_BASE modify platform name

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM_IMPERIAL, CONF_TEMPERATURE_UNIT, TEMP_CELSIUS,
     __version__, CONF_CUSTOMIZE, CONF_CUSTOMIZE_DOMAIN, CONF_CUSTOMIZE_GLOB,
     CONF_WHITELIST_EXTERNAL_DIRS, CONF_AUTH_PROVIDERS, CONF_AUTH_MFA_MODULES,
-    CONF_TYPE, CONF_ID)
+    CONF_TYPE, CONF_ID, CONF_PLATFORM)
 from homeassistant.core import callback, DOMAIN as CONF_CORE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import get_component, get_platform
@@ -736,6 +736,11 @@ def async_process_component_config(
                 async_log_exception(ex, domain, p_config, hass)
                 continue
 
+            # Allow PLATFORM_SCHEMA_BASE modify or inject platform name
+            # To avoid breaking change when we have to change platform name
+            # For example google/tts => google_translate/tts
+            p_name = p_validated.get(CONF_PLATFORM)
+
             # Not all platform components follow same pattern for platforms
             # So if p_name is None we are not going to validate platform
             # (the automation component is one of them)
@@ -753,7 +758,7 @@ def async_process_component_config(
                 # pylint: disable=no-member
                 try:
                     p_validated = platform.PLATFORM_SCHEMA(  # type: ignore
-                        p_config)
+                        p_validated)
                 except vol.Invalid as ex:
                     async_log_exception(ex, '{}.{}'.format(domain, p_name),
                                         p_config, hass)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 from homeassistant.util import location as location_util, dt as dt_util
 from homeassistant.util.yaml import SECRET_YAML
 from homeassistant.util.async_ import run_coroutine_threadsafe
-from homeassistant.helpers import config_validation as cv 
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.config.group import (
     CONFIG_PATH as GROUP_CONFIG_PATH)


### PR DESCRIPTION
## Description:
This is a change prepared for #23012. After this merged, we can move `google/tty.py` to `google_translate/tty.py` without breaking change. 

Changes
- Allow platform name read from the validated config by component level platform schema.
- Use validated config by component level platform schema as the input to execute platform level platform schema validation. (It actually revert an unintentional change made in #20743)
- Add bunch of tests

This PR need revise after #23082 merged.
 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
