### PR TITLE
deCONZ - Retry on BridgeBusy errors

### DIFF
--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -93,7 +93,7 @@ class DeconzCover(DeconzDevice, CoverDevice):
             data['on'] = True
             data['bri'] = int(position / 100 * 255)
 
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)
 
     async def async_open_cover(self, **kwargs):
         """Open cover."""
@@ -108,7 +108,7 @@ class DeconzCover(DeconzDevice, CoverDevice):
     async def async_stop_cover(self, **kwargs):
         """Stop cover."""
         data = {'bri_inc': 0}
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)
 
 
 class DeconzCoverZigbeeSpec(DeconzCover):
@@ -133,4 +133,4 @@ class DeconzCoverZigbeeSpec(DeconzCover):
             data['on'] = True
             data['bri'] = 255 - int(position / 100 * 255)
 
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -88,10 +88,12 @@ class DeconzCover(DeconzDevice, CoverDevice):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
         data = {'on': False}
+
         if position > 0:
             data['on'] = True
             data['bri'] = int(position / 100 * 255)
-        await self._device.async_set_state(data)
+
+        await self.async_device_set_state(data)
 
     async def async_open_cover(self, **kwargs):
         """Open cover."""
@@ -106,7 +108,7 @@ class DeconzCover(DeconzDevice, CoverDevice):
     async def async_stop_cover(self, **kwargs):
         """Stop cover."""
         data = {'bri_inc': 0}
-        await self._device.async_set_state(data)
+        await self.async_device_set_state(data)
 
 
 class DeconzCoverZigbeeSpec(DeconzCover):
@@ -126,7 +128,9 @@ class DeconzCoverZigbeeSpec(DeconzCover):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
         data = {'on': False}
+
         if position < 100:
             data['on'] = True
             data['bri'] = 255 - int(position / 100 * 255)
-        await self._device.async_set_state(data)
+
+        await self.async_device_set_state(data)

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -15,7 +15,6 @@ class DeconzDevice(Entity):
         self._device = device
         self.gateway = gateway
         self.unsub_dispatcher = None
-        self._cancel_retry_set_state = None
 
     async def async_added_to_hass(self):
         """Subscribe to device events."""
@@ -30,10 +29,6 @@ class DeconzDevice(Entity):
         self._device.remove_callback(self.async_update_callback)
         del self.gateway.deconz_ids[self.entity_id]
         self.unsub_dispatcher()
-
-        if self._cancel_retry_set_state is not None:
-            self._cancel_retry_set_state()
-            self._cancel_retry_set_state = None
 
     @callback
     def async_update_callback(self, reason):
@@ -79,21 +74,3 @@ class DeconzDevice(Entity):
             'sw_version': self._device.swversion,
             'via_hub': (DECONZ_DOMAIN, bridgeid),
         }
-
-    async def async_device_set_state(self, data, tries=0):
-        """Set state of device."""
-        from pydeconz import errors
-
-        try:
-            await self._device.async_set_state(data)
-
-        except errors.BridgeBusy:
-            async def retry_set_state(_now):
-                """Retry set state."""
-                await self.async_device_set_state(data, tries + 1)
-
-            if tries < 5:
-                retry_delay = 2 ** (tries + 1)
-                self._cancel_retry_set_state = \
-                    self.hass.helpers.event.async_call_later(
-                        retry_delay, retry_set_state)

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -140,7 +140,7 @@ class DeconzLight(DeconzDevice, Light):
             else:
                 data['effect'] = 'none'
 
-        await self._device.async_set_state(data)
+        await self.async_device_set_state(data)
 
     async def async_turn_off(self, **kwargs):
         """Turn off light."""
@@ -158,13 +158,15 @@ class DeconzLight(DeconzDevice, Light):
                 data['alert'] = 'lselect'
                 del data['on']
 
-        await self._device.async_set_state(data)
+        await self.async_device_set_state(data)
 
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
         attributes = {}
         attributes['is_deconz_group'] = self._device.type == 'LightGroup'
