### PR TITLE
Add more neurio energy sensors

### DIFF
--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -96,34 +96,35 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                                JSON_DATASET,
                                DAILY_TYPE,
                                update_dataset)]
-                )
+                 )
     # Active power sensor
     add_entities([NeurioEnergy(data,
                                ACTIVE_NAME,
                                ACTIVE_TYPE,
                                update_active)]
-                )
+                 )
     add_entities([NeurioEnergy(data,
                                GENERATION_NAME,
                                ACTIVE_TYPE,
                                update_generation)]
-                )
+                 )
     # Daily power sensor
     add_entities([NeurioEnergy(data,
                                DAILY_NAME,
                                DAILY_TYPE,
                                update_daily)]
-                )
+                 )
     add_entities([NeurioEnergy(data,
                                GENERATION_DAILY_NAME,
                                DAILY_TYPE,
                                update_generation_daily)]
-                )
+                 )
     add_entities([NeurioEnergy(data,
                                NET_CONSUMPTION,
                                DAILY_TYPE,
                                update_net_consumption)]
-                )
+                 )
+
 
 class NeurioData:
     """Stores data retrieved from Neurio sensor."""
@@ -187,8 +188,10 @@ class NeurioData:
         return self._net_consumption
 
     def get_dataset(self):
-        """Get the most recent data from the api once
-        so we don't hit the ratelimit each hour."""
+        """
+		Get the most recent data from the api once \
+        so we don't hit the ratelimit each hour.
+		"""
 
         start_time = dt_util.start_of_local_day() \
             .astimezone(dt_util.UTC).isoformat()

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -274,6 +274,7 @@ class NeurioEnergy(Entity):
     def update(self):
         """Get the latest data, update state."""
         self.update_sensor()
+        self._state = self._data.dataset
 
         if self._name == ACTIVE_NAME:
             self._state = self._data.active_power

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -188,10 +188,7 @@ class NeurioData:
         return self._net_consumption
 
     def get_dataset(self):
-        """Get the most recent data from the api once
-        so we don't hit the ratelimit each hour.
-
-        """
+        """Get the most recent data from the api once."""
         start_time = dt_util.start_of_local_day() \
             .astimezone(dt_util.UTC).isoformat()
         end_time = dt_util.utcnow().isoformat()
@@ -200,7 +197,8 @@ class NeurioData:
 
         try:
             self._dataset = self.neurio_client \
-                .get_samples_stats(self.sensor_id, start_time, 'days', end_time)
+                .get_samples_stats(
+                    self.sensor_id, start_time, 'days', end_time)
         except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update dataset")
             return None

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -92,21 +92,38 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     update_net_consumption()
 
     # Update Dataset
-    add_entities([NeurioEnergy(
-        data, JSON_DATASET, DAILY_TYPE, update_dataset)])
+    add_entities([NeurioEnergy(data,
+                               JSON_DATASET,
+                               DAILY_TYPE,
+                               update_dataset)]
+                )
     # Active power sensor
-    add_entities([NeurioEnergy(
-        data, ACTIVE_NAME, ACTIVE_TYPE, update_active)])
-    add_entities([NeurioEnergy(
-        data, GENERATION_NAME, ACTIVE_TYPE, update_generation)])
+    add_entities([NeurioEnergy(data,
+                               ACTIVE_NAME,
+                               ACTIVE_TYPE,
+                               update_active)]
+                )
+    add_entities([NeurioEnergy(data,
+                               GENERATION_NAME,
+                               ACTIVE_TYPE,
+                               update_generation)]
+                )
     # Daily power sensor
