### PR TITLE
Arch #208: 3: Template entity

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -1,4 +1,9 @@
-"""Support for exposing a templated binary sensor."""
+"""
+Support for exposing a templated binary sensor.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.template/
+"""
 import logging
 
 import voluptuous as vol
@@ -8,14 +13,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice, ENTITY_ID_FORMAT, PLATFORM_SCHEMA,
     DEVICE_CLASSES_SCHEMA)
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, CONF_VALUE_TEMPLATE,
+    ATTR_FRIENDLY_NAME, CONF_VALUE_TEMPLATE,
     CONF_ICON_TEMPLATE, CONF_ENTITY_PICTURE_TEMPLATE,
-    CONF_SENSORS, CONF_DEVICE_CLASS, EVENT_HOMEASSISTANT_START, MATCH_ALL)
-from homeassistant.exceptions import TemplateError
+    CONF_SENSORS, CONF_DEVICE_CLASS)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.event import (
-    async_track_state_change, async_track_same_state)
+from homeassistant.helpers.event import async_call_later
+from .template_entity import TemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +31,6 @@ SENSOR_SCHEMA = vol.Schema({
     vol.Optional(CONF_ICON_TEMPLATE): cv.template,
     vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
-    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
     vol.Optional(CONF_DELAY_ON):
         vol.All(cv.time_period, cv.positive_timedelta),
@@ -47,46 +50,14 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     for device, device_config in config[CONF_SENSORS].items():
         value_template = device_config[CONF_VALUE_TEMPLATE]
+        value_template.hass = hass
         icon_template = device_config.get(CONF_ICON_TEMPLATE)
+        if icon_template:
+            icon_template.hass = hass
         entity_picture_template = device_config.get(
             CONF_ENTITY_PICTURE_TEMPLATE)
-        entity_ids = set()
-        manual_entity_ids = device_config.get(ATTR_ENTITY_ID)
-
-        invalid_templates = []
-
-        for tpl_name, template in (
-                (CONF_VALUE_TEMPLATE, value_template),
-                (CONF_ICON_TEMPLATE, icon_template),
-                (CONF_ENTITY_PICTURE_TEMPLATE, entity_picture_template),
-        ):
-            if template is None:
-                continue
-            template.hass = hass
-
-            if manual_entity_ids is not None:
-                continue
-
-            template_entity_ids = template.extract_entities()
-            if template_entity_ids == MATCH_ALL:
-                entity_ids = MATCH_ALL
-                # Cut off _template from name
-                invalid_templates.append(tpl_name[:-9])
-            elif entity_ids != MATCH_ALL:
-                entity_ids |= set(template_entity_ids)
-
-        if manual_entity_ids is not None:
-            entity_ids = manual_entity_ids
-        elif entity_ids != MATCH_ALL:
-            entity_ids = list(entity_ids)
-
-        if invalid_templates:
-            _LOGGER.warning(
-                'Template binary sensor %s has no entity ids configured to'
-                ' track nor were we able to extract the entities to track'
-                ' from the %s template(s). This entity will only be able'
-                ' to be updated manually.',
-                device, ', '.join(invalid_templates))
+        if entity_picture_template:
+            entity_picture_template.hass = hass
 
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         device_class = device_config.get(CONF_DEVICE_CLASS)
@@ -96,7 +67,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         sensors.append(
             BinarySensorTemplate(
                 hass, device, friendly_name, device_class, value_template,
-                icon_template, entity_picture_template, entity_ids,
+                icon_template, entity_picture_template,
                 delay_on, delay_off)
             )
     if not sensors:
@@ -107,47 +78,64 @@ async def async_setup_platform(hass, config, async_add_entities,
     return True
 
 
-class BinarySensorTemplate(BinarySensorDevice):
+class BinarySensorTemplate(BinarySensorDevice, TemplateEntity):
     """A virtual binary sensor that triggers from another sensor."""
 
     def __init__(self, hass, device, friendly_name, device_class,
                  value_template, icon_template, entity_picture_template,
-                 entity_ids, delay_on, delay_off):
+                 delay_on, delay_off):
         """Initialize the Template binary sensor."""
+        super().__init__()
         self.hass = hass
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, device, hass=hass)
         self._name = friendly_name
         self._device_class = device_class
-        self._template = value_template
         self._state = None
-        self._icon_template = icon_template
-        self._entity_picture_template = entity_picture_template
         self._icon = None
         self._entity_picture = None
-        self._entities = entity_ids
         self._delay_on = delay_on
         self._delay_off = delay_off
+        self._delay_cancel = None
 
-    async def async_added_to_hass(self):
-        """Register callbacks."""
+        self.add_template_attribute(
+            '_state', value_template,
+            cv.boolean_true,
+            self._update_state)
+        if icon_template is not None:
+            self.add_template_attribute(
+                '_icon', icon_template,
+                vol.Or(cv.whitespace, cv.icon))
+        if entity_picture_template is not None:
+            self.add_template_attribute(
+                '_entity_picture', entity_picture_template)
+
+    def _update_state(self, state):
+        if self._delay_cancel:
+            self._delay_cancel()
+            self._delay_cancel = None
+
+        if state == self._state:
+            return
+
         @callback
-        def template_bsensor_state_listener(entity, old_state, new_state):
-            """Handle the target device state changes."""
-            self.async_check_state()
+        def set_state(now):
+            """Set state of template binary sensor."""
+            self._state = state
+            self.async_schedule_update_ha_state()
 
-        @callback
-        def template_bsensor_startup(event):
-            """Update template on startup."""
-            if self._entities != MATCH_ALL:
-                # Track state change only for valid templates
-                async_track_state_change(
-                    self.hass, self._entities, template_bsensor_state_listener)
+        # state without delay
+        if (state is None or
+                (state and not self._delay_on) or
+                (not state and not self._delay_off)):
+            set_state(None)
+            return
 
-            self.async_check_state()
-
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, template_bsensor_startup)
+        delay = (self._delay_on if state else self._delay_off).seconds
+        # state with delay. Cancelled if template result changes.
+        self._delay_cancel = async_call_later(
+            self.hass, delay,
+            set_state)
 
     @property
     def name(self):
@@ -178,71 +166,3 @@ class BinarySensorTemplate(BinarySensorDevice):
     def should_poll(self):
         """No polling needed."""
         return False
