### PR TITLE
Add homematicip cloud temperature sensor from thermostats (HMIP-eTRV, HMIP-eTRV-C), Cleanup Light Sensor HmIP-SLO

### DIFF
--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -38,6 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if isinstance(device, (AsyncHeatingThermostat,
                                AsyncHeatingThermostatCompact)):
             devices.append(HomematicipHeatingThermostat(home, device))
+            devices.append(HomematicipTemperatureSensor(home, device))
         if isinstance(device, (AsyncTemperatureHumiditySensorDisplay,
                                AsyncTemperatureHumiditySensorWithoutDisplay,
                                AsyncTemperatureHumiditySensorOutdoor,
@@ -46,15 +47,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                                AsyncWeatherSensorPro)):
             devices.append(HomematicipTemperatureSensor(home, device))
             devices.append(HomematicipHumiditySensor(home, device))
-        if isinstance(device, (AsyncMotionDetectorIndoor,
+        if isinstance(device, (AsyncLightSensor, AsyncMotionDetectorIndoor,
                                AsyncMotionDetectorOutdoor,
                                AsyncMotionDetectorPushButton,
                                AsyncWeatherSensor,
                                AsyncWeatherSensorPlus,
                                AsyncWeatherSensorPro)):
             devices.append(HomematicipIlluminanceSensor(home, device))
-        if isinstance(device, AsyncLightSensor):
-            devices.append(HomematicipLightSensor(home, device))
         if isinstance(device, (AsyncPlugableSwitchMeasuring,
                                AsyncBrandSwitchMeasuring,
                                AsyncFullFlushSwitchMeasuring)):
@@ -181,6 +180,9 @@ class HomematicipTemperatureSensor(HomematicipGenericDevice):
     @property
     def state(self):
         """Return the state."""
+        if hasattr(self._device, 'valveActualTemperature'):
+            return self._device.valveActualTemperature
+
         return self._device.actualTemperature
 
     @property
@@ -213,21 +215,15 @@ class HomematicipIlluminanceSensor(HomematicipGenericDevice):
     @property
     def state(self):
         """Return the state."""
+        if hasattr(self._device, 'averageIllumination'):
+            return self._device.averageIllumination
+
         return self._device.illumination
 
     @property
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return 'lx'
-
-
-class HomematicipLightSensor(HomematicipIlluminanceSensor):
-    """Represenation of a HomematicIP Illuminance device."""
-
-    @property
-    def state(self):
-        """Return the state."""
-        return self._device.averageIllumination
 
 
 class HomematicipPowerSensor(HomematicipGenericDevice):


### PR DESCRIPTION
## Breaking Change:

Homematic IP Cloud: Entity IDs of HmIP-SLO (Light Sensor Outdoor) will change.
Stale entities need to be removed from the entity registry.

## Description:

This PR adds a temperature sensor to HmIP thermostats.
These thermostat temperature values are not covered by climate entities in HmIP, as long these thermostats  are the only climate related devices in a HmIP-HeatingGroup.

Further explanations could be found in this [FR](https://community.home-assistant.io/t/homematic-ip-missing-attributes/112225)

This PR also cleans up the code for illumination related devices.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#9260


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. 
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
