### PR TITLE
Switch the Brottsplatskartan component to polling

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -71,6 +71,8 @@ omit =
     homeassistant/components/braviatv/media_player.py
     homeassistant/components/broadlink/sensor.py
     homeassistant/components/broadlink/switch.py
+    homeassistant/components/brottsplatskartan/__init__.py
+    homeassistant/components/brottsplatskartan/const.py
     homeassistant/components/brottsplatskartan/sensor.py
     homeassistant/components/browser/*
     homeassistant/components/brunt/cover.py

--- a/homeassistant/components/brottsplatskartan/__init__.py
+++ b/homeassistant/components/brottsplatskartan/__init__.py
@@ -80,6 +80,8 @@ def setup(hass, config):
     def hub_refresh(event_time):
         """Call Brottsplatskartan API to refresh information."""
         incidents = bpk.get_incidents()
+        if not incidents:
+            return False
         for incident_area in incidents:
             slugify_incident_area = slugify(incident_area)
             incident_area_update_signal = "{}_{}".format(

--- a/homeassistant/components/brottsplatskartan/__init__.py
+++ b/homeassistant/components/brottsplatskartan/__init__.py
@@ -1,1 +1,89 @@
-"""The brottsplatskartan component."""
+"""Component for Brottsplatskartan information."""
+import uuid
+
+import voluptuous as vol
+
+from homeassistant.const import (ATTR_ATTRIBUTION, CONF_LATITUDE,
+                                 CONF_LONGITUDE, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import (_LOGGER, ATTR_INCIDENTS, CONF_AREA, CONF_SENSOR,
+                    DEFAULT_NAME, DEFAULT_SCAN_INTERVAL, DOMAIN,
+                    SIGNAL_UPDATE_BPK)
+
+AREAS = [
+    "Blekinge län", "Dalarnas län", "Gotlands län", "Gävleborgs län",
+    "Hallands län", "Jämtlands län", "Jönköpings län", "Kalmar län",
+    "Kronobergs län", "Norrbottens län", "Skåne län", "Stockholms län",
+    "Södermanlands län", "Uppsala län", "Värmlands län", "Västerbottens län",
+    "Västernorrlands län", "Västmanlands län", "Västra Götalands län",
+    "Örebro län", "Östergötlands län"
+]
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN:
+        vol.Schema({
+            vol.Inclusive(CONF_LATITUDE, 'coordinates'):
+            cv.latitude,
+            vol.Inclusive(CONF_LONGITUDE, 'coordinates'):
+            cv.longitude,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME):
+            cv.string,
+            vol.Optional(CONF_AREA, default=[]):
+            vol.All(cv.ensure_list, [vol.In(AREAS)]),
+            vol.Optional(CONF_SENSOR):
+            cv.boolean,
+        })
+    },
+    extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Set up the Brottsplatskartan platform."""
+    if DOMAIN not in config:
+        return True
+
+    conf = config[DOMAIN]
+
+    area = conf.get(CONF_AREA)
+    latitude = conf.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = conf.get(CONF_LONGITUDE, hass.config.longitude)
+    name = conf.get(CONF_NAME)
+
+    # Every Home Assistant instance should have their own unique
+    # app parameter: https://brottsplatskartan.se/sida/api
+    app = 'ha-{}'.format(uuid.getnode())
+
+    import brottsplatskartan
+
+    hass.data[DOMAIN] = {}
+    bpk = brottsplatskartan.BrottsplatsKartan(app=app,
+                                              area=area,
+                                              latitude=latitude,
+                                              longitude=longitude)
+    incidents = bpk.get_incidents()
+
+    hass.data[DOMAIN][CONF_NAME] = name
+    hass.data[DOMAIN][ATTR_ATTRIBUTION] = brottsplatskartan.ATTRIBUTION
+    hass.data[DOMAIN][ATTR_INCIDENTS] = []
+    hass.data[DOMAIN][ATTR_INCIDENTS] = incidents
+
+    def hub_refresh(event_time):
+        """Call Brottsplatskartan API to refresh information."""
+        incidents = bpk.get_incidents()
+        if len(incidents) != len(hass.data[DOMAIN][ATTR_INCIDENTS]):
+            _LOGGER.debug("Updating Brottsplatskartan data")
+            hass.data[DOMAIN][ATTR_INCIDENTS].clear()
+            hass.data[DOMAIN][ATTR_INCIDENTS].extend(incidents)
+            async_dispatcher_send(hass, SIGNAL_UPDATE_BPK)
+
+    if conf.get(CONF_SENSOR):
+        hass.helpers.discovery.load_platform(CONF_SENSOR, DOMAIN, {}, config)
+
+    # Call the Brottsplatskartan API to refresh updates.
+    async_track_time_interval(hass, hub_refresh, DEFAULT_SCAN_INTERVAL)
+
+    return True

--- a/homeassistant/components/brottsplatskartan/__init__.py
+++ b/homeassistant/components/brottsplatskartan/__init__.py
@@ -7,8 +7,8 @@ from homeassistant.const import (ATTR_ATTRIBUTION, CONF_LATITUDE,
                                  CONF_LONGITUDE, CONF_MONITORED_CONDITIONS,
                                  CONF_NAME)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import track_time_interval
 from homeassistant.util import slugify
 
 from .const import (_LOGGER, ATTR_INCIDENTS, CONF_AREAS, CONF_SENSOR,
@@ -48,7 +48,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA)
 
 
-async def async_setup(hass, config):
+def setup(hass, config):
     """Set up the Brottsplatskartan platform."""
     if DOMAIN not in config:
         return True
@@ -91,7 +91,7 @@ async def async_setup(hass, config):
                 hass.data[DOMAIN][ATTR_INCIDENTS][incident_area].clear()
                 hass.data[DOMAIN][ATTR_INCIDENTS][incident_area].extend(
                     incidents[incident_area])
-                async_dispatcher_send(hass, incident_area_update_signal)
+                dispatcher_send(hass, incident_area_update_signal)
 
     monitored_conditions = conf.get(CONF_SENSOR).get(CONF_MONITORED_CONDITIONS)
     sensor_config = {
@@ -104,6 +104,6 @@ async def async_setup(hass, config):
                                              sensor_config, config)
 
     # Call the Brottsplatskartan API to refresh updates.
-    async_track_time_interval(hass, hub_refresh, DEFAULT_SCAN_INTERVAL)
+    track_time_interval(hass, hub_refresh, DEFAULT_SCAN_INTERVAL)
 
     return True

--- a/homeassistant/components/brottsplatskartan/const.py
+++ b/homeassistant/components/brottsplatskartan/const.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+"""Constants used by Brottsplatskartan components."""
+from datetime import timedelta
+import logging
+
+_LOGGER = logging.getLogger('.')
+
+ATTR_INCIDENTS = 'incidents'
+ATTR_TITLE_TYPE = 'title_type'
+
+CONF_AREA = 'area'
+CONF_SENSOR = 'sensor'
+
+DEFAULT_NAME = 'Brottsplatskartan'
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
+
+DOMAIN = 'brottsplatskartan'
+
+SIGNAL_UPDATE_BPK = 'brottsplatskartan_update'

--- a/homeassistant/components/brottsplatskartan/const.py
+++ b/homeassistant/components/brottsplatskartan/const.py
@@ -8,12 +8,14 @@ _LOGGER = logging.getLogger('.')
 ATTR_INCIDENTS = 'incidents'
 ATTR_TITLE_TYPE = 'title_type'
 
-CONF_AREA = 'area'
+CONF_AREAS = 'areas'
 CONF_SENSOR = 'sensor'
 
 DEFAULT_NAME = 'Brottsplatskartan'
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
 
 DOMAIN = 'brottsplatskartan'
+
+SENSOR_TYPES = ['counter']
 
 SIGNAL_UPDATE_BPK = 'brottsplatskartan_update'

--- a/homeassistant/components/brottsplatskartan/manifest.json
+++ b/homeassistant/components/brottsplatskartan/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brottsplatskartan",
   "documentation": "https://www.home-assistant.io/components/brottsplatskartan",
   "requirements": [
-    "brottsplatskartan==1.0.3"
+    "brottsplatskartan==1.0.5"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/brottsplatskartan/manifest.json
+++ b/homeassistant/components/brottsplatskartan/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brottsplatskartan",
   "documentation": "https://www.home-assistant.io/components/brottsplatskartan",
   "requirements": [
-    "brottsplatskartan==0.0.1"
+    "brottsplatskartan==1.0.2"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/brottsplatskartan/manifest.json
+++ b/homeassistant/components/brottsplatskartan/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brottsplatskartan",
   "documentation": "https://www.home-assistant.io/components/brottsplatskartan",
   "requirements": [
-    "brottsplatskartan==1.0.2"
+    "brottsplatskartan==1.0.3"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/brottsplatskartan/sensor.py
+++ b/homeassistant/components/brottsplatskartan/sensor.py
@@ -13,7 +13,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Brottsplatskartan platform."""
     monitored_conditions = discovery_info['monitored_conditions']
     attribution = hass.data[DOMAIN][ATTR_ATTRIBUTION]
-    bpk = hass.data[DOMAIN]
     name = hass.data[DOMAIN][CONF_NAME]
     incidents = hass.data[DOMAIN][ATTR_INCIDENTS]
 
@@ -28,9 +27,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             incident_area_update_signal = "{}_{}".format(
                 SIGNAL_UPDATE_BPK, slugify_incident_area)
             sensors.append(
-                BrottsplatskartanSensor(attribution, bpk,
-                                        incidents[incident_area], name,
-                                        condition,
+                BrottsplatskartanSensor(attribution, incidents[incident_area],
+                                        name, condition,
                                         incident_area_update_signal))
     add_entities(sensors, True)
 
@@ -38,12 +36,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class BrottsplatskartanSensor(Entity):
     """Representation of a Brottsplatskartan Sensor."""
 
-    def __init__(self, attribution, bpk, incidents, name, sensor,
-                 update_signal):
+    def __init__(self, attribution, incidents, name, sensor, update_signal):
         """Initialize the Brottsplatskartan sensor."""
         self._attribution = attribution
         self._attributes = {}
-        self._brottsplatskartan = bpk
         self._incidents = incidents
         self._name = name
         self._state = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -264,7 +264,7 @@ braviarc-homeassistant==0.3.7.dev0
 broadlink==0.9.0
 
 # homeassistant.components.brottsplatskartan
-brottsplatskartan==1.0.2
+brottsplatskartan==1.0.3
 
 # homeassistant.components.brunt
 brunt==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -264,7 +264,7 @@ braviarc-homeassistant==0.3.7.dev0
 broadlink==0.9.0
 
 # homeassistant.components.brottsplatskartan
-brottsplatskartan==1.0.3
+brottsplatskartan==1.0.5
 
 # homeassistant.components.brunt
 brunt==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -264,7 +264,7 @@ braviarc-homeassistant==0.3.7.dev0
 broadlink==0.9.0
 
 # homeassistant.components.brottsplatskartan
-brottsplatskartan==0.0.1
+brottsplatskartan==1.0.2
 
 # homeassistant.components.brunt
 brunt==0.1.3


### PR DESCRIPTION
* Let the component handle the API polling and when there is new data, let the
  sensor platform know by sending a signal.
* Put all constants in its own file.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

The configuration for this component/platform has changed.

## Description:

We want to let the component part of brottsplatskartan to do the polling to the API and let all (today there is only one platform) the platforms update its data from cache when they receive a signal to do so.

When we create more platforms for this component, they can all use the data from the component.

There are breaking changes because the configuration has changed. Because I didn't want to make two releases with breaking changes, I added the "areas" configuration change with this PR also.

## Example entry for `configuration.yaml` (if applicable):
```yaml
brottsplatskartan:
  areas:
    - Stockholms län
    - Hallands län
  sensor:
    monitored_conditions:
      - counter
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