-    add_entities([NeurioEnergy(
-        data, DAILY_NAME, DAILY_TYPE, update_daily)])
-    add_entities([NeurioEnergy(
-        data, GENERATION_DAILY_NAME, DAILY_TYPE, update_generation_daily)])
-    add_entities([NeurioEnergy(
-        data, NET_CONSUMPTION, DAILY_TYPE, update_net_consumption)])
-
+    add_entities([NeurioEnergy(data,
+                               DAILY_NAME,
+                               DAILY_TYPE,
+                               update_daily)]
+                )
+    add_entities([NeurioEnergy(data,
+                               GENERATION_DAILY_NAME,
+                               DAILY_TYPE,
+                               update_generation_daily)]
+                )
+    add_entities([NeurioEnergy(data,
+                               NET_CONSUMPTION,
+                               DAILY_TYPE,
+                               update_net_consumption)]
+                )
 
 class NeurioData:
     """Stores data retrieved from Neurio sensor."""
@@ -170,10 +187,8 @@ class NeurioData:
         return self._net_consumption
 
     def get_dataset(self):
-        """
-        Get the most recent data from the api once
-        so we don't hit the ratelimit each hour.
-        """
+        """Get the most recent data from the api once
+        so we don't hit the ratelimit each hour."""
 
         start_time = dt_util.start_of_local_day() \
             .astimezone(dt_util.UTC).isoformat()
@@ -182,8 +197,8 @@ class NeurioData:
         _LOGGER.debug('Start: %s, End: %s', start_time, end_time)
 
         try:
-            self._dataset = self.neurio_client.get_samples_stats
-            (self.sensor_id, start_time, 'days', end_time)
+            self._dataset = self.neurio_client.get_samples_stats \
+                (self.sensor_id, start_time, 'days', end_time)
         except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update dataset")
             return None
@@ -191,10 +206,10 @@ class NeurioData:
     def get_active_power(self):
         """Return current power value."""
         header = {'Authorization': 'bearer <token>'}
-        resp = requests.get(
-        	'http://' + self.sensor_ip + '/current-sample',
-            headers=header,
-            verify=False)
+        resp = requests.get('http://'+self.sensor_ip+'/current-sample',
+                            headers=header,
+                            verify=False
+                           )
         try:
             sample = json.loads(resp.text)
             self._active_power = sample['channels'][4]['p_W']
@@ -205,10 +220,10 @@ class NeurioData:
     def get_active_generation(self):
         """Return current solar generation value."""
         header = {'Authorization': 'bearer <token>'}
-        resp = requests.get(
-            'http://' + self.sensor_ip + '/current-sample',
-            headers=header,
-            verify=False)
+        resp = requests.get('http://'+self.sensor_ip+'/current-sample',
+                            headers=header,
+                            verify=False
+                           )
         try:
             sample = json.loads(resp.text)
             self._active_generation = sample['channels'][3]['p_W']

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -1,4 +1,4 @@
-"""Neurio Custom"""
+"""Neurio Energy Sensor for Homeassisant."""
 import logging
 import json
 from datetime import timedelta
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SENSOR_ID): cv.string,
     vol.Optional(CONF_SENSOR_IP): cv.string,
 })
