### PR TITLE
Remove loader.get_component

### DIFF
--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -5,7 +5,6 @@ from asynctest import patch
 import pytest
 
 from homeassistant.setup import async_setup_component
-import homeassistant.loader as loader
 from homeassistant.const import CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME
 from homeassistant.components import (
     device_tracker, light, device_sun_light_trigger)
@@ -18,13 +17,13 @@ from tests.components.light import common as common_light
 @pytest.fixture
 def scanner(hass):
     """Initialize components."""
-    scanner = loader.get_component(
-        hass, 'test.device_tracker').get_scanner(None, None)
+    scanner = getattr(
+        hass.components, 'test.device_tracker').get_scanner(None, None)
 
     scanner.reset()
     scanner.come_home('DEV1')
 
-    loader.get_component(hass, 'test.light').init()
+    getattr(hass.components, 'test.light').init()
 
     with patch(
         'homeassistant.components.device_tracker.load_yaml_config_file',

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -13,7 +13,6 @@ from homeassistant.components import zone
 from homeassistant.core import callback, State
 from homeassistant.setup import async_setup_component
 from homeassistant.helpers import discovery
-from homeassistant.loader import get_component
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN,
@@ -191,7 +190,7 @@ async def test_discover_platform(mock_demo_setup_scanner, mock_see, hass):
 
 async def test_update_stale(hass):
     """Test stalled update."""
-    scanner = get_component(hass, 'test.device_tracker').SCANNER
+    scanner = getattr(hass.components, 'test.device_tracker').SCANNER
     scanner.reset()
     scanner.come_home('DEV1')
 
@@ -255,7 +254,7 @@ async def test_device_hidden(hass, yaml_devices):
         hide_if_away=True)
     device_tracker.update_config(yaml_devices, dev_id, device)
 
-    scanner = get_component(hass, 'test.device_tracker').SCANNER
+    scanner = getattr(hass.components, 'test.device_tracker').SCANNER
     scanner.reset()
 
     with assert_setup_component(1, device_tracker.DOMAIN):
@@ -274,7 +273,7 @@ async def test_group_all_devices(hass, yaml_devices):
         hide_if_away=True)
     device_tracker.update_config(yaml_devices, dev_id, device)
 
-    scanner = get_component(hass, 'test.device_tracker').SCANNER
+    scanner = getattr(hass.components, 'test.device_tracker').SCANNER
     scanner.reset()
 
     with assert_setup_component(1, device_tracker.DOMAIN):
@@ -440,7 +439,7 @@ async def test_see_passive_zone_state(hass):
             'zone': zone_info
         })
 
-    scanner = get_component(hass, 'test.device_tracker').SCANNER
+    scanner = getattr(hass.components, 'test.device_tracker').SCANNER
     scanner.reset()
     scanner.come_home('dev1')
 
@@ -556,7 +555,7 @@ def test_bad_platform(hass):
 
 async def test_adding_unknown_device_to_config(mock_device_tracker_conf, hass):
     """Test the adding of unknown devices to configuration file."""
-    scanner = get_component(hass, 'test.device_tracker').SCANNER
+    scanner = getattr(hass.components, 'test.device_tracker').SCANNER
     scanner.reset()
     scanner.come_home('DEV1')
 

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -6,7 +6,6 @@ from homeassistant.setup import setup_component
 from homeassistant.components import switch, light
 from homeassistant.const import (
     CONF_PLATFORM, STATE_ON, SERVICE_TURN_ON, SUN_EVENT_SUNRISE)
