### PR TITLE
Drop unnecessary block_till_done, improve tests for MQTT sensor tests

### DIFF
--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -1,7 +1,6 @@
 """The tests for the MQTT sensor platform."""
 from datetime import datetime, timedelta
 import json
-import unittest
 from unittest.mock import ANY, patch
 
 from homeassistant.components import mqtt
@@ -9,361 +8,340 @@ from homeassistant.components.mqtt.discovery import async_start
 import homeassistant.components.sensor as sensor
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
 import homeassistant.core as ha
-from homeassistant.setup import async_setup_component, setup_component
+from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    MockConfigEntry, assert_setup_component, async_fire_mqtt_message,
-    async_mock_mqtt_component, fire_mqtt_message, get_test_home_assistant,
-    mock_component, mock_mqtt_component, mock_registry)
+    MockConfigEntry, async_fire_mqtt_message, async_mock_mqtt_component,
+    async_fire_time_changed, mock_registry)
 
 
-class TestSensorMQTT(unittest.TestCase):
-    """Test the MQTT sensor."""
+async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
+    """Test the setting of the value via MQTT."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit'
+        }
+    })
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        mock_mqtt_component(self.hass)
+    async_fire_mqtt_message(hass, 'test-topic', '100')
+    state = hass.states.get('sensor.test')
 
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop down everything that was started."""
-        self.hass.stop()
+    assert '100' == state.state
+    assert 'fav unit' == \
+        state.attributes.get('unit_of_measurement')
 
-    def test_setting_sensor_value_via_mqtt_message(self):
-        """Test the setting of the value via MQTT."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit'
-            }
-        })
 
-        fire_mqtt_message(self.hass, 'test-topic', '100')
-        self.hass.block_till_done()
-        state = self.hass.states.get('sensor.test')
+async def test_setting_sensor_value_expires(hass, mqtt_mock, caplog):
+    """Test the expiration of the value."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit',
+            'expire_after': '4',
+            'force_update': True
+        }
+    })
 
-        assert '100' == state.state
-        assert 'fav unit' == \
-            state.attributes.get('unit_of_measurement')
+    state = hass.states.get('sensor.test')
+    assert 'unknown' == state.state
 
-    @patch('homeassistant.core.dt_util.utcnow')
-    def test_setting_sensor_value_expires(self, mock_utcnow):
-        """Test the expiration of the value."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit',
-                'expire_after': '4',
-                'force_update': True
-            }
-        })
+    now = datetime(2017, 1, 1, 1, tzinfo=dt_util.UTC)
+    with patch(('homeassistant.helpers.event.'
+                'dt_util.utcnow'), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(hass, 'test-topic', '100')
+        await hass.async_block_till_done()
 
-        state = self.hass.states.get('sensor.test')
-        assert 'unknown' == state.state
+    # Value was set correctly.
+    state = hass.states.get('sensor.test')
+    assert '100' == state.state
 
-        now = datetime(2017, 1, 1, 1, tzinfo=dt_util.UTC)
-        mock_utcnow.return_value = now
-        fire_mqtt_message(self.hass, 'test-topic', '100')
-        self.hass.block_till_done()
+    # Time jump +3s
+    now = now + timedelta(seconds=3)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
 
-        # Value was set correctly.
-        state = self.hass.states.get('sensor.test')
-        assert '100' == state.state
+    # Value is not yet expired
+    state = hass.states.get('sensor.test')
+    assert '100' == state.state
 
-        # Time jump +3s
-        now = now + timedelta(seconds=3)
-        self._send_time_changed(now)
-        self.hass.block_till_done()
+    # Next message resets timer
+    with patch(('homeassistant.helpers.event.'
+                'dt_util.utcnow'), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(hass, 'test-topic', '101')
+        await hass.async_block_till_done()
 
-        # Value is not yet expired
-        state = self.hass.states.get('sensor.test')
-        assert '100' == state.state
+    # Value was updated correctly.
+    state = hass.states.get('sensor.test')
+    assert '101' == state.state
 
-        # Next message resets timer
-        mock_utcnow.return_value = now
-        fire_mqtt_message(self.hass, 'test-topic', '101')
-        self.hass.block_till_done()
+    # Time jump +3s
+    now = now + timedelta(seconds=3)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
 
-        # Value was updated correctly.
-        state = self.hass.states.get('sensor.test')
-        assert '101' == state.state
+    # Value is not yet expired
+    state = hass.states.get('sensor.test')
+    assert '101' == state.state
 
-        # Time jump +3s
-        now = now + timedelta(seconds=3)
-        self._send_time_changed(now)
-        self.hass.block_till_done()
+    # Time jump +2s
+    now = now + timedelta(seconds=2)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
 
-        # Value is not yet expired
-        state = self.hass.states.get('sensor.test')
-        assert '101' == state.state
+    # Value is expired now
+    state = hass.states.get('sensor.test')
+    assert 'unknown' == state.state
 
-        # Time jump +2s
-        now = now + timedelta(seconds=2)
-        self._send_time_changed(now)
-        self.hass.block_till_done()
 
-        # Value is expired now
-        state = self.hass.states.get('sensor.test')
-        assert 'unknown' == state.state
+async def test_setting_sensor_value_via_mqtt_json_message(hass, mqtt_mock):
+    """Test the setting of the value via MQTT with JSON payload."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit',
+            'value_template': '{{ value_json.val }}'
+        }
+    })
 
