### PR TITLE
Add and improve Homekit controller pairing messages and errors

### DIFF
--- a/homeassistant/components/homekit_controller/.translations/en.json
+++ b/homeassistant/components/homekit_controller/.translations/en.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "abort": {
+            "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
             "already_configured": "Accessory is already configured with this controller.",
             "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
             "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
@@ -9,15 +10,20 @@
         },
         "error": {
             "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
+            "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
+            "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
+            "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
+            "pairing_failed": "An unhandled error occured while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently.",
             "unable_to_pair": "Unable to pair, please try again.",
             "unknown_error": "Device reported an unknown error. Pairing failed."
         },
+        "flow_title": "HomeKit Accessory: {name}",
         "step": {
             "pair": {
                 "data": {
                     "pairing_code": "Pairing Code"
                 },
-                "description": "Enter your HomeKit pairing code to use this accessory",
+                "description": "Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory",
                 "title": "Pair with HomeKit Accessory"
             },
             "user": {

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -249,7 +249,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
                 return self.async_abort(reason='already_paired')
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception(
-                    "Pairing attempt failed with an unhandled exception."
+                    "Pairing attempt failed with an unhandled exception"
                 )
                 errors['pairing_code'] = 'pairing_failed'
 

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -237,8 +237,21 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
                 errors['pairing_code'] = 'authentication_error'
             except homekit.UnknownError:
                 errors['pairing_code'] = 'unknown_error'
+            except homekit.MaxTriesError:
+                errors['pairing_code'] = 'max_tries_error'
+            except homekit.BusyError:
+                errors['pairing_code'] = 'busy_error'
+            except homekit.MaxPeersError:
+                errors['pairing_code'] = 'max_peers_error'
+            except homekit.AccessoryNotFoundError:
+                return self.async_abort(reason='accessory_not_found_error')
             except homekit.UnavailableError:
                 return self.async_abort(reason='already_paired')
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(
+                    "Pairing attempt failed with an unhandled exception."
+                )
+                errors['pairing_code'] = 'pairing_failed'
 
         return self.async_show_form(
             step_id='pair',

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -12,7 +12,7 @@
             },
             "pair": {
                 "title": "Pair with HomeKit Accessory",
-                "description": "Enter your HomeKit pairing code to use this accessory",
+                "description": "Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory",
                 "data": {
                     "pairing_code": "Pairing Code"
                 }

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -21,14 +21,19 @@
         "error": {
             "unable_to_pair": "Unable to pair, please try again.",
             "unknown_error": "Device reported an unknown error. Pairing failed.",
-            "authentication_error": "Incorrect HomeKit code. Please check it and try again."
+            "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
+            "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
+            "busy_error": "Device refused to add pairing as it is already pairing with another controller.",
+            "max_tries_error": "Device refused to add pairing as it has received more than 100 unsuccessful authentication attempts.",
+            "pairing_failed": "An unhandled error occured while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently."
         },
         "abort": {
             "no_devices": "No unpaired devices could be found",
             "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
             "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
             "already_configured": "Accessory is already configured with this controller.",
-            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed."
+            "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed.",
+            "accessory_not_found_error": "Cannot add pairing as device can no longer be found."
         }
     }
 }


### PR DESCRIPTION
## Description:

This captures a few more errors that homekit_controller can raise and maps them to translatable strings. It also clarifies one existing string (people never know if they are supposed to enter the dashes in the pairing code).

This won't be active if merged just yet as the final config flow enablement isn't merged, but it will give translators more time to do their thing, which is why i'm eager to get it in there.

I captured an `Exception` because i want the user to get a suitable message in the UI, but I still log the exception. I think that's reasonable but I did have to do a pylint override.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.