### PR TITLE
Allow the ability for an entity to bypass automatic temperature unit …

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -189,6 +189,16 @@ class Entity:
         """Time that a context is considered recent."""
         return timedelta(seconds=5)
 
+    @property
+    def convert_units(self) -> bool:
+        """
+        Convert units to/from metric/imperial.
+
+        This currently only works with temperatures.
+        See Entity._async_write_ha_state() for details.
+        """
+        return True
+
     # DO NOT OVERWRITE
     # These properties and methods are either managed by Home Assistant or they
     # are used to perform a very specific function. Overwriting these may
@@ -304,7 +314,8 @@ class Entity:
         try:
             unit_of_measure = attr.get(ATTR_UNIT_OF_MEASUREMENT)
             units = self.hass.config.units
-            if (unit_of_measure in (TEMP_CELSIUS, TEMP_FAHRENHEIT) and
+            if (self.convert_units and
+                    unit_of_measure in (TEMP_CELSIUS, TEMP_FAHRENHEIT) and
                     unit_of_measure != units.temperature_unit):
                 prec = len(state) - state.index('.') - 1 if '.' in state else 0
                 temp = units.temperature(float(state), unit_of_measure)

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -8,6 +8,9 @@ from unittest.mock import MagicMock, patch, PropertyMock
 import pytest
 
 import homeassistant.helpers.entity as entity
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS, TEMP_FAHRENHEIT
+)
 from homeassistant.core import Context
 from homeassistant.const import ATTR_HIDDEN, ATTR_DEVICE_CLASS
 from homeassistant.config import DATA_CUSTOMIZE
@@ -113,6 +116,46 @@ class TestHelpersEntity:
             self.hass.block_till_done()
         state = self.hass.states.get(self.entity.entity_id)
         assert state.attributes.get(ATTR_DEVICE_CLASS) == 'test_class'
+
+    def test_default_convert_units(self):
+        """Test default convert_units attribute set to True."""
+        assert self.entity.convert_units
+
+        self.hass.config.units.temperature_unit = TEMP_CELSIUS
+        with patch('homeassistant.helpers.entity.Entity.unit_of_measurement',
+                   new=TEMP_FAHRENHEIT), \
+             patch('homeassistant.helpers.entity.Entity.state', new=32), \
+             patch.object(self.hass.states, 'async_set') as async_set_mock:
+            self.entity.async_write_ha_state()
+            self.hass.block_till_done()
+            async_set_mock.assert_called_with(
+                self.entity.entity_id,
+                '0',
+                {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS},
+                False,
+                None
+            )
+
+    def test_overwrite_convert_units(self):
+        """Test overwritten convert_units attribute set to False."""
+        assert self.entity.convert_units
+
+        self.hass.config.units.temperature_unit = TEMP_CELSIUS
+        with patch('homeassistant.helpers.entity.Entity.unit_of_measurement',
+                   new=TEMP_FAHRENHEIT), \
+                patch('homeassistant.helpers.entity.Entity.state', new=32), \
+                patch('homeassistant.helpers.entity.Entity.convert_units',
+                      new=False), \
+                patch.object(self.hass.states, 'async_set') as async_set_mock:
+            self.entity.async_write_ha_state()
+            self.hass.block_till_done()
+            async_set_mock.assert_called_with(
+                self.entity.entity_id,
+                '32',
+                {ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT},
+                False,
+                None
+            )
 
 
 @asyncio.coroutine

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -124,8 +124,8 @@ class TestHelpersEntity:
         self.hass.config.units.temperature_unit = TEMP_CELSIUS
         with patch('homeassistant.helpers.entity.Entity.unit_of_measurement',
                    new=TEMP_FAHRENHEIT), \
-             patch('homeassistant.helpers.entity.Entity.state', new=32), \
-             patch.object(self.hass.states, 'async_set') as async_set_mock:
+                patch('homeassistant.helpers.entity.Entity.state', new=32), \
+                patch.object(self.hass.states, 'async_set') as async_set_mock:
             self.entity.async_write_ha_state()
             self.hass.block_till_done()
             async_set_mock.assert_called_with(


### PR DESCRIPTION
When setting up home assistant, the user chooses if they use metric or imperial units (metric is default). The Entity class uses this value to convert all temperature values to what is provided in the config. This is annoying for developers as there are times where alternative units could be useful. While the default is already set and removing it could cause breaking changes. I propose a @property to be added to the Entity object to override this automatic conversion behavior.

## Breaking Change:

None

## Description:
Adds override to prevent the Entity class from converting temperature units.

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
N/A

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
