### PR TITLE
Broadlink fixup unintended breakage from service refactor

### DIFF
--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -21,7 +21,11 @@ DEFAULT_RETRY = 3
 
 def data_packet(value):
     """Decode a data packet given for broadlink."""
-    return b64decode(cv.string(value))
+    value = cv.string(value)
+    extra = len(value) % 4
+    if extra > 0:
+        value = value + ('=' * (4 - extra))
+    return b64decode(value)
 
 
 SERVICE_SEND_SCHEMA = vol.Schema({

--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 from base64 import b64decode, b64encode
 import logging
-import re
 import socket
 
 from datetime import timedelta

--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -19,26 +19,18 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_RETRY = 3
 
 
-def ipv4_address(value):
-    """Validate an ipv4 address."""
-    regex = re.compile(r'^\d+\.\d+\.\d+\.\d+$')
-    if not regex.match(value):
-        raise vol.Invalid('Invalid Ipv4 address, expected a.b.c.d')
-    return value
-
-
 def data_packet(value):
     """Decode a data packet given for broadlink."""
     return b64decode(cv.string(value))
 
 
 SERVICE_SEND_SCHEMA = vol.Schema({
-    vol.Required(CONF_HOST): ipv4_address,
+    vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PACKET): vol.All(cv.ensure_list, [data_packet])
 })
 
 SERVICE_LEARN_SCHEMA = vol.Schema({
-    vol.Required(CONF_HOST): ipv4_address,
+    vol.Required(CONF_HOST): cv.string,
 })
 
 

--- a/tests/components/broadlink/test_init.py
+++ b/tests/components/broadlink/test_init.py
@@ -26,7 +26,7 @@ def dummy_broadlink():
 
 
 async def test_padding(hass):
-    """Verify that non padding strings are allowed"""
+    """Verify that non padding strings are allowed."""
     assert data_packet('Jg') == b'&'
     assert data_packet('Jg=') == b'&'
     assert data_packet('Jg==') == b'&'

--- a/tests/components/broadlink/test_init.py
+++ b/tests/components/broadlink/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 
 from homeassistant.util.dt import utcnow
-from homeassistant.components.broadlink import async_setup_service
+from homeassistant.components.broadlink import async_setup_service, data_packet
 from homeassistant.components.broadlink.const import (
     DOMAIN, SERVICE_LEARN, SERVICE_SEND)
 
@@ -23,6 +23,13 @@ def dummy_broadlink():
             'broadlink': broadlink,
     }):
         yield broadlink
+
+
+async def test_padding(hass):
+    """Verify that non padding strings are allowed"""
+    assert data_packet('Jg') == b'&'
+    assert data_packet('Jg=') == b'&'
+    assert data_packet('Jg==') == b'&'
 
 
 async def test_send(hass):

--- a/tests/components/broadlink/test_init.py
+++ b/tests/components/broadlink/test_init.py
@@ -4,7 +4,6 @@ from base64 import b64decode
 from unittest.mock import MagicMock, patch, call
 
 import pytest
-import voluptuous as vol
 
 from homeassistant.util.dt import utcnow
 from homeassistant.components.broadlink import async_setup_service
@@ -100,18 +99,3 @@ async def test_learn_timeout(hass):
         assert mock_create.call_args == call(
             "No signal was received",
             title='Broadlink switch')
-
-
-async def test_ipv4():
-    """Test ipv4 parsing."""
-    from homeassistant.components.broadlink import ipv4_address
-
-    schema = vol.Schema(ipv4_address)
-
-    for value in ('invalid', '1', '192', '192.168',
-                  '192.168.0', '192.168.0.A'):
-        with pytest.raises(vol.MultipleInvalid):
-            schema(value)
-
-    for value in ('192.168.0.1', '10.0.0.1'):
-        schema(value)


### PR DESCRIPTION
## Description:
Restore allowing host for services calls and pad packets

**Related issue (if applicable):** fixes #18453

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~[_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).~
  - [ ] ~New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).~
  - [ ] ~New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - [ ] ~New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - [ ] ~New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
