### PR TITLE
Convert some test helpers to coroutines and adjust tests

### DIFF
--- a/tests/components/alarm_control_panel/common.py
+++ b/tests/components/alarm_control_panel/common.py
@@ -9,12 +9,9 @@ from homeassistant.const import (
     SERVICE_ALARM_DISARM, SERVICE_ALARM_ARM_HOME, SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_NIGHT, SERVICE_ALARM_ARM_CUSTOM_BYPASS)
 from homeassistant.loader import bind_hass
-from homeassistant.core import callback
 
 
-@callback
-@bind_hass
-def async_alarm_disarm(hass, code=None, entity_id=None):
+async def async_alarm_disarm(hass, code=None, entity_id=None):
     """Send the alarm the command for disarm."""
     data = {}
     if code:
@@ -22,8 +19,8 @@ def async_alarm_disarm(hass, code=None, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_ALARM_DISARM, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_ALARM_DISARM, data, blocking=True)
 
 
 @bind_hass
@@ -38,9 +35,7 @@ def alarm_disarm(hass, code=None, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_ALARM_DISARM, data)
 
 
-@callback
-@bind_hass
-def async_alarm_arm_home(hass, code=None, entity_id=None):
+async def async_alarm_arm_home(hass, code=None, entity_id=None):
     """Send the alarm the command for disarm."""
     data = {}
     if code:
@@ -48,8 +43,8 @@ def async_alarm_arm_home(hass, code=None, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_ALARM_ARM_HOME, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_ALARM_ARM_HOME, data, blocking=True)
 
 
 @bind_hass
@@ -64,9 +59,7 @@ def alarm_arm_home(hass, code=None, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_HOME, data)
 
 
-@callback
-@bind_hass
-def async_alarm_arm_away(hass, code=None, entity_id=None):
+async def async_alarm_arm_away(hass, code=None, entity_id=None):
     """Send the alarm the command for disarm."""
     data = {}
     if code:
@@ -74,8 +67,8 @@ def async_alarm_arm_away(hass, code=None, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_ALARM_ARM_AWAY, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_ALARM_ARM_AWAY, data, blocking=True)
 
 
 @bind_hass
@@ -90,9 +83,7 @@ def alarm_arm_away(hass, code=None, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_AWAY, data)
 
 
-@callback
-@bind_hass
-def async_alarm_arm_night(hass, code=None, entity_id=None):
+async def async_alarm_arm_night(hass, code=None, entity_id=None):
     """Send the alarm the command for disarm."""
     data = {}
     if code:
@@ -100,8 +91,8 @@ def async_alarm_arm_night(hass, code=None, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_ALARM_ARM_NIGHT, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_ALARM_ARM_NIGHT, data, blocking=True)
 
 
 @bind_hass
@@ -116,9 +107,7 @@ def alarm_arm_night(hass, code=None, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_ALARM_ARM_NIGHT, data)
 
 
-@callback
-@bind_hass
-def async_alarm_trigger(hass, code=None, entity_id=None):
+async def async_alarm_trigger(hass, code=None, entity_id=None):
     """Send the alarm the command for disarm."""
     data = {}
     if code:
@@ -126,8 +115,8 @@ def async_alarm_trigger(hass, code=None, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_ALARM_TRIGGER, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_ALARM_TRIGGER, data, blocking=True)
 
 
 @bind_hass
@@ -142,9 +131,7 @@ def alarm_trigger(hass, code=None, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_ALARM_TRIGGER, data)
 
 
-@callback
-@bind_hass
-def async_alarm_arm_custom_bypass(hass, code=None, entity_id=None):
+async def async_alarm_arm_custom_bypass(hass, code=None, entity_id=None):
     """Send the alarm the command for disarm."""
     data = {}
     if code:
@@ -152,9 +139,8 @@ def async_alarm_arm_custom_bypass(hass, code=None, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(
-            DOMAIN, SERVICE_ALARM_ARM_CUSTOM_BYPASS, data))
+    await hass.services.async_call(
+            DOMAIN, SERVICE_ALARM_ARM_CUSTOM_BYPASS, data, blocking=True)
 
 
 @bind_hass

--- a/tests/components/climate/common.py
+++ b/tests/components/climate/common.py
@@ -12,13 +12,10 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_FAN_MODE, SERVICE_SET_OPERATION_MODE, SERVICE_SET_SWING_MODE)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_TEMPERATURE)
-from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
 
-@callback
-@bind_hass
-def async_set_away_mode(hass, away_mode, entity_id=None):
+async def async_set_away_mode(hass, away_mode, entity_id=None):
     """Turn all or specified climate devices away mode on."""
     data = {
         ATTR_AWAY_MODE: away_mode
@@ -27,8 +24,8 @@ def async_set_away_mode(hass, away_mode, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_AWAY_MODE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_AWAY_MODE, data, blocking=True)
 
 
 @bind_hass
@@ -44,9 +41,7 @@ def set_away_mode(hass, away_mode, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_AWAY_MODE, data)
 
 
-@callback
-@bind_hass
-def async_set_hold_mode(hass, hold_mode, entity_id=None):
+async def async_set_hold_mode(hass, hold_mode, entity_id=None):
     """Set new hold mode."""
     data = {
         ATTR_HOLD_MODE: hold_mode
@@ -55,8 +50,8 @@ def async_set_hold_mode(hass, hold_mode, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_HOLD_MODE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_HOLD_MODE, data, blocking=True)
 
 
 @bind_hass
@@ -72,9 +67,7 @@ def set_hold_mode(hass, hold_mode, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_HOLD_MODE, data)
 
 
-@callback
-@bind_hass
-def async_set_aux_heat(hass, aux_heat, entity_id=None):
+async def async_set_aux_heat(hass, aux_heat, entity_id=None):
     """Turn all or specified climate devices auxiliary heater on."""
     data = {
         ATTR_AUX_HEAT: aux_heat
@@ -83,8 +76,8 @@ def async_set_aux_heat(hass, aux_heat, entity_id=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_AUX_HEAT, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_AUX_HEAT, data, blocking=True)
 
 
 @bind_hass
@@ -100,11 +93,9 @@ def set_aux_heat(hass, aux_heat, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_AUX_HEAT, data)
 
 
-@callback
-@bind_hass
-def async_set_temperature(hass, temperature=None, entity_id=None,
-                          target_temp_high=None, target_temp_low=None,
-                          operation_mode=None):
+async def async_set_temperature(hass, temperature=None, entity_id=None,
+                                target_temp_high=None, target_temp_low=None,
+                                operation_mode=None):
     """Set new target temperature."""
     kwargs = {
         key: value for key, value in [
@@ -116,8 +107,8 @@ def async_set_temperature(hass, temperature=None, entity_id=None,
         ] if value is not None
     }
     _LOGGER.debug("set_temperature start data=%s", kwargs)
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_TEMPERATURE, kwargs))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_TEMPERATURE, kwargs, blocking=True)
 
 
 @bind_hass
@@ -138,17 +129,15 @@ def set_temperature(hass, temperature=None, entity_id=None,
     hass.services.call(DOMAIN, SERVICE_SET_TEMPERATURE, kwargs)
 
 
-@callback
-@bind_hass
-def async_set_humidity(hass, humidity, entity_id=None):
+async def async_set_humidity(hass, humidity, entity_id=None):
     """Set new target humidity."""
     data = {ATTR_HUMIDITY: humidity}
 
     if entity_id is not None:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_HUMIDITY, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_HUMIDITY, data, blocking=True)
 
 
 @bind_hass
@@ -162,17 +151,15 @@ def set_humidity(hass, humidity, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_HUMIDITY, data)
 
 
-@callback
-@bind_hass
-def async_set_fan_mode(hass, fan, entity_id=None):
+async def async_set_fan_mode(hass, fan, entity_id=None):
     """Set all or specified climate devices fan mode on."""
     data = {ATTR_FAN_MODE: fan}
 
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_FAN_MODE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_FAN_MODE, data, blocking=True)
 
 
 @bind_hass
@@ -186,17 +173,15 @@ def set_fan_mode(hass, fan, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_FAN_MODE, data)
 
 
-@callback
-@bind_hass
-def async_set_operation_mode(hass, operation_mode, entity_id=None):
+async def async_set_operation_mode(hass, operation_mode, entity_id=None):
     """Set new target operation mode."""
     data = {ATTR_OPERATION_MODE: operation_mode}
 
     if entity_id is not None:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_OPERATION_MODE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_OPERATION_MODE, data, blocking=True)
 
 
 @bind_hass
@@ -210,17 +195,15 @@ def set_operation_mode(hass, operation_mode, entity_id=None):
     hass.services.call(DOMAIN, SERVICE_SET_OPERATION_MODE, data)
 
 
-@callback
-@bind_hass
-def async_set_swing_mode(hass, swing_mode, entity_id=None):
+async def async_set_swing_mode(hass, swing_mode, entity_id=None):
     """Set new target swing mode."""
     data = {ATTR_SWING_MODE: swing_mode}
 
     if entity_id is not None:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_SWING_MODE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_SWING_MODE, data, blocking=True)
 
 
 @bind_hass

--- a/tests/components/demo/test_fan.py
+++ b/tests/components/demo/test_fan.py
@@ -29,12 +29,10 @@ async def test_turn_on(hass):
     """Test turning on the device."""
     assert STATE_OFF == get_entity(hass).state
 
-    common.async_turn_on(hass, FAN_ENTITY_ID)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, FAN_ENTITY_ID)
     assert STATE_OFF != get_entity(hass).state
 
-    common.async_turn_on(hass, FAN_ENTITY_ID, fan.SPEED_HIGH)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, FAN_ENTITY_ID, fan.SPEED_HIGH)
     assert STATE_ON == get_entity(hass).state
     assert fan.SPEED_HIGH == \
         get_entity(hass).attributes[fan.ATTR_SPEED]
@@ -44,12 +42,10 @@ async def test_turn_off(hass):
     """Test turning off the device."""
     assert STATE_OFF == get_entity(hass).state
 
-    common.async_turn_on(hass, FAN_ENTITY_ID)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, FAN_ENTITY_ID)
     assert STATE_OFF != get_entity(hass).state
 
-    common.async_turn_off(hass, FAN_ENTITY_ID)
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, FAN_ENTITY_ID)
     assert STATE_OFF == get_entity(hass).state
 
 
@@ -57,12 +53,10 @@ async def test_turn_off_without_entity_id(hass):
     """Test turning off all fans."""
     assert STATE_OFF == get_entity(hass).state
 
-    common.async_turn_on(hass, FAN_ENTITY_ID)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, FAN_ENTITY_ID)
     assert STATE_OFF != get_entity(hass).state
 
-    common.async_turn_off(hass)
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass)
     assert STATE_OFF == get_entity(hass).state
 
 
@@ -70,8 +64,8 @@ async def test_set_direction(hass):
     """Test setting the direction of the device."""
     assert STATE_OFF == get_entity(hass).state
 
-    common.async_set_direction(hass, FAN_ENTITY_ID, fan.DIRECTION_REVERSE)
-    await hass.async_block_till_done()
+    await common.async_set_direction(hass, FAN_ENTITY_ID,
+                                     fan.DIRECTION_REVERSE)
     assert fan.DIRECTION_REVERSE == \
         get_entity(hass).attributes.get('direction')
 
@@ -80,8 +74,7 @@ async def test_set_speed(hass):
     """Test setting the speed of the device."""
     assert STATE_OFF == get_entity(hass).state
 
-    common.async_set_speed(hass, FAN_ENTITY_ID, fan.SPEED_LOW)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, FAN_ENTITY_ID, fan.SPEED_LOW)
     assert fan.SPEED_LOW == \
         get_entity(hass).attributes.get('speed')
 
@@ -90,12 +83,10 @@ async def test_oscillate(hass):
     """Test oscillating the fan."""
     assert not get_entity(hass).attributes.get('oscillating')
 
-    common.async_oscillate(hass, FAN_ENTITY_ID, True)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, FAN_ENTITY_ID, True)
     assert get_entity(hass).attributes.get('oscillating')
 
-    common.async_oscillate(hass, FAN_ENTITY_ID, False)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, FAN_ENTITY_ID, False)
     assert not get_entity(hass).attributes.get('oscillating')
 
 
@@ -103,6 +94,5 @@ async def test_is_on(hass):
     """Test is on service call."""
     assert not fan.is_on(hass, FAN_ENTITY_ID)
 
-    common.async_turn_on(hass, FAN_ENTITY_ID)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, FAN_ENTITY_ID)
     assert fan.is_on(hass, FAN_ENTITY_ID)

--- a/tests/components/demo/test_light.py
+++ b/tests/components/demo/test_light.py
@@ -20,32 +20,30 @@ def setup_comp(hass):
 
 async def test_state_attributes(hass):
     """Test light state attributes."""