-    def test_setting_sensor_value_via_mqtt_json_message(self):
-        """Test the setting of the value via MQTT with JSON payload."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit',
-                'value_template': '{{ value_json.val }}'
-            }
-        })
+    async_fire_mqtt_message(hass, 'test-topic', '{ "val": "100" }')
+    state = hass.states.get('sensor.test')
 
-        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
-        self.hass.block_till_done()
-        state = self.hass.states.get('sensor.test')
+    assert '100' == state.state
 
-        assert '100' == state.state
 
-    def test_force_update_disabled(self):
-        """Test force update option."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit'
-            }
-        })
+async def test_force_update_disabled(hass, mqtt_mock):
+    """Test force update option."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit'
+        }
+    })
 
-        events = []
+    events = []
 
-        @ha.callback
-        def callback(event):
-            events.append(event)
+    @ha.callback
+    def callback(event):
+        events.append(event)
 
-        self.hass.bus.listen(EVENT_STATE_CHANGED, callback)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
 
-        fire_mqtt_message(self.hass, 'test-topic', '100')
-        self.hass.block_till_done()
-        assert 1 == len(events)
+    async_fire_mqtt_message(hass, 'test-topic', '100')
+    await hass.async_block_till_done()
+    assert 1 == len(events)
 
-        fire_mqtt_message(self.hass, 'test-topic', '100')
-        self.hass.block_till_done()
-        assert 1 == len(events)
+    async_fire_mqtt_message(hass, 'test-topic', '100')
+    await hass.async_block_till_done()
+    assert 1 == len(events)
 
-    def test_force_update_enabled(self):
-        """Test force update option."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit',
-                'force_update': True
-            }
-        })
 
-        events = []
+async def test_force_update_enabled(hass, mqtt_mock):
+    """Test force update option."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit',
+            'force_update': True
+        }
+    })
 
-        @ha.callback
-        def callback(event):
-            events.append(event)
+    events = []
 
-        self.hass.bus.listen(EVENT_STATE_CHANGED, callback)
+    @ha.callback
+    def callback(event):
+        events.append(event)
 
-        fire_mqtt_message(self.hass, 'test-topic', '100')
-        self.hass.block_till_done()
-        assert 1 == len(events)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
 
-        fire_mqtt_message(self.hass, 'test-topic', '100')
-        self.hass.block_till_done()
-        assert 2 == len(events)
+    async_fire_mqtt_message(hass, 'test-topic', '100')
+    await hass.async_block_till_done()
+    assert 1 == len(events)
 
-    def test_default_availability_payload(self):
-        """Test availability by default payload with defined topic."""
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'availability_topic': 'availability-topic'
-            }
-        })
+    async_fire_mqtt_message(hass, 'test-topic', '100')
+    await hass.async_block_till_done()
+    assert 2 == len(events)
 
-        state = self.hass.states.get('sensor.test')
-        assert STATE_UNAVAILABLE == state.state
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'online')
-        self.hass.block_till_done()
+async def test_default_availability_payload(hass, mqtt_mock):
+    """Test availability by default payload with defined topic."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'availability_topic': 'availability-topic'
+        }
+    })
 
