### PR TITLE
Upgrade xmltodict to 0.12.0

### DIFF
--- a/homeassistant/components/bluesound/manifest.json
+++ b/homeassistant/components/bluesound/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bluesound",
   "documentation": "https://www.home-assistant.io/components/bluesound",
   "requirements": [
-    "xmltodict==0.11.0"
+    "xmltodict==0.12.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/startca/manifest.json
+++ b/homeassistant/components/startca/manifest.json
@@ -3,7 +3,7 @@
   "name": "Startca",
   "documentation": "https://www.home-assistant.io/components/startca",
   "requirements": [
-    "xmltodict==0.11.0"
+    "xmltodict==0.12.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/ted5000/manifest.json
+++ b/homeassistant/components/ted5000/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ted5000",
   "documentation": "https://www.home-assistant.io/components/ted5000",
   "requirements": [
-    "xmltodict==0.11.0"
+    "xmltodict==0.12.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/yr/manifest.json
+++ b/homeassistant/components/yr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yr",
   "documentation": "https://www.home-assistant.io/components/yr",
   "requirements": [
-    "xmltodict==0.11.0"
+    "xmltodict==0.12.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/zestimate/manifest.json
+++ b/homeassistant/components/zestimate/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zestimate",
   "documentation": "https://www.home-assistant.io/components/zestimate",
   "requirements": [
-    "xmltodict==0.11.0"
+    "xmltodict==0.12.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1812,7 +1812,7 @@ xknx==0.10.0
 # homeassistant.components.ted5000
 # homeassistant.components.yr
 # homeassistant.components.zestimate
-xmltodict==0.11.0
+xmltodict==0.12.0
 
 # homeassistant.components.xs1
 xs1-api-client==2.3.5


### PR DESCRIPTION
## Description:

- Upgrade xmltodict to version [0.12.0,](https://github.com/martinblech/xmltodict/blob/master/CHANGELOG.md#v0120) which has support for Python 3.7

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.