-    common.async_turn_on(
+    await common.async_turn_on(
         hass, ENTITY_LIGHT, xy_color=(.4, .4), brightness=25)
-    await hass.async_block_till_done()
     state = hass.states.get(ENTITY_LIGHT)
     assert light.is_on(hass, ENTITY_LIGHT)
     assert (0.4, 0.4) == state.attributes.get(light.ATTR_XY_COLOR)
     assert 25 == state.attributes.get(light.ATTR_BRIGHTNESS)
     assert (255, 234, 164) == state.attributes.get(light.ATTR_RGB_COLOR)
     assert 'rainbow' == state.attributes.get(light.ATTR_EFFECT)
-    common.async_turn_on(
+    await common.async_turn_on(
         hass, ENTITY_LIGHT, rgb_color=(251, 253, 255),
         white_value=254)
-    await hass.async_block_till_done()
     state = hass.states.get(ENTITY_LIGHT)
     assert 254 == state.attributes.get(light.ATTR_WHITE_VALUE)
     assert (250, 252, 255) == state.attributes.get(light.ATTR_RGB_COLOR)
     assert (0.319, 0.326) == state.attributes.get(light.ATTR_XY_COLOR)
-    common.async_turn_on(hass, ENTITY_LIGHT, color_temp=400, effect='none')
-    await hass.async_block_till_done()
+    await common.async_turn_on(
+        hass, ENTITY_LIGHT, color_temp=400, effect='none')
     state = hass.states.get(ENTITY_LIGHT)
     assert 400 == state.attributes.get(light.ATTR_COLOR_TEMP)
     assert 153 == state.attributes.get(light.ATTR_MIN_MIREDS)
     assert 500 == state.attributes.get(light.ATTR_MAX_MIREDS)
     assert 'none' == state.attributes.get(light.ATTR_EFFECT)
-    common.async_turn_on(hass, ENTITY_LIGHT, kelvin=3000, brightness_pct=50)
-    await hass.async_block_till_done()
+    await common.async_turn_on(
+        hass, ENTITY_LIGHT, kelvin=3000, brightness_pct=50)
     state = hass.states.get(ENTITY_LIGHT)
     assert 333 == state.attributes.get(light.ATTR_COLOR_TEMP)
     assert 127 == state.attributes.get(light.ATTR_BRIGHTNESS)

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -65,9 +65,7 @@ async def test_lights_on_when_sun_sets(hass, scanner):
             hass, device_sun_light_trigger.DOMAIN, {
                 device_sun_light_trigger.DOMAIN: {}})
 
-    common_light.async_turn_off(hass)
-
-    await hass.async_block_till_done()
+    await common_light.async_turn_off(hass)
 
     test_time = test_time.replace(hour=3)
     with patch('homeassistant.util.dt.utcnow', return_value=test_time):
@@ -79,9 +77,7 @@ async def test_lights_on_when_sun_sets(hass, scanner):
 
 async def test_lights_turn_off_when_everyone_leaves(hass, scanner):
     """Test lights turn off when everyone leaves the house."""
-    common_light.async_turn_on(hass)
-
-    await hass.async_block_till_done()
+    await common_light.async_turn_on(hass)
 
     assert await async_setup_component(
         hass, device_sun_light_trigger.DOMAIN, {
@@ -99,8 +95,7 @@ async def test_lights_turn_on_when_coming_home_after_sun_set(hass, scanner):
     """Test lights turn on when coming home after sun set."""
     test_time = datetime(2017, 4, 5, 3, 2, 3, tzinfo=dt_util.UTC)
     with patch('homeassistant.util.dt.utcnow', return_value=test_time):
-        common_light.async_turn_off(hass)
-        await hass.async_block_till_done()
+        await common_light.async_turn_off(hass)
 
         assert await async_setup_component(
             hass, device_sun_light_trigger.DOMAIN, {

--- a/tests/components/fan/common.py
+++ b/tests/components/fan/common.py
@@ -8,13 +8,10 @@ from homeassistant.components.fan import (
     SERVICE_OSCILLATE, SERVICE_SET_DIRECTION, SERVICE_SET_SPEED)
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
-from homeassistant.loader import bind_hass
-from homeassistant.core import callback
 
 
-@callback
-@bind_hass
-def async_turn_on(hass, entity_id: str = None, speed: str = None) -> None:
+async def async_turn_on(hass, entity_id: str = None,
+                        speed: str = None) -> None:
     """Turn all or specified fan on."""
     data = {
         key: value for key, value in [
@@ -23,24 +20,20 @@ def async_turn_on(hass, entity_id: str = None, speed: str = None) -> None:
         ] if value is not None
     }
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_TURN_ON, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, data, blocking=True)
 
 
-@callback
-@bind_hass
-def async_turn_off(hass, entity_id: str = None) -> None:
+async def async_turn_off(hass, entity_id: str = None) -> None:
     """Turn all or specified fan off."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_TURN_OFF, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, data, blocking=True)
 
 
-@callback
-@bind_hass
-def async_oscillate(hass, entity_id: str = None,
-                    should_oscillate: bool = True) -> None:
+async def async_oscillate(hass, entity_id: str = None,
+                          should_oscillate: bool = True) -> None:
     """Set oscillation on all or specified fan."""
     data = {
         key: value for key, value in [
@@ -49,13 +42,12 @@ def async_oscillate(hass, entity_id: str = None,
         ] if value is not None
     }
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_OSCILLATE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_OSCILLATE, data, blocking=True)
 
 
-@callback
-@bind_hass
-def async_set_speed(hass, entity_id: str = None, speed: str = None) -> None:
+async def async_set_speed(hass, entity_id: str = None,
+                          speed: str = None) -> None:
     """Set speed for all or specified fan."""
     data = {
         key: value for key, value in [
@@ -64,13 +56,11 @@ def async_set_speed(hass, entity_id: str = None, speed: str = None) -> None:
         ] if value is not None
     }
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_SPEED, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_SPEED, data, blocking=True)
 
 
-@callback
-@bind_hass
-def async_set_direction(
+async def async_set_direction(
         hass, entity_id: str = None, direction: str = None) -> None:
     """Set direction for all or specified fan."""
     data = {
@@ -80,5 +70,5 @@ def async_set_direction(
         ] if value is not None
     }
 
-    hass.async_create_task(
-        hass.services.async_call(DOMAIN, SERVICE_SET_DIRECTION, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_DIRECTION, data, blocking=True)

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -4,6 +4,8 @@ import pytest
 from asynctest import mock
 import pytz
 
+import voluptuous as vol
+
 import homeassistant.core as ha
 from homeassistant.core import (
     callback, DOMAIN as HASS_DOMAIN, CoreState, State)
@@ -88,8 +90,7 @@ async def test_heater_input_boolean(hass, setup_comp_1):
 
     _setup_sensor(hass, 18)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 23)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 23)
 
     assert STATE_ON == \
         hass.states.get(heater_switch).state
@@ -116,8 +117,7 @@ async def test_heater_switch(hass, setup_comp_1):
         hass.states.get(heater_switch).state
 
     _setup_sensor(hass, 18)
-    await hass.async_block_till_done()
-    common.async_set_temperature(hass, 23)
+    await common.async_set_temperature(hass, 23)
     await hass.async_block_till_done()
 
     assert STATE_ON == \
@@ -167,22 +167,19 @@ async def test_get_operation_modes(hass, setup_comp_2):
 
 async def test_set_target_temp(hass, setup_comp_2):
     """Test the setting of the target temperature."""
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     state = hass.states.get(ENTITY)
     assert 30.0 == state.attributes.get('temperature')
-    common.async_set_temperature(hass, None)
-    await hass.async_block_till_done()
+    with pytest.raises(vol.Invalid):
+        await common.async_set_temperature(hass, None)
     state = hass.states.get(ENTITY)
     assert 30.0 == state.attributes.get('temperature')
 
 
 async def test_set_away_mode(hass, setup_comp_2):
     """Test the setting away mode."""
-    common.async_set_temperature(hass, 23)
-    await hass.async_block_till_done()
-    common.async_set_away_mode(hass, True)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 23)
+    await common.async_set_away_mode(hass, True)
     state = hass.states.get(ENTITY)
     assert 16 == state.attributes.get('temperature')
 
@@ -192,14 +189,11 @@ async def test_set_away_mode_and_restore_prev_temp(hass, setup_comp_2):
 
     Verify original temperature is restored.
     """
-    common.async_set_temperature(hass, 23)
-    await hass.async_block_till_done()
-    common.async_set_away_mode(hass, True)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 23)
+    await common.async_set_away_mode(hass, True)
     state = hass.states.get(ENTITY)
     assert 16 == state.attributes.get('temperature')
-    common.async_set_away_mode(hass, False)
-    await hass.async_block_till_done()
+    await common.async_set_away_mode(hass, False)
     state = hass.states.get(ENTITY)
     assert 23 == state.attributes.get('temperature')
 
@@ -209,16 +203,12 @@ async def test_set_away_mode_twice_and_restore_prev_temp(hass, setup_comp_2):
 
     Verify original temperature is restored.
     """
-    common.async_set_temperature(hass, 23)
-    await hass.async_block_till_done()
-    common.async_set_away_mode(hass, True)
-    await hass.async_block_till_done()
-    common.async_set_away_mode(hass, True)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 23)
+    await common.async_set_away_mode(hass, True)
+    await common.async_set_away_mode(hass, True)
     state = hass.states.get(ENTITY)
     assert 16 == state.attributes.get('temperature')
-    common.async_set_away_mode(hass, False)
-    await hass.async_block_till_done()
+    await common.async_set_away_mode(hass, False)
     state = hass.states.get(ENTITY)
     assert 23 == state.attributes.get('temperature')
 
@@ -240,8 +230,7 @@ async def test_set_target_temp_heater_on(hass, setup_comp_2):
     calls = _setup_switch(hass, False)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     assert 1 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -254,8 +243,7 @@ async def test_set_target_temp_heater_off(hass, setup_comp_2):
     calls = _setup_switch(hass, True)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     assert 2 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -266,8 +254,7 @@ async def test_set_target_temp_heater_off(hass, setup_comp_2):
 async def test_temp_change_heater_on_within_tolerance(hass, setup_comp_2):
     """Test if temperature change doesn't turn on within tolerance."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 29)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -276,8 +263,7 @@ async def test_temp_change_heater_on_within_tolerance(hass, setup_comp_2):
 async def test_temp_change_heater_on_outside_tolerance(hass, setup_comp_2):
     """Test if temperature change turn heater on outside cold tolerance."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 27)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -290,8 +276,7 @@ async def test_temp_change_heater_on_outside_tolerance(hass, setup_comp_2):
 async def test_temp_change_heater_off_within_tolerance(hass, setup_comp_2):
     """Test if temperature change doesn't turn off within tolerance."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 33)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -300,8 +285,7 @@ async def test_temp_change_heater_off_within_tolerance(hass, setup_comp_2):
 async def test_temp_change_heater_off_outside_tolerance(hass, setup_comp_2):
     """Test if temperature change turn heater off outside hot tolerance."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 35)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -314,10 +298,8 @@ async def test_temp_change_heater_off_outside_tolerance(hass, setup_comp_2):
 async def test_running_when_operating_mode_is_off(hass, setup_comp_2):
     """Test that the switch turns off when enabled is set False."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
+    await common.async_set_operation_mode(hass, STATE_OFF)
     assert 1 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -328,10 +310,8 @@ async def test_running_when_operating_mode_is_off(hass, setup_comp_2):
 async def test_no_state_change_when_operation_mode_off(hass, setup_comp_2):
     """Test that the switch doesn't turn on when enabled is False."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
+    await common.async_set_operation_mode(hass, STATE_OFF)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -340,8 +320,7 @@ async def test_no_state_change_when_operation_mode_off(hass, setup_comp_2):
 @mock.patch('logging.Logger.error')
 async def test_invalid_operating_mode(log_mock, hass, setup_comp_2):
     """Test error handling for invalid operation mode."""
-    common.async_set_operation_mode(hass, 'invalid mode')
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, 'invalid mode')
     assert log_mock.call_count == 1
 
 
@@ -350,13 +329,12 @@ async def test_operating_mode_heat(hass, setup_comp_2):
 
     Switch turns on when temp below setpoint and mode changes.
     """
-    common.async_set_operation_mode(hass, STATE_OFF)
-    common.async_set_temperature(hass, 30)
+    await common.async_set_operation_mode(hass, STATE_OFF)
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     calls = _setup_switch(hass, False)
-    common.async_set_operation_mode(hass, STATE_HEAT)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_HEAT)
     assert 1 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -402,8 +380,7 @@ async def test_set_target_temp_ac_off(hass, setup_comp_3):
     calls = _setup_switch(hass, True)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     assert 2 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -413,12 +390,11 @@ async def test_set_target_temp_ac_off(hass, setup_comp_3):
 
 async def test_turn_away_mode_on_cooling(hass, setup_comp_3):
     """Test the setting away mode when cooling."""
+    _setup_switch(hass, True)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 19)
-    await hass.async_block_till_done()
-    common.async_set_away_mode(hass, True)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 19)
+    await common.async_set_away_mode(hass, True)
     state = hass.states.get(ENTITY)
     assert 30 == state.attributes.get('temperature')
 
