### PR TITLE
Upgrade discord.py to v1.0.1

### DIFF
--- a/homeassistant/components/discord/manifest.json
+++ b/homeassistant/components/discord/manifest.json
@@ -3,7 +3,7 @@
   "name": "Discord",
   "documentation": "https://www.home-assistant.io/components/discord",
   "requirements": [
-    "discord.py==0.16.12"
+    "discord.py==1.0.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -39,30 +39,53 @@ class DiscordNotificationService(BaseNotificationService):
 
         discord.VoiceClient.warn_nacl = False
         discord_bot = discord.Client(loop=self.hass.loop)
+        images = None
 
         if ATTR_TARGET not in kwargs:
             _LOGGER.error("No target specified")
             return None
+
+        if ATTR_DATA in kwargs:
+            data = kwargs.get(ATTR_DATA)
+
+            if ATTR_IMAGES in data:
+                import os.path
+                images = list()
+
+                for image in data.get(ATTR_IMAGES):
+                    if os.path.isfile(image):
+                        images.append(image)
+                    else:
+                        _LOGGER.warning("Image not found: %s", image)
 
         # pylint: disable=unused-variable
         @discord_bot.event
         async def on_ready():
             """Send the messages when the bot is ready."""
             try:
-                data = kwargs.get(ATTR_DATA)
-                images = None
-                if data:
-                    images = data.get(ATTR_IMAGES)
                 for channelid in kwargs[ATTR_TARGET]:
-                    channel = discord.Object(id=channelid)
-                    await discord_bot.send_message(channel, message)
+                    channelid = int(channelid)
+                    channel = discord_bot.get_channel(channelid)
+
+                    if channel is None:
+                        _LOGGER.warning(
+                            "Channel not found for id: %s",
+                            channelid)
+                        continue
+
+                    # Must create new instances of File for each channel.
+                    files = None
                     if images:
-                        for anum, f_name in enumerate(images):
-                            await discord_bot.send_file(channel, f_name)
+                        files = list()
+                        for image in images:
+                            files.append(discord.File(image))
+
+                    await channel.send(message, files=files)
             except (discord.errors.HTTPException,
                     discord.errors.NotFound) as error:
                 _LOGGER.warning("Communication error: %s", error)
             await discord_bot.logout()
             await discord_bot.close()
 
-        await discord_bot.start(self.token)
+        # Using reconnect=False prevents multiple ready events to be fired.
+        await discord_bot.start(self.token, reconnect=False)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -341,7 +341,7 @@ directpy==0.5
 discogs_client==2.2.1
 
 # homeassistant.components.discord
-discord.py==0.16.12
+discord.py==1.0.1
 
 # homeassistant.components.updater
 distro==1.4.0


### PR DESCRIPTION
## Description:
Upgrade discord.py to v1.0.1 to have Discord notify component working again

**Related issue:** fixes #21374

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
