### PR TITLE
HEOS maintain unique_id after firmware upgrade

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -267,3 +267,13 @@ class HeosRegistry:
         entry['version'] = version
         self._schedule_save()
         return entry['unique_id']
+
+    @callback
+    def update_entry(self, heos_id: int, name: str, version: str):
+        """Update the entry with the specified id."""
+        entry = next((entry for entry in self.entries
+                      if entry['heos_id'] == heos_id), None)
+        if entry and (entry['name'] != name or entry['version'] != version):
+            entry['name'] = name
+            entry['version'] = version
+            self._schedule_save()

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -221,10 +221,10 @@ class HeosRegistry:
     Registry of unique IDs for HEOS devices.
 
     HEOS issues IDs (int32) to players and groups which remain static until
-    a firmware upgrade, during wich all players and groups are randomly
-    renumbered. This registry maintains a mapping of a unique ID to the
-    underlying HEOS device so that after a firmware upgrade HA will not
-    think the devices are new.
+    a firmware upgrade, during which all players and groups are renumbered.
+    This registry maintains a mapping of a unique ID to the underlying HEOS
+    device so after a firmware upgrade it will map to the proper HA devices and
+    entities.
     """
 
     def __init__(self, hass: HomeAssistantType):
@@ -240,18 +240,18 @@ class HeosRegistry:
 
     @callback
     def _schedule_save(self):
-        """Schedule saving the device registry."""
+        """Schedule saving the registry."""
         self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
     def _data_to_save(self):
-        """Return data of device registry to store in a file."""
+        """Return data of registry to store in a file."""
         data = {'entries': self.entries.copy()}
         return data
 
     @callback
     def get_unique_id(self, heos_id: int, name: str, version: str) -> str:
-        """Return unique ID given the HEOS id, name, and firmware version."""
+        """Return unique ID given the HEOS id, name and firmware version."""
         # Find existing entry by ID or match name only if firmware version is
         # different. Name is used as an anchor to find the device again after
         # a firmware upgrade because the heos_id will have changed.
@@ -270,7 +270,7 @@ class HeosRegistry:
 
     @callback
     def update_entry(self, heos_id: int, name: str, version: str):
-        """Update the entry with the specified id."""
+        """Update the entry name and version."""
         entry = next((entry for entry in self.entries
                       if entry['heos_id'] == heos_id), None)
         if entry and (entry['name'] != name or entry['version'] != version):

--- a/homeassistant/components/heos/const.py
+++ b/homeassistant/components/heos/const.py
@@ -1,9 +1,15 @@
 """Const for the HEOS integration."""
+from datetime import timedelta
 
 COMMAND_RETRY_ATTEMPTS = 2
 COMMAND_RETRY_DELAY = 1
 DATA_CONTROLLER = "controller"
 DATA_SOURCE_MANAGER = "source_manager"
 DATA_DISCOVERED_HOSTS = "heos_discovered_hosts"
+DATA_REGISTRY = "registry"
 DOMAIN = 'heos'
 SIGNAL_HEOS_SOURCES_UPDATED = "heos_sources_updated"
+STORAGE_KEY = DOMAIN
+STORAGE_VERSION = 1
+MIN_UPDATE_SOURCES = timedelta(seconds=1)
+SAVE_DELAY = 10

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -86,6 +86,9 @@ class HeosMediaPlayer(MediaPlayerDevice):
         """Handle controller event."""
         from pyheos import const
         if event == const.EVENT_PLAYERS_CHANGED:
+            registry = self.hass.data[HEOS_DOMAIN][DATA_REGISTRY]
+            registry.update_entry(self._player.player_id, self._player.name,
+                                  self._player.version)
             await self.async_update_ha_state(True)
 
     async def _heos_event(self, event):

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -5,7 +5,8 @@ from asynctest.mock import Mock, patch as patch
 from pyheos import Dispatcher, HeosPlayer, HeosSource, InputSource, const
 import pytest
 
-from homeassistant.components.heos import DOMAIN
+from homeassistant.components.heos.const import (
+    DOMAIN, STORAGE_KEY, STORAGE_VERSION)
 from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
@@ -123,3 +124,16 @@ def discovery_data_fixture() -> dict:
         'udn': 'uuid:e61de70c-2250-1c22-0080-0005cdf512be',
         'upnp_device_type': 'urn:schemas-denon-com:device:AiosDevice:1'
     }
+
+
+@pytest.fixture(name="registry_data")
+def registry_data_fixture(hass_storage) -> dict:
+    """Return mock heos registry storage data for testing."""
+    data = {'entries': [{
+        'heos_id': 1,
+        'name': 'Test Player',
+        'version': '1.0.0',
+        'unique_id': '0aa1e574a9ca4cbe84b9ebb3677bbdef'
+    }]}
+    hass_storage[STORAGE_KEY] = {'data': data, "version": STORAGE_VERSION}
+    return data

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -179,3 +179,4 @@ async def test_registry_updates_after_firmware_upgrade(hass, registry_data):
     await registry.load()
     unique_id = registry.get_unique_id(2, "Test Player", "1.5.0")
     assert registry_data['entries'][0]['unique_id'] == unique_id
+    assert registry.entries[0]['heos_id'] == 2

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -5,7 +5,7 @@ from pyheos import CommandError, const
 
 from homeassistant.components.heos import media_player
 from homeassistant.components.heos.const import (
-    DATA_SOURCE_MANAGER, DOMAIN, SIGNAL_HEOS_SOURCES_UPDATED)
+    DATA_REGISTRY, DATA_SOURCE_MANAGER, DOMAIN, SIGNAL_HEOS_SOURCES_UPDATED)
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE, ATTR_INPUT_SOURCE_LIST, ATTR_MEDIA_ALBUM_NAME,
     ATTR_MEDIA_ARTIST, ATTR_MEDIA_CONTENT_ID, ATTR_MEDIA_CONTENT_TYPE,
@@ -84,7 +84,7 @@ async def test_entity_and_device_attributes(
 
 
 async def test_updates_start_from_signals(
-        hass, config_entry, config, controller, favorites):
+        hass, config_entry, config, controller, favorites, registry_data):
     """Tests dispatched signals update player."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
