### PR TITLE
Fix missing .homekit folder when pairing (fix for inclusion in 0.92)

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -145,9 +145,14 @@ class HKDevice():
 
         self.pairing = self.controller.pairings.get(self.hkid)
         if self.pairing is not None:
-            pairing_file = os.path.join(
+            pairing_dir = os.path.join(
                 self.hass.config.path(),
                 HOMEKIT_DIR,
+            )
+            if not os.path.exists(pairing_dir):
+                os.makedirs(pairing_dir)
+            pairing_file = os.path.join(
+                pairing_dir,
                 PAIRING_FILE,
             )
             self.controller.save_data(pairing_file)


### PR DESCRIPTION
## Description:

**WARNING** This PR targets `rc` not `dev` - the fix is already in `dev` but as part of a larger feature change so there isn't an existing commit that can be cherry-picked. So this is just the bug fix in isolation.

In 0.94 we are moving to config entries for homekit_controller. This will deprecate the current `.homekit` folder used to store pairing data. The code will stop writing to it, and only import old legacy data. Obviously thats 3 releases away. In the meantime in 0.91, refactoring to prep for config entries (mostly splitting a large PR into smaller ones for easier review) has prematurely removed the code that creates this folder if its missing. This means brand new homekit_controller users can't pair.

I have restored the code that creates the folder if its missing in dev, but failed to pull it out as a seperate PR so it could be included in 0.92. This is such a PR.

**Related issue (if applicable):** fixes #23259

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.