-
-    @callback
-    def _async_render(self):
-        """Get the state of template."""
-        state = None
-        try:
-            state = (self._template.async_render().lower() == 'true')
-        except TemplateError as ex:
-            if ex.args and ex.args[0].startswith(
-                    "UndefinedError: 'None' has no attribute"):
-                # Common during HA startup - so just a warning
-                _LOGGER.warning("Could not render template %s, "
-                                "the state is unknown", self._name)
-                return
-            _LOGGER.error("Could not render template %s: %s", self._name, ex)
-
-        for property_name, template in (
-                ('_icon', self._icon_template),
-                ('_entity_picture', self._entity_picture_template)):
-            if template is None:
-                continue
-
-            try:
-                setattr(self, property_name, template.async_render())
-            except TemplateError as ex:
-                friendly_property_name = property_name[1:].replace('_', ' ')
-                if ex.args and ex.args[0].startswith(
-                        "UndefinedError: 'None' has no attribute"):
-                    # Common during HA startup - so just a warning
-                    _LOGGER.warning('Could not render %s template %s,'
-                                    ' the state is unknown.',
-                                    friendly_property_name, self._name)
-                else:
-                    _LOGGER.error('Could not render %s template %s: %s',
-                                  friendly_property_name, self._name, ex)
-                return state
-
-        return state
-
-    @callback
-    def async_check_state(self):
-        """Update the state from the template."""
-        state = self._async_render()
-
-        # return if the state don't change or is invalid
-        if state is None or state == self.state:
-            return
-
-        @callback
-        def set_state():
-            """Set state of template binary sensor."""
-            self._state = state
-            self.async_schedule_update_ha_state()
-
-        # state without delay
-        if (state and not self._delay_on) or \
-                (not state and not self._delay_off):
-            set_state()
-            return
-
-        period = self._delay_on if state else self._delay_off
-        async_track_same_state(
-            self.hass, period, set_state, entity_ids=self._entities,
-            async_check_same_func=lambda *args: self._async_render() == state)
-
-    async def async_update(self):
-        """Force update of the state from the template."""
-        self.async_check_state()

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -1,0 +1,143 @@
+"""TemplateEntity utility class."""
+
+import logging
+from typing import Optional, Callable, Any, Union
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.config_validation import match_all
+from homeassistant.helpers.event import async_track_template_result, Event
+from homeassistant.helpers.template import Template
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _TemplateAttribute:
+    """Attribute value linked to template result."""
+
+    def __init__(
+            self,
+            entity: Entity,
+            attribute: str,
+            template: Template,
+            validator: Callable[[Any], Any] = match_all,
+            on_update: Optional[Callable[[Any], None]] = None):
+        """Initialiser."""
+        self._entity = entity
+        self._attribute = attribute
+        self.template = template
+        self.validator = validator
+        if on_update is None:
+            if not hasattr(entity, attribute):
+                raise AttributeError(
+                    "Attribute '{}' does not exist.".format(attribute))
+
+            def _default_update(result):
+                setattr(entity, attribute, result)
+                entity.async_schedule_update_ha_state()
+            self.on_update = _default_update
+        else:
+            self.on_update = on_update
+        self.async_update = match_all
+        self.async_will_remove_from_hass = match_all
+
+    @callback
+    def _handle_result(
+            self,
+            event: Optional[Event],
+            template: Template,
+            last_result: Optional[str],
+            result: Union[str, TemplateError]) -> None:
+        if isinstance(result, TemplateError):
+            _LOGGER.error(
+                "TemplateError('%s') "
+                "while processing template '%s' "
+                "for attribute '%s' in entity '%s'",
+                result,
+                self.template,
+                self._attribute,
+                self._entity.entity_id)
+            self.on_update(None)
+            return
+
+        try:
+            validated = self.validator(result)
+        except vol.Invalid as ex:
+            _LOGGER.error(
+                "Error validating template result '%s' "
+                "from template '%s' "
+                "for attribute '%s' in entity %s "
+                "validation message '%s'",
+                result,
+                self.template,
+                self._attribute,
+                self._entity.entity_id,
+                ex.msg)
+            self.on_update(None)
+            return
+
+        self.on_update(validated)
+
+    @callback
+    def async_added_to_hass(self) -> None:
+        """Call from containing entity when added to hass."""
+        result_info = async_track_template_result(
+            self._entity.hass,
+            self.template,
+            self._handle_result
+        )
+        self.async_will_remove_from_hass = result_info.async_remove
+        self.async_update = result_info.async_refresh
+
+
+class TemplateEntity(Entity):
+    """Entity that uses templates to calculate attributes."""
+
+    def __init__(self):
+        """Initialiser."""
+        self._template_attrs = []
+
+    def add_template_attribute(
+            self,
+            attribute: str,
+            template: Template,
+            validator: Callable[[Any], Any] = match_all,
+            on_update: Optional[Callable[[Any], None]] = None) -> None:
+        """
+        Call in the constructor to add a template linked to a attribute.
+
+        Parameters
+        ----------
+        attribute
+            The name of the attribute to link to. This attribute must exist
+            unless a custom on_update method is supplied.
+        template
+            The template to calculate.
+        validator
+            Validator function to parse the result and ensure it's valid.
+        on_update
+            Called to store the template result rather than storing it
+            the supplied attribute. Passed the result of the validator, or None
+            if the template or validator resulted in an error.
+
+        """
+        self._template_attrs.append(_TemplateAttribute(
+            self, attribute, template, validator, on_update))
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        for attribute in self._template_attrs:
+            attribute.async_added_to_hass()
+
+    async def async_update(self) -> None:
+        """Call for forced update."""
+        for attribute in self._template_attrs:
+            attribute.async_update()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        for attribute in self._template_attrs:
+            attribute.async_will_remove_from_hass()

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
     ENTITY_MATCH_ALL, CONF_ENTITY_NAMESPACE, __version__)
 from homeassistant.core import valid_entity_id, split_entity_id
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import template as template_helper
 from homeassistant.helpers.logging import KeywordStyleAdapter
 from homeassistant.util import slugify as util_slugify
 
