### PR TITLE
Drop unnecessary block_till_done, improve tests for MQTT Cover tests

### DIFF
--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -1,6 +1,5 @@
 """The tests for the MQTT cover platform."""
 import json
-import unittest
 from unittest.mock import ANY
 
 from homeassistant.components import cover, mqtt
@@ -13,1071 +12,1081 @@ from homeassistant.const import (
     SERVICE_SET_COVER_POSITION, SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER, STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE,
     STATE_UNKNOWN)
-from homeassistant.setup import async_setup_component, setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry, async_fire_mqtt_message, async_mock_mqtt_component,
-    fire_mqtt_message, get_test_home_assistant, mock_mqtt_component,
     mock_registry)
 
 
-class TestCoverMQTT(unittest.TestCase):
-    """Test the MQTT cover."""
+async def test_state_via_state_topic(hass, mqtt_mock):
+    """Test the controlling state via topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP'
+        }
+    })
 
-    def setUp(self):  # pylint: disable=invalid-name
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.mock_publish = mock_mqtt_component(self.hass)
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop down everything that was started."""
-        self.hass.stop()
+    async_fire_mqtt_message(hass, 'state-topic', STATE_CLOSED)
 
-    def test_state_via_state_topic(self):
-        """Test the controlling state via topic."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP'
-            }
-        })
+    state = hass.states.get('cover.test')
+    assert STATE_CLOSED == state.state
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
-        assert not state.attributes.get(ATTR_ASSUMED_STATE)
+    async_fire_mqtt_message(hass, 'state-topic', STATE_OPEN)
 
-        fire_mqtt_message(self.hass, 'state-topic', STATE_CLOSED)
-        self.hass.block_till_done()
+    state = hass.states.get('cover.test')
+    assert STATE_OPEN == state.state
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_CLOSED == state.state
 
-        fire_mqtt_message(self.hass, 'state-topic', STATE_OPEN)
-        self.hass.block_till_done()
+async def test_position_via_position_topic(hass, mqtt_mock):
+    """Test the controlling state via topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'position_topic': 'get-position-topic',
+            'position_open': 100,
+            'position_closed': 0,
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP'
+        }
+    })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_OPEN == state.state
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
-    def test_position_via_position_topic(self):
-        """Test the controlling state via topic."""
-        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'position_topic': 'get-position-topic',
-                'position_open': 100,
-                'position_closed': 0,
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP'
-            }
-        }))
+    async_fire_mqtt_message(hass, 'get-position-topic', '0')
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
-        assert not state.attributes.get(ATTR_ASSUMED_STATE)
+    state = hass.states.get('cover.test')
+    assert STATE_CLOSED == state.state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '0')
-        self.hass.block_till_done()
+    async_fire_mqtt_message(hass, 'get-position-topic', '100')
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_CLOSED == state.state
+    state = hass.states.get('cover.test')
+    assert STATE_OPEN == state.state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '100')
-        self.hass.block_till_done()
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_OPEN == state.state
+async def test_state_via_template(hass, mqtt_mock):
+    """Test the controlling state via topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'value_template': '\
+                {% if (value | multiply(0.01) | int) == 0  %}\
+                  closed\
+                {% else %}\
+                  open\
+                {% endif %}'
+        }
+    })
 
-    def test_state_via_template(self):
-        """Test the controlling state via topic."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'value_template': '\
-                    {% if (value | multiply(0.01) | int) == 0  %}\
-                      closed\
-                    {% else %}\
-                      open\
-                    {% endif %}'
-            }
-        })
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
+    async_fire_mqtt_message(hass, 'state-topic', '10000')
 
-        fire_mqtt_message(self.hass, 'state-topic', '10000')
-        self.hass.block_till_done()
+    state = hass.states.get('cover.test')
+    assert STATE_OPEN == state.state
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_OPEN == state.state
+    async_fire_mqtt_message(hass, 'state-topic', '99')
 
-        fire_mqtt_message(self.hass, 'state-topic', '99')
-        self.hass.block_till_done()
+    state = hass.states.get('cover.test')
+    assert STATE_CLOSED == state.state
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_CLOSED == state.state
 
