### PR TITLE
Added message to data_template at notify REST

### DIFF
--- a/homeassistant/components/rest/notify.py
+++ b/homeassistant/components/rest/notify.py
@@ -111,6 +111,7 @@ class RestNotificationService(BaseNotificationService):
             data.update(self._data)
         elif self._data_template:
             kwargs[ATTR_MESSAGE] = message
+
             def _data_template_creator(value):
                 """Recursive template creator helper function."""
                 if isinstance(value, list):
@@ -120,6 +121,7 @@ class RestNotificationService(BaseNotificationService):
                             for key, item in value.items()}
                 value.hass = self._hass
                 return value.async_render(kwargs)
+
             data.update(_data_template_creator(self._data_template))
 
         if self._method == 'POST':

--- a/homeassistant/components/rest/notify.py
+++ b/homeassistant/components/rest/notify.py
@@ -11,8 +11,8 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.notify import (
-    ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT, PLATFORM_SCHEMA,
-    BaseNotificationService)
+    ATTR_TARGET, ATTR_TITLE, ATTR_TITLE_DEFAULT, ATTR_MESSAGE,
+    PLATFORM_SCHEMA, BaseNotificationService)
 
 CONF_DATA = 'data'
 CONF_DATA_TEMPLATE = 'data_template'
@@ -110,6 +110,7 @@ class RestNotificationService(BaseNotificationService):
         if self._data:
             data.update(self._data)
         elif self._data_template:
+            kwargs[ATTR_MESSAGE] = message
             def _data_template_creator(value):
                 """Recursive template creator helper function."""
                 if isinstance(value, list):


### PR DESCRIPTION
## Description:
This PR adds the possibility to use the message of a notification in the data_template at the notify REST component. This can be useful for when the notification service expects the message to be on a specific place in the request.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.