### PR TITLE
Catch RequestException in influxdb writer

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -321,7 +321,9 @@ class InfluxThread(threading.Thread):
 
                 _LOGGER.debug("Wrote %d events", len(json))
                 break
-            except (exceptions.InfluxDBClientError, IOError):
+            except (exceptions.InfluxDBClientError,
+                    requests.exceptions.RequestException,
+                    IOError):
                 if retry < self.max_tries:
                     time.sleep(RETRY_DELAY)
                 else:


### PR DESCRIPTION
## Description:

Handle the below error.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/homeassistant/components/influxdb/__init__.py", line 316, in write_to_influxdb
    self.influx.write_points(json)
  File "/usr/local/lib/python3.7/site-packages/influxdb/client.py", line 490, in write_points
    tags=tags, protocol=protocol)
  File "/usr/local/lib/python3.7/site-packages/influxdb/client.py", line 551, in _write_points
    protocol=protocol
  File "/usr/local/lib/python3.7/site-packages/influxdb/client.py", line 327, in write
    headers=headers
  File "/usr/local/lib/python3.7/site-packages/influxdb/client.py", line 267, in request
    timeout=self._timeout
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/requests/adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPConnectionPool(host='10.0.1.2', port=8086): Read timed out. (read timeout=5)
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
