### PR TITLE
Return appropriate value in Plex Media Player supported_features

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -672,7 +672,7 @@ class PlexClient(MediaPlayerDevice):
     def supported_features(self):
         """Flag media player features that are supported."""
         if not self._is_player_active:
-            return None
+            return 0
 
         # force show all controls
         if self.config.get(CONF_SHOW_ALL_CONTROLS):
@@ -683,7 +683,7 @@ class PlexClient(MediaPlayerDevice):
 
         # only show controls when we know what device is connecting
         if not self._make:
-            return None
+            return 0
         # no mute support
         if self.make.lower() == "shield android tv":
             _LOGGER.debug(
@@ -708,7 +708,7 @@ class PlexClient(MediaPlayerDevice):
                     SUPPORT_VOLUME_SET | SUPPORT_PLAY |
                     SUPPORT_TURN_OFF | SUPPORT_VOLUME_MUTE)
 
-        return None
+        return 0
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""


### PR DESCRIPTION
## Description:
Corrects the `supported_features` property to return `0` instead of `None`.  This was identified by @Villhellm and is a result of #22878.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.