### PR TITLE
Fix Homematic IP Cloud handling of sabotage info

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -78,7 +78,7 @@ class HomematicipShutterContact(HomematicipGenericDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return true if the shutter contact is on/open."""
-        if self._device.sabotage:
+        if hasattr(self._device, 'sabotage') and self._device.sabotage:
             return True
         if self._device.windowState is None:
             return None
@@ -96,7 +96,7 @@ class HomematicipMotionDetector(HomematicipGenericDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return true if motion is detected."""
-        if self._device.sabotage:
+        if hasattr(self._device, 'sabotage') and self._device.sabotage:
             return True
         return self._device.motionDetected
 


### PR DESCRIPTION
## Description:
This PR fixes handling of sabotage info.
This property is now only evaluated if property exists for the device.

**Related issue (if applicable):** fixes #23399


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
