### PR TITLE
Arch #208: 2: event.track_template_result

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
     ENTITY_MATCH_ALL, CONF_ENTITY_NAMESPACE, __version__)
 from homeassistant.core import valid_entity_id, split_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 
@@ -461,6 +460,8 @@ unit_system = vol.All(vol.Lower, vol.Any(CONF_UNIT_SYSTEM_METRIC,
 
 def template(value):
     """Validate a jinja2 template."""
+    from homeassistant.helpers import template as template_helper
+
     if value is None:
         raise vol.Invalid('template value is None')
     if isinstance(value, (list, dict, template_helper.Template)):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -99,6 +99,23 @@ def boolean(value: Any) -> bool:
     return bool(value)
 
 
+def boolean_true(value: Any) -> bool:
+    """Coerce a boolean value to true, or return false."""
+    if isinstance(value, str):
+        value = value.lower()
+        return value in ('1', 'true', 'yes', 'on', 'enable')
+    return bool(value)
+
+
+_WS = re.compile('\\s*')
+
+
+@vol.truth
+def whitespace(value: Any) -> str:
+    """Validate result contains only whitespace."""
+    return isinstance(value, str) and _WS.fullmatch(value)
+
+
 def isdevice(value):
     """Validate that value is a real device."""
     try:

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,5 +1,5 @@
 """Helper class to implement include/exclude of entities and domains."""
-from typing import Callable, Dict, Iterable
+from typing import Callable, Dict, Iterable, Any, Optional, Set
 
 import voluptuous as vol
 
@@ -39,71 +39,122 @@ def generate_filter(include_domains: Iterable[str],
                     exclude_domains: Iterable[str],
                     exclude_entities: Iterable[str]) -> Callable[[str], bool]:
     """Return a function that will filter entities based on the args."""
-    include_d = set(include_domains)
-    include_e = set(include_entities)
-    exclude_d = set(exclude_domains)
-    exclude_e = set(exclude_entities)
-
-    have_exclude = bool(exclude_e or exclude_d)
-    have_include = bool(include_e or include_d)
-
     # Case 1 - no includes or excludes - pass all entities
-    if not have_include and not have_exclude:
-        return lambda entity_id: True
+    if (not include_domains and not include_entities
+            and not exclude_domains and not exclude_entities):
+        return EntityFilter(include_all=True)
 
-    # Case 2 - includes, no excludes - only include specified entities
-    if have_include and not have_exclude:
-        def entity_filter_2(entity_id: str) -> bool:
-            """Return filter function for case 2."""
+    return EntityFilter(include_domains=include_domains,
+                        include_entities=include_entities,
+                        exclude_domains=exclude_domains,
+                        exclude_entities=exclude_entities)
+
+
+class EntityFilter:
+    """Filter for entitity IDs."""
+
+    def __init__(self, include_all: bool = False,
+                 include_domains: Optional[Iterable[str]] = None,
+                 include_entities: Optional[Iterable[str]] = None,
+                 exclude_domains: Optional[Iterable[str]] = None,
+                 exclude_entities: Optional[Iterable[str]] = None):
+        """Initialiser."""
+        self.include_all = include_all
+        self._include_domains = set(include_domains or [])
+        self._include_entities = set(include_entities or [])
+        self._exclude_domains = set(exclude_domains or [])
+        self._exclude_entities = set(exclude_entities or [])
+
+    @property
+    def include_domains(self) -> Set[str]:
+        """Domains included in the filter."""
+        return self._include_domains
+
+    @property
+    def include_entities(self) -> Set[str]:
+        """Entities included in the filter."""
+        return self._include_entities
+
+    @property
+    def exclude_domains(self) -> Set[str]:
+        """Domains excluded from the filter."""
+        return self._exclude_domains
+
+    @property
+    def exclude_entities(self) -> Set[str]:
+        """Entities excluded from the filter."""
+        return self._exclude_entities
+
+    def __eq__(self, other: Any) -> bool:
+        """Test equivalence of two filters."""
+        if isinstance(other, EntityFilter):
+            return (
+                self.include_all == other.include_all and
+                self._include_domains == other.include_domains and
+                self._include_entities == other.include_entities and
+                self._exclude_domains == other.exclude_domains and
+                self._exclude_entities == other.exclude_entities)
+        return False
+
+    def __repr__(self) -> str:
+        """Convert to string."""
+        return (
+            "EntityFilter(" +
+            ("include_all=True " if self.include_all else "") +
+            (("include_domains=" + str(self._include_domains) + " ")
+             if self._include_domains else "") +
+            (("include_entities=" + str(self._include_entities) + " ")
+             if self._include_entities else "") +
+            (("exclude_domains=" + str(self._exclude_domains) + " ")
+             if self._exclude_domains else "") +
+            (("exclude_entities=" + str(self._exclude_entities) + " ")
+             if self._exclude_entities else "") +
+            ")")
+
+    def __call__(self, entity_id: str) -> bool:
+        """Filter entities based on the filter."""
+        # Case 1 - pass all entities
+        if self.include_all:
+            return True
+
+        have_exclude = bool(self._exclude_entities or self._exclude_domains)
+        have_include = bool(self._include_entities or self._include_domains)
+
+        # Case 1a - fail all entities
+        if not have_exclude and not have_include:
+            return False
+
+        # Case 2 - includes, no excludes - only include specified entities
+        if have_include and not have_exclude:
+            return (entity_id in self._include_entities or
+                    split_entity_id(entity_id)[0] in self._include_domains)
+
+        # Case 3 - excludes, no includes - only exclude specified entities
+        if not have_include and have_exclude:
+            return (entity_id not in self._exclude_entities and
+                    split_entity_id(entity_id)[0] not in self._exclude_domains)
+
+        # Case 4 - both includes and excludes specified
+        # Case 4a - include domain specified
+        #  - if domain is included, pass if entity not excluded
+        #  - if domain is not included, pass if entity is included
+        # note: if both include and exclude domains specified,
+        #   the exclude domains are ignored
+        if self._include_domains:
             domain = split_entity_id(entity_id)[0]
-            return (entity_id in include_e or
-                    domain in include_d)
+            if domain in self._include_domains:
+                return entity_id not in self._exclude_entities
+            return entity_id in self._include_entities
 
-        return entity_filter_2
-
-    # Case 3 - excludes, no includes - only exclude specified entities
-    if not have_include and have_exclude:
-        def entity_filter_3(entity_id: str) -> bool:
-            """Return filter function for case 3."""
+        # Case 4b - exclude domain specified
+        #  - if domain is excluded, pass if entity is included
+        #  - if domain is not excluded, pass if entity not excluded
+        if self._exclude_domains:
             domain = split_entity_id(entity_id)[0]
-            return (entity_id not in exclude_e and
-                    domain not in exclude_d)
+            if domain in self._exclude_domains:
+                return entity_id in self._include_entities
+            return entity_id not in self._exclude_entities
 
-        return entity_filter_3
-
-    # Case 4 - both includes and excludes specified
-    # Case 4a - include domain specified
-    #  - if domain is included, pass if entity not excluded
-    #  - if domain is not included, pass if entity is included
-    # note: if both include and exclude domains specified,
-    #   the exclude domains are ignored
-    if include_d:
-        def entity_filter_4a(entity_id: str) -> bool:
-            """Return filter function for case 4a."""
-            domain = split_entity_id(entity_id)[0]
-            if domain in include_d:
-                return entity_id not in exclude_e
-            return entity_id in include_e
-
-        return entity_filter_4a
-
-    # Case 4b - exclude domain specified
-    #  - if domain is excluded, pass if entity is included
-    #  - if domain is not excluded, pass if entity not excluded
-    if exclude_d:
-        def entity_filter_4b(entity_id: str) -> bool:
-            """Return filter function for case 4b."""
-            domain = split_entity_id(entity_id)[0]
-            if domain in exclude_d:
-                return entity_id in include_e
-            return entity_id not in exclude_e
-
-        return entity_filter_4b
-
-    # Case 4c - neither include or exclude domain specified
-    #  - Only pass if entity is included.  Ignore entity excludes.
-    def entity_filter_4c(entity_id: str) -> bool:
-        """Return filter function for case 4c."""
-        return entity_id in include_e
-
-    return entity_filter_4c
+        # Case 4c - neither include or exclude domain specified
+        #  - Only pass if entity is included.  Ignore entity excludes.
+        return entity_id in self._include_entities

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1,15 +1,23 @@
 """Helpers for listening to events."""
-from datetime import timedelta
 import functools as ft
+import logging
+from datetime import timedelta
+from typing import Any, Callable, Mapping, Optional, Union
 
+import homeassistant.helpers.config_validation as cv
+from homeassistant.exceptions import TemplateError
 from homeassistant.loader import bind_hass
-from homeassistant.helpers.sun import get_astral_event_next
-from ..core import HomeAssistant, callback
-from ..const import (
-    ATTR_NOW, EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL,
-    SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+
+from ..const import (ATTR_NOW, EVENT_STATE_CHANGED, EVENT_TIME_CHANGED,
+                     MATCH_ALL, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+from ..core import Event, HomeAssistant, State, callback
 from ..util import dt as dt_util
 from ..util.async_ import run_callback_threadsafe
+from .sun import get_astral_event_next
+from .template import Template
+from .typing import TemplateVarsType
+
+_LOGGER = logging.getLogger(__name__)
 
 # PyLint does not like the use of threaded_listener_factory
 # pylint: disable=invalid-name
@@ -89,32 +97,267 @@ track_state_change = threaded_listener_factory(async_track_state_change)
 
 @callback
 @bind_hass
-def async_track_template(hass, template, action, variables=None):
-    """Add a listener that track state changes with template condition."""
-    from . import condition
+def async_track_template(
+        hass: HomeAssistant,
+        template: Template,
+        action: Callable[[str, Optional[State], Optional[State]], None],
+        variables: Optional[TemplateVarsType] = None) \
+        -> Callable[[], None]:
+    """Add a listener that fires when a a template evaluates to 'true'.
 
-    # Local variable to keep track of if the action has already been triggered
-    already_triggered = False
+    Listen for the result of the template becomming true, or a true-like
+    string result, such as 'On', 'Open', or 'Yes'. If the template results
+    in an error state when the value changes, this will be logged and not
+    passed through.
 
+    On template registration, the action will be called with an entity_id
+    and state of some entity referenced by the template, or '*' if no
+    entity is referenced by the template.
+
+    If the initial run of the template is invalid and results in an
+    exception, the listener will still be registered but will only
+    fire if the template result becomes true without an exception.
+
+    Action arguments
+    ----------------
+    entity_id
+        ID of the entity that triggered the state change.
+    old_state
+        The old state of the entity that changed.
+    new_state
+        New state of the entity that changed.
+
+    Parameters
+    ----------
+    hass
+        Home assistant object.
+    template
+        The template to calculate.
+    action
+        Callable to call with results. See above for arguments.
+    variables
+        Variables to pass to the template.
+
+    Returns
+    -------
+    Callable to unregister the listener.
+
+    """
     @callback
-    def template_condition_listener(entity_id, from_s, to_s):
+    def state_changed_listener(event, template, last_result, result):
         """Check if condition is correct and run action."""
-        nonlocal already_triggered
-        template_result = condition.async_template(hass, template, variables)
+        if isinstance(result, TemplateError):
+            _LOGGER.exception(result)
+            return
 
-        # Check to see if template returns true
-        if template_result and not already_triggered:
-            already_triggered = True
-            hass.async_run_job(action, entity_id, from_s, to_s)
-        elif not template_result:
-            already_triggered = False
+        result = cv.boolean_true(result)
 
-    return async_track_state_change(
-        hass, template.extract_entities(variables),
-        template_condition_listener)
+        if last_result is not None:
+            last_result = cv.boolean_true(last_result)
+            if not last_result and result:
+                hass.async_run_job(action, event.data.get('entity_id'),
+                                   event.data.get('old_state'),
+                                   event.data.get('new_state'))
+        elif result:
+            # First run of the listener. Figure out an entity ID to
+            # pass back to the action because it expects one.
+            (_, entity_filter) = \
+                template.async_render_with_collect(variables)
+            state = None
+            entity_id = None
+            for eid in entity_filter.include_entities:
+                state = hass.states.get(eid)
+                if state:
+                    entity_id = eid
+                    break
+            if not state:
+                for st in hass.states.async_all():
+                    if entity_filter(st.entity_id):
+                        state = st
+                        entity_id = st.entity_id
+                        break
+            hass.async_run_job(
+                action, entity_id or MATCH_ALL, state, state)
+
+    info = async_track_template_result(
+        hass, template, state_changed_listener, variables)
+
+    return info.async_remove
 
 
 track_template = threaded_listener_factory(async_track_template)
+
+
+class TrackTemplateResultInfo:
+    """Return value from async_track_template_result."""
+
+    def __init__(self, hass, template, action, variables):
+        """Initialiser, should be package private."""
+        self.hass = hass
+        self._template = template
+        self._action = action
+        self._variables = variables
+
+        (self._last_result, self._entity_filter) = \
+            template.async_render_with_collect(variables)
+        if isinstance(self._last_result, TemplateError):
+            self._last_exception = self._last_result
+            self._last_result = None
+        else:
+            self._last_exception = None
+        self._cancel = hass.bus.async_listen(
+            EVENT_STATE_CHANGED, self._state_changed_listener)
+
+        self.hass.async_run_job(
+            self._action, None, self._template,
+            None, self._last_exception or self._last_result)
+
+    @property
+    def template(self) -> Template:
+        """Return the template that is being tracked."""
+        return self._template
+
+    def remove(self) -> None:
+        """Cancel the listener."""
+        self.hass.add_job(self.async_remove)
+
+    @callback
+    def async_remove(self) -> None:
+        """Cancel the listener."""
+        self._cancel()
+
+    def refresh(self) -> None:
+        """Force recalculate the template."""
+        self.hass.add_job(self.async_refresh)
+
+    @callback
+    def async_refresh(self) -> None:
+        """Force recalculate the template."""
+        self._refresh()
+
+    def __call__(self) -> None:
+        """Cancel the listener."""
+        self.remove()
+
+    @callback
+    def _state_changed_listener(self, event):
+        """Check if condition is correct and run action."""
+        entity_id = event.data.get('entity_id')
+        # Optimisation: if the old and new states are not None then this is
+        # a state change rather than a life-cycle event, and therefore we
+        # only need to check the include entities.
+        old_state = event.data.get('old_state')
+        new_state = event.data.get('new_state')
+        if old_state is not None and new_state is not None:
+            if entity_id not in self._entity_filter.include_entities:
+                return
+        elif not self._entity_filter(entity_id):
+            return
+
+        self._refresh(event)
+
+    def _refresh(self, event=None) -> None:
+        (result, self._entity_filter) = \
+            self._template.async_render_with_collect(self._variables)
+
+        if isinstance(result, TemplateError):
+            if self._last_exception is None:
+                self.hass.async_run_job(
+                    self._action, event, self._template,
+                    self._last_result, result)
+                self._last_exception = result
+            return
+        self._last_exception = None
+
+        # Check to see if the result has changed
+        if result != self._last_result:
+            self.hass.async_run_job(
+                self._action, event, self._template,
+                self._last_result, result)
+            self._last_result = result
+
+
+TrackTemplateResultListener = Callable[[
+    Optional[Event],
+    Template,
+    Optional[str],
+    Union[str, TemplateError]], None]
+"""Type for the listener for template results.
+
+    Action arguments
+    ----------------
+    event
+        Event that caused the template to change output. None if not
+        triggered by an event.
+    template
+        The template that has changed.
+    last_result
+        The output from the template on the last successful run, or None
+        if no previous successful run.
+    result
+        Result from the template run. This will be a string or an
+        TemplateError if the template resulted in an error.
+"""
+
+
+@callback
+@bind_hass
+def async_track_template_result(
+        hass: HomeAssistant,
+        template: Template,
+        action: TrackTemplateResultListener,
+        variables: Optional[Mapping[str, Any]] = None) \
+        -> TrackTemplateResultInfo:
+    """Add a listener that fires when a the result of a template changes.
+
+    The action will fire with the initial result from the template, and
+    then whenever the output from the template changes. The template will
+    be reevaluated if any states referenced in the last run of the
+    template change, or if manually triggered. If the result of the
+    evaluation is different from the previous run, the listener is passed
+    the result.
+
+    If the template results in an TemplateError, this will be returned to
+    the listener the first time this happens but not for subsequent errors.
+    Once the template returns to a non-error condition the result is sent
+    to the action as usual.
+
+    Parameters
+    ----------
+    hass
+        Home assistant object.
+    template
+        The template to calculate.
+    action
+        Callable to call with results.
+    variables
+        Variables to pass to the template.
+
+    Returns
+    -------
+    Info object used to unregister the listener, and refresh the template.
+
+    """
+    return TrackTemplateResultInfo(hass, template, action, variables)
+
+
+def track_template_result(
+        hass: HomeAssistant,
+        template: Template,
+        action: Callable[[
+            Event,
+            Template,
+            Optional[str],
+            Union[str, TemplateError]], None],
+        variables: Optional[Mapping[str, Any]] = None) \
+        -> (Callable[[], None], Union[str, TemplateError]):
+    """Add a listener that fires whenever a template changes."""
+    result = run_callback_threadsafe(
+        hass.loop, ft.partial(
+            async_track_template_result, hass, template,
+            action, variables)).result()
+
+    return result
 
 
 @callback

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1,24 +1,25 @@
 """Template helper methods for rendering strings with Home Assistant data."""
-from datetime import datetime
+import base64
 import json
 import logging
 import math
 import random
-import base64
 import re
+from datetime import datetime
+from typing import Union
 
 import jinja2
 from jinja2 import contextfilter
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
 
-from homeassistant.const import (
-    ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_UNIT_OF_MEASUREMENT, MATCH_ALL,
-    STATE_UNKNOWN)
-from homeassistant.core import State, valid_entity_id
+from homeassistant.const import (ATTR_LATITUDE, ATTR_LONGITUDE, MATCH_ALL,
+                                 ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
+from homeassistant.core import State, callback, valid_entity_id
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import location as loc_helper
 from homeassistant.helpers.typing import TemplateVarsType
+from homeassistant.helpers.entityfilter import EntityFilter
 from homeassistant.loader import bind_hass
 from homeassistant.util import convert
 from homeassistant.util import dt as dt_util
@@ -28,6 +29,8 @@ from homeassistant.util.async_ import run_callback_threadsafe
 _LOGGER = logging.getLogger(__name__)
 _SENTINEL = object()
 DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+_COLLECT_KEY = 'template.collect'
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
@@ -124,6 +127,7 @@ class Template:
         return run_callback_threadsafe(
             self.hass.loop, self.async_render, kwargs).result()
 
+    @callback
     def async_render(self, variables: TemplateVarsType = None,
                      **kwargs) -> str:
         """Render given template.
@@ -141,6 +145,34 @@ class Template:
         except jinja2.TemplateError as err:
             raise TemplateError(err)
 
+    def render_with_collect(
+            self, variables: TemplateVarsType = None,
+            **kwargs) -> (Union[str, TemplateError],
+                          EntityFilter):
+        """Render given template and collect an entity filter."""
+        if variables is not None:
+            kwargs.update(variables)
+
+        return run_callback_threadsafe(
+            self.hass.loop, self.async_render_with_collect,
+            kwargs).result()
+
+    @callback
+    def async_render_with_collect(
+            self, variables: TemplateVarsType = None,
+            **kwargs) -> (Union[str, TemplateError],
+                          EntityFilter):
+        """Render the template and collect an entity filter."""
+        assert self.hass and _COLLECT_KEY not in self.hass.data
+        entity_collect = self.hass.data[_COLLECT_KEY] = EntityFilter()
+        try:
+            result = self.async_render(variables, **kwargs)
+            return (result, entity_collect)
+        except TemplateError as ex:
+            return (ex, entity_collect)
+        finally:
+            del self.hass.data[_COLLECT_KEY]
+
     def render_with_possible_json_value(self, value, error_value=_SENTINEL):
         """Render template with value exposed.
 
@@ -150,6 +182,7 @@ class Template:
             self.hass.loop, self.async_render_with_possible_json_value, value,
             error_value).result()
 
+    @callback
     def async_render_with_possible_json_value(self, value,
                                               error_value=_SENTINEL,
                                               variables=None):
@@ -190,7 +223,7 @@ class Template:
         global_vars = ENV.make_globals({
             'closest': template_methods.closest,
             'distance': template_methods.distance,
-            'is_state': self.hass.states.is_state,
+            'is_state': template_methods.is_state,
             'is_state_attr': template_methods.is_state_attr,
             'state_attr': template_methods.state_attr,
             'states': AllStates(self.hass),
@@ -207,6 +240,14 @@ class Template:
                 self.template == other.template and
                 self.hass == other.hass)
 
+    def __hash__(self):
+        """Hash code for template."""
+        return hash(self.template)
+
+    def __repr__(self):
+        """Representation of Template."""
+        return 'Template(\"' + self.template + '\")'
+
 
 class AllStates:
     """Class to expose all HA states as attributes."""
@@ -217,23 +258,40 @@ class AllStates:
 
     def __getattr__(self, name):
         """Return the domain state."""
+        if '.' in name:
+            if not valid_entity_id(name):
+                raise TemplateError("Invalid entity ID '{}'".format(name))
+            return _get_state(self._hass, name)
+        if not valid_entity_id(name + '.entity'):
+            raise TemplateError("Invalid domain name '{}'".format(name))
         return DomainStates(self._hass, name)
+
+    def _collect_all(self):
+        entity_collect = self._hass.data.get(_COLLECT_KEY)
+        if entity_collect is not None:
+            entity_collect.include_all = True
 
     def __iter__(self):
         """Return all states."""
+        self._collect_all()
         return iter(
-            _wrap_state(state) for state in
+            _wrap_state(self._hass, state) for state in
             sorted(self._hass.states.async_all(),
                    key=lambda state: state.entity_id))
 
     def __len__(self):
         """Return number of states."""
+        self._collect_all()
         return len(self._hass.states.async_entity_ids())
 
     def __call__(self, entity_id):
         """Return the states."""
-        state = self._hass.states.get(entity_id)
+        state = _get_state(self._hass, entity_id)
         return STATE_UNKNOWN if state is None else state.state
+
+    def __repr__(self):
+        """Representation of All States."""
+        return '<template AllStates>'
 
 
 class DomainStates:
@@ -246,19 +304,33 @@ class DomainStates:
 
     def __getattr__(self, name):
         """Return the states."""
-        return _wrap_state(
-            self._hass.states.get('{}.{}'.format(self._domain, name)))
+        entity_id = '{}.{}'.format(self._domain, name)
+        if not valid_entity_id(entity_id):
+            raise TemplateError("Invalid entity ID '{}'".format(entity_id))
+        return _get_state(self._hass, entity_id)
+
+    def _collect_domain(self):
+        entity_collect = self._hass.data.get(_COLLECT_KEY)
+        if entity_collect is not None:
+            entity_collect.include_domains.add(self._domain)
 
     def __iter__(self):
         """Return the iteration over all the states."""
+        self._collect_domain()
         return iter(sorted(
-            (_wrap_state(state) for state in self._hass.states.async_all()
+            (_wrap_state(self._hass, state)
+             for state in self._hass.states.async_all()
              if state.domain == self._domain),
             key=lambda state: state.entity_id))
 
     def __len__(self):
         """Return number of states."""
+        self._collect_domain()
         return len(self._hass.states.async_entity_ids(self._domain))
+
+    def __repr__(self):
+        """Representation of Domain States."""
+        return '<template DomainStates(\'{}\')>'.format(self._domain)
 
 
 class TemplateState(State):
@@ -266,14 +338,21 @@ class TemplateState(State):
 
     # Inheritance is done so functions that check against State keep working
     # pylint: disable=super-init-not-called
-    def __init__(self, state):
+    def __init__(self, hass, state):
         """Initialize template state."""
+        self._hass = hass
         self._state = state
+
+    def _access_state(self):
+        state = object.__getattribute__(self, '_state')
+        hass = object.__getattribute__(self, '_hass')
+        _collect_state(hass, state.entity_id)
+        return state
 
     @property
     def state_with_unit(self):
         """Return the state concatenated with the unit if available."""
-        state = object.__getattribute__(self, '_state')
+        state = object.__getattribute__(self, '_access_state')()
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         if unit is None:
             return state.state
@@ -281,19 +360,43 @@ class TemplateState(State):
 
     def __getattribute__(self, name):
         """Return an attribute of the state."""
+        # This one doesn't count as an access of the state
+        # since we either found it by looking direct for the ID
+        # or got it off an iterator.
+        if name == 'entity_id' or name in object.__dict__:
+            state = object.__getattribute__(self, '_state')
+            return getattr(state, name)
         if name in TemplateState.__dict__:
             return object.__getattribute__(self, name)
-        return getattr(object.__getattribute__(self, '_state'), name)
+        state = object.__getattribute__(self, '_access_state')()
+        return getattr(state, name)
 
     def __repr__(self):
         """Representation of Template State."""
-        rep = object.__getattribute__(self, '_state').__repr__()
+        state = object.__getattribute__(self, '_access_state')()
+        rep = state.__repr__()
         return '<template ' + rep[1:]
 
 
-def _wrap_state(state):
+def _collect_state(hass, entity_id):
+    entity_collect = hass.data.get(_COLLECT_KEY)
+    if entity_collect is not None:
+        entity_collect.include_entities.add(entity_id)
+
+
+def _wrap_state(hass, state):
     """Wrap a state."""
-    return None if state is None else TemplateState(state)
+    return None if state is None else TemplateState(hass, state)
+
+
+def _get_state(hass, entity_id):
+    state = hass.states.get(entity_id)
+    if state is None:
+        # Only need to collect if none, if not none collect first actuall
+        # access to the state properties in the state wrapper.
+        _collect_state(hass, entity_id)
+        return None
+    return _wrap_state(hass, state)
 
 
 class TemplateMethods:
@@ -359,12 +462,14 @@ class TemplateMethods:
             else:
                 gr_entity_id = str(entities)
 
-            group = self._hass.components.group
+            _collect_state(self._hass, gr_entity_id)
 
-            states = [self._hass.states.get(entity_id) for entity_id
+            group = self._hass.components.group
+            states = [_get_state(self._hass, entity_id) for entity_id
                       in group.expand_entity_ids([gr_entity_id])]
 
-        return _wrap_state(loc_helper.closest(latitude, longitude, states))
+        # state will already be wrapped here
+        return loc_helper.closest(latitude, longitude, states)
 
     def distance(self, *args):
         """Calculate distance.
@@ -421,14 +526,19 @@ class TemplateMethods:
         return self._hass.config.units.length(
             loc_util.distance(*locations[0] + locations[1]), 'm')
 
+    def is_state(self, entity_id: str, state: State) -> bool:
+        """Test if a state is a specific value."""
+        state_obj = _get_state(self._hass, entity_id)
+        return state_obj is not None and state_obj.state == state
+
     def is_state_attr(self, entity_id, name, value):
-        """Test if a state is a specific attribute."""
+        """Test if a state's attribute is a specific value."""
         state_attr = self.state_attr(entity_id, name)
         return state_attr is not None and state_attr == value
 
     def state_attr(self, entity_id, name):
         """Get a specific attribute from a state."""
-        state_obj = self._hass.states.get(entity_id)
+        state_obj = _get_state(self._hass, entity_id)
         if state_obj is not None:
             return state_obj.attributes.get(name)
         return None
@@ -438,7 +548,7 @@ class TemplateMethods:
         if isinstance(entity_id_or_state, State):
             return entity_id_or_state
         if isinstance(entity_id_or_state, str):
-            return self._hass.states.get(entity_id_or_state)
+            return _get_state(self._hass, entity_id_or_state)
         return None
 
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -106,8 +106,8 @@ async def test_if_not_fires_on_change_bool(hass, calls):
     assert 0 == len(calls)
 
 
-async def test_if_not_fires_on_change_str(hass, calls):
-    """Test for not firing on string change."""
+async def test_if_fires_on_change_bare_str(hass, calls):
+    """Test should fire once for a bare string of true."""
     assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'trigger': {
@@ -119,10 +119,12 @@ async def test_if_not_fires_on_change_str(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
+    assert 1 == len(calls)
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert 0 == len(calls)
+    assert 1 == len(calls)
 
 
 async def test_if_not_fires_on_change_str_crazy(hass, calls):
@@ -225,10 +227,11 @@ async def test_if_not_fires_on_change_with_template(hass, calls):
     })
 
     await hass.async_block_till_done()
+    assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_fires_on_change_with_template_advanced(hass, calls):
@@ -307,21 +310,6 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     })
 
     await hass.async_block_till_done()
-
-    hass.states.async_set('test.entity', 'world')
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-    hass.states.async_set('test.entity', 'home')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'work')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'not_home')
-    await hass.async_block_till_done()
     assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
@@ -331,6 +319,22 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     hass.states.async_set('test.entity', 'home')
     await hass.async_block_till_done()
     assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'work')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'not_home')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'world')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'home')
