### PR TITLE
Position is reversed for horizontal awnings

### DIFF
--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -163,7 +163,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
         if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
             self.apply_action('setPosition', kwargs.get(ATTR_POSITION, 0))
         else:
-            self.apply_action('setPosition', 
+            self.apply_action('setPosition',
                               100 - kwargs.get(ATTR_POSITION, 0))
 
     @property

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -161,9 +161,9 @@ class TahomaCover(TahomaDevice, CoverDevice):
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-            self.apply_action('setPosition', kwargs.get(ATTR_POSITION))
+            self.apply_action('setPosition', kwargs.get(ATTR_POSITION, 0))
         else:
-            self.apply_action('setPosition', 100 - kwargs.get(ATTR_POSITION))
+            self.apply_action('setPosition', 100 - kwargs.get(ATTR_POSITION, 0))
 
     @property
     def is_closed(self):
@@ -173,7 +173,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
     @property
     def device_class(self):
         """Return the class of the device."""
-        return TAHOMA_DEVICE_CLASSES.get(self.tahoma_device.type, None)
+        return TAHOMA_DEVICE_CLASSES.get(self.tahoma_device.type)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -2,10 +2,10 @@
 from datetime import timedelta
 import logging
 
-from homeassistant.components.cover import (ATTR_POSITION,
-    DEVICE_CLASS_AWNING, DEVICE_CLASS_BLIND, DEVICE_CLASS_CURTAIN,
-    DEVICE_CLASS_GARAGE, DEVICE_CLASS_SHUTTER, DEVICE_CLASS_WINDOW,
-    CoverDevice)
+from homeassistant.components.cover import (
+    ATTR_POSITION, DEVICE_CLASS_AWNING, DEVICE_CLASS_BLIND,
+    DEVICE_CLASS_CURTAIN, DEVICE_CLASS_GARAGE, DEVICE_CLASS_SHUTTER,
+    DEVICE_CLASS_WINDOW, CoverDevice)
 from homeassistant.util.dt import utcnow
 
 from . import DOMAIN as TAHOMA_DOMAIN, TahomaDevice

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -163,7 +163,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
         if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
             self.apply_action('setPosition', kwargs.get(ATTR_POSITION, 0))
         else:
-            self.apply_action('setPosition', 100 - kwargs.get(ATTR_POSITION, 0))
+            self.apply_action('setPosition', 
+                              100 - kwargs.get(ATTR_POSITION, 0))
 
     @property
     def is_closed(self):

--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -19,6 +19,24 @@ ATTR_LOCK_END_TS = 'lock_end_ts'
 ATTR_LOCK_LEVEL = 'lock_level'
 ATTR_LOCK_ORIG = 'lock_originator'
 
+TAHOMA_DEVICE_CLASSES = {
+    'io:ExteriorVenetianBlindIOComponent': DEVICE_CLASS_BLIND,
+    'io:HorizontalAwningIOComponent': DEVICE_CLASS_AWNING,
+    'io:RollerShutterGenericIOComponent': DEVICE_CLASS_SHUTTER,
+    'io:RollerShutterUnoIOComponent': DEVICE_CLASS_SHUTTER,
+    'io:RollerShutterVeluxIOComponent': DEVICE_CLASS_SHUTTER,
+    'io:RollerShutterWithLowSpeedManagementIOComponent': DEVICE_CLASS_SHUTTER,
+    'io:VerticalExteriorAwningIOComponent': DEVICE_CLASS_AWNING,
+    'io:WindowOpenerVeluxIOComponent': DEVICE_CLASS_WINDOW,
+    'io:GarageOpenerIOComponent': DEVICE_CLASS_GARAGE,
+    'rts:BlindRTSComponent': DEVICE_CLASS_BLIND,
+    'rts:CurtainRTSComponent': DEVICE_CLASS_CURTAIN,
+    'rts:DualCurtainRTSComponent': DEVICE_CLASS_CURTAIN,
+    'rts:ExteriorVenetianBlindRTSComponent': DEVICE_CLASS_BLIND,
+    'rts:RollerShutterRTSComponent': DEVICE_CLASS_SHUTTER,
+    'rts:VenetianBlindRTSComponent': DEVICE_CLASS_BLIND
+}
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Tahoma covers."""
@@ -155,37 +173,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
     @property
     def device_class(self):
         """Return the class of the device."""
-        if self.tahoma_device.type == 'io:ExteriorVenetianBlindIOComponent':
-            return DEVICE_CLASS_BLIND
-        elif self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-            return DEVICE_CLASS_AWNING
-        elif self.tahoma_device.type == 'io:RollerShutterGenericIOComponent':
-            return DEVICE_CLASS_SHUTTER
-        elif self.tahoma_device.type == 'io:RollerShutterUnoIOComponent':
-            return DEVICE_CLASS_SHUTTER
-        elif self.tahoma_device.type == 'io:RollerShutterVeluxIOComponent':
-            return DEVICE_CLASS_SHUTTER
-        elif self.tahoma_device.type == 'io:RollerShutterWithLowSpeedManagementIOComponent':
-            return DEVICE_CLASS_SHUTTER
-        elif self.tahoma_device.type == 'io:VerticalExteriorAwningIOComponent':
-            return DEVICE_CLASS_AWNING
-        elif self.tahoma_device.type == 'io:WindowOpenerVeluxIOComponent':
-            return DEVICE_CLASS_WINDOW
-        elif self.tahoma_device.type == 'io:GarageOpenerIOComponent':
-            return DEVICE_CLASS_GARAGE
-        elif self.tahoma_device.type == 'rts:BlindRTSComponent':
-            return DEVICE_CLASS_BLIND
-        elif self.tahoma_device.type == 'rts:CurtainRTSComponent':
-            return DEVICE_CLASS_CURTAIN
-        elif self.tahoma_device.type == 'rts:DualCurtainRTSComponent':
-            return DEVICE_CLASS_CURTAIN
-        elif self.tahoma_device.type == 'rts:ExteriorVenetianBlindRTSComponent':
-            return DEVICE_CLASS_BLIND
-        elif self.tahoma_device.type == 'rts:RollerShutterRTSComponent':
-            return DEVICE_CLASS_SHUTTER
-        elif self.tahoma_device.type == 'rts:VenetianBlindRTSComponent':
-            return DEVICE_CLASS_BLIND
-        return None
+        return TAHOMA_DEVICE_CLASSES.get(self.tahoma_device.type, None)
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Description:
Tahoma covers that are awnings are treated differently than other covers such as blinds.  The "open" state of the awning is fully extended while closed is retracted.

Also added appropriate device classes

**Related issue (if applicable):** fixes #16868

**Breaking Change:** Tahoma horizontal awnings 'open' and 'closed' positions reversed