### PR TITLE
Add error handling for migration failure

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -398,8 +398,12 @@ def process_ha_config_upgrade(hass: HomeAssistant) -> None:
         if TTS_PRE_92 in config_raw:
             _LOGGER.info("Migrating google tts to google_translate tts")
             config_raw = config_raw.replace(TTS_PRE_92, TTS_92)
-            with open(config_path, 'wt', encoding='utf-8') as config_file:
-                config_file.write(config_raw)
+            try:
+                with open(config_path, 'wt', encoding='utf-8') as config_file:
+                    config_file.write(config_raw)
+            except IOError:
+                _LOGGER.exception("Migrating to google_translate tts failed")
+                pass
 
     with open(version_path, 'wt') as outp:
         outp.write(__version__)


### PR DESCRIPTION
## Description:

Add error handling for migration failure. User may removed the write permission to their configuration yaml file 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

