### PR TITLE
Added afvalwijzer component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,7 @@ omit =
     homeassistant/components/actiontec/device_tracker.py
     homeassistant/components/ads/*
     homeassistant/components/aftership/sensor.py
+    homeassistant/components/afvalwijzer/sensor.py
     homeassistant/components/airvisual/sensor.py
     homeassistant/components/aladdin_connect/cover.py
     homeassistant/components/alarm_control_panel/manual_mqtt.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,7 @@ virtualization/Docker/* @home-assistant/docker
 homeassistant/scripts/check_config.py @kellerza
 
 # Integrations
+homeassistant/components/afvalwijzer/* @ThaStealth
 homeassistant/components/airvisual/* @bachya
 homeassistant/components/alarm_control_panel/* @colinodell
 homeassistant/components/alpha_vantage/* @fabaff

--- a/homeassistant/components/afvalwijzer/__init__.py
+++ b/homeassistant/components/afvalwijzer/__init__.py
@@ -1,0 +1,1 @@
+"""AfvalWijzer component."""

--- a/homeassistant/components/afvalwijzer/manifest.json
+++ b/homeassistant/components/afvalwijzer/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "afvalwijzer",
+  "name": "Afvalwijzer",
+  "documentation": "https://www.home-assistant.io/components/afvalwijzer",
+  "dependencies": [],
+  "codeowners": ["@ThaStealth"],
+  "requirements": ["afvalwijzerapi==0.0.2"]
+}
+

--- a/homeassistant/components/afvalwijzer/sensor.py
+++ b/homeassistant/components/afvalwijzer/sensor.py
@@ -24,8 +24,8 @@ MONITORED_CONDITIONS = {
     'pmd': ['PMD', None, 'mdi:beer'],
     'gft': ['GFT', None, 'mdi:delete'],
     'papier': ['Papier', None, 'mdi:email-outline'],
-    'takken': ['Snoeiafval', None, 'mdi:tree'],
-    'kerstboom': ['Kerstbomen', None, 'mdi:pine-tree']
+    'snoeiafval': ['Snoeiafval', None, 'mdi:tree'],
+    'kerstbomen': ['Kerstbomen', None, 'mdi:pine-tree']
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/afvalwijzer/sensor.py
+++ b/homeassistant/components/afvalwijzer/sensor.py
@@ -40,12 +40,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the AfvalwijzerSensor sensors."""
-    zip = config.get(CONF_ZIPCODE)
+    zipcode = config.get(CONF_ZIPCODE)
     housenumber = config.get(CONF_HOUSENUMBER)
     numberaddition = config.get(CONF_HOUSENUMBERADDITION)
 
     from afvalwijzer_pkg.afvalwijzerapi import AfvalwijzerAPI
-    api = AfvalwijzerAPI(zip, housenumber, numberaddition)
+    api = AfvalwijzerAPI(zipcode, housenumber, numberaddition)
     if not api.available:
         raise PlatformNotReady
 
@@ -61,7 +61,7 @@ class AfvalwijzerSensor(Entity):
     def __init__(self, api, index):
         """Initialize an AfvalwijzerSensor sensor."""
         self._api = api
-        self._garbageType = index
+        self._garbage_type = index
         self._name = MONITORED_CONDITIONS[index][0]
         self._icon = MONITORED_CONDITIONS[index][2]
 
@@ -83,7 +83,7 @@ class AfvalwijzerSensor(Entity):
     @property
     def state(self):
         """Return the state of the garbagetype."""
-        return self._api.getPickupDate(self._garbageType)
+        return self._api.getPickupDate(self._garbage_type)
 
     @property
     def available(self):

--- a/homeassistant/components/afvalwijzer/sensor.py
+++ b/homeassistant/components/afvalwijzer/sensor.py
@@ -1,0 +1,95 @@
+"""AfvalWijzer component."""
+from datetime import timedelta
+import logging
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+CONF_ZIPCODE = "zipcode"
+CONF_HOUSENUMBER = "housenumber"
+CONF_HOUSENUMBERADDITION = "housenumberaddition"
+DEFAULT_HOUSENMBERADDITION = ""
+REQUIREMENTS = ['afvalwijzerapi==0.0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(minutes=1440)
+
+MONITORED_CONDITIONS = {
+    'restafval': ['Restafval', None, 'mdi:delete'],
+    'pmd': ['PMD', None, 'mdi:beer'],
+    'gft': ['GFT', None, 'mdi:delete'],
+    'papier': ['Papier', None, 'mdi:email-outline'],
+    'takken': ['Snoeiafval', None, 'mdi:tree'],
+    'kerstboom': ['Kerstbomen', None, 'mdi:pine-tree']
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ZIPCODE): cv.string,
+    vol.Required(CONF_HOUSENUMBER): cv.port,
+    vol.Optional(CONF_HOUSENUMBERADDITION,
+                 default=DEFAULT_HOUSENMBERADDITION): cv.string,
+    vol.Required(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the AfvalwijzerSensor sensors."""
+    zip = config.get(CONF_ZIPCODE)
+    housenumber = config.get(CONF_HOUSENUMBER)
+    numberaddition = config.get(CONF_HOUSENUMBERADDITION)
+
+    from afvalwijzer_pkg.afvalwijzerapi import AfvalwijzerAPI
+    api = AfvalwijzerAPI(zip, housenumber, numberaddition)
+    if not api.available:
+        raise PlatformNotReady
+
+    sensors = [AfvalwijzerSensor(api, condition)
+               for condition in config[CONF_MONITORED_CONDITIONS]]
+
+    add_devices(sensors, True)
+
+
+class AfvalwijzerSensor(Entity):
+    """Representation of an AfvalwijzerSensor sensor."""
+
+    def __init__(self, api, index):
+        """Initialize an AfvalwijzerSensor sensor."""
+        self._api = api
+        self._garbageType = index
+        self._name = MONITORED_CONDITIONS[index][0]
+        self._icon = MONITORED_CONDITIONS[index][2]
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of the value."""
+        return ''
+
+    @property
+    def state(self):
+        """Return the state of the garbagetype."""
+        return self._api.getPickupDate(self._garbageType)
+
+    @property
+    def available(self):
+        """Could the API be accessed during the last update call."""
+        return self._api.available
+
+    def update(self):
+        """Get the latest data from the Afvalwijzer API."""
+        self._api.update()

--- a/homeassistant/components/afvalwijzer/sensor.py
+++ b/homeassistant/components/afvalwijzer/sensor.py
@@ -24,8 +24,8 @@ MONITORED_CONDITIONS = {
     'pmd': ['PMD', None, 'mdi:beer'],
     'gft': ['GFT', None, 'mdi:delete'],
     'papier': ['Papier', None, 'mdi:email-outline'],
-    'snoeiafval': ['Snoeiafval', None, 'mdi:tree'],
-    'kerstbomen': ['Kerstbomen', None, 'mdi:pine-tree']
+    'takken': ['Snoeiafval', None, 'mdi:tree'],
+    'kerstboom': ['Kerstbomen', None, 'mdi:pine-tree']
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -96,6 +96,9 @@ abodepy==0.15.0
 # homeassistant.components.frontier_silicon
 afsapi==0.0.4
 
+# homeassistant.components.afvalwijzer
+afvalwijzerapi==0.0.2
+
 # homeassistant.components.ambient_station
 aioambient==0.3.0
 


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9237

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: afvalwijzer
    zipcode: 1234AB
    housenumber: 1
    monitored_conditions:
      - gft
      - pmd
      - restafval
      - papier
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
