### PR TITLE
Upgrade pyotp to 2.2.7

### DIFF
--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from . import MultiFactorAuthModule, MULTI_FACTOR_AUTH_MODULES, \
     MULTI_FACTOR_AUTH_MODULE_SCHEMA, SetupFlow
 
-REQUIREMENTS = ['pyotp==2.2.6']
+REQUIREMENTS = ['pyotp==2.2.7']
 
 CONF_MESSAGE = 'message'
 

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from . import MultiFactorAuthModule, MULTI_FACTOR_AUTH_MODULES, \
     MULTI_FACTOR_AUTH_MODULE_SCHEMA, SetupFlow
 
-REQUIREMENTS = ['pyotp==2.2.6', 'PyQRCode==1.2.1']
+REQUIREMENTS = ['pyotp==2.2.7', 'PyQRCode==1.2.1']
 
 CONFIG_SCHEMA = MULTI_FACTOR_AUTH_MODULE_SCHEMA.extend({
 }, extra=vol.PREVENT_EXTRA)

--- a/homeassistant/components/otp/manifest.json
+++ b/homeassistant/components/otp/manifest.json
@@ -3,7 +3,7 @@
   "name": "Otp",
   "documentation": "https://www.home-assistant.io/components/otp",
   "requirements": [
-    "pyotp==2.2.6"
+    "pyotp==2.2.7"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1216,7 +1216,7 @@ pyotgw==0.4b3
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.otp
-pyotp==2.2.6
+pyotp==2.2.7
 
 # homeassistant.components.owlet
 pyowlet==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -240,7 +240,7 @@ pyopenuv==1.0.9
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.otp
-pyotp==2.2.6
+pyotp==2.2.7
 
 # homeassistant.components.ps4
 pyps4-homeassistant==0.5.2


### PR DESCRIPTION
## Description:

- Upgrade pyotp to version 2.2.7 ([release notes](https://github.com/pyauth/pyotp/blob/master/Changes.rst#changes-for-v227-2018-11-05)), which is, for now, the latest version and also to be sync with the version, which is in OpenWrt.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
