### PR TITLE
Revert #23330 & #23339 Reorg Homematic IP Cloud imports

### DIFF
--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -1,10 +1,6 @@
 """Support for HomematicIP Cloud alarm control panel."""
 import logging
 
-from homematicip.aio.group import AsyncSecurityZoneGroup
-from homematicip.aio.home import AsyncHome
-from homematicip.base.enums import WindowState
-
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -25,7 +21,9 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                             async_add_entities) -> None:
-    """Set up the HomematicIP alrm control panel from a config entry."""
+    """Set up the HomematicIP alarm control panel from a config entry."""
+    from homematicip.aio.group import AsyncSecurityZoneGroup
+
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for group in home.groups:
@@ -39,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 class HomematicipSecurityZone(HomematicipGenericDevice, AlarmControlPanel):
     """Representation of an HomematicIP Cloud security zone group."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the security zone group."""
         device.modelType = 'Group-SecurityZone'
         device.windowState = None
@@ -48,6 +46,8 @@ class HomematicipSecurityZone(HomematicipGenericDevice, AlarmControlPanel):
     @property
     def state(self) -> str:
         """Return the state of the device."""
+        from homematicip.base.enums import WindowState
+
         if self._device.active:
             if (self._device.sabotage or self._device.motionDetected or
                     self._device.windowState == WindowState.OPEN or

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -1,9 +1,6 @@
 """Support for HomematicIP Cloud climate devices."""
 import logging
 
-from homematicip.aio.group import AsyncHeatingGroup
-from homematicip.aio.home import AsyncHome
-
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     STATE_AUTO, STATE_MANUAL, SUPPORT_TARGET_TEMPERATURE)
@@ -32,6 +29,8 @@ async def async_setup_platform(
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                             async_add_entities) -> None:
     """Set up the HomematicIP climate from a config entry."""
+    from homematicip.aio.group import AsyncHeatingGroup
+
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.groups:
@@ -45,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
     """Representation of a HomematicIP heating group."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize heating group."""
         device.modelType = 'Group-Heating'
         super().__init__(home, device)

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -2,8 +2,6 @@
 import logging
 from typing import Optional
 
-from homematicip.aio.device import AsyncFullFlushShutter
-
 from homeassistant.components.cover import ATTR_POSITION, CoverDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -25,6 +23,8 @@ async def async_setup_platform(
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                             async_add_entities) -> None:
     """Set up the HomematicIP cover from a config entry."""
+    from homematicip.aio.device import AsyncFullFlushShutter
+
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -2,9 +2,6 @@
 import logging
 from typing import Optional
 
-from homematicip.aio.device import AsyncDevice
-from homematicip.aio.home import AsyncHome
-
 from homeassistant.components import homematicip_cloud
 from homeassistant.helpers.entity import Entity
 
@@ -23,7 +20,7 @@ ATTR_GROUP_MEMBER_UNREACHABLE = 'group_member_unreachable'
 class HomematicipGenericDevice(Entity):
     """Representation of an HomematicIP generic device."""
 
