### PR TITLE
Fix failing tests for the Dyson air quality and fan components

### DIFF
--- a/tests/components/dyson/test_air_quality.py
+++ b/tests/components/dyson/test_air_quality.py
@@ -86,8 +86,11 @@ async def test_purecool_aiq_update_state(devices, login, hass):
     device.environmental_state = \
         DysonEnvironmentalSensorV2State(json.dumps(event))
 
-    callback = device.add_message_listener.call_args_list[2][0][0]
-    callback(device.environmental_state)
+    for call in device.add_message_listener.call_args_list:
+        callback = call[0][0]
+        if type(callback.__self__) == dyson.DysonAirSensor:
+            callback(device.environmental_state)
+
     await hass.async_block_till_done()
     fan_state = hass.states.get("air_quality.living_room")
     attributes = fan_state.attributes

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -680,8 +680,11 @@ async def test_purecool_update_state(devices, login, hass):
                                "osau": "0095", "ancp": "CUST"}}
     device.state = DysonPureCoolV2State(json.dumps(event))
 
-    callback = device.add_message_listener.call_args_list[3][0][0]
-    callback(device.state)
+    for call in device.add_message_listener.call_args_list:
+        callback = call[0][0]
+        if type(callback.__self__) == dyson.DysonPureCoolDevice:
+            callback(device.state)
+
     await hass.async_block_till_done()
     fan_state = hass.states.get("fan.living_room")
     attributes = fan_state.attributes


### PR DESCRIPTION
## Description: 
Fix the state update tests in the fan and air quality components of the dyson integration.

**Related issue (if applicable):** fixes #23573

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

## Example entry for `configuration.yaml` (if applicable):

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_