### PR TITLE
Fix ESPHome setup errors in beta

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -149,7 +149,8 @@ class RuntimeEntryData:
 
 
 def _attr_obj_from_dict(cls, **kwargs):
-    return cls(**{key: kwargs[key] for key in attr.fields_dict(cls)})
+    return cls(**{key: kwargs[key] for key in attr.fields_dict(cls)
+                  if key in kwargs})
 
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "documentation": "https://www.home-assistant.io/components/esphome",
   "requirements": [
-    "aioesphomeapi==2.0.0"
+    "aioesphomeapi==2.0.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -115,7 +115,7 @@ aiobotocore==0.10.2
 aiodns==1.1.1
 
 # homeassistant.components.esphome
-aioesphomeapi==2.0.0
+aioesphomeapi==2.0.1
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.8


### PR DESCRIPTION
## Description:

Model migration resulted in that error. Ultimately each model in aioesphomeapi will need to have dedicated serialize/deserialize methods, this is only a quick fix that solves the issue.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/23214

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
