### PR TITLE
Only include agent user ID in SYNC responses

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -100,10 +100,13 @@ class CloudClient(Interface):
 
                 return google_conf['filter'](entity.entity_id)
 
+            username = self._hass.data[DOMAIN].claims["cognito:username"]
+
             self._google_config = ga_h.Config(
                 should_expose=should_expose,
                 secure_devices_pin=self._prefs.google_secure_devices_pin,
                 entity_config=google_conf.get(CONF_ENTITY_CONFIG),
+                agent_user_id=username,
             )
 
         # Set it to the latest.
@@ -149,18 +152,9 @@ class CloudClient(Interface):
         if not self._prefs.google_enabled:
             return ga.turned_off_response(payload)
 
-        answer = await ga.async_handle_message(
+        return await ga.async_handle_message(
             self._hass, self.google_config, self.prefs.cloud_user, payload
         )
-
-        # Fix AgentUserId
-        try:
-            cloud = self._hass.data[DOMAIN]
-            answer['payload']['agentUserId'] = cloud.claims['cognito:username']
-        except (TypeError, KeyError):
-            return ga.turned_off_response(payload)
-
-        return answer
 
     async def async_webhook_message(
             self, payload: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -20,11 +20,15 @@ class Config:
     """Hold the configuration for Google Assistant."""
 
     def __init__(self, should_expose,
-                 entity_config=None, secure_devices_pin=None):
+                 entity_config=None, secure_devices_pin=None,
+                 agent_user_id=None):
         """Initialize the configuration."""
         self.should_expose = should_expose
         self.entity_config = entity_config or {}
         self.secure_devices_pin = secure_devices_pin
+
+        # Agent User Id to use for query responses
+        self.agent_user_id = agent_user_id
 
 
 class RequestData:

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -99,7 +99,7 @@ async def async_devices_sync(hass, data, payload):
         devices.append(serialized)
 
     response = {
-        'agentUserId': data.context.user_id,
+        'agentUserId': data.config.agent_user_id or data.context.user_id,
         'devices': devices,
     }
 


### PR DESCRIPTION
## Description:
Cloud would set `agentUserId` on every response, while it's only necessary for SYNC responses. This fixes the issue.

**Related issue (if applicable):** #23412

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