-    def test_position_via_template(self):
-        """Test the controlling state via topic."""
-        self.assertTrue(setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'position_topic': 'get-position-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'value_template': '{{ (value | multiply(0.01)) | int }}'
-            }
-        }))
+async def test_position_via_template(hass, mqtt_mock):
+    """Test the controlling state via topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'position_topic': 'get-position-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'value_template': '{{ (value | multiply(0.01)) | int }}'
+        }
+    })
 
-        state = self.hass.states.get('cover.test')
-        self.assertEqual(STATE_UNKNOWN, state.state)
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '10000')
-        self.hass.block_till_done()
+    async_fire_mqtt_message(hass, 'get-position-topic', '10000')
 
-        state = self.hass.states.get('cover.test')
-        self.assertEqual(STATE_OPEN, state.state)
+    state = hass.states.get('cover.test')
+    assert STATE_OPEN == state.state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '5000')
-        self.hass.block_till_done()
+    async_fire_mqtt_message(hass, 'get-position-topic', '5000')
 
-        state = self.hass.states.get('cover.test')
-        self.assertEqual(STATE_OPEN, state.state)
+    state = hass.states.get('cover.test')
+    assert STATE_OPEN == state.state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '99')
-        self.hass.block_till_done()
+    async_fire_mqtt_message(hass, 'get-position-topic', '99')
 
-        state = self.hass.states.get('cover.test')
-        self.assertEqual(STATE_CLOSED, state.state)
+    state = hass.states.get('cover.test')
+    assert STATE_CLOSED == state.state
 
-    def test_optimistic_state_change(self):
-        """Test changing state optimistically."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'command_topic': 'command-topic',
-                'qos': 0,
-            }
-        })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
-        assert state.attributes.get(ATTR_ASSUMED_STATE)
+async def test_optimistic_state_change(hass, mqtt_mock):
+    """Test changing state optimistically."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'command_topic': 'command-topic',
+            'qos': 0,
+        }
+    })
 
-        self.hass.services.call(
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
+    assert state.attributes.get(ATTR_ASSUMED_STATE)
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_OPEN_COVER,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'command-topic', 'OPEN', 0, False)
-        self.mock_publish.async_publish.reset_mock()
-        state = self.hass.states.get('cover.test')
-        assert STATE_OPEN == state.state
+    mqtt_mock.async_publish.assert_called_once_with(
+        'command-topic', 'OPEN', 0, False)
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get('cover.test')
+    assert STATE_OPEN == state.state
 
-        self.hass.services.call(
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_CLOSE_COVER,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'command-topic', 'CLOSE', 0, False)
-        state = self.hass.states.get('cover.test')
-        assert STATE_CLOSED == state.state
+    mqtt_mock.async_publish.assert_called_once_with(
+        'command-topic', 'CLOSE', 0, False)
+    state = hass.states.get('cover.test')
+    assert STATE_CLOSED == state.state
 
-    def test_send_open_cover_command(self):
-        """Test the sending of open_cover."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 2
-            }
-        })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
+async def test_send_open_cover_command(hass, mqtt_mock):
+    """Test the sending of open_cover."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 2
+        }
+    })
 
-        self.hass.services.call(
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_OPEN_COVER,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'command-topic', 'OPEN', 2, False)
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
+    mqtt_mock.async_publish.assert_called_once_with(
+        'command-topic', 'OPEN', 2, False)
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
 
-    def test_send_close_cover_command(self):
-        """Test the sending of close_cover."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 2
-            }
-        })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
+async def test_send_close_cover_command(hass, mqtt_mock):
+    """Test the sending of close_cover."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 2
+        }
+    })
 
-        self.hass.services.call(
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_CLOSE_COVER,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'command-topic', 'CLOSE', 2, False)
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
+    mqtt_mock.async_publish.assert_called_once_with(
+        'command-topic', 'CLOSE', 2, False)
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
 
-    def test_send_stop__cover_command(self):
-        """Test the sending of stop_cover."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 2
-            }
-        })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
+async def test_send_stop__cover_command(hass, mqtt_mock):
+    """Test the sending of stop_cover."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 2
+        }
+    })
 
-        self.hass.services.call(
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_STOP_COVER,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'command-topic', 'STOP', 2, False)
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNKNOWN == state.state
+    mqtt_mock.async_publish.assert_called_once_with(
+        'command-topic', 'STOP', 2, False)
+    state = hass.states.get('cover.test')
+    assert STATE_UNKNOWN == state.state
 
-    def test_current_cover_position(self):
-        """Test the current cover position."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'position_topic': 'get-position-topic',
-                'command_topic': 'command-topic',
-                'position_open': 100,
-                'position_closed': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP'
-            }
-        })
 
-        state_attributes_dict = self.hass.states.get(
-            'cover.test').attributes
-        assert not ('current_position' in state_attributes_dict)
-        assert not ('current_tilt_position' in state_attributes_dict)
-        assert not (4 & self.hass.states.get(
-            'cover.test').attributes['supported_features'] == 4)
+async def test_current_cover_position(hass, mqtt_mock):
+    """Test the current cover position."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'position_topic': 'get-position-topic',
+            'command_topic': 'command-topic',
+            'position_open': 100,
+            'position_closed': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP'
+        }
+    })
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '0')
-        self.hass.block_till_done()
-        current_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 0 == current_cover_position
+    state_attributes_dict = hass.states.get(
+        'cover.test').attributes
+    assert not ('current_position' in state_attributes_dict)
+    assert not ('current_tilt_position' in state_attributes_dict)
+    assert not (4 & hass.states.get(
+        'cover.test').attributes['supported_features'] == 4)
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '50')
-        self.hass.block_till_done()
-        current_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 50 == current_cover_position
+    async_fire_mqtt_message(hass, 'get-position-topic', '0')
+    current_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 0 == current_cover_position
 
-        fire_mqtt_message(self.hass, 'get-position-topic', 'non-numeric')
-        self.hass.block_till_done()
-        current_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 50 == current_cover_position
+    async_fire_mqtt_message(hass, 'get-position-topic', '50')
+    current_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 50 == current_cover_position
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '101')
-        self.hass.block_till_done()
-        current_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 100 == current_cover_position
+    async_fire_mqtt_message(hass, 'get-position-topic', 'non-numeric')
+    current_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 50 == current_cover_position
 
-    def test_current_cover_position_inverted(self):
-        """Test the current cover position."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'position_topic': 'get-position-topic',
-                'command_topic': 'command-topic',
-                'position_open': 0,
-                'position_closed': 100,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP'
-            }
-        })
+    async_fire_mqtt_message(hass, 'get-position-topic', '101')
+    current_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 100 == current_cover_position
 
