### PR TITLE
Pass configured host string instead of always forcing an ip-address

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -262,7 +262,7 @@ def setup(hass, config):
     # Create hosts-dictionary for pyhomematic
     for rname, rconfig in conf[CONF_INTERFACES].items():
         remotes[rname] = {
-            'ip': socket.gethostbyname(rconfig.get(CONF_HOST)),
+            'ip': rconfig.get(CONF_HOST),
             'port': rconfig.get(CONF_PORT),
             'path': rconfig.get(CONF_PATH),
             'resolvenames': rconfig.get(CONF_RESOLVENAMES),
@@ -278,7 +278,7 @@ def setup(hass, config):
 
     for sname, sconfig in conf[CONF_HOSTS].items():
         remotes[sname] = {
-            'ip': socket.gethostbyname(sconfig.get(CONF_HOST)),
+            'ip': sconfig.get(CONF_HOST),
             'port': DEFAULT_PORT,
             'username': sconfig.get(CONF_USERNAME),
             'password': sconfig.get(CONF_PASSWORD),

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -2,7 +2,6 @@
 from datetime import timedelta
 from functools import partial
 import logging
-import socket
 
 import voluptuous as vol
 


### PR DESCRIPTION
Pass the configured host (https://www.home-assistant.io/components/homematic/#host) instead of always forcing an ip-address. This is required to get SSL certificate validation working.

## Breaking Change:

Not that I'm aware of
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

The current implementation in the component at lines [homeassistant/components/homematic/__init__.py#L265](https://github.com/home-assistant/home-assistant/blob/177ae3fd322e116f460c3b23d7c0a7a74dc90cd2/homeassistant/components/homematic/__init__.py#L265) and [homeassistant/components/homematic/__init__.py#L281](https://github.com/home-assistant/home-assistant/blob/177ae3fd322e116f460c3b23d7c0a7a74dc90cd2/homeassistant/components/homematic/__init__.py#L281) always forces an ip-address passed to [pyhomematic](https://github.com/danielperna84/pyhomematic). This made it practically impossible to get SSL certificate validation working. With the proposed changes the configured value for [host](https://www.home-assistant.io/components/homematic/#host) is passed to [pyhomematic](https://github.com/danielperna84/pyhomematic). If a user wants to pass an ip-address he is free to do.

Talking to @danielperna84 the maintainer of [pyhomematic](https://github.com/danielperna84/pyhomematic) he wasn't even aware of this. I would have renamed the key ```'id'``` to ```'host'``` but @danielperna84 said it's not worth the effort as [pyhomematic](https://github.com/danielperna84/pyhomematic) has to be adpted than as well.

This is my first pull request for Home Assistant so please bear with me if I have forgotten something.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_