### PR TITLE
Clean up redundant same-package ..package imports

### DIFF
--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.const import CONF_NAME, CONF_TEMPERATURE_UNIT, POWER_WATT
 from homeassistant.helpers.entity import Entity
 
-from ..greeneye_monitor import (
+from . import (
     CONF_COUNTED_QUANTITY,
     CONF_COUNTED_QUANTITY_PER_PULSE,
     CONF_MONITOR_SERIAL_NUMBER,

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -9,7 +9,7 @@ from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, DeviceScanner,
 )
 from homeassistant.const import CONF_URL
-from ..huawei_lte import DATA_KEY, RouterData
+from . import DATA_KEY, RouterData
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_URL): cv.url,

--- a/homeassistant/components/huawei_lte/notify.py
+++ b/homeassistant/components/huawei_lte/notify.py
@@ -9,7 +9,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_RECIPIENT, CONF_URL
 import homeassistant.helpers.config_validation as cv
 
-from ..huawei_lte import DATA_KEY
+from . import DATA_KEY
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-from ..huawei_lte import DATA_KEY, RouterData
+from . import DATA_KEY, RouterData
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tplink_lte/notify.py
+++ b/homeassistant/components/tplink_lte/notify.py
@@ -7,7 +7,7 @@ from homeassistant.components.notify import (
     ATTR_TARGET, BaseNotificationService)
 from homeassistant.const import CONF_RECIPIENT
 
-from ..tplink_lte import DATA_KEY
+from . import DATA_KEY
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description:

SSIA, probably leftovers from tree restructuring.

## Checklist:
  - [x] The code change is tested and works locally (**huawei_lte only**).
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