-        state_attributes_dict = self.hass.states.get(
-            'cover.test').attributes
-        assert not ('current_position' in state_attributes_dict)
-        assert not ('current_tilt_position' in state_attributes_dict)
-        assert not (4 & self.hass.states.get(
-            'cover.test').attributes['supported_features'] == 4)
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '100')
-        self.hass.block_till_done()
-        current_percentage_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 0 == current_percentage_cover_position
-        assert STATE_CLOSED == self.hass.states.get(
-            'cover.test').state
+async def test_current_cover_position_inverted(hass, mqtt_mock):
+    """Test the current cover position."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'position_topic': 'get-position-topic',
+            'command_topic': 'command-topic',
+            'position_open': 0,
+            'position_closed': 100,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP'
+        }
+    })
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '0')
-        self.hass.block_till_done()
-        current_percentage_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 100 == current_percentage_cover_position
-        assert STATE_OPEN == self.hass.states.get(
-            'cover.test').state
+    state_attributes_dict = hass.states.get(
+        'cover.test').attributes
+    assert not ('current_position' in state_attributes_dict)
+    assert not ('current_tilt_position' in state_attributes_dict)
+    assert not (4 & hass.states.get(
+        'cover.test').attributes['supported_features'] == 4)
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '50')
-        self.hass.block_till_done()
-        current_percentage_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 50 == current_percentage_cover_position
-        assert STATE_OPEN == self.hass.states.get(
-            'cover.test').state
+    async_fire_mqtt_message(hass, 'get-position-topic', '100')
+    current_percentage_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 0 == current_percentage_cover_position
+    assert STATE_CLOSED == hass.states.get(
+        'cover.test').state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', 'non-numeric')
-        self.hass.block_till_done()
-        current_percentage_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 50 == current_percentage_cover_position
-        assert STATE_OPEN == self.hass.states.get(
-            'cover.test').state
+    async_fire_mqtt_message(hass, 'get-position-topic', '0')
+    current_percentage_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 100 == current_percentage_cover_position
+    assert STATE_OPEN == hass.states.get(
+        'cover.test').state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '101')
-        self.hass.block_till_done()
-        current_percentage_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 0 == current_percentage_cover_position
-        assert STATE_CLOSED == self.hass.states.get(
-            'cover.test').state
+    async_fire_mqtt_message(hass, 'get-position-topic', '50')
+    current_percentage_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 50 == current_percentage_cover_position
+    assert STATE_OPEN == hass.states.get(
+        'cover.test').state
 
-    def test_set_cover_position(self):
-        """Test setting cover position."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'position_topic': 'get-position-topic',
-                'command_topic': 'command-topic',
-                'set_position_topic': 'set-position-topic',
-                'position_open': 100,
-                'position_closed': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP'
-            }
-        })
+    async_fire_mqtt_message(hass, 'get-position-topic', 'non-numeric')
+    current_percentage_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 50 == current_percentage_cover_position
+    assert STATE_OPEN == hass.states.get(
+        'cover.test').state
 
-        state_attributes_dict = self.hass.states.get(
-            'cover.test').attributes
-        assert not ('current_position' in state_attributes_dict)
-        assert not ('current_tilt_position' in state_attributes_dict)
-        assert 4 & self.hass.states.get(
-            'cover.test').attributes['supported_features'] == 4
+    async_fire_mqtt_message(hass, 'get-position-topic', '101')
+    current_percentage_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 0 == current_percentage_cover_position
+    assert STATE_CLOSED == hass.states.get(
+        'cover.test').state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '22')
-        self.hass.block_till_done()
-        state_attributes_dict = self.hass.states.get(
-            'cover.test').attributes
-        assert 'current_position' in state_attributes_dict
-        assert not ('current_tilt_position' in state_attributes_dict)
-        current_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 22 == current_cover_position
 
