### PR TITLE
Use remote media images for HEOS

### DIFF
--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -279,6 +279,11 @@ class HeosMediaPlayer(MediaPlayerDevice):
         return self._media_position_updated_at
 
     @property
+    def media_image_remotely_accessible(self) -> bool:
+        """If the image url is remotely accessible."""
+        return True
+
+    @property
     def media_image_url(self) -> str:
         """Image url of current playing media."""
         # May be an empty string, if so, return None


### PR DESCRIPTION
## Description:
Takes advantage of the new media player `media_image_remotely_accessible` property so that HEOS images are not proxies via the backend and used directly as they are internet accessible URLs.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.