### PR TITLE
Handle traccar connection errors

### DIFF
--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -93,8 +93,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
         config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
         config[CONF_MONITORED_CONDITIONS], config[CONF_EVENT])
 
-    await scanner.async_init()
-    return True
+    return await scanner.async_init()
 
 
 class TraccarScanner:
@@ -119,6 +118,11 @@ class TraccarScanner:
         async_track_time_interval(self._hass,
                                   self._async_update,
                                   self._scan_interval)
+        if self._api.connected and not self._api.authenticated:
+            _LOGGER.error("Authentication for Traccar failed")
+            return False
+        else:
+            return True
 
     async def _async_update(self, now=None):
         """Update info from Traccar."""

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -121,8 +121,8 @@ class TraccarScanner:
         else:
             await self._async_update()
             async_track_time_interval(self._hass,
-                                    self._async_update,
-                                    self._scan_interval)
+                                      self._async_update,
+                                      self._scan_interval)
             return True
 
     async def _async_update(self, now=None):

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -110,7 +110,7 @@ class TraccarScanner:
         self._scan_interval = scan_interval
         self._async_see = async_see
         self._api = api
-        self.connected = None
+        self.connected = False
         self._hass = hass
 
     async def async_init(self):
@@ -122,20 +122,15 @@ class TraccarScanner:
 
     async def _async_update(self, now=None):
         """Update info from Traccar."""
-        if self.connected is None:
-            # We should only get here on the first run.
-            await self._api.test_connection()
-            self.connected = self._api.connected
-            if not self._api.connected:
-                _LOGGER.error("Not connected to Traccar")
-
         if not self.connected:
             _LOGGER.debug('Testing connection to Traccar')
             await self._api.test_connection()
             self.connected = self._api.connected
             if self.connected:
                 _LOGGER.info("Connection to Traccar restored")
-        else:
+            else:
+                _LOGGER.error("Not connected to Traccar")
+        if self.connected:
             _LOGGER.debug('Updating device data')
             await self._api.get_device_info(self._custom_attributes)
             self._hass.async_create_task(self.import_device_data())

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -127,16 +127,16 @@ class TraccarScanner:
             await self._api.test_connection()
             self.connected = self._api.connected
             if not self._api.connected:
-                _LOGGER.error("Not connected to Traccar.")
+                _LOGGER.error("Not connected to Traccar")
 
         if not self.connected:
-            _LOGGER.debug('Testing connection to Traccar.')
+            _LOGGER.debug('Testing connection to Traccar')
             await self._api.test_connection()
             self.connected = self._api.connected
             if self.connected:
-                _LOGGER.info("Connection to Traccar restored.")
+                _LOGGER.info("Connection to Traccar restored")
         else:
-            _LOGGER.debug('Updating device data.')
+            _LOGGER.debug('Updating device data')
             await self._api.get_device_info(self._custom_attributes)
             self._hass.async_create_task(self.import_device_data())
             if self._event_types:

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -118,12 +118,12 @@ class TraccarScanner:
         if self._api.connected and not self._api.authenticated:
             _LOGGER.error("Authentication for Traccar failed")
             return False
-        else:
-            await self._async_update()
-            async_track_time_interval(self._hass,
-                                      self._async_update,
-                                      self._scan_interval)
-            return True
+
+        await self._async_update()
+        async_track_time_interval(self._hass,
+                                  self._async_update,
+                                  self._scan_interval)
+        return True
 
     async def _async_update(self, now=None):
         """Update info from Traccar."""
@@ -134,14 +134,13 @@ class TraccarScanner:
             if self.connected:
                 _LOGGER.info("Connection to Traccar restored")
             else:
-                _LOGGER.error("Not connected to Traccar")
-        if self.connected:
-            _LOGGER.debug('Updating device data')
-            await self._api.get_device_info(self._custom_attributes)
-            self._hass.async_create_task(self.import_device_data())
-            if self._event_types:
-                self._hass.async_create_task(self.import_events())
-            self.connected = self._api.connected
+                return
+        _LOGGER.debug('Updating device data')
+        await self._api.get_device_info(self._custom_attributes)
+        self._hass.async_create_task(self.import_device_data())
+        if self._event_types:
+            self._hass.async_create_task(self.import_events())
+        self.connected = self._api.connected
 
     async def import_device_data(self):
         """Import device data from Traccar."""

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -114,14 +114,15 @@ class TraccarScanner:
 
     async def async_init(self):
         """Further initialize connection to Traccar."""
-        await self._async_update()
-        async_track_time_interval(self._hass,
-                                  self._async_update,
-                                  self._scan_interval)
+        await self._api.test_connection()
         if self._api.connected and not self._api.authenticated:
             _LOGGER.error("Authentication for Traccar failed")
             return False
         else:
+            await self._async_update()
+            async_track_time_interval(self._hass,
+                                    self._async_update,
+                                    self._scan_interval)
             return True
 
     async def _async_update(self, now=None):

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -117,8 +117,8 @@ class TraccarScanner:
         """Further initialize connection to Traccar."""
         await self._async_update()
         async_track_time_interval(self._hass,
-                                    self._async_update,
-                                    self._scan_interval)
+                                  self._async_update,
+                                  self._scan_interval)
 
     async def _async_update(self, now=None):
         """Update info from Traccar."""

--- a/homeassistant/components/traccar/manifest.json
+++ b/homeassistant/components/traccar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Traccar",
   "documentation": "https://www.home-assistant.io/components/traccar",
   "requirements": [
-    "pytraccar==0.7.0",
+    "pytraccar==0.8.0",
     "stringcase==1.2.0"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1432,7 +1432,7 @@ pytile==2.0.6
 pytouchline==0.7
 
 # homeassistant.components.traccar
-pytraccar==0.7.0
+pytraccar==0.8.0
 
 # homeassistant.components.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
## Description:

_Better handle connection errors._
If HA starts and Traccar is not ready (like if you have _rebooted_ your HassIO server.), it will just trust that the configuration is OK, and that Traccar will be ready at some point.

If the connection is lost during operation, it will no longer spam the log file once every X (12) seconds.
If will post a info message stating it's return.


**Related issue (if applicable):** fixes #20853
<!--
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
-->
## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: traccar
    host: 192.168.2.105
    port: 8072
    username: admin
    password: admin
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
-->
If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
<!--
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
-->