-    def test_set_position_templated(self):
-        """Test setting cover position via template."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'position_topic': 'get-position-topic',
-                'command_topic': 'command-topic',
-                'position_open': 100,
-                'position_closed': 0,
-                'set_position_topic': 'set-position-topic',
-                'set_position_template': '{{100-62}}',
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP'
-            }
-        })
+async def test_set_cover_position(hass, mqtt_mock):
+    """Test setting cover position."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'position_topic': 'get-position-topic',
+            'command_topic': 'command-topic',
+            'set_position_topic': 'set-position-topic',
+            'position_open': 100,
+            'position_closed': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP'
+        }
+    })
 
-        self.hass.services.call(
+    state_attributes_dict = hass.states.get(
+        'cover.test').attributes
+    assert not ('current_position' in state_attributes_dict)
+    assert not ('current_tilt_position' in state_attributes_dict)
+    assert 4 & hass.states.get(
+        'cover.test').attributes['supported_features'] == 4
+
+    async_fire_mqtt_message(hass, 'get-position-topic', '22')
+    state_attributes_dict = hass.states.get(
+        'cover.test').attributes
+    assert 'current_position' in state_attributes_dict
+    assert not ('current_tilt_position' in state_attributes_dict)
+    current_cover_position = hass.states.get(
+        'cover.test').attributes['current_position']
+    assert 22 == current_cover_position
+
+
+async def test_set_position_templated(hass, mqtt_mock):
+    """Test setting cover position via template."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'position_topic': 'get-position-topic',
+            'command_topic': 'command-topic',
+            'position_open': 100,
+            'position_closed': 0,
+            'set_position_topic': 'set-position-topic',
+            'set_position_template': '{{100-62}}',
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP'
+        }
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_SET_COVER_POSITION,
-            {ATTR_ENTITY_ID: 'cover.test', ATTR_POSITION: 100}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test', ATTR_POSITION: 100}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'set-position-topic', '38', 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        'set-position-topic', '38', 0, False)
 
-    def test_set_position_untemplated(self):
-        """Test setting cover position via template."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'position_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'set_position_topic': 'position-topic',
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP'
-            }
-        })
 
-        self.hass.services.call(
+async def test_set_position_untemplated(hass, mqtt_mock):
+    """Test setting cover position via template."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'position_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'set_position_topic': 'position-topic',
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP'
+        }
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_SET_COVER_POSITION,
-            {ATTR_ENTITY_ID: 'cover.test', ATTR_POSITION: 62}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test', ATTR_POSITION: 62}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'position-topic', 62, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        'position-topic', 62, 0, False)
 
-    def test_no_command_topic(self):
-        """Test with no command topic."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command',
-                'tilt_status_topic': 'tilt-status'
-            }
-        })
 
-        assert 240 == self.hass.states.get(
-            'cover.test').attributes['supported_features']
+async def test_no_command_topic(hass, mqtt_mock):
+    """Test with no command topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command',
+            'tilt_status_topic': 'tilt-status'
+        }
+    })
 
-    def test_with_command_topic_and_tilt(self):
-        """Test with command topic and tilt config."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'command_topic': 'test',
-                'platform': 'mqtt',
-                'name': 'test',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command',
-                'tilt_status_topic': 'tilt-status'
-            }
-        })
+    assert 240 == hass.states.get(
+        'cover.test').attributes['supported_features']
 
-        assert 251 == self.hass.states.get(
-            'cover.test').attributes['supported_features']
 
-    def test_tilt_defaults(self):
-        """Test the defaults."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command',
-                'tilt_status_topic': 'tilt-status'
-            }
-        })
+async def test_with_command_topic_and_tilt(hass, mqtt_mock):
+    """Test with command topic and tilt config."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'command_topic': 'test',
+            'platform': 'mqtt',
+            'name': 'test',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command',
+            'tilt_status_topic': 'tilt-status'
+        }
+    })
 
-        state_attributes_dict = self.hass.states.get(
-            'cover.test').attributes
-        assert 'current_tilt_position' in state_attributes_dict
+    assert 251 == hass.states.get(
+        'cover.test').attributes['supported_features']
 
-        current_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_tilt_position']
-        assert STATE_UNKNOWN == current_cover_position
 
-    def test_tilt_via_invocation_defaults(self):
-        """Test tilt defaults on close/open."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic'
-            }
-        })
+async def test_tilt_defaults(hass, mqtt_mock):
+    """Test the defaults."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command',
+            'tilt_status_topic': 'tilt-status'
+        }
+    })
 
-        self.hass.services.call(
+    state_attributes_dict = hass.states.get(
+        'cover.test').attributes
+    assert 'current_tilt_position' in state_attributes_dict
+
+    current_cover_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert STATE_UNKNOWN == current_cover_position
+
+
+async def test_tilt_via_invocation_defaults(hass, mqtt_mock):
+    """Test tilt defaults on close/open."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic'
+        }
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_OPEN_COVER_TILT,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'tilt-command-topic', 100, 0, False)
-        self.mock_publish.async_publish.reset_mock()
+    mqtt_mock.async_publish.assert_called_once_with(
+        'tilt-command-topic', 100, 0, False)
+    mqtt_mock.async_publish.reset_mock()
 
-        self.hass.services.call(
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_CLOSE_COVER_TILT,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'tilt-command-topic', 0, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        'tilt-command-topic', 0, 0, False)
 
-    def test_tilt_given_value(self):
-        """Test tilting to a given value."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'tilt_opened_value': 400,
-                'tilt_closed_value': 125
-            }
-        })
 