@@ -428,13 +404,12 @@ async def test_operating_mode_cool(hass, setup_comp_3):
 
     Switch turns on when temp below setpoint and mode changes.
     """
-    common.async_set_operation_mode(hass, STATE_OFF)
-    common.async_set_temperature(hass, 25)
+    await common.async_set_operation_mode(hass, STATE_OFF)
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     calls = _setup_switch(hass, False)
-    common.async_set_operation_mode(hass, STATE_COOL)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_COOL)
     assert 1 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -447,8 +422,7 @@ async def test_set_target_temp_ac_on(hass, setup_comp_3):
     calls = _setup_switch(hass, False)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     assert 1 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -459,8 +433,7 @@ async def test_set_target_temp_ac_on(hass, setup_comp_3):
 async def test_temp_change_ac_off_within_tolerance(hass, setup_comp_3):
     """Test if temperature change doesn't turn ac off within tolerance."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 29.8)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -469,8 +442,7 @@ async def test_temp_change_ac_off_within_tolerance(hass, setup_comp_3):
 async def test_set_temp_change_ac_off_outside_tolerance(hass, setup_comp_3):
     """Test if temperature change turn ac off."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 27)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -483,8 +455,7 @@ async def test_set_temp_change_ac_off_outside_tolerance(hass, setup_comp_3):
 async def test_temp_change_ac_on_within_tolerance(hass, setup_comp_3):
     """Test if temperature change doesn't turn ac on within tolerance."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 25.2)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -493,8 +464,7 @@ async def test_temp_change_ac_on_within_tolerance(hass, setup_comp_3):
 async def test_temp_change_ac_on_outside_tolerance(hass, setup_comp_3):
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -507,10 +477,8 @@ async def test_temp_change_ac_on_outside_tolerance(hass, setup_comp_3):
 async def test_running_when_operating_mode_is_off_2(hass, setup_comp_3):
     """Test that the switch turns off when enabled is set False."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
+    await common.async_set_operation_mode(hass, STATE_OFF)
     assert 1 == len(calls)
     call = calls[0]
     assert HASS_DOMAIN == call.domain
@@ -521,10 +489,8 @@ async def test_running_when_operating_mode_is_off_2(hass, setup_comp_3):
 async def test_no_state_change_when_operation_mode_off_2(hass, setup_comp_3):
     """Test that the switch doesn't turn on when enabled is False."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
+    await common.async_set_operation_mode(hass, STATE_OFF)
     _setup_sensor(hass, 35)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -550,8 +516,7 @@ def setup_comp_4(hass):
 async def test_temp_change_ac_trigger_on_not_long_enough(hass, setup_comp_4):
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -564,8 +529,7 @@ async def test_temp_change_ac_trigger_on_long_enough(hass, setup_comp_4):
     with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                     return_value=fake_changed):
         calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -578,8 +542,7 @@ async def test_temp_change_ac_trigger_on_long_enough(hass, setup_comp_4):
 async def test_temp_change_ac_trigger_off_not_long_enough(hass, setup_comp_4):
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -592,8 +555,7 @@ async def test_temp_change_ac_trigger_off_long_enough(hass, setup_comp_4):
     with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                     return_value=fake_changed):
         calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -606,13 +568,11 @@ async def test_temp_change_ac_trigger_off_long_enough(hass, setup_comp_4):
 async def test_mode_change_ac_trigger_off_not_long_enough(hass, setup_comp_4):
     """Test if mode change turns ac off despite minimum cycle."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 0 == len(calls)
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_OFF)
     assert 1 == len(calls)
     call = calls[0]
     assert 'homeassistant' == call.domain
@@ -623,13 +583,11 @@ async def test_mode_change_ac_trigger_off_not_long_enough(hass, setup_comp_4):
 async def test_mode_change_ac_trigger_on_not_long_enough(hass, setup_comp_4):
     """Test if mode change turns ac on despite minimum cycle."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 0 == len(calls)
-    common.async_set_operation_mode(hass, STATE_HEAT)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_HEAT)
     assert 1 == len(calls)
     call = calls[0]
     assert 'homeassistant' == call.domain
@@ -657,8 +615,7 @@ def setup_comp_5(hass):
 async def test_temp_change_ac_trigger_on_not_long_enough_2(hass, setup_comp_5):
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -671,8 +628,7 @@ async def test_temp_change_ac_trigger_on_long_enough_2(hass, setup_comp_5):
     with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                     return_value=fake_changed):
         calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -686,8 +642,7 @@ async def test_temp_change_ac_trigger_off_not_long_enough_2(
         hass, setup_comp_5):
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -700,8 +655,7 @@ async def test_temp_change_ac_trigger_off_long_enough_2(hass, setup_comp_5):
     with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                     return_value=fake_changed):
         calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -715,13 +669,11 @@ async def test_mode_change_ac_trigger_off_not_long_enough_2(
         hass, setup_comp_5):
     """Test if mode change turns ac off despite minimum cycle."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 0 == len(calls)
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_OFF)
     assert 1 == len(calls)
     call = calls[0]
     assert 'homeassistant' == call.domain
@@ -732,13 +684,11 @@ async def test_mode_change_ac_trigger_off_not_long_enough_2(
 async def test_mode_change_ac_trigger_on_not_long_enough_2(hass, setup_comp_5):
     """Test if mode change turns ac on despite minimum cycle."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 0 == len(calls)
-    common.async_set_operation_mode(hass, STATE_HEAT)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_HEAT)
     assert 1 == len(calls)
     call = calls[0]
     assert 'homeassistant' == call.domain
@@ -766,8 +716,7 @@ async def test_temp_change_heater_trigger_off_not_long_enough(
         hass, setup_comp_6):
     """Test if temp change doesn't turn heater off because of time."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -777,8 +726,7 @@ async def test_temp_change_heater_trigger_on_not_long_enough(
         hass, setup_comp_6):
     """Test if temp change doesn't turn heater on because of time."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 0 == len(calls)
@@ -791,8 +739,7 @@ async def test_temp_change_heater_trigger_on_long_enough(hass, setup_comp_6):
     with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                     return_value=fake_changed):
         calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -809,8 +756,7 @@ async def test_temp_change_heater_trigger_off_long_enough(hass, setup_comp_6):
     with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                     return_value=fake_changed):
         calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 1 == len(calls)
@@ -824,13 +770,11 @@ async def test_mode_change_heater_trigger_off_not_long_enough(
         hass, setup_comp_6):
     """Test if mode change turns heater off despite minimum cycle."""
     calls = _setup_switch(hass, True)
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
     assert 0 == len(calls)
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_OFF)
     assert 1 == len(calls)
     call = calls[0]
     assert 'homeassistant' == call.domain
@@ -842,13 +786,11 @@ async def test_mode_change_heater_trigger_on_not_long_enough(
         hass, setup_comp_6):
     """Test if mode change turns heater on despite minimum cycle."""
     calls = _setup_switch(hass, False)
-    common.async_set_temperature(hass, 30)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 30)
     _setup_sensor(hass, 25)
     await hass.async_block_till_done()
     assert 0 == len(calls)
-    common.async_set_operation_mode(hass, STATE_HEAT)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_HEAT)
     assert 1 == len(calls)
     call = calls[0]
     assert 'homeassistant' == call.domain
@@ -881,8 +823,7 @@ async def test_temp_change_ac_trigger_on_long_enough_3(hass, setup_comp_7):
     await hass.async_block_till_done()
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     test_time = datetime.datetime.now(pytz.UTC)
     _send_time_changed(hass, test_time)
     await hass.async_block_till_done()
@@ -905,8 +846,7 @@ async def test_temp_change_ac_trigger_off_long_enough_3(hass, setup_comp_7):
     await hass.async_block_till_done()
     _setup_sensor(hass, 20)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     test_time = datetime.datetime.now(pytz.UTC)
     _send_time_changed(hass, test_time)
     await hass.async_block_till_done()
@@ -952,8 +892,7 @@ async def test_temp_change_heater_trigger_on_long_enough_2(hass, setup_comp_8):
     await hass.async_block_till_done()
     _setup_sensor(hass, 20)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     test_time = datetime.datetime.now(pytz.UTC)
     _send_time_changed(hass, test_time)
     await hass.async_block_till_done()
@@ -977,8 +916,7 @@ async def test_temp_change_heater_trigger_off_long_enough_2(
     await hass.async_block_till_done()
     _setup_sensor(hass, 30)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 25)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 25)
     test_time = datetime.datetime.now(pytz.UTC)
     _send_time_changed(hass, test_time)
     await hass.async_block_till_done()
@@ -1019,8 +957,7 @@ def setup_comp_9(hass):
 
 async def test_turn_on_when_off(hass, setup_comp_9):
     """Test if climate.turn_on turns on a turned off device."""
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_OFF)
     await hass.services.async_call('climate', SERVICE_TURN_ON)
     await hass.async_block_till_done()
     state_heat = hass.states.get(HEAT_ENTITY)
@@ -1033,9 +970,8 @@ async def test_turn_on_when_off(hass, setup_comp_9):
 
 async def test_turn_on_when_on(hass, setup_comp_9):
     """Test if climate.turn_on does nothing to a turned on device."""
-    common.async_set_operation_mode(hass, STATE_HEAT, HEAT_ENTITY)
-    common.async_set_operation_mode(hass, STATE_COOL, COOL_ENTITY)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_HEAT, HEAT_ENTITY)
+    await common.async_set_operation_mode(hass, STATE_COOL, COOL_ENTITY)
     await hass.services.async_call('climate', SERVICE_TURN_ON)
     await hass.async_block_till_done()
     state_heat = hass.states.get(HEAT_ENTITY)
@@ -1048,9 +984,8 @@ async def test_turn_on_when_on(hass, setup_comp_9):
 
 async def test_turn_off_when_on(hass, setup_comp_9):
     """Test if climate.turn_off turns off a turned on device."""
-    common.async_set_operation_mode(hass, STATE_HEAT, HEAT_ENTITY)
-    common.async_set_operation_mode(hass, STATE_COOL, COOL_ENTITY)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_HEAT, HEAT_ENTITY)
+    await common.async_set_operation_mode(hass, STATE_COOL, COOL_ENTITY)
     await hass.services.async_call('climate', SERVICE_TURN_OFF)
     await hass.async_block_till_done()
     state_heat = hass.states.get(HEAT_ENTITY)
@@ -1063,8 +998,7 @@ async def test_turn_off_when_on(hass, setup_comp_9):
 
 async def test_turn_off_when_off(hass, setup_comp_9):
     """Test if climate.turn_off does nothing to a turned off device."""
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_OFF)
     await hass.services.async_call('climate', SERVICE_TURN_OFF)
     await hass.async_block_till_done()
     state_heat = hass.states.get(HEAT_ENTITY)
@@ -1096,12 +1030,10 @@ def setup_comp_10(hass):
 
 async def test_precision(hass, setup_comp_10):
     """Test that setting precision to tenths works as intended."""
-    common.async_set_operation_mode(hass, STATE_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, STATE_OFF)
     await hass.services.async_call('climate', SERVICE_TURN_OFF)
     await hass.async_block_till_done()
-    common.async_set_temperature(hass, 23.27)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, 23.27)
     state = hass.states.get(ENTITY)
     assert 23.3 == state.attributes.get('temperature')
 

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -301,30 +301,26 @@ async def test_service_calls(hass):
     await hass.async_block_till_done()
 
     assert hass.states.get('light.light_group').state == 'on'
-    common.async_toggle(hass, 'light.light_group')
-    await hass.async_block_till_done()
+    await common.async_toggle(hass, 'light.light_group')
 
     assert hass.states.get('light.bed_light').state == 'off'
     assert hass.states.get('light.ceiling_lights').state == 'off'
     assert hass.states.get('light.kitchen_lights').state == 'off'
 
-    common.async_turn_on(hass, 'light.light_group')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.light_group')
 
     assert hass.states.get('light.bed_light').state == 'on'
     assert hass.states.get('light.ceiling_lights').state == 'on'
     assert hass.states.get('light.kitchen_lights').state == 'on'
 
