### PR TITLE
Fix netatmo_public sensor to use netatmo authentication

### DIFF
--- a/homeassistant/components/netatmo_public/sensor.py
+++ b/homeassistant/components/netatmo_public/sensor.py
@@ -12,6 +12,8 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
+from homeassistant.components.netatmo.const import DATA_NETATMO_AUTH
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_AREAS = 'areas'
@@ -54,12 +56,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the access to Netatmo binary sensor."""
-    netatmo = hass.components.netatmo
+    auth = hass.data[DATA_NETATMO_AUTH]
 
     sensors = []
     areas = config.get(CONF_AREAS)
     for area_conf in areas:
-        data = NetatmoPublicData(netatmo.NETATMO_AUTH,
+        data = NetatmoPublicData(auth,
                                  lat_ne=area_conf.get(CONF_LAT_NE),
                                  lon_ne=area_conf.get(CONF_LON_NE),
                                  lat_sw=area_conf.get(CONF_LAT_SW),


### PR DESCRIPTION
## Description:
netatmo_public was broken due to changes in #23429.

**Related issue (if applicable):** fixes #23474

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_