### PR TITLE
Make get_states faster

### DIFF
--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -11,6 +11,7 @@ from .models import PermissionLookup
 from .types import PolicyType
 from .entities import ENTITY_POLICY_SCHEMA, compile_entities
 from .merge import merge_policies  # noqa
+from .util import test_all
 
 
 POLICY_SCHEMA = vol.Schema({
@@ -27,6 +28,10 @@ class AbstractPermissions:
 
     def _entity_func(self) -> Callable[[str, str], bool]:
         """Return a function that can test entity access."""
+        raise NotImplementedError
+
+    def access_all_entities(self, key: str) -> bool:
+        """Check if we have a certain access to all entities."""
         raise NotImplementedError
 
     def check_entity(self, entity_id: str, key: str) -> bool:
@@ -48,6 +53,10 @@ class PolicyPermissions(AbstractPermissions):
         self._policy = policy
         self._perm_lookup = perm_lookup
 
+    def access_all_entities(self, key: str) -> bool:
+        """Check if we have a certain access to all entities."""
+        return test_all(self._policy.get(CAT_ENTITIES), key)
+
     def _entity_func(self) -> Callable[[str, str], bool]:
         """Return a function that can test entity access."""
         return compile_entities(self._policy.get(CAT_ENTITIES),
@@ -64,6 +73,10 @@ class _OwnerPermissions(AbstractPermissions):
     """Owner permissions."""
 
     # pylint: disable=no-self-use
+
+    def access_all_entities(self, key: str) -> bool:
+        """Check if we have a certain access to all entities."""
+        return True
 
     def _entity_func(self) -> Callable[[str, str], bool]:
         """Return a function that can test entity access."""

--- a/homeassistant/auth/permissions/util.py
+++ b/homeassistant/auth/permissions/util.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 from typing import Callable, Dict, List, Optional, Union, cast  # noqa: F401
 
+from .const import SUBCAT_ALL
 from .models import PermissionLookup
 from .types import CategoryType, SubCategoryDict, ValueType
 
@@ -96,3 +97,16 @@ def _gen_dict_test_func(
         return schema.get(key)
 
     return test_value
+
+
+def test_all(policy: CategoryType, key: str) -> bool:
+    """Test if a policy has an ALL access for a specific key."""
+    if not isinstance(policy, dict):
+        return bool(policy)
+
+    all_policy = policy.get(SUBCAT_ALL)
+
+    if not isinstance(all_policy, dict):
+        return bool(all_policy)
+
+    return all_policy.get(key, False)

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -142,11 +142,14 @@ def handle_get_states(hass, connection, msg):
 
     Async friendly.
     """
-    entity_perm = connection.user.permissions.check_entity
-    states = [
-        state for state in hass.states.async_all()
-        if entity_perm(state.entity_id, 'read')
-    ]
+    if connection.user.permissions.access_all_entities('read'):
+        states = hass.states.async_all()
+    else:
+        entity_perm = connection.user.permissions.check_entity
+        states = [
+            state for state in hass.states.async_all()
+            if entity_perm(state.entity_id, 'read')
+        ]
 
     connection.send_message(messages.result_message(
         msg['id'], states))

--- a/tests/auth/permissions/test_util.py
+++ b/tests/auth/permissions/test_util.py
@@ -1,0 +1,21 @@
+"""Test the permission utils."""
+
+from homeassistant.auth.permissions import util
+
+
+def test_test_all():
+    """Test if we can test the all group."""
+    for val in (
+            None,
+            {},
+            {'all': None},
+            {'all': {}},
+    ):
+        assert util.test_all(val, 'read') is False
+
+    for val in (
+            True,
+            {'all': True},
+            {'all': {'read': True}},
+    ):
+        assert util.test_all(val, 'read') is True


### PR DESCRIPTION
## Description:
Currently we only have users that can access all entities. This adds a fast-path for these users when accessing all states. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
