### PR TITLE
WIP: Dynamic panels for Hass.io

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -14,7 +14,8 @@ from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.components.http.const import KEY_AUTHENTICATED
 from homeassistant.components import websocket_api
 from homeassistant.config import find_config_file, load_yaml_config_file
-from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
+from homeassistant.const import (
+    CONF_NAME, EVENT_THEMES_UPDATED, EVENT_PANELS_UPDATED)
 from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
@@ -173,6 +174,27 @@ async def async_register_built_in_panel(hass, component_name,
         hass.data[DATA_FINALIZE_PANEL](panel)
 
     panels[panel.frontend_url_path] = panel
+    hass.bus.async_fire(EVENT_PANELS_UPDATED, {
+        'action': 'added',
+        'url_path': panel.frontend_url_path
+    })
+
+
+@bind_hass
+@callback
+def remove_built_in_panel(hass, frontend_url_path):
+    """Remove a built-in panel."""
+    panels = hass.data.get(DATA_PANELS, {})
+
+    if frontend_url_path not in panels:
+        _LOGGER.warning("No panel with %s is registered", frontend_url_path)
+        return
+
+    panel = panels.pop(frontend_url_path)
+    hass.bus.async_fire(EVENT_PANELS_UPDATED, {
+        'action': 'removed',
+        'url_path': panel.frontend_url_path
+    })
 
 
 @bind_hass

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -175,6 +175,7 @@ EVENT_THEMES_UPDATED = 'themes_updated'
 EVENT_TIMER_OUT_OF_SYNC = 'timer_out_of_sync'
 EVENT_AUTOMATION_TRIGGERED = 'automation_triggered'
 EVENT_SCRIPT_STARTED = 'script_started'
+EVENT_PANELS_UPDATED = 'panels_updated'
 
 # #### DEVICE CLASSES ####
 DEVICE_CLASS_BATTERY = 'battery'

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
     DOMAIN, CONF_JS_VERSION, CONF_THEMES, CONF_EXTRA_HTML_URL,
-    CONF_EXTRA_HTML_URL_ES5)
+    CONF_EXTRA_HTML_URL_ES5, EVENT_PANELS_UPDATED)
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 
 from tests.common import mock_coro
@@ -342,3 +342,74 @@ async def test_auth_authorize(mock_http_client):
     assert str(resp.url.relative()) == (
         '/frontend_latest/authorize.html?latest&response_type=code&client_id='
         'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
+
+
+async def test_register_panels_event(hass):
+    """Test get_panels command."""
+    events = []
+    await async_setup_component(hass, 'frontend', {})
+
+    async def _catch_panel_updates(event):
+        """Catch panel updates event."""
+        events.append(event)
+
+    hass.bus.async_listen(EVENT_PANELS_UPDATED, _catch_panel_updates)
+
+    await hass.components.frontend.async_register_built_in_panel(
+        'map', 'Map', 'mdi:tooltip-account', require_admin=True)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[-1].event_type == EVENT_PANELS_UPDATED
+    assert events[-1].data == {'action': 'added', 'url_path': 'map'}
+
+
+async def test_remove_panels_event(hass, hass_ws_client):
+    """Test get_panels command."""
+    events = []
+    await async_setup_component(hass, 'frontend', {})
+
+    async def _catch_panel_updates(event):
+        """Catch panel updates event."""
+        events.append(event)
+
+    hass.bus.async_listen(EVENT_PANELS_UPDATED, _catch_panel_updates)
+
+    await hass.components.frontend.async_register_built_in_panel(
+        'map', 'Map', 'mdi:tooltip-account', require_admin=True)
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        'id': 5,
+        'type': 'get_panels',
+    })
+
+    msg = await client.receive_json()
+
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+    assert msg['result']['map']['component_name'] == 'map'
+    assert msg['result']['map']['url_path'] == 'map'
+    assert msg['result']['map']['icon'] == 'mdi:tooltip-account'
+    assert msg['result']['map']['title'] == 'Map'
+    assert msg['result']['map']['require_admin'] is True
+    assert len(events) == 1
+
+    hass.components.frontend.remove_built_in_panel('map')
+
+    await client.send_json({
+        'id': 6,
+        'type': 'get_panels',
+    })
+
+    msg = await client.receive_json()
+
+    assert msg['id'] == 6
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+    assert 'map' not in msg['result']
+
+    assert len(events) == 2
+    assert events[-1].event_type == EVENT_PANELS_UPDATED
+    assert events[-1].data == {'action': 'removed', 'url_path': 'map'}


### PR DESCRIPTION
## Description:

Allow Hass.io Add-ons with Ingress support to add panels on runtime to Navigation.

- [x] Frontend functions
- [x] Test for Frontend
- [ ] Hass.io component API function they called by the supervisor
- [ ] Tests for Hass.io component Home Assistant API