### PR TITLE
Restore battery_quantity for zha devices

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -219,3 +219,5 @@ class PowerConfigurationChannel(ZigbeeChannel):
             'battery_percentage_remaining', from_cache=from_cache)
         await self.get_attribute_value(
             'battery_voltage', from_cache=from_cache)
+        await self.get_attribute_value(
+            'battery_quantity', from_cache=from_cache)


### PR DESCRIPTION
## Description:

The `battery_quantity` didn't survive a restart of home assistant. Now it will get the cached values just like e. g. `battery_size`.

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
