### PR TITLE
Camera platform for buienradar imagery

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,7 +43,7 @@ homeassistant/components/braviatv/* @robbiet480
 homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
-homeassistant/components/buienradar/camera @ties
+homeassistant/components/buienradar/* @ties
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,7 @@ homeassistant/components/braviatv/* @robbiet480
 homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
+homeassistant/components/buienradar/camera @ties
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/homeassistant/components/buienradar/camera.py
+++ b/homeassistant/components/buienradar/camera.py
@@ -1,0 +1,125 @@
+"""Provide animated GIF loops of Buienradar imagery."""
+import aiohttp
+import asyncio
+import logging
+import voluptuous as vol
+
+from datetime import timedelta
+from typing import Optional
+
+from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
+from homeassistant.const import CONF_ID, CONF_NAME
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from homeassistant.util import dt as dt_util
+
+CONF_DIMENSION = 'dimension'
+CONF_INTERVAL = 'interval'
+
+RADAR_MAP_URL_TEMPLATE = ('https://api.buienradar.nl/image/1.0/'
+                          'RadarMapNL?w={w}&h={h}')
+
+_LOG = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Optional(CONF_DIMENSION): cv.positive_int,
+        vol.Optional(CONF_INTERVAL): cv.positive_int,
+        vol.Optional(CONF_NAME): cv.string,
+    }))
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                         discovery_info=None):
+    """Set up buienradar radar-loop camera component."""
+    c_id = config.get(CONF_ID)
+    dimension = config.get(CONF_DIMENSION) or 512
+    interval = config.get(CONF_INTERVAL) or 600 
+    name = config.get(CONF_NAME) or "Buienradar Radar Loop"
+
+    async_add_entities([BuienradarCam(hass, name, c_id, dimension, interval)])
+
+
+class BuienradarCam(Camera):
+    _dimension: int
+    """ Deadline for image refresh """
+    _deadline: Optional[int]
+    _name: str
+    _interval: Optional[int]
+    """
+    A camera component producing animated buienradar radar-imagery GIFs.
+
+    Image URL taken from https://www.buienradar.nl/overbuienradar/gratis-weerdata
+    """
+
+    def __init__(self, hass, name: str, c_id: Optional[str], dimension: int, interval: Optional[int]):
+        """Initialize the component."""
+        super().__init__()
+        self._hass = hass
+        self._name = name
+
+        self._dimension = dimension
+        self._interval = interval
+
+        self._lock = asyncio.Lock(loop=hass.loop)
+
+        self._last_image = None
+        # deadline for image to be refreshed
+        self._deadline = None
+
+    @property
+    def name(self):
+        """Return the component name."""
+        return self._name
+
+    # Cargo-cult from components/proxy/camera.py
+    def camera_image(self):
+        """Return camera image."""
+        return run_coroutine_threadsafe(
+            self.async_camera_image(), self.hass.loop).result()
+
+    def __needs_refresh(self) -> bool:
+        if not (self._interval and self._deadline and self._last_image):
+            _LOG.info("refresh due to preconditions")
+            return True
+
+        if dt_util.utcnow() > self._deadline:
+            _LOG.info("refresh due to refresh interval")
+        return dt_util.utcnow() > self._deadline
+
+    async def async_camera_image(self):
+        """Return a still image response from the camera."""
+        if not self.__needs_refresh():
+            _LOG.info(f"r: cached image {self._deadline}, {self._interval}")
+            return self._last_image
+
+        async with self._lock:
+            # check if image was loaded while locked
+            if not self.__needs_refresh():
+                _LOG.info(f"return fresh cached image {self._deadline}, "
+                         f"{self._interval}")
+                return self._last_image
+
+            _LOG.info(f"getting new image.")
+
+            # deadline has passed, get shared ClientSession to load new image.
+            # note that this session dies when another component (i.e. aiohue)
+            # throws.
+            session: asyncio.ClientSession = async_get_clientsession(self._hass)
+
+            now = dt_util.utcnow()
+            url = RADAR_MAP_URL_TEMPLATE.format(w=self._dimension,
+                                                h=self._dimension)
+            try:
+                async with session.get(url, timeout=5) as res:
+                    if res.status != 200:
+                        _LOG.error("Failed to fetch image, %s", res.status)
+                    else:
+                        self._last_image = await res.read()
+                        self._deadline = now + timedelta(seconds=self._interval)
+                        _LOG.info(f"return newly loaded image, deadline: {self._deadline}, {self._interval}")
+            except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+                _LOG.error("Failed to fetch image, %s", type(e))
+
+            return self._last_image

--- a/homeassistant/components/buienradar/camera.py
+++ b/homeassistant/components/buienradar/camera.py
@@ -9,10 +9,12 @@ from typing import Optional
 
 from homeassistant.components.camera import PLATFORM_SCHEMA, Camera
 from homeassistant.const import CONF_ID, CONF_NAME
+
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from homeassistant.util import dt as dt_util
+from homeassistant.util.async_ import run_coroutine_threadsafe
 
 CONF_DIMENSION = 'dimension'
 CONF_INTERVAL = 'interval'
@@ -22,9 +24,12 @@ RADAR_MAP_URL_TEMPLATE = ('https://api.buienradar.nl/image/1.0/'
 
 _LOG = logging.getLogger(__name__)
 
+# Maximum range according to docs
+DIM_RANGE = vol.All(vol.Coerce(int), vol.Range(min=120, max=700))
+
 PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend({
-        vol.Optional(CONF_DIMENSION): cv.positive_int,
+        vol.Optional(CONF_DIMENSION): DIM_RANGE,
         vol.Optional(CONF_INTERVAL): cv.positive_int,
         vol.Optional(CONF_NAME): cv.string,
     }))
@@ -36,7 +41,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     c_id = config.get(CONF_ID)
     dimension = config.get(CONF_DIMENSION) or 512
     interval = config.get(CONF_INTERVAL) or 600 
-    name = config.get(CONF_NAME) or "Buienradar Radar Loop"
+    name = config.get(CONF_NAME) or "Buienradar loop"
 
     async_add_entities([BuienradarCam(hass, name, c_id, dimension, interval)])
 
@@ -47,10 +52,19 @@ class BuienradarCam(Camera):
     _deadline: Optional[int]
     _name: str
     _interval: Optional[int]
+    _condition: asyncio.Condition
+    """ Loading status """
+    _loading: bool
+
+    _last_image: Optional[bytes]
+    """ last modified HTTP response header"""
+    _last_modified: Optional[str]
     """
     A camera component producing animated buienradar radar-imagery GIFs.
 
     Image URL taken from https://www.buienradar.nl/overbuienradar/gratis-weerdata
+
+
     """
 
     def __init__(self, hass, name: str, c_id: Optional[str], dimension: int, interval: Optional[int]):
@@ -62,9 +76,11 @@ class BuienradarCam(Camera):
         self._dimension = dimension
         self._interval = interval
 
-        self._lock = asyncio.Lock(loop=hass.loop)
+        self._condition = asyncio.Condition(loop=hass.loop)
 
         self._last_image = None
+        self._last_modified = None
+        self._loading = False
         # deadline for image to be refreshed
         self._deadline = None
 
@@ -81,45 +97,80 @@ class BuienradarCam(Camera):
 
     def __needs_refresh(self) -> bool:
         if not (self._interval and self._deadline and self._last_image):
-            _LOG.info("refresh due to preconditions")
             return True
 
-        if dt_util.utcnow() > self._deadline:
-            _LOG.info("refresh due to refresh interval")
         return dt_util.utcnow() > self._deadline
 
+    async def __retrieve_radar_image(self) -> bool:
+        """
+        Retrieve new radar image and return whether this succeeded.
+        """
+        session: asyncio.ClientSession = async_get_clientsession(self._hass)
+
+        url = RADAR_MAP_URL_TEMPLATE.format(w=self._dimension,
+                                            h=self._dimension)
+
+        if self._last_modified:
+            headers = {'If-Modified-Since': self._last_modified}
+        else:
+            headers = {}
+
+        try:
+            async with session.get(url, timeout=5, headers=headers) as res:
+                if res.status == 304:
+                    _LOG.debug("HTTP 304 - success")
+                    return True
+                elif res.status != 200:
+                    _LOG.error("HTTP %s - failure", res.status)
+                    return False
+                else:
+                    last_modified = res.headers.get('Last-Modified', None)
+                    if last_modified:
+                        self._last_modified = last_modified
+
+                    self._last_image = await res.read()
+                    _LOG.debug("HTTP 200 - Last-Modified: %s", last_modified)
+
+                    return True
+        except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+            _LOG.error("Failed to fetch image, %s", type(e))
+            return False
+
+
     async def async_camera_image(self):
-        """Return a still image response from the camera."""
+        """
+        Return a still image response from the camera.
+
+        Uses ayncio conditions to make sure only one task enters the critical
+        section at the same time. Othertiwse, two http requests would start
+        when two tabs with home assistant are open.
+
+        An additional boolean (_loading) is used to indicate the loading status
+        instead of _last_image since that is initialized to None.
+        """
         if not self.__needs_refresh():
-            _LOG.info(f"r: cached image {self._deadline}, {self._interval}")
             return self._last_image
 
-        async with self._lock:
-            # check if image was loaded while locked
-            if not self.__needs_refresh():
-                _LOG.info(f"return fresh cached image {self._deadline}, "
-                         f"{self._interval}")
+        # get lock, check iff loading, await notification if loading
+        async with self._condition:
+            if self._loading:
+                _LOG.debug("already loading - waiting for notification")
+                await self._condition.wait()
                 return self._last_image
 
-            _LOG.info(f"getting new image.")
+            # Set loading status **while holding lock**, makes other tasks wait
+            self._loading = True
 
-            # deadline has passed, get shared ClientSession to load new image.
-            # note that this session dies when another component (i.e. aiohue)
-            # throws.
-            session: asyncio.ClientSession = async_get_clientsession(self._hass)
-
+        try:
             now = dt_util.utcnow()
-            url = RADAR_MAP_URL_TEMPLATE.format(w=self._dimension,
-                                                h=self._dimension)
-            try:
-                async with session.get(url, timeout=5) as res:
-                    if res.status != 200:
-                        _LOG.error("Failed to fetch image, %s", res.status)
-                    else:
-                        self._last_image = await res.read()
-                        self._deadline = now + timedelta(seconds=self._interval)
-                        _LOG.info(f"return newly loaded image, deadline: {self._deadline}, {self._interval}")
-            except (asyncio.TimeoutError, aiohttp.ClientError) as e:
-                _LOG.error("Failed to fetch image, %s", type(e))
+            res = await self.__retrieve_radar_image()
+            # successful response? update deadline to time before loading
+            if res:
+                self._deadline = now + timedelta(seconds=self._interval)
 
             return self._last_image
+        finally:
+            # get lock, unset loading status, notify all waiting tasks
+            async with self._condition:
+                self._loading = False
+                self._condition.notify_all()

--- a/homeassistant/components/buienradar/camera.py
+++ b/homeassistant/components/buienradar/camera.py
@@ -43,8 +43,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     delta = config[CONF_DELTA]
     name = config[CONF_NAME]
 
-    async_add_entities([BuienradarCam(name, dimension, delta,
-                                      loop=hass.loop)])
+    async_add_entities([BuienradarCam(name, dimension, delta)])
 
 
 class BuienradarCam(Camera):
@@ -56,13 +55,11 @@ class BuienradarCam(Camera):
     [0]: https://www.buienradar.nl/overbuienradar/gratis-weerdata
     """
 
-    def __init__(self, name: str, dimension: int, delta: float,
-                 loop: Optional[asyncio.AbstractEventLoop] = None):
+    def __init__(self, name: str, dimension: int, delta: float):
         """
         Initialize the component.
 
-        This constructor must be run in the event loop _or_ be provided with
-        an applicable event loop as argument.
+        This constructor must be run in the event loop.
         """
         super().__init__()
 
@@ -80,7 +77,7 @@ class BuienradarCam(Camera):
         # time, and that all readers are notified after this request completes.
         #
         # invariant: this condition is private to and owned by this instance.
-        self._condition = asyncio.Condition(loop=loop)
+        self._condition = asyncio.Condition()
 
         self._last_image = None     # type: Optional[bytes]
         # value of the last seen last modified header

--- a/homeassistant/components/buienradar/camera.py
+++ b/homeassistant/components/buienradar/camera.py
@@ -31,7 +31,7 @@ PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend({
         vol.Optional(CONF_DIMENSION): DIM_RANGE,
         vol.Optional(CONF_DELTA): vol.All(vol.Coerce(float),
-                                             vol.Range(min=0)),
+                                          vol.Range(min=0)),
         vol.Optional(CONF_NAME): cv.string,
     }))
 

--- a/homeassistant/components/buienradar/manifest.json
+++ b/homeassistant/components/buienradar/manifest.json
@@ -6,5 +6,5 @@
     "buienradar==0.91"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@ties"]
 }

--- a/tests/components/buienradar/test_camera.py
+++ b/tests/components/buienradar/test_camera.py
@@ -1,7 +1,12 @@
 """The tests for generic camera component."""
 import asyncio
 
+from homeassistant.util import dt as dt_util
+
 from homeassistant.setup import async_setup_component
+
+# An infinitesimally small time-delta.
+EPSILON_DELTA = 0.0000000001
 
 
 def radar_map_url(dim: int = 512) -> str:
@@ -37,31 +42,30 @@ def test_fetching_url_and_caching(aioclient_mock, hass, hass_client):
     assert aioclient_mock.call_count == 1
 
 
-async def test_expire_delta(aioclient_mock, hass, hass_client):
+@asyncio.coroutine
+def test_expire_delta(aioclient_mock, hass, hass_client):
     """Test that the cache expires after delta."""
     aioclient_mock.get(radar_map_url(), text='hello world')
 
-    delta = 0.0000000001
-
-    await async_setup_component(hass, 'camera', {
+    yield from async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
-            'delta': delta,
+            'delta': EPSILON_DELTA,
         }})
 
-    client = await hass_client()
+    client = yield from hass_client()
 
-    resp = await client.get('/api/camera_proxy/camera.config_test')
+    resp = yield from client.get('/api/camera_proxy/camera.config_test')
 
     assert resp.status == 200
     assert aioclient_mock.call_count == 1
-    body = await resp.text()
+    body = yield from resp.text()
     assert body == 'hello world'
 
-    await asyncio.sleep(delta)
-    # delta has passed -> should immediately call again
-    resp = await client.get('/api/camera_proxy/camera.config_test')
+    yield from asyncio.sleep(EPSILON_DELTA)
+    # tiny delta has passed -> should immediately call again
+    resp = yield from client.get('/api/camera_proxy/camera.config_test')
     assert aioclient_mock.call_count == 2
 
 
@@ -125,3 +129,44 @@ def test_failure_response_not_cached(aioclient_mock, hass, hass_client):
     yield from client.get('/api/camera_proxy/camera.config_test')
 
     assert aioclient_mock.call_count == 2
+
+
+@asyncio.coroutine
+def test_last_modified_updates(aioclient_mock, hass, hass_client):
+    """Test that it does respect HTTP not modified."""
+    # Build Last-Modified header value
+    now = dt_util.utcnow()
+    last_modified = now.strftime("%a, %d %m %Y %H:%M:%S GMT")
+
+    aioclient_mock.get(radar_map_url(), text='hello world', status=200,
+                       headers={
+                           'Last-Modified':  last_modified,
+                       })
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'buienradar',
+            'delta': EPSILON_DELTA,
+        }})
+
+    client = yield from hass_client()
+
+    resp_1 = yield from client.get('/api/camera_proxy/camera.config_test')
+    # It is not possible to check if header was sent.
+    assert aioclient_mock.call_count == 1
+
+    yield from asyncio.sleep(EPSILON_DELTA)
+
+    # Content has expired, change response to a 304 NOT MODIFIED, which has no
+    # text, i.e. old value should be kept
+    aioclient_mock.clear_requests()
+    # mock call count is now reset as well:
+    assert aioclient_mock.call_count == 0
+
+    aioclient_mock.get(radar_map_url(), text=None, status=304)
+
+    resp_2 = yield from client.get('/api/camera_proxy/camera.config_test')
+    assert aioclient_mock.call_count == 1
+
+    assert (yield from resp_1.read()) == (yield from resp_2.read())

--- a/tests/components/buienradar/test_camera.py
+++ b/tests/components/buienradar/test_camera.py
@@ -30,24 +30,24 @@ def test_fetching_url_and_caching(aioclient_mock, hass, hass_client):
     body = yield from resp.text()
     assert body == 'hello world'
 
-    # default interval is 600s -> should be the same when calling immediately
+    # default delta is 600s -> should be the same when calling immediately
     # afterwards.
 
     resp = yield from client.get('/api/camera_proxy/camera.config_test')
     assert aioclient_mock.call_count == 1
 
 
-async def test_expire_interval(aioclient_mock, hass, hass_client):
-    """Test that the cache expires after interval."""
+async def test_expire_delta(aioclient_mock, hass, hass_client):
+    """Test that the cache expires after delta."""
     aioclient_mock.get(radar_map_url(), text='hello world')
 
-    interval = 0.0000000001
+    delta = 0.0000000001
 
     await async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
-            'interval': interval,
+            'delta': delta,
         }})
 
     client = await hass_client()
@@ -59,8 +59,8 @@ async def test_expire_interval(aioclient_mock, hass, hass_client):
     body = await resp.text()
     assert body == 'hello world'
 
-    await asyncio.sleep(interval)
-    # interval has passed -> should immediately call again
+    await asyncio.sleep(delta)
+    # delta has passed -> should immediately call again
     resp = await client.get('/api/camera_proxy/camera.config_test')
     assert aioclient_mock.call_count == 2
 

--- a/tests/components/buienradar/test_camera.py
+++ b/tests/components/buienradar/test_camera.py
@@ -1,0 +1,127 @@
+"""The tests for generic camera component."""
+import asyncio
+
+from homeassistant.setup import async_setup_component
+
+
+def radar_map_url(dim: int = 512) -> str:
+    """Build map url, defaulting to 512 wide (as in component)."""
+    return ("https://api.buienradar.nl/"
+            "image/1.0/RadarMapNL?w={dim}&h={dim}").format(dim=dim)
+
+
+@asyncio.coroutine
+def test_fetching_url_and_caching(aioclient_mock, hass, hass_client):
+    """Test that it fetches the given url."""
+    aioclient_mock.get(radar_map_url(), text='hello world')
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'buienradar',
+        }})
+
+    client = yield from hass_client()
+
+    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+
+    assert resp.status == 200
+    assert aioclient_mock.call_count == 1
+    body = yield from resp.text()
+    assert body == 'hello world'
+
+    # default interval is 600s -> should be the same when calling immediately
+    # afterwards.
+
+    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+    assert aioclient_mock.call_count == 1
+
+
+async def test_expire_interval(aioclient_mock, hass, hass_client):
+    """Test that the cache expires after interval."""
+    aioclient_mock.get(radar_map_url(), text='hello world')
+
+    interval = 0.0000000001
+
+    await async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'buienradar',
+            'interval': interval,
+        }})
+
+    client = await hass_client()
+
+    resp = await client.get('/api/camera_proxy/camera.config_test')
+
+    assert resp.status == 200
+    assert aioclient_mock.call_count == 1
+    body = await resp.text()
+    assert body == 'hello world'
+
+    await asyncio.sleep(interval)
+    # interval has passed -> should immediately call again
+    resp = await client.get('/api/camera_proxy/camera.config_test')
+    assert aioclient_mock.call_count == 2
+
+
+@asyncio.coroutine
+def test_only_one_fetch_at_a_time(aioclient_mock, hass, hass_client):
+    """Test that it fetches with only one request at the same time."""
+    aioclient_mock.get(radar_map_url(), text='hello world')
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'buienradar',
+        }})
+
+    client = yield from hass_client()
+
+    resp_1 = client.get('/api/camera_proxy/camera.config_test')
+    resp_2 = client.get('/api/camera_proxy/camera.config_test')
+
+    resp = yield from resp_1
+    resp_2 = yield from resp_2
+
+    assert (yield from resp.text()) == (yield from resp_2.text())
+
+    assert aioclient_mock.call_count == 1
+
+
+@asyncio.coroutine
+def test_dimension(aioclient_mock, hass, hass_client):
+    """Test that it actually adheres to the dimension."""
+    aioclient_mock.get(radar_map_url(700), text='hello world')
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'buienradar',
+            'dimension': 700,
+        }})
+
+    client = yield from hass_client()
+
+    yield from client.get('/api/camera_proxy/camera.config_test')
+
+    assert aioclient_mock.call_count == 1
+
+
+@asyncio.coroutine
+def test_failure_response_not_cached(aioclient_mock, hass, hass_client):
+    """Test that it does not cache a failure response."""
+    aioclient_mock.get(radar_map_url(), text='hello world', status=401)
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'buienradar',
+        }})
+
+    client = yield from hass_client()
+
+    yield from client.get('/api/camera_proxy/camera.config_test')
+    yield from client.get('/api/camera_proxy/camera.config_test')
+
+    assert aioclient_mock.call_count == 2

--- a/tests/components/buienradar/test_camera.py
+++ b/tests/components/buienradar/test_camera.py
@@ -1,5 +1,6 @@
 """The tests for generic camera component."""
 import asyncio
+from aiohttp.client_exceptions import ClientResponseError
 
 from homeassistant.util import dt as dt_util
 
@@ -15,124 +16,118 @@ def radar_map_url(dim: int = 512) -> str:
             "image/1.0/RadarMapNL?w={dim}&h={dim}").format(dim=dim)
 
 
-@asyncio.coroutine
-def test_fetching_url_and_caching(aioclient_mock, hass, hass_client):
+async def test_fetching_url_and_caching(aioclient_mock, hass, hass_client):
     """Test that it fetches the given url."""
     aioclient_mock.get(radar_map_url(), text='hello world')
 
-    yield from async_setup_component(hass, 'camera', {
+    await async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
         }})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+    resp = await client.get('/api/camera_proxy/camera.config_test')
 
     assert resp.status == 200
     assert aioclient_mock.call_count == 1
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == 'hello world'
 
     # default delta is 600s -> should be the same when calling immediately
     # afterwards.
 
-    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+    resp = await client.get('/api/camera_proxy/camera.config_test')
     assert aioclient_mock.call_count == 1
 
 
-@asyncio.coroutine
-def test_expire_delta(aioclient_mock, hass, hass_client):
+async def test_expire_delta(aioclient_mock, hass, hass_client):
     """Test that the cache expires after delta."""
     aioclient_mock.get(radar_map_url(), text='hello world')
 
-    yield from async_setup_component(hass, 'camera', {
+    await async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
             'delta': EPSILON_DELTA,
         }})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+    resp = await client.get('/api/camera_proxy/camera.config_test')
 
     assert resp.status == 200
     assert aioclient_mock.call_count == 1
-    body = yield from resp.text()
+    body = await resp.text()
     assert body == 'hello world'
 
-    yield from asyncio.sleep(EPSILON_DELTA)
+    await asyncio.sleep(EPSILON_DELTA)
     # tiny delta has passed -> should immediately call again
-    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+    resp = await client.get('/api/camera_proxy/camera.config_test')
     assert aioclient_mock.call_count == 2
 
 
-@asyncio.coroutine
-def test_only_one_fetch_at_a_time(aioclient_mock, hass, hass_client):
+async def test_only_one_fetch_at_a_time(aioclient_mock, hass, hass_client):
     """Test that it fetches with only one request at the same time."""
     aioclient_mock.get(radar_map_url(), text='hello world')
 
-    yield from async_setup_component(hass, 'camera', {
+    await async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
         }})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     resp_1 = client.get('/api/camera_proxy/camera.config_test')
     resp_2 = client.get('/api/camera_proxy/camera.config_test')
 
-    resp = yield from resp_1
-    resp_2 = yield from resp_2
+    resp = await resp_1
+    resp_2 = await resp_2
 
-    assert (yield from resp.text()) == (yield from resp_2.text())
+    assert (await resp.text()) == (await resp_2.text())
 
     assert aioclient_mock.call_count == 1
 
 
-@asyncio.coroutine
-def test_dimension(aioclient_mock, hass, hass_client):
+async def test_dimension(aioclient_mock, hass, hass_client):
     """Test that it actually adheres to the dimension."""
     aioclient_mock.get(radar_map_url(700), text='hello world')
 
-    yield from async_setup_component(hass, 'camera', {
+    await async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
             'dimension': 700,
         }})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    yield from client.get('/api/camera_proxy/camera.config_test')
+    await client.get('/api/camera_proxy/camera.config_test')
 
     assert aioclient_mock.call_count == 1
 
 
-@asyncio.coroutine
-def test_failure_response_not_cached(aioclient_mock, hass, hass_client):
+async def test_failure_response_not_cached(aioclient_mock, hass, hass_client):
     """Test that it does not cache a failure response."""
     aioclient_mock.get(radar_map_url(), text='hello world', status=401)
 
-    yield from async_setup_component(hass, 'camera', {
+    await async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
         }})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    yield from client.get('/api/camera_proxy/camera.config_test')
-    yield from client.get('/api/camera_proxy/camera.config_test')
+    await client.get('/api/camera_proxy/camera.config_test')
+    await client.get('/api/camera_proxy/camera.config_test')
 
     assert aioclient_mock.call_count == 2
 
 
-@asyncio.coroutine
-def test_last_modified_updates(aioclient_mock, hass, hass_client):
+async def test_last_modified_updates(aioclient_mock, hass, hass_client):
     """Test that it does respect HTTP not modified."""
     # Build Last-Modified header value
     now = dt_util.utcnow()
@@ -143,20 +138,20 @@ def test_last_modified_updates(aioclient_mock, hass, hass_client):
                            'Last-Modified':  last_modified,
                        })
 
-    yield from async_setup_component(hass, 'camera', {
+    await async_setup_component(hass, 'camera', {
         'camera': {
             'name': 'config_test',
             'platform': 'buienradar',
             'delta': EPSILON_DELTA,
         }})
 
-    client = yield from hass_client()
+    client = await hass_client()
 
-    resp_1 = yield from client.get('/api/camera_proxy/camera.config_test')
+    resp_1 = await client.get('/api/camera_proxy/camera.config_test')
     # It is not possible to check if header was sent.
     assert aioclient_mock.call_count == 1
 
-    yield from asyncio.sleep(EPSILON_DELTA)
+    await asyncio.sleep(EPSILON_DELTA)
 
     # Content has expired, change response to a 304 NOT MODIFIED, which has no
     # text, i.e. old value should be kept
@@ -166,7 +161,42 @@ def test_last_modified_updates(aioclient_mock, hass, hass_client):
 
     aioclient_mock.get(radar_map_url(), text=None, status=304)
 
-    resp_2 = yield from client.get('/api/camera_proxy/camera.config_test')
+    resp_2 = await client.get('/api/camera_proxy/camera.config_test')
     assert aioclient_mock.call_count == 1
 
-    assert (yield from resp_1.read()) == (yield from resp_2.read())
+    assert (await resp_1.read()) == (await resp_2.read())
+
+
+async def test_retries_after_error(aioclient_mock, hass, hass_client):
+    """Test that it does retry after an error instead of caching."""
+    await async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'buienradar',
+        }})
+
+    client = await hass_client()
+
+    aioclient_mock.get(radar_map_url(), text=None, status=500)
+
+    # A 404 should not return data and throw:
+    try:
+        await client.get('/api/camera_proxy/camera.config_test')
+    except ClientResponseError:
+        pass
+
+    assert aioclient_mock.call_count == 1
+
+    # Change the response to a 200
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(radar_map_url(), text="DEADBEEF")
+
+    assert aioclient_mock.call_count == 0
+
+    # http error should not be cached, immediate retry.
+    resp_2 = await client.get('/api/camera_proxy/camera.config_test')
+    assert aioclient_mock.call_count == 1
+
+    # Binary text can not be added as body to `aioclient_mock.get(text=...)`,
+    # while `resp.read()` returns bytes, encode the value.
+    assert (await resp_2.read()) == b"DEADBEEF"


### PR DESCRIPTION
## Description:
This PR adds a [dutch rain radar](http://www.buienradar.nl) camera component that delivers the weather-radar imagery from [buienradar.nl](http://www.buienradar.nl) to the existing `buienradar` integration. 

This idea was inspired by https://github.com/home-assistant/home-assistant/pull/22816. _Most_ of the current PR's functionality could be provided by a generic IP camera using the given URL from `buienradar.nl` documentation.

The main contribution of this PR is that it caches images for the given `delta` and prevents multiple parallel http calls, which happened with multiple browser tabs open.

This behaviour is verified in the test. When testing the PR manually this situation can be exacerbate by adding an `asyncio.Sleep` in the function that makes the actual http call. This behaviour is different from `util.Throttle` because it does not return the old value but instead it waits for the request to finish. The generic IP does not include this feature.

In addition it adds the camera component by implicitly documenting the URL. Factoring out the http request to a PyPI package would create a trivial package which would hardly be re-usable since it needs aiohttp passed in and would return `(result_data: Optional[bytes], result_status: bool, last_modified: Optional[str])` triples instead of a more idiomatic python api which would return just the result.

Alternatively the improved re-entrant behaviour could be added to the Generic IP camera and the radar imagery URL documented in the `buienradar` component.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here> to be added after discussion on the PR's utility.

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: buienradar
    name: buienradar
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.


[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
