### PR TITLE
Cloud: Always use latest Google Assistant pin

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -106,6 +106,10 @@ class CloudClient(Interface):
                 entity_config=google_conf.get(CONF_ENTITY_CONFIG),
             )
 
+        # Set it to the latest.
+        self._google_config.secure_devices_pin = \
+            self._prefs.google_secure_devices_pin
+
         return self._google_config
 
     @property


### PR DESCRIPTION
## Description:
No longer require the restart of Home Assistant to update the pin to interact with devices.

Fix for issue reported by Cogneato. 