-        state = self.hass.states.get('sensor.test')
-        assert STATE_UNAVAILABLE != state.state
+    state = hass.states.get('sensor.test')
+    assert STATE_UNAVAILABLE == state.state
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
-        self.hass.block_till_done()
+    async_fire_mqtt_message(hass, 'availability-topic', 'online')
 
-        state = self.hass.states.get('sensor.test')
-        assert STATE_UNAVAILABLE == state.state
+    state = hass.states.get('sensor.test')
+    assert STATE_UNAVAILABLE != state.state
 
-    def test_custom_availability_payload(self):
-        """Test availability by custom payload with defined topic."""
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'availability_topic': 'availability-topic',
-                'payload_available': 'good',
-                'payload_not_available': 'nogood'
-            }
-        })
+    async_fire_mqtt_message(hass, 'availability-topic', 'offline')
 
-        state = self.hass.states.get('sensor.test')
-        assert STATE_UNAVAILABLE == state.state
+    state = hass.states.get('sensor.test')
+    assert STATE_UNAVAILABLE == state.state
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'good')
-        self.hass.block_till_done()
 
-        state = self.hass.states.get('sensor.test')
-        assert STATE_UNAVAILABLE != state.state
+async def test_custom_availability_payload(hass, mqtt_mock):
+    """Test availability by custom payload with defined topic."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'availability_topic': 'availability-topic',
+            'payload_available': 'good',
+            'payload_not_available': 'nogood'
+        }
+    })
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'nogood')
-        self.hass.block_till_done()
+    state = hass.states.get('sensor.test')
+    assert STATE_UNAVAILABLE == state.state
 
-        state = self.hass.states.get('sensor.test')
-        assert STATE_UNAVAILABLE == state.state
+    async_fire_mqtt_message(hass, 'availability-topic', 'good')
 
-    def _send_time_changed(self, now):
-        """Send a time changed event."""
-        self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})
+    state = hass.states.get('sensor.test')
+    assert STATE_UNAVAILABLE != state.state
 
-    def test_setting_sensor_attribute_via_mqtt_json_message(self):
-        """Test the setting of attribute via MQTT with JSON payload."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit',
-                'json_attributes': 'val'
-            }
-        })
+    async_fire_mqtt_message(hass, 'availability-topic', 'nogood')
 
-        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
-        self.hass.block_till_done()
-        state = self.hass.states.get('sensor.test')
+    state = hass.states.get('sensor.test')
+    assert STATE_UNAVAILABLE == state.state
 
-        assert '100' == \
-            state.attributes.get('val')
 
-    @patch('homeassistant.components.mqtt.sensor._LOGGER')
-    def test_update_with_json_attrs_not_dict(self, mock_logger):
-        """Test attributes get extracted from a JSON result."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit',
-                'json_attributes': 'val'
-            }
-        })
+async def test_setting_sensor_attribute_via_legacy_mqtt_json_message(
+        hass, mqtt_mock):
+    """Test the setting of attribute via MQTT with JSON payload."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit',
+            'json_attributes': 'val'
+        }
+    })
 
-        fire_mqtt_message(self.hass, 'test-topic', '[ "list", "of", "things"]')
-        self.hass.block_till_done()
-        state = self.hass.states.get('sensor.test')
+    async_fire_mqtt_message(hass, 'test-topic', '{ "val": "100" }')
+    state = hass.states.get('sensor.test')
 
