### PR TITLE
Bump pyheos to 0.4.1

### DIFF
--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Heos",
   "documentation": "https://www.home-assistant.io/components/heos",
   "requirements": [
-    "pyheos==0.4.0"
+    "pyheos==0.4.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,4 +1,5 @@
 """Denon HEOS Media Player."""
+import asyncio
 from functools import reduce, wraps
 import logging
 from operator import ior
@@ -48,7 +49,7 @@ def log_command_error(command: str):
             from pyheos import CommandError
             try:
                 await func(*args, **kwargs)
-            except CommandError as ex:
+            except (CommandError, asyncio.TimeoutError, ConnectionError) as ex:
                 _LOGGER.error("Unable to %s: %s", command, ex)
         return wrapper
     return decorator
@@ -86,6 +87,13 @@ class HeosMediaPlayer(MediaPlayerDevice):
 
     async def _heos_event(self, event):
         """Handle connection event."""
+        from pyheos import CommandError, const
+        if event == const.EVENT_CONNECTED:
+            try:
+                await self._player.refresh()
+            except (CommandError, asyncio.TimeoutError, ConnectionError) as ex:
+                _LOGGER.error("Unable to refresh player %s: %s",
+                              self._player, ex)
         await self.async_update_ha_state(True)
 
     async def _player_update(self, player_id, event):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1079,7 +1079,7 @@ pygtt==1.1.2
 pyhaversion==2.2.1
 
 # homeassistant.components.heos
-pyheos==0.4.0
+pyheos==0.4.1
 
 # homeassistant.components.hikvision
 pyhik==0.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -223,7 +223,7 @@ pydeconz==54
 pydispatcher==2.0.5
 
 # homeassistant.components.heos
-pyheos==0.4.0
+pyheos==0.4.1
 
 # homeassistant.components.homematic
 pyhomematic==0.1.58


### PR DESCRIPTION
## Description:
Updates `pyheos` to latest version to fix an issue where a `TimeoutError` in the heartbeat was not caught and breaks the reconnection logic.  Also adds logic to refresh the player state after a connection (reconnection) event.

**Related issue (if applicable):** fixes #23287

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.