-import homeassistant.loader as loader
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
@@ -74,7 +73,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_flux_when_switch_is_off(self):
         """Test the flux switch when it is off."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -114,7 +113,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_flux_before_sunrise(self):
         """Test the flux switch before sunrise."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -159,7 +158,7 @@ class TestSwitchFlux(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_flux_after_sunrise_before_sunset(self):
         """Test the flux switch after sunrise and before sunset."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -205,7 +204,7 @@ class TestSwitchFlux(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_flux_after_sunset_before_stop(self):
         """Test the flux switch after sunset and before stop."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -252,7 +251,7 @@ class TestSwitchFlux(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_flux_after_stop_before_sunrise(self):
         """Test the flux switch after stop and before sunrise."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -297,7 +296,7 @@ class TestSwitchFlux(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_flux_with_custom_start_stop_times(self):
         """Test the flux with custom start and stop times."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -347,7 +346,7 @@ class TestSwitchFlux(unittest.TestCase):
 
         This test has the stop_time on the next day (after midnight).
         """
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -398,7 +397,7 @@ class TestSwitchFlux(unittest.TestCase):
 
         This test has the stop_time on the next day (after midnight).
         """
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -448,7 +447,7 @@ class TestSwitchFlux(unittest.TestCase):
 
         This test has the stop_time on the next day (after midnight).
         """
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -497,7 +496,7 @@ class TestSwitchFlux(unittest.TestCase):
 
         This test has the stop_time on the next day (after midnight).
         """
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -547,7 +546,7 @@ class TestSwitchFlux(unittest.TestCase):
 
         This test has the stop_time on the next day (after midnight).
         """
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -594,7 +593,7 @@ class TestSwitchFlux(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_flux_with_custom_colortemps(self):
         """Test the flux with custom start and stop colortemps."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -643,7 +642,7 @@ class TestSwitchFlux(unittest.TestCase):
     # pylint: disable=invalid-name
     def test_flux_with_custom_brightness(self):
         """Test the flux with custom start and stop colortemps."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -690,7 +689,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_flux_with_multiple_lights(self):
         """Test the flux switch with multiple light entities."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -758,7 +757,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_flux_with_mired(self):
         """Test the flux switch´s mode mired."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})
@@ -802,7 +801,7 @@ class TestSwitchFlux(unittest.TestCase):
 
     def test_flux_with_rgb(self):
         """Test the flux switch´s mode rgb."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
                                {light.DOMAIN: {CONF_PLATFORM: 'test'}})

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
     ATTR_TEMPERATURE
 )
