### PR TITLE
Display person component as occupancy sensor

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -110,9 +110,7 @@ def get_accessory(hass, driver, state, aid, config):
     if state.domain == 'alarm_control_panel':
         a_type = 'SecuritySystem'
 
-    elif state.domain == 'binary_sensor' or \
-            state.domain == 'device_tracker' or \
-            state.domain == 'person':
+    elif state.domain in ('binary_sensor', 'device_tracker', 'person'):
         a_type = 'BinarySensor'
 
     elif state.domain == 'climate':

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -110,7 +110,7 @@ def get_accessory(hass, driver, state, aid, config):
     if state.domain == 'alarm_control_panel':
         a_type = 'SecuritySystem'
 
-    elif state.domain == 'binary_sensor' or state.domain == 'device_tracker':
+    elif state.domain == 'binary_sensor' or state.domain == 'device_tracker' or state.domain == 'person':
         a_type = 'BinarySensor'
 
     elif state.domain == 'climate':

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -110,7 +110,9 @@ def get_accessory(hass, driver, state, aid, config):
     if state.domain == 'alarm_control_panel':
         a_type = 'SecuritySystem'
 
-    elif state.domain == 'binary_sensor' or state.domain == 'device_tracker' or state.domain == 'person':
+    elif state.domain == 'binary_sensor' or \
+            state.domain == 'device_tracker' or \
+            state.domain == 'person':
         a_type = 'BinarySensor'
 
     elif state.domain == 'climate':

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -105,6 +105,7 @@ def test_type_covers(type_name, entity_id, state, attrs):
     ('BinarySensor', 'binary_sensor.opening', 'on',
      {ATTR_DEVICE_CLASS: 'opening'}),
     ('BinarySensor', 'device_tracker.someone', 'not_home', {}),
+    ('BinarySensor', 'person.someone', 'home', {}),
     ('AirQualitySensor', 'sensor.air_quality_pm25', '40', {}),
     ('AirQualitySensor', 'sensor.air_quality', '40',
      {ATTR_DEVICE_CLASS: 'pm25'}),


### PR DESCRIPTION
## Description:

Display person component as occupancy sensor, like device_tracker component.

**Pull request in home-assistant.io with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9329

## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
  filter:
    exclude_domains:
      - device_tracker
    include_domains:
      - person
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