-
+ 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Neurio sensor."""
     api_key = config.get(CONF_API_KEY)
@@ -91,13 +91,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     update_net_consumption()
 
     #Update Dataset
-    add_entities([NeurioEnergy(data, JSON_DATASET, DAILY_TYPE, update_dataset)])
-    # Active power sensor
-    add_entities([NeurioEnergy(data, ACTIVE_NAME, ACTIVE_TYPE, update_active)])
-    add_entities([NeurioEnergy(data, GENERATION_NAME, ACTIVE_TYPE, update_generation)])
-    # Daily power sensor
-    add_entities([NeurioEnergy(data, DAILY_NAME, DAILY_TYPE, update_daily)])
-    add_entities([NeurioEnergy(data, GENERATION_DAILY_NAME, DAILY_TYPE, update_generation_daily)])
+    add_entities([NeurioEnergy(data, \
+        JSON_DATASET, DAILY_TYPE, update_dataset)])
+    #Active power sensor
+    add_entities([NeurioEnergy(data, \
+        ACTIVE_NAME, ACTIVE_TYPE, update_active)])
+    add_entities([NeurioEnergy(data, \
+        GENERATION_NAME, ACTIVE_TYPE, update_generation)])
+    #Daily power sensor
+    add_entities([NeurioEnergy(data, \
+        DAILY_NAME, DAILY_TYPE, update_daily)])
+    add_entities([NeurioEnergy(data, GENERATION_DAILY_NAME, \
+        DAILY_TYPE, update_generation_daily)])
     add_entities([NeurioEnergy(data, NET_CONSUMPTION, DAILY_TYPE, update_net_consumption)])
 
 
@@ -112,14 +117,14 @@ class NeurioData:
         self.api_secret = api_secret
         self.sensor_id = sensor_id
         self.sensor_ip = sensor_ip
-        
+
         self._dataset = None
         self._daily_usage = None
         self._active_power = None
         self._active_generation = None
         self._generation_daily = None
         self._net_consumption = None
-        
+
         self._state = None
 
         neurio_tp = neurio.TokenProvider(key=api_key, secret=api_secret)
@@ -140,17 +145,17 @@ class NeurioData:
     def daily_usage(self):
         """Return latest daily usage value."""
         return self._daily_usage
-    
+
     @property
     def active_power(self):
         """Return latest active power value."""
         return self._active_power
-    
+
     @property
     def active_generation(self):
         """Return latest active power value."""
         return self._active_generation
-    
+
     @property
     def daily_generation(self):
         """Return latest active power value."""
@@ -160,7 +165,7 @@ class NeurioData:
     def net_consumption(self):
         """Return latest active power value."""
         return self._net_consumption
-    
+
     def get_dataset(self):
         """
         Get the most recent data from the api once
@@ -173,7 +178,8 @@ class NeurioData:
         _LOGGER.debug('Start: %s, End: %s', start_time, end_time)
 
         try:
-            self._dataset = self.neurio_client.get_samples_stats(self.sensor_id, start_time, 'days', end_time)
+            self._dataset = self.neurio_client.get_samples_stats \
+                (self.sensor_id, start_time, 'days', end_time)
         except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update dataset")
             return None
@@ -181,7 +187,7 @@ class NeurioData:
     def get_active_power(self):
         """Return current power value."""
         header = {'Authorization': 'bearer <token>'}