-        assert state.attributes.get('val') is None
-        assert mock_logger.warning.called
+    assert '100' == \
+        state.attributes.get('val')
 
-    @patch('homeassistant.components.mqtt.sensor._LOGGER')
-    def test_update_with_json_attrs_bad_JSON(self, mock_logger):
-        """Test attributes get extracted from a JSON result."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit',
-                'json_attributes': 'val'
-            }
-        })
 
-        fire_mqtt_message(self.hass, 'test-topic', 'This is not JSON')
-        self.hass.block_till_done()
+async def test_update_with_legacy_json_attrs_not_dict(hass, mqtt_mock, caplog):
+    """Test attributes get extracted from a JSON result."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit',
+            'json_attributes': 'val'
+        }
+    })
 
-        state = self.hass.states.get('sensor.test')
-        assert state.attributes.get('val') is None
-        assert mock_logger.warning.called
-        assert mock_logger.debug.called
+    async_fire_mqtt_message(hass, 'test-topic', '[ "list", "of", "things"]')
+    state = hass.states.get('sensor.test')
 
-    def test_update_with_json_attrs_and_template(self):
-        """Test attributes get extracted from a JSON result."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, sensor.DOMAIN, {
-            sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'unit_of_measurement': 'fav unit',
-                'value_template': '{{ value_json.val }}',
-                'json_attributes': 'val'
-            }
-        })
+    assert state.attributes.get('val') is None
+    assert 'JSON result was not a dictionary' in caplog.text
 
-        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
-        self.hass.block_till_done()
-        state = self.hass.states.get('sensor.test')
 
-        assert '100' == \
-            state.attributes.get('val')
-        assert '100' == state.state
+async def test_update_with_legacy_json_attrs_bad_JSON(hass, mqtt_mock, caplog):
+    """Test attributes get extracted from a JSON result."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit',
+            'json_attributes': 'val'
+        }
+    })
 
-    def test_invalid_device_class(self):
-        """Test device_class option with invalid value."""
-        with assert_setup_component(0):
-            assert setup_component(self.hass, 'sensor', {
-                'sensor': {
-                    'platform': 'mqtt',
-                    'name': 'Test 1',
-                    'state_topic': 'test-topic',
-                    'device_class': 'foobarnotreal'
-                }
-            })
+    async_fire_mqtt_message(hass, 'test-topic', 'This is not JSON')
 
-    def test_valid_device_class(self):
-        """Test device_class option with valid values."""
-        assert setup_component(self.hass, 'sensor', {
-            'sensor': [{
-                'platform': 'mqtt',
-                'name': 'Test 1',
-                'state_topic': 'test-topic',
-                'device_class': 'temperature'
-            }, {
-                'platform': 'mqtt',
-                'name': 'Test 2',
-                'state_topic': 'test-topic',
-            }]
-        })
-        self.hass.block_till_done()
+    state = hass.states.get('sensor.test')
+    assert state.attributes.get('val') is None
+    assert 'Erroneous JSON: This is not JSON' in caplog.text
 
