### PR TITLE
Fixes local_file camera service

### DIFF
--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -124,17 +124,19 @@ async def test_update_file_path(hass):
 
     with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
             mock.patch('os.access', mock.Mock(return_value=True)):
+
+        camera_1 = {
+            'platform': 'local_file',
+            'file_path': 'mock/path.jpg'
+            }
+        camera_2 = {
+            'platform': 'local_file',
+            'name': 'local_file_camera_2',
+            'file_path': 'mock/path_2.jpg'
+            }
         await async_setup_component(hass, 'camera', {
-            'camera': [{
-                'platform': 'local_file',
-                'file_path': 'mock/path.jpg'
-            },
-            {
-                'platform': 'local_file',
-                'name': 'local_file_camera_2',
-                'file_path': 'mock/path_2.jpg'
-            }]
-        })
+            'camera': [camera_1, camera_2]
+            })
 
         # Fetch state and check motion detection attribute
         state = hass.states.get('camera.local_file')

--- a/tests/components/local_file/test_camera.py
+++ b/tests/components/local_file/test_camera.py
@@ -125,10 +125,15 @@ async def test_update_file_path(hass):
     with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
             mock.patch('os.access', mock.Mock(return_value=True)):
         await async_setup_component(hass, 'camera', {
-            'camera': {
+            'camera': [{
                 'platform': 'local_file',
                 'file_path': 'mock/path.jpg'
-            }
+            },
+            {
+                'platform': 'local_file',
+                'name': 'local_file_camera_2',
+                'file_path': 'mock/path_2.jpg'
+            }]
         })
 
         # Fetch state and check motion detection attribute
@@ -148,3 +153,7 @@ async def test_update_file_path(hass):
 
         state = hass.states.get('camera.local_file')
         assert state.attributes.get('file_path') == 'new/path.jpg'
+
+        # Check that local_file_camera_2 file_path is still as configured
+        state = hass.states.get('camera.local_file_camera_2')
+        assert state.attributes.get('file_path') == 'mock/path_2.jpg'


### PR DESCRIPTION
## Description:
Fixes service so only the target camera is updated

**Related issue (if applicable):** fixes #<https://github.com/home-assistant/home-assistant/issues/21385>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.