-        resp = requests.get('http://'+self.sensor_ip+'/current-sample', 
+        resp = requests.get('http://'+self.sensor_ip+'/current-sample',
         headers = header, 
         verify=False)
         try:
@@ -194,11 +200,9 @@ class NeurioData:
     def get_active_generation(self):
         """Return current solar generation value."""
         header = {'Authorization': 'bearer <token>'}
-        resp = requests.get('http://'+self.sensor_ip+'/current-sample', 
+        resp = requests.get('http://'+self.sensor_ip+'/current-sample',
         headers = header, 
         verify=False)
-        #print(resp.status_code)
-        #print(resp.text)
         try:
             sample = json.loads(resp.text)
             self._active_generation = sample['channels'][3]['p_W']

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -92,20 +92,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     update_net_consumption()
 
     # Update Dataset
-    add_entities([NeurioEnergy(data, 
-        JSON_DATASET, DAILY_TYPE, update_dataset)])
+    add_entities([NeurioEnergy(
+        data, JSON_DATASET, DAILY_TYPE, update_dataset)])
     # Active power sensor
-    add_entities([NeurioEnergy(data, \
-        ACTIVE_NAME, ACTIVE_TYPE, update_active)])
-    add_entities([NeurioEnergy(data, 
-        GENERATION_NAME, ACTIVE_TYPE, update_generation)])
+    add_entities([NeurioEnergy(
+        data, ACTIVE_NAME, ACTIVE_TYPE, update_active)])
+    add_entities([NeurioEnergy(
+        data, GENERATION_NAME, ACTIVE_TYPE, update_generation)])
     # Daily power sensor
-    add_entities([NeurioEnergy(data, 
-        DAILY_NAME, DAILY_TYPE, update_daily)])
-    add_entities([NeurioEnergy(data, GENERATION_DAILY_NAME, 
-        DAILY_TYPE, update_generation_daily)])
-    add_entities([NeurioEnergy(data, 
-	    NET_CONSUMPTION, DAILY_TYPE, update_net_consumption)])
+    add_entities([NeurioEnergy(
+        data, DAILY_NAME, DAILY_TYPE, update_daily)])
+    add_entities([NeurioEnergy(
+        data, GENERATION_DAILY_NAME, DAILY_TYPE, update_generation_daily)])
+    add_entities([NeurioEnergy(
+        data, NET_CONSUMPTION, DAILY_TYPE, update_net_consumption)])
 
 
 class NeurioData:
@@ -182,8 +182,8 @@ class NeurioData:
         _LOGGER.debug('Start: %s, End: %s', start_time, end_time)
 
         try:
-            self._dataset = self.neurio_client.get_samples_stats \
-                (self.sensor_id, start_time, 'days', end_time)
+            self._dataset = self.neurio_client.get_samples_stats
+            (self.sensor_id, start_time, 'days', end_time)
         except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update dataset")
             return None
@@ -191,9 +191,10 @@ class NeurioData:
     def get_active_power(self):
         """Return current power value."""
         header = {'Authorization': 'bearer <token>'}
-        resp=requests.get('http://'+self.sensor_ip+'/current-sample',
-        headers=header,
-        verify=False)
+        resp = requests.get(
+        	'http://' + self.sensor_ip + '/current-sample',
+            headers=header,
+            verify=False)
         try:
             sample = json.loads(resp.text)
             self._active_power = sample['channels'][4]['p_W']
@@ -204,9 +205,10 @@ class NeurioData:
     def get_active_generation(self):
         """Return current solar generation value."""
         header = {'Authorization': 'bearer <token>'}
-        resp=requests.get('http://'+self.sensor_ip+'/current-sample',
-        headers=header,
-        verify=False)
+        resp = requests.get(
+            'http://' + self.sensor_ip + '/current-sample',
+            headers=header,
+            verify=False)
         try:
             sample = json.loads(resp.text)
             self._active_generation = sample['channels'][3]['p_W']

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -188,10 +188,9 @@ class NeurioData:
         return self._net_consumption
 
     def get_dataset(self):
-        """
-		Get the most recent data from the api once \
+        """Get the most recent data from the api once
         so we don't hit the ratelimit each hour.
-		"""
+        """
 
         start_time = dt_util.start_of_local_day() \
             .astimezone(dt_util.UTC).isoformat()
@@ -201,7 +200,7 @@ class NeurioData:
 
         try:
             self._dataset = self.neurio_client.get_samples_stats \
-                (self.sensor_id, start_time, 'days', end_time)
+               (self.sensor_id, start_time, 'days', end_time)
         except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update dataset")
             return None
@@ -212,7 +211,7 @@ class NeurioData:
         resp = requests.get('http://'+self.sensor_ip+'/current-sample',
                             headers=header,
                             verify=False
-                           )
+                            )
         try:
             sample = json.loads(resp.text)
             self._active_power = sample['channels'][4]['p_W']
@@ -226,7 +225,7 @@ class NeurioData:
         resp = requests.get('http://'+self.sensor_ip+'/current-sample',
                             headers=header,
                             verify=False
-                           )
+                            )
         try:
             sample = json.loads(resp.text)
             self._active_generation = sample['channels'][3]['p_W']

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -188,8 +188,10 @@ class NeurioData:
         return self._net_consumption
 
     def get_dataset(self):
-        """Get the most recent data from the api once so we don't hit the ratelimit each hour."""
+        """Get the most recent data from the api once
+        so we don't hit the ratelimit each hour.
 
+        """
         start_time = dt_util.start_of_local_day() \
             .astimezone(dt_util.UTC).isoformat()
         end_time = dt_util.utcnow().isoformat()

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -43,7 +43,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SENSOR_ID): cv.string,
     vol.Optional(CONF_SENSOR_IP): cv.string,
 })
