### PR TITLE
Add Remote RPi Component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -481,6 +481,7 @@ omit =
     homeassistant/components/reddit/*
     homeassistant/components/rejseplanen/sensor.py
     homeassistant/components/remember_the_milk/__init__.py
+    homeassistant/components/remote_rpi_gpio/*
     homeassistant/components/rest/binary_sensor.py
     homeassistant/components/rest/notify.py
     homeassistant/components/rest/switch.py

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -1,10 +1,6 @@
 """Support for controlling GPIO pins of a Raspberry Pi."""
 import logging
 
-from homeassistant.core import HomeAssistant
-
-REQUIREMENTS = ['gpiozero==1.4.1']
-
 _LOGGER = logging.getLogger(__name__)
 
 CONF_BOUNCETIME = 'bouncetime'
@@ -18,7 +14,7 @@ DEFAULT_PULL_MODE = "UP"
 DOMAIN = 'remote_rpi_gpio'
 
 
-def setup(hass: HomeAssistant, config):
+def setup(hass, config):
     """Set up the Raspberry Pi Remote GPIO component."""
     return True
 

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -1,13 +1,13 @@
 """Support for controlling GPIO pins of a Raspberry Pi."""
 import logging
 
-import voluptuous as vol
+# import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_HOST, CONF_BINARY_SENSORS, CONF_SWITCHES)
+# from homeassistant.const import (
+#    CONF_HOST, CONF_BINARY_SENSORS, CONF_SWITCHES)
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import load_platform
+# import homeassistant.helpers.config_validation as cv
+# from homeassistant.helpers.discovery import load_platform
 
 REQUIREMENTS = ['gpiozero==1.4.1']
 
@@ -23,54 +23,54 @@ DEFAULT_PULL_MODE = "UP"
 
 DOMAIN = 'remote_rpi_gpio'
 
-_SENSORS_SCHEMA = vol.Schema({
-    cv.positive_int: cv.string,
-})
+# _SENSORS_SCHEMA = vol.Schema({
+#    cv.positive_int: cv.string,
+# })
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_BINARY_SENSORS, default={}): _SENSORS_SCHEMA,
-        vol.Optional(CONF_SWITCHES, default={}): _SENSORS_SCHEMA,
-        vol.Optional(CONF_BOUNCETIME,
-                     default=DEFAULT_BOUNCETIME): cv.positive_int,
-        vol.Optional(CONF_INVERT_LOGIC,
-                     default=DEFAULT_INVERT_LOGIC): cv.boolean,
-        vol.Optional(CONF_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
-    })]),
-}, extra=vol.ALLOW_EXTRA)
+# CONFIG_SCHEMA = vol.Schema({
+#    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
+#        vol.Required(CONF_HOST): cv.string,
+#        vol.Optional(CONF_BINARY_SENSORS, default={}): _SENSORS_SCHEMA,
+#        vol.Optional(CONF_SWITCHES, default={}): _SENSORS_SCHEMA,
+#        vol.Optional(CONF_BOUNCETIME,
+#                     default=DEFAULT_BOUNCETIME): cv.positive_int,
+#        vol.Optional(CONF_INVERT_LOGIC,
+#                     default=DEFAULT_INVERT_LOGIC): cv.boolean,
+#        vol.Optional(CONF_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
+#    })]),
+# }, extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass: HomeAssistant, config):
     """Set up the Raspberry Pi Remote GPIO component."""
-    if DOMAIN not in config:
+#    if DOMAIN not in config:
         # Skip setup if no configuration is present
-        return True
+#        return True
 
-    for remote_gpio in config[DOMAIN]:
-        address = remote_gpio[CONF_HOST]
-        pull_mode = remote_gpio[CONF_PULL_MODE]
-        bouncetime = remote_gpio[CONF_BOUNCETIME]
-        invert_logic = remote_gpio[CONF_INVERT_LOGIC]
+#    for remote_gpio in config[DOMAIN]:
+#        address = remote_gpio[CONF_HOST]
+#        pull_mode = remote_gpio[CONF_PULL_MODE]
+#        bouncetime = remote_gpio[CONF_BOUNCETIME]
+#        invert_logic = remote_gpio[CONF_INVERT_LOGIC]
 
-        b_sensors = remote_gpio[CONF_BINARY_SENSORS]
-        load_platform(hass,
-                      'binary_sensor',
-                      DOMAIN,
-                      {'address': address,
-                       'invert_logic': invert_logic,
-                       'pull_mode': pull_mode,
-                       'bouncetime': bouncetime,
-                       'binary_sensors': b_sensors},
-                      config)
+#        b_sensors = remote_gpio[CONF_BINARY_SENSORS]
+#        load_platform(hass,
+#                      'binary_sensor',
+#                      DOMAIN,
+#                      {'address': address,
+#                       'invert_logic': invert_logic,
+#                       'pull_mode': pull_mode,
+#                       'bouncetime': bouncetime,
+#                       'binary_sensors': b_sensors},
+#                      config)
 
-        switches = remote_gpio[CONF_SWITCHES]
-        load_platform(hass, 'switch',
-                      DOMAIN,
-                      {'address': address,
-                       'invert_logic': invert_logic,
-                       'switches': switches},
-                      config)
+#        switches = remote_gpio[CONF_SWITCHES]
+#        load_platform(hass, 'switch',
+#                      DOMAIN,
+#                      {'address': address,
+#                       'invert_logic': invert_logic,
+#                       'switches': switches},
+#                      config)
 
     return True
 

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -78,7 +78,7 @@ def setup(hass: HomeAssistant, config):
 def setup_output(address, port, invert_logic):
     """Set up a GPIO as output."""
     from gpiozero import LED
-    from gpiozero.pins.pigpio import PiGPIOFactory  # noqa: E501 pylint: disable=import-error
+    from gpiozero.pins.pigpio import PiGPIOFactory
 
     try:
         return LED(port, active_high=invert_logic,

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -1,13 +1,7 @@
 """Support for controlling GPIO pins of a Raspberry Pi."""
 import logging
 
-# import voluptuous as vol
-
-# from homeassistant.const import (
-#    CONF_HOST, CONF_BINARY_SENSORS, CONF_SWITCHES)
 from homeassistant.core import HomeAssistant
-# import homeassistant.helpers.config_validation as cv
-# from homeassistant.helpers.discovery import load_platform
 
 REQUIREMENTS = ['gpiozero==1.4.1']
 
@@ -23,55 +17,9 @@ DEFAULT_PULL_MODE = "UP"
 
 DOMAIN = 'remote_rpi_gpio'
 
-# _SENSORS_SCHEMA = vol.Schema({
-#    cv.positive_int: cv.string,
-# })
-
-# CONFIG_SCHEMA = vol.Schema({
-#    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
-#        vol.Required(CONF_HOST): cv.string,
-#        vol.Optional(CONF_BINARY_SENSORS, default={}): _SENSORS_SCHEMA,
-#        vol.Optional(CONF_SWITCHES, default={}): _SENSORS_SCHEMA,
-#        vol.Optional(CONF_BOUNCETIME,
-#                     default=DEFAULT_BOUNCETIME): cv.positive_int,
-#        vol.Optional(CONF_INVERT_LOGIC,
-#                     default=DEFAULT_INVERT_LOGIC): cv.boolean,
-#        vol.Optional(CONF_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
-#    })]),
-# }, extra=vol.ALLOW_EXTRA)
-
 
 def setup(hass: HomeAssistant, config):
     """Set up the Raspberry Pi Remote GPIO component."""
-#    if DOMAIN not in config:
-# Skip setup if no configuration is present
-#        return True
-
-#    for remote_gpio in config[DOMAIN]:
-#        address = remote_gpio[CONF_HOST]
-#        pull_mode = remote_gpio[CONF_PULL_MODE]
-#        bouncetime = remote_gpio[CONF_BOUNCETIME]
-#        invert_logic = remote_gpio[CONF_INVERT_LOGIC]
-
-#        b_sensors = remote_gpio[CONF_BINARY_SENSORS]
-#        load_platform(hass,
-#                      'binary_sensor',
-#                      DOMAIN,
-#                      {'address': address,
-#                       'invert_logic': invert_logic,
-#                       'pull_mode': pull_mode,
-#                       'bouncetime': bouncetime,
-#                       'binary_sensors': b_sensors},
-#                      config)
-
-#        switches = remote_gpio[CONF_SWITCHES]
-#        load_platform(hass, 'switch',
-#                      DOMAIN,
-#                      {'address': address,
-#                       'invert_logic': invert_logic,
-#                       'switches': switches},
-#                      config)
-
     return True
 
 

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 
-REQUIREMENTS = ['gpiozero==1.4.1', 'pigpio==1.42', 'RPi.GPIO==0.6.5']
+REQUIREMENTS = ['gpiozero==1.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,8 +43,6 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass: HomeAssistant, config):
     """Set up the Raspberry Pi Remote GPIO component."""
-    success = False
-
     if DOMAIN not in config:
         # Skip setup if no configuration is present
         return True
@@ -74,13 +72,12 @@ def setup(hass: HomeAssistant, config):
                        'switches': switches},
                       config)
 
-    success = True
-    return success
+    return True
 
 
 def setup_output(address, port, invert_logic):
     """Set up a GPIO as output."""
-    from gpiozero import LED  # pylint: disable=import-error
+    from gpiozero import LED
     from gpiozero.pins.pigpio import PiGPIOFactory  # noqa: E501 pylint: disable=import-error
 
     try:
@@ -97,7 +94,7 @@ def setup_input(address, port, pull_mode, bouncetime):
 
     if pull_mode == "UP":
         pull_gpio_up = True
-    if pull_mode == "DOWN":
+    elif pull_mode == "DOWN":
         pull_gpio_up = False
 
     try:

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -44,7 +44,7 @@ DOMAIN = 'remote_rpi_gpio'
 def setup(hass: HomeAssistant, config):
     """Set up the Raspberry Pi Remote GPIO component."""
 #    if DOMAIN not in config:
-        # Skip setup if no configuration is present
+# Skip setup if no configuration is present
 #        return True
 
 #    for remote_gpio in config[DOMAIN]:

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -1,0 +1,122 @@
+"""Support for controlling GPIO pins of a Raspberry Pi."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_HOST, CONF_BINARY_SENSORS, CONF_SWITCHES)
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import load_platform
+
+REQUIREMENTS = ['gpiozero==1.4.1', 'pigpio==1.42', 'RPi.GPIO==0.6.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_BOUNCETIME = 'bouncetime'
+CONF_INVERT_LOGIC = 'invert_logic'
+CONF_PULL_MODE = 'pull_mode'
+
+DEFAULT_BOUNCETIME = 50
+DEFAULT_INVERT_LOGIC = False
+DEFAULT_PULL_MODE = "UP"
+
+DOMAIN = 'remote_rpi_gpio'
+
+_SENSORS_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_BINARY_SENSORS, default={}): _SENSORS_SCHEMA,
+        vol.Optional(CONF_SWITCHES, default={}): _SENSORS_SCHEMA,
+        vol.Optional(CONF_BOUNCETIME,
+                     default=DEFAULT_BOUNCETIME): cv.positive_int,
+        vol.Optional(CONF_INVERT_LOGIC,
+                     default=DEFAULT_INVERT_LOGIC): cv.boolean,
+        vol.Optional(CONF_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
+    })]),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass: HomeAssistant, config):
+    """Set up the Raspberry Pi Remote GPIO component."""
+    success = False
+
+    if DOMAIN not in config:
+        # Skip setup if no configuration is present
+        return True
+
+    for remote_gpio in config[DOMAIN]:
+        address = remote_gpio[CONF_HOST]
+        pull_mode = remote_gpio[CONF_PULL_MODE]
+        bouncetime = remote_gpio[CONF_BOUNCETIME]
+        invert_logic = remote_gpio[CONF_INVERT_LOGIC]
+
+        b_sensors = remote_gpio[CONF_BINARY_SENSORS]
+        load_platform(hass,
+                      'binary_sensor',
+                      DOMAIN,
+                      {'address': address,
+                       'invert_logic': invert_logic,
+                       'pull_mode': pull_mode,
+                       'bouncetime': bouncetime,
+                       'binary_sensors': b_sensors},
+                      config)
+
+        switches = remote_gpio[CONF_SWITCHES]
+        load_platform(hass, 'switch',
+                      DOMAIN,
+                      {'address': address,
+                       'invert_logic': invert_logic,
+                       'switches': switches},
+                      config)
+
+    success = True
+    return success
+
+
+def setup_output(address, port, invert_logic):
+    """Set up a GPIO as output."""
+    from gpiozero import LED  # pylint: disable=import-error
+    from gpiozero.pins.pigpio import PiGPIOFactory  # noqa: E501 pylint: disable=import-error
+
+    try:
+        return LED(port, active_high=invert_logic,
+                   pin_factory=PiGPIOFactory(address))
+    except (ValueError, IndexError, KeyError):
+        return None
+
+
+def setup_input(address, port, pull_mode, bouncetime):
+    """Set up a GPIO as input."""
+    from gpiozero import Button
+    from gpiozero.pins.pigpio import PiGPIOFactory
+
+    if pull_mode == "UP":
+        pull_gpio_up = True
+    if pull_mode == "DOWN":
+        pull_gpio_up = False
+
+    try:
+        return Button(port,
+                      pull_up=pull_gpio_up,
+                      bounce_time=bouncetime,
+                      pin_factory=PiGPIOFactory(address))
+    except (ValueError, IndexError, KeyError, IOError):
+        return None
+
+
+def write_output(switch, value):
+    """Write a value to a GPIO."""
+    if value == 1:
+        switch.on()
+    if value == 0:
+        switch.off()
+
+
+def read_input(button):
+    """Read a value from a GPIO."""
+    return button.is_pressed

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -1,0 +1,83 @@
+"""Support for binary sensor using RPi GPIO."""
+import logging
+
+import requests
+
+from homeassistant.components import remote_rpi_gpio
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['remote_rpi_gpio']
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Raspberry PI GPIO devices."""
+    if discovery_info is None:
+        return
+
+    address = discovery_info['address']
+    pull_mode = discovery_info['pull_mode']
+    invert_logic = discovery_info['invert_logic']
+    bouncetime = discovery_info['bouncetime']/1000
+    ports = discovery_info['binary_sensors']
+
+    devices = []
+    for port_num, port_name in ports.items():
+        try:
+            button = remote_rpi_gpio.setup_input(address,
+                                                 port_num,
+                                                 pull_mode,
+                                                 bouncetime)
+        except (ValueError, IndexError, KeyError, IOError):
+            return None
+        new_sensor = RemoteRPiGPIOBinarySensor(port_name, button, invert_logic)
+        devices.append(new_sensor)
+    add_entities(devices, True)
+
+
+class RemoteRPiGPIOBinarySensor(BinarySensorDevice):
+    """Represent a binary sensor that uses a Remote Raspberry Pi GPIO."""
+
+    def __init__(self, name, button, invert_logic):
+        """Initialize the RPi binary sensor."""
+        self._name = name
+        self._invert_logic = invert_logic
+        self._state = False
+        self._button = button
+
+        def read_gpio():
+            """Read state from GPIO."""
+            self._state = remote_rpi_gpio.read_input(self._button)
+            self.schedule_update_ha_state()
+
+        self._button.when_released = read_gpio
+        self._button.when_pressed = read_gpio
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the state of the entity."""
+        return self._state != self._invert_logic
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor, from DEVICE_CLASSES."""
+        return None
+
+    def update(self):
+        """Update the GPIO state."""
+        try:
+            self._state = remote_rpi_gpio.read_input(self._button)
+        except requests.exceptions.ConnectionError:
+            return

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -56,6 +56,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             return None
         new_sensor = RemoteRPiGPIOBinarySensor(port_name, button, invert_logic)
         devices.append(new_sensor)
+
     add_entities(devices, True)
 
 
@@ -69,6 +70,8 @@ class RemoteRPiGPIOBinarySensor(BinarySensorDevice):
         self._state = False
         self._button = button
 
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
         def read_gpio():
             """Read state from GPIO."""
             self._state = remote_rpi_gpio.read_input(self._button)

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -17,8 +17,6 @@ from .. import remote_rpi_gpio
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['remote_rpi_gpio']
-
 CONF_PORTS = 'ports'
 
 _SENSORS_SCHEMA = vol.Schema({
@@ -53,7 +51,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                                                  pull_mode,
                                                  bouncetime)
         except (ValueError, IndexError, KeyError, IOError):
-            return None
+            return
         new_sensor = RemoteRPiGPIOBinarySensor(port_name, button, invert_logic)
         devices.append(new_sensor)
 
@@ -98,7 +96,7 @@ class RemoteRPiGPIOBinarySensor(BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of this sensor, from DEVICE_CLASSES."""
-        return None
+        return
 
     def update(self):
         """Update the GPIO state."""

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -5,7 +5,8 @@ import voluptuous as vol
 
 import requests
 
-from homeassistant.components import remote_rpi_gpio
+# from homeassistant.components import remote_rpi_gpio
+from .. import remote_rpi_gpio
 from homeassistant.const import CONF_HOST
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
@@ -39,18 +40,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Raspberry PI GPIO devices."""
-    if discovery_info is None:
-        address = config['host']
-        invert_logic = config[CONF_INVERT_LOGIC]
-        pull_mode = config[CONF_PULL_MODE]
-        ports = config['ports']
-        bouncetime = config[CONF_BOUNCETIME]/1000
-    else:
-        address = discovery_info['address']
-        pull_mode = discovery_info['pull_mode']
-        invert_logic = discovery_info['invert_logic']
-        bouncetime = discovery_info['bouncetime']/1000
-        ports = discovery_info['binary_sensors']
+#    if discovery_info is None:
+    address = config['host']
+    invert_logic = config[CONF_INVERT_LOGIC]
+    pull_mode = config[CONF_PULL_MODE]
+    ports = config['ports']
+    bouncetime = config[CONF_BOUNCETIME]/1000
+#    else:
+#        address = discovery_info['address']
+#        pull_mode = discovery_info['pull_mode']
+#        invert_logic = discovery_info['invert_logic']
+#        bouncetime = discovery_info['bouncetime']/1000
+#        ports = discovery_info['binary_sensors']
 
     devices = []
     for port_num, port_name in ports.items():

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -1,27 +1,56 @@
 """Support for binary sensor using RPi GPIO."""
 import logging
 
+import voluptuous as vol
+
 import requests
 
 from homeassistant.components import remote_rpi_gpio
+from homeassistant.const import CONF_HOST
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice)
+    BinarySensorDevice, PLATFORM_SCHEMA)
+
+import homeassistant.helpers.config_validation as cv
+
+from . import (CONF_BOUNCETIME, CONF_PULL_MODE, CONF_INVERT_LOGIC,
+               DEFAULT_BOUNCETIME, DEFAULT_INVERT_LOGIC, DEFAULT_PULL_MODE)
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['remote_rpi_gpio']
 
+CONF_PORTS = 'ports'
+
+_SENSORS_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORTS): _SENSORS_SCHEMA,
+    vol.Optional(CONF_INVERT_LOGIC,
+                 default=DEFAULT_INVERT_LOGIC): cv.boolean,
+    vol.Optional(CONF_BOUNCETIME,
+                 default=DEFAULT_BOUNCETIME): cv.positive_int,
+    vol.Optional(CONF_PULL_MODE,
+                 default=DEFAULT_PULL_MODE): cv.string,
+})
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Raspberry PI GPIO devices."""
     if discovery_info is None:
-        return
-
-    address = discovery_info['address']
-    pull_mode = discovery_info['pull_mode']
-    invert_logic = discovery_info['invert_logic']
-    bouncetime = discovery_info['bouncetime']/1000
-    ports = discovery_info['binary_sensors']
+        address = config['host']
+        invert_logic = config[CONF_INVERT_LOGIC]
+        pull_mode = config[CONF_PULL_MODE]
+        ports = config['ports']
+        bouncetime = config[CONF_BOUNCETIME]/1000
+    else:
+        address = discovery_info['address']
+        pull_mode = discovery_info['pull_mode']
+        invert_logic = discovery_info['invert_logic']
+        bouncetime = discovery_info['bouncetime']/1000
+        ports = discovery_info['binary_sensors']
 
     devices = []
     for port_num, port_name in ports.items():

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -5,8 +5,6 @@ import voluptuous as vol
 
 import requests
 
-# from homeassistant.components import remote_rpi_gpio
-from .. import remote_rpi_gpio
 from homeassistant.const import CONF_HOST
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
@@ -15,6 +13,7 @@ import homeassistant.helpers.config_validation as cv
 
 from . import (CONF_BOUNCETIME, CONF_PULL_MODE, CONF_INVERT_LOGIC,
                DEFAULT_BOUNCETIME, DEFAULT_INVERT_LOGIC, DEFAULT_PULL_MODE)
+from .. import remote_rpi_gpio
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,18 +39,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Raspberry PI GPIO devices."""
-#    if discovery_info is None:
     address = config['host']
     invert_logic = config[CONF_INVERT_LOGIC]
     pull_mode = config[CONF_PULL_MODE]
     ports = config['ports']
     bouncetime = config[CONF_BOUNCETIME]/1000
-#    else:
-#        address = discovery_info['address']
-#        pull_mode = discovery_info['pull_mode']
-#        invert_logic = discovery_info['invert_logic']
-#        bouncetime = discovery_info['bouncetime']/1000
-#        ports = discovery_info['binary_sensors']
 
     devices = []
     for port_num, port_name in ports.items():

--- a/homeassistant/components/remote_rpi_gpio/manifest.json
+++ b/homeassistant/components/remote_rpi_gpio/manifest.json
@@ -1,0 +1,12 @@
+{
+    "domain": "remote_rpi_gpio",
+    "name": "remote_rpi_gpio",
+    "documentation": "https://www.home-assistant.io/components/remote_rpi_gpio",
+    "requirements": [
+      "gpiozero==1.4.1",
+      "pigpio==1.42",
+      "RPi.GPIO==0.6.5"
+    ],
+    "dependencies": [],
+    "codeowners": []
+}

--- a/homeassistant/components/remote_rpi_gpio/manifest.json
+++ b/homeassistant/components/remote_rpi_gpio/manifest.json
@@ -3,9 +3,7 @@
     "name": "remote_rpi_gpio",
     "documentation": "https://www.home-assistant.io/components/remote_rpi_gpio",
     "requirements": [
-      "gpiozero==1.4.1",
-      "pigpio==1.42",
-      "RPi.GPIO==0.6.5"
+      "gpiozero==1.4.1"
     ],
     "dependencies": [],
     "codeowners": []

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -1,23 +1,44 @@
 """Allows to configure a switch using RPi GPIO."""
 import logging
 
+import voluptuous as vol
+
 from homeassistant.components import remote_rpi_gpio
-from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.const import DEVICE_DEFAULT_NAME, CONF_HOST
+
+import homeassistant.helpers.config_validation as cv
+
+from . import CONF_INVERT_LOGIC, DEFAULT_INVERT_LOGIC
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['remote_rpi_gpio']
 
+CONF_PORTS = 'ports'
+
+_SENSORS_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORTS): _SENSORS_SCHEMA,
+    vol.Optional(CONF_INVERT_LOGIC,
+                 default=DEFAULT_INVERT_LOGIC): cv.boolean
+})
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Remote Raspberry PI GPIO devices."""
     if discovery_info is None:
-        return
-
-    address = discovery_info['address']
-    invert_logic = discovery_info['invert_logic']
-    ports = discovery_info['switches']
+        address = config[CONF_HOST]
+        invert_logic = config[CONF_INVERT_LOGIC]
+        ports = config[CONF_PORTS]
+    else:
+        address = discovery_info['address']
+        invert_logic = discovery_info['invert_logic']
+        ports = discovery_info['switches']
 
     devices = []
     for port, name in ports.items():

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import remote_rpi_gpio
+from .. import remote_rpi_gpio
 from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
 from homeassistant.const import DEVICE_DEFAULT_NAME, CONF_HOST
 
@@ -31,14 +31,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Remote Raspberry PI GPIO devices."""
-    if discovery_info is None:
-        address = config[CONF_HOST]
-        invert_logic = config[CONF_INVERT_LOGIC]
-        ports = config[CONF_PORTS]
-    else:
-        address = discovery_info['address']
-        invert_logic = discovery_info['invert_logic']
-        ports = discovery_info['switches']
+#    if discovery_info is None:
+    address = config[CONF_HOST]
+    invert_logic = config[CONF_INVERT_LOGIC]
+    ports = config[CONF_PORTS]
+#    else:
+#        address = discovery_info['address']
+#        invert_logic = discovery_info['invert_logic']
+#        ports = discovery_info['switches']
 
     devices = []
     for port, name in ports.items():

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -3,13 +3,13 @@ import logging
 
 import voluptuous as vol
 
-from .. import remote_rpi_gpio
 from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
 from homeassistant.const import DEVICE_DEFAULT_NAME, CONF_HOST
 
 import homeassistant.helpers.config_validation as cv
 
 from . import CONF_INVERT_LOGIC, DEFAULT_INVERT_LOGIC
+from .. import remote_rpi_gpio
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,14 +31,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Remote Raspberry PI GPIO devices."""
-#    if discovery_info is None:
     address = config[CONF_HOST]
     invert_logic = config[CONF_INVERT_LOGIC]
     ports = config[CONF_PORTS]
-#    else:
-#        address = discovery_info['address']
-#        invert_logic = discovery_info['invert_logic']
-#        ports = discovery_info['switches']
 
     devices = []
     for port, name in ports.items():

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -38,13 +38,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     devices = []
     for port, name in ports.items():
         try:
-            led = remote_rpi_gpio.setup_output(address,
-                                               port,
-                                               invert_logic)
+            led = remote_rpi_gpio.setup_output(
+                address, port, invert_logic)
         except (ValueError, IndexError, KeyError, IOError):
             return None
         new_switch = RemoteRPiGPIOSwitch(name, led, invert_logic)
         devices.append(new_switch)
+
     add_entities(devices)
 
 
@@ -67,6 +67,11 @@ class RemoteRPiGPIOSwitch(SwitchDevice):
     def should_poll(self):
         """No polling needed."""
         return False
+
+    @property
+    def assumed_state(self):
+        """If unable to access real state of the entity."""
+        return True
 
     @property
     def is_on(self):

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -1,0 +1,72 @@
+"""Allows to configure a switch using RPi GPIO."""
+import logging
+
+from homeassistant.components import remote_rpi_gpio
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.const import DEVICE_DEFAULT_NAME
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['remote_rpi_gpio']
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Remote Raspberry PI GPIO devices."""
+    if discovery_info is None:
+        return
+
+    address = discovery_info['address']
+    invert_logic = discovery_info['invert_logic']
+    ports = discovery_info['switches']
+
+    devices = []
+    for port, name in ports.items():
+        try:
+            led = remote_rpi_gpio.setup_output(address,
+                                               port,
+                                               invert_logic)
+        except (ValueError, IndexError, KeyError, IOError):
+            return None
+        new_switch = RemoteRPiGPIOSwitch(name, led, invert_logic)
+        devices.append(new_switch)
+    add_entities(devices)
+
+
+class RemoteRPiGPIOSwitch(SwitchDevice):
+    """Representation of a Remtoe Raspberry Pi GPIO."""
+
+    def __init__(self, name, led, invert_logic):
+        """Initialize the pin."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._state = False
+        self._invert_logic = invert_logic
+        self._switch = led
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        remote_rpi_gpio.write_output(self._switch,
+                                     0 if self._invert_logic else 1)
+        self._state = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        remote_rpi_gpio.write_output(self._switch,
+                                     1 if self._invert_logic else 0)
+        self._state = False
+        self.schedule_update_ha_state()

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -13,8 +13,6 @@ from .. import remote_rpi_gpio
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['remote_rpi_gpio']
-
 CONF_PORTS = 'ports'
 
 _SENSORS_SCHEMA = vol.Schema({
@@ -41,7 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             led = remote_rpi_gpio.setup_output(
                 address, port, invert_logic)
         except (ValueError, IndexError, KeyError, IOError):
-            return None
+            return
         new_switch = RemoteRPiGPIOSwitch(name, led, invert_logic)
         devices.append(new_switch)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -72,7 +72,6 @@ PyTransportNSW==0.1.1
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.12.3
 
-# homeassistant.components.remote_rpi_gpio
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.5
 
@@ -836,9 +835,6 @@ pifacedigitalio==3.0.5
 
 # homeassistant.components.piglow
 piglow==1.2.4
-
-# homeassistant.components.remote_rpi_gpio
-pigpio==1.42
 
 # homeassistant.components.pilight
 pilight==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -72,6 +72,7 @@ PyTransportNSW==0.1.1
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.12.3
 
+# homeassistant.components.remote_rpi_gpio
 # homeassistant.components.rpi_gpio
 # RPi.GPIO==0.6.5
 
@@ -499,6 +500,9 @@ googledevices==1.0.2
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1
 
+# homeassistant.components.remote_rpi_gpio
+gpiozero==1.4.1
+
 # homeassistant.components.gpsd
 gps3==0.33.3
 
@@ -832,6 +836,9 @@ pifacedigitalio==3.0.5
 
 # homeassistant.components.piglow
 piglow==1.2.4
+
+# homeassistant.components.remote_rpi_gpio
+pigpio==1.42
 
 # homeassistant.components.pilight
 pilight==0.1.1


### PR DESCRIPTION
## Description:

Adding support for Remote RPi GPIO pins.  Configuration is same as local binary_sensor and switch with the addition of address of remote pi.  Remote GPIO must be enabled on remote rPI, pigpio must be installed and pigpiod must be running.  Currently only the default port (8888) is supported.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8662

## Example entry for `configuration.yaml` (if applicable):
```yaml
   binary_sensor:
     - platform: remote_rpi_gpio
       address: <address of remote pi>
       ports:
         #: name

   switch:
     - platform: remote_rpi_gpio
       address: <address of remote pi>
       ports:
         #: name
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
