### PR TITLE
Added option to use self-signed certificates

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -51,7 +51,8 @@ def setup_platform(hass, config, add_entities, disc_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    if config.get(CONF_VERIFY_SSL):
+    client = caldav.DAVClient(url, None, username, password,
+                              ssl_verify_cert=config[CONF_VERIFY_SSL])
         client = caldav.DAVClient(url, None, username, password)
     else:
         client = caldav.DAVClient(url, None, username, password, None, False)

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.calendar import (
     PLATFORM_SCHEMA, CalendarEventDevice, get_date)
 from homeassistant.const import (
-    CONF_NAME, CONF_PASSWORD, CONF_URL, CONF_USERNAME)
+    CONF_NAME, CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, dt
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -52,7 +52,7 @@ def setup_platform(hass, config, add_entities, disc_info=None):
     password = config.get(CONF_PASSWORD)
 
     client = caldav.DAVClient(url, None, username, password,
-                              ssl_verify_cert=config[CONF_VERIFY_SSL])
+                              ssl_verify_cert=config.get(CONF_VERIFY_SSL))
 
     calendars = client.principal().calendars()
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -53,9 +53,6 @@ def setup_platform(hass, config, add_entities, disc_info=None):
 
     client = caldav.DAVClient(url, None, username, password,
                               ssl_verify_cert=config[CONF_VERIFY_SSL])
-        client = caldav.DAVClient(url, None, username, password)
-    else:
-        client = caldav.DAVClient(url, None, username, password, None, False)
 
     calendars = client.principal().calendars()
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -36,7 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                 vol.Required(CONF_NAME): cv.string,
                 vol.Required(CONF_SEARCH): cv.string,
             })
-        ]))
+        ])),
     vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean
 })
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -37,6 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                 vol.Required(CONF_SEARCH): cv.string,
             })
         ]))
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean
 })
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
@@ -50,7 +51,10 @@ def setup_platform(hass, config, add_entities, disc_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    client = caldav.DAVClient(url, None, username, password)
+    if config.get(CONF_VERIFY_SSL):
+        client = caldav.DAVClient(url, None, username, password)
+    else:
+        client = caldav.DAVClient(url, None, username, password, None, False)
 
     calendars = client.principal().calendars()
 


### PR DESCRIPTION
## Description:

I defined a new option for configuration.yaml, 'verify_ssl', which is set to 'True' by default for obvious security reasons. However, in order to work with self-signed certificates, it is now possible to disable the certificate validation.(eg, I use a nextcloud instance with self-signed certificates)
Credit for code in line 57 goes to user 'gen2' on the homeassistant community, who suggested this solution. 
https://community.home-assistant.io/t/caldav-configuration/38198/25
I only took it a step further and made it a config option.

## Example entry for `configuration.yaml` (if applicable):
```yaml
calendar:
  - platform: caldav
    username: <myname>
    password: <mysupersecretpassword>
    url: <nextcloudurl>
    verify_ssl: False
    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
