### PR TITLE
Hassfest: skip empty folder

### DIFF
--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -43,7 +43,19 @@ class Integration:
         assert path.is_dir()
         integrations = {}
         for fil in path.iterdir():
-            if fil.is_file() or fil.name == '__pycache__':
+            if (
+                    # Skip files
+                    fil.is_file() or
+                    # Skip Python cache dir
+                    fil.name == '__pycache__'
+            ):
+                continue
+
+            # Skip folders that are empty or just contain a cache dir
+            # These can be caused when integrations are removed from
+            # repo but locally contain a cache dir from when parsed.
+            if all(fil.name == '__pycache__' for fil in fil.iterdir()):
+                print("Warning: skipping empty dir {}".format(fil))
                 continue
 
             integration = cls(fil)


### PR DESCRIPTION
## Description:
Git is file based. And so if an integration is removed, the folder will remain on the developers machine because Python will have stored the bytecode cache in the folder `__pycache__`. This caused hassfest to fail validation.

With this PR, hassfest will treat empty folders or folders with just Python bytecode as a warning, not an error.