@@ -120,12 +120,14 @@ async def test_updates_start_from_signals(
     assert state.attributes[ATTR_MEDIA_POSITION] == 1
 
     # Test controller player change updates
+    player.name = "New Name"
     player.available = False
     player.heos.dispatcher.send(
         const.SIGNAL_CONTROLLER_EVENT, const.EVENT_PLAYERS_CHANGED)
     await hass.async_block_till_done()
     state = hass.states.get('media_player.test_player')
     assert state.state == STATE_UNAVAILABLE
+    assert hass.data[DOMAIN][DATA_REGISTRY].entries[0]['name'] == 'New Name'
 
     # Test heos events update
     player.available = True

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -1,7 +1,7 @@
 """Tests for the Heos Media Player platform."""
 import asyncio
 
-from pyheos import const, CommandError
+from pyheos import CommandError, const
 
 from homeassistant.components.heos import media_player
 from homeassistant.components.heos.const import (
@@ -62,6 +62,25 @@ async def test_state_attributes(hass, config_entry, config, controller):
     assert ATTR_INPUT_SOURCE not in state.attributes
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == \
         hass.data[DOMAIN][DATA_SOURCE_MANAGER].source_list
+
+
+async def test_entity_and_device_attributes(
+        hass, config_entry, config, controller, registry_data):
+    """Test the attributes of the entity are correct."""
+    await setup_platform(hass, config_entry, config)
+    player = controller.players[1]
+    # Device registry attributes
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_id = registry_data['entries'][0]['unique_id']
+    entry = device_registry.async_get_device({(DOMAIN, device_id)}, [])
+    assert entry.name == player.name
+    assert entry.model == player.model
+    assert entry.manufacturer == 'HEOS'
+    assert entry.sw_version == player.version
+    # Entity registry attributes
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entry = entity_registry.async_get("media_player.test_player")
+    assert entry.unique_id == device_id + "_player"
 
 
 async def test_updates_start_from_signals(

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -66,7 +66,7 @@ async def test_state_attributes(hass, config_entry, config, controller):
 
 async def test_entity_and_device_attributes(
         hass, config_entry, config, controller, registry_data):
-    """Test the attributes of the entity are correct."""
+    """Test the attributes of the device and entity are correct."""
     await setup_platform(hass, config_entry, config)
     player = controller.players[1]
     # Device registry attributes


### PR DESCRIPTION
## Description:
It has been discovered that HEOS device IDs change after a firmware update.  This PR implements a solution to establish a unique ID that is used the device and entity registries that points back to a HEOS device.  A registry has been created to contain these pointers which will update after a firmware change using the device name as a before/after upgrade anchor.

**This needs to be cherry-picked for 0.92 to avoid a future breaking change (including #23222)**

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