-        self.hass.services.call(
+async def test_tilt_given_value(hass, mqtt_mock):
+    """Test tilting to a given value."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'tilt_opened_value': 400,
+            'tilt_closed_value': 125
+        }
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_OPEN_COVER_TILT,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'tilt-command-topic', 400, 0, False)
-        self.mock_publish.async_publish.reset_mock()
+    mqtt_mock.async_publish.assert_called_once_with(
+        'tilt-command-topic', 400, 0, False)
+    mqtt_mock.async_publish.reset_mock()
 
-        self.hass.services.call(
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_CLOSE_COVER_TILT,
-            {ATTR_ENTITY_ID: 'cover.test'}, blocking=True)
-        self.hass.block_till_done()
+            {ATTR_ENTITY_ID: 'cover.test'}))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'tilt-command-topic', 125, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        'tilt-command-topic', 125, 0, False)
 
-    def test_tilt_via_topic(self):
-        """Test tilt by updating status via MQTT."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'tilt_opened_value': 400,
-                'tilt_closed_value': 125
-            }
-        })
 
-        fire_mqtt_message(self.hass, 'tilt-status-topic', '0')
-        self.hass.block_till_done()
+async def test_tilt_via_topic(hass, mqtt_mock):
+    """Test tilt by updating status via MQTT."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'tilt_opened_value': 400,
+            'tilt_closed_value': 125
+        }
+    })
 
-        current_cover_tilt_position = self.hass.states.get(
-            'cover.test').attributes['current_tilt_position']
-        assert 0 == current_cover_tilt_position
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '0')
 
-        fire_mqtt_message(self.hass, 'tilt-status-topic', '50')
-        self.hass.block_till_done()
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert 0 == current_cover_tilt_position
 
-        current_cover_tilt_position = self.hass.states.get(
-            'cover.test').attributes['current_tilt_position']
-        assert 50 == current_cover_tilt_position
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '50')
 
-    def test_tilt_via_topic_altered_range(self):
-        """Test tilt status via MQTT with altered tilt range."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'tilt_opened_value': 400,
-                'tilt_closed_value': 125,
-                'tilt_min': 0,
-                'tilt_max': 50
-            }
-        })
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert 50 == current_cover_tilt_position
 
-        fire_mqtt_message(self.hass, 'tilt-status-topic', '0')
-        self.hass.block_till_done()
 
-        current_cover_tilt_position = self.hass.states.get(
-            'cover.test').attributes['current_tilt_position']
-        assert 0 == current_cover_tilt_position
+async def test_tilt_via_topic_altered_range(hass, mqtt_mock):
+    """Test tilt status via MQTT with altered tilt range."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'tilt_opened_value': 400,
+            'tilt_closed_value': 125,
+            'tilt_min': 0,
+            'tilt_max': 50
+        }
+    })
 
-        fire_mqtt_message(self.hass, 'tilt-status-topic', '50')
-        self.hass.block_till_done()
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '0')
 
-        current_cover_tilt_position = self.hass.states.get(
-            'cover.test').attributes['current_tilt_position']
-        assert 100 == current_cover_tilt_position
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert 0 == current_cover_tilt_position
 
-        fire_mqtt_message(self.hass, 'tilt-status-topic', '25')
-        self.hass.block_till_done()
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '50')
 
-        current_cover_tilt_position = self.hass.states.get(
-            'cover.test').attributes['current_tilt_position']
-        assert 50 == current_cover_tilt_position
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert 100 == current_cover_tilt_position
 
-    def test_tilt_position(self):
-        """Test tilt via method invocation."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'tilt_opened_value': 400,
-                'tilt_closed_value': 125
-            }
-        })
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '25')
 
-        self.hass.services.call(
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert 50 == current_cover_tilt_position
+
+
+async def test_tilt_position(hass, mqtt_mock):
+    """Test tilt via method invocation."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'tilt_opened_value': 400,
+            'tilt_closed_value': 125
+        }
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_SET_COVER_TILT_POSITION,
             {ATTR_ENTITY_ID: 'cover.test', ATTR_TILT_POSITION: 50},
-            blocking=True)
-        self.hass.block_till_done()
+            blocking=True))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'tilt-command-topic', 50, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        'tilt-command-topic', 50, 0, False)
 
-    def test_tilt_position_altered_range(self):
-        """Test tilt via method invocation with altered range."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'qos': 0,
-                'payload_open': 'OPEN',
-                'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'tilt_opened_value': 400,
-                'tilt_closed_value': 125,
-                'tilt_min': 0,
-                'tilt_max': 50
-            }
-        })
 
