### PR TITLE
Configurable sources and simulate volume

### DIFF
--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -1,9 +1,5 @@
-"""
-Support for interface with an Harman/Kardon or JBL AVR.
+"""Support for interface with an Harman/Kardon or JBL AVR."""
 
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/media_player.harman_kardon_avr/
-"""
 import logging
 import time
 
@@ -11,14 +7,12 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA, MediaPlayerDevice)
+    MediaPlayerDevice, PLATFORM_SCHEMA)
 from homeassistant.components.media_player.const import (
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
     SUPPORT_TURN_ON, SUPPORT_SELECT_SOURCE, SUPPORT_VOLUME_SET)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, CONF_SOURCE, STATE_OFF, STATE_ON)
-
-REQUIREMENTS = ['hkavr==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,12 +53,12 @@ def setup_platform(hass, config, add_entities, discover_info=None):
     """Set up the AVR platform."""
     import hkavr
 
-    name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    key_interval = config.get(CONF_KEY_INTERVAL)
-    simulate_volume_set = config.get(CONF_SIMULATE_VOLUME_SET)
-    sources = config.get(CONF_SOURCES)
+    name = config[CONF_NAME]
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+    key_interval = config[CONF_KEY_INTERVAL]
+    simulate_volume_set = config[CONF_SIMULATE_VOLUME_SET]
+    sources = config[CONF_SOURCES]
 
     avr = hkavr.HkAVR(host, port, name)
     avr_device = HkAvrDevice(avr, key_interval, sources, simulate_volume_set)

--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -112,7 +112,7 @@ class HkAvrDevice(MediaPlayerDevice):
             try:
                 self._avr.send_command("HEARTBEAT")
                 self._state = None
-            except Error:
+            except:
                 self._state = STATE_OFF
 
         self._muted = self._avr.muted

--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -208,7 +208,7 @@ class HkAvrDevice(MediaPlayerDevice):
         else:
             _steps = 5
 
-        for i in range(_steps):
+        for _ in range(_steps):
             _func()
             time.sleep(self._key_interval)
 

--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -48,8 +48,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_KEY_INTERVAL, default=DEFAULT_KEY_INTERVAL):
         cv.small_float,
-    vol.Optional(CONF_SIMULATE_VOLUME_SET, default=DEFAULT_SIMULATE_VOLUME_SET):
-        cv.boolean,
+    vol.Optional(CONF_SIMULATE_VOLUME_SET,
+                 default=DEFAULT_SIMULATE_VOLUME_SET): cv.boolean,
     vol.Optional(CONF_SOURCES, default=DEFAULT_SOURCES):
         vol.All(cv.ensure_list, [SOURCE_SCHEMA])
 })
@@ -104,19 +104,16 @@ class HkAvrDevice(MediaPlayerDevice):
 
     def update(self):
         """Update the state of this media_player."""
+        self._muted = self._avr.muted
+        self._current_source = self._avr.current_source
+
         if self._avr.is_on():
             self._state = STATE_ON
         elif self._avr.is_off():
             self._state = STATE_OFF
         else:
-            try:
-                self._avr.send_command("HEARTBEAT")
-                self._state = None
-            except:
-                self._state = STATE_OFF
-
-        self._muted = self._avr.muted
-        self._current_source = self._avr.current_source
+            self._avr.send_command("HEARTBEAT")
+            self._state = None
 
     @property
     def name(self):

--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -1,30 +1,54 @@
-"""Support for interface with an Harman/Kardon or JBL AVR."""
+"""
+Support for interface with an Harman/Kardon or JBL AVR.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.harman_kardon_avr/
+"""
 import logging