-    def __init__(self, home: AsyncHome, device,
+    def __init__(self, home, device,
                  post: Optional[str] = None) -> None:
         """Initialize the generic device."""
         self._home = home
@@ -34,6 +31,7 @@ class HomematicipGenericDevice(Entity):
     @property
     def device_info(self):
         """Return device specific attributes."""
+        from homematicip.aio.device import AsyncDevice
         # Only physical devices should be HA devices.
         if isinstance(self._device, AsyncDevice):
             return {

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -2,10 +2,6 @@
 import asyncio
 import logging
 
-from homematicip.aio.auth import AsyncAuth
-from homematicip.aio.home import AsyncHome
-from homematicip.base.base_connection import HmipConnectionError
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -41,6 +37,8 @@ class HomematicipAuth:
 
     async def async_checkbutton(self):
         """Check blue butten has been pressed."""
+        from homematicip.base.base_connection import HmipConnectionError
+
         try:
             return await self.auth.isRequestAcknowledged()
         except HmipConnectionError:
@@ -48,6 +46,8 @@ class HomematicipAuth:
 
     async def async_register(self):
         """Register client at HomematicIP."""
+        from homematicip.base.base_connection import HmipConnectionError
+
         try:
             authtoken = await self.auth.requestAuthToken()
             await self.auth.confirmAuthToken(authtoken)
@@ -57,6 +57,9 @@ class HomematicipAuth:
 
     async def get_auth(self, hass, hapid, pin):
         """Create a HomematicIP access point object."""
+        from homematicip.aio.auth import AsyncAuth
+        from homematicip.base.base_connection import HmipConnectionError
+
         auth = AsyncAuth(hass.loop, async_get_clientsession(hass))
         try:
             await auth.init(hapid)
@@ -136,6 +139,8 @@ class HomematicipHAP:
 
     def get_state_finished(self, future):
         """Execute when get_state coroutine has finished."""
+        from homematicip.base.base_connection import HmipConnectionError
+
         try:
             future.result()
         except HmipConnectionError:
@@ -158,6 +163,8 @@ class HomematicipHAP:
 
     async def async_connect(self):
         """Start WebSocket connection."""
+        from homematicip.base.base_connection import HmipConnectionError
+
         tries = 0
         while True:
             retry_delay = 2 ** min(tries, 8)
@@ -198,8 +205,11 @@ class HomematicipHAP:
         return True
 
     async def get_hap(self, hass: HomeAssistant, hapid: str, authtoken: str,
-                      name: str) -> AsyncHome:
+                      name: str):
         """Create a HomematicIP access point object."""
+        from homematicip.aio.home import AsyncHome
+        from homematicip.base.base_connection import HmipConnectionError
+
         home = AsyncHome(hass.loop, async_get_clientsession(hass))
 
         home.name = name

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -1,18 +1,6 @@
 """Support for HomematicIP Cloud sensors."""
 import logging
 
-from homematicip.aio.device import (
-    AsyncBrandSwitchMeasuring, AsyncFullFlushSwitchMeasuring,
-    AsyncHeatingThermostat, AsyncHeatingThermostatCompact, AsyncLightSensor,
-    AsyncMotionDetectorIndoor, AsyncMotionDetectorOutdoor,
-    AsyncMotionDetectorPushButton, AsyncPlugableSwitchMeasuring,
-    AsyncTemperatureHumiditySensorDisplay,
-    AsyncTemperatureHumiditySensorOutdoor,
-    AsyncTemperatureHumiditySensorWithoutDisplay, AsyncWeatherSensor,
-    AsyncWeatherSensorPlus, AsyncWeatherSensorPro)
-from homematicip.aio.home import AsyncHome
-from homematicip.base.enums import ValveState
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE, DEVICE_CLASS_POWER,
@@ -37,6 +25,16 @@ async def async_setup_platform(
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                             async_add_entities) -> None:
     """Set up the HomematicIP Cloud sensors from a config entry."""
+    from homematicip.aio.device import (
+        AsyncHeatingThermostat, AsyncHeatingThermostatCompact,
+        AsyncTemperatureHumiditySensorWithoutDisplay,
+        AsyncTemperatureHumiditySensorDisplay, AsyncMotionDetectorIndoor,
+        AsyncMotionDetectorOutdoor, AsyncTemperatureHumiditySensorOutdoor,
+        AsyncMotionDetectorPushButton, AsyncLightSensor,
+        AsyncPlugableSwitchMeasuring, AsyncBrandSwitchMeasuring,
+        AsyncFullFlushSwitchMeasuring, AsyncWeatherSensor,
+        AsyncWeatherSensorPlus, AsyncWeatherSensorPro)
+
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = [HomematicipAccesspointStatus(home)]
     for device in home.devices:
@@ -78,7 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 class HomematicipAccesspointStatus(HomematicipGenericDevice):
     """Representation of an HomeMaticIP Cloud access point."""
 
-    def __init__(self, home: AsyncHome) -> None:
+    def __init__(self, home) -> None:
         """Initialize access point device."""
         super().__init__(home, home)
 
@@ -117,13 +115,15 @@ class HomematicipAccesspointStatus(HomematicipGenericDevice):
 class HomematicipHeatingThermostat(HomematicipGenericDevice):
     """Represenation of a HomematicIP heating thermostat device."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize heating thermostat device."""
         super().__init__(home, device, 'Heating')
 
     @property
     def icon(self) -> str:
         """Return the icon."""
+        from homematicip.base.enums import ValveState
+
         if super().icon:
             return super().icon
         if self._device.valveState != ValveState.ADAPTION_DONE:
@@ -133,6 +133,8 @@ class HomematicipHeatingThermostat(HomematicipGenericDevice):
     @property
     def state(self) -> int:
         """Return the state of the radiator valve."""
+        from homematicip.base.enums import ValveState
+
         if self._device.valveState != ValveState.ADAPTION_DONE:
             return self._device.valveState
         return round(self._device.valvePosition*100)
@@ -146,7 +148,7 @@ class HomematicipHeatingThermostat(HomematicipGenericDevice):
 class HomematicipHumiditySensor(HomematicipGenericDevice):
     """Represenation of a HomematicIP Cloud humidity device."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the thermometer device."""
         super().__init__(home, device, 'Humidity')
 
@@ -169,7 +171,7 @@ class HomematicipHumiditySensor(HomematicipGenericDevice):
 class HomematicipTemperatureSensor(HomematicipGenericDevice):
     """Representation of a HomematicIP Cloud thermometer device."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the thermometer device."""
         super().__init__(home, device, 'Temperature')
 
@@ -204,7 +206,7 @@ class HomematicipTemperatureSensor(HomematicipGenericDevice):
 class HomematicipIlluminanceSensor(HomematicipGenericDevice):
     """Represenation of a HomematicIP Illuminance device."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the  device."""
         super().__init__(home, device, 'Illuminance')
 
@@ -230,7 +232,7 @@ class HomematicipIlluminanceSensor(HomematicipGenericDevice):
 class HomematicipPowerSensor(HomematicipGenericDevice):
     """Represenation of a HomematicIP power measuring device."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the  device."""
         super().__init__(home, device, 'Power')
 
@@ -253,7 +255,7 @@ class HomematicipPowerSensor(HomematicipGenericDevice):
 class HomematicipWindspeedSensor(HomematicipGenericDevice):
     """Represenation of a HomematicIP wind speed sensor."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the  device."""
         super().__init__(home, device, 'Windspeed')
 
@@ -285,7 +287,7 @@ class HomematicipWindspeedSensor(HomematicipGenericDevice):
 class HomematicipTodayRainSensor(HomematicipGenericDevice):
     """Represenation of a HomematicIP rain counter of a day sensor."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the  device."""
         super().__init__(home, device, 'Today Rain')
 

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -1,13 +1,6 @@
 """Support for HomematicIP Cloud switches."""
 import logging
 
-from homematicip.aio.device import (
-    AsyncBrandSwitchMeasuring, AsyncFullFlushSwitchMeasuring, AsyncMultiIOBox,
-    AsyncOpenCollector8Module, AsyncPlugableSwitch,
-    AsyncPlugableSwitchMeasuring)
-from homematicip.aio.group import AsyncSwitchingGroup
-from homematicip.aio.home import AsyncHome
-
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -27,6 +20,17 @@ async def async_setup_platform(
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                             async_add_entities) -> None:
     """Set up the HomematicIP switch from a config entry."""
+    from homematicip.aio.device import (
+        AsyncPlugableSwitch,
+        AsyncPlugableSwitchMeasuring,
+        AsyncBrandSwitchMeasuring,
+        AsyncFullFlushSwitchMeasuring,
+        AsyncOpenCollector8Module,
+        AsyncMultiIOBox,
+    )
+
+    from homematicip.aio.group import AsyncSwitchingGroup
+
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:
@@ -59,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 class HomematicipSwitch(HomematicipGenericDevice, SwitchDevice):
     """representation of a HomematicIP Cloud switch device."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the switch device."""
         super().__init__(home, device)
 
@@ -80,7 +84,7 @@ class HomematicipSwitch(HomematicipGenericDevice, SwitchDevice):
 class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
     """representation of a HomematicIP switching group."""
 
-    def __init__(self, home: AsyncHome, device, post: str = 'Group') -> None:
+    def __init__(self, home, device, post: str = 'Group') -> None:
         """Initialize switching group."""
         device.modelType = 'HmIP-{}'.format(post)
         super().__init__(home, device, post)
@@ -135,7 +139,7 @@ class HomematicipSwitchMeasuring(HomematicipSwitch):
 class HomematicipMultiSwitch(HomematicipGenericDevice, SwitchDevice):
     """Representation of a HomematicIP Cloud multi switch device."""
 
-    def __init__(self, home: AsyncHome, device, channel: int):
+    def __init__(self, home, device, channel: int):
         """Initialize the multi switch device."""
         self.channel = channel
         super().__init__(home, device, 'Channel{}'.format(channel))

--- a/homeassistant/components/homematicip_cloud/weather.py
+++ b/homeassistant/components/homematicip_cloud/weather.py
@@ -2,10 +2,6 @@
 """Support for HomematicIP Cloud weather devices."""
 import logging
 
-from homematicip.aio.device import (
-    AsyncWeatherSensor, AsyncWeatherSensorPlus, AsyncWeatherSensorPro)
-from homematicip.aio.home import AsyncHome
-
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
@@ -25,6 +21,10 @@ async def async_setup_platform(
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                             async_add_entities) -> None:
     """Set up the HomematicIP weather sensor from a config entry."""
+    from homematicip.aio.device import (
+        AsyncWeatherSensor, AsyncWeatherSensorPlus, AsyncWeatherSensorPro,
+    )
+
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:
@@ -40,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 class HomematicipWeatherSensor(HomematicipGenericDevice, WeatherEntity):
     """representation of a HomematicIP Cloud weather sensor plus & basic."""
 
-    def __init__(self, home: AsyncHome, device) -> None:
+    def __init__(self, home, device) -> None:
         """Initialize the weather sensor."""
         super().__init__(home, device)
 


### PR DESCRIPTION
## Description:
With relation to #23519 this reverts the PRs #23330 & #23339.

It seems to be necessary again **not to have dependency imports at the top of a file**.
**Please only merge/revert if really necessary for 0.93.0.**
This code is not in 0.92.x. releases


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
