### PR TITLE
Axis change how new event is signalled

### DIFF
--- a/homeassistant/components/axis/binary_sensor.py
+++ b/homeassistant/components/axis/binary_sensor.py
@@ -18,8 +18,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     device = hass.data[AXIS_DOMAIN][serial_number]
 
     @callback
-    def async_add_sensor(event):
+    def async_add_sensor(event_id):
         """Add binary sensor from Axis device."""
+        event = device.api.event.events[event_id]
         async_add_entities([AxisBinarySensor(event, device)], True)
 
     device.listeners.append(async_dispatcher_connect(
@@ -83,12 +84,12 @@ class AxisBinarySensor(BinarySensorDevice):
     def name(self):
         """Return the name of the event."""
         return '{} {} {}'.format(
-            self.device.name, self.event.event_type, self.event.id)
+            self.device.name, self.event.TYPE, self.event.id)
 
     @property
     def device_class(self):
         """Return the class of the event."""
-        return self.event.event_class
+        return self.event.CLASS
 
     @property
     def unique_id(self):

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -140,10 +140,10 @@ class AxisNetworkDevice:
         return 'axis_add_sensor_{}'.format(self.serial)
 
     @callback
-    def async_event_callback(self, action, event):
+    def async_event_callback(self, action, event_id):
         """Call to configure events when initialized on event stream."""
         if action == 'add':
-            async_dispatcher_send(self.hass, self.event_new_sensor, event)
+            async_dispatcher_send(self.hass, self.event_new_sensor, event_id)
 
     @callback
     def start(self, fut):

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -2,7 +2,7 @@
   "domain": "axis",
   "name": "Axis",
   "documentation": "https://www.home-assistant.io/components/axis",
-  "requirements": ["axis==21"],
+  "requirements": ["axis==22"],
   "dependencies": [],
   "codeowners": ["@kane610"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -192,7 +192,7 @@ av==6.1.2
 # avion==0.10
 
 # homeassistant.components.axis
-axis==21
+axis==22
 
 # homeassistant.components.baidu
 baidu-aip==1.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -61,7 +61,7 @@ apns2==0.3.0
 av==6.1.2
 
 # homeassistant.components.axis
-axis==21
+axis==22
 
 # homeassistant.components.zha
 bellows-homeassistant==0.7.2

--- a/tests/components/axis/test_device.py
+++ b/tests/components/axis/test_device.py
@@ -167,7 +167,7 @@ async def test_new_event_sends_signal(hass):
     axis_device = device.AxisNetworkDevice(hass, entry)
 
     with patch.object(device, 'async_dispatcher_send') as mock_dispatch_send:
-        axis_device.async_event_callback(action='add', event='event')
+        axis_device.async_event_callback(action='add', event_id='event')
         await hass.async_block_till_done()
 
     assert len(mock_dispatch_send.mock_calls) == 1


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Mainly improvements in backend, events in signalling is now event_id instead of an object

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_