### PR TITLE
Add media player external url

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -1047,6 +1047,11 @@ class CastDevice(MediaPlayerDevice):
         return images[0].url if images and images[0].url else None
 
     @property
+    def media_image_remotely_accessible(self) -> bool:
+        """If the image url is remotely accessible."""
+        return True
+
+    @property
     def media_title(self):
         """Title of current playing media."""
         media_status, _ = self._media_status()

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -341,7 +341,6 @@ class MediaPlayerDevice(Entity):
     async def async_get_media_image(self):
         """Fetch media image of current playing image."""
         url = self.media_image_url
-
         if url is None:
             return None, None
 
@@ -857,11 +856,8 @@ async def websocket_handle_thumbnail(hass, connection, msg):
             'Failed to fetch thumbnail'))
         return
 
-    if content_type != TYPE_URL:
-        data = base64.b64encode(data).decode('utf-8')
-
     connection.send_message(websocket_api.result_message(
         msg['id'], {
             'content_type': content_type,
-            'content': data
+            'content': base64.b64encode(data).decode('utf-8')
         }))

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -64,7 +64,6 @@ ENTITY_IMAGE_CACHE = {
     CACHE_MAXSIZE: 16
 }
 
-TYPE_URL = 'text/url'
 SCAN_INTERVAL = timedelta(seconds=10)
 
 # Service call validation schemas

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -345,7 +345,8 @@ class MediaPlayerDevice(Entity):
 
         if url is None:
             return None, None
-        elif self.media_image_remotely_accessible:
+
+        if self.media_image_remotely_accessible:
             return url, TYPE_URL
 
         return await _async_fetch_image(self.hass, url)

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -819,7 +819,7 @@ class MediaPlayerImageView(HomeAssistantView):
         if player.media_image_remotely_accessible:
             url = player.media_image_url
             if url is not None:
-                return web.Response(status=301, headers={
+                return web.Response(status=302, headers={
                     'location': url
                 })
             return web.Response(status=500)

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -4,12 +4,13 @@ from unittest.mock import patch
 
 from homeassistant.setup import async_setup_component
 from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.components import media_player
 
 from tests.common import mock_coro
 
 
-async def test_get_panels(hass, hass_ws_client):
-    """Test get_panels command."""
+async def test_get_image(hass, hass_ws_client):
+    """Test get image via WS command."""
     await async_setup_component(hass, 'media_player', {
         'media_player': {
             'platform': 'demo'
@@ -35,3 +36,68 @@ async def test_get_panels(hass, hass_ws_client):
     assert msg['result']['content_type'] == 'image/jpeg'
     assert msg['result']['content'] == \
         base64.b64encode(b'image').decode('utf-8')
+
+
+async def test_get_image_url(hass, hass_ws_client):
+    """Test get image url via WS command."""
+    await async_setup_component(hass, 'media_player', {
+        'media_player': {
+            'platform': 'demo'
+        }
+    })
+
+    client = await hass_ws_client(hass)
+
+    with patch('homeassistant.components.media_player.MediaPlayerDevice.'
+               'async_get_media_image', return_value=mock_coro(
+                   ('https://www.home-assistant.io', media_player.TYPE_URL))):
+        await client.send_json({
+            'id': 5,
+            'type': 'media_player_thumbnail',
+            'entity_id': 'media_player.bedroom',
+        })
+
+        msg = await client.receive_json()
+
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+    assert msg['result']['content_type'] == 'text/url'
+    assert msg['result']['content'] == 'https://www.home-assistant.io'
+
+
+async def test_get_image_http(hass, hass_client):
+    """Test get image via http command."""
+    await async_setup_component(hass, 'media_player', {
+        'media_player': {
+            'platform': 'demo'
+        }
+    })
+
+    client = await hass_client()
+
+    with patch('homeassistant.components.media_player.MediaPlayerDevice.'
+               'async_get_media_image', return_value=mock_coro(
+                   (b'image', 'image/jpeg'))):
+        resp = await client.get('/api/media_player_proxy/media_player.bedroom')
+        content = await resp.read()
+
+    assert content == b'image'
+
+
+async def test_get_image_http_url(hass, hass_client):
+    """Test get image url via http command."""
+    await async_setup_component(hass, 'media_player', {
+        'media_player': {
+            'platform': 'demo'
+        }
+    })
+
+    client = await hass_client()
+
+    with patch('homeassistant.components.media_player.MediaPlayerDevice.'
+               'async_get_media_image', return_value=mock_coro(
+                   ('https://www.home-assistant.io', media_player.TYPE_URL))):
+        resp = await client.get('/api/media_player_proxy/media_player.bedroom',
+                                allow_redirects=False)
+        assert resp.headers['Location'] == 'https://www.home-assistant.io'

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from homeassistant.setup import async_setup_component
 from homeassistant.components.websocket_api.const import TYPE_RESULT
-from homeassistant.components import media_player
 
 from tests.common import mock_coro
 
@@ -38,34 +37,6 @@ async def test_get_image(hass, hass_ws_client):
         base64.b64encode(b'image').decode('utf-8')
 
 
-async def test_get_image_url(hass, hass_ws_client):
-    """Test get image url via WS command."""
-    await async_setup_component(hass, 'media_player', {
-        'media_player': {
-            'platform': 'demo'
-        }
-    })
-
-    client = await hass_ws_client(hass)
-
-    with patch('homeassistant.components.media_player.MediaPlayerDevice.'
-               'async_get_media_image', return_value=mock_coro(
-                   ('https://www.home-assistant.io', media_player.TYPE_URL))):
-        await client.send_json({
-            'id': 5,
-            'type': 'media_player_thumbnail',
-            'entity_id': 'media_player.bedroom',
-        })
-
-        msg = await client.receive_json()
-
-    assert msg['id'] == 5
-    assert msg['type'] == TYPE_RESULT
-    assert msg['success']
-    assert msg['result']['content_type'] == 'text/url'
-    assert msg['result']['content'] == 'https://www.home-assistant.io'
-
-
 async def test_get_image_http(hass, hass_client):
     """Test get image via http command."""
     await async_setup_component(hass, 'media_player', {
@@ -96,8 +67,8 @@ async def test_get_image_http_url(hass, hass_client):
     client = await hass_client()
 
     with patch('homeassistant.components.media_player.MediaPlayerDevice.'
-               'async_get_media_image', return_value=mock_coro(
-                   ('https://www.home-assistant.io', media_player.TYPE_URL))):
+               'media_image_remotely_accessible', return_value=True):
         resp = await client.get('/api/media_player_proxy/media_player.bedroom',
                                 allow_redirects=False)
-        assert resp.headers['Location'] == 'https://www.home-assistant.io'
+        assert resp.headers['Location'] == \
+            'https://img.youtube.com/vi/kxopViU98Xo/hqdefault.jpg'


### PR DESCRIPTION
## Description:
Allow integrations to indicate that their cover urls can be accessed externally, indicating to the frontend that we don't have to proxy the image.

When property set to True, the entity_picture will default to just that url. 

To do:
 - [x] Frontend support https://github.com/home-assistant/home-assistant-polymer/pull/3120
 - [x] Dev docs for new prop https://github.com/home-assistant/developers.home-assistant/pull/234

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/211

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
