### PR TITLE
Load integrations only once

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -152,3 +152,13 @@ def test_integration_properties(hass):
     assert integration.domain == 'hue'
     assert integration.dependencies == ['test-dep']
     assert integration.requirements == ['test-req==1.0.0']
+
+
+async def test_integrations_only_once(hass):
+    """Test that we load integrations only once."""
+    int_1 = hass.async_create_task(
+        loader.async_get_integration(hass, 'hue'))
+    int_2 = hass.async_create_task(
+        loader.async_get_integration(hass, 'hue'))
+
+    assert await int_1 is await int_2


### PR DESCRIPTION
## Description:
Make sure that we load each integration only once.

Uses the approach used by @Swamp-Ig for registries.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
