### PR TITLE
Fix issue for ps4 where new entity_id is used when ps4 is offline at startup

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -280,7 +280,7 @@ class PS4Device(MediaPlayerDevice):
                     self._unique_id = entry.unique_id
                     self.entity_id = entity_id
                     break
-            for device_id, device in d_registry.devices.items():
+            for device in d_registry.devices.values():
                 if self._entry_id in device.config_entries:
                     self._info = {
                         'name': device.name,
@@ -289,6 +289,7 @@ class PS4Device(MediaPlayerDevice):
                         'manufacturer': device.manufacturer,
                         'sw_version': device.sw_version
                     }
+                    break
 
         else:
             _sw_version = status['system-version']

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -289,7 +289,6 @@ class PS4Device(MediaPlayerDevice):
                         'manufacturer': device.manufacturer,
                         'sw_version': device.sw_version
                     }
-                    _LOGGER.warning(self.entity_id)
 
         else:
             _sw_version = status['system-version']


### PR DESCRIPTION
## Description:
Entity gets unique_id/identifier from polling device. If PS4 is offline, ie. (fully powered down, no internet connection) at HA Startup then the identifier never gets set and a new entity_id is generated instead.

**Related issue (if applicable):** fixes #22931

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
