### PR TITLE
Fix tox.ini lint target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-    python script/gen_requirements_all.py validate
+    python -m script.gen_requirements_all validate
     flake8 {posargs}
     pydocstyle {posargs:homeassistant tests}
 


### PR DESCRIPTION
tox fails due to being unable to reference the `script` module when
trying to run `script/gen_requirements_all.py`. Instead it needs to be
run as a module.

This was found while I was debugging #20197

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.