### PR TITLE
Fix verify_ssl configuration 

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -194,7 +194,7 @@ def load_data(hass, url=None, filepath=None, username=None, password=None,
                     params["auth"] = HTTPDigestAuth(username, password)
                 else:
                     params["auth"] = HTTPBasicAuth(username, password)
-            if verify_ssl:
+            if verify_ssl is not None:
                 params["verify"] = verify_ssl
             retry_num = 0
             while retry_num < num_retries:


### PR DESCRIPTION
**Related issue (if applicable):** fixes #23140

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
- alias: Telegram /photo command
  hide_entity: true
  trigger:
    platform: event
    event_type: telegram_command
    event_data:
      command: /photo
  action:
  - service: telegram_bot.send_photo
    data_template:
      target: '{{ trigger.event.data.user_id }}'
      url: !secret hall_cam_url
      verify_ssl: False
      username: !secret xiaomi_camera_user
      password: !secret xiaomi_camera_pass
      authentication: basic
      caption: Hall camera
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.