### PR TITLE
Only preload when stream is setup

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, \
-    SERVICE_TURN_ON, EVENT_HOMEASSISTANT_START, CONF_FILENAME
+    SERVICE_TURN_ON, CONF_FILENAME
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity import Entity
@@ -32,6 +32,7 @@ from homeassistant.components.stream.const import (
     CONF_DURATION, SERVICE_RECORD, DOMAIN as DOMAIN_STREAM)
 from homeassistant.components import websocket_api
 import homeassistant.helpers.config_validation as cv
+from homeassistant.setup import async_when_setup
 
 from .const import DOMAIN, DATA_CAMERA_PREFS
 from .prefs import CameraPreferences
@@ -217,14 +218,13 @@ async def async_setup(hass, config):
 
     await component.async_setup(config)
 
-    @callback
-    def preload_stream(event):
+    async def preload_stream(hass, _):
         for camera in component.entities:
             camera_prefs = prefs.get(camera.entity_id)
             if camera.stream_source and camera_prefs.preload_stream:
                 request_stream(hass, camera.stream_source, keepalive=True)
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, preload_stream)
+    async_when_setup(hass, DOMAIN_STREAM, preload_stream)
 
     @callback
     def update_tokens(time):


### PR DESCRIPTION
## Description:

Switches preload stream to use `async_when_setup` instead of being called on Home Assistant start.

**Related issue (if applicable):** fixes #23131

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

