### PR TITLE
Don't load component when fetching translations

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -52,11 +52,9 @@ async def component_translation_file(hass: HomeAssistantType, component: str,
         filename = "{}.{}.json".format(parts[0], language)
         return str(integration.file_path / '.translations' / filename)
 
-    module = integration.get_component()
-
     # If it's a component that is just one file, we don't support translations
     # Example custom_components/my_component.py
-    if module.__name__ != module.__package__:
+    if integration.file_path.name != domain:
         return None
 
     filename = '{}.json'.format(language)


### PR DESCRIPTION
## Description:
Loading translations would load all the integrations component files, resulting in an error for Hue, since Hue imports its requirements at the top.

Fix issue reported by @VDRainer on Discord.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