-    common.async_turn_off(hass, 'light.light_group')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.light_group')
 
     assert hass.states.get('light.bed_light').state == 'off'
     assert hass.states.get('light.ceiling_lights').state == 'off'
     assert hass.states.get('light.kitchen_lights').state == 'off'
 
-    common.async_turn_on(hass, 'light.light_group', brightness=128,
-                         effect='Random', rgb_color=(42, 255, 255))
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.light_group', brightness=128,
+                               effect='Random', rgb_color=(42, 255, 255))
 
     state = hass.states.get('light.bed_light')
     assert state.state == 'on'

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -9,7 +9,6 @@ from homeassistant.components.light import (
     ATTR_RGB_COLOR, ATTR_TRANSITION, ATTR_WHITE_VALUE, ATTR_XY_COLOR, DOMAIN)
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON)
-from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
 
@@ -25,13 +24,11 @@ def turn_on(hass, entity_id=None, transition=None, brightness=None,
         profile, flash, effect, color_name)
 
 
-@callback
-@bind_hass
-def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
-                  brightness_pct=None, rgb_color=None, xy_color=None,
-                  hs_color=None, color_temp=None, kelvin=None,
-                  white_value=None, profile=None, flash=None, effect=None,
-                  color_name=None):
+async def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
+                        brightness_pct=None, rgb_color=None, xy_color=None,
+                        hs_color=None, color_temp=None, kelvin=None,
+                        white_value=None, profile=None, flash=None,
+                        effect=None, color_name=None):
     """Turn all or specified light on."""
     data = {
         key: value for key, value in [
@@ -52,7 +49,8 @@ def async_turn_on(hass, entity_id=None, transition=None, brightness=None,
         ] if value is not None
     }
 
-    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_TURN_ON, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, data, blocking=True)
 
 
 @bind_hass
@@ -61,9 +59,7 @@ def turn_off(hass, entity_id=None, transition=None):
     hass.add_job(async_turn_off, hass, entity_id, transition)
 
 
-@callback
-@bind_hass
-def async_turn_off(hass, entity_id=None, transition=None):
+async def async_turn_off(hass, entity_id=None, transition=None):
     """Turn all or specified light off."""
     data = {
         key: value for key, value in [
@@ -72,8 +68,8 @@ def async_turn_off(hass, entity_id=None, transition=None):
         ] if value is not None
     }
 
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, data, blocking=True)
 
 
 @bind_hass
@@ -82,9 +78,7 @@ def toggle(hass, entity_id=None, transition=None):
     hass.add_job(async_toggle, hass, entity_id, transition)
 
 
-@callback
-@bind_hass
-def async_toggle(hass, entity_id=None, transition=None):
+async def async_toggle(hass, entity_id=None, transition=None):
     """Toggle all or specified light."""
     data = {
         key: value for key, value in [
@@ -93,5 +87,5 @@ def async_toggle(hass, entity_id=None, transition=None):
         ] if value is not None
     }
 
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TOGGLE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TOGGLE, data, blocking=True)

--- a/tests/components/lock/common.py
+++ b/tests/components/lock/common.py
@@ -6,7 +6,6 @@ components. Instead call the service directly.
 from homeassistant.components.lock import DOMAIN
 from homeassistant.const import (
     ATTR_CODE, ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK, SERVICE_OPEN)
-from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
 
@@ -22,9 +21,7 @@ def lock(hass, entity_id=None, code=None):
     hass.services.call(DOMAIN, SERVICE_LOCK, data)
 
 
-@callback
-@bind_hass
-def async_lock(hass, entity_id=None, code=None):
+async def async_lock(hass, entity_id=None, code=None):
     """Lock all or specified locks."""
     data = {}
     if code:
@@ -32,7 +29,7 @@ def async_lock(hass, entity_id=None, code=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_LOCK, data))
+    await hass.services.async_call(DOMAIN, SERVICE_LOCK, data, blocking=True)
 
 
 @bind_hass
@@ -47,9 +44,7 @@ def unlock(hass, entity_id=None, code=None):
     hass.services.call(DOMAIN, SERVICE_UNLOCK, data)
 
 
-@callback
-@bind_hass
-def async_unlock(hass, entity_id=None, code=None):
+async def async_unlock(hass, entity_id=None, code=None):
     """Lock all or specified locks."""
     data = {}
     if code:
@@ -57,7 +52,7 @@ def async_unlock(hass, entity_id=None, code=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_UNLOCK, data))
+    await hass.services.async_call(DOMAIN, SERVICE_UNLOCK, data, blocking=True)
 
 
 @bind_hass
@@ -72,9 +67,7 @@ def open_lock(hass, entity_id=None, code=None):
     hass.services.call(DOMAIN, SERVICE_OPEN, data)
 
 
-@callback
-@bind_hass
-def async_open_lock(hass, entity_id=None, code=None):
+async def async_open_lock(hass, entity_id=None, code=None):
     """Lock all or specified locks."""
     data = {}
     if code:
@@ -82,4 +75,4 @@ def async_open_lock(hass, entity_id=None, code=None):
     if entity_id:
         data[ATTR_ENTITY_ID] = entity_id
 
-    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_OPEN, data))
+    await hass.services.async_call(DOMAIN, SERVICE_OPEN, data, blocking=True)

--- a/tests/components/manual/test_alarm_control_panel.py
+++ b/tests/components/manual/test_alarm_control_panel.py
@@ -42,8 +42,7 @@ async def test_arm_home_no_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_home(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass, CODE)
 
     assert STATE_ALARM_ARMED_HOME == \
         hass.states.get(entity_id).state
@@ -66,8 +65,7 @@ async def test_arm_home_with_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_home(hass, CODE, entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass, CODE, entity_id)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -102,8 +100,7 @@ async def test_arm_home_with_invalid_code(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_home(hass, CODE + '2')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass, CODE + '2')
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -126,8 +123,7 @@ async def test_arm_away_no_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE, entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE, entity_id)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
@@ -150,8 +146,7 @@ async def test_arm_home_with_template_code(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_home(hass, 'abc')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass, 'abc')
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_ARMED_HOME == state.state
@@ -174,8 +169,7 @@ async def test_arm_away_with_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -210,8 +204,7 @@ async def test_arm_away_with_invalid_code(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE + '2')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE + '2')
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -234,8 +227,7 @@ async def test_arm_night_no_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_night(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass, CODE)
 
     assert STATE_ALARM_ARMED_NIGHT == \
         hass.states.get(entity_id).state
@@ -258,8 +250,7 @@ async def test_arm_night_with_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_night(hass, CODE, entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass, CODE, entity_id)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -278,8 +269,7 @@ async def test_arm_night_with_pending(hass):
     assert state.state == STATE_ALARM_ARMED_NIGHT
 
     # Do not go to the pending state when updating to the same state
-    common.async_alarm_arm_night(hass, CODE, entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass, CODE, entity_id)
 
     assert STATE_ALARM_ARMED_NIGHT == \
         hass.states.get(entity_id).state