- 
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Neurio sensor."""
     api_key = config.get(CONF_API_KEY)
@@ -90,20 +91,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     update_generation_daily()
     update_net_consumption()
 
-    #Update Dataset
-    add_entities([NeurioEnergy(data, \
+    # Update Dataset
+    add_entities([NeurioEnergy(data, 
         JSON_DATASET, DAILY_TYPE, update_dataset)])
-    #Active power sensor
+    # Active power sensor
     add_entities([NeurioEnergy(data, \
         ACTIVE_NAME, ACTIVE_TYPE, update_active)])
-    add_entities([NeurioEnergy(data, \
+    add_entities([NeurioEnergy(data, 
         GENERATION_NAME, ACTIVE_TYPE, update_generation)])
-    #Daily power sensor
-    add_entities([NeurioEnergy(data, \
+    # Daily power sensor
+    add_entities([NeurioEnergy(data, 
         DAILY_NAME, DAILY_TYPE, update_daily)])
-    add_entities([NeurioEnergy(data, GENERATION_DAILY_NAME, \
+    add_entities([NeurioEnergy(data, GENERATION_DAILY_NAME, 
         DAILY_TYPE, update_generation_daily)])
-    add_entities([NeurioEnergy(data, NET_CONSUMPTION, DAILY_TYPE, update_net_consumption)])
+    add_entities([NeurioEnergy(data, 
+	    NET_CONSUMPTION, DAILY_TYPE, update_net_consumption)])
 
 
 class NeurioData:
@@ -141,6 +143,7 @@ class NeurioData:
     def dataset(self):
         """Return latest data."""
         return self._dataset
+
     @property
     def daily_usage(self):
         """Return latest daily usage value."""
@@ -171,6 +174,7 @@ class NeurioData:
         Get the most recent data from the api once
         so we don't hit the ratelimit each hour.
         """
+
         start_time = dt_util.start_of_local_day() \
             .astimezone(dt_util.UTC).isoformat()
         end_time = dt_util.utcnow().isoformat()
@@ -187,8 +191,8 @@ class NeurioData:
     def get_active_power(self):
         """Return current power value."""
         header = {'Authorization': 'bearer <token>'}
