### PR TITLE
Fixed bug with max_result of Google Calendar

### DIFF
--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -76,7 +76,7 @@ class GoogleCalendarData:
         params = dict(DEFAULT_GOOGLE_SEARCH_PARAMS)
         params['calendarId'] = self.calendar_id
         if self.max_results:
-            params['max_results'] = self.max_results
+            params['maxResults'] = self.max_results
         if self.search:
             params['q'] = self.search
 


### PR DESCRIPTION
## Description:
The config option 'max_results' was assigned to not existing 'max_results' variable, it should be assigned to 'maxResults'.
The current version causes an error `Got an unexpected keyword argument "max_results"`
when max_results parameter is used in `params['max_results']`

**Related issue (if applicable):** fixes #23504 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
