### PR TITLE
Improve handling of unavailable Sonos speakers

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.10"
+    "pysonos==0.0.11"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1288,7 +1288,7 @@ pysmartthings==0.6.7
 pysnmp==4.4.8
 
 # homeassistant.components.sonos
-pysonos==0.0.10
+pysonos==0.0.11
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.7
 
 # homeassistant.components.sonos
-pysonos==0.0.10
+pysonos==0.0.11
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

This is to avoid unhandled exceptions when a speaker is powered off.

* Update pysonos so we get `SoCoException` and not `requests` exceptions
* Handle `SoCoException` in more situations
* Import at top of file rather than adding even more local imports
* Remove `async_add_executor_job()` from the unavailable path in `update()`

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
