### PR TITLE
Additional validators

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -89,6 +89,8 @@ def has_at_most_one_key(*keys: str) -> Callable:
 
 def boolean(value: Any) -> bool:
     """Validate and coerce a boolean value."""
+    if value is None:
+        return False
     if isinstance(value, bool):
         return value
     if isinstance(value, str):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -94,7 +94,7 @@ def boolean(value: Any) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
-        value = value.lower()
+        value = value.lower().strip()
         if value in ('1', 'true', 'yes', 'on', 'enable'):
             return True
         if value in ('0', 'false', 'no', 'off', 'disable'):
@@ -110,7 +110,7 @@ def boolean_true(value: Any) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
-        value = value.lower()
+        value = value.lower().strip()
         return value in ('1', 'true', 'yes', 'on', 'enable')
     if isinstance(value, Number):
         return value != 0

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -105,16 +105,8 @@ def boolean(value: Any) -> bool:
     raise vol.Invalid('invalid boolean value {}'.format(value))
 
 
-def boolean_tolerant(value: Any) -> bool:
-    """Coerce a boolean value to true, or return false."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        value = value.lower().strip()
-        return value in ('1', 'true', 'yes', 'on', 'enable')
-    if isinstance(value, Number):
-        return value != 0
-    return False
+boolean_coerce = vol.Any(boolean, lambda val: False)
+"""Coerce a boolean value to true, or return false."""
 
 
 _WS = re.compile('\\s*')

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -120,11 +120,14 @@ def boolean_tolerant(value: Any) -> bool:
 _WS = re.compile('\\s*')
 
 
-def whitespace(value: Any) -> str:
-    """Validate result contains only whitespace."""
-    if isinstance(value, str) and _WS.fullmatch(value):
-        return ''
-    raise vol.Invalid('invalid whitespace string "{}"'.format(value))
+def whitespace_as(value: Any = None) -> Callable:
+    """Accept only whitespace and returns the passed value."""
+    def validate(obj: Any) -> Any:
+        if isinstance(obj, str) and _WS.fullmatch(obj):
+            return value
+        raise vol.Invalid('invalid whitespace string {}'
+                          .format(repr(value)))
+    return validate
 
 
 def isdevice(value):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -105,7 +105,7 @@ def boolean(value: Any) -> bool:
     raise vol.Invalid('invalid boolean value {}'.format(value))
 
 
-def boolean_true(value: Any) -> bool:
+def boolean_tolerant(value: Any) -> bool:
     """Coerce a boolean value to true, or return false."""
     if isinstance(value, bool):
         return value

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -12,9 +12,6 @@ import voluptuous as vol
 import homeassistant
 import homeassistant.helpers.config_validation as cv
 
-#  pylint: disable=redefined-outer-name, len-as-condition
-#  pylint: disable=misplaced-comparison-constant
-
 
 def test_boolean():
     """Test boolean validation."""
@@ -34,14 +31,14 @@ def test_boolean():
         assert not schema(value)
 
 
-def test_boolean_true():
+def test_boolean_tolerant():
     """Test boolean_true validation."""
-    schema = vol.Schema(cv.boolean_true)
+    schema = vol.Schema(cv.boolean_tolerant)
 
     for value in (
             'false', 'Off', '0', 'NO', 'disable', 0, False,
             'T', 'negative', 'lock', 'true like', 'tr ue',
-            None, [], [1, 2], {'one': 'two'}, test_boolean_true):
+            None, [], [1, 2], {'one': 'two'}, test_boolean_tolerant):
         assert not schema(value)
 
     for value in ('true', 'On', '1', 'YES', '   true ',

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -31,14 +31,14 @@ def test_boolean():
         assert not schema(value)
 
 
-def test_boolean_tolerant():
+def test_boolean_coerce():
     """Test boolean_true validation."""
-    schema = vol.Schema(cv.boolean_tolerant)
+    schema = vol.Schema(cv.boolean_coerce)
 
     for value in (
             'false', 'Off', '0', 'NO', 'disable', 0, False,
             'T', 'negative', 'lock', 'true like', 'tr ue',
-            None, [], [1, 2], {'one': 'two'}, test_boolean_tolerant):
+            None, [], [1, 2], {'one': 'two'}, test_boolean_coerce):
         assert not schema(value)
 
     for value in ('true', 'On', '1', 'YES', '   true ',

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -21,12 +21,12 @@ def test_boolean():
     schema = vol.Schema(cv.boolean)
 
     for value in (
-            'T', 'negative', 'lock',
+            'T', 'negative', 'lock', 'tr  ue',
             [], [1, 2], {'one': 'two'}, test_boolean):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
-    for value in ('true', 'On', '1', 'YES',
+    for value in ('true', 'On', '1', 'YES', '   true  ',
                   'enable', 1, 50, True, 0.1):
         assert schema(value)
 
@@ -40,11 +40,11 @@ def test_boolean_true():
 
     for value in (
             'false', 'Off', '0', 'NO', 'disable', 0, False,
-            'T', 'negative', 'lock', 'true like',
+            'T', 'negative', 'lock', 'true like', 'tr ue',
             None, [], [1, 2], {'one': 'two'}, test_boolean_true):
         assert not schema(value)
 
-    for value in ('true', 'On', '1', 'YES',
+    for value in ('true', 'On', '1', 'YES', '   true ',
                   'enable', 1, 50, True, 0.1):
         assert schema(value)
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -12,20 +12,55 @@ import voluptuous as vol
 import homeassistant
 import homeassistant.helpers.config_validation as cv
 
+#  pylint: disable=redefined-outer-name, len-as-condition
+#  pylint: disable=misplaced-comparison-constant
+
 
 def test_boolean():
     """Test boolean validation."""
     schema = vol.Schema(cv.boolean)
 
-    for value in ('T', 'negative', 'lock'):
+    for value in (
+            'T', 'negative', 'lock',
+            None, [], [1, 2], {'one': 'two'}, test_boolean):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
-    for value in ('true', 'On', '1', 'YES', 'enable', 1, True):
+    for value in ('true', 'On', '1', 'YES',
+                  'enable', 1, 50, True, 0.1):
         assert schema(value)
 
     for value in ('false', 'Off', '0', 'NO', 'disable', 0, False):
         assert not schema(value)
+
+
+def test_boolean_true():
+    """Test boolean_true validation."""
+    schema = vol.Schema(cv.boolean_true)
+
+    for value in (
+            'false', 'Off', '0', 'NO', 'disable', 0, False,
+            'T', 'negative', 'lock', 'true like',
+            None, [], [1, 2], {'one': 'two'}, test_boolean_true):
+        assert not schema(value)
+
+    for value in ('true', 'On', '1', 'YES',
+                  'enable', 1, 50, True, 0.1):
+        assert schema(value)
+
+
+def test_whitespace():
+    """Test whitespace validation."""
+    schema = vol.Schema(cv.whitespace)
+
+    for value in ('  ', '  \t', '\r\n\t\t', ''):
+        assert schema(value) == ''
+
+    for value in (
+            'false', 'Off', '0', 'NO', 'disable',
+            0, False, None, [], [1, 2], {'one': 'two'}):
+        with pytest.raises(vol.Invalid):
+            schema(value)
 
 
 def test_latitude():

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -22,7 +22,7 @@ def test_boolean():
 
     for value in (
             'T', 'negative', 'lock',
-            None, [], [1, 2], {'one': 'two'}, test_boolean):
+            [], [1, 2], {'one': 'two'}, test_boolean):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
@@ -30,7 +30,7 @@ def test_boolean():
                   'enable', 1, 50, True, 0.1):
         assert schema(value)
 
-    for value in ('false', 'Off', '0', 'NO', 'disable', 0, False):
+    for value in (None, 'false', 'Off', '0', 'NO', 'disable', 0, False):
         assert not schema(value)
 
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -48,10 +48,15 @@ def test_boolean_tolerant():
 
 def test_whitespace():
     """Test whitespace validation."""
-    schema = vol.Schema(cv.whitespace)
+    schema = vol.Schema(cv.whitespace_as())
 
     for value in ('  ', '  \t', '\r\n\t\t', ''):
-        assert schema(value) == ''
+        assert schema(value) is None
+
+    schema = vol.Schema(cv.whitespace_as(test_whitespace))
+
+    for value in ('  ', '  \t', '\r\n\t\t', ''):
+        assert schema(value) is test_whitespace
 
     for value in (
             'false', 'Off', '0', 'NO', 'disable',


### PR DESCRIPTION
## Description:

Adds additional validators, and improves the boolean validator:

#### Improved boolean validator

No longer allows non-boolean, non-number, non-string, non None types through (invalid value). Strips out surrounding white space. It seemed odd that `"  true"` would be an invalid value as would `"dog"`, but `[56]` would not and would validate to True. 

Happy just to leave as it was if desired, or maybe to allow things that python considers true to be true (like non-empty sets and maps). The core of the validator is unchanged in that strings are either explicitly true or false, or invalid, it's just more robust in the face of non-string types and whitespace.

It may be worth considering 'open' to be true and 'closed' to be false as well.

#### Boolean_tolerant validator

Accepts true booleans, true-like strings and non-zero number types as true (everything true above). Everything else coerced to false. The difference between this and the above is that it never results in an invalid exception and things like lists and sets are explicitly false.

#### Whitespace validator

Coerces any combination of whitespace characters to empty string, rejects anything else.
Useful as part of an Or validator, where whitespace *or* some other object is accepted. Whitespace could arguably be better defined as None.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
