### PR TITLE
Move I/O to executor thread pool

### DIFF
--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -33,6 +33,11 @@ class DiscordNotificationService(BaseNotificationService):
         self.token = token
         self.hass = hass
 
+    def file_exists(self, filename):
+        import os.path
+
+        return os.path.isfile(filename)
+
     async def async_send_message(self, message, **kwargs):
         """Login to Discord, send message to channel(s) and log out."""
         import discord
@@ -49,11 +54,14 @@ class DiscordNotificationService(BaseNotificationService):
             data = kwargs.get(ATTR_DATA)
 
             if ATTR_IMAGES in data:
-                import os.path
                 images = list()
 
                 for image in data.get(ATTR_IMAGES):
-                    if os.path.isfile(image):
+                    image_exists = await self.hass.async_add_executor_job(
+                            self.file_exists,
+                            image)
+
+                    if image_exists:
                         images.append(image)
                     else:
                         _LOGGER.warning("Image not found: %s", image)

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -1,5 +1,6 @@
 """Discord platform for notify component."""
 import logging
+import os.path
 
 import voluptuous as vol
 
@@ -35,8 +36,6 @@ class DiscordNotificationService(BaseNotificationService):
 
     def file_exists(self, filename):
         """Check if a file exists on disk and is in authorized path."""
-        import os.path
-
         if not self.hass.config.is_allowed_path(filename):
             return False
 

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -61,8 +61,8 @@ class DiscordNotificationService(BaseNotificationService):
 
                 for image in data.get(ATTR_IMAGES):
                     image_exists = await self.hass.async_add_executor_job(
-                            self.file_exists,
-                            image)
+                        self.file_exists,
+                        image)
 
                     if image_exists:
                         images.append(image)

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -34,7 +34,11 @@ class DiscordNotificationService(BaseNotificationService):
         self.hass = hass
 
     def file_exists(self, filename):
+        """Check if a file exists on disk and is in authorized path."""
         import os.path
+
+        if not self.hass.config.is_allowed_path(filename):
+            return False
 
         return os.path.isfile(filename)
 


### PR DESCRIPTION
## Breaking Change:
The images passed to the payload must be within a whitelisted external dir

## Description:
Change requested by @MartinHjelmare on my previous PR #23523 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
