### PR TITLE
Only comment with changed coverage on release PRs [skip-ci]

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,3 +13,4 @@ coverage:
         url: "secret:TgWDUM4Jw0w7wMJxuxNF/yhSOHglIo1fGwInJnRLEVPy2P2aLimkoK1mtKCowH5TFw+baUXVXT3eAqefbdvIuM8BjRR4aRji95C6CYyD0QHy4N8i7nn1SQkWDPpS8IthYTg07rUDF7s5guurkKv2RrgoCdnnqjAMSzHoExMOF7xUmblMdhBTWJgBpWEhASJy85w/xxjlsE1xoTkzeJu9Q67pTXtRcn+5kb5/vIzPSYg="
 comment:
   require_changes: yes
+  branches: master


### PR DESCRIPTION
## Description:
Limit code cov comments when the PR is aimed at the master branch. That way we still get the comments on the release PRs.