-        self.hass.services.call(
+async def test_tilt_position_altered_range(hass, mqtt_mock):
+    """Test tilt via method invocation with altered range."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'tilt_opened_value': 400,
+            'tilt_closed_value': 125,
+            'tilt_min': 0,
+            'tilt_max': 50
+        }
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(
             cover.DOMAIN, SERVICE_SET_COVER_TILT_POSITION,
             {ATTR_ENTITY_ID: 'cover.test', ATTR_TILT_POSITION: 50},
-            blocking=True)
-        self.hass.block_till_done()
+            blocking=True))
+    await hass.async_block_till_done()
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'tilt-command-topic', 25, 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        'tilt-command-topic', 25, 0, False)
 
-    def test_find_percentage_in_range_defaults(self):
-        """Test find percentage in range with default range."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 100,  'position_closed': 0,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 100, 'tilt_closed_position': 0,
-                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
-                'tilt_invert_state': False,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
 
-        assert 44 == mqtt_cover.find_percentage_in_range(44)
-        assert 44 == mqtt_cover.find_percentage_in_range(44, 'cover')
+async def test_find_percentage_in_range_defaults(hass, mqtt_mock):
+    """Test find percentage in range with default range."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 100,  'position_closed': 0,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 100, 'tilt_closed_position': 0,
+            'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+            'tilt_invert_state': False,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-    def test_find_percentage_in_range_altered(self):
-        """Test find percentage in range with altered range."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 180,  'position_closed': 80,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 180, 'tilt_closed_position': 80,
-                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
-                'tilt_invert_state': False,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
+    assert 44 == mqtt_cover.find_percentage_in_range(44)
+    assert 44 == mqtt_cover.find_percentage_in_range(44, 'cover')
 
-        assert 40 == mqtt_cover.find_percentage_in_range(120)
-        assert 40 == mqtt_cover.find_percentage_in_range(120, 'cover')
 
-    def test_find_percentage_in_range_defaults_inverted(self):
-        """Test find percentage in range with default range but inverted."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 0,  'position_closed': 100,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 100, 'tilt_closed_position': 0,
-                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
-                'tilt_invert_state': True,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
+async def test_find_percentage_in_range_altered(hass, mqtt_mock):
+    """Test find percentage in range with altered range."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 180,  'position_closed': 80,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 180, 'tilt_closed_position': 80,
+            'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+            'tilt_invert_state': False,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-        assert 56 == mqtt_cover.find_percentage_in_range(44)
-        assert 56 == mqtt_cover.find_percentage_in_range(44, 'cover')
+    assert 40 == mqtt_cover.find_percentage_in_range(120)
+    assert 40 == mqtt_cover.find_percentage_in_range(120, 'cover')
 
-    def test_find_percentage_in_range_altered_inverted(self):
-        """Test find percentage in range with altered range and inverted."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 80,  'position_closed': 180,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 180, 'tilt_closed_position': 80,
-                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
-                'tilt_invert_state': True,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
 
-        assert 60 == mqtt_cover.find_percentage_in_range(120)
-        assert 60 == mqtt_cover.find_percentage_in_range(120, 'cover')
+async def test_find_percentage_in_range_defaults_inverted(hass, mqtt_mock):
+    """Test find percentage in range with default range but inverted."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 0,  'position_closed': 100,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 100, 'tilt_closed_position': 0,
+            'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+            'tilt_invert_state': True,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-    def test_find_in_range_defaults(self):
-        """Test find in range with default range."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 100, 'position_closed': 0,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 100, 'tilt_closed_position': 0,
-                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
-                'tilt_invert_state': False,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
+    assert 56 == mqtt_cover.find_percentage_in_range(44)
+    assert 56 == mqtt_cover.find_percentage_in_range(44, 'cover')
 
-        assert 44 == mqtt_cover.find_in_range_from_percent(44)
-        assert 44 == mqtt_cover.find_in_range_from_percent(44, 'cover')
 
-    def test_find_in_range_altered(self):
-        """Test find in range with altered range."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 180, 'position_closed': 80,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 180, 'tilt_closed_position': 80,
-                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
-                'tilt_invert_state': False,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
+async def test_find_percentage_in_range_altered_inverted(hass, mqtt_mock):
+    """Test find percentage in range with altered range and inverted."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 80,  'position_closed': 180,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 180, 'tilt_closed_position': 80,
+            'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+            'tilt_invert_state': True,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-        assert 120 == mqtt_cover.find_in_range_from_percent(40)
-        assert 120 == mqtt_cover.find_in_range_from_percent(40, 'cover')
+    assert 60 == mqtt_cover.find_percentage_in_range(120)
+    assert 60 == mqtt_cover.find_percentage_in_range(120, 'cover')
 
-    def test_find_in_range_defaults_inverted(self):
-        """Test find in range with default range but inverted."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 0, 'position_closed': 100,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 100, 'tilt_closed_position': 0,
-                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
-                'tilt_invert_state': True,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
 
-        assert 44 == mqtt_cover.find_in_range_from_percent(56)
-        assert 44 == mqtt_cover.find_in_range_from_percent(56, 'cover')
+async def test_find_in_range_defaults(hass, mqtt_mock):
+    """Test find in range with default range."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 100, 'position_closed': 0,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 100, 'tilt_closed_position': 0,
+            'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+            'tilt_invert_state': False,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-    def test_find_in_range_altered_inverted(self):
-        """Test find in range with altered range and inverted."""
-        mqtt_cover = MqttCover(
-            {
-                'name': 'cover.test',
-                'state_topic': 'state-topic',
-                'get_position_topic': None,
-                'command_topic': 'command-topic',
-                'availability_topic': None,
-                'tilt_command_topic': 'tilt-command-topic',
-                'tilt_status_topic': 'tilt-status-topic',
-                'qos': 0,
-                'retain': False,
-                'state_open': 'OPEN', 'state_closed': 'CLOSE',
-                'position_open': 80, 'position_closed': 180,
-                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
-                'payload_stop': 'STOP',
-                'payload_available': None, 'payload_not_available': None,
-                'optimistic': False, 'value_template': None,
-                'tilt_open_position': 180, 'tilt_closed_position': 80,
-                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
-                'tilt_invert_state': True,
-                'set_position_topic': None, 'set_position_template': None,
-                'unique_id': None, 'device_config': None,
-            },
-            None,
-            None)
+    assert 44 == mqtt_cover.find_in_range_from_percent(44)
+    assert 44 == mqtt_cover.find_in_range_from_percent(44, 'cover')
 
-        assert 120 == mqtt_cover.find_in_range_from_percent(60)
-        assert 120 == mqtt_cover.find_in_range_from_percent(60, 'cover')
 
-    def test_availability_without_topic(self):
-        """Test availability without defined availability topic."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic'
-            }
-        })
+async def test_find_in_range_altered(hass, mqtt_mock):
+    """Test find in range with altered range."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 180, 'position_closed': 80,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 180, 'tilt_closed_position': 80,
+            'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+            'tilt_invert_state': False,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNAVAILABLE != state.state
+    assert 120 == mqtt_cover.find_in_range_from_percent(40)
+    assert 120 == mqtt_cover.find_in_range_from_percent(40, 'cover')
 
-    def test_availability_by_defaults(self):
-        """Test availability by defaults with defined topic."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'availability_topic': 'availability-topic'
-            }
-        })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNAVAILABLE == state.state
+async def test_find_in_range_defaults_inverted(hass, mqtt_mock):
+    """Test find in range with default range but inverted."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 0, 'position_closed': 100,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 100, 'tilt_closed_position': 0,
+            'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+            'tilt_invert_state': True,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'online')
-        self.hass.block_till_done()
+    assert 44 == mqtt_cover.find_in_range_from_percent(56)
+    assert 44 == mqtt_cover.find_in_range_from_percent(56, 'cover')
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNAVAILABLE != state.state
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
-        self.hass.block_till_done()
+async def test_find_in_range_altered_inverted(hass, mqtt_mock):
+    """Test find in range with altered range and inverted."""
+    mqtt_cover = MqttCover(
+        {
+            'name': 'cover.test',
+            'state_topic': 'state-topic',
+            'get_position_topic': None,
+            'command_topic': 'command-topic',
+            'availability_topic': None,
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'qos': 0,
+            'retain': False,
+            'state_open': 'OPEN', 'state_closed': 'CLOSE',
+            'position_open': 80, 'position_closed': 180,
+            'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'payload_available': None, 'payload_not_available': None,
+            'optimistic': False, 'value_template': None,
+            'tilt_open_position': 180, 'tilt_closed_position': 80,
+            'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+            'tilt_invert_state': True,
+            'set_position_topic': None, 'set_position_template': None,
+            'unique_id': None, 'device_config': None,
+        },
+        None,
+        None)
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNAVAILABLE == state.state
+    assert 120 == mqtt_cover.find_in_range_from_percent(60)
+    assert 120 == mqtt_cover.find_in_range_from_percent(60, 'cover')
 
-    def test_availability_by_custom_payload(self):
-        """Test availability by custom payload with defined topic."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'state-topic',
-                'command_topic': 'command-topic',
-                'availability_topic': 'availability-topic',
-                'payload_available': 'good',
-                'payload_not_available': 'nogood'
-            }
-        })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNAVAILABLE == state.state
+async def test_availability_without_topic(hass, mqtt_mock):
+    """Test availability without defined availability topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic'
+        }
+    })
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'good')
-        self.hass.block_till_done()
+    state = hass.states.get('cover.test')
+    assert STATE_UNAVAILABLE != state.state
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNAVAILABLE != state.state
 
-        fire_mqtt_message(self.hass, 'availability-topic', 'nogood')
-        self.hass.block_till_done()
+async def test_availability_by_defaults(hass, mqtt_mock):
+    """Test availability by defaults with defined topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'availability_topic': 'availability-topic'
+        }
+    })
 
