### PR TITLE
Add missing service for persistent_notification

### DIFF
--- a/homeassistant/components/persistent_notification/services.yaml
+++ b/homeassistant/components/persistent_notification/services.yaml
@@ -17,3 +17,10 @@ dismiss:
     notification_id:
       description: Target ID of the notification, which should be removed. [Required]
       example: 1234
+      
+mark_read:
+  description: Mark a notification read.
+  fields:
+    notification_id:
+      description: Target ID of the notification, which should be mark read. [Required]
+      example: 1234


### PR DESCRIPTION
## Description:
Add missing mark_read service for persistent_notification

**Related issue (if applicable):** #23197