+    await hass.async_block_till_done()
+    assert len(calls) == 3
 
 
 async def test_if_action(hass, calls):
@@ -413,7 +417,7 @@ async def test_wait_template_with_trigger(hass, calls):
             },
             'action': [
                 {'wait_template':
-                    "{{ is_state(trigger.entity_id, 'hello') }}"},
+                 "{{ is_state(trigger.entity_id, 'hello') }}"},
                 {'service': 'test.automation',
                  'data_template': {
                     'some':

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,5 +1,6 @@
 """Test the condition helper."""
 from unittest.mock import patch
+from logging import ERROR
 
 from homeassistant.helpers import condition
 from homeassistant.util import dt
@@ -164,3 +165,18 @@ class TestConditionHelper:
             self.hass.states.set('sensor.temperature', 'unknown')
             assert not test(self.hass)
             assert len(logwarn.mock_calls) == 0
+
+
+async def test_condition_template_error(hass, caplog):
+    """Test invalid template."""
+    caplog.set_level(ERROR)
+
+    test = condition.async_from_config({
+        'condition': 'template',
+        'value_template': '{{ undefined.state }}',
+    })
+
+    assert not test(hass)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message\
+        .startswith("Error during template condition: UndefinedError:")

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -1,5 +1,22 @@
 """The tests for the EntityFilter component."""
-from homeassistant.helpers.entityfilter import generate_filter, FILTER_SCHEMA
+from homeassistant.helpers.entityfilter import (
+        generate_filter, EntityFilter, FILTER_SCHEMA)
+
+
+def test_identity():
+    """Test filter comparison and hashing."""
+    test_1 = EntityFilter(include_entities=["test.one"])
+    test_1a = EntityFilter(include_entities=["test.one"])
+    test_2 = EntityFilter(exclude_entities=["test.one"])
+    test_3 = EntityFilter(include_entities=["test.one", "test.two"])
+    test_4 = EntityFilter(include_domains=["test"])
+
+    assert test_1 == test_1a
+    assert test_1 != test_2
+    assert test_2 != test_3
+    assert test_3 != test_4
+    assert test_2 != test_4
+    assert test_1 != "pickle"
 
 
 def test_no_filters_case_1():


### PR DESCRIPTION
## Description:

Broken up version of #23160, which was refactor of #22588. Lots of notes #22588 and in the arch issue [#208](https://github.com/home-assistant/architecture/issues/208) on the algorithm change.

This PR only includes the last commit in the sequence and will need a rebase against #23283

**Related issue (if applicable):** fixes #22587

#### Add async_track_template_result method

This uses the code submitted in ##23283 to add a listener that fires when the result of a template changes. The method is much better documented to explain when it's supposed to fire. 

I've also updated `track_template` to be a wrapper around this method.
