### PR TITLE
Show correct stable version for docker.

### DIFF
--- a/homeassistant/components/version/manifest.json
+++ b/homeassistant/components/version/manifest.json
@@ -3,7 +3,7 @@
   "name": "Version",
   "documentation": "https://www.home-assistant.io/components/version",
   "requirements": [
-    "pyhaversion==2.2.0"
+    "pyhaversion==2.2.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1079,7 +1079,7 @@ pygtfs==0.1.5
 pygtt==1.1.2
 
 # homeassistant.components.version
-pyhaversion==2.2.0
+pyhaversion==2.2.1
 
 # homeassistant.components.heos
 pyheos==0.4.0


### PR DESCRIPTION
## Description:

The current version has a bug where it shows the beta version for docker even if you did not want it to show that.
This update fixes that, the version with the bug was introduced to the current beta, so this should be included as a beta fix.
<!--
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
-->
## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: version
    source: docker
    image: raspberrypi3
  - platform: version
    source: docker
    image: raspberrypi3
    beta: true
```

### Without the fix:

![image](https://user-images.githubusercontent.com/15093472/56474831-bada3e80-647f-11e9-9da2-560df931431b.png)

### With the fix:
![image](https://user-images.githubusercontent.com/15093472/56474846-fecd4380-647f-11e9-9fce-fed7cdf86585.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
-->
If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
<!--
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
-->