### PR TITLE
Device type garage for binary sensor garage_door

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -100,7 +100,7 @@ DEVICE_CLASS_TO_GOOGLE_TYPES = {
     (switch.DOMAIN, switch.DEVICE_CLASS_OUTLET): TYPE_OUTLET,
     (binary_sensor.DOMAIN, binary_sensor.DEVICE_CLASS_DOOR): TYPE_DOOR,
     (binary_sensor.DOMAIN, binary_sensor.DEVICE_CLASS_GARAGE_DOOR):
-    TYPE_SENSOR,
+    TYPE_GARAGE,
     (binary_sensor.DOMAIN, binary_sensor.DEVICE_CLASS_LOCK): TYPE_SENSOR,
     (binary_sensor.DOMAIN, binary_sensor.DEVICE_CLASS_OPENING): TYPE_SENSOR,
     (binary_sensor.DOMAIN, binary_sensor.DEVICE_CLASS_WINDOW): TYPE_SENSOR,

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -646,6 +646,7 @@ async def test_device_class_binary_sensor(hass, device_class, google_type):
 @pytest.mark.parametrize("device_class,google_type", [
     ('non_existing_class', 'action.devices.types.BLINDS'),
     ('door', 'action.devices.types.DOOR'),
+    ('garage', 'action.devices.types.GARAGE'),
 ])
 async def test_device_class_cover(hass, device_class, google_type):
     """Test that a binary entity syncs to the correct device type."""

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -602,7 +602,7 @@ async def test_device_class_switch(hass, device_class, google_type):
 
 @pytest.mark.parametrize("device_class,google_type", [
     ('door', 'action.devices.types.DOOR'),
-    ('garage_door', 'action.devices.types.SENSOR'),
+    ('garage_door', 'action.devices.types.GARAGE'),
     ('lock', 'action.devices.types.SENSOR'),
     ('opening', 'action.devices.types.SENSOR'),
     ('window', 'action.devices.types.SENSOR'),


### PR DESCRIPTION
## Description:
Match cover types for binary sensor

**Related issue (if applicable):** #23307

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~[_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).~
  - [ ] ~New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).~
  - [ ] ~New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - [ ] ~New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - [ ] ~New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
