### PR TITLE
Fix returned info for ZHA bindable devices API call

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -351,10 +351,11 @@ async def websocket_get_bindable_devices(hass, connection, msg):
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     source_ieee = msg[ATTR_IEEE]
     source_device = zha_gateway.get_device(source_ieee)
+    ha_device_registry = await async_get_registry(hass)
     devices = [
-        {
-            **device.device_info
-        } for device in zha_gateway.devices.values() if
+        async_get_device_info(
+            hass, device, ha_device_registry=ha_device_registry
+        ) for device in zha_gateway.devices.values() if
         async_is_bindable_target(source_device, device)
     ]
 


### PR DESCRIPTION
## Description:

This PR corrects an issue where we weren't returning the all of the device info for bindable devices.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.