### PR TITLE
Fix homekit_controller climate supported operation_list being blank

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -65,15 +65,15 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         else:
             valid_values = DEFAULT_VALID_MODES
             if 'minValue' in characteristic:
-                valid_values = filter(
-                    lambda val: val >= characteristic['minValue'],
-                    valid_values
-                )
+                valid_values = [
+                    val for val in valid_values
+                    if val >= characteristic['minValue']
+                ]
             if 'maxValue' in characteristic:
-                valid_values = filter(
-                    lambda val: val <= characteristic['maxValue'],
-                    valid_values
-                )
+                valid_values = [
+                    val for val in valid_values
+                    if val <= characteristic['maxValue']
+                ]
 
         self._valid_modes = [
             MODE_HOMEKIT_TO_HASS[mode] for mode in valid_values

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -58,10 +58,10 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         self._features |= SUPPORT_OPERATION_MODE
 
         if 'valid-values' in characteristic:
-            valid_values = filter(
-                lambda val: val in DEFAULT_VALID_MODES,
-                characteristic['valid-values']
-            )
+            valid_values = [
+                val for val in DEFAULT_VALID_MODES
+                if val in characteristic['valid-values']
+            ]
         else:
             valid_values = DEFAULT_VALID_MODES
             if 'minValue' in characteristic:

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -36,12 +36,12 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
 
     def __init__(self, *args):
         """Initialise the device."""
-        super().__init__(*args)
         self._state = None
         self._current_mode = None
         self._valid_modes = []
         self._current_temp = None
         self._target_temp = None
+        super().__init__(*args)
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
@@ -57,10 +57,26 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
     def _setup_heating_cooling_target(self, characteristic):
         self._features |= SUPPORT_OPERATION_MODE
 
-        valid_values = characteristic.get(
-            'valid-values', DEFAULT_VALID_MODES)
+        if 'valid-values' in characteristic:
+            valid_values = filter(
+                lambda val: val in DEFAULT_VALID_MODES,
+                characteristic['valid-values']
+            )
+        else:
+            valid_values = DEFAULT_VALID_MODES
+            if 'minValue' in characteristic:
+                valid_values = filter(
+                    lambda val: val >= characteristic['minValue'],
+                    valid_values
+                )
+            if 'maxValue' in characteristic:
+                valid_values = filter(
+                    lambda val: val <= characteristic['maxValue'],
+                    valid_values
+                )
+
         self._valid_modes = [
-            MODE_HOMEKIT_TO_HASS.get(mode) for mode in valid_values
+            MODE_HOMEKIT_TO_HASS[mode] for mode in valid_values
         ]
 
     def _setup_temperature_target(self, characteristic):


### PR DESCRIPTION
## Description:

This is a bugfix change that applies to all climate devices backed by homekit_controller.

As part of #16971 an adjacent issue was discovered. For one thing, `super().__init__()` is getting called in the wrong place and this is unsetting the list of valid operation modes. The PR fixes that.

For another, it turns own some HomeKit devices use the `validValues` characteristic to limit the list of valid operations. Others use `minValue` and `maxValue`. This PR makes sure both are handled.

It updates the tests accordingly.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.