### PR TITLE
Update PR template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
             <<# parameters.all >>pip install -q --progress-bar off -r requirements_all.txt -c homeassistant/package_constraints.txt<</ parameters.all>>
             <<# parameters.test >>pip install -q --progress-bar off -r requirements_test.txt -c homeassistant/package_constraints.txt<</ parameters.test>>
             <<# parameters.test_all >>pip install -q --progress-bar off -r requirements_test_all.txt -c homeassistant/package_constraints.txt<</ parameters.test_all>>
-          no_output_timeout: 15m  
+          no_output_timeout: 15m
       - save_cache:
           paths:
             - ./venv
@@ -90,7 +90,7 @@ jobs:
           name: run static check
           command: |
             . venv/bin/activate
-            flake8
+            flake8 homeassistant tests script
 
       - run:
           name: run static type check

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,19 +18,18 @@
   - [ ] The code change is tested and works locally.
   - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
   - [ ] There is no commented out code in this PR.
+  - [ ] I have followed the [development checklist][dev-checklist]
 
 If user exposed functionality or configuration variables are added/changed:
   - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
 
 If the code communicates with devices, web services, or third-party tools:
-  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]). Update and include derived files by running `python3 -m script.hassfest`.
+  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
   - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
-  - [ ] Python dependencies are only imported inside functions that use them ([example][ex-import]).
   - [ ] Untested files have been added to `.coveragerc`.
 
 If the code does not interact with devices:
   - [ ] Tests have been added to verify that the new code works.
 
-[ex-manifest]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
-[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L16
-[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
+[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
+[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 **Related issue (if applicable):** fixes #<home-assistant issue number goes here>
 
-**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
+**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
 
 ## Example entry for `configuration.yaml` (if applicable):
 ```yaml
@@ -23,14 +23,14 @@ If user exposed functionality or configuration variables are added/changed:
   - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
 
 If the code communicates with devices, web services, or third-party tools:
-  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
-  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
-  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
-  - [ ] New files were added to `.coveragerc`.
+  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]). Update and include derived files by running `python3 -m script.hassfest`.
+  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
+  - [ ] Python dependencies are only imported inside functions that use them ([example][ex-import]).
+  - [ ] Untested files have been added to `.coveragerc`.
 
 If the code does not interact with devices:
   - [ ] Tests have been added to verify that the new code works.
 
-[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
-[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
+[ex-manifest]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
+[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L16
 [manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
 commands =
     python -m script.gen_requirements_all validate
     python -m script.hassfest validate
-    flake8 {posargs}
+    flake8 {posargs: homeassistant tests script}
     pydocstyle {posargs:homeassistant tests}
 
 [testenv:typing]

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
      -r{toxinidir}/requirements_test.txt
 commands =
     python -m script.gen_requirements_all validate
+    python -m script.hassfest validate
     flake8 {posargs}
     pydocstyle {posargs:homeassistant tests}
 


### PR DESCRIPTION
## Description:
Update the PR template:
 - ~Reinstate the requirement to import dependencies  (revert #23471)~
 - Link to the manifest docs that include examples, instead of example fiels
 - Mention to run hassfest to update code
 - Add hassfest to tox lint action.
 - Scope tox.ini and circle CI to only run flake8 on `homeassistant tests script`, so config folder is skipped.

