### PR TITLE
Added epson workforce component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -162,6 +162,7 @@ omit =
     homeassistant/components/envisalink/*
     homeassistant/components/ephember/climate.py
     homeassistant/components/epson/media_player.py
+    homeassistant/components/epsonworkforce/sensor.py
     homeassistant/components/eq3btsmart/climate.py
     homeassistant/components/esphome/__init__.py
     homeassistant/components/esphome/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,6 +67,7 @@ homeassistant/components/eight_sleep/* @mezz64
 homeassistant/components/emby/* @mezz64
 homeassistant/components/enigma2/* @fbradyirl
 homeassistant/components/ephember/* @ttroy50
+homeassistant/components/epsonworkforce/* @ThaStealth
 homeassistant/components/eq3btsmart/* @rytilahti
 homeassistant/components/esphome/* @OttoWinter
 homeassistant/components/file/* @fabaff

--- a/homeassistant/components/epsonworkforce/__init__.py
+++ b/homeassistant/components/epsonworkforce/__init__.py
@@ -1,0 +1,1 @@
+"""The epsonworkforce component."""

--- a/homeassistant/components/epsonworkforce/manifest.json
+++ b/homeassistant/components/epsonworkforce/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "epsonworkforce",
+  "name": "Epson Workforce",
+  "documentation": "https://www.home-assistant.io/components/epsonworkforce",
+  "dependencies": [],
+  "codeowners": ["@ThaStealth"],
+  "requirements": ["epsonprinter==0.0.8"]
+}
+

--- a/homeassistant/components/epsonworkforce/sensor.py
+++ b/homeassistant/components/epsonworkforce/sensor.py
@@ -1,0 +1,85 @@
+"""Support for Epson Workforce Printer."""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_HOST, CONF_MONITORED_CONDITIONS
+from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['epsonprinter==0.0.8']
+
+_LOGGER = logging.getLogger(__name__)
+MONITORED_CONDITIONS = {
+    'black': ['Inklevel Black', '%', 'mdi:water'],
+    'magenta': ['Inklevel Magenta', '%', 'mdi:water'],
+    'cyan': ['Inklevel Cyan', '%', 'mdi:water'],
+    'yellow': ['Inklevel Yellow', '%', 'mdi:water'],
+    'clean': ['Inklevel Cleaning', '%', 'mdi:water'],
+}
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
+})
+SCAN_INTERVAL = timedelta(minutes=60)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the cartridge sensor."""
+    host = config.get(CONF_HOST)
+
+    from epsonprinter_pkg.epsonprinterapi import EpsonPrinterAPI
+    api = EpsonPrinterAPI(host)
+    if not api.available:
+        raise PlatformNotReady()
+
+    sensors = [EpsonPrinterCartridge(api, condition)
+               for condition in config[CONF_MONITORED_CONDITIONS]]
+
+    add_devices(sensors, True)
+
+
+class EpsonPrinterCartridge(Entity):
+    """Representation of a cartridge sensor."""
+
+    def __init__(self, api, cartridgeidx):
+        """Initialize a cartridge sensor."""
+        self._api = api
+
+        self._id = cartridgeidx
+        self._name = MONITORED_CONDITIONS[self._id][0]
+        self._unit = MONITORED_CONDITIONS[self._id][1]
+        self._icon = MONITORED_CONDITIONS[self._id][2]
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._api.getSensorValue(self._id)
+
+    @property
+    def available(self):
+        """Could the device be accessed during the last update call."""
+        return self._api.available
+
+    def update(self):
+        """Get the latest data from the Epson printer."""
+        self._api.update()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -397,6 +397,9 @@ ephem==3.7.6.0
 # homeassistant.components.epson
 epson-projector==0.1.3
 
+# homeassistant.components.epsonworkforce
+epsonprinter==0.0.8
+
 # homeassistant.components.netgear_lte
 eternalegypt==0.0.7
 


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9200

## Example entry for `configuration.yaml` (if applicable):
```yaml
   - platform: epsonworkforce
     host: 192.168.0.123
     monitored_conditions:
     - black     
     - yellow
     - magenta
     - cyan
     - clean      
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
