### PR TITLE
Fix config test when current version is 92

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -318,7 +318,8 @@ class TestConfig(unittest.TestCase):
         ha_version = '0.92.0'
 
         mock_open = mock.mock_open()
-        with mock.patch('homeassistant.config.open', mock_open, create=True):
+        with mock.patch('homeassistant.config.open', mock_open, create=True), \
+                mock.patch.object(config_util, '__version__', '0.91.0'):
             opened_file = mock_open.return_value
             # pylint: disable=no-member
             opened_file.readline.return_value = ha_version
@@ -326,7 +327,7 @@ class TestConfig(unittest.TestCase):
             config_util.process_ha_config_upgrade(self.hass)
 
             assert opened_file.write.call_count == 1
-            assert opened_file.write.call_args == mock.call(__version__)
+            assert opened_file.write.call_args == mock.call('0.91.0')
 
     def test_config_upgrade_same_version(self):
         """Test no update of version on no upgrade."""


### PR DESCRIPTION
## Description:
One of our tests would not work under 0.92.0, because it compared versions.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
