### PR TITLE
Added thresholds configuration for zones

### DIFF
--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -272,7 +272,7 @@ async def async_handle_waypoint(hass, name_base, waypoint):
         return
 
     zone = zone_comp.Zone(hass, pretty_name, lat, lon, rad,
-                          zone_comp.ICON_IMPORT, False)
+                          zone_comp.ICON_IMPORT, False, None, None)
     zone.entity_id = entity_id
     await zone.async_update_ha_state()
 

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -11,7 +11,8 @@ from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.util import slugify
 
 from .config_flow import configured_zones
-from .const import CONF_PASSIVE, DOMAIN, HOME_ZONE
+from .const import (CONF_PASSIVE, DOMAIN, HOME_ZONE,
+                    CONF_AREA_THRESHOLD, CONF_ACCURACY_THRESHOLD)
 from .zone import Zone
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,6 +35,8 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_RADIUS, default=DEFAULT_RADIUS): vol.Coerce(float),
     vol.Optional(CONF_PASSIVE, default=DEFAULT_PASSIVE): cv.boolean,
     vol.Optional(CONF_ICON): cv.icon,
+    vol.Optional(CONF_AREA_THRESHOLD): vol.Coerce(float),
+    vol.Optional(CONF_ACCURACY_THRESHOLD): vol.Coerce(float),
 }, extra=vol.ALLOW_EXTRA)
 
 
@@ -46,7 +49,9 @@ async def async_setup(hass, config):
         if slugify(entry[CONF_NAME]) not in zone_entries:
             zone = Zone(hass, entry[CONF_NAME], entry[CONF_LATITUDE],
                         entry[CONF_LONGITUDE], entry.get(CONF_RADIUS),
-                        entry.get(CONF_ICON), entry.get(CONF_PASSIVE))
+                        entry.get(CONF_ICON), entry.get(CONF_PASSIVE),
+                        entry.get(CONF_AREA_THRESHOLD),
+                        entry.get(CONF_ACCURACY_THRESHOLD))
             zone.entity_id = async_generate_entity_id(
                 ENTITY_ID_FORMAT, entry[CONF_NAME], entities)
             hass.async_create_task(zone.async_update_ha_state())
@@ -55,7 +60,7 @@ async def async_setup(hass, config):
     if ENTITY_ID_HOME not in entities and HOME_ZONE not in zone_entries:
         zone = Zone(hass, hass.config.location_name,
                     hass.config.latitude, hass.config.longitude,
-                    DEFAULT_RADIUS, ICON_HOME, False)
+                    DEFAULT_RADIUS, ICON_HOME, False, None, None)
         zone.entity_id = ENTITY_ID_HOME
         hass.async_create_task(zone.async_update_ha_state())
 
@@ -68,7 +73,9 @@ async def async_setup_entry(hass, config_entry):
     name = entry[CONF_NAME]
     zone = Zone(hass, name, entry[CONF_LATITUDE], entry[CONF_LONGITUDE],
                 entry.get(CONF_RADIUS, DEFAULT_RADIUS), entry.get(CONF_ICON),
-                entry.get(CONF_PASSIVE, DEFAULT_PASSIVE))
+                entry.get(CONF_PASSIVE, DEFAULT_PASSIVE),
+                entry.get(CONF_AREA_THRESHOLD),
+                entry.get(CONF_ACCURACY_THRESHOLD))
     zone.entity_id = async_generate_entity_id(
         ENTITY_ID_FORMAT, name, None, hass)
     hass.async_create_task(zone.async_update_ha_state())

--- a/homeassistant/components/zone/config_flow.py
+++ b/homeassistant/components/zone/config_flow.py
@@ -9,7 +9,8 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.util import slugify
 
-from .const import CONF_PASSIVE, DOMAIN, HOME_ZONE
+from .const import (CONF_PASSIVE, DOMAIN, HOME_ZONE,
+                    CONF_AREA_THRESHOLD, CONF_ACCURACY_THRESHOLD)
 
 
 @callback
@@ -55,6 +56,8 @@ class ZoneFlowHandler(config_entries.ConfigFlow):
                 vol.Optional(CONF_RADIUS): vol.Coerce(float),
                 vol.Optional(CONF_ICON): str,
                 vol.Optional(CONF_PASSIVE): bool,
