### PR TITLE
Update components that can be used without being set up

### DIFF
--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -22,9 +22,15 @@ def grep_dir(path: pathlib.Path, glob_pattern: str, search_pattern: str) \
     return found
 
 
-# These components will always be set up
 ALLOWED_USED_COMPONENTS = {
+    # This component will always be set up
     'persistent_notification',
+    # These allow to register things without being set up
+    'conversation',
+    'frontend',
+    'hassio',
+    'system_health',
+    'websocket_api',
 }
 
 


### PR DESCRIPTION
## Description:
Update hassfest dependencies checker to allow a couple more integrations to be referenced by integrations using `hass.components.` without them being loaded.

