### PR TITLE
async_setup_component stage_1_domains

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -355,7 +355,7 @@ async def _async_set_up_integrations(
     if stage_1_domains:
         await asyncio.gather(*[
             async_setup_component(hass, domain, config)
-            for domain in logging_domains
+            for domain in stage_1_domains
         ])
 
     # Load all integrations


### PR DESCRIPTION
## Description:
seem not async_setup_component stage_1_domains in bootstrap.py

## Checklist:
  - [x] The code change is tested and works locally.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