-from homeassistant import loader
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.components import input_boolean, switch
 from homeassistant.components.climate.const import (
@@ -98,7 +97,7 @@ async def test_heater_input_boolean(hass, setup_comp_1):
 
 async def test_heater_switch(hass, setup_comp_1):
     """Test heater switching test switch."""
-    platform = loader.get_component(hass, 'test.switch')
+    platform = getattr(hass.components, 'test.switch')
     platform.init()
     switch_1 = platform.DEVICES[1]
     assert await async_setup_component(hass, switch.DOMAIN, {'switch': {

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -7,7 +7,7 @@ from io import StringIO
 
 import pytest
 
-from homeassistant import core, loader
+from homeassistant import core
 from homeassistant.exceptions import Unauthorized
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.const import (
@@ -121,7 +121,7 @@ class TestLight(unittest.TestCase):
 
     def test_services(self):
         """Test the provided services."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
 
         platform.init()
         assert setup_component(self.hass, light.DOMAIN,
@@ -308,7 +308,7 @@ class TestLight(unittest.TestCase):
 
     def test_broken_light_profiles(self):
         """Test light profiles."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
 
         user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)
@@ -323,7 +323,7 @@ class TestLight(unittest.TestCase):
 
     def test_light_profiles(self):
         """Test light profiles."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
 
         user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)
@@ -362,7 +362,7 @@ class TestLight(unittest.TestCase):
 
     def test_default_profiles_group(self):
         """Test default turn-on light profile for all lights."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
 
         user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)
@@ -400,7 +400,7 @@ class TestLight(unittest.TestCase):
 
     def test_default_profiles_light(self):
         """Test default turn-on light profile for a specific light."""
-        platform = loader.get_component(self.hass, 'test.light')
+        platform = getattr(self.hass.components, 'test.light')
         platform.init()
 
         user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -3,7 +3,6 @@ import io
 import unittest
 
 from homeassistant.setup import setup_component
-from homeassistant import loader
 from homeassistant.components import light, scene
 from homeassistant.util import yaml
 

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -18,7 +18,7 @@ class TestScene(unittest.TestCase):
     def setUp(self):  # pylint: disable=invalid-name
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        test_light = loader.get_component(self.hass, 'test.light')
+        test_light = getattr(self.hass.components, 'test.light')
         test_light.init()
 
         assert setup_component(self.hass, light.DOMAIN, {

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -3,7 +3,7 @@
 import unittest
 
 from homeassistant.setup import setup_component, async_setup_component
-from homeassistant import core, loader
+from homeassistant import core
 from homeassistant.components import switch
 from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
 
@@ -18,7 +18,7 @@ class TestSwitch(unittest.TestCase):
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        platform = loader.get_component(self.hass, 'test.switch')
+        platform = getattr(self.hass.components, 'test.switch')
         platform.init()
         # Switch 1 is ON, switch 2 is OFF
         self.switch_1, self.switch_2, self.switch_3 = \
@@ -77,7 +77,7 @@ class TestSwitch(unittest.TestCase):
     def test_setup_two_platforms(self):
         """Test with bad configuration."""
         # Test if switch component returns 0 switches
-        test_platform = loader.get_component(self.hass, 'test.switch')
+        test_platform = getattr(self.hass.components, 'test.switch')
         test_platform.init(True)
 
         mock_entity_platform(self.hass, 'switch.test2', test_platform)

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -10,7 +10,7 @@ import pytest
 
 # To prevent circular import when running just this file
 import homeassistant.components  # noqa
-from homeassistant import core as ha, loader, exceptions
+from homeassistant import core as ha, exceptions
 from homeassistant.const import STATE_ON, STATE_OFF, ATTR_ENTITY_ID
 from homeassistant.setup import async_setup_component
 import homeassistant.helpers.config_validation as cv

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -177,7 +177,7 @@ async def test_extract_entity_ids(hass):
     hass.states.async_set('light.Ceiling', STATE_OFF)
     hass.states.async_set('light.Kitchen', STATE_OFF)
 
-    await loader.get_component(hass, 'group').Group.async_create_group(
+    await hass.components.group.Group.async_create_group(
         hass, 'test', ['light.Ceiling', 'light.Kitchen'])
 
     call = ha.ServiceCall('light', 'turn_on',
@@ -252,7 +252,7 @@ async def test_extract_entity_ids_from_area(hass):
 @asyncio.coroutine
 def test_async_get_all_descriptions(hass):
     """Test async_get_all_descriptions."""
-    group = loader.get_component(hass, 'group')
+    group = hass.components.group
     group_config = {group.DOMAIN: {}}
     yield from async_setup_component(hass, group.DOMAIN, group_config)
     descriptions = yield from service.async_get_all_descriptions(hass)
@@ -262,7 +262,7 @@ def test_async_get_all_descriptions(hass):
     assert 'description' in descriptions['group']['reload']
     assert 'fields' in descriptions['group']['reload']
 
-    logger = loader.get_component(hass, 'logger')
+    logger = hass.components.logger
     logger_config = {logger.DOMAIN: {}}
     yield from async_setup_component(hass, logger.DOMAIN, logger_config)
     descriptions = yield from service.async_get_all_descriptions(hass)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -113,7 +113,7 @@ async def test_log_warning_custom_component(hass, caplog):
     assert 'You are using a custom integration for test_standalone' \
         in caplog.text
 
-    integration = await loader.async_get_integration(hass, 'test')
+    await loader.async_get_integration(hass, 'test')
     assert 'You are using a custom integration for test ' in caplog.text
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -8,11 +8,6 @@ from homeassistant.components.hue import light as hue_light
 from tests.common import MockModule, async_mock_service, mock_integration
 
 
-def test_get_component(hass):
-    """Test if get_component works."""
-    assert http == loader.get_component(hass, 'http')
-
-
 async def test_component_dependencies(hass):
     """Test if we can get the proper load order of components."""
     mock_integration(hass, MockModule('mod1'))
@@ -84,17 +79,28 @@ async def test_helpers_wrapper(hass):
 
 async def test_custom_component_name(hass):
     """Test the name attribte of custom components."""
-    comp = loader.get_component(hass, 'test_standalone')
+    integration = await loader.async_get_integration(hass, 'test_standalone')
+    int_comp = integration.get_component()
+    assert int_comp.__name__ == 'custom_components.test_standalone'
+    assert int_comp.__package__ == 'custom_components'
+
+    comp = hass.components.test_standalone
     assert comp.__name__ == 'custom_components.test_standalone'
     assert comp.__package__ == 'custom_components'
 
-    comp = loader.get_component(hass, 'test_package')
+    integration = await loader.async_get_integration(hass, 'test_package')
+    int_comp = integration.get_component()
+    assert int_comp.__name__ == 'custom_components.test_package'
+    assert int_comp.__package__ == 'custom_components.test_package'
+
+    comp = hass.components.test_package
     assert comp.__name__ == 'custom_components.test_package'
     assert comp.__package__ == 'custom_components.test_package'
 
-    comp = loader.get_component(hass, 'test.light')
-    assert comp.__name__ == 'custom_components.test.light'
-    assert comp.__package__ == 'custom_components.test'
+    integration = await loader.async_get_integration(hass, 'test')
+    platform = integration.get_platform('light')
+    assert platform.__name__ == 'custom_components.test.light'
+    assert platform.__package__ == 'custom_components.test'
 
     # Test custom components is mounted
     from custom_components.test_package import TEST
@@ -103,12 +109,12 @@ async def test_custom_component_name(hass):
 
 async def test_log_warning_custom_component(hass, caplog):
     """Test that we log a warning when loading a custom component."""
-    loader.get_component(hass, 'test_standalone')
-    assert \
-        'You are using a custom component for test_standalone' in caplog.text
+    hass.components.test_standalone
+    assert 'You are using a custom integration for test_standalone' \
+        in caplog.text
 
-    loader.get_component(hass, 'test.light')
-    assert 'You are using a custom component for test.light' in caplog.text
+    integration = await loader.async_get_integration(hass, 'test')
+    assert 'You are using a custom integration for test ' in caplog.text
 
 
 async def test_get_integration(hass):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -502,8 +502,6 @@ class TestSetup:
             MockModule('disabled_component', setup=lambda hass, config: False))
 
         assert not setup.setup_component(self.hass, 'disabled_component', {})
-        assert loader.get_component(
-            self.hass, 'disabled_component') is not None
         assert 'disabled_component' not in self.hass.config.components
 
         self.hass.data.pop(setup.DATA_SETUP)
@@ -512,8 +510,6 @@ class TestSetup:
             MockModule('disabled_component', setup=lambda hass, config: True))
 
         assert setup.setup_component(self.hass, 'disabled_component', {})
-        assert loader.get_component(
-            self.hass, 'disabled_component') is not None
         assert 'disabled_component' in self.hass.config.components
 
     def test_all_work_done_before_start(self):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -12,7 +12,7 @@ from homeassistant.core import callback
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_COMPONENT_LOADED)
 import homeassistant.config as config_util
-from homeassistant import setup, loader
+from homeassistant import setup
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.config_validation import (
     PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)


### PR DESCRIPTION
## Description:
This removes the internal method `loader.get_component`. Instead, use `hass.components.X` or `loader.async_get_integration` (preferred).

Fixes #23111

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
