### PR TITLE
Zestimate - Added check for the existence of data in XML response

### DIFF
--- a/homeassistant/components/zestimate/sensor.py
+++ b/homeassistant/components/zestimate/sensor.py
@@ -113,12 +113,16 @@ class ZestimateDataSensor(Entity):
             return
         data = data_dict['response'][NAME]
         details = {}
-        details[ATTR_AMOUNT] = data['amount']['#text']
-        details[ATTR_CURRENCY] = data['amount']['@currency']
-        details[ATTR_LAST_UPDATED] = data['last-updated']
-        details[ATTR_CHANGE] = int(data['valueChange']['#text'])
-        details[ATTR_VAL_HI] = int(data['valuationRange']['high']['#text'])
-        details[ATTR_VAL_LOW] = int(data['valuationRange']['low']['#text'])
+        if 'amount' in data and data['amount'] is not None:
+            details[ATTR_AMOUNT] = data['amount']['#text']
+            details[ATTR_CURRENCY] = data['amount']['@currency']
+        if 'last-updated' in data and data['last-updated'] is not None:
+            details[ATTR_LAST_UPDATED] = data['last-updated']
+        if 'valueChange' in data and data['valueChange'] is not None:
+            details[ATTR_CHANGE] = int(data['valueChange']['#text'])
+        if 'valuationRange' in data and data['valuationRange'] is not None:
+            details[ATTR_VAL_HI] = int(data['valuationRange']['high']['#text'])
+            details[ATTR_VAL_LOW] = int(data['valuationRange']['low']['#text'])
         self.address = data_dict['response']['address']['street']
         self.data = details
         if self.data is not None:


### PR DESCRIPTION
Zillow API no longer sending valueChange field in API response XML. Added checks for values before assigning to variables

Should be tagged for 0.92 as the API is still returning invalid responses.

Related issue (if applicable): fixes #23272

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
