### PR TITLE
Update Sesame component to use Candy House's library using the V3 API

### DIFF
--- a/homeassistant/components/sesame/lock.py
+++ b/homeassistant/components/sesame/lock.py
@@ -62,7 +62,7 @@ class SesameDevice(LockDevice):
     @property
     def state(self) -> str:
         """Get the state of the device."""
-        return self._is_locked and STATE_LOCKED or STATE_UNLOCKED
+        return STATE_LOCKED if self._is_locked else STATE_UNLOCKED
 
     def lock(self, **kwargs) -> None:
         """Lock the device."""

--- a/homeassistant/components/sesame/lock.py
+++ b/homeassistant/components/sesame/lock.py
@@ -5,15 +5,14 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.lock import LockDevice, PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, CONF_EMAIL, CONF_PASSWORD,
+    ATTR_ID, ATTR_BATTERY_LEVEL, CONF_API_KEY,
     STATE_LOCKED, STATE_UNLOCKED)
 from homeassistant.helpers.typing import ConfigType
 
-ATTR_DEVICE_ID = 'device_id'
+ATTR_SERIAL_NO = 'serial'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_EMAIL): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string
+    vol.Required(CONF_API_KEY): cv.string
 })
 
 
@@ -21,13 +20,12 @@ def setup_platform(
         hass, config: ConfigType,
         add_entities: Callable[[list], None], discovery_info=None):
     """Set up the Sesame platform."""
-    import pysesame
+    import pysesame2
 
-    email = config.get(CONF_EMAIL)
-    password = config.get(CONF_PASSWORD)
+    api_key = config.get(CONF_API_KEY)
 
     add_entities([SesameDevice(sesame) for sesame in
-                  pysesame.get_sesames(email, password)],
+                  pysesame2.get_sesames(api_key)],
                  update_before_add=True)
 
 
@@ -40,9 +38,10 @@ class SesameDevice(LockDevice):
 
         # Cached properties from pysesame object.
         self._device_id = None
+        self._serial = None
         self._nickname = None
-        self._is_unlocked = False
-        self._api_enabled = False
+        self._is_locked = False
+        self._responsive = False
         self._battery = -1
 
     @property
@@ -53,19 +52,17 @@ class SesameDevice(LockDevice):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._api_enabled
+        return self._responsive
 
     @property
     def is_locked(self) -> bool:
         """Return True if the device is currently locked, else False."""
-        return not self._is_unlocked
+        return self._is_locked
 
     @property
     def state(self) -> str:
         """Get the state of the device."""
-        if self._is_unlocked:
-            return STATE_UNLOCKED
-        return STATE_LOCKED
+        return self._is_locked and STATE_LOCKED or STATE_UNLOCKED
 
     def lock(self, **kwargs) -> None:
         """Lock the device."""
@@ -77,17 +74,19 @@ class SesameDevice(LockDevice):
 
     def update(self) -> None:
         """Update the internal state of the device."""
-        self._sesame.update_state()
+        status = self._sesame.get_status()
         self._nickname = self._sesame.nickname
-        self._api_enabled = self._sesame.api_enabled
-        self._is_unlocked = self._sesame.is_unlocked
-        self._device_id = self._sesame.device_id
-        self._battery = self._sesame.battery
+        self._device_id = str(self._sesame.id)
+        self._serial = self._sesame.serial
+        self._battery = status['battery']
+        self._is_locked = status['locked']
+        self._responsive = status['responsive']
 
     @property
     def device_state_attributes(self) -> dict:
         """Return the state attributes."""
         attributes = {}
-        attributes[ATTR_DEVICE_ID] = self._device_id
+        attributes[ATTR_ID] = self._device_id
+        attributes[ATTR_SERIAL_NO] = self._serial
         attributes[ATTR_BATTERY_LEVEL] = self._battery
         return attributes

--- a/homeassistant/components/sesame/manifest.json
+++ b/homeassistant/components/sesame/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sesame",
   "documentation": "https://www.home-assistant.io/components/sesame",
   "requirements": [
-    "pysesame==0.1.0"
+    "pysesame2==1.0.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/sesame/manifest.json
+++ b/homeassistant/components/sesame/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "sesame",
-  "name": "Sesame",
+  "name": "Sesame Smart Lock",
   "documentation": "https://www.home-assistant.io/components/sesame",
   "requirements": [
     "pysesame2==1.0.1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1270,7 +1270,7 @@ pyserial-asyncio==0.4
 pyserial==3.1.1
 
 # homeassistant.components.sesame
-pysesame==0.1.0
+pysesame2==1.0.1
 
 # homeassistant.components.goalfeed
 pysher==1.0.1


### PR DESCRIPTION
## Breaking Change:

The Sesame smart lock's 1.0 API uses a username/password pair to authenticate, and may be deprecated in the future. The V3 API uses an API key, so it will require users to update their HA config.

## Description:

**Related issue (if applicable):** fixes #19003

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9355

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: sesame
    api_key: !secret sesame_api_key
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
