### PR TITLE
Do not log tracebacks for influxdb write errors

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -321,14 +321,12 @@ class InfluxThread(threading.Thread):
 
                 _LOGGER.debug("Wrote %d events", len(json))
                 break
-            except (exceptions.InfluxDBClientError,
-                    requests.exceptions.RequestException,
-                    IOError):
+            except (exceptions.InfluxDBClientError, IOError):
                 if retry < self.max_tries:
                     time.sleep(RETRY_DELAY)
                 else:
                     if not self.write_errors:
-                        _LOGGER.exception("Write error")
+                        _LOGGER.error("Write error")
                     self.write_errors += len(json)
 
     def run(self):

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -321,12 +321,12 @@ class InfluxThread(threading.Thread):
 
                 _LOGGER.debug("Wrote %d events", len(json))
                 break
-            except (exceptions.InfluxDBClientError, IOError):
+            except (exceptions.InfluxDBClientError, IOError) as err:
                 if retry < self.max_tries:
                     time.sleep(RETRY_DELAY)
                 else:
                     if not self.write_errors:
-                        _LOGGER.error("Write error")
+                        _LOGGER.error("Write error: %s", err)
                     self.write_errors += len(json)
 
     def run(self):


### PR DESCRIPTION
## Description:

This reverts #23508. The problem is not that we do not catch `RequestException`, we do because it is an `IOError`. Rather, the problem is that the traceback is logged due to leftover debug code in #12882.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
