### PR TITLE
Add support for flow sensor metrics in RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -8,9 +8,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from . import (
     BINARY_SENSORS, DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN,
     OPERATION_RESTRICTIONS_CURRENT, OPERATION_RESTRICTIONS_UNIVERSAL,
-    SENSOR_UPDATE_TOPIC, TYPE_FREEZE, TYPE_FREEZE_PROTECTION, TYPE_HOT_DAYS,
-    TYPE_HOURLY, TYPE_MONTH, TYPE_RAINDELAY, TYPE_RAINSENSOR, TYPE_WEEKDAY,
-    RainMachineEntity)
+    SENSOR_UPDATE_TOPIC, TYPE_FLOW_SENSOR, TYPE_FREEZE, TYPE_FREEZE_PROTECTION,
+    TYPE_HOT_DAYS, TYPE_HOURLY, TYPE_MONTH, TYPE_RAINDELAY, TYPE_RAINSENSOR,
+    TYPE_WEEKDAY, RainMachineEntity)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,6 +79,9 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
 
     async def async_update(self):
         """Update the state."""
+        if self._sensor_type == TYPE_FREEZE:
+            self._state = self.rainmachine.data[
+                OPERATION_RESTRICTIONS_CURRENT]['freeze']
         if self._sensor_type == TYPE_FREEZE:
             self._state = self.rainmachine.data[
                 OPERATION_RESTRICTIONS_CURRENT]['freeze']

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import (
     BINARY_SENSORS, DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN,
-    OPERATION_RESTRICTIONS_CURRENT, OPERATION_RESTRICTIONS_UNIVERSAL,
+    PROVISION_SETTINGS, RESTRICTIONS_CURRENT, RESTRICTIONS_UNIVERSAL,
     SENSOR_UPDATE_TOPIC, TYPE_FLOW_SENSOR, TYPE_FREEZE, TYPE_FREEZE_PROTECTION,
     TYPE_HOT_DAYS, TYPE_HOURLY, TYPE_MONTH, TYPE_RAINDELAY, TYPE_RAINSENSOR,
     TYPE_WEEKDAY, RainMachineEntity)
@@ -79,30 +79,27 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
 
     async def async_update(self):
         """Update the state."""
-        if self._sensor_type == TYPE_FREEZE:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_CURRENT]['freeze']
-        if self._sensor_type == TYPE_FREEZE:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_CURRENT]['freeze']
+        if self._sensor_type == TYPE_FLOW_SENSOR:
+            self._state = self.rainmachine.data[PROVISION_SETTINGS].get(
+                'useFlowSensor')
+        elif self._sensor_type == TYPE_FREEZE:
+            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]['freeze']
         elif self._sensor_type == TYPE_FREEZE_PROTECTION:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_UNIVERSAL]['freezeProtectEnabled']
+            self._state = self.rainmachine.data[RESTRICTIONS_UNIVERSAL][
+                'freezeProtectEnabled']
         elif self._sensor_type == TYPE_HOT_DAYS:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_UNIVERSAL]['hotDaysExtraWatering']
+            self._state = self.rainmachine.data[RESTRICTIONS_UNIVERSAL][
+                'hotDaysExtraWatering']
         elif self._sensor_type == TYPE_HOURLY:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_CURRENT]['hourly']
+            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]['hourly']
         elif self._sensor_type == TYPE_MONTH:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_CURRENT]['month']
+            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT]['month']
         elif self._sensor_type == TYPE_RAINDELAY:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_CURRENT]['rainDelay']
+            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT][
+                'rainDelay']
         elif self._sensor_type == TYPE_RAINSENSOR:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_CURRENT]['rainSensor']
+            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT][
+                'rainSensor']
         elif self._sensor_type == TYPE_WEEKDAY:
-            self._state = self.rainmachine.data[
-                OPERATION_RESTRICTIONS_CURRENT]['weekDay']
+            self._state = self.rainmachine.data[RESTRICTIONS_CURRENT][
+                'weekDay']

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -12,7 +12,8 @@ DEFAULT_PORT = 8080
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 DEFAULT_SSL = True
 
-OPERATION_RESTRICTIONS_CURRENT = 'restrictions.current'
-OPERATION_RESTRICTIONS_UNIVERSAL = 'restrictions.universal'
+PROVISION_SETTINGS = 'provision.settings'
+RESTRICTIONS_CURRENT = 'restrictions.current'
+RESTRICTIONS_UNIVERSAL = 'restrictions.universal'
 
 TOPIC_UPDATE = 'update_{0}'


### PR DESCRIPTION
## Description:

This PR adds the following sensors to RainMachine:

* `flow_sensor`
* `flow_sensor_clicks_cubic_meter`
* `flow_sensor_consumed_liters`
* `flow_sensor_start_index`
* `flow_sensor_watering_clicks`

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9250

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_ip
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_