### PR TITLE
Drop unnecessary block_till_done for MQTT Lock tests

### DIFF
--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -32,14 +32,11 @@ async def test_controlling_state_via_topic(hass, mqtt_mock):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, 'state-topic', 'LOCK')
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is STATE_LOCKED
 
     async_fire_mqtt_message(hass, 'state-topic', 'UNLOCK')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is STATE_UNLOCKED
@@ -63,14 +60,11 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock):
     assert state.state is STATE_UNLOCKED
 
     async_fire_mqtt_message(hass, 'state-topic', '{"val":"LOCK"}')
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is STATE_LOCKED
 
     async_fire_mqtt_message(hass, 'state-topic', '{"val":"UNLOCK"}')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is STATE_UNLOCKED
@@ -170,14 +164,11 @@ async def test_default_availability_payload(hass, mqtt_mock):
     assert state.state is STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'online')
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is not STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'offline')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is STATE_UNAVAILABLE
@@ -203,14 +194,11 @@ async def test_custom_availability_payload(hass, mqtt_mock):
     assert state.state is STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'good')
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is not STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'nogood')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.state is STATE_UNAVAILABLE
@@ -228,7 +216,6 @@ async def test_setting_attribute_via_mqtt_json_message(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '{ "val": "100" }')
-    await hass.async_block_till_done()
     state = hass.states.get('lock.test')
 
     assert '100' == state.attributes.get('val')
@@ -246,7 +233,6 @@ async def test_update_with_json_attrs_not_dict(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '[ "list", "of", "things"]')
-    await hass.async_block_till_done()
     state = hass.states.get('lock.test')
 
     assert state.attributes.get('val') is None
@@ -265,7 +251,6 @@ async def test_update_with_json_attrs_bad_JSON(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', 'This is not JSON')
-    await hass.async_block_till_done()
 
     state = hass.states.get('lock.test')
     assert state.attributes.get('val') is None
@@ -290,8 +275,6 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
                             data1)
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "100" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('lock.beer')
     assert '100' == state.attributes.get('val')
 
@@ -299,19 +282,14 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     # Verify we are no longer subscribing to the old topic
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "50" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('lock.beer')
     assert '100' == state.attributes.get('val')
 
     # Verify we are subscribing to the new topic
     async_fire_mqtt_message(hass, 'attr-topic2', '{ "val": "75" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('lock.beer')
     assert '75' == state.attributes.get('val')
 
@@ -335,7 +313,6 @@ async def test_unique_id(hass):
         }]
     })
     async_fire_mqtt_message(hass, 'test-topic', 'payload')
-    await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(lock.DOMAIN)) == 1
 
 
@@ -355,7 +332,6 @@ async def test_discovery_removal_lock(hass, mqtt_mock, caplog):
     assert state.name == 'Beer'
     async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
                             '')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get('lock.beer')
     assert state is None
@@ -383,7 +359,6 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
                             data2)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('lock.milk')
@@ -417,7 +392,6 @@ async def test_discovery_update_lock(hass, mqtt_mock, caplog):
     assert state.name == 'Beer'
     async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
                             data2)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get('lock.beer')
     assert state is not None
@@ -453,7 +427,6 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     })
     async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -495,7 +468,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
                             data)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
     assert device is not None
@@ -505,7 +477,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     data = json.dumps(config)
     async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -536,7 +507,6 @@ async def test_entity_id_update(hass, mqtt_mock):
     mock_mqtt.async_subscribe.reset_mock()
 
     registry.async_update_entity('lock.beer', new_entity_id='lock.milk')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('lock.beer')


### PR DESCRIPTION
## Description:
Drop unnecessary block_till_done, improve tests for MQTT Lock tests

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