@@ -461,6 +460,8 @@ unit_system = vol.All(vol.Lower, vol.Any(CONF_UNIT_SYSTEM_METRIC,
 
 def template(value):
     """Validate a jinja2 template."""
+    from homeassistant.helpers import template as template_helper
+
     if value is None:
         raise vol.Invalid('template value is None')
     if isinstance(value, (list, dict, template_helper.Template)):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -99,6 +99,23 @@ def boolean(value: Any) -> bool:
     return bool(value)
 
 
+def boolean_true(value: Any) -> bool:
+    """Coerce a boolean value to true, or return false."""
+    if isinstance(value, str):
+        value = value.lower()
+        return value in ('1', 'true', 'yes', 'on', 'enable')
+    return bool(value)
+
+
+_WS = re.compile('\\s*')
+
+
+@vol.truth
+def whitespace(value: Any) -> str:
+    """Validate result contains only whitespace."""
+    return isinstance(value, str) and _WS.fullmatch(value)
+
+
 def isdevice(value):
     """Validate that value is a real device."""
     try:

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,5 +1,5 @@
 """Helper class to implement include/exclude of entities and domains."""
-from typing import Callable, Dict, Iterable
+from typing import Callable, Dict, Iterable, Any, Optional, Set
 
 import voluptuous as vol
 
@@ -39,71 +39,122 @@ def generate_filter(include_domains: Iterable[str],
                     exclude_domains: Iterable[str],
                     exclude_entities: Iterable[str]) -> Callable[[str], bool]:
     """Return a function that will filter entities based on the args."""
-    include_d = set(include_domains)
-    include_e = set(include_entities)
-    exclude_d = set(exclude_domains)
-    exclude_e = set(exclude_entities)
-
-    have_exclude = bool(exclude_e or exclude_d)
-    have_include = bool(include_e or include_d)
-
     # Case 1 - no includes or excludes - pass all entities
-    if not have_include and not have_exclude:
-        return lambda entity_id: True
+    if (not include_domains and not include_entities
+            and not exclude_domains and not exclude_entities):
+        return EntityFilter(include_all=True)
 
-    # Case 2 - includes, no excludes - only include specified entities
-    if have_include and not have_exclude:
-        def entity_filter_2(entity_id: str) -> bool:
-            """Return filter function for case 2."""
+    return EntityFilter(include_domains=include_domains,
+                        include_entities=include_entities,
+                        exclude_domains=exclude_domains,
+                        exclude_entities=exclude_entities)
+
+
+class EntityFilter:
+    """Filter for entitity IDs."""
+
+    def __init__(self, include_all: bool = False,
+                 include_domains: Optional[Iterable[str]] = None,
+                 include_entities: Optional[Iterable[str]] = None,
+                 exclude_domains: Optional[Iterable[str]] = None,
+                 exclude_entities: Optional[Iterable[str]] = None):
+        """Initialiser."""
+        self.include_all = include_all
+        self._include_domains = set(include_domains or [])
+        self._include_entities = set(include_entities or [])
+        self._exclude_domains = set(exclude_domains or [])
+        self._exclude_entities = set(exclude_entities or [])
+
+    @property
+    def include_domains(self) -> Set[str]:
+        """Domains included in the filter."""
+        return self._include_domains
+
+    @property
+    def include_entities(self) -> Set[str]:
+        """Entities included in the filter."""
+        return self._include_entities
+
+    @property
+    def exclude_domains(self) -> Set[str]:
+        """Domains excluded from the filter."""
+        return self._exclude_domains
+
+    @property
+    def exclude_entities(self) -> Set[str]:
+        """Entities excluded from the filter."""
+        return self._exclude_entities
+
+    def __eq__(self, other: Any) -> bool:
+        """Test equivalence of two filters."""
+        if isinstance(other, EntityFilter):
+            return (
+                self.include_all == other.include_all and
+                self._include_domains == other.include_domains and
+                self._include_entities == other.include_entities and
+                self._exclude_domains == other.exclude_domains and
+                self._exclude_entities == other.exclude_entities)
+        return False
+
+    def __repr__(self) -> str:
+        """Convert to string."""
+        return (
+            "EntityFilter(" +
+            ("include_all=True " if self.include_all else "") +
+            (("include_domains=" + str(self._include_domains) + " ")
+             if self._include_domains else "") +
+            (("include_entities=" + str(self._include_entities) + " ")
+             if self._include_entities else "") +
+            (("exclude_domains=" + str(self._exclude_domains) + " ")
+             if self._exclude_domains else "") +
+            (("exclude_entities=" + str(self._exclude_entities) + " ")
+             if self._exclude_entities else "") +
+            ")")
+
+    def __call__(self, entity_id: str) -> bool:
+        """Filter entities based on the filter."""
+        # Case 1 - pass all entities
+        if self.include_all:
+            return True
+
+        have_exclude = bool(self._exclude_entities or self._exclude_domains)
+        have_include = bool(self._include_entities or self._include_domains)
+
+        # Case 1a - fail all entities
+        if not have_exclude and not have_include:
+            return False
+
+        # Case 2 - includes, no excludes - only include specified entities
+        if have_include and not have_exclude:
+            return (entity_id in self._include_entities or
+                    split_entity_id(entity_id)[0] in self._include_domains)
+
+        # Case 3 - excludes, no includes - only exclude specified entities
+        if not have_include and have_exclude:
+            return (entity_id not in self._exclude_entities and
+                    split_entity_id(entity_id)[0] not in self._exclude_domains)
+
+        # Case 4 - both includes and excludes specified
+        # Case 4a - include domain specified
+        #  - if domain is included, pass if entity not excluded
+        #  - if domain is not included, pass if entity is included
+        # note: if both include and exclude domains specified,
+        #   the exclude domains are ignored
+        if self._include_domains:
             domain = split_entity_id(entity_id)[0]
-            return (entity_id in include_e or
-                    domain in include_d)
+            if domain in self._include_domains:
+                return entity_id not in self._exclude_entities
+            return entity_id in self._include_entities
 
-        return entity_filter_2
-
-    # Case 3 - excludes, no includes - only exclude specified entities
-    if not have_include and have_exclude:
-        def entity_filter_3(entity_id: str) -> bool:
-            """Return filter function for case 3."""
+        # Case 4b - exclude domain specified
+        #  - if domain is excluded, pass if entity is included
+        #  - if domain is not excluded, pass if entity not excluded
+        if self._exclude_domains:
             domain = split_entity_id(entity_id)[0]
-            return (entity_id not in exclude_e and
-                    domain not in exclude_d)
+            if domain in self._exclude_domains:
+                return entity_id in self._include_entities
+            return entity_id not in self._exclude_entities
 
-        return entity_filter_3
-
-    # Case 4 - both includes and excludes specified
-    # Case 4a - include domain specified
-    #  - if domain is included, pass if entity not excluded
-    #  - if domain is not included, pass if entity is included
-    # note: if both include and exclude domains specified,
-    #   the exclude domains are ignored
-    if include_d:
-        def entity_filter_4a(entity_id: str) -> bool:
-            """Return filter function for case 4a."""
-            domain = split_entity_id(entity_id)[0]
-            if domain in include_d:
-                return entity_id not in exclude_e
-            return entity_id in include_e
-
-        return entity_filter_4a
-
-    # Case 4b - exclude domain specified
-    #  - if domain is excluded, pass if entity is included
-    #  - if domain is not excluded, pass if entity not excluded
-    if exclude_d:
-        def entity_filter_4b(entity_id: str) -> bool:
-            """Return filter function for case 4b."""
-            domain = split_entity_id(entity_id)[0]
-            if domain in exclude_d:
-                return entity_id in include_e
-            return entity_id not in exclude_e
-
-        return entity_filter_4b
-
-    # Case 4c - neither include or exclude domain specified
-    #  - Only pass if entity is included.  Ignore entity excludes.
-    def entity_filter_4c(entity_id: str) -> bool:
-        """Return filter function for case 4c."""
-        return entity_id in include_e
-
-    return entity_filter_4c
+        # Case 4c - neither include or exclude domain specified
+        #  - Only pass if entity is included.  Ignore entity excludes.
+        return entity_id in self._include_entities

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1,15 +1,23 @@
 """Helpers for listening to events."""
-from datetime import timedelta
 import functools as ft
+import logging
+from datetime import timedelta
+from typing import Any, Callable, Mapping, Optional, Union
 
+import homeassistant.helpers.config_validation as cv
+from homeassistant.exceptions import TemplateError
 from homeassistant.loader import bind_hass
-from homeassistant.helpers.sun import get_astral_event_next
-from ..core import HomeAssistant, callback
-from ..const import (
-    ATTR_NOW, EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL,
-    SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+
+from ..const import (ATTR_NOW, EVENT_STATE_CHANGED, EVENT_TIME_CHANGED,
+                     MATCH_ALL, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+from ..core import Event, HomeAssistant, State, callback
 from ..util import dt as dt_util
 from ..util.async_ import run_callback_threadsafe
+from .sun import get_astral_event_next
+from .template import Template
+from .typing import TemplateVarsType
+
+_LOGGER = logging.getLogger(__name__)
 
 # PyLint does not like the use of threaded_listener_factory
 # pylint: disable=invalid-name
@@ -89,32 +97,267 @@ track_state_change = threaded_listener_factory(async_track_state_change)
 
 @callback
 @bind_hass
-def async_track_template(hass, template, action, variables=None):
-    """Add a listener that track state changes with template condition."""
-    from . import condition
+def async_track_template(
+        hass: HomeAssistant,
+        template: Template,
+        action: Callable[[str, Optional[State], Optional[State]], None],
+        variables: Optional[TemplateVarsType] = None) \
+        -> Callable[[], None]:
+    """Add a listener that fires when a a template evaluates to 'true'.
 
-    # Local variable to keep track of if the action has already been triggered
-    already_triggered = False
+    Listen for the result of the template becomming true, or a true-like
+    string result, such as 'On', 'Open', or 'Yes'. If the template results
+    in an error state when the value changes, this will be logged and not
+    passed through.
 
+    On template registration, the action will be called with an entity_id
+    and state of some entity referenced by the template, or '*' if no
+    entity is referenced by the template.
+
+    If the initial run of the template is invalid and results in an
+    exception, the listener will still be registered but will only
+    fire if the template result becomes true without an exception.
+
+    Action arguments
+    ----------------
+    entity_id
+        ID of the entity that triggered the state change.
+    old_state
+        The old state of the entity that changed.
+    new_state
+        New state of the entity that changed.
+
+    Parameters
+    ----------
+    hass
+        Home assistant object.
+    template
+        The template to calculate.
+    action
+        Callable to call with results. See above for arguments.
+    variables
+        Variables to pass to the template.
+
+    Returns
+    -------
+    Callable to unregister the listener.
+
+    """
     @callback
-    def template_condition_listener(entity_id, from_s, to_s):
+    def state_changed_listener(event, template, last_result, result):
         """Check if condition is correct and run action."""
-        nonlocal already_triggered
-        template_result = condition.async_template(hass, template, variables)
+        if isinstance(result, TemplateError):
+            _LOGGER.exception(result)
+            return
 
-        # Check to see if template returns true
-        if template_result and not already_triggered:
-            already_triggered = True
-            hass.async_run_job(action, entity_id, from_s, to_s)
-        elif not template_result:
-            already_triggered = False
+        result = cv.boolean_true(result)
 
-    return async_track_state_change(
-        hass, template.extract_entities(variables),
-        template_condition_listener)
+        if last_result is not None:
+            last_result = cv.boolean_true(last_result)
+            if not last_result and result:
+                hass.async_run_job(action, event.data.get('entity_id'),
+                                   event.data.get('old_state'),
+                                   event.data.get('new_state'))
+        elif result:
+            # First run of the listener. Figure out an entity ID to
+            # pass back to the action because it expects one.
+            (_, entity_filter) = \
+                template.async_render_with_collect(variables)
+            state = None
+            entity_id = None
+            for eid in entity_filter.include_entities:
+                state = hass.states.get(eid)
+                if state:
+                    entity_id = eid
+                    break
+            if not state:
+                for st in hass.states.async_all():
+                    if entity_filter(st.entity_id):
+                        state = st
+                        entity_id = st.entity_id
+                        break
+            hass.async_run_job(
+                action, entity_id or MATCH_ALL, state, state)
+
+    info = async_track_template_result(
+        hass, template, state_changed_listener, variables)
+
+    return info.async_remove
 
 
 track_template = threaded_listener_factory(async_track_template)
+
+
+class TrackTemplateResultInfo:
+    """Return value from async_track_template_result."""
+
+    def __init__(self, hass, template, action, variables):
+        """Initialiser, should be package private."""
+        self.hass = hass
+        self._template = template
+        self._action = action
+        self._variables = variables
+
+        (self._last_result, self._entity_filter) = \
+            template.async_render_with_collect(variables)
+        if isinstance(self._last_result, TemplateError):
+            self._last_exception = self._last_result
+            self._last_result = None
+        else:
+            self._last_exception = None
+        self._cancel = hass.bus.async_listen(
+            EVENT_STATE_CHANGED, self._state_changed_listener)
+
+        self.hass.async_run_job(
+            self._action, None, self._template,
+            None, self._last_exception or self._last_result)
+
+    @property
+    def template(self) -> Template:
+        """Return the template that is being tracked."""
+        return self._template
+
+    def remove(self) -> None:
+        """Cancel the listener."""
+        self.hass.add_job(self.async_remove)
+
+    @callback
+    def async_remove(self) -> None:
+        """Cancel the listener."""
+        self._cancel()
+
+    def refresh(self) -> None:
+        """Force recalculate the template."""
+        self.hass.add_job(self.async_refresh)
+
+    @callback
+    def async_refresh(self) -> None:
+        """Force recalculate the template."""
+        self._refresh()
+
+    def __call__(self) -> None:
+        """Cancel the listener."""
+        self.remove()
+
+    @callback
+    def _state_changed_listener(self, event):
+        """Check if condition is correct and run action."""
+        entity_id = event.data.get('entity_id')
+        # Optimisation: if the old and new states are not None then this is
+        # a state change rather than a life-cycle event, and therefore we
+        # only need to check the include entities.
+        old_state = event.data.get('old_state')
+        new_state = event.data.get('new_state')
+        if old_state is not None and new_state is not None:
+            if entity_id not in self._entity_filter.include_entities:
+                return
+        elif not self._entity_filter(entity_id):
+            return
+
+        self._refresh(event)
+
+    def _refresh(self, event=None) -> None:
+        (result, self._entity_filter) = \
+            self._template.async_render_with_collect(self._variables)
+
+        if isinstance(result, TemplateError):
+            if self._last_exception is None:
+                self.hass.async_run_job(
+                    self._action, event, self._template,
+                    self._last_result, result)
+                self._last_exception = result
+            return
+        self._last_exception = None
+
+        # Check to see if the result has changed
+        if result != self._last_result:
+            self.hass.async_run_job(
+                self._action, event, self._template,
+                self._last_result, result)
+            self._last_result = result
+
+
+TrackTemplateResultListener = Callable[[
+    Optional[Event],
+    Template,
+    Optional[str],
+    Union[str, TemplateError]], None]
+"""Type for the listener for template results.
+
+    Action arguments
+    ----------------
+    event
+        Event that caused the template to change output. None if not
+        triggered by an event.
+    template
+        The template that has changed.
+    last_result
+        The output from the template on the last successful run, or None
+        if no previous successful run.
+    result
+        Result from the template run. This will be a string or an
+        TemplateError if the template resulted in an error.
+"""
+
+
+@callback
+@bind_hass
+def async_track_template_result(
+        hass: HomeAssistant,
+        template: Template,
+        action: TrackTemplateResultListener,
+        variables: Optional[Mapping[str, Any]] = None) \
+        -> TrackTemplateResultInfo:
+    """Add a listener that fires when a the result of a template changes.
+
+    The action will fire with the initial result from the template, and
+    then whenever the output from the template changes. The template will
+    be reevaluated if any states referenced in the last run of the
+    template change, or if manually triggered. If the result of the
+    evaluation is different from the previous run, the listener is passed
+    the result.
+
+    If the template results in an TemplateError, this will be returned to
+    the listener the first time this happens but not for subsequent errors.
+    Once the template returns to a non-error condition the result is sent
+    to the action as usual.
+
+    Parameters
+    ----------
+    hass
+        Home assistant object.
+    template
+        The template to calculate.
+    action
+        Callable to call with results.
+    variables
+        Variables to pass to the template.
+
+    Returns
+    -------
+    Info object used to unregister the listener, and refresh the template.
+
+    """
+    return TrackTemplateResultInfo(hass, template, action, variables)
+
+
+def track_template_result(
+        hass: HomeAssistant,
+        template: Template,
+        action: Callable[[
+            Event,
+            Template,
+            Optional[str],
+            Union[str, TemplateError]], None],
+        variables: Optional[Mapping[str, Any]] = None) \
+        -> (Callable[[], None], Union[str, TemplateError]):
+    """Add a listener that fires whenever a template changes."""
+    result = run_callback_threadsafe(
+        hass.loop, ft.partial(
+            async_track_template_result, hass, template,
+            action, variables)).result()
+
+    return result
 
 
 @callback

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1,24 +1,25 @@
 """Template helper methods for rendering strings with Home Assistant data."""
-from datetime import datetime
+import base64
 import json
 import logging
 import math
 import random
-import base64
 import re
+from datetime import datetime
+from typing import Union
 
 import jinja2
 from jinja2 import contextfilter
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
 
-from homeassistant.const import (
-    ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_UNIT_OF_MEASUREMENT, MATCH_ALL,
-    STATE_UNKNOWN)
-from homeassistant.core import State, valid_entity_id
+from homeassistant.const import (ATTR_LATITUDE, ATTR_LONGITUDE, MATCH_ALL,
+                                 ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN)
+from homeassistant.core import State, callback, valid_entity_id
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import location as loc_helper
 from homeassistant.helpers.typing import TemplateVarsType
+from homeassistant.helpers.entityfilter import EntityFilter
 from homeassistant.loader import bind_hass
 from homeassistant.util import convert
 from homeassistant.util import dt as dt_util
@@ -28,6 +29,8 @@ from homeassistant.util.async_ import run_callback_threadsafe
 _LOGGER = logging.getLogger(__name__)
 _SENTINEL = object()
 DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+_COLLECT_KEY = 'template.collect'
 
 _RE_NONE_ENTITIES = re.compile(r"distance\(|closest\(", re.I | re.M)
 _RE_GET_ENTITIES = re.compile(
@@ -124,6 +127,7 @@ class Template:
         return run_callback_threadsafe(
             self.hass.loop, self.async_render, kwargs).result()
 
+    @callback
     def async_render(self, variables: TemplateVarsType = None,
                      **kwargs) -> str:
         """Render given template.
@@ -141,6 +145,34 @@ class Template:
         except jinja2.TemplateError as err:
             raise TemplateError(err)
 
+    def render_with_collect(
+            self, variables: TemplateVarsType = None,
+            **kwargs) -> (Union[str, TemplateError],
+                          EntityFilter):
+        """Render given template and collect an entity filter."""
+        if variables is not None:
+            kwargs.update(variables)
+
+        return run_callback_threadsafe(
+            self.hass.loop, self.async_render_with_collect,
+            kwargs).result()
+
+    @callback
+    def async_render_with_collect(
+            self, variables: TemplateVarsType = None,
+            **kwargs) -> (Union[str, TemplateError],
+                          EntityFilter):
+        """Render the template and collect an entity filter."""
+        assert self.hass and _COLLECT_KEY not in self.hass.data
+        entity_collect = self.hass.data[_COLLECT_KEY] = EntityFilter()
+        try:
+            result = self.async_render(variables, **kwargs)
+            return (result, entity_collect)
+        except TemplateError as ex:
+            return (ex, entity_collect)
+        finally:
+            del self.hass.data[_COLLECT_KEY]
+
     def render_with_possible_json_value(self, value, error_value=_SENTINEL):
         """Render template with value exposed.
 
@@ -150,6 +182,7 @@ class Template:
             self.hass.loop, self.async_render_with_possible_json_value, value,
             error_value).result()
 
+    @callback
     def async_render_with_possible_json_value(self, value,
                                               error_value=_SENTINEL,
                                               variables=None):
@@ -190,7 +223,7 @@ class Template:
         global_vars = ENV.make_globals({
             'closest': template_methods.closest,
             'distance': template_methods.distance,
-            'is_state': self.hass.states.is_state,
+            'is_state': template_methods.is_state,
             'is_state_attr': template_methods.is_state_attr,
             'state_attr': template_methods.state_attr,
             'states': AllStates(self.hass),
@@ -207,6 +240,14 @@ class Template:
                 self.template == other.template and
                 self.hass == other.hass)
 
+    def __hash__(self):
+        """Hash code for template."""
+        return hash(self.template)
+
+    def __repr__(self):
+        """Representation of Template."""
+        return 'Template(\"' + self.template + '\")'
+
 
 class AllStates:
     """Class to expose all HA states as attributes."""
@@ -217,23 +258,40 @@ class AllStates:
 
     def __getattr__(self, name):
         """Return the domain state."""
+        if '.' in name:
+            if not valid_entity_id(name):
+                raise TemplateError("Invalid entity ID '{}'".format(name))
+            return _get_state(self._hass, name)
+        if not valid_entity_id(name + '.entity'):
+            raise TemplateError("Invalid domain name '{}'".format(name))
         return DomainStates(self._hass, name)
+
+    def _collect_all(self):
+        entity_collect = self._hass.data.get(_COLLECT_KEY)
+        if entity_collect is not None:
+            entity_collect.include_all = True
 
     def __iter__(self):
         """Return all states."""
+        self._collect_all()
         return iter(
-            _wrap_state(state) for state in
+            _wrap_state(self._hass, state) for state in
             sorted(self._hass.states.async_all(),
                    key=lambda state: state.entity_id))
 
     def __len__(self):
         """Return number of states."""
+        self._collect_all()
         return len(self._hass.states.async_entity_ids())
 
     def __call__(self, entity_id):
         """Return the states."""
-        state = self._hass.states.get(entity_id)
+        state = _get_state(self._hass, entity_id)
         return STATE_UNKNOWN if state is None else state.state
+
+    def __repr__(self):
+        """Representation of All States."""
+        return '<template AllStates>'
 
 
 class DomainStates:
@@ -246,19 +304,33 @@ class DomainStates:
 
     def __getattr__(self, name):
         """Return the states."""
-        return _wrap_state(
-            self._hass.states.get('{}.{}'.format(self._domain, name)))
+        entity_id = '{}.{}'.format(self._domain, name)
+        if not valid_entity_id(entity_id):
+            raise TemplateError("Invalid entity ID '{}'".format(entity_id))
+        return _get_state(self._hass, entity_id)
+
+    def _collect_domain(self):
+        entity_collect = self._hass.data.get(_COLLECT_KEY)
+        if entity_collect is not None:
+            entity_collect.include_domains.add(self._domain)
 
     def __iter__(self):
         """Return the iteration over all the states."""
+        self._collect_domain()
         return iter(sorted(
-            (_wrap_state(state) for state in self._hass.states.async_all()
+            (_wrap_state(self._hass, state)
+             for state in self._hass.states.async_all()
              if state.domain == self._domain),
             key=lambda state: state.entity_id))
 
     def __len__(self):
         """Return number of states."""
+        self._collect_domain()
         return len(self._hass.states.async_entity_ids(self._domain))
+
+    def __repr__(self):
+        """Representation of Domain States."""
+        return '<template DomainStates(\'{}\')>'.format(self._domain)
 
 
 class TemplateState(State):
@@ -266,14 +338,21 @@ class TemplateState(State):
 
     # Inheritance is done so functions that check against State keep working
     # pylint: disable=super-init-not-called
-    def __init__(self, state):
+    def __init__(self, hass, state):
         """Initialize template state."""
+        self._hass = hass
         self._state = state
+
+    def _access_state(self):
+        state = object.__getattribute__(self, '_state')
+        hass = object.__getattribute__(self, '_hass')
+        _collect_state(hass, state.entity_id)
+        return state
 
     @property
     def state_with_unit(self):
         """Return the state concatenated with the unit if available."""
-        state = object.__getattribute__(self, '_state')
+        state = object.__getattribute__(self, '_access_state')()
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         if unit is None:
             return state.state
@@ -281,19 +360,43 @@ class TemplateState(State):
 
     def __getattribute__(self, name):
         """Return an attribute of the state."""
+        # This one doesn't count as an access of the state
+        # since we either found it by looking direct for the ID
+        # or got it off an iterator.
+        if name == 'entity_id' or name in object.__dict__:
+            state = object.__getattribute__(self, '_state')
+            return getattr(state, name)
         if name in TemplateState.__dict__:
             return object.__getattribute__(self, name)
-        return getattr(object.__getattribute__(self, '_state'), name)
+        state = object.__getattribute__(self, '_access_state')()
+        return getattr(state, name)
 
     def __repr__(self):
         """Representation of Template State."""
-        rep = object.__getattribute__(self, '_state').__repr__()
+        state = object.__getattribute__(self, '_access_state')()
+        rep = state.__repr__()
         return '<template ' + rep[1:]
 
 
-def _wrap_state(state):
+def _collect_state(hass, entity_id):
+    entity_collect = hass.data.get(_COLLECT_KEY)
+    if entity_collect is not None:
+        entity_collect.include_entities.add(entity_id)
+
+
+def _wrap_state(hass, state):
     """Wrap a state."""
-    return None if state is None else TemplateState(state)
+    return None if state is None else TemplateState(hass, state)
+
+
+def _get_state(hass, entity_id):
+    state = hass.states.get(entity_id)
+    if state is None:
+        # Only need to collect if none, if not none collect first actuall
+        # access to the state properties in the state wrapper.
+        _collect_state(hass, entity_id)
+        return None
+    return _wrap_state(hass, state)
 
 
 class TemplateMethods:
@@ -359,12 +462,14 @@ class TemplateMethods:
             else:
                 gr_entity_id = str(entities)
 
-            group = self._hass.components.group
+            _collect_state(self._hass, gr_entity_id)
 
-            states = [self._hass.states.get(entity_id) for entity_id
+            group = self._hass.components.group
+            states = [_get_state(self._hass, entity_id) for entity_id
                       in group.expand_entity_ids([gr_entity_id])]
 
-        return _wrap_state(loc_helper.closest(latitude, longitude, states))
+        # state will already be wrapped here
+        return loc_helper.closest(latitude, longitude, states)
 
     def distance(self, *args):
         """Calculate distance.
@@ -421,14 +526,19 @@ class TemplateMethods:
         return self._hass.config.units.length(
             loc_util.distance(*locations[0] + locations[1]), 'm')
 
+    def is_state(self, entity_id: str, state: State) -> bool:
+        """Test if a state is a specific value."""
+        state_obj = _get_state(self._hass, entity_id)
+        return state_obj is not None and state_obj.state == state
+
     def is_state_attr(self, entity_id, name, value):
-        """Test if a state is a specific attribute."""
+        """Test if a state's attribute is a specific value."""
         state_attr = self.state_attr(entity_id, name)
         return state_attr is not None and state_attr == value
 
     def state_attr(self, entity_id, name):
         """Get a specific attribute from a state."""
-        state_obj = self._hass.states.get(entity_id)
+        state_obj = _get_state(self._hass, entity_id)
         if state_obj is not None:
             return state_obj.attributes.get(name)
         return None
@@ -438,7 +548,7 @@ class TemplateMethods:
         if isinstance(entity_id_or_state, State):
             return entity_id_or_state
         if isinstance(entity_id_or_state, str):
-            return self._hass.states.get(entity_id_or_state)
+            return _get_state(self._hass, entity_id_or_state)
         return None
 
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -106,8 +106,8 @@ async def test_if_not_fires_on_change_bool(hass, calls):
     assert 0 == len(calls)
 
 
-async def test_if_not_fires_on_change_str(hass, calls):
-    """Test for not firing on string change."""
+async def test_if_fires_on_change_bare_str(hass, calls):
+    """Test should fire once for a bare string of true."""
     assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'trigger': {
@@ -119,10 +119,12 @@ async def test_if_not_fires_on_change_str(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
+    assert 1 == len(calls)
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert 0 == len(calls)
+    assert 1 == len(calls)
 
 
 async def test_if_not_fires_on_change_str_crazy(hass, calls):
@@ -225,10 +227,11 @@ async def test_if_not_fires_on_change_with_template(hass, calls):
     })
 
     await hass.async_block_till_done()
+    assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_fires_on_change_with_template_advanced(hass, calls):
@@ -307,21 +310,6 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     })
 
     await hass.async_block_till_done()
-
-    hass.states.async_set('test.entity', 'world')
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-    hass.states.async_set('test.entity', 'home')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'work')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'not_home')
-    await hass.async_block_till_done()
     assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
@@ -331,6 +319,22 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     hass.states.async_set('test.entity', 'home')
     await hass.async_block_till_done()
     assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'work')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'not_home')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'world')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'home')
