### PR TITLE
Add support for MAIN_REPEATER phantom scenes

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -17,6 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 LUTRON_BUTTONS = 'lutron_buttons'
 LUTRON_CONTROLLER = 'lutron_controller'
 LUTRON_DEVICES = 'lutron_devices'
+BUTTON_UNKNOWN = "Unknown Button"
+BUTTON_TYPE = ('SingleAction', 'Toggle')
 
 # Attribute on events that indicates what action was taken with the button.
 ATTR_ACTION = 'action'
@@ -65,13 +67,13 @@ def setup(hass, base_config):
                 # which buttons actually control scenes.
                 for led in keypad.leds:
                     if (led.number == button.number and
-                            button.name != 'Unknown Button' and
-                            button.button_type in ('SingleAction', 'Toggle')):
+                            button.name != BUTTON_UNKNOWN and
+                            button.button_type in BUTTON_TYPE):
                         hass.data[LUTRON_DEVICES]['scene'].append(
                             (area.name, keypad.name, button, led))
                 # catch for main_repeater scenes
-                if (button.name != 'Unknown Button' and
-                        button.button_type in ('SingleAction', 'Toggle') and
+                if (button.name != BUTTON_UNKNOWN and
+                        button.button_type in BUTTON_TYPE and
                         keypad.name == 'Enclosure Device 001'):
                     hass.data[LUTRON_DEVICES]['scene'].append(
                         (area.name, keypad.name, button, None))

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -69,6 +69,12 @@ def setup(hass, base_config):
                             button.button_type in ('SingleAction', 'Toggle')):
                         hass.data[LUTRON_DEVICES]['scene'].append(
                             (area.name, keypad.name, button, led))
+                # catch for main_repeater scenes
+                if (button.name != 'Unknown Button' and
+                        button.button_type in ('SingleAction', 'Toggle') and
+                        keypad.name == 'Enclosure Device 001'):
+                    hass.data[LUTRON_DEVICES]['scene'].append(
+                        (area.name, keypad.name, button, None))
 
                 hass.data[LUTRON_BUTTONS].append(
                     LutronButton(hass, keypad, button))


### PR DESCRIPTION
## Description:
PyLutron was enhanced to support RadioRa2 MAIN_REPEATER phantom scenes. After this enhancement, the lutron HASS component needed to be extended to support this.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
