### PR TITLE
Add more CPU temp. labels to Glances

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -175,8 +175,9 @@ class GlancesSensor(Entity):
                 self._state = value['quicklook']['cpu']
             elif self.type == 'cpu_temp':
                 for sensor in value['sensors']:
-                    if sensor['label'] in ['CPU', "Package id 0",
-                                           "Physical id 0", "cpu-thermal 1",
+                    if sensor['label'] in ['CPU', "CPU Temperature",
+                                           "Package id 0", "Physical id 0",
+                                           "cpu_thermal 1", "cpu-thermal 1",
                                            "exynos-therm 1", "soc_thermal 1"]:
                         self._state = sensor['value']
             elif self.type == 'docker_active':


### PR DESCRIPTION
## Description:
Add more CPU temperature labels to Glances.

* On my Raspberry Pi 3's, running Aarch64 Arch Linux, the label is `cpu_thermal 1` (this is different from the other one, `cpu-thermal 1`, dash vs underscore...)
* On my main server, `CPU Temperature` is actually exposed.

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: glances
    host: localhost
    version: 3
    resources: [ cpu_temp ]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
