### PR TITLE
Add a warning that honeywell/EU is to be deprecated

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -55,9 +55,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     _LOGGER.warning(
         "The honeywell component is deprecated for EU (i.e. non-US) systems, "
-        "this functionality will be removed in a future version of HA.")
+        "this functionality will be removed in version 0.96.")
     _LOGGER.warning(
-        "Please switch to the evohome componenent, "
+        "Please switch to the evohome component, "
         "see: https://home-assistant.io/components/evohome")
 
     return _setup_round(username, password, config, add_entities)

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -53,6 +53,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if region == 'us':
         return _setup_us(username, password, config, add_entities)
 
+    _LOGGER.warning(
+        "The honeywell component is deprecated for EU (i.e. non-US) systems, "
+        "this functionality will be removed in a future version of HA.")
+    _LOGGER.warning(
+        "Please switch to the evohome componenent, "
+        "see: https://home-assistant.io/components/evohome")
+
     return _setup_round(username, password, config, add_entities)
 
 


### PR DESCRIPTION
## Description:
The **honeywell** component actually contains two mutually-exclusive integrations, based upon either the `somecomfort` (US) or `evohome-client` (EU) client libraries.  The `evohome` functionality is better provided in the **evohome** component, which uses the same client library.

This PR will add a warning to users of the `honeywell` component that support for EU-based systems is deprecated in favour of the `evohome` component.  

_This warning does not apply to / will not be seen by users of US-based systems._

**Related issue (if applicable):** None

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** None

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools: 
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices: **N/A**
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