+import time
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.media_player import (
-    MediaPlayerDevice, PLATFORM_SCHEMA)
+    PLATFORM_SCHEMA, MediaPlayerDevice)
 from homeassistant.components.media_player.const import (
     SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
-    SUPPORT_TURN_ON, SUPPORT_SELECT_SOURCE)
+    SUPPORT_TURN_ON, SUPPORT_SELECT_SOURCE, SUPPORT_VOLUME_SET)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_ON)
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_SOURCE, STATE_OFF, STATE_ON)
+
+REQUIREMENTS = ['hkavr==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_KEY_INTERVAL = 'key_interval'
+CONF_SIMULATE_VOLUME_SET = 'simulate_volume_set'
+CONF_SOURCES = 'sources'
+
 DEFAULT_NAME = 'Harman Kardon AVR'
 DEFAULT_PORT = 10025
+DEFAULT_KEY_INTERVAL = 0.2
+DEFAULT_SIMULATE_VOLUME_SET = False
+DEFAULT_SOURCES = [{"name":"STB"}, {"name":"Radio"}, {"name":"TV"}, {"name":"Game"}, {"name":"AUX"}]
 
 SUPPORT_HARMAN_KARDON_AVR = SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | \
                             SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
                             SUPPORT_SELECT_SOURCE
 
+SOURCE_SCHEMA = vol.Schema({
+    vol.Required(CONF_SOURCE): cv.string,
+    vol.Optional(CONF_NAME): cv.string
+})
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_KEY_INTERVAL, default=DEFAULT_KEY_INTERVAL): cv.small_float,
+    vol.Optional(CONF_SIMULATE_VOLUME_SET, default=DEFAULT_SIMULATE_VOLUME_SET): cv.boolean,
+    vol.Optional(CONF_SOURCES, default=DEFAULT_SOURCES):
+        vol.All(cv.ensure_list, [SOURCE_SCHEMA])
 })
 
 
@@ -32,12 +56,15 @@ def setup_platform(hass, config, add_entities, discover_info=None):
     """Set up the AVR platform."""
     import hkavr
 
-    name = config[CONF_NAME]
-    host = config[CONF_HOST]
-    port = config[CONF_PORT]
+    name                = config.get(CONF_NAME)
+    host                = config.get(CONF_HOST)
+    port                = config.get(CONF_PORT)
+    key_interval        = config.get(CONF_KEY_INTERVAL)
+    simulate_volume_set = config.get(CONF_SIMULATE_VOLUME_SET)
+    sources             = config.get(CONF_SOURCES)
 
     avr = hkavr.HkAVR(host, port, name)
-    avr_device = HkAvrDevice(avr)
+    avr_device = HkAvrDevice(avr, key_interval, sources, simulate_volume_set)
 
     add_entities([avr_device], True)
 
@@ -45,15 +72,28 @@ def setup_platform(hass, config, add_entities, discover_info=None):
 class HkAvrDevice(MediaPlayerDevice):
     """Representation of a Harman Kardon AVR / JBL AVR TV."""
 
-    def __init__(self, avr):
+    def __init__(self, avr, key_interval, sources, simulate_volume_set):
         """Initialize a new HarmanKardonAVR."""
         self._avr = avr
 
         self._name = avr.name
         self._host = avr.host
         self._port = avr.port
+        self._key_interval = key_interval
 
-        self._source_list = avr.sources
+        self._volume = 0.5
+        
+        self._simulate_volume_set = simulate_volume_set
+
+        _sources = []
+        for entry in sources:
+            if CONF_NAME in entry:
+                _sources.append(entry[CONF_NAME])
+            else:
+                _sources.append(entry[CONF_SOURCE])
+
+        self._sources = _sources
+        self._source_mapping = sources
 
         self._state = None
         self._muted = avr.muted
@@ -61,12 +101,17 @@ class HkAvrDevice(MediaPlayerDevice):
 
     def update(self):
         """Update the state of this media_player."""
+
         if self._avr.is_on():
             self._state = STATE_ON
         elif self._avr.is_off():
             self._state = STATE_OFF
         else:
-            self._state = None
+            try:
+                self._avr.send_command("HEARTBEAT")
+                self._state = None
+            except:
+                self._state = STATE_OFF
 
         self._muted = self._avr.muted
         self._current_source = self._avr.current_source
@@ -87,6 +132,14 @@ class HkAvrDevice(MediaPlayerDevice):
         return self._muted
 
     @property
+    def volume_level(self):
+        """Return the volume level."""
+        if not self._simulate_volume_set:
+            raise NotImplementedError
+
+        return self._volume
+
+    @property
     def source(self):
         """Return the current input source."""
         return self._current_source
@@ -94,11 +147,13 @@ class HkAvrDevice(MediaPlayerDevice):
     @property
     def source_list(self):
         """Available sources."""
-        return self._source_list
+        return self._sources
 
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
+        if self._simulate_volume_set:
+            return SUPPORT_HARMAN_KARDON_AVR | SUPPORT_VOLUME_SET
         return SUPPORT_HARMAN_KARDON_AVR
 
     def turn_on(self):
@@ -111,7 +166,15 @@ class HkAvrDevice(MediaPlayerDevice):
 
     def select_source(self, source):
         """Select input source."""
-        return self._avr.select_source(source)
+        _avr_source = source
+
+        # Find the source key as given in the configuration
+        for src in self._source_mapping:
+            if src[CONF_NAME] is source:
+                _avr_source = src[CONF_SOURCE]
+                break
+
+        return self._avr.select_source(_avr_source)
 
     def volume_up(self):
         """Volume up the AVR."""
