### PR TITLE
Upgrade to pyubee==0.6

### DIFF
--- a/homeassistant/components/ubee/device_tracker.py
+++ b/homeassistant/components/ubee/device_tracker.py
@@ -18,7 +18,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Optional(CONF_MODEL, default=DEFAULT_MODEL): cv.string
+    vol.Optional(CONF_MODEL, default=DEFAULT_MODEL):
+        vol.Any(
+            'EVW32C-0N',
+            'EVW320B',
+            'EVW3200-Wifi',
+            'EVW3226@UPC',
+        ),
 })
 
 

--- a/homeassistant/components/ubee/manifest.json
+++ b/homeassistant/components/ubee/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ubee",
   "documentation": "https://www.home-assistant.io/components/ubee",
   "requirements": [
-    "pyubee==0.5"
+    "pyubee==0.6"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1441,7 +1441,7 @@ pytradfri[async]==6.0.1
 pytrafikverket==0.1.5.9
 
 # homeassistant.components.ubee
-pyubee==0.5
+pyubee==0.6
 
 # homeassistant.components.unifi
 pyunifi==2.16


### PR DESCRIPTION
## Description:

Upgrade to `pyubee==0.6`, supporting more models.
Also specify list of supported models.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
