### PR TITLE
Redesign AlarmControlPanel for Homematic IP

### DIFF
--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -16,6 +16,8 @@ from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 
 _LOGGER = logging.getLogger(__name__)
 
+CONST_ALARM_CONTROL_PANEL_NAME = 'HmIP Alarm Control Panel'
+
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -28,9 +30,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
     """Set up the HomematicIP alrm control panel from a config entry."""
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
+    security_zones = []
     for group in home.groups:
         if isinstance(group, AsyncSecurityZoneGroup):
+            security_zones.append(group)
+            # to be removed in later release.
             devices.append(HomematicipSecurityZone(home, group))
+
+    if security_zones:
+        devices.append(HomematicipAlarmControlPanel(home, security_zones))
 
     if devices:
         async_add_entities(devices)
@@ -44,6 +52,10 @@ class HomematicipSecurityZone(HomematicipGenericDevice, AlarmControlPanel):
         device.modelType = 'Group-SecurityZone'
         device.windowState = None
         super().__init__(home, device)
+        _LOGGER.error("Homematic IP: %s %s is deprecated. Please switch to "
+                      "alarm_control_panel.hmip_alarm_control_panel.",
+                      self.name,
+                      self._device.modelType)
 
     @property
     def state(self) -> str:
@@ -73,3 +85,103 @@ class HomematicipSecurityZone(HomematicipGenericDevice, AlarmControlPanel):
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
         await self._home.set_security_zones_activation(True, True)
+
+
+class HomematicipAlarmControlPanel(AlarmControlPanel):
+    """Representation of an alarm control panel."""
+
+    def __init__(self, home: AsyncHome, security_zones) -> None:
+        """Initialize the alarm control panel."""
+        self._home = home
+        self.alarm_state = STATE_ALARM_DISARMED
+
+        for security_zone in security_zones:
+            if security_zone.label == 'INTERNAL':
+                self._internal_alarm_zone = security_zone
+            else:
+                self._external_alarm_zone = security_zone
+
+    @property
+    def state(self) -> str:
+        """Return the state of the device."""
+        activation_state = self._home.get_security_zones_activation()
+        # check arm_away
+        if activation_state == (True, True):
+            if self._internal_alarm_zone_state or \
+                    self._external_alarm_zone_state:
+                return STATE_ALARM_TRIGGERED
+            return STATE_ALARM_ARMED_AWAY
+        # check arm_home
+        if activation_state == (False, True):
+            if self._external_alarm_zone_state:
+                return STATE_ALARM_TRIGGERED
+            return STATE_ALARM_ARMED_HOME
+
+        return STATE_ALARM_DISARMED
+
+    @property
+    def _internal_alarm_zone_state(self) -> bool:
+        return _get_zone_alarm_state(self._internal_alarm_zone)
+
+    @property
+    def _external_alarm_zone_state(self) -> bool:
+        """Return the state of the device."""
+        return _get_zone_alarm_state(self._external_alarm_zone)
+
+    async def async_alarm_disarm(self, code=None):
+        """Send disarm command."""
+        await self._home.set_security_zones_activation(False, False)
+
+    async def async_alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        await self._home.set_security_zones_activation(False, True)
+
+    async def async_alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        await self._home.set_security_zones_activation(True, True)
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self._internal_alarm_zone.on_update(self._device_changed)
+        self._external_alarm_zone.on_update(self._device_changed)
+
+    def _device_changed(self, *args, **kwargs):
+        """Handle device state changes."""
+        _LOGGER.debug("Event %s (%s)", self.name, CONST_ALARM_CONTROL_PANEL_NAME)
+        self.async_schedule_update_ha_state()
+
+    @property
+    def name(self) -> str:
+        """Return the name of the generic device."""
+        name = CONST_ALARM_CONTROL_PANEL_NAME
+        if self._home.name is not None and self._home.name != '':
+            name = "{} {}".format(self._home.name, name)
+        return name
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """Device available."""
+        return not self._internal_alarm_zone.unreach or \
+            not self._external_alarm_zone.unreach
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return "{}_{}".format(self.__class__.__name__, self._home.id)
+
+
+def _get_zone_alarm_state(security_zone) -> bool:
+    if security_zone.active:
+        if (security_zone.sabotage or
+                security_zone.motionDetected or
+                security_zone.presenceDetected or
+                security_zone.windowState == WindowState.OPEN or
+                security_zone.windowState == WindowState.TILTED):
+            return True
+
+    return False

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -147,7 +147,8 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
 
     def _device_changed(self, *args, **kwargs):
         """Handle device state changes."""
-        _LOGGER.debug("Event %s (%s)", self.name, CONST_ALARM_CONTROL_PANEL_NAME)
+        _LOGGER.debug("Event %s (%s)", self.name,
+                      CONST_ALARM_CONTROL_PANEL_NAME)
         self.async_schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -51,9 +51,9 @@ class HomematicipGenericDevice(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._device.on_update(self._device_changed)
+        self._device.on_update(self._async_device_changed)
 
-    def _device_changed(self, *args, **kwargs):
+    def _async_device_changed(self, *args, **kwargs):
         """Handle device state changes."""
         _LOGGER.debug("Event %s (%s)", self.name, self._device.modelType)
         self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:
Current implementation is quiet confusing for users, because it consists of to AlarmControlpanels, that represent the INTERNAL and EXTERNAL zones delivered by Homematic IP API, and both are able to control the state of Alarm.

This new new implementation unifies EXTERNAL and INTERNAL Zone to create a single AlarmControlPanel in the sense of HASS.
The old AlarmControlpanels still exists, but will have a deprecation message in the log when starting HASS.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_