-        state = self.hass.states.get('sensor.test_1')
-        assert state.attributes['device_class'] == 'temperature'
-        state = self.hass.states.get('sensor.test_2')
-        assert 'device_class' not in state.attributes
+
+async def test_update_with_legacy_json_attrs_and_template(hass, mqtt_mock):
+    """Test attributes get extracted from a JSON result."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'unit_of_measurement': 'fav unit',
+            'value_template': '{{ value_json.val }}',
+            'json_attributes': 'val'
+        }
+    })
+
+    async_fire_mqtt_message(hass, 'test-topic', '{ "val": "100" }')
+    state = hass.states.get('sensor.test')
+
+    assert '100' == \
+        state.attributes.get('val')
+    assert '100' == state.state
+
+
+async def test_invalid_device_class(hass, mqtt_mock):
+    """Test device_class option with invalid value."""
+    assert await async_setup_component(hass, sensor.DOMAIN, {
+        sensor.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'test-topic',
+            'device_class': 'foobarnotreal'
+        }
+    })
+
+    state = hass.states.get('sensor.test')
+    assert state is None
+
+
+async def test_valid_device_class(hass, mqtt_mock):
+    """Test device_class option with valid values."""
+    assert await async_setup_component(hass, 'sensor', {
+        'sensor': [{
+            'platform': 'mqtt',
+            'name': 'Test 1',
+            'state_topic': 'test-topic',
+            'device_class': 'temperature'
+        }, {
+            'platform': 'mqtt',
+            'name': 'Test 2',
+            'state_topic': 'test-topic',
+        }]
+    })
+    await hass.async_block_till_done()
+
+    state = hass.states.get('sensor.test_1')
+    assert state.attributes['device_class'] == 'temperature'
+    state = hass.states.get('sensor.test_2')
+    assert 'device_class' not in state.attributes
 
 
 async def test_setting_attribute_via_mqtt_json_message(hass, mqtt_mock):
@@ -378,7 +356,6 @@ async def test_setting_attribute_via_mqtt_json_message(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '{ "val": "100" }')
-    await hass.async_block_till_done()
     state = hass.states.get('sensor.test')
 
     assert '100' == state.attributes.get('val')
@@ -398,7 +375,6 @@ async def test_setting_attribute_with_template(hass, mqtt_mock):
 
     async_fire_mqtt_message(hass, 'attr-topic', json.dumps(
         {"Timer1": {"Arm": 0, "Time": "22:18"}}))
-    await hass.async_block_till_done()
     state = hass.states.get('sensor.test')
 
     assert 0 == state.attributes.get('Arm')
@@ -417,7 +393,6 @@ async def test_update_with_json_attrs_not_dict(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '[ "list", "of", "things"]')
-    await hass.async_block_till_done()
     state = hass.states.get('sensor.test')
 
     assert state.attributes.get('val') is None
@@ -436,7 +411,6 @@ async def test_update_with_json_attrs_bad_JSON(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', 'This is not JSON')
-    await hass.async_block_till_done()
 
     state = hass.states.get('sensor.test')
     assert state.attributes.get('val') is None
@@ -461,8 +435,6 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
                             data1)
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "100" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('sensor.beer')
     assert '100' == state.attributes.get('val')
 
@@ -470,19 +442,14 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     # Verify we are no longer subscribing to the old topic
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "50" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('sensor.beer')
     assert '100' == state.attributes.get('val')
 
     # Verify we are subscribing to the new topic
     async_fire_mqtt_message(hass, 'attr-topic2', '{ "val": "75" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('sensor.beer')
     assert '75' == state.attributes.get('val')
 
@@ -505,7 +472,6 @@ async def test_unique_id(hass):
     })
 
     async_fire_mqtt_message(hass, 'test-topic', 'payload')
-    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
 
@@ -526,7 +492,6 @@ async def test_discovery_removal_sensor(hass, mqtt_mock, caplog):
     assert state.name == 'Beer'
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
                             '')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get('sensor.beer')
     assert state is None
@@ -554,7 +519,6 @@ async def test_discovery_update_sensor(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
                             data2)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('sensor.beer')
@@ -589,7 +553,6 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('sensor.milk')
     assert state is not None
@@ -623,7 +586,6 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     })
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -664,7 +626,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
                             data)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
     assert device is not None
@@ -674,7 +635,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     data = json.dumps(config)
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -704,7 +664,6 @@ async def test_entity_id_update(hass, mqtt_mock):
     mock_mqtt.async_subscribe.reset_mock()
 
     registry.async_update_entity('sensor.beer', new_entity_id='sensor.milk')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('sensor.beer')
@@ -742,7 +701,6 @@ async def test_entity_device_info_with_hub(hass, mqtt_mock):
         'unique_id': 'veryunique'
     })
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config', data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())


### PR DESCRIPTION
## Description:
Drop unnecessary block_till_done, improve tests for MQTT sensor tests

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
