### PR TITLE
Fix problem with using Traccar events

### DIFF
--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -192,7 +192,7 @@ class TraccarScanner:
         if events is not None:
             for event in events:
                 device_name = next((
-                    dev.get('name') for dev in self._api.devices()
+                    dev.get('name') for dev in self._api.devices
                     if dev.get('id') == event['deviceId']), None)
                 self._hass.bus.async_fire(
                     'traccar_' + self._event_types.get(event["type"]), {


### PR DESCRIPTION
## Description:
When using Traccar events, I received an error message with the current code. This fix makes it possible to use the event config variable again, I have already tested it locally.
![](https://cdn.discordapp.com/attachments/510950993383391233/572211743946833941/unknown.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
