### PR TITLE
Fix clearing error message for MQTT vacuum

### DIFF
--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -313,7 +313,7 @@ class MqttVacuum(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 error = self._templates[CONF_ERROR_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         msg.payload, error_value=None)
-                if error:
+                if error is not None:
                     self._error = cv.string(error)
 
             if self._docked:

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -298,7 +298,6 @@ async def test_status_error(hass, mock_publish):
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert 'Error: Error1' == state.attributes.get(ATTR_STATUS)
 
@@ -306,7 +305,6 @@ async def test_status_error(hass, mock_publish):
         "error": ""
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert 'Stopped' == state.attributes.get(ATTR_STATUS)

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -302,6 +302,15 @@ async def test_status_error(hass, mock_publish):
     state = hass.states.get('vacuum.mqtttest')
     assert 'Error: Error1' == state.attributes.get(ATTR_STATUS)
 
+    message = """{
+        "error": ""
+    }"""
+    async_fire_mqtt_message(hass, 'vacuum/state', message)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    state = hass.states.get('vacuum.mqtttest')
+    assert 'Stopped' == state.attributes.get(ATTR_STATUS)
+
 
 async def test_battery_template(hass, mock_publish):
     """Test that you can use non-default templates for battery_level."""


### PR DESCRIPTION
## Description:
Tweak handling of error message to make it possible to clear the error.

**Related issue (if applicable):** fixes #19643

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.