### PR TITLE
Prevent turning on tellduslive lights with 0 brightness

### DIFF
--- a/homeassistant/components/tellduslive/light.py
+++ b/homeassistant/components/tellduslive/light.py
@@ -69,7 +69,8 @@ class TelldusLiveLight(TelldusLiveEntity, Light):
         brightness = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness)
         if brightness == 0:
             fallback_brightness = 75
-            _LOGGER.info("Setting brightness to " + str(fallback_brightness) + "% before turning on, because it was 0")
+            _LOGGER.info("Setting brightness to %d%%, because it was 0",
+                         fallback_brightness)
             brightness = int(fallback_brightness*255/100)
         self.device.dim(level=brightness)
         self.changed()

--- a/homeassistant/components/tellduslive/light.py
+++ b/homeassistant/components/tellduslive/light.py
@@ -67,6 +67,10 @@ class TelldusLiveLight(TelldusLiveEntity, Light):
     def turn_on(self, **kwargs):
         """Turn the light on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness)
+        if brightness == 0:
+            fallback_brightness = 75
+            _LOGGER.info("Setting brightness to " + str(fallback_brightness) + "% before turning on, because it was 0")
+            brightness = int(fallback_brightness*255/100)
         self.device.dim(level=brightness)
         self.changed()
 

--- a/homeassistant/components/tellduslive/light.py
+++ b/homeassistant/components/tellduslive/light.py
@@ -68,7 +68,7 @@ class TelldusLiveLight(TelldusLiveEntity, Light):
         """Turn the light on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness)
         if brightness == 0:
-            fallback_brightness = 75
+            fallback_brightness = 100
             _LOGGER.info("Setting brightness to %d%%, because it was 0",
                          fallback_brightness)
             brightness = int(fallback_brightness*255/100)


### PR DESCRIPTION
## Description:
It was possible for the light compontent to get in a state where the last_brightness was set to zero, and when turning on (by calling turn_on) it would call the TellStick with 0 dim level, ergo not turning on the light.

With this, it will fall back on a 75% dim level if the level is set to zero.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

There are no existing tests for this component (except for the config flow test), bad excuse, but a reason for why I haven't added a test for it.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