@@ -120,6 +183,35 @@ class HkAvrDevice(MediaPlayerDevice):
     def volume_down(self):
         """Volume down AVR."""
         return self._avr.volume_down()
+
+    def set_volume_level(self, volume):
+        """Set the volume level."""
+        if not self._simulate_volume_set:
+            raise NotImplementedError
+
+        _volume = volume * 100.0
+
+        _func = self.volume_up if _volume > 50 else self.volume_down
+
+        _steps = 1
+        if _volume > 90:
+            _steps = 5
+        elif _volume > 70:
+            _steps = 3
+        elif _volume > 50:
+            _steps = 1
+        elif _volume == 50:
+            _steps = 0
+        elif _volume > 30:
+            _steps = 1
+        elif _volume > 10:
+            _steps = 3
+        else:
+            _steps = 5
+
+        for i in range(_steps):
+            _func()
+            time.sleep(self._key_interval)
 
     def mute_volume(self, mute):
         """Send mute command."""

--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -30,7 +30,8 @@ DEFAULT_NAME = 'Harman Kardon AVR'
 DEFAULT_PORT = 10025
 DEFAULT_KEY_INTERVAL = 0.2
 DEFAULT_SIMULATE_VOLUME_SET = False
-DEFAULT_SOURCES = [{"name":"STB"}, {"name":"Radio"}, {"name":"TV"}, {"name":"Game"}, {"name":"AUX"}]
+DEFAULT_SOURCES = [{"name": "STB"}, {"name": "Radio"}, {"name": "TV"},
+                   {"name": "Game"}, {"name": "AUX"}]
 
 SUPPORT_HARMAN_KARDON_AVR = SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | \
                             SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
@@ -45,8 +46,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_KEY_INTERVAL, default=DEFAULT_KEY_INTERVAL): cv.small_float,
-    vol.Optional(CONF_SIMULATE_VOLUME_SET, default=DEFAULT_SIMULATE_VOLUME_SET): cv.boolean,
+    vol.Optional(CONF_KEY_INTERVAL, default=DEFAULT_KEY_INTERVAL):
+        cv.small_float,
+    vol.Optional(CONF_SIMULATE_VOLUME_SET, default=DEFAULT_SIMULATE_VOLUME_SET):
+        cv.boolean,
     vol.Optional(CONF_SOURCES, default=DEFAULT_SOURCES):
         vol.All(cv.ensure_list, [SOURCE_SCHEMA])
 })
@@ -56,12 +59,12 @@ def setup_platform(hass, config, add_entities, discover_info=None):
     """Set up the AVR platform."""
     import hkavr
 
-    name                = config.get(CONF_NAME)
-    host                = config.get(CONF_HOST)
-    port                = config.get(CONF_PORT)
-    key_interval        = config.get(CONF_KEY_INTERVAL)
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    key_interval = config.get(CONF_KEY_INTERVAL)
     simulate_volume_set = config.get(CONF_SIMULATE_VOLUME_SET)
-    sources             = config.get(CONF_SOURCES)
+    sources = config.get(CONF_SOURCES)
 
     avr = hkavr.HkAVR(host, port, name)
     avr_device = HkAvrDevice(avr, key_interval, sources, simulate_volume_set)
@@ -82,7 +85,7 @@ class HkAvrDevice(MediaPlayerDevice):
         self._key_interval = key_interval
 
         self._volume = 0.5
-        
+
         self._simulate_volume_set = simulate_volume_set
 
         _sources = []
@@ -101,7 +104,6 @@ class HkAvrDevice(MediaPlayerDevice):
 
     def update(self):
         """Update the state of this media_player."""
-
         if self._avr.is_on():
             self._state = STATE_ON
         elif self._avr.is_off():
@@ -110,7 +112,7 @@ class HkAvrDevice(MediaPlayerDevice):
             try:
                 self._avr.send_command("HEARTBEAT")
                 self._state = None
-            except:
+            except Error:
                 self._state = STATE_OFF
 
         self._muted = self._avr.muted


### PR DESCRIPTION
## Description:
This allows the user to:
- Configure the input sources of the AVR
- Configure a key interval to sleep between the sending of the key commands
- Simulate the volume setter of the AVR (This enables to control the volume through Google Assistant)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9254

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: harman_kardon_avr
    host: IP_HERE
    key_interval: 0.3
    simulate_volume_set: True
    sources:
      - source: TV
        name: Television
      - source: Game
        name: Xbox One
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
