### PR TITLE
Continuous discovery of Sonos speakers

### DIFF
--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -35,8 +35,10 @@ def soco_fixture(music_library, speaker_info, dummy_soco_service):
 @pytest.fixture(name="discover")
 def discover_fixture(soco):
     """Create a mock pysonos discover fixture."""
-    with patch('pysonos.discover') as mock:
-        mock.return_value = {soco}
+    def do_callback(callback, **kwargs):
+        callback(soco)
+
+    with patch('pysonos.discover_thread', side_effect=do_callback) as mock:
         yield mock
 
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -13,10 +13,14 @@ async def setup_platform(hass, config_entry, config):
 async def test_async_setup_entry_hosts(hass, config_entry, config, soco):
     """Test static setup."""
     await setup_platform(hass, config_entry, config)
-    assert hass.data[media_player.DATA_SONOS].entities[0].soco == soco
+
+    entity = hass.data[media_player.DATA_SONOS].entities[0]
+    assert entity.soco == soco
 
 
 async def test_async_setup_entry_discover(hass, config_entry, discover):
     """Test discovery setup."""
     await setup_platform(hass, config_entry, {})
-    assert hass.data[media_player.DATA_SONOS].uids == {'RINCON_test'}
+
+    entity = hass.data[media_player.DATA_SONOS].entities[0]
+    assert entity.unique_id == 'RINCON_test'


### PR DESCRIPTION
## Description:

This adds a periodic discovery of Sonos so powered on speakers can be found without restarting Home Assistant.

The timestamp of the last succesful discovery is used to calculate the `available` property.

We no longer allow adding "invisible" players (such as stereo slaves) because we cannot control them.

Finally, it turns out that we do not need to update `uids` because it is not used after #23385.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.