### PR TITLE
Add track_template_result method to events

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -157,9 +157,6 @@ def async_track_template(
             _LOGGER.exception(result)
             return
 
-        # These really should use the new `cv.boolean_coerce`
-        # validator as per #23293 rather than have potential exceptions
-        # thrown. Change once #23293 merged.
         if last_result is not None:
             if not _boolean_coerce(last_result) \
                     and _boolean_coerce(result):

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -180,7 +180,7 @@ def async_track_template(
                     break
             if not state:
                 for st in hass.states.async_all():
-                    if info.filter(st.entity_id):
+                    if info.filter_lifecycle(st.entity_id):
                         state = st
                         entity_id = st.entity_id
                         break

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -196,6 +196,9 @@ def async_track_template(
 track_template = threaded_listener_factory(async_track_template)
 
 
+_UNCHANGED = object()
+
+
 class TrackTemplateResultInfo:
     """Return value from async_track_template_result."""
 
@@ -230,8 +233,10 @@ class TrackTemplateResultInfo:
         self._cancel()
 
     @callback
-    def async_refresh(self) -> None:
+    def async_refresh(self, variables=_UNCHANGED) -> None:
         """Force recalculate the template."""
+        if variables is not _UNCHANGED:
+            self._variables = variables
         self._refresh()
 
     @callback

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -7,19 +7,19 @@ from typing import Any, Callable, Mapping, Optional, Union
 import attr
 import voluptuous as vol
 
-from ..const import (
+from homeassistant.const import (
     ATTR_NOW, EVENT_CORE_CONFIG_UPDATE, EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED, MATCH_ALL, SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET)
-from ..core import Event, HomeAssistant, State, callback
-from ..exceptions import TemplateError
-from ..loader import bind_hass
-from ..util import dt as dt_util
-from ..util.async_ import run_callback_threadsafe
-from . import config_validation as cv
-from .sun import get_astral_event_next
-from .template import Template
-from .typing import TemplateVarsType
+from homeassistant.core import Event, HomeAssistant, State, callback
+from homeassistant.exceptions import TemplateError
+from homeassistant.loader import bind_hass
+from homeassistant.util import dt as dt_util
+from homeassistant.util.async_ import run_callback_threadsafe
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.sun import get_astral_event_next
+from homeassistant.helpers.template import Template
+from homeassistant.helpers.typing import TemplateVarsType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -197,7 +197,7 @@ _UNCHANGED = object()
 
 
 class TrackTemplateResultInfo:
-    """Return value from async_track_template_result."""
+    """Handle removal / refresh of tracker."""
 
     def __init__(self, hass, template, action, variables):
         """Initialiser, should be package private."""

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -111,8 +111,8 @@ async def test_if_not_fires_on_change_bool(hass, calls):
     assert 0 == len(calls)
 
 
-async def test_if_not_fires_on_change_str(hass, calls):
-    """Test for not firing on string change."""
+async def test_if_fires_on_change_bare_str(hass, calls):
+    """Test should fire once for a bare string of true."""
     assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'trigger': {
@@ -124,10 +124,12 @@ async def test_if_not_fires_on_change_str(hass, calls):
             }
         }
     })
+    await hass.async_block_till_done()
+    assert 1 == len(calls)
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert 0 == len(calls)
+    assert 1 == len(calls)
 
 
 async def test_if_not_fires_on_change_str_crazy(hass, calls):
@@ -230,10 +232,11 @@ async def test_if_not_fires_on_change_with_template(hass, calls):
     })
 
     await hass.async_block_till_done()
+    assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(calls) == 1
 
 
 async def test_if_fires_on_change_with_template_advanced(hass, calls):
@@ -312,21 +315,6 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     })
 
     await hass.async_block_till_done()
-
-    hass.states.async_set('test.entity', 'world')
-    await hass.async_block_till_done()
-    assert len(calls) == 0
-
-    hass.states.async_set('test.entity', 'home')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'work')
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    hass.states.async_set('test.entity', 'not_home')
-    await hass.async_block_till_done()
     assert len(calls) == 1
 
     hass.states.async_set('test.entity', 'world')
@@ -336,6 +324,22 @@ async def test_if_fires_on_change_with_template_2(hass, calls):
     hass.states.async_set('test.entity', 'home')
     await hass.async_block_till_done()
     assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'work')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'not_home')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'world')
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+    hass.states.async_set('test.entity', 'home')
+    await hass.async_block_till_done()
+    assert len(calls) == 3
 
 
 async def test_if_action(hass, calls):

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,4 +1,5 @@
 """Test the condition helper."""
+from logging import ERROR
 from unittest.mock import patch
 
 from homeassistant.helpers import condition
@@ -164,3 +165,18 @@ class TestConditionHelper:
             self.hass.states.set('sensor.temperature', 'unknown')
             assert not test(self.hass)
             assert len(logwarn.mock_calls) == 0
+
+
+async def test_condition_template_error(hass, caplog):
+    """Test invalid template."""
+    caplog.set_level(ERROR)
+
+    test = condition.async_from_config({
+        'condition': 'template',
+        'value_template': '{{ undefined.state }}',
+    })
+
+    assert not test(hass)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message\
+        .startswith("Error during template condition: UndefinedError:")

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -289,8 +289,7 @@ async def test_track_template_result(hass):
     async_track_template_result(
         hass, template_condition, wildcard_run_callback)
 
-    @asyncio.coroutine
-    def wildercard_run_callback(event, template, old_result, new_result):
+    async def wildercard_run_callback(event, template, old_result, new_result):
         wildercard_runs.append((int(old_result or 0), int(new_result)))
 
     async_track_template_result(

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -485,6 +485,24 @@ async def test_track_template_result_refresh_cancel(hass):
 
     assert len(refresh_runs) == 3
 
+    template_refresh = Template(
+        "{{ value }}", hass)
+    refresh_runs = []
+
+    info = async_track_template_result(
+        hass, template_refresh,
+        refresh_listener, {'value': 'duck'})
+    await hass.async_block_till_done()
+    assert refresh_runs == ['duck']
+
+    info.async_refresh()
+    await hass.async_block_till_done()
+    assert refresh_runs == ['duck']
+
+    info.async_refresh({'value': 'dog'})
+    await hass.async_block_till_done()
+    assert refresh_runs == ['duck', 'dog']
+
 
 async def test_track_same_state_simple_trigger(hass):
     """Test track_same_change with trigger simple."""


### PR DESCRIPTION
## Description:

This is the continuation from #23283

#### Add `async_track_template_result` method

This uses the previous changes to template for the next layer of the algorithm. This method fires on any change of a template, and will automatically listen for state changes on any referenced entities.

I've also updated `track_template` to be a wrapper around this method.

#### Tests with odd odd semantics

Some of the test cases are affected by the new code. The previous tests are reliant on the extract_entities regexp, which had various issues which I have explored before.

The tests affected relied on a template never being evaluated, and therefore it was never true, because there was no states referenced. This didn't make a lot of semantic sense, since a template like:

`True` would not result in a listener fire, while `{{ True }}` or even `{% if True %}True{% endif %}` would result in a fire, even though the templates rendered to exactly the same result.

**Related issue:** #22587

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
