### PR TITLE
Await merge_packages_config().

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -121,7 +121,7 @@ async def async_from_config_dict(config: Dict[str, Any],
     config = OrderedDict(config)
 
     # Merge packages
-    conf_util.merge_packages_config(
+    await conf_util.merge_packages_config(
         hass, config, core_config.get(conf_util.CONF_PACKAGES, {}))
 
     hass.config_entries = config_entries.ConfigEntries(hass, config)


### PR DESCRIPTION
## Description:
await merge_packages_config() since https://github.com/home-assistant/home-assistant/pull/23082 made it an async function.

```
/home/ha/src/ac-hass/homeassistant/bootstrap.py:125: RuntimeWarning: coroutine 'merge_packages_config' was never awaited
  hass, config, core_config.get(conf_util.CONF_PACKAGES, {}))
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
