### PR TITLE
Fix check config script

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -817,7 +817,7 @@ async def async_check_ha_config_file(hass: HomeAssistant) -> Optional[str]:
     """
     from homeassistant.scripts.check_config import check_ha_config_file
 
-    res = await check_ha_config_file(hass)
+    res = await check_ha_config_file(hass)  # type: ignore
 
     if not res.errors:
         return None

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -817,8 +817,7 @@ async def async_check_ha_config_file(hass: HomeAssistant) -> Optional[str]:
     """
     from homeassistant.scripts.check_config import check_ha_config_file
 
-    res = await hass.async_add_executor_job(
-        check_ha_config_file, hass)
+    res = await check_ha_config_file(hass)
 
     if not res.errors:
         return None

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -201,7 +201,8 @@ def check(config_dir, secrets=False):
         hass = core.HomeAssistant()
         hass.config.config_dir = config_dir
 
-        res['components'] = check_ha_config_file(hass)
+        res['components'] = hass.loop.run_until_complete(
+            check_ha_config_file(hass))
         res['secret_cache'] = OrderedDict(yaml.__SECRET_CACHE)
 
         for err in res['components'].errors:
@@ -280,7 +281,7 @@ class HomeAssistantConfig(OrderedDict):
         return self
 
 
-def check_ha_config_file(hass):
+async def check_ha_config_file(hass):
     """Check if Home Assistant configuration file is valid."""
     config_dir = hass.config.config_dir
     result = HomeAssistantConfig()
@@ -300,10 +301,12 @@ def check_ha_config_file(hass):
 
     # Load configuration.yaml
     try:
-        config_path = find_config_file(config_dir)
+        config_path = await hass.async_add_executor_job(
+            find_config_file, config_dir)
         if not config_path:
             return result.add_error("File configuration.yaml not found.")
-        config = load_yaml_config_file(config_path)
+        config = await hass.async_add_executor_job(
+            load_yaml_config_file, config_path)
     except HomeAssistantError as err:
         return result.add_error(
             "Error loading {}: {}".format(config_path, err))
@@ -320,8 +323,8 @@ def check_ha_config_file(hass):
         core_config = {}
 
     # Merge packages
-    hass.loop.run_until_complete(merge_packages_config(
-        hass, config, core_config.get(CONF_PACKAGES, {}), _pack_error))
+    await merge_packages_config(
+        hass, config, core_config.get(CONF_PACKAGES, {}), _pack_error)
     core_config.pop(CONF_PACKAGES, None)
 
     # Filter out repeating config sections
@@ -330,8 +333,7 @@ def check_ha_config_file(hass):
     # Process and validate config
     for domain in components:
         try:
-            integration = hass.loop.run_until_complete(
-                loader.async_get_integration(hass, domain))
+            integration = await loader.async_get_integration(hass, domain)
         except loader.IntegrationNotFound:
             result.add_error("Integration not found: {}".format(domain))
             continue
@@ -350,21 +352,19 @@ def check_ha_config_file(hass):
                 _comp_error(ex, domain, config)
                 continue
 
-        if (not hasattr(component, 'PLATFORM_SCHEMA') and
-                not hasattr(component, 'PLATFORM_SCHEMA_BASE')):
+        component_platform_schema = getattr(
+            component, 'PLATFORM_SCHEMA_BASE',
+            getattr(component, 'PLATFORM_SCHEMA', None))
+
+        if component_platform_schema is None:
             continue
 
         platforms = []
         for p_name, p_config in config_per_platform(config, domain):
             # Validate component specific platform schema
             try:
-                if hasattr(component, 'PLATFORM_SCHEMA_BASE'):
-                    p_validated = \
-                        component.PLATFORM_SCHEMA_BASE(  # type: ignore
-                            p_config)
-                else:
-                    p_validated = component.PLATFORM_SCHEMA(  # type: ignore
-                        p_config)
+                p_validated = component_platform_schema(  # type: ignore
+                    p_config)
             except vol.Invalid as ex:
                 _comp_error(ex, domain, config)
                 continue
@@ -377,8 +377,8 @@ def check_ha_config_file(hass):
                 continue
 
             try:
-                p_integration = hass.loop.run_until_complete(
-                    loader.async_get_integration(hass, p_name))
+                p_integration = await loader.async_get_integration(hass,
+                                                                   p_name)
             except loader.IntegrationNotFound:
                 result.add_error(
                     "Integration {} not found when trying to verify its {} "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -539,7 +539,8 @@ class TestConfig(unittest.TestCase):
         assert len(self.hass.config.whitelist_external_dirs) == 1
         assert "/test/config/www" in self.hass.config.whitelist_external_dirs
 
-    @mock.patch('homeassistant.scripts.check_config.check_ha_config_file')
+    @asynctest.mock.patch(
+        'homeassistant.scripts.check_config.check_ha_config_file')
     def test_check_ha_config_file_correct(self, mock_check):
         """Check that restart propagates to stop."""
         mock_check.return_value = check_config.HomeAssistantConfig()
@@ -548,7 +549,8 @@ class TestConfig(unittest.TestCase):
             self.hass.loop
         ).result() is None
 
-    @mock.patch('homeassistant.scripts.check_config.check_ha_config_file')
+    @asynctest.mock.patch(
+        'homeassistant.scripts.check_config.check_ha_config_file')
     def test_check_ha_config_file_wrong(self, mock_check):
         """Check that restart with a bad config doesn't propagate to stop."""
         mock_check.return_value = check_config.HomeAssistantConfig()


### PR DESCRIPTION
## Description:
Fix check_config script being called from the async_check_config service call.

This is quite gross tbh, we should not have the core rely on anything that is inside a script. The script also has side effects like clearing the secret cache, and shares a lot of code with `homeassistant.config.async_process_component_config`

**Related issue (if applicable):** fixes #23114

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
