### PR TITLE
update caldav to fix calendar issues with synology clients

### DIFF
--- a/homeassistant/components/caldav/manifest.json
+++ b/homeassistant/components/caldav/manifest.json
@@ -3,7 +3,7 @@
   "name": "Caldav",
   "documentation": "https://www.home-assistant.io/components/caldav",
   "requirements": [
-    "caldav==0.5.0"
+    "caldav==0.6.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -270,7 +270,7 @@ btsmarthub_devicelist==0.1.3
 buienradar==0.91
 
 # homeassistant.components.caldav
-caldav==0.5.0
+caldav==0.6.1
 
 # homeassistant.components.cisco_mobility_express
 ciscomobilityexpress==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -67,7 +67,7 @@ axis==21
 bellows-homeassistant==0.7.2
 
 # homeassistant.components.caldav
-caldav==0.5.0
+caldav==0.6.1
 
 # homeassistant.components.coinmarketcap
 coinmarketcap==5.0.3


### PR DESCRIPTION
## Description:
The python caldav client has issues in .5.0 which prevented Synology calendar users from using this component. Previously I've needed to install master manually.

The library has finally been updated in pypi.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
