### PR TITLE
Set placeholders in homekit config flow title

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -130,6 +130,11 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         status_flags = int(properties['sf'])
         paired = not status_flags & 0x01
 
+        # pylint: disable=unsupported-assignment-operation
+        self.context['title_placeholders'] = {
+            'name': discovery_info['name'],
+        }
+
         # The configuration number increases every time the characteristic map
         # needs updating. Some devices use a slightly off-spec name so handle
         # both cases.

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "title": "HomeKit Accessory",
+        "flow_title": "HomeKit Accessory: {name}",
         "step": {
             "user": {
                 "title": "Pair with HomeKit Accessory",

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -12,9 +12,17 @@ from tests.components.homekit_controller.common import (
 )
 
 
+def _setup_flow_handler(hass):
+    flow = config_flow.HomekitControllerFlowHandler()
+    flow.hass = hass
+    flow.context = {}
+    return flow
+
+
 async def test_discovery_works(hass):
     """Test a device being discovered."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -25,12 +33,12 @@ async def test_discovery_works(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     pairing = mock.Mock(pairing_data={
         'AccessoryPairingID': '00:00:00:00:00:00',
@@ -66,6 +74,7 @@ async def test_discovery_works(hass):
 async def test_discovery_works_upper_case(hass):
     """Test a device being discovered."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -76,12 +85,12 @@ async def test_discovery_works_upper_case(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     pairing = mock.Mock(pairing_data={
         'AccessoryPairingID': '00:00:00:00:00:00',
@@ -117,6 +126,7 @@ async def test_discovery_works_upper_case(hass):
 async def test_discovery_works_missing_csharp(hass):
     """Test a device being discovered that has missing mdns attrs."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -126,12 +136,12 @@ async def test_discovery_works_missing_csharp(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     pairing = mock.Mock(pairing_data={
         'AccessoryPairingID': '00:00:00:00:00:00',
@@ -167,6 +177,7 @@ async def test_discovery_works_missing_csharp(hass):
 async def test_pair_already_paired_1(hass):
     """Already paired."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -177,17 +188,18 @@ async def test_pair_already_paired_1(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_paired'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
 
 async def test_discovery_ignored_model(hass):
     """Already paired."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -198,12 +210,12 @@ async def test_discovery_ignored_model(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'ignored_model'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
 
 async def test_discovery_invalid_config_entry(hass):
@@ -216,6 +228,7 @@ async def test_discovery_invalid_config_entry(hass):
     assert len(hass.config_entries.async_entries()) == 1
 
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -226,12 +239,12 @@ async def test_discovery_invalid_config_entry(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     # Discovery of a HKID that is in a pairable state but for which there is
     # already a config entry - in that case the stale config entry is
@@ -243,6 +256,7 @@ async def test_discovery_invalid_config_entry(hass):
 async def test_discovery_already_configured(hass):
     """Already configured."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -259,12 +273,12 @@ async def test_discovery_already_configured(hass):
     conn.config_num = 1
     hass.data[KNOWN_DEVICES]['00:00:00:00:00:00'] = conn
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_configured'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     assert conn.async_config_num_changed.call_count == 0
 
@@ -272,6 +286,7 @@ async def test_discovery_already_configured(hass):
 async def test_discovery_already_configured_config_change(hass):
     """Already configured."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -288,12 +303,12 @@ async def test_discovery_already_configured_config_change(hass):
     conn.config_num = 1
     hass.data[KNOWN_DEVICES]['00:00:00:00:00:00'] = conn
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_configured'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     assert conn.async_refresh_entity_map.call_args == mock.call(2)
 
@@ -301,6 +316,7 @@ async def test_discovery_already_configured_config_change(hass):
 async def test_pair_unable_to_pair(hass):
     """Pairing completed without exception, but didn't create a pairing."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -311,12 +327,12 @@ async def test_pair_unable_to_pair(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     controller = mock.Mock()
     controller.pairings = {}
@@ -334,6 +350,7 @@ async def test_pair_unable_to_pair(hass):
 async def test_pair_authentication_error(hass):
     """Pairing code is incorrect."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -344,12 +361,12 @@ async def test_pair_authentication_error(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     controller = mock.Mock()
     controller.pairings = {}
@@ -369,6 +386,7 @@ async def test_pair_authentication_error(hass):
 async def test_pair_unknown_error(hass):
     """Pairing failed for an unknown rason."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -379,12 +397,12 @@ async def test_pair_unknown_error(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     controller = mock.Mock()
     controller.pairings = {}
@@ -404,6 +422,7 @@ async def test_pair_unknown_error(hass):
 async def test_pair_already_paired(hass):
     """Device is already paired."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -414,12 +433,12 @@ async def test_pair_already_paired(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_step_discovery(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
     controller = mock.Mock()
     controller.pairings = {}
@@ -439,6 +458,7 @@ async def test_pair_already_paired(hass):
 async def test_import_works(hass):
     """Test a device being discovered."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -468,8 +488,7 @@ async def test_import_works(hass):
         }]
     }]
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
 