+                vol.Optional(CONF_AREA_THRESHOLD): vol.Coerce(float),
+                vol.Optional(CONF_ACCURACY_THRESHOLD): vol.Coerce(float),
             }),
             errors=errors,
         )

--- a/homeassistant/components/zone/const.py
+++ b/homeassistant/components/zone/const.py
@@ -1,5 +1,7 @@
 """Constants for the zone component."""
 
 CONF_PASSIVE = 'passive'
+CONF_AREA_THRESHOLD = 'area_threshold'
+CONF_ACCURACY_THRESHOLD = 'accuracy_threshold'
 DOMAIN = 'zone'
 HOME_ZONE = 'home'

--- a/homeassistant/components/zone/strings.json
+++ b/homeassistant/components/zone/strings.json
@@ -10,6 +10,8 @@
                     "longitude": "Longitude",
                     "radius": "Radius",
                     "passive": "Passive",
+                    "area_threshold": "Area threshold",
+                    "accuracy_threshold": "Accuracy threshold",
                     "icon": "Icon"
                 }
             }

--- a/homeassistant/components/zone/zone.py
+++ b/homeassistant/components/zone/zone.py
@@ -9,6 +9,8 @@ from .const import DOMAIN
 
 ATTR_PASSIVE = 'passive'
 ATTR_RADIUS = 'radius'
+ATTR_AREA_THRESHOLD = 'area_threshold'
+ATTR_ACCURACY_THRESHOLD = 'accuracy_threshold'
 
 STATE = 'zoning'
 
@@ -22,7 +24,7 @@ def active_zone(hass, latitude, longitude, radius=0):
 
 
 @bind_hass
-def async_active_zone(hass, latitude, longitude, radius=0):
+def async_active_zone(hass, latitude, longitude, accuracy_radius=0):
     """Find the active zone for given latitude, longitude.
 
     This method must be run in the event loop.
@@ -42,7 +44,7 @@ def async_active_zone(hass, latitude, longitude, radius=0):
             latitude, longitude,
             zone.attributes[ATTR_LATITUDE], zone.attributes[ATTR_LONGITUDE])
 
-        within_zone = zone_dist - radius < zone.attributes[ATTR_RADIUS]
+        within_zone = in_zone(zone, latitude, longitude, accuracy_radius)
         closer_zone = closest is None or zone_dist < min_dist
         smaller_zone = (zone_dist == min_dist and
                         zone.attributes[ATTR_RADIUS] <
@@ -55,7 +57,7 @@ def async_active_zone(hass, latitude, longitude, radius=0):
     return closest
 
 
-def in_zone(zone, latitude, longitude, radius=0) -> bool:
+def in_zone(zone, latitude, longitude, accuracy_radius=0) -> bool:
     """Test if given latitude, longitude is in given zone.
 
     Async friendly.
@@ -64,13 +66,53 @@ def in_zone(zone, latitude, longitude, radius=0) -> bool:
         latitude, longitude,
         zone.attributes[ATTR_LATITUDE], zone.attributes[ATTR_LONGITUDE])
 
-    return zone_dist - radius < zone.attributes[ATTR_RADIUS]
+    if ATTR_ACCURACY_THRESHOLD in zone.attributes and \
+       accuracy_radius > zone.attributes[ATTR_ACCURACY_THRESHOLD]:
+        return False
+
+    if ATTR_AREA_THRESHOLD in zone.attributes:
+        import math
+
+        intersection_area = circles_intersection_area(
+            zone_dist,
+            accuracy_radius,
+            zone.attributes[ATTR_RADIUS]
+        )
+
+        entity_circle_area = math.pi * accuracy_radius ** 2
+
+        intersection_fraction = intersection_area / entity_circle_area
+
+        return intersection_fraction >= zone.attributes[ATTR_AREA_THRESHOLD]
+
+    return zone_dist < accuracy_radius + zone.attributes[ATTR_RADIUS]
+
+
+def circles_intersection_area(centers_distance, radius1, radius2) -> float:
+    """Return the area of intersection of two circles."""
+    import math
+
+    if centers_distance <= abs(radius1 - radius2):
+        # One circle is entirely enclosed in the other.
+        return math.pi * min(radius1, radius2) ** 2
+    if centers_distance >= radius2 + radius1:
+        # The circles don't overlap at all.
+        return 0
+
+    r2_2, r1_2, d_2 = radius2 ** 2, radius1 ** 2, centers_distance ** 2
+    alpha = math.acos((d_2 + r2_2 - r1_2) / (2 * centers_distance * radius2))
+    beta = math.acos((d_2 + r1_2 - r2_2) / (2 * centers_distance * radius1))
+    return (
+        r2_2 * alpha + r1_2 * beta -
+        0.5 * (r2_2 * math.sin(2*alpha) + r1_2 * math.sin(2*beta))
+    )
 
 
 class Zone(Entity):
     """Representation of a Zone."""
 
