### PR TITLE
Install deps and reqs early for config flows

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -706,6 +706,10 @@ class ConfigEntries:
             _LOGGER.error('Cannot find integration %s', handler_key)
             raise data_entry_flow.UnknownHandler
 
+        # Make sure requirements and dependencies of component are resolved
+        await async_process_deps_reqs(
+            self.hass, self._hass_config, integration)
+
         try:
             integration.get_component()
         except ImportError as err:
@@ -720,10 +724,6 @@ class ConfigEntries:
             raise data_entry_flow.UnknownHandler
 
         source = context['source']
-
-        # Make sure requirements and dependencies of component are resolved
-        await async_process_deps_reqs(
-            self.hass, self._hass_config, integration)
 
         # Create notification.
         if source in DISCOVERY_SOURCES:


### PR DESCRIPTION
## Description:
While writing up https://github.com/home-assistant/architecture/issues/201 I realized that we do not yet install requirements/dependencies before loading the component when starting a new config flow. This corrects it.

