### PR TITLE
Fix min/max temp and humidity for homekit_controller climate

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -46,8 +46,8 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         self._target_humidity = None
         self._min_target_temp = None
         self._max_target_temp = None
-        self._min_target_humidty = None
-        self._max_target_humidty = None
+        self._min_target_humidity = None
+        self._max_target_humidity = None
         super().__init__(*args)
 
     def get_characteristic_types(self):
@@ -101,11 +101,11 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         self._features |= SUPPORT_TARGET_HUMIDITY
 
         if 'minValue' in characteristic:
-            self._min_target_humidty = characteristic['minValue']
+            self._min_target_humidity = characteristic['minValue']
             self._features |= SUPPORT_TARGET_HUMIDITY_LOW
 
         if 'maxValue' in characteristic:
-            self._max_target_humidty = characteristic['maxValue']
+            self._max_target_humidity = characteristic['maxValue']
             self._features |= SUPPORT_TARGET_HUMIDITY_HIGH
 
     def _update_heating_cooling_current(self, value):
@@ -198,12 +198,12 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
     @property
     def min_humidity(self):
         """Return the minimum humidity."""
-        return self._min_target_humidty
+        return self._min_target_humidity
 
     @property
     def max_humidity(self):
         """Return the maximum humidity."""
-        return self._max_target_humidty
+        return self._max_target_humidity
 
     @property
     def current_operation(self):

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -4,7 +4,8 @@ import logging
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     STATE_COOL, STATE_HEAT, STATE_IDLE, SUPPORT_OPERATION_MODE,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY)
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_HUMIDITY_HIGH, SUPPORT_TARGET_HUMIDITY_LOW)
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, TEMP_CELSIUS
 
 from . import KNOWN_DEVICES, HomeKitEntity
@@ -43,6 +44,10 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         self._target_temp = None
         self._current_humidity = None
         self._target_humidity = None
+        self._min_target_temp = None
+        self._max_target_temp = None
+        self._min_target_humidty = None
+        self._max_target_humidty = None
         super().__init__(*args)
 
     def get_characteristic_types(self):
@@ -86,8 +91,22 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
     def _setup_temperature_target(self, characteristic):
         self._features |= SUPPORT_TARGET_TEMPERATURE
 
+        if 'minValue' in characteristic:
+            self._min_target_temp = characteristic['minValue']
+
+        if 'maxValue' in characteristic:
+            self._max_target_temp = characteristic['maxValue']
+
     def _setup_relative_humidity_target(self, characteristic):
         self._features |= SUPPORT_TARGET_HUMIDITY
+
+        if 'minValue' in characteristic:
+            self._min_target_humidty = characteristic['minValue']
+            self._features |= SUPPORT_TARGET_HUMIDITY_LOW
+
+        if 'maxValue' in characteristic:
+            self._max_target_humidty = characteristic['maxValue']
+            self._features |= SUPPORT_TARGET_HUMIDITY_HIGH
 
     def _update_heating_cooling_current(self, value):
         self._state = MODE_HOMEKIT_TO_HASS.get(value)
@@ -153,6 +172,20 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         return self._target_temp
 
     @property
+    def min_temp(self):
+        """Return the minimum target temp."""
+        if self._max_target_temp:
+            return self._min_target_temp
+        return super().min_temp
+
+    @property
+    def max_temp(self):
+        """Return the maximum target temp."""
+        if self._max_target_temp:
+            return self._max_target_temp
+        return super().max_temp
+
+    @property
     def current_humidity(self):
         """Return the current humidity."""
         return self._current_humidity
@@ -161,6 +194,16 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
     def target_humidity(self):
         """Return the humidity we try to reach."""
         return self._target_humidity
+
+    @property
+    def min_humidity(self):
+        """Return the minimum humidity."""
+        return self._min_target_humidty
+
+    @property
+    def max_humidity(self):
+        """Return the maximum humidity."""
+        return self._max_target_humidty
 
     @property
     def current_operation(self):

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -180,6 +180,12 @@ async def setup_accessories_from_file(hass, path):
                     char.description = char_data['description']
                 if 'value' in char_data:
                     char.value = char_data['value']
+                if 'minValue' in char_data:
+                    char.minValue = char_data['minValue']
+                if 'maxValue' in char_data:
+                    char.maxValue = char_data['maxValue']
+                if 'valid-values' in char_data:
+                    char.valid_values = char_data['valid-values']
                 service.characteristics.append(char)
 
             accessory.services.append(service)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -10,6 +10,7 @@ from homekit import AccessoryDisconnectedError
 
 from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_HUMIDITY_HIGH, SUPPORT_TARGET_HUMIDITY_LOW,
     SUPPORT_OPERATION_MODE)
 from tests.components.homekit_controller.common import (
     FakePairing, device_config_changed, setup_accessories_from_file,
@@ -32,8 +33,14 @@ async def test_ecobee3_setup(hass):
     assert climate_state.attributes['friendly_name'] == 'HomeW'
     assert climate_state.attributes['supported_features'] == (
         SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_HUMIDITY |
+        SUPPORT_TARGET_HUMIDITY_HIGH | SUPPORT_TARGET_HUMIDITY_LOW |
         SUPPORT_OPERATION_MODE
     )
+
+    assert climate_state.attributes['min_temp'] == 7.2
+    assert climate_state.attributes['max_temp'] == 33.3
+    assert climate_state.attributes['min_humidity'] == 20
+    assert climate_state.attributes['max_humidity'] == 50
 
     occ1 = entity_registry.async_get('binary_sensor.kitchen')
     assert occ1.unique_id == 'homekit-AB1C-56'

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -138,6 +138,8 @@ async def test_climate_read_thermostat_state(hass, utcnow):
     assert state.state == 'heat'
     assert state.attributes['current_temperature'] == 19
     assert state.attributes['current_humidity'] == 50
+    assert state.attributes['min_temp'] == 7
+    assert state.attributes['max_temp'] == 35
 
     # Simulate that cooling is on
     helper.characteristics[TEMPERATURE_CURRENT].value = 21


### PR DESCRIPTION
## Description:

As of 0.92.0 HomeKit controller climate devices now support the current and target relative humidity characteristics. With the changes in 0.92.0 the humidity values are correctly collected into the state and the set_humidity service can be used from automations. However we weren't using the min/max values exposed on these characteristics and that meant the UI for setting the target humidity was broken.

This sets the min and max values for temperature and humidity and updates the tests accordingly.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
