### PR TITLE
Added Dockerfile for unprivileged hass user

### DIFF
--- a/virtualization/Docker/Dockerfile.hass-user
+++ b/virtualization/Docker/Dockerfile.hass-user
@@ -1,0 +1,48 @@
+# Notice:
+# When updating this file, please also update virtualization/Docker/Dockerfile.dev
+# This way, the development image and the production image are kept in sync.
+
+FROM python:3.7
+LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
+
+# Uncomment any of the following lines to disable the installation.
+#ENV INSTALL_TELLSTICK no
+#ENV INSTALL_OPENALPR no
+#ENV INSTALL_FFMPEG no
+#ENV INSTALL_LIBCEC no
+#ENV INSTALL_SSOCR no
+#ENV INSTALL_DLIB no
+#ENV INSTALL_IPERF3 no
+
+VOLUME /config
+
+WORKDIR /usr/src/app
+
+# Add unprivileged 'hass' user and group so we aren't running as root
+RUN groupadd --system --gid 8123 hass
+RUN useradd --system --uid 8123 --gid hass \
+	--home-dir /usr/src/app \
+	--groups dialout \
+	--no-create-home \
+	hass \
+		&& chown -R hass:hass /config \
+		&& chown -R hass:hass /usr/src/app
+
+# Copy build scripts
+COPY virtualization/Docker/ virtualization/Docker/
+RUN virtualization/Docker/setup_docker_prereqs
+
+# Install hass component dependencies
+COPY requirements_all.txt requirements_all.txt
+# Uninstall enum34 because some dependencies install it but breaks Python 3.4+.
+# See PR #8103 for more info.
+RUN pip3 install --no-cache-dir -r requirements_all.txt && \
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop==0.12.2 cchardet cython tensorflow
+
+# Switch to 'hass' user
+USER hass
+
+# Copy source
+COPY . .
+
+CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
## Description:

Adds a Dockerfile to run Home Assistant as an unprivileged (non-root) user.  The pre-defined user and group are both "hass" and have uid/gid 8123.  This lets the docker host set up data volumes that are isolated from other running containers.

Use:
docker build -f virtualization/Docker/Dockerfile.hass-user -t home-assistant-noroot:ver .

## Checklist:
  - [X] The code change is tested and works locally.
  - [NA] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [NA] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [NA] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [NA] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [NA] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [NA] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [NA] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [NA] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