@@ -302,8 +292,7 @@ async def test_arm_night_with_invalid_code(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_night(hass, CODE + '2')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass, CODE + '2')
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -325,8 +314,7 @@ async def test_trigger_no_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -359,14 +347,12 @@ async def test_trigger_with_delay(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_PENDING == state.state
@@ -400,8 +386,7 @@ async def test_trigger_zero_trigger_time(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass)
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -424,8 +409,7 @@ async def test_trigger_zero_trigger_time_with_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass)
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -448,8 +432,7 @@ async def test_trigger_with_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -497,14 +480,12 @@ async def test_trigger_with_unused_specific_delay(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_PENDING == state.state
@@ -542,14 +523,12 @@ async def test_trigger_with_specific_delay(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_PENDING == state.state
@@ -587,14 +566,12 @@ async def test_trigger_with_pending_and_delay(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -644,14 +621,12 @@ async def test_trigger_with_pending_and_specific_delay(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ALARM_PENDING
@@ -692,8 +667,7 @@ async def test_armed_home_with_specific_pending(hass):
 
     entity_id = 'alarm_control_panel.test'
 
-    common.async_alarm_arm_home(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -723,8 +697,7 @@ async def test_armed_away_with_specific_pending(hass):
 
     entity_id = 'alarm_control_panel.test'
 
-    common.async_alarm_arm_away(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -754,8 +727,7 @@ async def test_armed_night_with_specific_pending(hass):
 
     entity_id = 'alarm_control_panel.test'
 
-    common.async_alarm_arm_night(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -787,8 +759,7 @@ async def test_trigger_with_specific_pending(hass):
 
     entity_id = 'alarm_control_panel.test'
 
-    common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -829,8 +800,7 @@ async def test_trigger_with_disarm_after_trigger(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_TRIGGERED == \
         hass.states.get(entity_id).state
@@ -865,8 +835,7 @@ async def test_trigger_with_zero_specific_trigger_time(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -892,8 +861,7 @@ async def test_trigger_with_unused_zero_specific_trigger_time(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_TRIGGERED == \
         hass.states.get(entity_id).state
@@ -927,8 +895,7 @@ async def test_trigger_with_specific_trigger_time(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_TRIGGERED == \
         hass.states.get(entity_id).state
@@ -960,14 +927,12 @@ async def test_trigger_with_no_disarm_after_trigger(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE, entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE, entity_id)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_TRIGGERED == \
         hass.states.get(entity_id).state
@@ -999,14 +964,12 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE, entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE, entity_id)
 
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_TRIGGERED == \
         hass.states.get(entity_id).state
@@ -1020,8 +983,7 @@ async def test_back_to_back_trigger_with_no_disarm_after_trigger(hass):
     assert STATE_ALARM_ARMED_AWAY == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     assert STATE_ALARM_TRIGGERED == \
         hass.states.get(entity_id).state
@@ -1052,14 +1014,12 @@ async def test_disarm_while_pending_trigger(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_disarm(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass, entity_id=entity_id)
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -1091,14 +1051,12 @@ async def test_disarm_during_trigger_with_invalid_code(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_trigger(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_disarm(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass, entity_id=entity_id)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -1131,20 +1089,17 @@ async def test_disarm_with_template_code(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_home(hass, 'def')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass, 'def')
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_ARMED_HOME == state.state
 
-    common.async_alarm_disarm(hass, 'def')
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass, 'def')
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_ARMED_HOME == state.state
 
-    common.async_alarm_disarm(hass, 'abc')
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass, 'abc')
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_DISARMED == state.state
@@ -1167,8 +1122,7 @@ async def test_arm_custom_bypass_no_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_custom_bypass(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_custom_bypass(hass, CODE)
 
     assert STATE_ALARM_ARMED_CUSTOM_BYPASS == \
         hass.states.get(entity_id).state
@@ -1191,8 +1145,7 @@ async def test_arm_custom_bypass_with_pending(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_custom_bypass(hass, CODE, entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_custom_bypass(hass, CODE, entity_id)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -1228,8 +1181,7 @@ async def test_arm_custom_bypass_with_invalid_code(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_custom_bypass(hass, CODE + '2')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_custom_bypass(hass, CODE + '2')
 
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
@@ -1250,8 +1202,7 @@ async def test_armed_custom_bypass_with_specific_pending(hass):
 
     entity_id = 'alarm_control_panel.test'
 
-    common.async_alarm_arm_custom_bypass(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_custom_bypass(hass)
 
     assert STATE_ALARM_PENDING == \
         hass.states.get(entity_id).state
@@ -1290,8 +1241,7 @@ async def test_arm_away_after_disabled_disarmed(hass):
     assert STATE_ALARM_DISARMED == \
         hass.states.get(entity_id).state
 
-    common.async_alarm_arm_away(hass, CODE)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, CODE)
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_PENDING == state.state
@@ -1300,8 +1250,7 @@ async def test_arm_away_after_disabled_disarmed(hass):
     assert STATE_ALARM_ARMED_AWAY == \
         state.attributes['post_pending_state']
 
-    common.async_alarm_trigger(hass, entity_id=entity_id)
-    await hass.async_block_till_done()
+    await common.async_alarm_trigger(hass, entity_id=entity_id)
 
     state = hass.states.get(entity_id)
     assert STATE_ALARM_PENDING == state.state
@@ -1319,8 +1268,7 @@ async def test_arm_away_after_disabled_disarmed(hass):
         state = hass.states.get(entity_id)
         assert STATE_ALARM_ARMED_AWAY == state.state
 
-        common.async_alarm_trigger(hass, entity_id=entity_id)
-        await hass.async_block_till_done()
+        await common.async_alarm_trigger(hass, entity_id=entity_id)
 
         state = hass.states.get(entity_id)
         assert STATE_ALARM_PENDING == state.state

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -92,8 +92,7 @@ async def test_arm_home_publishes_mqtt(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_arm_home(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'ARM_HOME', 0, False)
 
@@ -116,8 +115,7 @@ async def test_arm_home_not_publishes_mqtt_with_invalid_code_when_req(
     })
 
     call_count = mqtt_mock.async_publish.call_count
-    common.async_alarm_arm_home(hass, 'abcd')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass, 'abcd')
     assert mqtt_mock.async_publish.call_count == call_count
 
 
@@ -137,8 +135,7 @@ async def test_arm_home_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_arm_home(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_home(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'ARM_HOME', 0, False)
 
@@ -154,8 +151,7 @@ async def test_arm_away_publishes_mqtt(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_arm_away(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'ARM_AWAY', 0, False)
 
@@ -178,8 +174,7 @@ async def test_arm_away_not_publishes_mqtt_with_invalid_code_when_req(
     })
 
     call_count = mqtt_mock.async_publish.call_count
-    common.async_alarm_arm_away(hass, 'abcd')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass, 'abcd')
     assert mqtt_mock.async_publish.call_count == call_count
 
 
@@ -199,8 +194,7 @@ async def test_arm_away_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_arm_away(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_away(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'ARM_AWAY', 0, False)
 
@@ -216,8 +210,7 @@ async def test_arm_night_publishes_mqtt(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_arm_night(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'ARM_NIGHT', 0, False)
 
@@ -240,8 +233,7 @@ async def test_arm_night_not_publishes_mqtt_with_invalid_code_when_req(
     })
 
     call_count = mqtt_mock.async_publish.call_count
-    common.async_alarm_arm_night(hass, 'abcd')
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass, 'abcd')
     assert mqtt_mock.async_publish.call_count == call_count
 
 
@@ -261,8 +253,7 @@ async def test_arm_night_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_arm_night(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_arm_night(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'ARM_NIGHT', 0, False)
 
@@ -278,8 +269,7 @@ async def test_disarm_publishes_mqtt(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_disarm(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'DISARM', 0, False)
 
@@ -301,8 +291,7 @@ async def test_disarm_publishes_mqtt_with_template(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_disarm(hass, 1234)
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass, 1234)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', '{\"action\":\"DISARM\",\"code\":\"1234\"}',
         0,
@@ -325,8 +314,7 @@ async def test_disarm_publishes_mqtt_when_code_not_req(hass, mqtt_mock):
         }
     })
 
-    common.async_alarm_disarm(hass)
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass)
     mqtt_mock.async_publish.assert_called_once_with(
         'alarm/command', 'DISARM', 0, False)
 
@@ -349,8 +337,7 @@ async def test_disarm_not_publishes_mqtt_with_invalid_code_when_req(
     })
 
     call_count = mqtt_mock.async_publish.call_count
-    common.async_alarm_disarm(hass, 'abcd')
-    await hass.async_block_till_done()
+    await common.async_alarm_disarm(hass, 'abcd')
     assert mqtt_mock.async_publish.call_count == call_count
 
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -1,8 +1,11 @@
 """The tests for the mqtt climate component."""
 import copy
 import json
+import pytest
 import unittest
 from unittest.mock import ANY
+
+import voluptuous as vol
 
 from homeassistant.components import mqtt
 from homeassistant.components.climate import (
@@ -89,11 +92,11 @@ async def test_set_operation_bad_attr_and_state(hass, mqtt_mock, caplog):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'off'
     assert state.state == 'off'
-    common.async_set_operation_mode(hass, None, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    with pytest.raises(vol.Invalid) as excinfo:
+        await common.async_set_operation_mode(hass, None, ENTITY_CLIMATE)
     assert ("string value is None for dictionary value @ "
             "data['operation_mode']")\
-        in caplog.text
+        in str(excinfo.value)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'off'
     assert state.state == 'off'
@@ -106,8 +109,7 @@ async def test_set_operation(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'off'
     assert state.state == 'off'
-    common.async_set_operation_mode(hass, 'cool', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, 'cool', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'cool'
     assert state.state == 'cool'
@@ -125,8 +127,7 @@ async def test_set_operation_pessimistic(hass, mqtt_mock):
     assert state.attributes.get('operation_mode') is None
     assert state.state == 'unknown'
 
-    common.async_set_operation_mode(hass, 'cool', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, 'cool', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') is None
     assert state.state == 'unknown'
@@ -151,8 +152,7 @@ async def test_set_operation_with_power_command(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'off'
     assert state.state == 'off'
-    common.async_set_operation_mode(hass, 'on', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, 'on', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'on'
     assert state.state == 'on'
@@ -162,8 +162,7 @@ async def test_set_operation_with_power_command(hass, mqtt_mock):
     ])
     mqtt_mock.async_publish.reset_mock()
 
-    common.async_set_operation_mode(hass, 'off', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, 'off', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'off'
     assert state.state == 'off'
@@ -180,10 +179,10 @@ async def test_set_fan_mode_bad_attr(hass, mqtt_mock, caplog):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('fan_mode') == 'low'
-    common.async_set_fan_mode(hass, None, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    with pytest.raises(vol.Invalid) as excinfo:
+        await common.async_set_fan_mode(hass, None, ENTITY_CLIMATE)
     assert "string value is None for dictionary value @ data['fan_mode']"\
-        in caplog.text
+        in str(excinfo.value)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('fan_mode') == 'low'
 
@@ -197,8 +196,7 @@ async def test_set_fan_mode_pessimistic(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('fan_mode') is None
 
-    common.async_set_fan_mode(hass, 'high', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_fan_mode(hass, 'high', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('fan_mode') is None
 
@@ -217,8 +215,7 @@ async def test_set_fan_mode(hass, mqtt_mock):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('fan_mode') == 'low'
-    common.async_set_fan_mode(hass, 'high', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_fan_mode(hass, 'high', ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'fan-mode-topic', 'high', 0, False)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -231,10 +228,10 @@ async def test_set_swing_mode_bad_attr(hass, mqtt_mock, caplog):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('swing_mode') == 'off'
-    common.async_set_swing_mode(hass, None, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    with pytest.raises(vol.Invalid) as excinfo:
+        await common.async_set_swing_mode(hass, None, ENTITY_CLIMATE)
     assert "string value is None for dictionary value @ data['swing_mode']"\
-        in caplog.text
+        in str(excinfo.value)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('swing_mode') == 'off'
 
@@ -248,8 +245,7 @@ async def test_set_swing_pessimistic(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('swing_mode') is None
 
-    common.async_set_swing_mode(hass, 'on', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_swing_mode(hass, 'on', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('swing_mode') is None
 
@@ -268,8 +264,7 @@ async def test_set_swing(hass, mqtt_mock):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('swing_mode') == 'off'
-    common.async_set_swing_mode(hass, 'on', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_swing_mode(hass, 'on', ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'swing-mode-topic', 'on', 0, False)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -282,16 +277,14 @@ async def test_set_target_temperature(hass, mqtt_mock):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('temperature') == 21
-    common.async_set_operation_mode(hass, 'heat', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, 'heat', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'heat'
     mqtt_mock.async_publish.assert_called_once_with(
         'mode-topic', 'heat', 0, False)
     mqtt_mock.async_publish.reset_mock()
-    common.async_set_temperature(hass, temperature=47,
-                                 entity_id=ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, temperature=47,
+                                       entity_id=ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('temperature') == 47
     mqtt_mock.async_publish.assert_called_once_with(
@@ -299,10 +292,9 @@ async def test_set_target_temperature(hass, mqtt_mock):
 
     # also test directly supplying the operation mode to set_temperature
     mqtt_mock.async_publish.reset_mock()
-    common.async_set_temperature(hass, temperature=21,
-                                 operation_mode='cool',
-                                 entity_id=ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, temperature=21,
+                                       operation_mode='cool',
+                                       entity_id=ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('operation_mode') == 'cool'
     assert state.attributes.get('temperature') == 21
@@ -321,11 +313,9 @@ async def test_set_target_temperature_pessimistic(hass, mqtt_mock):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('temperature') is None
-    common.async_set_operation_mode(hass, 'heat', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
-    common.async_set_temperature(hass, temperature=47,
-                                 entity_id=ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_operation_mode(hass, 'heat', ENTITY_CLIMATE)
+    await common.async_set_temperature(hass, temperature=47,
+                                       entity_id=ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('temperature') is None
 
@@ -342,10 +332,9 @@ async def test_set_target_temperature_low_high(hass, mqtt_mock):
     """Test setting the low/high target temperature."""
     assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
 
-    common.async_set_temperature(hass, target_temp_low=20,
-                                 target_temp_high=23,
-                                 entity_id=ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, target_temp_low=20,
+                                       target_temp_high=23,
+                                       entity_id=ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('target_temp_low') == 20
     assert state.attributes.get('target_temp_high') == 23
@@ -367,10 +356,9 @@ async def test_set_target_temperature_low_highpessimistic(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('target_temp_low') is None
     assert state.attributes.get('target_temp_high') is None
-    common.async_set_temperature(hass, target_temp_low=20,
-                                 target_temp_high=23,
-                                 entity_id=ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_temperature(hass, target_temp_low=20,
+                                       target_temp_high=23,
+                                       entity_id=ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('target_temp_low') is None
     assert state.attributes.get('target_temp_high') is None
@@ -414,8 +402,7 @@ async def test_set_away_mode_pessimistic(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('away_mode') == 'off'
 
-    common.async_set_away_mode(hass, True, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_away_mode(hass, True, ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('away_mode') == 'off'
 
@@ -442,16 +429,14 @@ async def test_set_away_mode(hass, mqtt_mock):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('away_mode') == 'off'
-    common.async_set_away_mode(hass, True, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_away_mode(hass, True, ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'away-mode-topic', 'AN', 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('away_mode') == 'on'
 
-    common.async_set_away_mode(hass, False, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_away_mode(hass, False, ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'away-mode-topic', 'AUS', 0, False)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -467,8 +452,7 @@ async def test_set_hold_pessimistic(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('hold_mode') is None
 
-    common.async_set_hold_mode(hass, 'on', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_hold_mode(hass, 'on', ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('hold_mode') is None
 
@@ -487,16 +471,14 @@ async def test_set_hold(hass, mqtt_mock):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('hold_mode') is None
-    common.async_set_hold_mode(hass, 'on', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_hold_mode(hass, 'on', ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'hold-topic', 'on', 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('hold_mode') == 'on'
 
-    common.async_set_hold_mode(hass, 'off', ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_hold_mode(hass, 'off', ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'hold-topic', 'off', 0, False)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -512,8 +494,7 @@ async def test_set_aux_pessimistic(hass, mqtt_mock):
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('aux_heat') == 'off'
 
-    common.async_set_aux_heat(hass, True, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_aux_heat(hass, True, ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('aux_heat') == 'off'
 
@@ -536,16 +517,14 @@ async def test_set_aux(hass, mqtt_mock):
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('aux_heat') == 'off'
-    common.async_set_aux_heat(hass, True, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_aux_heat(hass, True, ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'aux-topic', 'ON', 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get('aux_heat') == 'on'
 
-    common.async_set_aux_heat(hass, False, ENTITY_CLIMATE)
-    await hass.async_block_till_done()
+    await common.async_set_aux_heat(hass, False, ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_called_once_with(
         'aux-topic', 'OFF', 0, False)
     state = hass.states.get(ENTITY_CLIMATE)

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -172,8 +172,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_turn_on(hass, 'fan.test')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'fan.test')
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'StAtE_On', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -181,8 +180,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_ON
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_turn_off(hass, 'fan.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'fan.test')
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'StAtE_OfF', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -190,8 +188,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_oscillate(hass, 'fan.test', True)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, 'fan.test', True)
     mqtt_mock.async_publish.assert_called_once_with(
         'oscillation-command-topic', 'OsC_On', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -199,8 +196,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_oscillate(hass, 'fan.test', False)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, 'fan.test', False)
     mqtt_mock.async_publish.assert_called_once_with(
         'oscillation-command-topic', 'OsC_OfF', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -208,8 +204,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_LOW)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_LOW)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'speed_lOw', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -217,8 +212,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_MEDIUM)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_MEDIUM)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'speed_mEdium', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -226,8 +220,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_HIGH)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_HIGH)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'speed_High', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -235,8 +228,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_OFF)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'speed_OfF', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -265,8 +257,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_turn_on(hass, 'fan.test')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'fan.test')
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'ON', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -274,8 +265,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_ON
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_turn_off(hass, 'fan.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'fan.test')
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'OFF', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -283,8 +273,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_oscillate(hass, 'fan.test', True)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, 'fan.test', True)
     mqtt_mock.async_publish.assert_called_once_with(
         'oscillation-command-topic', 'oscillate_on', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -292,8 +281,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_oscillate(hass, 'fan.test', False)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, 'fan.test', False)
     mqtt_mock.async_publish.assert_called_once_with(
         'oscillation-command-topic', 'oscillate_off', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -301,8 +289,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_LOW)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_LOW)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'low', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -310,8 +297,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_MEDIUM)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_MEDIUM)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'medium', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -319,8 +305,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_HIGH)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_HIGH)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'high', 0, False)
     mqtt_mock.async_publish.reset_mock()
@@ -328,8 +313,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_set_speed(hass, 'fan.test', fan.SPEED_OFF)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, 'fan.test', fan.SPEED_OFF)
     mqtt_mock.async_publish.assert_called_once_with(
         'speed-command-topic', 'off', 0, False)
     mqtt_mock.async_publish.reset_mock()

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -66,82 +66,61 @@ async def test_all_commands(hass, mqtt_mock):
         vacuum.DOMAIN: config,
     })
 
-    common.turn_on(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/command', 'turn_on', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.turn_off(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/command', 'turn_off', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.stop(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_stop(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/command', 'stop', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.clean_spot(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_clean_spot(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/command', 'clean_spot', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.locate(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_locate(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/command', 'locate', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.start_pause(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_start_pause(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/command', 'start_pause', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.return_to_base(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_return_to_base(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/command', 'return_to_base', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.set_fan_speed(hass, 'high', 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_set_fan_speed(hass, 'high', 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/set_fan_speed', 'high', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.send_command(hass, '44 FE 93', entity_id='vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_send_command(hass, '44 FE 93',
+                                    entity_id='vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/send_command', '44 FE 93', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.send_command(hass, '44 FE 93', {"key": "value"},
-                        entity_id='vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_send_command(hass, '44 FE 93', {"key": "value"},
+                                    entity_id='vacuum.mqtttest')
     assert json.loads(mqtt_mock.async_publish.mock_calls[-1][1][1]) == {
         "command": "44 FE 93",
         "key": "value"
     }
 
-    common.send_command(hass, '44 FE 93', {"key": "value"},
-                        entity_id='vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_send_command(hass, '44 FE 93', {"key": "value"},
+                                    entity_id='vacuum.mqtttest')
     assert json.loads(mqtt_mock.async_publish.mock_calls[-1][1][1]) == {
         "command": "44 FE 93",
         "key": "value"
@@ -160,57 +139,40 @@ async def test_commands_without_supported_features(hass, mqtt_mock):
         vacuum.DOMAIN: config,
     })
 
-    common.turn_on(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.turn_off(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.stop(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_stop(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.clean_spot(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_clean_spot(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.locate(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_locate(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.start_pause(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_start_pause(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.return_to_base(hass, 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_return_to_base(hass, 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.set_fan_speed(hass, 'high', 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_set_fan_speed(hass, 'high', 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.send_command(hass, '44 FE 93', entity_id='vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_send_command(hass, '44 FE 93',
+                                    entity_id='vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
@@ -228,7 +190,7 @@ async def test_attributes_without_supported_features(hass, mqtt_mock):
     })
 
     state = hass.states.get('vacuum.mqtttest')
-    assert STATE_OFF == state.state
+    assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_BATTERY_LEVEL) is None
     assert state.attributes.get(ATTR_BATTERY_ICON) is None
 
@@ -251,8 +213,6 @@ async def test_status(hass, mqtt_mock):
         "fan_speed": "max"
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_BATTERY_ICON) == 'mdi:battery-50'
@@ -268,8 +228,6 @@ async def test_status(hass, mqtt_mock):
     }"""
 
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_BATTERY_ICON) == 'mdi:battery-charging-60'
@@ -291,8 +249,6 @@ async def test_status_battery(hass, mqtt_mock):
         "battery_level": 54
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.attributes.get(ATTR_BATTERY_ICON) == 'mdi:battery-50'
 
@@ -311,8 +267,6 @@ async def test_status_cleaning(hass, mqtt_mock):
         "cleaning": true
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_ON
 
@@ -331,8 +285,6 @@ async def test_status_docked(hass, mqtt_mock):
         "docked": true
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_OFF
 
@@ -351,8 +303,6 @@ async def test_status_charging(hass, mqtt_mock):
         "charging": true
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.attributes.get(ATTR_BATTERY_ICON) == 'mdi:battery-outline'
 
@@ -371,8 +321,6 @@ async def test_status_fan_speed(hass, mqtt_mock):
         "fan_speed": "max"
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.attributes.get(ATTR_FAN_SPEED) == 'max'
 
@@ -391,7 +339,6 @@ async def test_status_error(hass, mqtt_mock):
         "error": "Error1"
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.attributes.get(ATTR_STATUS) == 'Error: Error1'
 
@@ -399,7 +346,6 @@ async def test_status_error(hass, mqtt_mock):
         "error": ""
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.attributes.get(ATTR_STATUS) == 'Stopped'
 
@@ -419,7 +365,6 @@ async def test_battery_template(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'retroroomba/battery_level', '54')
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.attributes.get(ATTR_BATTERY_LEVEL) == 54
     assert state.attributes.get(ATTR_BATTERY_ICON) == 'mdi:battery-50'
@@ -436,7 +381,6 @@ async def test_status_invalid_json(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'vacuum/state', '{"asdfasas false}')
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_STATUS) == "Stopped"
@@ -532,21 +476,17 @@ async def test_default_availability_payload(hass, mqtt_mock):
     })
 
     state = hass.states.get('vacuum.mqtttest')
-    assert STATE_UNAVAILABLE == state.state
+    assert state.state == STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'online')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
-    assert STATE_UNAVAILABLE != state.state
+    assert state.state != STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'offline')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
-    assert STATE_UNAVAILABLE == state.state
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_custom_availability_payload(hass, mqtt_mock):
@@ -563,21 +503,17 @@ async def test_custom_availability_payload(hass, mqtt_mock):
     })
 
     state = hass.states.get('vacuum.mqtttest')
-    assert STATE_UNAVAILABLE == state.state
+    assert state.state == STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'good')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
-    assert STATE_UNAVAILABLE != state.state
+    assert state.state != STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'nogood')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
-    assert STATE_UNAVAILABLE == state.state
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_discovery_removal_vacuum(hass, mqtt_mock):
@@ -593,14 +529,12 @@ async def test_discovery_removal_vacuum(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.beer')
     assert state is not None
     assert state.name == 'Beer'
 
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config', '')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.beer')
@@ -630,7 +564,6 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data2)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.milk')
@@ -665,7 +598,6 @@ async def test_discovery_update_vacuum(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.beer')
     assert state is not None
@@ -686,7 +618,6 @@ async def test_setting_attribute_via_mqtt_json_message(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '{ "val": "100" }')
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.test')
 
     assert state.attributes.get('val') == '100'
@@ -704,7 +635,6 @@ async def test_update_with_json_attrs_not_dict(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '[ "list", "of", "things"]')
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.test')
 
     assert state.attributes.get('val') is None
@@ -723,7 +653,6 @@ async def test_update_with_json_attrs_bad_json(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', 'This is not JSON')
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.test')
     assert state.attributes.get('val') is None
@@ -748,8 +677,6 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
                             data1)
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "100" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.beer')
     assert state.attributes.get('val') == '100'
 
@@ -757,19 +684,14 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     # Verify we are no longer subscribing to the old topic
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "50" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.beer')
     assert state.attributes.get('val') == '100'
 
     # Verify we are subscribing to the new topic
     async_fire_mqtt_message(hass, 'attr-topic2', '{ "val": "75" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.beer')
     assert state.attributes.get('val') == '75'
 
@@ -792,8 +714,6 @@ async def test_unique_id(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'test-topic', 'payload')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids()) == 2
     # all vacuums group is 1, unique id created is 1
@@ -824,7 +744,6 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     })
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -866,7 +785,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
     assert device is not None
@@ -876,7 +794,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     data = json.dumps(config)
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -540,8 +540,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.attributes.get('white_value') == 50
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_turn_on(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', 'on', 2, False)
@@ -549,8 +548,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_ON
 
-    common.async_turn_off(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', 'off', 2, False)
@@ -559,13 +557,12 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state == STATE_OFF
 
     mqtt_mock.reset_mock()
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, xy_color=[0.123, 0.123])
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, hs_color=[359, 78])
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
-                         white_value=80)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, xy_color=[0.123, 0.123])
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, hs_color=[359, 78])
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
+                               white_value=80)
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call('test_light_rgb/set', 'on', 2, False),
@@ -604,8 +601,7 @@ async def test_sending_mqtt_rgb_command_with_template(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 64])
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 64])
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call('test_light_rgb/set', 'on', 0, False),
@@ -635,8 +631,7 @@ async def test_sending_mqtt_color_temp_command_with_template(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test', color_temp=100)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', color_temp=100)
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call('test_light_color_temp/set', 'on', 0, False),
@@ -801,8 +796,7 @@ async def test_on_command_first(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test', brightness=50)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', brightness=50)
 
     # Should get the following MQTT messages.
     #    test_light/set: 'ON'
@@ -813,8 +807,7 @@ async def test_on_command_first(hass, mqtt_mock):
     ], any_order=True)
     mqtt_mock.async_publish.reset_mock()
 
-    common.async_turn_off(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light/set', 'OFF', 0, False)
@@ -834,8 +827,7 @@ async def test_on_command_last(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test', brightness=50)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', brightness=50)
 
     # Should get the following MQTT messages.
     #    test_light/bright: 50
@@ -846,8 +838,7 @@ async def test_on_command_last(hass, mqtt_mock):
     ], any_order=True)
     mqtt_mock.async_publish.reset_mock()
 
-    common.async_turn_off(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light/set', 'OFF', 0, False)
@@ -870,8 +861,7 @@ async def test_on_command_brightness(hass, mqtt_mock):
     assert state.state == STATE_OFF
 
     # Turn on w/ no brightness - should set to max
-    common.async_turn_on(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test')
 
     # Should get the following MQTT messages.
     #    test_light/bright: 255
@@ -879,28 +869,24 @@ async def test_on_command_brightness(hass, mqtt_mock):
         'test_light/bright', 255, 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.async_turn_off(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light/set', 'OFF', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     # Turn on w/ brightness
-    common.async_turn_on(hass, 'light.test', brightness=50)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', brightness=50)
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light/bright', 50, 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.async_turn_off(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test')
 
     # Turn on w/ just a color to insure brightness gets
     # added and sent.
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0])
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0])
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call('test_light/rgb', '255,128,0', 0, False),
@@ -922,8 +908,7 @@ async def test_on_command_rgb(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test', brightness=127)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', brightness=127)
 
     # Should get the following MQTT messages.
     #    test_light/rgb: '127,127,127'
@@ -934,8 +919,7 @@ async def test_on_command_rgb(hass, mqtt_mock):
     ], any_order=True)
     mqtt_mock.async_publish.reset_mock()
 
-    common.async_turn_off(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light/set', 'OFF', 0, False)

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -306,8 +306,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 191
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_turn_on(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', '{"state": "ON"}', 2, False)
@@ -315,8 +314,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_ON
 
-    common.async_turn_off(hass, 'light.test')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', '{"state": "OFF"}', 2, False)
@@ -325,13 +323,12 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state == STATE_OFF
 
     mqtt_mock.reset_mock()
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, xy_color=[0.123, 0.123])
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, hs_color=[359, 78])
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
-                         white_value=80)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, xy_color=[0.123, 0.123])
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, hs_color=[359, 78])
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
+                               white_value=80)
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call(
@@ -383,13 +380,12 @@ async def test_sending_hs_color(hass, mqtt_mock):
     assert state.state == STATE_OFF
 
     mqtt_mock.reset_mock()
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, xy_color=[0.123, 0.123])
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, hs_color=[359, 78])
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
-                         white_value=80)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, xy_color=[0.123, 0.123])
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, hs_color=[359, 78])
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
+                               white_value=80)
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call(
@@ -428,13 +424,12 @@ async def test_sending_rgb_color_no_brightness(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, xy_color=[0.123, 0.123])
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, hs_color=[359, 78])
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
-                         brightness=255)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, xy_color=[0.123, 0.123])
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, hs_color=[359, 78])
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
+                               brightness=255)
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call(
@@ -471,13 +466,12 @@ async def test_sending_rgb_color_with_brightness(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, xy_color=[0.123, 0.123])
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, hs_color=[359, 78])
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
-                         white_value=80)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, xy_color=[0.123, 0.123])
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, hs_color=[359, 78])
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
+                               white_value=80)
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call(
@@ -517,13 +511,12 @@ async def test_sending_xy_color(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_OFF
 
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, xy_color=[0.123, 0.123])
-    common.async_turn_on(hass, 'light.test',
-                         brightness=50, hs_color=[359, 78])
-    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
-                         white_value=80)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, xy_color=[0.123, 0.123])
+    await common.async_turn_on(hass, 'light.test',
+                               brightness=50, hs_color=[359, 78])
+    await common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
+                               white_value=80)
 
     mqtt_mock.async_publish.assert_has_calls([
         mock.call(
@@ -565,8 +558,7 @@ async def test_flash_short_and_long(hass, mqtt_mock):
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 40
 
-    common.async_turn_on(hass, 'light.test', flash='short')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', flash='short')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', JsonValidator(
@@ -575,8 +567,7 @@ async def test_flash_short_and_long(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_ON
 
-    common.async_turn_on(hass, 'light.test', flash='long')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', flash='long')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', JsonValidator(
@@ -602,8 +593,7 @@ async def test_transition(hass, mqtt_mock):
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 40
 
-    common.async_turn_on(hass, 'light.test', transition=15)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.test', transition=15)
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', JsonValidator(
@@ -612,8 +602,7 @@ async def test_transition(hass, mqtt_mock):
     state = hass.states.get('light.test')
     assert state.state == STATE_ON
 
-    common.async_turn_off(hass, 'light.test', transition=30)
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.test', transition=30)
 
     mqtt_mock.async_publish.assert_called_once_with(
         'test_light_rgb/set', JsonValidator(

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -86,8 +86,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_UNLOCKED
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_lock(hass, 'lock.test')
-    await hass.async_block_till_done()
+    await common.async_lock(hass, 'lock.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'LOCK', 0, False)
@@ -96,8 +95,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
     assert state.state is STATE_LOCKED
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_unlock(hass, 'lock.test')
-    await hass.async_block_till_done()
+    await common.async_unlock(hass, 'lock.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'UNLOCK', 0, False)
@@ -125,8 +123,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_UNLOCKED
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_lock(hass, 'lock.test')
-    await hass.async_block_till_done()
+    await common.async_lock(hass, 'lock.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'LOCK', 0, False)
@@ -135,8 +132,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock):
     assert state.state is STATE_LOCKED
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.async_unlock(hass, 'lock.test')
-    await hass.async_block_till_done()
+    await common.async_unlock(hass, 'lock.test')
 
     mqtt_mock.async_publish.assert_called_once_with(
         'command-topic', 'UNLOCK', 0, False)

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -64,70 +64,53 @@ async def test_all_commands(hass, mqtt_mock):
 
     await hass.services.async_call(
         DOMAIN, SERVICE_START, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
         COMMAND_TOPIC, 'start', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_STOP, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
         COMMAND_TOPIC, 'stop', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_PAUSE, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
         COMMAND_TOPIC, 'pause', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_LOCATE, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
         COMMAND_TOPIC, 'locate', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_CLEAN_SPOT, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
         COMMAND_TOPIC, 'clean_spot', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_RETURN_TO_BASE, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_called_once_with(
         COMMAND_TOPIC, 'return_to_base', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.set_fan_speed(hass, 'medium', 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_set_fan_speed(hass, 'medium', 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/set_fan_speed', 'medium', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.send_command(hass, '44 FE 93', entity_id='vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_send_command(hass, '44 FE 93',
+                                    entity_id='vacuum.mqtttest')
     mqtt_mock.async_publish.assert_called_once_with(
         'vacuum/send_command', '44 FE 93', 0, False)
     mqtt_mock.async_publish.reset_mock()
 
-    common.send_command(hass, '44 FE 93', {"key": "value"},
-                        entity_id='vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_send_command(hass, '44 FE 93', {"key": "value"},
+                                    entity_id='vacuum.mqtttest')
     assert json.loads(mqtt_mock.async_publish.mock_calls[-1][1][1]) == {
         "command": "44 FE 93",
         "key": "value"
@@ -148,56 +131,40 @@ async def test_commands_without_supported_features(hass, mqtt_mock):
 
     await hass.services.async_call(
         DOMAIN, SERVICE_START, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_PAUSE, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_STOP, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_RETURN_TO_BASE, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_LOCATE, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
     await hass.services.async_call(
         DOMAIN, SERVICE_CLEAN_SPOT, blocking=True)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.set_fan_speed(hass, 'medium', 'vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_set_fan_speed(hass, 'medium', 'vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
     mqtt_mock.async_publish.reset_mock()
 
-    common.send_command(hass, '44 FE 93', {"key": "value"},
-                        entity_id='vacuum.mqtttest')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_send_command(hass, '44 FE 93', {"key": "value"},
+                                    entity_id='vacuum.mqtttest')
     mqtt_mock.async_publish.assert_not_called()
 
 
@@ -217,8 +184,6 @@ async def test_status(hass, mqtt_mock):
         "fan_speed": "max"
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_CLEANING
     assert state.attributes.get(ATTR_BATTERY_LEVEL) == 54
@@ -232,8 +197,6 @@ async def test_status(hass, mqtt_mock):
     }"""
 
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_DOCKED
     assert state.attributes.get(ATTR_BATTERY_ICON) == 'mdi:battery-charging-60'
@@ -259,8 +222,6 @@ async def test_no_fan_vacuum(hass, mqtt_mock):
         "state": "cleaning"
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_CLEANING
     assert state.attributes.get(ATTR_FAN_SPEED) is None
@@ -274,8 +235,6 @@ async def test_no_fan_vacuum(hass, mqtt_mock):
         "fan_speed": "max"
     }"""
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
 
     assert state.state == STATE_CLEANING
@@ -291,8 +250,6 @@ async def test_no_fan_vacuum(hass, mqtt_mock):
     }"""
 
     async_fire_mqtt_message(hass, 'vacuum/state', message)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_DOCKED
     assert state.attributes.get(ATTR_BATTERY_ICON) == 'mdi:battery-charging-60'
@@ -311,7 +268,6 @@ async def test_status_invalid_json(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'vacuum/state', '{"asdfasas false}')
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_UNKNOWN
 
@@ -331,15 +287,11 @@ async def test_default_availability_payload(hass, mqtt_mock):
     assert state.state == STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'online')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
     assert STATE_UNAVAILABLE != state.state
 
     async_fire_mqtt_message(hass, 'availability-topic', 'offline')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_UNAVAILABLE
@@ -362,15 +314,11 @@ async def test_custom_availability_payload(hass, mqtt_mock):
     assert state.state == STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'good')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
     assert state.state != STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, 'availability-topic', 'nogood')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.mqtttest')
     assert state.state == STATE_UNAVAILABLE
@@ -390,14 +338,12 @@ async def test_discovery_removal_vacuum(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.beer')
     assert state is not None
     assert state.name == 'Beer'
 
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config', '')
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.beer')
@@ -429,7 +375,6 @@ async def test_discovery_broken(hass, mqtt_mock, caplog):
 
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data2)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.milk')
@@ -466,7 +411,6 @@ async def test_discovery_update_vacuum(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.beer')
     assert state is not None
@@ -487,7 +431,6 @@ async def test_setting_attribute_via_mqtt_json_message(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '{ "val": "100" }')
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.test')
 
     assert state.attributes.get('val') == '100'
@@ -505,7 +448,6 @@ async def test_update_with_json_attrs_not_dict(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', '[ "list", "of", "things"]')
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.test')
 
     assert state.attributes.get('val') is None
@@ -524,7 +466,6 @@ async def test_update_with_json_attrs_bad_json(hass, mqtt_mock, caplog):
     })
 
     async_fire_mqtt_message(hass, 'attr-topic', 'This is not JSON')
-    await hass.async_block_till_done()
 
     state = hass.states.get('vacuum.test')
     assert state.attributes.get('val') is None
@@ -549,8 +490,6 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
                             data1)
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "100" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.beer')
     assert state.attributes.get('val') == '100'
 
@@ -558,19 +497,14 @@ async def test_discovery_update_attr(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data2)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     # Verify we are no longer subscribing to the old topic
     async_fire_mqtt_message(hass, 'attr-topic1', '{ "val": "50" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.beer')
     assert state.attributes.get('val') == '100'
 
     # Verify we are subscribing to the new topic
     async_fire_mqtt_message(hass, 'attr-topic2', '{ "val": "75" }')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
     state = hass.states.get('vacuum.beer')
     assert state.attributes.get('val') == '75'
 
@@ -593,8 +527,6 @@ async def test_unique_id(hass, mqtt_mock):
     })
 
     async_fire_mqtt_message(hass, 'test-topic', 'payload')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids()) == 2
     # all vacuums group is 1, unique id created is 1
@@ -625,7 +557,6 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     })
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
@@ -667,7 +598,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
     assert device is not None
@@ -677,7 +607,6 @@ async def test_entity_device_info_update(hass, mqtt_mock):
     data = json.dumps(config)
     async_fire_mqtt_message(hass, 'homeassistant/vacuum/bla/config',
                             data)
-    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -74,8 +74,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mock_publish):
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    common.turn_on(hass, 'switch.test')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'switch.test')
 
     mock_publish.async_publish.assert_called_once_with(
         'command-topic', 'beer on', 2, False)
@@ -83,9 +82,7 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mock_publish):
     state = hass.states.get('switch.test')
     assert state.state == STATE_ON
 
-    common.turn_off(hass, 'switch.test')
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'switch.test')
 
     mock_publish.async_publish.assert_called_once_with(
         'command-topic', 'beer off', 2, False)

--- a/tests/components/switch/common.py
+++ b/tests/components/switch/common.py
@@ -6,7 +6,6 @@ components. Instead call the service directly.
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
-from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
 
@@ -16,12 +15,11 @@ def turn_on(hass, entity_id=None):
     hass.add_job(async_turn_on, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_turn_on(hass, entity_id=None):
+async def async_turn_on(hass, entity_id=None):
     """Turn all or specified switch on."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(DOMAIN, SERVICE_TURN_ON, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, data, blocking=True)
 
 
 @bind_hass
@@ -30,10 +28,8 @@ def turn_off(hass, entity_id=None):
     hass.add_job(async_turn_off, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_turn_off(hass, entity_id=None):
+async def async_turn_off(hass, entity_id=None):
     """Turn all or specified switch off."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(
-        hass.services.async_call(DOMAIN, SERVICE_TURN_OFF, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, data, blocking=True)

--- a/tests/components/switch/test_light.py
+++ b/tests/components/switch/test_light.py
@@ -37,20 +37,17 @@ async def test_light_service_calls(hass):
 
     assert hass.states.get('light.light_switch').state == 'on'
 
-    common.async_toggle(hass, 'light.light_switch')
-    await hass.async_block_till_done()
+    await common.async_toggle(hass, 'light.light_switch')
 
     assert hass.states.get('switch.decorative_lights').state == 'off'
     assert hass.states.get('light.light_switch').state == 'off'
 
-    common.async_turn_on(hass, 'light.light_switch')
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, 'light.light_switch')
 
     assert hass.states.get('switch.decorative_lights').state == 'on'
     assert hass.states.get('light.light_switch').state == 'on'
 
-    common.async_turn_off(hass, 'light.light_switch')
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, 'light.light_switch')
 
     assert hass.states.get('switch.decorative_lights').state == 'off'
     assert hass.states.get('light.light_switch').state == 'off'
@@ -68,14 +65,12 @@ async def test_switch_service_calls(hass):
 
     assert hass.states.get('light.light_switch').state == 'on'
 
-    switch_common.async_turn_off(hass, 'switch.decorative_lights')
-    await hass.async_block_till_done()
+    await switch_common.async_turn_off(hass, 'switch.decorative_lights')
 
     assert hass.states.get('switch.decorative_lights').state == 'off'
     assert hass.states.get('light.light_switch').state == 'off'
 
-    switch_common.async_turn_on(hass, 'switch.decorative_lights')
-    await hass.async_block_till_done()
+    await switch_common.async_turn_on(hass, 'switch.decorative_lights')
 
     assert hass.states.get('switch.decorative_lights').state == 'on'
     assert hass.states.get('light.light_switch').state == 'on'

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -279,16 +279,14 @@ async def test_on_off(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # verify
     assert hass.states.get(_STATE_INPUT_BOOLEAN).state == STATE_ON
     _verify(hass, STATE_ON, None, None, None)
 
     # Turn off fan
-    common.async_turn_off(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_off(hass, _TEST_FAN)
 
     # verify
     assert hass.states.get(_STATE_INPUT_BOOLEAN).state == STATE_OFF
@@ -300,8 +298,7 @@ async def test_on_with_speed(hass, calls):
     await _register_components(hass)
 
     # Turn on fan with high speed
-    common.async_turn_on(hass, _TEST_FAN, SPEED_HIGH)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN, SPEED_HIGH)
 
     # verify
     assert hass.states.get(_STATE_INPUT_BOOLEAN).state == STATE_ON
@@ -314,20 +311,17 @@ async def test_set_speed(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's speed to high
-    common.async_set_speed(hass, _TEST_FAN, SPEED_HIGH)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, _TEST_FAN, SPEED_HIGH)
 
     # verify
     assert hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_HIGH
     _verify(hass, STATE_ON, SPEED_HIGH, None, None)
 
     # Set fan's speed to medium
-    common.async_set_speed(hass, _TEST_FAN, SPEED_MEDIUM)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, _TEST_FAN, SPEED_MEDIUM)
 
     # verify
     assert hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_MEDIUM
@@ -339,12 +333,10 @@ async def test_set_invalid_speed_from_initial_stage(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's speed to 'invalid'
-    common.async_set_speed(hass, _TEST_FAN, 'invalid')
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, _TEST_FAN, 'invalid')
 
     # verify speed is unchanged
     assert hass.states.get(_SPEED_INPUT_SELECT).state == ''
@@ -356,20 +348,17 @@ async def test_set_invalid_speed(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's speed to high
-    common.async_set_speed(hass, _TEST_FAN, SPEED_HIGH)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, _TEST_FAN, SPEED_HIGH)
 
     # verify
     assert hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_HIGH
     _verify(hass, STATE_ON, SPEED_HIGH, None, None)
 
     # Set fan's speed to 'invalid'
-    common.async_set_speed(hass, _TEST_FAN, 'invalid')
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, _TEST_FAN, 'invalid')
 
     # verify speed is unchanged
     assert hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_HIGH
@@ -381,20 +370,17 @@ async def test_custom_speed_list(hass, calls):
     await _register_components(hass, ['1', '2', '3'])
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's speed to '1'
-    common.async_set_speed(hass, _TEST_FAN, '1')
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, _TEST_FAN, '1')
 
     # verify
     assert hass.states.get(_SPEED_INPUT_SELECT).state == '1'
     _verify(hass, STATE_ON, '1', None, None)
 
     # Set fan's speed to 'medium' which is invalid
-    common.async_set_speed(hass, _TEST_FAN, SPEED_MEDIUM)
-    await hass.async_block_till_done()
+    await common.async_set_speed(hass, _TEST_FAN, SPEED_MEDIUM)
 
     # verify that speed is unchanged
     assert hass.states.get(_SPEED_INPUT_SELECT).state == '1'
@@ -406,20 +392,17 @@ async def test_set_osc(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's osc to True
-    common.async_oscillate(hass, _TEST_FAN, True)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, _TEST_FAN, True)
 
     # verify
     assert hass.states.get(_OSC_INPUT).state == 'True'
     _verify(hass, STATE_ON, None, True, None)
 
     # Set fan's osc to False
-    common.async_oscillate(hass, _TEST_FAN, False)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, _TEST_FAN, False)
 
     # verify
     assert hass.states.get(_OSC_INPUT).state == 'False'
@@ -431,12 +414,10 @@ async def test_set_invalid_osc_from_initial_state(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's osc to 'invalid'
-    common.async_oscillate(hass, _TEST_FAN, 'invalid')
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, _TEST_FAN, 'invalid')
 
     # verify
     assert hass.states.get(_OSC_INPUT).state == ''
@@ -448,20 +429,17 @@ async def test_set_invalid_osc(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's osc to True
-    common.async_oscillate(hass, _TEST_FAN, True)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, _TEST_FAN, True)
 
     # verify
     assert hass.states.get(_OSC_INPUT).state == 'True'
     _verify(hass, STATE_ON, None, True, None)
 
     # Set fan's osc to False
-    common.async_oscillate(hass, _TEST_FAN, None)
-    await hass.async_block_till_done()
+    await common.async_oscillate(hass, _TEST_FAN, None)
 
     # verify osc is unchanged
     assert hass.states.get(_OSC_INPUT).state == 'True'
@@ -473,12 +451,10 @@ async def test_set_direction(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's direction to forward
-    common.async_set_direction(hass, _TEST_FAN, DIRECTION_FORWARD)
-    await hass.async_block_till_done()
+    await common.async_set_direction(hass, _TEST_FAN, DIRECTION_FORWARD)
 
     # verify
     assert hass.states.get(_DIRECTION_INPUT_SELECT).state \
@@ -486,8 +462,7 @@ async def test_set_direction(hass, calls):
     _verify(hass, STATE_ON, None, None, DIRECTION_FORWARD)
 
     # Set fan's direction to reverse
-    common.async_set_direction(hass, _TEST_FAN, DIRECTION_REVERSE)
-    await hass.async_block_till_done()
+    await common.async_set_direction(hass, _TEST_FAN, DIRECTION_REVERSE)
 
     # verify
     assert hass.states.get(_DIRECTION_INPUT_SELECT).state \
@@ -500,12 +475,10 @@ async def test_set_invalid_direction_from_initial_stage(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's direction to 'invalid'
-    common.async_set_direction(hass, _TEST_FAN, 'invalid')
-    await hass.async_block_till_done()
+    await common.async_set_direction(hass, _TEST_FAN, 'invalid')
 
     # verify direction is unchanged
     assert hass.states.get(_DIRECTION_INPUT_SELECT).state == ''
@@ -517,12 +490,10 @@ async def test_set_invalid_direction(hass, calls):
     await _register_components(hass)
 
     # Turn on fan
-    common.async_turn_on(hass, _TEST_FAN)
-    await hass.async_block_till_done()
+    await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's direction to forward
-    common.async_set_direction(hass, _TEST_FAN, DIRECTION_FORWARD)
-    await hass.async_block_till_done()
+    await common.async_set_direction(hass, _TEST_FAN, DIRECTION_FORWARD)
 
     # verify
     assert hass.states.get(_DIRECTION_INPUT_SELECT).state == \
@@ -530,8 +501,7 @@ async def test_set_invalid_direction(hass, calls):
     _verify(hass, STATE_ON, None, None, DIRECTION_FORWARD)
 
     # Set fan's direction to 'invalid'
-    common.async_set_direction(hass, _TEST_FAN, 'invalid')
-    await hass.async_block_till_done()
+    await common.async_set_direction(hass, _TEST_FAN, 'invalid')
 
     # verify direction is unchanged
     assert hass.states.get(_DIRECTION_INPUT_SELECT).state == \

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -2,6 +2,8 @@
 import logging
 import pytest
 
+import voluptuous as vol
+
 from homeassistant import setup
 from homeassistant.const import STATE_ON, STATE_OFF
 from homeassistant.components.fan import (
@@ -417,7 +419,8 @@ async def test_set_invalid_osc_from_initial_state(hass, calls):
     await common.async_turn_on(hass, _TEST_FAN)
 
     # Set fan's osc to 'invalid'
-    await common.async_oscillate(hass, _TEST_FAN, 'invalid')
+    with pytest.raises(vol.Invalid):
+        await common.async_oscillate(hass, _TEST_FAN, 'invalid')
 
     # verify
     assert hass.states.get(_OSC_INPUT).state == ''
@@ -438,8 +441,9 @@ async def test_set_invalid_osc(hass, calls):
     assert hass.states.get(_OSC_INPUT).state == 'True'
     _verify(hass, STATE_ON, None, True, None)
 
-    # Set fan's osc to False
-    await common.async_oscillate(hass, _TEST_FAN, None)
+    # Set fan's osc to None
+    with pytest.raises(vol.Invalid):
+        await common.async_oscillate(hass, _TEST_FAN, None)
 
     # verify osc is unchanged
     assert hass.states.get(_OSC_INPUT).state == 'True'

--- a/tests/components/vacuum/common.py
+++ b/tests/components/vacuum/common.py
@@ -10,7 +10,6 @@ from homeassistant.components.vacuum import (
 from homeassistant.const import (
     ATTR_COMMAND, ATTR_ENTITY_ID, SERVICE_TOGGLE,
     SERVICE_TURN_OFF, SERVICE_TURN_ON)
-from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 
 
@@ -20,13 +19,11 @@ def turn_on(hass, entity_id=None):
     hass.add_job(async_turn_on, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_turn_on(hass, entity_id=None):
+async def async_turn_on(hass, entity_id=None):
     """Turn all or specified vacuum on."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TURN_ON, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, data, blocking=True)
 
 
 @bind_hass
@@ -35,13 +32,11 @@ def turn_off(hass, entity_id=None):
     hass.add_job(async_turn_off, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_turn_off(hass, entity_id=None):
+async def async_turn_off(hass, entity_id=None):
     """Turn all or specified vacuum off."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, data, blocking=True)
 
 
 @bind_hass
@@ -50,13 +45,11 @@ def toggle(hass, entity_id=None):
     hass.add_job(async_toggle, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_toggle(hass, entity_id=None):
+async def async_toggle(hass, entity_id=None):
     """Toggle all or specified vacuum."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_TOGGLE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TOGGLE, data, blocking=True)
 
 
 @bind_hass
@@ -65,13 +58,11 @@ def locate(hass, entity_id=None):
     hass.add_job(async_locate, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_locate(hass, entity_id=None):
+async def async_locate(hass, entity_id=None):
     """Locate all or specified vacuum."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_LOCATE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_LOCATE, data, blocking=True)
 
 
 @bind_hass
@@ -80,13 +71,11 @@ def clean_spot(hass, entity_id=None):
     hass.add_job(async_clean_spot, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_clean_spot(hass, entity_id=None):
+async def async_clean_spot(hass, entity_id=None):
     """Tell all or specified vacuum to perform a spot clean-up."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_CLEAN_SPOT, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_CLEAN_SPOT, data, blocking=True)
 
 
 @bind_hass
@@ -95,13 +84,11 @@ def return_to_base(hass, entity_id=None):
     hass.add_job(async_return_to_base, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_return_to_base(hass, entity_id=None):
+async def async_return_to_base(hass, entity_id=None):
     """Tell all or specified vacuum to return to base."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_RETURN_TO_BASE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_RETURN_TO_BASE, data, blocking=True)
 
 
 @bind_hass
@@ -110,13 +97,11 @@ def start_pause(hass, entity_id=None):
     hass.add_job(async_start_pause, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_start_pause(hass, entity_id=None):
+async def async_start_pause(hass, entity_id=None):
     """Tell all or specified vacuum to start or pause the current task."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_START_PAUSE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_START_PAUSE, data, blocking=True)
 
 
 @bind_hass
@@ -125,13 +110,11 @@ def start(hass, entity_id=None):
     hass.add_job(async_start, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_start(hass, entity_id=None):
+async def async_start(hass, entity_id=None):
     """Tell all or specified vacuum to start or resume the current task."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_START, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_START, data, blocking=True)
 
 
 @bind_hass
@@ -140,13 +123,11 @@ def pause(hass, entity_id=None):
     hass.add_job(async_pause, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_pause(hass, entity_id=None):
+async def async_pause(hass, entity_id=None):
     """Tell all or the specified vacuum to pause the current task."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_PAUSE, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_PAUSE, data, blocking=True)
 
 
 @bind_hass
@@ -155,13 +136,11 @@ def stop(hass, entity_id=None):
     hass.add_job(async_stop, hass, entity_id)
 
 
-@callback
-@bind_hass
-def async_stop(hass, entity_id=None):
+async def async_stop(hass, entity_id=None):
     """Stop all or specified vacuum."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_STOP, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_STOP, data, blocking=True)
 
 
 @bind_hass
@@ -170,14 +149,12 @@ def set_fan_speed(hass, fan_speed, entity_id=None):
     hass.add_job(async_set_fan_speed, hass, fan_speed, entity_id)
 
 
-@callback
-@bind_hass
-def async_set_fan_speed(hass, fan_speed, entity_id=None):
+async def async_set_fan_speed(hass, fan_speed, entity_id=None):
     """Set fan speed for all or specified vacuum."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     data[ATTR_FAN_SPEED] = fan_speed
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_SET_FAN_SPEED, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_FAN_SPEED, data, blocking=True)
 
 
 @bind_hass
@@ -186,13 +163,11 @@ def send_command(hass, command, params=None, entity_id=None):
     hass.add_job(async_send_command, hass, command, params, entity_id)
 
 
-@callback
-@bind_hass
-def async_send_command(hass, command, params=None, entity_id=None):
+async def async_send_command(hass, command, params=None, entity_id=None):
     """Send command to all or specified vacuum."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     data[ATTR_COMMAND] = command
     if params is not None:
         data[ATTR_PARAMS] = params
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_SEND_COMMAND, data))
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SEND_COMMAND, data, blocking=True)


### PR DESCRIPTION
## Description:
Convert some test helpers to coroutines and adjust tests to not have to sprinkle the tests with
`await hass.async_block_till_done()`

Let me know if this PR is touching too many files and it would be better to split it, for example one PR per base component.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
