### PR TITLE
Potential None

### DIFF
--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -31,6 +31,6 @@ async def async_trigger(hass, config, action, automation_info):
                 'from_state': from_s,
                 'to_state': to_s,
             },
-        }, context=to_s.context))
+        }, context=(to_s.context if to_s else None)))
 
     return async_track_template(hass, value_template, template_listener)


### PR DESCRIPTION
## Description:

Minor bugfix. Line of code fixed has potential for target state to be None when state is being deleted and an exception would happen.

In this case it's not unreasonable to not pass the context because that will be a system event anyhow. This will be fixed anyhow as part of #22587 anyhow.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
