### PR TITLE
Misc. ZHA changes

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -167,6 +167,11 @@ class ZigbeeChannel:
 
     async def async_initialize(self, from_cache):
         """Initialize channel."""
+        _LOGGER.debug(
+            'initializing channel: %s from_cache: %s',
+            self._channel_name,
+            from_cache
+        )
         self._status = ChannelStatus.INITIALIZED
 
     @callback

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/zha/
 import logging
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_call_later
 from . import ZigbeeChannel, parse_and_log_command, MAINS_POWERED
 from ..helpers import get_attr_id_by_name
 from ..const import (
@@ -40,10 +41,27 @@ class OnOffChannel(ZigbeeChannel):
 
         if cmd in ('off', 'off_with_effect'):
             self.attribute_updated(self.ON_OFF, False)
-        elif cmd in ('on', 'on_with_recall_global_scene', 'on_with_timed_off'):
+        elif cmd in ('on', 'on_with_recall_global_scene'):
             self.attribute_updated(self.ON_OFF, True)
+        elif cmd == 'on_with_timed_off':
+            should_accept = args[0]
+            off_time = args[2]
+            # 0 is always accept 1 is only accept when already on
+            if should_accept == 0 or (should_accept == 1 and self._state):
+                self.attribute_updated(self.ON_OFF, True)
+                if off_time > 0:
+                    async_call_later(
+                        self.device.hass,
+                        (off_time / 10),  # value is in 10ths of a second
+                        self.set_to_off
+                    )
         elif cmd == 'toggle':
             self.attribute_updated(self.ON_OFF, not bool(self._state))
+
+    @callback
+    def set_to_off(self, *_):
+        """Set the state to off."""
+        self.attribute_updated(self.ON_OFF, False)
 
     @callback
     def attribute_updated(self, attrid, value):

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -45,14 +45,14 @@ class OnOffChannel(ZigbeeChannel):
             self.attribute_updated(self.ON_OFF, True)
         elif cmd == 'on_with_timed_off':
             should_accept = args[0]
-            off_time = args[2]
+            on_time = args[1]
             # 0 is always accept 1 is only accept when already on
             if should_accept == 0 or (should_accept == 1 and self._state):
                 self.attribute_updated(self.ON_OFF, True)
-                if off_time > 0:
+                if on_time > 0:
                     async_call_later(
                         self.device.hass,
-                        (off_time / 10),  # value is in 10ths of a second
+                        (on_time / 10),  # value is in 10ths of a second
                         self.set_to_off
                     )
         elif cmd == 'toggle':

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -269,8 +269,9 @@ class ZHADevice:
         for channel in channels:
             if channel.name == ZDO_CHANNEL:
                 # pylint: disable=E1111
-                zdo_task = self._async_create_task(
-                    semaphore, channel, task_name, *args)
+                if zdo_task is None:  # We only want to do this once
+                    zdo_task = self._async_create_task(
+                        semaphore, channel, task_name, *args)
             else:
                 channel_tasks.append(
                     self._async_create_task(

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -259,40 +259,25 @@ class ZHAGateway:
         """Handle device joined and basic information discovered (async)."""
         zha_device = self._async_get_or_create_device(device, is_new_join)
 
-        if zha_device.status is DeviceStatus.INITIALIZED:
+        is_rejoin = False
+        if zha_device.status is not DeviceStatus.INITIALIZED:
+            discovery_infos = []
+            for endpoint_id, endpoint in device.endpoints.items():
+                async_process_endpoint(
+                    self._hass, self._config, endpoint_id, endpoint,
+                    discovery_infos, device, zha_device, is_new_join
+                )
+                if endpoint_id != 0:
+                    for cluster in endpoint.in_clusters.values():
+                        cluster.bind_only = False
+                    for cluster in endpoint.out_clusters.values():
+                        cluster.bind_only = True
+        else:
+            is_rejoin = is_new_join is True
             _LOGGER.debug(
-                'skipping discovery for previously paired device: %s',
-                zha_device.ieee
+                'skipping discovery for previously discovered device: %s',
+                "{} - is rejoin: {}".format(zha_device.ieee, is_rejoin)
             )
-            # still get fresh state
-            _LOGGER.debug(
-                'refreshing state for previously paired device: %s',
-                zha_device.ieee
-            )
-            await zha_device.async_initialize(from_cache=False)
-            # still push the device details to the front end add device panel
-            device_info = async_get_device_info(self._hass, zha_device)
-            async_dispatcher_send(
-                self._hass,
-                ZHA_GW_MSG,
-                {
-                    TYPE: DEVICE_FULL_INIT,
-                    DEVICE_INFO: device_info
-                }
-            )
-            return None  # Guard against reinitializing an initialized device
-
-        discovery_infos = []
-        for endpoint_id, endpoint in device.endpoints.items():
-            async_process_endpoint(
-                self._hass, self._config, endpoint_id, endpoint,
-                discovery_infos, device, zha_device, is_new_join
-            )
-            if endpoint_id != 0:
-                for cluster in endpoint.in_clusters.values():
-                    cluster.bind_only = False
-                for cluster in endpoint.out_clusters.values():
-                    cluster.bind_only = True
 
         if is_new_join:
             # configure the device
@@ -313,15 +298,16 @@ class ZHAGateway:
         else:
             await zha_device.async_initialize(from_cache=True)
 
-        for discovery_info in discovery_infos:
-            async_dispatch_discovery_info(
-                self._hass,
-                is_new_join,
-                discovery_info
-            )
+        if not is_rejoin:
+            for discovery_info in discovery_infos:
+                async_dispatch_discovery_info(
+                    self._hass,
+                    is_new_join,
+                    discovery_info
+                )
 
-        device_entity = async_create_device_entity(zha_device)
-        await self._component.async_add_entities([device_entity])
+            device_entity = async_create_device_entity(zha_device)
+            await self._component.async_add_entities([device_entity])
 
         if is_new_join:
             device_info = async_get_device_info(self._hass, zha_device)


### PR DESCRIPTION
## Description:
This PR implements on with timed off and it also cleans up the configuration phase for ZCL clusters to ensure we don't pass the same cluster through configuration multiple times. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.