### PR TITLE
Axis - start stream when system is ready

### DIFF
--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -95,11 +95,11 @@ class AxisNetworkDevice:
             task = self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
                     self.config_entry, 'binary_sensor'))
-            task.add_done_callback(self.start)
 
             self.api.stream.connection_status_callback = \
                 self.async_connection_status_callback
             self.api.enable_events(event_callback=self.async_event_callback)
+            task.add_done_callback(self.start)
 
         self.config_entry.add_update_listener(self.async_new_address_callback)
 

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -92,14 +92,14 @@ class AxisNetworkDevice:
                     self.config_entry, 'camera'))
 
         if self.config_entry.options[CONF_EVENTS]:
-            self.hass.async_create_task(
+            task = self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
                     self.config_entry, 'binary_sensor'))
+            task.add_done_callback(self.start)
 
             self.api.stream.connection_status_callback = \
                 self.async_connection_status_callback
             self.api.enable_events(event_callback=self.async_event_callback)
-            self.api.start()
 
         self.config_entry.add_update_listener(self.async_new_address_callback)
 
@@ -148,6 +148,11 @@ class AxisNetworkDevice:
         """Call to configure events when initialized on event stream."""
         if action == 'add':
             async_dispatcher_send(self.hass, self.event_new_sensor, event)
+
+    @callback
+    def start(self, fut):
+        """Start the event stream."""
+        self.api.start()
 
     @callback
     def shutdown(self, event):


### PR DESCRIPTION
There isn't an official issue on this, but has been reported on the forums by multiple users.

## Description:
Don't start event stream until sensor listeners are set up in platforms.

Background: the previous design didn't take concurrency into effect so on a loaded system the event stream would start before the platforms listeners have been set up resulting in no creation of entities.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.