-        state = self.hass.states.get('cover.test')
-        assert STATE_UNAVAILABLE == state.state
+    state = hass.states.get('cover.test')
+    assert STATE_UNAVAILABLE == state.state
 
-    def test_valid_device_class(self):
-        """Test the setting of a valid sensor class."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'device_class': 'garage',
-                'state_topic': 'test-topic',
-            }
-        })
+    async_fire_mqtt_message(hass, 'availability-topic', 'online')
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get('cover.test')
-        assert 'garage' == state.attributes.get('device_class')
+    state = hass.states.get('cover.test')
+    assert STATE_UNAVAILABLE != state.state
 
-    def test_invalid_device_class(self):
-        """Test the setting of an invalid sensor class."""
-        assert setup_component(self.hass, cover.DOMAIN, {
-            cover.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'device_class': 'abc123',
-                'state_topic': 'test-topic',
-            }
-        })
+    async_fire_mqtt_message(hass, 'availability-topic', 'offline')
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get('cover.test')
-        assert state is None
+    state = hass.states.get('cover.test')
+    assert STATE_UNAVAILABLE == state.state
+
+
+async def test_availability_by_custom_payload(hass, mqtt_mock):
+    """Test availability by custom payload with defined topic."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'availability_topic': 'availability-topic',
+            'payload_available': 'good',
+            'payload_not_available': 'nogood'
+        }
+    })
+
+    state = hass.states.get('cover.test')
+    assert STATE_UNAVAILABLE == state.state
+
+    async_fire_mqtt_message(hass, 'availability-topic', 'good')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('cover.test')
+    assert STATE_UNAVAILABLE != state.state
+
+    async_fire_mqtt_message(hass, 'availability-topic', 'nogood')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('cover.test')
+    assert STATE_UNAVAILABLE == state.state
+
+
+async def test_valid_device_class(hass, mqtt_mock):
+    """Test the setting of a valid sensor class."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'device_class': 'garage',
+            'state_topic': 'test-topic',
+        }
+    })
+
+    state = hass.states.get('cover.test')
+    assert 'garage' == state.attributes.get('device_class')
+
+
+async def test_invalid_device_class(hass, mqtt_mock):
+    """Test the setting of an invalid sensor class."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'device_class': 'abc123',
+            'state_topic': 'test-topic',
+        }
+    })
+
+    state = hass.states.get('cover.test')
+    assert state is None
 
 
 async def test_setting_attribute_via_mqtt_json_message(hass, mqtt_mock):
