### PR TITLE
Limit concurrent updates for ZHA light and sensor

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -24,6 +24,7 @@ CAPABILITIES_COLOR_TEMP = 0x10
 
 UNSUPPORTED_ATTRIBUTE = 0x86
 SCAN_INTERVAL = timedelta(minutes=60)
+PARALLEL_UPDATES = 5
 
 
 async def async_setup_platform(hass, config, async_add_entities,

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -14,6 +14,7 @@ from .core.const import (
     SIGNAL_ATTR_UPDATED, SIGNAL_STATE_ATTR)
 from .entity import ZhaEntity
 
+PARALLEL_UPDATES = 5
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Description:
This PR sets PARALLEL_UPDATES to 5 for lights and sensors to avoid flooding the zigbee network with update requests when the network contains large amounts of light bulbs or electrical measurement sensors. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#23512

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
