### PR TITLE
Potential bug / data leak in Entity

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -241,9 +241,9 @@ class Entity:
         """Write the state to the state machine."""
         start = timer()
 
+        attr = {}
         if not self.available:
             state = STATE_UNAVAILABLE
-            attr = {}
         else:
             state = self.state
 
@@ -252,10 +252,8 @@ class Entity:
             else:
                 state = str(state)
 
-            attr = self.state_attributes or {}
-            device_attr = self.device_state_attributes
-            if device_attr is not None:
-                attr.update(device_attr)
+            attr.update(self.state_attributes or {})
+            attr.update(self.device_state_attributes or {})
 
         unit_of_measurement = self.unit_of_measurement
         if unit_of_measurement is not None:


### PR DESCRIPTION
## Description:

@balloob 

I think this is a potential bug that I noticed in core. Setting all the stuff in the returned `state_attributes` below this line will leak back to the returned dict. This will stop that.

If it's not an issue, reject the PR.