### PR TITLE
Add core APIs to migrate device identifiers and entity unique_id

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -142,14 +142,6 @@ class DeviceRegistry:
     @callback
     def async_migrate_device_identifiers(self, device_id, identifiers: set):
         """Update the identifiers of a device."""
-        conflict = next((
-            device for device in self.devices.values()
-            if device.id != device_id
-            and any(iden in device.identifiers for iden in identifiers)), None)
-        if conflict:
-            raise ValueError(
-                "Identifiers '{}' are already in use by device id '{}'".format(
-                    identifiers, conflict.id))
         new = self.devices[device_id] = attr.evolve(
             self.devices[device_id], identifiers=identifiers)
         self.async_schedule_save()

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -134,24 +134,19 @@ class DeviceRegistry:
 
     @callback
     def async_update_device(
-            self, device_id, *, area_id=_UNDEF, name_by_user=_UNDEF):
+            self, device_id, *, area_id=_UNDEF, name_by_user=_UNDEF,
+            new_identifiers=_UNDEF):
         """Update properties of a device."""
         return self._async_update_device(
-            device_id, area_id=area_id, name_by_user=name_by_user)
-
-    @callback
-    def async_migrate_device_identifiers(self, device_id, identifiers: set):
-        """Update the identifiers of a device."""
-        new = self.devices[device_id] = attr.evolve(
-            self.devices[device_id], identifiers=identifiers)
-        self.async_schedule_save()
-        return new
+            device_id, area_id=area_id, name_by_user=name_by_user,
+            new_identifiers=new_identifiers)
 
     @callback
     def _async_update_device(self, device_id, *, add_config_entry_id=_UNDEF,
                              remove_config_entry_id=_UNDEF,
                              merge_connections=_UNDEF,
                              merge_identifiers=_UNDEF,
+                             new_identifiers=_UNDEF,
                              manufacturer=_UNDEF,
                              model=_UNDEF,
                              name=_UNDEF,
@@ -185,6 +180,9 @@ class DeviceRegistry:
             # If not undefined, check if `value` contains new items.
             if value is not _UNDEF and not value.issubset(old_value):
                 changes[attr_name] = old_value | value
+
+        if new_identifiers is not _UNDEF:
+            changes['identifiers'] = new_identifiers
 
         for attr_name, value in (
                 ('manufacturer', manufacturer),

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -148,7 +148,7 @@ class DeviceRegistry:
             and any(iden in device.identifiers for iden in identifiers)), None)
         if conflict:
             raise ValueError(
-                "Identifiers '{}' already in use by device id '{}'".format(
+                "Identifiers '{}' are already in use by device id '{}'".format(
                     identifiers, conflict.id))
         new = self.devices[device_id] = attr.evolve(
             self.devices[device_id], identifiers=identifiers)

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -169,6 +169,20 @@ class EntityRegistry:
         )
 
     @callback
+    def async_migrate_entity_unique_id(self, entity_id, unique_id):
+        """Migrate unique_id of a device."""
+        conflict = next((entity for entity in self.entities.values()
+                         if entity.entity_id != entity_id
+                         and entity.unique_id == unique_id), None)
+        if conflict:
+            raise ValueError("Unique id '{}' is already in use by '{}'".format(
+                unique_id, conflict.entity_id))
+        new = self.entities[entity_id] = attr.evolve(
+            self.entities[entity_id], unique_id=unique_id)
+        self.async_schedule_save()
+        return new
+
+    @callback
     def _async_update_entity(self, entity_id, *, name=_UNDEF,
                              config_entry_id=_UNDEF, new_entity_id=_UNDEF,
                              device_id=_UNDEF):

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -160,33 +160,19 @@ class EntityRegistry:
 
     @callback
     def async_update_entity(self, entity_id, *, name=_UNDEF,
-                            new_entity_id=_UNDEF):
+                            new_entity_id=_UNDEF, new_unique_id=_UNDEF):
         """Update properties of an entity."""
         return self._async_update_entity(
             entity_id,
             name=name,
-            new_entity_id=new_entity_id
+            new_entity_id=new_entity_id,
+            new_unique_id=new_unique_id
         )
