### PR TITLE
Add support for SET_AWAY_MODE and TURN_ON/OFF on Daikin Climate

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -8,8 +8,8 @@ from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
     ATTR_CURRENT_TEMPERATURE, ATTR_FAN_MODE, ATTR_OPERATION_MODE,
     ATTR_SWING_MODE, STATE_AUTO, STATE_COOL, STATE_DRY, STATE_FAN_ONLY,
-    STATE_HEAT, SUPPORT_FAN_MODE, SUPPORT_OPERATION_MODE, SUPPORT_SWING_MODE,
-    SUPPORT_TARGET_TEMPERATURE)
+    STATE_HEAT, SUPPORT_FAN_MODE, SUPPORT_ON_OFF, SUPPORT_OPERATION_MODE,
+    SUPPORT_SWING_MODE, SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import (
     ATTR_TEMPERATURE, CONF_HOST, CONF_NAME, STATE_OFF, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
@@ -93,8 +93,8 @@ class DaikinClimate(ClimateDevice):
             ),
         }
 
-        self._supported_features = SUPPORT_TARGET_TEMPERATURE \
-            | SUPPORT_OPERATION_MODE
+        self._supported_features = (SUPPORT_ON_OFF | SUPPORT_OPERATION_MODE
+                                    | SUPPORT_TARGET_TEMPERATURE)
 
         if self._api.device.support_fan_mode:
             self._supported_features |= SUPPORT_FAN_MODE
@@ -266,3 +266,18 @@ class DaikinClimate(ClimateDevice):
     def device_info(self):
         """Return a device description for device registry."""
         return self._api.device_info
+
+    @property
+    def is_on(self):
+        """Return true if on."""
+        return self._api.device.represent(
+            HA_ATTR_TO_DAIKIN[ATTR_OPERATION_MODE])[1] != STATE_OFF
+
+    async def async_turn_on(self):
+        """Turn device on."""
+        await self._api.device.set({})
+
+    async def async_turn_off(self):
+        """Turn device off."""
+        await self._api.device.set(
+            {HA_ATTR_TO_DAIKIN[ATTR_OPERATION_MODE]: STATE_OFF})

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -6,10 +6,11 @@ import voluptuous as vol
 
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
 from homeassistant.components.climate.const import (
-    ATTR_CURRENT_TEMPERATURE, ATTR_FAN_MODE, ATTR_OPERATION_MODE,
-    ATTR_SWING_MODE, STATE_AUTO, STATE_COOL, STATE_DRY, STATE_FAN_ONLY,
-    STATE_HEAT, SUPPORT_FAN_MODE, SUPPORT_ON_OFF, SUPPORT_OPERATION_MODE,
-    SUPPORT_SWING_MODE, SUPPORT_TARGET_TEMPERATURE)
+    ATTR_AWAY_MODE, ATTR_CURRENT_TEMPERATURE, ATTR_FAN_MODE,
+    ATTR_OPERATION_MODE, ATTR_SWING_MODE, STATE_AUTO, STATE_COOL, STATE_DRY,
+    STATE_FAN_ONLY, STATE_HEAT, SUPPORT_AWAY_MODE, SUPPORT_FAN_MODE,
+    SUPPORT_ON_OFF, SUPPORT_OPERATION_MODE, SUPPORT_SWING_MODE,
+    SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import (
     ATTR_TEMPERATURE, CONF_HOST, CONF_NAME, STATE_OFF, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
@@ -44,6 +45,7 @@ DAIKIN_TO_HA_STATE = {
 }
 
 HA_ATTR_TO_DAIKIN = {
+    ATTR_AWAY_MODE: 'en_hol',
     ATTR_OPERATION_MODE: 'mode',
     ATTR_FAN_MODE: 'f_rate',
     ATTR_SWING_MODE: 'f_dir',
@@ -93,7 +95,8 @@ class DaikinClimate(ClimateDevice):
             ),
         }
 
-        self._supported_features = (SUPPORT_ON_OFF | SUPPORT_OPERATION_MODE
+        self._supported_features = (SUPPORT_AWAY_MODE | SUPPORT_ON_OFF
+                                    | SUPPORT_OPERATION_MODE
                                     | SUPPORT_TARGET_TEMPERATURE)
 
         if self._api.device.support_fan_mode:
@@ -281,3 +284,17 @@ class DaikinClimate(ClimateDevice):
         """Turn device off."""
         await self._api.device.set(
             {HA_ATTR_TO_DAIKIN[ATTR_OPERATION_MODE]: STATE_OFF})
+
+    @property
+    def is_away_mode_on(self):
+        """Return true if away mode is on."""
+        return self._api.device.represent(
+            HA_ATTR_TO_DAIKIN[ATTR_AWAY_MODE])[1] != STATE_OFF
+
+    async def async_turn_away_mode_on(self):
+        """Turn away mode on."""
+        await self._api.device.set({HA_ATTR_TO_DAIKIN[ATTR_AWAY_MODE]: '1'})
+
+    async def async_turn_away_mode_off(self):
+        """Turn away mode off."""
+        await self._api.device.set({HA_ATTR_TO_DAIKIN[ATTR_AWAY_MODE]: '0'})


### PR DESCRIPTION
## Description:

Adds support for SET_AWAY_MODE and TURN_ON/OFF on Daikin Climate

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9370

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
