### PR TITLE
Return of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,8 @@ matrix:
       env: TOXENV=pylint
     - python: "3.5.3"
       env: TOXENV=typing
-    - python: "3.6"
-      env: TOXENV=py36
-    - python: "3.7"
-      env: TOXENV=py37
-    - python: "3.8-dev"
-      env: TOXENV=py38
-      if: branch = dev AND type = push
-  allow_failures:
+    - python: "3.5.3"
+      env: TOXENV=py35
     - python: "3.8-dev"
       env: TOXENV=py38
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ matrix:
       env: TOXENV=typing
     - python: "3.5.3"
       env: TOXENV=py35
-    - python: "3.8-dev"
-      env: TOXENV=py38
+    - python: "3.7"
+      env: TOXENV=py37
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,3 @@ language: python
 script: travis_wait 40 tox --develop
 services:
   - docker
-before_deploy:
-  - docker pull lokalise/lokalise-cli@sha256:2198814ebddfda56ee041a4b427521757dd57f75415ea9693696a64c550cef21
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: script/travis_deploy
-  on:
-    branch: dev
-    condition: $TOXENV = lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,3 @@ cache:
 install: pip install -U tox
 language: python
 script: travis_wait 40 tox --develop
-services:
-  - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ matrix:
       env: TOXENV=pylint
     - python: "3.5.3"
       env: TOXENV=typing
-    - python: "3.5.3"
-      env: TOXENV=cov
-      after_success: coveralls
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"
@@ -39,7 +36,7 @@ matrix:
 cache:
   directories:
     - $HOME/.cache/pip
-install: pip install -U tox coveralls
+install: pip install -U tox
 language: python
 script: travis_wait 40 tox --develop
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+sudo: false
+dist: xenial
+addons:
+  apt:
+    sources:
+      - sourceline: "ppa:jonathonf/ffmpeg-4"
+    packages:
+      - libudev-dev
+      - libavformat-dev
+      - libavcodec-dev
+      - libavdevice-dev
+      - libavutil-dev
+      - libswscale-dev
+      - libswresample-dev
+      - libavfilter-dev
+matrix:
+  fast_finish: true
+  include:
+    - python: "3.5.3"
+      env: TOXENV=lint
+    - python: "3.5.3"
+      env: TOXENV=pylint
+    - python: "3.5.3"
+      env: TOXENV=typing
+    - python: "3.5.3"
+      env: TOXENV=cov
+      after_success: coveralls
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+    - python: "3.8-dev"
+      env: TOXENV=py38
+      if: branch = dev AND type = push
+  allow_failures:
+    - python: "3.8-dev"
+      env: TOXENV=py38
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+install: pip install -U tox coveralls
+language: python
+script: travis_wait 40 tox --develop
+services:
+  - docker
+before_deploy:
+  - docker pull lokalise/lokalise-cli@sha256:2198814ebddfda56ee041a4b427521757dd57f75415ea9693696a64c550cef21
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: script/travis_deploy
+  on:
+    branch: dev
+    condition: $TOXENV = lint


### PR DESCRIPTION
## Description:

As discussed in Discord, this returns `.travis.yml` for the purpose of checking personal forks before creating PRs. CircleCI does not yet work well for this use case.

I removed coveralls because it is slow and flaky as far as I remember.