+    await hass.async_block_till_done()
+    assert len(calls) == 3
 
 
 async def test_if_action(hass, calls):
@@ -413,7 +417,7 @@ async def test_wait_template_with_trigger(hass, calls):
             },
             'action': [
                 {'wait_template':
-                    "{{ is_state(trigger.entity_id, 'hello') }}"},
+                 "{{ is_state(trigger.entity_id, 'hello') }}"},
                 {'service': 'test.automation',
                  'data_template': {
                     'some':

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -3,7 +3,8 @@ from datetime import timedelta
 import unittest
 from unittest import mock
 
-from homeassistant.const import MATCH_ALL, EVENT_HOMEASSISTANT_START
+from logging import ERROR
+
 from homeassistant import setup
 from homeassistant.components.template import binary_sensor as template
 from homeassistant.exceptions import TemplateError
@@ -159,17 +160,68 @@ class TestBinarySensorTemplate(unittest.TestCase):
         state = self.hass.states.get('binary_sensor.test_template_sensor')
         assert state.attributes['entity_picture'] == '/local/sensor.png'
 
+    def test_nondeterministic(self):
+        """Test entity_picture template."""
+        with mock.patch('random.choice') as random:
+            random.return_value = 15
+
+            with assert_setup_component(1):
+                assert setup.setup_component(self.hass, 'binary_sensor', {
+                    'binary_sensor': {
+                        'platform': 'template',
+                        'sensors': {
+                            'test_template_sensor': {
+                                'value_template':
+                                    "{{ states('binary_sensor.xyz') }}",
+                                'entity_picture_template':
+                                    "/local/picture_{{ range(10)|random }}"
+                            }
+                        }
+                    }
+                })
+
+            self.hass.start()
+            self.hass.block_till_done()
+
+            state = self.hass.states.get('binary_sensor.test_template_sensor')
+            assert state.attributes.get('entity_picture') == \
+                '/local/picture_15'
+
+            # Doesn't recalculate even when the sensor changes state
+            random.return_value = 16
+            self.hass.states.set('binary_sensor.xyz', 'True')
+            self.hass.block_till_done()
+
+            state = self.hass.states.get('binary_sensor.test_template_sensor')
+            assert state.attributes.get('entity_picture') == \
+                '/local/picture_15'
+
+            # Force a recalc
+            self.hass.add_job(
+                self.hass.helpers.entity_component.
+                async_update_entity('binary_sensor.test_template_sensor'))
+            self.hass.block_till_done()
+
+            state = self.hass.states.get('binary_sensor.test_template_sensor')
+            assert state.attributes.get('entity_picture') == \
+                '/local/picture_16'
+
     @mock.patch('homeassistant.components.template.binary_sensor.'
-                'BinarySensorTemplate._async_render')
-    def test_match_all(self, _async_render):
-        """Test MATCH_ALL in template."""
+                'BinarySensorTemplate._update_state')
+    def test_match_all(self, _update_state):
+        """Test template that is rerendered on any state lifecycle."""
         with assert_setup_component(1):
             assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
                     'platform': 'template',
                     'sensors': {
                         'match_all_template_sensor': {
-                            'value_template': "{{ 42 }}",
+                            'value_template': (
+                                "{% for state in states %}"
+                                "{% if state.entity_id == 'sensor.humidity' %}"
+                                "{{ state.entity_id }}={{ state.state }}"
+                                "{% endif %}"
+                                "{% endfor %}"),
                         },
                     }
                 }
