### PR TITLE
Add sensor and binary senseor to default expose

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -34,6 +34,7 @@ DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
     'climate', 'cover', 'fan', 'group', 'input_boolean', 'light',
     'media_player', 'scene', 'script', 'switch', 'vacuum', 'lock',
+    'binary_sensor', 'sensor'
 ]
 
 PREFIX_TYPES = 'action.devices.types.'


### PR DESCRIPTION
## Description:
By default, Google Assistant should expose sensors/binary sensors that are supported.
