### PR TITLE
Use the timezone defined in Home Assistant when making the API call

### DIFF
--- a/homeassistant/components/vasttrafik/sensor.py
+++ b/homeassistant/components/vasttrafik/sensor.py
@@ -54,15 +54,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         config.get(CONF_KEY), config.get(CONF_SECRET))
     sensors = []
 
-    timezone = str(hass.config.time_zone)
-
     for departure in config.get(CONF_DEPARTURES):
         sensors.append(
             VasttrafikDepartureSensor(
                 vasttrafik, planner, departure.get(CONF_NAME),
                 departure.get(CONF_FROM), departure.get(CONF_HEADING),
-                departure.get(CONF_LINES), departure.get(CONF_DELAY),
-                timezone))
+                departure.get(CONF_LINES), departure.get(CONF_DELAY)))
     add_entities(sensors, True)
 
 
@@ -70,10 +67,9 @@ class VasttrafikDepartureSensor(Entity):
     """Implementation of a Vasttrafik Departure Sensor."""
 
     def __init__(self, vasttrafik, planner, name, departure, heading,
-                 lines, delay, timezone):
+                 lines, delay):
         """Initialize the sensor."""
         self._vasttrafik = vasttrafik
-        self.timezone = timezone
         self._planner = planner
         self._name = name or departure
         self._departure = planner.location_name(departure)[0]
@@ -112,7 +108,8 @@ class VasttrafikDepartureSensor(Entity):
             self._departureboard = self._planner.departureboard(
                 self._departure['id'],
                 direction=self._heading['id'] if self._heading else None,
-                date=datetime.now(pytz.timezone(self.timezone))+self._delay)
+                date=datetime.now(
+                    pytz.timezone(str(self.hass.config.time_zone)))+self._delay)
         except self._vasttrafik.Error:
             _LOGGER.debug("Unable to read departure board, updating token")
             self._planner.update_token()

--- a/homeassistant/components/vasttrafik/sensor.py
+++ b/homeassistant/components/vasttrafik/sensor.py
@@ -1,8 +1,6 @@
 """Support for Västtrafik public transport."""
-from datetime import datetime
 from datetime import timedelta
 import logging
-import pytz
 
 import voluptuous as vol
 
@@ -11,6 +9,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+from homeassistant.util.dt import now
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,8 +107,7 @@ class VasttrafikDepartureSensor(Entity):
             self._departureboard = self._planner.departureboard(
                 self._departure['id'],
                 direction=self._heading['id'] if self._heading else None,
-                date=datetime.now(
-                    pytz.timezone(str(self.hass.config.time_zone)))+self._delay)
+                date=now(self.hass.config.time_zone)+self._delay)
         except self._vasttrafik.Error:
             _LOGGER.debug("Unable to read departure board, updating token")
             self._planner.update_token()

--- a/homeassistant/components/vasttrafik/sensor.py
+++ b/homeassistant/components/vasttrafik/sensor.py
@@ -107,7 +107,7 @@ class VasttrafikDepartureSensor(Entity):
             self._departureboard = self._planner.departureboard(
                 self._departure['id'],
                 direction=self._heading['id'] if self._heading else None,
-                date=now(self.hass.config.time_zone)+self._delay)
+                date=now()+self._delay)
         except self._vasttrafik.Error:
             _LOGGER.debug("Unable to read departure board, updating token")
             self._planner.update_token()


### PR DESCRIPTION
## Breaking Change:

```text
If you have used the `delay` option to compensate for the timezone difference you should now remove that.
```
_This will only be a breaking change for users that have used the `delay` option to compensate, all other users will be unaffected by this._

## Description:

This change forces the use of the `time_zone` option from the general `homeassistant` configuration, rather than trusting the TZ of the host.
This is a problem especially for users on HassOS.

<!--
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
-->
## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: vasttrafik
    key: SUPERSECRETAPIKEY
    secret: SUPERSECRETAPISECRET
    departures:
      - from: Musikvägen
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
-->