### PR TITLE
Extend HEOS play_media for favorites, playlists, and quick_selects

### DIFF
--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -19,15 +19,19 @@ def config_entry_fixture():
 
 
 @pytest.fixture(name="controller")
-def controller_fixture(players, favorites, input_sources, dispatcher):
+def controller_fixture(
+        players, favorites, input_sources, playlists, dispatcher):
     """Create a mock Heos controller fixture."""
     with patch("pyheos.Heos", autospec=True) as mock:
         mock_heos = mock.return_value
+        for player in players.values():
+            player.heos = mock_heos
         mock_heos.dispatcher = dispatcher
         mock_heos.get_players.return_value = players
         mock_heos.players = players
         mock_heos.get_favorites.return_value = favorites
         mock_heos.get_input_sources.return_value = input_sources
+        mock_heos.get_playlists.return_value = playlists
         mock_heos.is_signed_in = True
         mock_heos.signed_in_username = "user@user.com"
         yield mock_heos
@@ -42,10 +46,9 @@ def config_fixture():
 
 
 @pytest.fixture(name="players")
-def player_fixture(dispatcher):
+def player_fixture(quick_selects):
     """Create a mock HeosPlayer."""
     player = Mock(HeosPlayer)
-    player.heos.dispatcher = dispatcher
     player.player_id = 1
     player.name = "Test Player"
     player.model = "Test Model"
@@ -71,6 +74,7 @@ def player_fixture(dispatcher):
     player.now_playing_media.current_position = None
     player.now_playing_media.image_url = "http://"
     player.now_playing_media.song = "Song"
+    player.get_quick_selects.return_value = quick_selects
     return {player.player_id: player}
 
 
@@ -123,3 +127,25 @@ def discovery_data_fixture() -> dict:
         'udn': 'uuid:e61de70c-2250-1c22-0080-0005cdf512be',
         'upnp_device_type': 'urn:schemas-denon-com:device:AiosDevice:1'
     }
+
+
+@pytest.fixture(name="quick_selects")
+def quick_selects_fixture() -> Dict[int, str]:
+    """Create a dict of quick selects for testing."""
+    return {
+        1: "Quick Select 1",
+        2: "Quick Select 2",
+        3: "Quick Select 3",
+        4: "Quick Select 4",
+        5: "Quick Select 5",
+        6: "Quick Select 6"
+    }
+
+
+@pytest.fixture(name="playlists")
+def playlists_fixture() -> Sequence[HeosSource]:
+    """Create favorites fixture."""
+    playlist = Mock(HeosSource)
+    playlist.type = const.TYPE_PLAYLIST
+    playlist.name = "Awesome Music"
+    return [playlist]


### PR DESCRIPTION
## Description:
Extend support in the `play_media` service for HEOS favorites, playlists, and quick_selects.  This is a community requested feature.
 
CC @Cadish

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#9359

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
