### PR TITLE
Fix broken forecast trend attribute in IQVIA

### DIFF
--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -48,6 +48,7 @@ RATING_MAPPING = [{
     'maximum': 12
 }]
 
+TREND_FLAT = 'Flat'
 TREND_INCREASING = 'Increasing'
 TREND_SUBSIDING = 'Subsiding'
 
@@ -90,17 +91,18 @@ def calculate_average_rating(indices):
 
 def calculate_trend(indices):
     """Calculate the "moving average" of a set of indices."""
-    def moving_average(data, samples):
-        """Determine the "moving average" (http://tinyurl.com/yaereb3c)."""
-        ret = np.cumsum(data, dtype=float)
-        ret[samples:] = ret[samples:] - ret[:-samples]
-        return ret[samples - 1:] / samples
+    index_range = np.arange(0, len(indices))
+    index_array = np.array(indices)
+    linear_fit = np.polyfit(index_range, index_array, 1)
+    slope = round(linear_fit[0], 2)
 
-    increasing = np.all(np.diff(moving_average(np.array(indices), 4)) > 0)
-
-    if increasing:
+    if slope > 0:
         return TREND_INCREASING
-    return TREND_SUBSIDING
+
+    if slope < 0:
+        return TREND_SUBSIDING
+
+    return TREND_FLAT
 
 
 class ForecastSensor(IQVIAEntity):


### PR DESCRIPTION
## Description:

This PR fixes an incorrect `trend` attribute in IQVIA's forecast sensors; in so doing, it also allows for a valid value of `Flat` (which couldn't have happened before).

**Related issue (if applicable):** fixes #23452

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
iqvia:
  zip_code: "12345"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
