### PR TITLE
Support STATE_AUTO in homekit_controller climate

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    STATE_COOL, STATE_HEAT, STATE_IDLE, SUPPORT_OPERATION_MODE,
+    STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_IDLE, SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
     SUPPORT_TARGET_HUMIDITY_HIGH, SUPPORT_TARGET_HUMIDITY_LOW)
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, TEMP_CELSIUS
@@ -17,6 +17,7 @@ MODE_HOMEKIT_TO_HASS = {
     0: STATE_OFF,
     1: STATE_HEAT,
     2: STATE_COOL,
+    3: STATE_AUTO,
 }
 
 # Map of hass operation modes to homekit modes

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -128,7 +128,15 @@ class FakeCharacteristic(AbstractCharacteristic):
     needed even though it doesn't add any methods.
     """
 
-    pass
+    def to_accessory_and_service_list(self):
+        """Serialize the characteristic."""
+        # Upstream doesn't correctly serialize valid_values
+        # This fix will be upstreamed and this function removed when it
+        # is fixed.
+        record = super().to_accessory_and_service_list()
+        if self.valid_values:
+            record['valid-values'] = self.valid_values
+        return record
 
 
 class FakeService(AbstractService):

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -37,6 +37,13 @@ async def test_ecobee3_setup(hass):
         SUPPORT_OPERATION_MODE
     )
 
+    assert climate_state.attributes['operation_list'] == [
+        'off',
+        'heat',
+        'cool',
+        'auto',
+    ]
+
     assert climate_state.attributes['min_temp'] == 7.2
     assert climate_state.attributes['max_temp'] == 33.3
     assert climate_state.attributes['min_humidity'] == 20

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -58,7 +58,7 @@ async def test_climate_respect_supported_op_modes_2(hass, utcnow):
     service = FakeService('public.hap.service.thermostat')
     char = service.add_characteristic('heating-cooling.target')
     char.value = 0
-    char.validValues = [0, 1, 2]
+    char.valid_values = [0, 1, 2]
 
     helper = await setup_test_component(hass, [service])
 


### PR DESCRIPTION
## Description:

This fixes support for `auto` in HomeKit climate devices. The underlying code supported the state but looks like we never mapped HA constants to HK constants for `auto`.

Reported in #15336 (but that ticket is more about pairing, so this is a side issue - merging this isn't the fix for that issue).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
