### PR TITLE
Install requirements when checking config

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 import attr
 import voluptuous as vol
 
-from homeassistant import bootstrap, core, loader
+from homeassistant import bootstrap, core, loader, requirements
 from homeassistant.config import (
     get_default_config_dir, CONF_CORE, CORE_CONFIG_SCHEMA,
     CONF_PACKAGES, merge_packages_config, _format_config_error,
@@ -342,6 +342,13 @@ async def check_ha_config_file(hass):
             component = integration.get_component()
         except ImportError:
             result.add_error("Component not found: {}".format(domain))
+            continue
+
+        if (not hass.config.skip_pip and integration.requirements and
+            not await requirements.async_process_requirements(
+                hass, integration.domain, integration.requirements)):
+            result.add_error("Unable to install all requirements: {}".format(
+                ', '.join(integration.requirements)))
             continue
 
         if hasattr(component, 'CONFIG_SCHEMA'):

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -345,8 +345,8 @@ async def check_ha_config_file(hass):
             continue
 
         if (not hass.config.skip_pip and integration.requirements and
-            not await requirements.async_process_requirements(
-                hass, integration.domain, integration.requirements)):
+                not await requirements.async_process_requirements(
+                    hass, integration.domain, integration.requirements)):
             result.add_error("Unable to install all requirements: {}".format(
                 ', '.join(integration.requirements)))
             continue


### PR DESCRIPTION
## Description:
When we are checking config, we should install requirements because we are loading the Python files, and Python files are allowed to reference their requirements at the top of the file.

**Related issue (if applicable):** fixes #23488

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