@@ -1092,7 +1101,6 @@ async def test_setting_attribute_via_mqtt_json_message(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '{ "val": "100" }')
-    await hass.async_block_till_done()
     state = hass.states.get('cover.test')
 
     assert '100' == state.attributes.get('val')
@@ -1110,7 +1118,6 @@ async def test_update_with_json_attrs_not_dict(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '[ "list", "of", "things"]')
-    await hass.async_block_till_done()
     state = hass.states.get('cover.test')
 
     assert state.attributes.get('val') is None
@@ -1129,7 +1136,6 @@ async def test_update_with_json_attrs_bad_JSON(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', 'This is not JSON')
-    await hass.async_block_till_done()
 
     state = hass.states.get('cover.test')
     assert state.attributes.get('val') is None
@@ -1154,8 +1160,6 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
                             data1)
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "100" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('cover.beer')
     assert '100' == state.attributes.get('val')
 
@@ -1163,19 +1167,14 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     # Verify we are no longer subscribing to the old topic
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "50" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('cover.beer')
     assert '100' == state.attributes.get('val')
 
     # Verify we are subscribing to the new topic
     async_fire_mqtt_message(hass, 'attr-topic2', '{ "val": "75" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('cover.beer')
     assert '75' == state.attributes.get('val')
 
@@ -1196,7 +1195,6 @@ async def test_discovery_removal_cover(hass, mqtt_mock, caplog):
     assert state.name == 'Beer'
     async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
                             '')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get('cover.beer')
     assert state is None
@@ -1223,7 +1221,6 @@ async def test_discovery_update_cover(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
                             data2)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('cover.beer')
@@ -1258,7 +1255,6 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('cover.milk')
     assert state is not None
@@ -1285,7 +1281,6 @@ async def test_unique_id(hass):
     })
 
     async_fire_mqtt_message(hass, 'test-topic', 'payload')
-    await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(cover.DOMAIN)) == 1
 
@@ -1316,7 +1311,6 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     })
     async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -1358,7 +1352,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
                             data)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
     assert device is not None
@@ -1368,7 +1361,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     data = json.dumps(config)
     async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -1398,7 +1390,6 @@ async def test_entity_id_update(hass, mqtt_mock):
     mock_mqtt.async_subscribe.reset_mock()
 
     registry.async_update_entity('cover.beer', new_entity_id='cover.milk')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('cover.beer')


### PR DESCRIPTION
## Description:
Drop unnecessary block_till_done, improve tests for MQTT Cover tests

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
