### PR TITLE
Fix oasa_telematics missing key parameter

### DIFF
--- a/homeassistant/components/oasa_telematics/sensor.py
+++ b/homeassistant/components/oasa_telematics/sensor.py
@@ -187,5 +187,5 @@ class OASATelematicsData():
             return
 
         # Sort the data by time
-        sort = sorted(self.info, itemgetter(ATTR_NEXT_ARRIVAL))
+        sort = sorted(self.info, key=itemgetter(ATTR_NEXT_ARRIVAL))
         self.info = sort


### PR DESCRIPTION
## Description:

`key=` parameter was missing from `sorted()` resulting in `TypeError`.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
