### PR TITLE
Allow removing Telegram reply keyboard

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -446,11 +446,15 @@ class TelegramNotificationService:
                 params[ATTR_REPLY_TO_MSGID] = data[ATTR_REPLY_TO_MSGID]
             # Keyboards:
             if ATTR_KEYBOARD in data:
-                from telegram import ReplyKeyboardMarkup
+                from telegram import ReplyKeyboardMarkup, ReplyKeyboardRemove
                 keys = data.get(ATTR_KEYBOARD)
                 keys = keys if isinstance(keys, list) else [keys]
-                params[ATTR_REPLYMARKUP] = ReplyKeyboardMarkup(
-                    [[key.strip() for key in row.split(",")] for row in keys])
+                if keys:
+                    params[ATTR_REPLYMARKUP] = ReplyKeyboardMarkup(
+                        [[key.strip() for key in row.split(",")]
+                         for row in keys])
+                else:
+                    params[ATTR_REPLYMARKUP] = ReplyKeyboardRemove(True)
             elif ATTR_KEYBOARD_INLINE in data:
                 from telegram import InlineKeyboardMarkup
                 keys = data.get(ATTR_KEYBOARD_INLINE)

--- a/homeassistant/components/telegram_bot/services.yaml
+++ b/homeassistant/components/telegram_bot/services.yaml
@@ -22,7 +22,7 @@ send_message:
       description: Disables link previews for links in the message.
       example: true
     keyboard:
-      description: List of rows of commands, comma-separated, to make a custom keyboard.
+      description: List of rows of commands, comma-separated, to make a custom keyboard. Empty list clears a previously set keyboard.
       example: '["/command1, /command2", "/command3"]'
     inline_keyboard:
       description: List of rows of commands, comma-separated, to make a custom inline keyboard with buttons with associated callback data.


### PR DESCRIPTION
## Description:
A reply keyboard set via the `keyboard` argument of `telegram_bot.send_*` is sticky, and currently you can only replace it by a new keyboard, but not remove it.
This change allows specifying `keyboard: []`, which will remove the reply keyboard.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9339


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
