### PR TITLE
Fixed AlexaPowerController to report power state for thermostats

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -449,9 +449,9 @@ class _AlexaPowerController(_AlexaInterface):
         if name != 'powerState':
             raise _UnsupportedProperty(name)
 
-        if self.entity.state == STATE_ON:
-            return 'ON'
-        return 'OFF'
+        if self.entity.state == STATE_OFF:
+            return 'OFF'
+        return 'ON'
 
 
 class _AlexaLockController(_AlexaInterface):


### PR DESCRIPTION
Issue: #20216
Fixed AlexaPowerController to report power state for thermostats, to look if state is OFF return OFF, otherwise report ON as thermostats have multiple values for ON

