### PR TITLE
Fix Homematic IP Cloud remaining light imports 

### DIFF
--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -1,9 +1,10 @@
 """Support for HomematicIP Cloud lights."""
 import logging
 
-from homematicip.aio.device import AsyncBrandSwitchMeasuring, AsyncDimmer,
-    AsyncPluggableDimmer, AsyncBrandDimmer, AsyncFullFlushDimmer,
-    AsyncBrandSwitchNotificationLight
+from homematicip.aio.device import (
+    AsyncBrandSwitchMeasuring, AsyncDimmer, AsyncPluggableDimmer, 
+    AsyncBrandDimmer, AsyncFullFlushDimmer, 
+    AsyncBrandSwitchNotificationLight)
 from homematicip.base.enums import RGBColorState
 
 from homeassistant.components.light import (

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -1,6 +1,9 @@
 """Support for HomematicIP Cloud lights."""
 import logging
 
+from homematicip.aio.device import AsyncBrandSwitchMeasuring, AsyncDimmer,
+    AsyncPluggableDimmer, AsyncBrandDimmer, AsyncFullFlushDimmer,
+    AsyncBrandSwitchNotificationLight
 from homematicip.base.enums import RGBColorState
 
 from homeassistant.components.light import (
@@ -23,10 +26,6 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the HomematicIP Cloud lights from a config entry."""
-    from homematicip.aio.device import AsyncBrandSwitchMeasuring, AsyncDimmer,\
-        AsyncPluggableDimmer, AsyncBrandDimmer, AsyncFullFlushDimmer,\
-        AsyncBrandSwitchNotificationLight
-
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -2,8 +2,8 @@
 import logging
 
 from homematicip.aio.device import (
-    AsyncBrandSwitchMeasuring, AsyncDimmer, AsyncPluggableDimmer, 
-    AsyncBrandDimmer, AsyncFullFlushDimmer, 
+    AsyncBrandSwitchMeasuring, AsyncDimmer, AsyncPluggableDimmer,
+    AsyncBrandDimmer, AsyncFullFlushDimmer,
     AsyncBrandSwitchNotificationLight)
 from homematicip.base.enums import RGBColorState
 


### PR DESCRIPTION
## Description:
This PR relates to #23330.
There was a missing import left in light.py

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. 
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
