### PR TITLE
Add bypass and automatic bypass switch for Danfoss Air

### DIFF
--- a/homeassistant/components/danfoss_air/__init__.py
+++ b/homeassistant/components/danfoss_air/__init__.py
@@ -85,5 +85,9 @@ class DanfossAir:
             = self._client.command(ReadCommand.boost)
         self._data[ReadCommand.battery_percent] \
             = self._client.command(ReadCommand.battery_percent)
+        self._data[ReadCommand.bypass] \
+            = self._client.command(ReadCommand.bypass)
+        self._data[ReadCommand.automatic_bypass] \
+            = self._client.command(ReadCommand.automatic_bypass)
 
         _LOGGER.debug("Done fetching data from Danfoss Air CCM module")

--- a/homeassistant/components/danfoss_air/manifest.json
+++ b/homeassistant/components/danfoss_air/manifest.json
@@ -3,7 +3,7 @@
   "name": "Danfoss air",
   "documentation": "https://www.home-assistant.io/components/danfoss_air",
   "requirements": [
-    "pydanfossair==0.0.7"
+    "pydanfossair==0.1.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/danfoss_air/switch.py
+++ b/homeassistant/components/danfoss_air/switch.py
@@ -19,6 +19,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
          ReadCommand.boost,
          UpdateCommand.boost_activate,
          UpdateCommand.boost_deactivate],
+        ["Danfoss Air Bypass",
+         ReadCommand.bypass,
+         UpdateCommand.bypass_activate,
+         UpdateCommand.bypass_deactivate],
+        ["Danfoss Air Automatic Bypass",
+         ReadCommand.automatic_bypass,
+         UpdateCommand.bypass_activate,
+         UpdateCommand.bypass_deactivate],
     ]
 
     dev = []
@@ -59,7 +67,7 @@ class DanfossAir(SwitchDevice):
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
-        _LOGGER.debug("Turning of switch with command %s", self._off_command)
+        _LOGGER.debug("Turning off switch with command %s", self._off_command)
         self._data.update_state(self._off_command, self._state_command)
 
     def update(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1003,7 +1003,7 @@ pycsspeechtts==1.0.2
 pydaikin==1.4.0
 
 # homeassistant.components.danfoss_air
-pydanfossair==0.0.7
+pydanfossair==0.1.0
 
 # homeassistant.components.deconz
 pydeconz==55


### PR DESCRIPTION
## Description:
Add bypass and automatic bypass switch for Danfoss Air. 

**Related issue (if applicable):** fixes N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9357

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
