### PR TITLE
Add play URL support to HEOS media players

### DIFF
--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -6,10 +6,10 @@ from typing import Sequence
 
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
-    DOMAIN, MEDIA_TYPE_MUSIC, SUPPORT_CLEAR_PLAYLIST, SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE,
-    SUPPORT_SHUFFLE_SET, SUPPORT_STOP, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP)
+    DOMAIN, MEDIA_TYPE_MUSIC, MEDIA_TYPE_URL, SUPPORT_CLEAR_PLAYLIST,
+    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA,
+    SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_SHUFFLE_SET,
+    SUPPORT_STOP, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 from homeassistant.helpers.typing import HomeAssistantType
@@ -20,7 +20,8 @@ from .const import (
 
 BASE_SUPPORTED_FEATURES = SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET | \
                           SUPPORT_VOLUME_STEP | SUPPORT_CLEAR_PLAYLIST | \
-                          SUPPORT_SHUFFLE_SET | SUPPORT_SELECT_SOURCE
+                          SUPPORT_SHUFFLE_SET | SUPPORT_SELECT_SOURCE | \
+                          SUPPORT_PLAY_MEDIA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -152,6 +153,15 @@ class HeosMediaPlayer(MediaPlayerDevice):
     async def async_mute_volume(self, mute):
         """Mute the volume."""
         await self._player.set_mute(mute)
+
+    @log_command_error("play media")
+    async def async_play_media(self, media_type, media_id, **kwargs):
+        """Play a piece of media."""
+        if media_type == MEDIA_TYPE_URL:
+            await self._player.play_url(media_id)
+        else:
+            _LOGGER.error("Unable to play media: Unsupported media type '%s'",
+                          media_type)
 
     @log_command_error("select source")
     async def async_select_source(self, source):

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -1,7 +1,7 @@
 """Tests for the Heos Media Player platform."""
 import asyncio
 
-from pyheos import const, CommandError
+from pyheos import CommandError, const
 
 from homeassistant.components.heos import media_player
 from homeassistant.components.heos.const import (
@@ -12,8 +12,9 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_DURATION, ATTR_MEDIA_POSITION, ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_MEDIA_SHUFFLE, ATTR_MEDIA_TITLE, ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED, DOMAIN as MEDIA_PLAYER_DOMAIN, MEDIA_TYPE_MUSIC,
-    SERVICE_CLEAR_PLAYLIST, SERVICE_SELECT_SOURCE, SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PREVIOUS_TRACK, SUPPORT_STOP)
+    MEDIA_TYPE_URL, SERVICE_CLEAR_PLAYLIST, SERVICE_PLAY_MEDIA,
+    SERVICE_SELECT_SOURCE, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY,
+    SUPPORT_PREVIOUS_TRACK, SUPPORT_STOP)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_SUPPORTED_FEATURES,
     SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY,
@@ -415,3 +416,34 @@ async def test_unload_config_entry(hass, config_entry, config, controller):
     await setup_platform(hass, config_entry, config)
     await config_entry.async_unload(hass)
     assert not hass.states.get('media_player.test_player')
+
+
+async def test_play_media_url(hass, config_entry, config, controller, caplog):
+    """Test the play media service with type url."""
+    await setup_platform(hass, config_entry, config)
+    player = controller.players[1]
+    url = "http://news/podcast.mp3"
+    # First pass completes successfully, second pass raises command error
+    for _ in range(2):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN, SERVICE_PLAY_MEDIA,
+            {ATTR_ENTITY_ID: 'media_player.test_player',
+             ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_URL,
+             ATTR_MEDIA_CONTENT_ID: url}, blocking=True)
+        player.play_url.assert_called_once_with(url)
+        player.play_url.reset_mock()
+        player.play_url.side_effect = CommandError(None, "Failure", 1)
+    assert "Unable to play media: Failure (1)" in caplog.text
+
+
+async def test_play_media_invalid_type(
+        hass, config_entry, config, controller, caplog):
+    """Test the play media service with an invalid type."""
+    await setup_platform(hass, config_entry, config)
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN, SERVICE_PLAY_MEDIA,
+        {ATTR_ENTITY_ID: 'media_player.test_player',
+         ATTR_MEDIA_CONTENT_TYPE: "Other",
+         ATTR_MEDIA_CONTENT_ID: ""}, blocking=True)
+    assert "Unable to play media: Unsupported media type 'Other'" \
+        in caplog.text


### PR DESCRIPTION
## Description:
Add support for playing URL streams through the `media_player.play_media` service to the HEOS media player.  Community requested feature from @Cadish

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#9261
 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.