-    def __init__(self, hass, name, latitude, longitude, radius, icon, passive):
+    def __init__(self, hass, name, latitude, longitude, radius, icon, passive,
+                 area_threshold=None, accuracy_threshold=None):
         """Initialize the zone."""
         self.hass = hass
         self._name = name
@@ -79,6 +121,8 @@ class Zone(Entity):
         self._radius = radius
         self._icon = icon
         self._passive = passive
+        self._area_threshold = area_threshold
+        self._accuracy_threshold = accuracy_threshold
 
     @property
     def name(self):
@@ -106,4 +150,8 @@ class Zone(Entity):
         }
         if self._passive:
             data[ATTR_PASSIVE] = self._passive
+        if self._area_threshold:
+            data[ATTR_AREA_THRESHOLD] = self._area_threshold
+        if self._accuracy_threshold:
+            data[ATTR_ACCURACY_THRESHOLD] = self._accuracy_threshold
         return data

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -221,3 +221,58 @@ class TestComponentZone(unittest.TestCase):
 
         assert zone.zone.in_zone(self.hass.states.get('zone.passive_zone'),
                                  latitude, longitude)
+
+    def test_in_zone_honors_area_threshold(self):
+        """Test working in passive zones."""
+        zone_latitude = 32.880600
+        zone_longitude = -117.237561
+        latitude = 32.880600
+        longitude_1 = -117.237200
+        longitude_2 = -117.237000
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
+            'zone': [
+                {
+                    'name': 'Area Threshold Zone',
+                    'latitude': zone_latitude,
+                    'longitude': zone_longitude,
+                    'radius': 50,
+                    'area_threshold': 0.5
+                },
+            ]
+        })
+
+        assert zone.zone.in_zone(
+            self.hass.states.get('zone.area_threshold_zone'),
+            latitude, longitude_1, 20
+        )
+        assert not zone.zone.in_zone(
+            self.hass.states.get('zone.area_threshold_zone'),
+            latitude, longitude_2, 20
+        )
+
+    def test_in_zone_honors_accuracy_threshold(self):
+        """Test working in passive zones."""
+        zone_latitude = 32.880600
+        zone_longitude = -117.237561
+        latitude = 32.880600
+        longitude = -117.237200
+        assert setup.setup_component(self.hass, zone.DOMAIN, {
+            'zone': [
+                {
+                    'name': 'Accuracy Threshold Zone',
+                    'latitude': zone_latitude,
+                    'longitude': zone_longitude,
+                    'radius': 50,
+                    'accuracy_threshold': 20
+                },
+            ]
+        })
+
+        assert zone.zone.in_zone(
+            self.hass.states.get('zone.accuracy_threshold_zone'),
+            latitude, longitude, 15
+        )
+        assert not zone.zone.in_zone(
+            self.hass.states.get('zone.accuracy_threshold_zone'),
+            latitude, longitude, 50
+        )


### PR DESCRIPTION
## Description:

This adds thresholds definition for Zone entities, so that zones can filter GPS coordinates based either on the accuracy or on circles intersection. The latter works as a minimum portion of accuracy circle area intersecting with zone circle.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9350

## Example entry for `configuration.yaml` (if applicable):
```yaml
zone:
  - name: home
    latitude: !secret home_latitude
    longitude: !secret home_longitude
    icon: mdi:home
    radius: 100
    area_threshold: 0.5
  - name: office
    latitude: !secret office_latitude
    longitude: !secret office_longitude
    icon: mdi:server-network
    radius: 50
    accuracy_threshold: 25

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