@@ -486,6 +505,7 @@ async def test_import_works(hass):
 async def test_import_already_configured(hass):
     """Test importing a device from .homekit that is already a ConfigEntry."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -502,12 +522,11 @@ async def test_import_already_configured(hass):
 
     config_entry = MockConfigEntry(
         domain='homekit_controller',
-        data=import_info
+        data=import_info,
     )
     config_entry.add_to_hass(hass)
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     result = await flow.async_import_legacy_pairing(
         discovery_info['properties'], import_info)
@@ -518,6 +537,7 @@ async def test_import_already_configured(hass):
 async def test_user_works(hass):
     """Test user initiated disovers devices."""
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -550,8 +570,7 @@ async def test_user_works(hass):
         discovery_info,
     ]
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     with mock.patch('homekit.Controller') as controller_cls:
         controller_cls.return_value = controller
@@ -577,8 +596,7 @@ async def test_user_works(hass):
 
 async def test_user_no_devices(hass):
     """Test user initiated pairing where no devices discovered."""
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     with mock.patch('homekit.Controller') as controller_cls:
         controller_cls.return_value.discover.return_value = []
@@ -590,10 +608,10 @@ async def test_user_no_devices(hass):
 
 async def test_user_no_unpaired_devices(hass):
     """Test user initiated pairing where no unpaired devices discovered."""
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -638,6 +656,7 @@ async def test_parse_new_homekit_json(hass):
     mock_open = mock.mock_open(read_data=json.dumps(read_data))
 
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -648,8 +667,7 @@ async def test_parse_new_homekit_json(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
 
@@ -662,6 +680,7 @@ async def test_parse_new_homekit_json(hass):
     assert result['type'] == 'create_entry'
     assert result['title'] == 'TestDevice'
     assert result['data']['AccessoryPairingID'] == '00:00:00:00:00:00'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
 
 async def test_parse_old_homekit_json(hass):
@@ -694,6 +713,7 @@ async def test_parse_old_homekit_json(hass):
     mock_open = mock.mock_open(read_data=json.dumps(read_data))
 
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -704,8 +724,7 @@ async def test_parse_old_homekit_json(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
 
@@ -719,6 +738,7 @@ async def test_parse_old_homekit_json(hass):
     assert result['type'] == 'create_entry'
     assert result['title'] == 'TestDevice'
     assert result['data']['AccessoryPairingID'] == '00:00:00:00:00:00'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
 
 
 async def test_parse_overlapping_homekit_json(hass):
@@ -762,6 +782,7 @@ async def test_parse_overlapping_homekit_json(hass):
     side_effects = [mock_open_1.return_value, mock_open_2.return_value]
 
     discovery_info = {
+        'name': 'TestDevice',
         'host': '127.0.0.1',
         'port': 8080,
         'properties': {
@@ -772,8 +793,7 @@ async def test_parse_overlapping_homekit_json(hass):
         }
     }
 
-    flow = config_flow.HomekitControllerFlowHandler()
-    flow.hass = hass
+    flow = _setup_flow_handler(hass)
 
     pairing_cls_imp = "homekit.controller.ip_implementation.IpPairing"
 
@@ -789,3 +809,4 @@ async def test_parse_overlapping_homekit_json(hass):
     assert result['type'] == 'create_entry'
     assert result['title'] == 'TestDevice'
     assert result['data']['AccessoryPairingID'] == '00:00:00:00:00:00'
+    assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}


### PR DESCRIPTION
## Description:

This is the server side change that corresponds with https://github.com/home-assistant/home-assistant-polymer/pull/3106.

This sets `title_placeholders` on homekit_controller's config flow context. This lets us use placeholders in a new `flow_title` translation. This means if you have 2 active flows for a homekit accessory you can actually tell them apart:

![56458793-0529c580-6383-11e9-9640-8a9ff06fd598](https://user-images.githubusercontent.com/11544/56526168-e161ad80-6543-11e9-9851-e924419c8364.png)

This change is currently a no-op:

 * The JS that uses this field isn't released yet
 * This config flow isn't active yet

It is inert - the pull requests are independent of each other so it doesn't matter if this does go out before the JS change is live.

I wanted to merge it as there isn't a server side example of using the new `flow_title` and i wanted to get the review out of the way. I also wanted to allow some translations to get underway.

@balloob interest because he dealt with the JS review.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.