### PR TITLE
Adding Watson TTS (IBM Cloud)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -22,7 +22,6 @@ omit =
     homeassistant/components/alarmdotcom/alarm_control_panel.py
     homeassistant/components/alpha_vantage/sensor.py
     homeassistant/components/amazon_polly/tts.py
-    homeassistant/components/watson_tts/tts.py
     homeassistant/components/ambient_station/*
     homeassistant/components/amcrest/*
     homeassistant/components/ampio/*
@@ -648,6 +647,7 @@ omit =
     homeassistant/components/waqi/sensor.py
     homeassistant/components/waterfurnace/*
     homeassistant/components/watson_iot/*
+    homeassistant/components/watson_tts/tts.py
     homeassistant/components/waze_travel_time/sensor.py
     homeassistant/components/webostv/*
     homeassistant/components/wemo/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -22,6 +22,7 @@ omit =
     homeassistant/components/alarmdotcom/alarm_control_panel.py
     homeassistant/components/alpha_vantage/sensor.py
     homeassistant/components/amazon_polly/tts.py
+    homeassistant/components/watson_tts/tts.py
     homeassistant/components/ambient_station/*
     homeassistant/components/amcrest/*
     homeassistant/components/ampio/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -240,6 +240,7 @@ homeassistant/components/velux/* @Julius2342
 homeassistant/components/version/* @fabaff
 homeassistant/components/vizio/* @raman325
 homeassistant/components/waqi/* @andrey-git
+homeassistant/components/watson_tts/* @rutkai
 homeassistant/components/weather/* @fabaff
 homeassistant/components/weblink/* @home-assistant/core
 homeassistant/components/websocket_api/* @home-assistant/core

--- a/homeassistant/components/watson_tts/__init__.py
+++ b/homeassistant/components/watson_tts/__init__.py
@@ -1,0 +1,1 @@
+"""Support for IBM Watson TTS integration."""

--- a/homeassistant/components/watson_tts/manifest.json
+++ b/homeassistant/components/watson_tts/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "watson_tts",
+  "name": "IBM Watson TTS",
+  "documentation": "https://www.home-assistant.io/components/watson_tts",
+  "requirements": [
+    "ibm-watson==3.0.3"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@rutkai"
+  ]
+}

--- a/homeassistant/components/watson_tts/tts.py
+++ b/homeassistant/components/watson_tts/tts.py
@@ -18,6 +18,7 @@ CONF_VOICE = 'voice'
 CONF_OUTPUT_FORMAT = 'output_format'
 CONF_TEXT_TYPE = 'text'
 
+# List from https://tinyurl.com/watson-tts-docs
 SUPPORTED_VOICES = [
     "de-DE_BirgitVoice",
     "de-DE_BirgitV2Voice",
@@ -66,7 +67,7 @@ DEFAULT_OUTPUT_FORMAT = 'audio/mp3'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_URL, default=DEFAULT_URL): cv.string,
-    vol.Inclusive(CONF_APIKEY, ATTR_CREDENTIALS): cv.string,
+    vol.Required(CONF_APIKEY): cv.string,
     vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(SUPPORTED_VOICES),
     vol.Optional(CONF_OUTPUT_FORMAT, default=DEFAULT_OUTPUT_FORMAT):
         vol.In(SUPPORTED_OUTPUT_FORMATS),
@@ -78,13 +79,13 @@ def get_engine(hass, config):
     from ibm_watson import TextToSpeechV1
 
     service = TextToSpeechV1(
-        url=config.get(CONF_URL),
-        iam_apikey=config.get(CONF_APIKEY)
+        url=config[CONF_URL],
+        iam_apikey=config[CONF_APIKEY]
     )
 
     supported_languages = list({s[:5] for s in SUPPORTED_VOICES})
-    default_voice = config.get(CONF_VOICE)
-    output_format = config.get(CONF_OUTPUT_FORMAT)
+    default_voice = config[CONF_VOICE]
+    output_format = config[CONF_OUTPUT_FORMAT]
 
     return WatsonTTSProvider(
         service, supported_languages, default_voice, output_format)
@@ -98,7 +99,7 @@ class WatsonTTSProvider(Provider):
                  supported_languages,
                  default_voice,
                  output_format):
-        """Initialize Amazon Polly provider for TTS."""
+        """Initialize Watson TTS provider."""
         self.service = service
         self.supported_langs = supported_languages
         self.default_lang = default_voice[:5]

--- a/homeassistant/components/watson_tts/tts.py
+++ b/homeassistant/components/watson_tts/tts.py
@@ -1,0 +1,136 @@
+"""Support for IBM Watson TTS integration."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.tts import PLATFORM_SCHEMA, Provider
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_URL = 'watson_url'
+CONF_APIKEY = 'watson_apikey'
+ATTR_CREDENTIALS = 'credentials'
+
+DEFAULT_URL = 'https://stream.watsonplatform.net/text-to-speech/api'
+
+CONF_VOICE = 'voice'
+CONF_OUTPUT_FORMAT = 'output_format'
+CONF_TEXT_TYPE = 'text'
+
+SUPPORTED_VOICES = [
+    "de-DE_BirgitVoice",
+    "de-DE_BirgitV2Voice",
+    "de-DE_DieterVoice",
+    "de-DE_DieterV2Voice"
+    "en-GB_KateVoice",
+    "en-US_AllisonVoice",
+    "en-US_AllisonV2Voice",
+    "en-US_LisaVoice",
+    "en-US_LisaV2Voice",
+    "en-US_MichaelVoice",
+    "en-US_MichaelV2Voice",
+    "es-ES_EnriqueVoice",
+    "es-ES_LauraVoice",
+    "es-LA_SofiaVoice",
+    "es-US_SofiaVoice",
+    "fr-FR_ReneeVoice",
+    "it-IT_FrancescaVoice",
+    "it-IT_FrancescaV2Voice",
+    "ja-JP_EmiVoice",
+    "pt-BR_IsabelaVoice"
+]
+
+SUPPORTED_OUTPUT_FORMATS = [
+    'audio/flac',
+    'audio/mp3',
+    'audio/mpeg',
+    'audio/ogg',
+    'audio/ogg;codecs=opus',
+    'audio/ogg;codecs=vorbis',
+    'audio/wav'
+]
+
+CONTENT_TYPE_EXTENSIONS = {
+    'audio/flac': 'flac',
+    'audio/mp3': 'mp3',
+    'audio/mpeg': 'mp3',
+    'audio/ogg': 'ogg',
+    'audio/ogg;codecs=opus': 'ogg',
+    'audio/ogg;codecs=vorbis': 'ogg',
+    'audio/wav': 'wav',
+}
+
+DEFAULT_VOICE = 'en-US_AllisonVoice'
+DEFAULT_OUTPUT_FORMAT = 'audio/mp3'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_URL, default=DEFAULT_URL): cv.string,
+    vol.Inclusive(CONF_APIKEY, ATTR_CREDENTIALS): cv.string,
+    vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(SUPPORTED_VOICES),
+    vol.Optional(CONF_OUTPUT_FORMAT, default=DEFAULT_OUTPUT_FORMAT):
+        vol.In(SUPPORTED_OUTPUT_FORMATS),
+})
+
+
+def get_engine(hass, config):
+    """Set up IBM Watson TTS component."""
+    from ibm_watson import TextToSpeechV1
+
+    service = TextToSpeechV1(
+        url=config.get(CONF_URL),
+        iam_apikey=config.get(CONF_APIKEY)
+    )
+
+    supported_languages = list({s[:5] for s in SUPPORTED_VOICES})
+    default_voice = config.get(CONF_VOICE)
+    output_format = config.get(CONF_OUTPUT_FORMAT)
+
+    return WatsonTTSProvider(
+        service, supported_languages, default_voice, output_format)
+
+
+class WatsonTTSProvider(Provider):
+    """IBM Watson TTS api provider."""
+
+    def __init__(self,
+                 service,
+                 supported_languages,
+                 default_voice,
+                 output_format):
+        """Initialize Amazon Polly provider for TTS."""
+        self.service = service
+        self.supported_langs = supported_languages
+        self.default_lang = default_voice[:5]
+        self.default_voice = default_voice
+        self.output_format = output_format
+        self.name = 'Watson TTS'
+
+    @property
+    def supported_languages(self):
+        """Return a list of supported languages."""
+        return self.supported_langs
+
+    @property
+    def default_language(self):
+        """Return the default language."""
+        return self.default_lang
+
+    @property
+    def default_options(self):
+        """Return dict include default options."""
+        return {CONF_VOICE: self.default_voice}
+
+    @property
+    def supported_options(self):
+        """Return a list of supported options."""
+        return [CONF_VOICE]
+
+    def get_tts_audio(self, message, language=None, options=None):
+        """Request TTS file from Watson TTS."""
+        response = self.service.synthesize(
+            message, accept=self.output_format,
+            voice=self.default_voice).get_result()
+
+        return (CONTENT_TYPE_EXTENSIONS[self.output_format],
+                response.content)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -586,6 +586,9 @@ hydrawiser==0.1.1
 # homeassistant.components.htu21d
 # i2csense==0.0.4
 
+# homeassistant.components.watson_tts
+ibm-watson==3.0.3
+
 # homeassistant.components.watson_iot
 ibmiotf==0.3.4
 


### PR DESCRIPTION
## Description:

This new component adds the possibility to connect Homeassistant with IBM Cloud (Watson) TTS service.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#9279

## Example entry for `configuration.yaml` (if applicable):
```yaml
tts:
  - platform: watson_tts
    watson_url: https://stream.watsonplatform.net/text-to-speech/api/v1/synthesize
    watson_apikey: your-generated-apikey
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
