### PR TITLE
Drop unnecessary block_till_done for MQTT tests

### DIFF
--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -236,8 +236,6 @@ async def test_discovery_expansion(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'test_topic/some/base/topic',
                             'ON')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('switch.DiscoveryExpansionTest1')
     assert state.state == STATE_ON
@@ -271,8 +269,6 @@ async def test_implicit_state_topic_alarm(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(
         hass, 'homeassistant/alarm_control_panel/bla/state', 'armed_away')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('alarm_control_panel.Test1')
     assert state.state == 'armed_away'
@@ -305,8 +301,6 @@ async def test_implicit_state_topic_binary_sensor(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/state',
                             'ON')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('binary_sensor.Test1')
     assert state.state == 'on'
@@ -339,8 +333,6 @@ async def test_implicit_state_topic_sensor(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/state',
                             '1234')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('sensor.Test1')
     assert state.state == '1234'
@@ -374,8 +366,6 @@ async def test_no_implicit_state_topic_switch(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/switch/bla/state',
                             'ON')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('switch.Test1')
     assert state.state == 'off'

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -33,15 +33,12 @@ async def test_subscribe_topics(hass, mqtt_mock, caplog):
                          'msg_callback': record_calls2}})
 
     async_fire_mqtt_message(hass, 'test-topic1', 'test-payload1')
-    await hass.async_block_till_done()
     assert 1 == len(calls1)
     assert 'test-topic1' == calls1[0][0].topic
     assert 'test-payload1' == calls1[0][0].payload
     assert 0 == len(calls2)
 
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload2')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     assert 1 == len(calls1)
     assert 1 == len(calls2)
     assert 'test-topic2' == calls2[0][0].topic
@@ -52,7 +49,6 @@ async def test_subscribe_topics(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'test-topic1', 'test-payload')
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
 
-    await hass.async_block_till_done()
     assert 1 == len(calls1)
     assert 1 == len(calls2)
 
@@ -82,13 +78,10 @@ async def test_modify_topics(hass, mqtt_mock, caplog):
                          'msg_callback': record_calls2}})
 
     async_fire_mqtt_message(hass, 'test-topic1', 'test-payload')
-    await hass.async_block_till_done()
     assert 1 == len(calls1)
     assert 0 == len(calls2)
 
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     assert 1 == len(calls1)
     assert 1 == len(calls2)
 
@@ -99,14 +92,10 @@ async def test_modify_topics(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'test-topic1', 'test-payload')
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     assert 1 == len(calls1)
     assert 1 == len(calls2)
 
     async_fire_mqtt_message(hass, 'test-topic1_1', 'test-payload')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     assert 2 == len(calls1)
     assert 'test-topic1_1' == calls1[1][0].topic
     assert 'test-payload' == calls1[1][0].payload
@@ -117,7 +106,6 @@ async def test_modify_topics(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'test-topic1_1', 'test-payload')
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
 
-    await hass.async_block_till_done()
     assert 2 == len(calls1)
     assert 1 == len(calls2)
 


### PR DESCRIPTION
## Description:
Drop unnecessary block_till_done for MQTT tests

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
