### PR TITLE
Upgrade zeroconf to 0.22.0

### DIFF
--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zeroconf",
   "documentation": "https://www.home-assistant.io/components/zeroconf",
   "requirements": [
-    "zeroconf==0.21.3"
+    "zeroconf==0.22.0"
   ],
   "dependencies": [
     "api"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1836,7 +1836,7 @@ youtube_dl==2019.04.24
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.21.3
+zeroconf==0.22.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.8


### PR DESCRIPTION
## Breaking Change:

Technically backwards incompatible from their changelog (on [pypi.org](https://pypi.org/project/zeroconf/)):

Adjusted query intervals to match RFC 6762
Made default TTL-s match RFC 6762

## Description:

Upgrade zeroconf to version 0.22.0. Their Github repository: https://github.com/jstasiak/python-zeroconf

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

___

I will appreciate any test with Bonjour.