-
-    @callback
-    def async_migrate_entity_unique_id(self, from_unique_id, to_unique_id):
-        """Migrate unique_id of a device."""
-        conflict = next((entity for entity in self.entities.values()
-                         if entity.unique_id == to_unique_id), None)
-        if conflict:
-            raise ValueError("Unique id '{}' is already in use by '{}'".format(
-                to_unique_id, conflict.entity_id))
-        old = next(entity for entity in self.entities.values()
-                   if entity.unique_id == from_unique_id)
-        new = self.entities[old.entity_id] = attr.evolve(
-            old, unique_id=to_unique_id)
-        self.async_schedule_save()
-        return new
 
     @callback
     def _async_update_entity(self, entity_id, *, name=_UNDEF,
                              config_entry_id=_UNDEF, new_entity_id=_UNDEF,
-                             device_id=_UNDEF):
+                             device_id=_UNDEF, new_unique_id=_UNDEF):
         """Private facing update properties method."""
         old = self.entities[entity_id]
 
@@ -215,6 +201,17 @@ class EntityRegistry:
 
             self.entities.pop(entity_id)
             entity_id = changes['entity_id'] = new_entity_id
+
+        if new_unique_id is not _UNDEF:
+            conflict = next((entity for entity in self.entities.values()
+                             if entity.unique_id == new_unique_id
+                             and entity.domain == old.domain
+                             and entity.platform == old.platform), None)
+            if conflict:
+                raise ValueError(
+                    "Unique id '{}' is already in use by '{}'".format(
+                        new_unique_id, conflict.entity_id))
+            changes['unique_id'] = new_unique_id
 
         if not changes:
             return old

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -169,16 +169,17 @@ class EntityRegistry:
         )
 
     @callback
-    def async_migrate_entity_unique_id(self, entity_id, unique_id):
+    def async_migrate_entity_unique_id(self, from_unique_id, to_unique_id):
         """Migrate unique_id of a device."""
         conflict = next((entity for entity in self.entities.values()
-                         if entity.entity_id != entity_id
-                         and entity.unique_id == unique_id), None)
+                         if entity.unique_id == to_unique_id), None)
         if conflict:
             raise ValueError("Unique id '{}' is already in use by '{}'".format(
-                unique_id, conflict.entity_id))
-        new = self.entities[entity_id] = attr.evolve(
-            self.entities[entity_id], unique_id=unique_id)
+                to_unique_id, conflict.entity_id))
+        old = next(entity for entity in self.entities.values()
+                   if entity.unique_id == from_unique_id)
+        new = self.entities[old.entity_id] = attr.evolve(
+            old, unique_id=to_unique_id)
         self.async_schedule_save()
         return new
 

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -398,8 +398,7 @@ async def test_migrate_device_identifiers(registry):
         ('hue', '654'),
         ('bla', '321')
     }
-    with patch('homeassistant.helpers.device_registry'
-               '.DeviceRegistry.async_schedule_save') as mock_save:
+    with patch.object(registry, 'async_schedule_save') as mock_save:
         updated_entry = registry.async_migrate_device_identifiers(
             entry.id, new_identifiers)
     assert updated_entry != entry
@@ -417,8 +416,7 @@ async def test_migrate_device_identifies_collision(registry):
         config_entry_id='1234',
         identifiers={('hue', '654'), ('bla', '321')},
     )
