### PR TITLE
load cleanups

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -36,38 +36,6 @@ STAGE_1_INTEGRATIONS = {
 }
 
 
-def from_config_dict(config: Dict[str, Any],
-                     hass: Optional[core.HomeAssistant] = None,
-                     config_dir: Optional[str] = None,
-                     enable_log: bool = True,
-                     verbose: bool = False,
-                     skip_pip: bool = False,
-                     log_rotate_days: Any = None,
-                     log_file: Any = None,
-                     log_no_color: bool = False) \
-                     -> Optional[core.HomeAssistant]:
-    """Try to configure Home Assistant from a configuration dictionary.
-
-    Dynamically loads required components and its dependencies.
-    """
-    if hass is None:
-        hass = core.HomeAssistant()
-        if config_dir is not None:
-            config_dir = os.path.abspath(config_dir)
-            hass.config.config_dir = config_dir
-            if not is_virtual_env():
-                hass.loop.run_until_complete(
-                    async_mount_local_lib_path(config_dir))
-
-    # run task
-    hass = hass.loop.run_until_complete(
-        async_from_config_dict(
-            config, hass, config_dir, enable_log, verbose, skip_pip,
-            log_rotate_days, log_file, log_no_color)
-    )
-    return hass
-
-
 async def async_from_config_dict(config: Dict[str, Any],
                                  hass: core.HomeAssistant,
                                  config_dir: Optional[str] = None,
@@ -225,32 +193,6 @@ async def async_from_config_dict(config: Dict[str, Any],
         hass.components.persistent_notification.async_create(
             '\n\n'.join(msg), "Config Warning", "config_warning"
         )
-
-    return hass
-
-
-def from_config_file(config_path: str,
-                     hass: Optional[core.HomeAssistant] = None,
-                     verbose: bool = False,
-                     skip_pip: bool = True,
-                     log_rotate_days: Any = None,
-                     log_file: Any = None,
-                     log_no_color: bool = False)\
-        -> Optional[core.HomeAssistant]:
-    """Read the configuration file and try to start all the functionality.
-
-    Will add functionality to 'hass' parameter if given,
-    instantiates a new Home Assistant object if 'hass' is not given.
-    """
-    if hass is None:
-        hass = core.HomeAssistant()
-
-    # run task
-    hass = hass.loop.run_until_complete(
-        async_from_config_file(
-            config_path, hass, verbose, skip_pip,
-            log_rotate_days, log_file, log_no_color)
-    )
 
     return hass
 

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -1,6 +1,7 @@
 """Code to handle a Hue bridge."""
 import asyncio
 
+import aiohue
 import async_timeout
 import voluptuous as vol
 
@@ -133,8 +134,6 @@ class HueBridge:
 
 async def get_bridge(hass, host, username=None):
     """Create a bridge object and verify authentication."""
-    import aiohue
-
     bridge = aiohue.Bridge(
         host, username=username,
         websession=aiohttp_client.async_get_clientsession(hass)

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import os
 
+from aiohue.discovery import discover_nupnp
 import async_timeout
 import voluptuous as vol
 
@@ -57,8 +58,6 @@ class HueFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_init(self, user_input=None):
         """Handle a flow start."""
-        from aiohue.discovery import discover_nupnp
-
         if user_input is not None:
             self.host = user_input['host']
             return await self.async_step_link()

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -5,6 +5,7 @@ import logging
 from time import monotonic
 import random
 
+import aiohue
 import async_timeout
 
 from homeassistant.components import hue
@@ -152,8 +153,6 @@ async def async_update_items(hass, bridge, async_add_entities,
                              request_bridge_update, is_group, current,
                              progress_waiting):
     """Update either groups or lights from the bridge."""
-    import aiohue
-
     if is_group:
         api_type = 'group'
         api = bridge.api.groups

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -29,8 +29,6 @@ if TYPE_CHECKING:
 
 CALLABLE_T = TypeVar('CALLABLE_T', bound=Callable)  # noqa pylint: disable=invalid-name
 
-PREPARED = False
-
 DEPENDENCY_BLACKLIST = {'config'}
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -163,6 +163,7 @@ async def async_get_integration(hass: 'HomeAssistant', domain: str)\
             return integration
 
     except ImportError:
+        # Import error if "custom_components" doesn't exist
         pass
 
     from homeassistant import components
@@ -387,9 +388,6 @@ async def _async_component_dependencies(hass,  # type: HomeAssistant
     Async friendly.
     """
     integration = await async_get_integration(hass, domain)
-
-    if integration is None:
-        raise IntegrationNotFound(domain)
 
     loading.add(domain)
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -114,17 +114,19 @@ async def _async_setup_component(hass: core.HomeAssistant,
             "%s -> %s", domain, err.from_domain, err.to_domain)
         return False
 
+    # Process requirements as soon as possible, so we can import the component
+    # without requiring imports to be in functions.
+    try:
+        await async_process_deps_reqs(hass, config, integration)
+    except HomeAssistantError as err:
+        log_error(str(err))
+        return False
+
     processed_config = await conf_util.async_process_component_config(
         hass, config, integration)
 
     if processed_config is None:
         log_error("Invalid config.")
-        return False
-
-    try:
-        await async_process_deps_reqs(hass, config, integration)
-    except HomeAssistantError as err:
-        log_error(str(err))
         return False
 
     start = timer()

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -213,6 +213,14 @@ async def async_prepare_setup_platform(hass: core.HomeAssistant,
         log_error("Integration not found")
         return None
 
+    # Process deps and reqs as soon as possible, so that requirements are
+    # available when we import the platform.
+    try:
+        await async_process_deps_reqs(hass, hass_config, integration)
+    except HomeAssistantError as err:
+        log_error(str(err))
+        return None
+
     try:
         platform = integration.get_platform(domain)
     except ImportError:
@@ -239,12 +247,6 @@ async def async_prepare_setup_platform(hass: core.HomeAssistant,
             ):
                 log_error("Unable to set up component.")
                 return None
-
-    try:
-        await async_process_deps_reqs(hass, hass_config, integration)
-    except HomeAssistantError as err:
-        log_error(str(err))
-        return None
 
     return platform
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -100,12 +100,6 @@ async def _async_setup_component(hass: core.HomeAssistant,
         log_error("Integration not found.", False)
         return False
 
-    try:
-        component = integration.get_component()
-    except ImportError:
-        log_error("Unable to import component", False)
-        return False
-
     # Validate all dependencies exist and there are no circular dependencies
     try:
         await loader.async_component_dependencies(hass, domain)
@@ -135,6 +129,12 @@ async def _async_setup_component(hass: core.HomeAssistant,
 
     start = timer()
     _LOGGER.info("Setting up %s", domain)
+
+    try:
+        component = integration.get_component()
+    except ImportError:
+        log_error("Unable to import component", False)
+        return False
 
     if hasattr(component, 'PLATFORM_SCHEMA'):
         # Entity components have their own warning

--- a/tests/components/panel_custom/test_init.py
+++ b/tests/components/panel_custom/test_init.py
@@ -25,8 +25,11 @@ async def test_webcomponent_custom_path_not_found(hass):
             hass, 'panel_custom', config
         )
         assert not result
-        assert len(hass.data.get(frontend.DATA_PANELS, {})) == 0
 
+        panels = hass.data.get(frontend.DATA_PANELS, [])
+
+        assert panels
+        assert 'nice_url' not in panels
 
 async def test_webcomponent_custom_path(hass):
     """Test if a web component is found in config panels dir."""

--- a/tests/components/panel_custom/test_init.py
+++ b/tests/components/panel_custom/test_init.py
@@ -31,6 +31,7 @@ async def test_webcomponent_custom_path_not_found(hass):
         assert panels
         assert 'nice_url' not in panels
 
+
 async def test_webcomponent_custom_path(hass):
     """Test if a web component is found in config panels dir."""
     filename = 'mock.file'

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -52,31 +52,6 @@ def test_home_assistant_core_config_validation(hass):
     assert result is None
 
 
-def test_from_config_dict_not_mount_deps_folder(loop):
-    """Test that we do not mount the deps folder inside from_config_dict."""
-    with patch('homeassistant.bootstrap.is_virtual_env', return_value=False), \
-        patch('homeassistant.core.HomeAssistant',
-              return_value=Mock(loop=loop)), \
-        patch('homeassistant.bootstrap.async_mount_local_lib_path',
-              return_value=mock_coro()) as mock_mount, \
-        patch('homeassistant.bootstrap.async_from_config_dict',
-              return_value=mock_coro()):
-
-        bootstrap.from_config_dict({}, config_dir='.')
-        assert len(mock_mount.mock_calls) == 1
-
-    with patch('homeassistant.bootstrap.is_virtual_env', return_value=True), \
-        patch('homeassistant.core.HomeAssistant',
-              return_value=Mock(loop=loop)), \
-        patch('homeassistant.bootstrap.async_mount_local_lib_path',
-              return_value=mock_coro()) as mock_mount, \
-        patch('homeassistant.bootstrap.async_from_config_dict',
-              return_value=mock_coro()):
-
-        bootstrap.from_config_dict({}, config_dir='.')
-        assert len(mock_mount.mock_calls) == 0
-
-
 async def test_async_from_config_file_not_mount_deps_folder(loop):
     """Test that we not mount the deps folder inside async_from_config_file."""
     hass = Mock(


### PR DESCRIPTION
## Description:

Tweak the loading:
 - Reduce stage 1 integrations to the ones that matter. It had a few that were there in proxy, because in the past, we didn't resolve all domains. Now we do, so we only need to include the ones that are actually having to be stage 1.
 - Start resolving domains while setting up the core integration
 - Reuse same code for stage 1 and 2 loading
 - Await `async_setup_component`
 - Only do a single `async_block_till_done` at the end, so all tasks that got fired off, will finish before set up is done. 
 - Set up requirements and dependencies before validating any config, so that we can import requirements at the top of files.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
