### PR TITLE
Fix empty components not having DOMAIN

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -51,11 +51,11 @@ CUSTOM_WARNING = (
 _UNDEF = object()
 
 
-def manifest_from_legacy_module(module: ModuleType) -> Dict:
+def manifest_from_legacy_module(domain: str, module: ModuleType) -> Dict:
     """Generate a manifest from a legacy module."""
     return {
-        'domain': module.DOMAIN,  # type: ignore
-        'name': module.DOMAIN,  # type: ignore
+        'domain': domain,
+        'name': domain,
         'documentation': None,
         'requirements': getattr(module, 'REQUIREMENTS', []),
         'dependencies': getattr(module, 'DEPENDENCIES', []),
@@ -106,7 +106,7 @@ class Integration:
 
         return cls(
             hass, comp.__name__, pathlib.Path(comp.__file__).parent,
-            manifest_from_legacy_module(comp)
+            manifest_from_legacy_module(domain, comp)
         )
 
     def __init__(self, hass: 'HomeAssistant', pkg_path: str,

--- a/tests/common.py
+++ b/tests/common.py
@@ -487,7 +487,7 @@ class MockModule:
     def mock_manifest(self):
         """Generate a mock manifest to represent this module."""
         return {
-            **loader.manifest_from_legacy_module(self),
+            **loader.manifest_from_legacy_module(self.DOMAIN, self),
             **(self._partial_manifest or {})
         }
 


### PR DESCRIPTION
## Description:
When a platform is loaded, we will now always load the component. We incorrectly assumed that when we load the component, there was a `DOMAIN` constant.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