-    with patch('homeassistant.helpers.device_registry'
-               '.DeviceRegistry.async_schedule_save') as mock_save, \
-         pytest.raises(ValueError):
+    with patch.object(registry, 'async_schedule_save') as mock_save, \
+            pytest.raises(ValueError):
         registry.async_migrate_device_identifiers(entry.id, {('hue', '654')})
     assert mock_save.call_count == 0

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -404,19 +404,3 @@ async def test_migrate_device_identifiers(registry):
     assert updated_entry != entry
     assert updated_entry.identifiers == new_identifiers
     assert mock_save.call_count == 1
-
-
-async def test_migrate_device_identifies_collision(registry):
-    """Test migration raises when identifier used in another device."""
-    entry = registry.async_get_or_create(
-        config_entry_id='1234',
-        identifiers={('hue', '456'), ('bla', '123')},
-    )
-    registry.async_get_or_create(
-        config_entry_id='1234',
-        identifiers={('hue', '654'), ('bla', '321')},
-    )
-    with patch.object(registry, 'async_schedule_save') as mock_save, \
-            pytest.raises(ValueError):
-        registry.async_migrate_device_identifiers(entry.id, {('hue', '654')})
-    assert mock_save.call_count == 0

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -273,20 +273,20 @@ async def test_loading_race_condition(hass):
         assert results[0] == results[1]
 
 
-async def test_migrate_entity_unique_id(registry):
+async def test_update_entity_unique_id(registry):
     """Test entity's unique_id is updated."""
     entry = registry.async_get_or_create(
         'light', 'hue', '5678', config_entry_id='mock-id-1')
     new_unique_id = '1234'
     with patch.object(registry, 'async_schedule_save') as mock_schedule_save:
-        updated_entry = registry.async_migrate_entity_unique_id(
-            entry.unique_id, new_unique_id)
+        updated_entry = registry.async_update_entity(
+            entry.entity_id, new_unique_id=new_unique_id)
     assert updated_entry != entry
     assert updated_entry.unique_id == new_unique_id
     assert mock_schedule_save.call_count == 1
 
 
-async def test_migrate_entity_unique_id_collision(registry):
+async def test_update_entity_unique_id_conflict(registry):
     """Test migration raises when unique_id already in use."""
     entry = registry.async_get_or_create(
         'light', 'hue', '5678', config_entry_id='mock-id-1')
@@ -294,6 +294,6 @@ async def test_migrate_entity_unique_id_collision(registry):
         'light', 'hue', '1234', config_entry_id='mock-id-1')
     with patch.object(registry, 'async_schedule_save') as mock_schedule_save, \
             pytest.raises(ValueError):
-        registry.async_migrate_entity_unique_id(
-            entry.unique_id, entry2.unique_id)
+        registry.async_update_entity(
+            entry.entity_id, new_unique_id=entry2.unique_id)
     assert mock_schedule_save.call_count == 0

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -280,7 +280,7 @@ async def test_migrate_entity_unique_id(registry):
     new_unique_id = '1234'
     with patch.object(registry, 'async_schedule_save') as mock_schedule_save:
         updated_entry = registry.async_migrate_entity_unique_id(
-            entry.entity_id, new_unique_id)
+            entry.unique_id, new_unique_id)
     assert updated_entry != entry
     assert updated_entry.unique_id == new_unique_id
     assert mock_schedule_save.call_count == 1
@@ -294,5 +294,6 @@ async def test_migrate_entity_unique_id_collision(registry):
         'light', 'hue', '1234', config_entry_id='mock-id-1')
     with patch.object(registry, 'async_schedule_save') as mock_schedule_save, \
             pytest.raises(ValueError):
-        registry.async_migrate_entity_unique_id(entry, entry2.unique_id)
+        registry.async_migrate_entity_unique_id(
+            entry.unique_id, entry2.unique_id)
     assert mock_schedule_save.call_count == 0


### PR DESCRIPTION
## Description:
Add core APIs to migrate device identifiers to a new set and entity unique_id to a new value.  This lays the foundation which will be utilized by HEOS as described in this alternate approach #23295 

**Related architectural issue:** fixes home-assistant/architecture#215

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.