@@ -177,11 +229,11 @@ class TestBinarySensorTemplate(unittest.TestCase):
 
         self.hass.start()
         self.hass.block_till_done()
-        init_calls = len(_async_render.mock_calls)
+        init_calls = len(_update_state.mock_calls)
 
         self.hass.states.set('sensor.any_state', 'update')
         self.hass.block_till_done()
-        assert len(_async_render.mock_calls) == init_calls
+        assert len(_update_state.mock_calls) == init_calls
 
     def test_attributes(self):
         """Test the attributes."""
@@ -189,23 +241,16 @@ class TestBinarySensorTemplate(unittest.TestCase):
             self.hass.loop, template.BinarySensorTemplate,
             self.hass, 'parent', 'Parent', 'motion',
             template_hlpr.Template('{{ 1 > 1 }}', self.hass),
-            None, None, MATCH_ALL, None, None
+            None, None, None, None
         ).result()
         assert not vs.should_poll
-        assert 'motion' == vs.device_class
-        assert 'Parent' == vs.name
+        assert vs.device_class == 'motion'
+        assert vs.name == 'Parent'
 
-        run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()
         assert not vs.is_on
 
-        # pylint: disable=protected-access
-        vs._template = template_hlpr.Template("{{ 2 > 1 }}", self.hass)
-
-        run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()
-        assert vs.is_on
-
-    def test_event(self):
-        """Test the event."""
+    def test_state_clone(self):
+        """Test using the state directly."""
         config = {
             'binary_sensor': {
                 'platform': 'template',
@@ -213,7 +258,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
                     'test': {
                         'friendly_name': 'virtual thingy',
                         'value_template':
-                            "{{ states.sensor.test_state.state == 'on' }}",
+                            "{{ states.sensor.test_state.state }}",
                         'device_class': 'motion',
                     },
                 },
@@ -235,20 +280,80 @@ class TestBinarySensorTemplate(unittest.TestCase):
         state = self.hass.states.get('binary_sensor.test')
         assert state.state == 'on'
 
-    @mock.patch('homeassistant.helpers.template.Template.render')
-    def test_update_template_error(self, mock_render):
-        """Test the template update error."""
+
+def test_update_template_error(caplog):
+    """Test the template update error."""
+    caplog.set_level(ERROR)
+    hass = get_test_home_assistant()
+    try:
         vs = run_callback_threadsafe(
-            self.hass.loop, template.BinarySensorTemplate,
-            self.hass, 'parent', 'Parent', 'motion',
-            template_hlpr.Template('{{ 1 > 1 }}', self.hass),
-            None, None, MATCH_ALL, None, None
+            hass.loop, template.BinarySensorTemplate,
+            hass, 'parent', 'Parent', 'motion',
+            template_hlpr.Template('{{ 1 > 1 }}', hass),
+            None, None, None, None
         ).result()
-        mock_render.side_effect = TemplateError('foo')
-        run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()
-        mock_render.side_effect = TemplateError(
-            "UndefinedError: 'None' has no attribute")
-        run_callback_threadsafe(self.hass.loop, vs.async_check_state).result()
+
+        # pylint: disable=protected-access
+        run_callback_threadsafe(
+            hass.loop, vs._template_attrs[0]._handle_result,
+            None, None, None, 'on').result()
+        assert vs._state is True
+        assert len(caplog.records) == 0
+
+        run_callback_threadsafe(
+            hass.loop, vs._template_attrs[0]._handle_result,
+            None, None, None, TemplateError('foo')).result()
+        assert vs._state is None
+        assert len(caplog.records) == 1
+        assert caplog.records[0].message.startswith("TemplateError")
+
+        run_callback_threadsafe(
+            hass.loop, vs._template_attrs[0]._handle_result,
+            None, None, None, '').result()
+        assert vs._state is False
+        assert len(caplog.records) == 1
+    finally:
+        hass.stop()
+
+
+async def test_template_validation_error(hass, caplog):
+    """Test binary sensor template delay on."""
+    caplog.set_level(ERROR)
+    config = {
+        'binary_sensor': {
+            'platform': 'template',
+            'sensors': {
+                'test': {
+                    'friendly_name': 'virtual thingy',
+                    'value_template': 'True',
+                    'icon_template':
+                        "{{ states.sensor.test_state.state }}",
+                    'device_class': 'motion',
+                    'delay_on': 5
+                },
+            },
+        },
+    }
+    await setup.async_setup_component(hass, 'binary_sensor', config)
+    await hass.async_start()
+
+    state = hass.states.get('binary_sensor.test')
+    assert state.attributes.get('icon') == ''
+
+    hass.states.async_set('sensor.test_state', 'mdi:check')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('binary_sensor.test')
+    assert state.attributes.get('icon') == 'mdi:check'
+
+    hass.states.async_set('sensor.test_state', 'invalid_icon')
+    await hass.async_block_till_done()
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message.startswith(
+        "Error validating template result \'invalid_icon\' from template")
+
+    state = hass.states.get('binary_sensor.test')
+    assert state.attributes.get('icon') is None
 
 
 async def test_template_delay_on(hass):
@@ -368,69 +473,3 @@ async def test_template_delay_off(hass):
 
     state = hass.states.get('binary_sensor.test')
     assert state.state == 'on'
-
-
-async def test_no_update_template_match_all(hass, caplog):
-    """Test that we do not update sensors that match on all."""
-    hass.states.async_set('binary_sensor.test_sensor', 'true')
-
-    await setup.async_setup_component(hass, 'binary_sensor', {
-        'binary_sensor': {
-            'platform': 'template',
-            'sensors': {
-                'all_state': {
-                    'value_template': '{{ "true" }}',
-                },
-                'all_icon': {
-                    'value_template':
-                        '{{ states.binary_sensor.test_sensor.state }}',
-                    'icon_template': '{{ 1 + 1 }}',
-                },
-                'all_entity_picture': {
-                    'value_template':
-                        '{{ states.binary_sensor.test_sensor.state }}',
-                    'entity_picture_template': '{{ 1 + 1 }}',
-                },
-            }
-        }
-    })
-    await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 4
-    assert ('Template binary sensor all_state has no entity ids '
-            'configured to track nor were we able to extract the entities to '
-            'track from the value template') in caplog.text
-    assert ('Template binary sensor all_icon has no entity ids '
-            'configured to track nor were we able to extract the entities to '
-            'track from the icon template') in caplog.text
-    assert ('Template binary sensor all_entity_picture has no entity ids '
-            'configured to track nor were we able to extract the entities to '
-            'track from the entity_picture template') in caplog.text
-
-    assert hass.states.get('binary_sensor.all_state').state == 'off'
-    assert hass.states.get('binary_sensor.all_icon').state == 'off'
-    assert hass.states.get('binary_sensor.all_entity_picture').state == 'off'
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
-
-    assert hass.states.get('binary_sensor.all_state').state == 'on'
-    assert hass.states.get('binary_sensor.all_icon').state == 'on'
-    assert hass.states.get('binary_sensor.all_entity_picture').state == 'on'
-
-    hass.states.async_set('binary_sensor.test_sensor', 'false')
-    await hass.async_block_till_done()
-
-    assert hass.states.get('binary_sensor.all_state').state == 'on'
-    assert hass.states.get('binary_sensor.all_icon').state == 'on'
-    assert hass.states.get('binary_sensor.all_entity_picture').state == 'on'
-
-    await hass.helpers.entity_component.async_update_entity(
-        'binary_sensor.all_state')
-    await hass.helpers.entity_component.async_update_entity(
-        'binary_sensor.all_icon')
-    await hass.helpers.entity_component.async_update_entity(
-        'binary_sensor.all_entity_picture')
-
-    assert hass.states.get('binary_sensor.all_state').state == 'on'
-    assert hass.states.get('binary_sensor.all_icon').state == 'off'
-    assert hass.states.get('binary_sensor.all_entity_picture').state == 'off'

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,5 +1,6 @@
 """Test the condition helper."""
 from unittest.mock import patch
+from logging import ERROR
 
 from homeassistant.helpers import condition
 from homeassistant.util import dt
@@ -164,3 +165,18 @@ class TestConditionHelper:
             self.hass.states.set('sensor.temperature', 'unknown')
             assert not test(self.hass)
             assert len(logwarn.mock_calls) == 0
+
+
+async def test_condition_template_error(hass, caplog):
+    """Test invalid template."""
+    caplog.set_level(ERROR)
+
+    test = condition.async_from_config({
+        'condition': 'template',
+        'value_template': '{{ undefined.state }}',
+    })
+
+    assert not test(hass)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message\
+        .startswith("Error during template condition: UndefinedError:")

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -1,5 +1,22 @@
 """The tests for the EntityFilter component."""
-from homeassistant.helpers.entityfilter import generate_filter, FILTER_SCHEMA
+from homeassistant.helpers.entityfilter import (
+        generate_filter, EntityFilter, FILTER_SCHEMA)
+
+
+def test_identity():
+    """Test filter comparison and hashing."""
+    test_1 = EntityFilter(include_entities=["test.one"])
+    test_1a = EntityFilter(include_entities=["test.one"])
+    test_2 = EntityFilter(exclude_entities=["test.one"])
+    test_3 = EntityFilter(include_entities=["test.one", "test.two"])
+    test_4 = EntityFilter(include_domains=["test"])
+
+    assert test_1 == test_1a
+    assert test_1 != test_2
+    assert test_2 != test_3
+    assert test_3 != test_4
+    assert test_2 != test_4
+    assert test_1 != "pickle"
 
 
 def test_no_filters_case_1():


### PR DESCRIPTION
## Description:

Broken up version of #23160, which was refactor of #22588. Lots of notes #22588 and in the arch issue [#208](https://github.com/home-assistant/architecture/issues/208) on the algorithm change.

This PR only includes the last two commits in the sequence and will need a rebase against #23285

**Related issue (if applicable):** fixes #22587

#### Add template entity

This is a utility Entity base class for the template component, which handles all the details of having an instance attribute track the results of a template, including validating template output, logging errors, listening for forced updates, and cleaning up on entity removal.

### Demonstration of how it works

#### Template binary_sensor

Updates the template binary_sensor to the new code. This demonstrates all of the added features. The test case is updated too.