+
         if self._device.type == 'LightGroup':
             attributes['all_on'] = self._device.all_on
+
         return attributes

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -140,7 +140,7 @@ class DeconzLight(DeconzDevice, Light):
             else:
                 data['effect'] = 'none'
 
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)
 
     async def async_turn_off(self, **kwargs):
         """Turn off light."""
@@ -158,7 +158,7 @@ class DeconzLight(DeconzDevice, Light):
                 data['alert'] = 'lselect'
                 del data['on']
 
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "Deconz",
   "documentation": "https://www.home-assistant.io/components/deconz",
   "requirements": [
-    "pydeconz==57"
+    "pydeconz==58"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "Deconz",
   "documentation": "https://www.home-assistant.io/components/deconz",
   "requirements": [
-    "pydeconz==56"
+    "pydeconz==57"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "Deconz",
   "documentation": "https://www.home-assistant.io/components/deconz",
   "requirements": [
-    "pydeconz==55"
+    "pydeconz==56"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -53,12 +53,12 @@ class DeconzPowerPlug(DeconzDevice, SwitchDevice):
     async def async_turn_on(self, **kwargs):
         """Turn on switch."""
         data = {'on': True}
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)
 
     async def async_turn_off(self, **kwargs):
         """Turn off switch."""
         data = {'on': False}
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)
 
 
 class DeconzSiren(DeconzDevice, SwitchDevice):
@@ -72,9 +72,9 @@ class DeconzSiren(DeconzDevice, SwitchDevice):
     async def async_turn_on(self, **kwargs):
         """Turn on switch."""
         data = {'alert': 'lselect'}
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)
 
     async def async_turn_off(self, **kwargs):
         """Turn off switch."""
         data = {'alert': 'none'}
-        await self.async_device_set_state(data)
+        await self._device.async_set_state(data)

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -53,12 +53,12 @@ class DeconzPowerPlug(DeconzDevice, SwitchDevice):
     async def async_turn_on(self, **kwargs):
         """Turn on switch."""
         data = {'on': True}
-        await self._device.async_set_state(data)
+        await self.async_device_set_state(data)
 
     async def async_turn_off(self, **kwargs):
         """Turn off switch."""
         data = {'on': False}
-        await self._device.async_set_state(data)
+        await self.async_device_set_state(data)
 
 
 class DeconzSiren(DeconzDevice, SwitchDevice):
@@ -72,9 +72,9 @@ class DeconzSiren(DeconzDevice, SwitchDevice):
     async def async_turn_on(self, **kwargs):
         """Turn on switch."""
         data = {'alert': 'lselect'}
-        await self._device.async_set_state(data)
+        await self.async_device_set_state(data)
 
     async def async_turn_off(self, **kwargs):
         """Turn off switch."""
         data = {'alert': 'none'}
-        await self._device.async_set_state(data)
+        await self.async_device_set_state(data)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1009,7 +1009,7 @@ pydaikin==1.4.0
 pydanfossair==0.0.7
 
 # homeassistant.components.deconz
-pydeconz==56
+pydeconz==57
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1009,7 +1009,7 @@ pydaikin==1.4.0
 pydanfossair==0.0.7
 
 # homeassistant.components.deconz
-pydeconz==55
+pydeconz==56
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1009,7 +1009,7 @@ pydaikin==1.4.0
 pydanfossair==0.0.7
 
 # homeassistant.components.deconz
-pydeconz==57
+pydeconz==58
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -217,7 +217,7 @@ pyHS100==0.3.5
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==56
+pydeconz==57
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -217,7 +217,7 @@ pyHS100==0.3.5
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==55
+pydeconz==56
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -217,7 +217,7 @@ pyHS100==0.3.5
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==57
+pydeconz==58
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
If you try to control too many devices at the same time like when calling on/off for group.all_lights some requests will get BridgeBusy errors from deCONZ. This tries to mitigate the issue with not all lights being controlled by adding a retry with a max of 3 tries.

**Related issue (if applicable):** fixes #22852

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
