### PR TITLE
Added option to select photoblack cartridge

### DIFF
--- a/homeassistant/components/epsonworkforce/manifest.json
+++ b/homeassistant/components/epsonworkforce/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/components/epsonworkforce",
   "dependencies": [],
   "codeowners": ["@ThaStealth"],
-  "requirements": ["epsonprinter==0.0.8"]
+  "requirements": ["epsonprinter==0.0.9"]
 }
 

--- a/homeassistant/components/epsonworkforce/sensor.py
+++ b/homeassistant/components/epsonworkforce/sensor.py
@@ -15,7 +15,7 @@ REQUIREMENTS = ['epsonprinter==0.0.9']
 _LOGGER = logging.getLogger(__name__)
 MONITORED_CONDITIONS = {
     'black': ['Inklevel Black', '%', 'mdi:water'],
-    'photoblack': ['Inklevel Photoblack','%', 'mdi:water'],
+    'photoblack': ['Inklevel Photoblack', '%', 'mdi:water'],
     'magenta': ['Inklevel Magenta', '%', 'mdi:water'],
     'cyan': ['Inklevel Cyan', '%', 'mdi:water'],
     'yellow': ['Inklevel Yellow', '%', 'mdi:water'],

--- a/homeassistant/components/epsonworkforce/sensor.py
+++ b/homeassistant/components/epsonworkforce/sensor.py
@@ -14,12 +14,12 @@ REQUIREMENTS = ['epsonprinter==0.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 MONITORED_CONDITIONS = {
-    'black': ['Inklevel Black', '%', 'mdi:water'],
-    'photoblack': ['Inklevel Photoblack', '%', 'mdi:water'],
-    'magenta': ['Inklevel Magenta', '%', 'mdi:water'],
-    'cyan': ['Inklevel Cyan', '%', 'mdi:water'],
-    'yellow': ['Inklevel Yellow', '%', 'mdi:water'],
-    'clean': ['Inklevel Cleaning', '%', 'mdi:water'],
+    'black': ['Ink level Black', '%', 'mdi:water'],
+    'photoblack': ['Ink level Photoblack', '%', 'mdi:water'],
+    'magenta': ['Ink level Magenta', '%', 'mdi:water'],
+    'cyan': ['Ink level Cyan', '%', 'mdi:water'],
+    'yellow': ['Ink level Yellow', '%', 'mdi:water'],
+    'clean': ['Cleaning level', '%', 'mdi:water'],
 }
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,

--- a/homeassistant/components/epsonworkforce/sensor.py
+++ b/homeassistant/components/epsonworkforce/sensor.py
@@ -10,11 +10,12 @@ from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['epsonprinter==0.0.8']
+REQUIREMENTS = ['epsonprinter==0.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 MONITORED_CONDITIONS = {
     'black': ['Inklevel Black', '%', 'mdi:water'],
+    'photoblack': ['Inklevel Photoblack','%', 'mdi:water'],
     'magenta': ['Inklevel Magenta', '%', 'mdi:water'],
     'cyan': ['Inklevel Cyan', '%', 'mdi:water'],
     'yellow': ['Inklevel Yellow', '%', 'mdi:water'],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -401,7 +401,7 @@ ephem==3.7.6.0
 epson-projector==0.1.3
 
 # homeassistant.components.epsonworkforce
-epsonprinter==0.0.8
+epsonprinter==0.0.9
 
 # homeassistant.components.netgear_lte
 eternalegypt==0.0.7


### PR DESCRIPTION
## Description:

Added the option to add photo black cartridge as a setting. Also correct the spelling of Inklevel -> Ink level

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9371

## Example entry for `configuration.yaml` (if applicable):
```yaml
   - platform: epsonworkforce
     host: IP_ADDRESS
     monitored_conditions:
     - black     
     - photoblack
     - yellow
     - magenta
     - cyan
     - clean      
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