-        resp = requests.get('http://'+self.sensor_ip+'/current-sample',
-        headers = header, 
+        resp=requests.get('http://'+self.sensor_ip+'/current-sample',
+        headers=header,
         verify=False)
         try:
             sample = json.loads(resp.text)
@@ -200,8 +204,8 @@ class NeurioData:
     def get_active_generation(self):
         """Return current solar generation value."""
         header = {'Authorization': 'bearer <token>'}
-        resp = requests.get('http://'+self.sensor_ip+'/current-sample',
-        headers = header, 
+        resp=requests.get('http://'+self.sensor_ip+'/current-sample',
+        headers=header,
         verify=False)
         try:
             sample = json.loads(resp.text)

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -259,7 +259,7 @@ class NeurioData:
             kwh_in += result['importedEnergy'] / 3600000
         for result in history:
             kwh_out += result['exportedEnergy'] / 3600000
-        self._net_consumption = round(kwhIn-kwhOut, 2)
+        self._net_consumption = round(kwh_in-kwh_out, 2)
 
 
 class NeurioEnergy(Entity):

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -142,7 +142,7 @@ class NeurioData:
         self._daily_usage = None
         self._active_power = None
         self._active_generation = None
-        self._generation_daily = None
+        self._daily_generation = None
         self._net_consumption = None
 
         self._state = None
@@ -251,14 +251,14 @@ class NeurioData:
 
     def get_net_consumption(self):
         """Return current daily power usage."""
-        kwhIn = 0
-        kwhOut = 0
+        kwh_in = 0
+        kwh_out = 0
 
         history = self._dataset
         for result in history:
-            kwhIn += result['importedEnergy'] / 3600000
+            kwh_in += result['importedEnergy'] / 3600000
         for result in history:
-            kwhOut += result['exportedEnergy'] / 3600000
+            kwh_out += result['exportedEnergy'] / 3600000
         self._net_consumption = round(kwhIn-kwhOut, 2)
 
 

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -188,9 +188,7 @@ class NeurioData:
         return self._net_consumption
 
     def get_dataset(self):
-        """Get the most recent data from the api once
-        so we don't hit the ratelimit each hour.
-        """
+        """Get the most recent data from the api once so we don't hit the ratelimit each hour."""
 
         start_time = dt_util.start_of_local_day() \
             .astimezone(dt_util.UTC).isoformat()
@@ -199,8 +197,8 @@ class NeurioData:
         _LOGGER.debug('Start: %s, End: %s', start_time, end_time)
 
         try:
-            self._dataset = self.neurio_client.get_samples_stats \
-               (self.sensor_id, start_time, 'days', end_time)
+            self._dataset = self.neurio_client \
+                .get_samples_stats(self.sensor_id, start_time, 'days', end_time)
         except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update dataset")
             return None

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -170,16 +170,13 @@ class NeurioData:
         _LOGGER.debug('Start: %s, End: %s', start_time, end_time)
 
         try:
-            history = self.neurio_client.get_samples_stats(
-                self.sensor_id, start_time, 'days', end_time)
+            history = self.neurio_client.get_samples_stats(self.sensor_id, start_time, 'days', end_time)
+            for result in history:
+                kwh += result['consumptionEnergy'] / 3600000
+            self._daily_usage = round(kwh, 2)
         except (requests.exceptions.RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update daily power usage")
             return None
-
-        for result in history:
-            kwh += result['consumptionEnergy'] / 3600000
-
-        self._daily_usage = round(kwh, 2)
 		
     def get_daily_generation(self):
         """Return current daily power usage."""
@@ -191,16 +188,15 @@ class NeurioData:
         _LOGGER.debug('Start: %s, End: %s', start_time, end_time)
 
         try:
-            history = self.neurio_client.get_samples_stats(
-                self.sensor_id, start_time, 'days', end_time)
+            history = self.neurio_client.get_samples_stats(self.sensor_id, start_time, 'days', end_time)
+            for result in history:
+                kwh += result['generationEnergy'] / 3600000
+            self._daily_generation = round(kwh, 2)
         except (requests.exceptions.RequestException, ValueError, KeyError):
-            _LOGGER.warning("Could not update daily power usage")
+            _LOGGER.warning("Could not update daily generation")
             return None
 
-        for result in history:
-            kwh += result['generationEnergy'] / 3600000
-
-        self._daily_generation = round(kwh, 2)
+        
 		
     def get_net_consumption(self):
         """Return current daily power usage."""
@@ -213,25 +209,17 @@ class NeurioData:
         _LOGGER.debug('Start: %s, End: %s', start_time, end_time)
 
         try:
-            historyImported = self.neurio_client.get_samples_stats(
-                self.sensor_id, start_time, 'days', end_time)
+            history = self.neurio_client.get_samples_stats(self.sensor_id, start_time, 'days', end_time)
+            for result in history:
+                kwhIn += result['importedEnergy'] / 3600000
+            for result in history:
+                kwhOut += result['exportedEnergy'] / 3600000
+            self._net_consumption = round(kwhIn-kwhOut, 2)
         except (requests.exceptions.RequestException, ValueError, KeyError):
-            _LOGGER.warning("Could not update daily power usage")
+            _LOGGER.warning("Could not update net consumption")
             return None
 
-        try:
-            historyExported = self.neurio_client.get_samples_stats(
-                self.sensor_id, start_time, 'days', end_time)
-        except (requests.exceptions.RequestException, ValueError, KeyError):
-            _LOGGER.warning("Could not update daily power usage")
-            return None
 
-        for result in historyImported:
-            kwhIn += result['importedEnergy'] / 3600000
-        for result in historyExported:
-            kwhOut += result['exportedEnergy'] / 3600000
-
-        self._net_consumption = round(kwhIn-kwhOut, 2)
 
 
 class NeurioEnergy(Entity):


### PR DESCRIPTION


## Breaking Change:

None known

## Description:

Adds in Solar Gen (active), Solar Gen (total) and Net consumption (used-generated).

## Example entry for `configuration.yaml` (if applicable):
```yaml
Adds sensors:
    - sensor.solar_generation
    - sensor.generation_total
    - sensor.net_consumption
```
