### PR TITLE
Fix low battery threshold issue HomeKit

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -20,7 +20,8 @@ from .const import (
     ATTR_DISPLAY_NAME, ATTR_VALUE, BRIDGE_MODEL, BRIDGE_SERIAL_NUMBER,
     CHAR_BATTERY_LEVEL, CHAR_CHARGING_STATE, CHAR_STATUS_LOW_BATTERY,
     CONF_LINKED_BATTERY_SENSOR, CONF_LOW_BATTERY_THRESHOLD, DEBOUNCE_TIMEOUT,
-    EVENT_HOMEKIT_CHANGED, MANUFACTURER, SERV_BATTERY_SERVICE)
+    DEFAULT_LOW_BATTERY_THRESHOLD, EVENT_HOMEKIT_CHANGED, MANUFACTURER,
+    SERV_BATTERY_SERVICE)
 from .util import convert_to_float, dismiss_setup_message, show_setup_message
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,7 +75,8 @@ class HomeAccessory(Accessory):
         self.linked_battery_sensor = \
             self.config.get(CONF_LINKED_BATTERY_SENSOR)
         self.low_battery_threshold = \
-            self.config.get(CONF_LOW_BATTERY_THRESHOLD)
+            self.config.get(CONF_LOW_BATTERY_THRESHOLD,
+                            DEFAULT_LOW_BATTERY_THRESHOLD)
 
         """Add battery service if available"""
         battery_found = self.hass.states.get(self.entity_id).attributes \

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -14,7 +14,7 @@ from homeassistant.components.homekit.const import (
     BRIDGE_MODEL, BRIDGE_NAME, BRIDGE_SERIAL_NUMBER, CHAR_FIRMWARE_REVISION,
     CHAR_MANUFACTURER, CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER,
     CONF_LINKED_BATTERY_SENSOR, CONF_LOW_BATTERY_THRESHOLD,
-    DEFAULT_LOW_BATTERY_THRESHOLD, MANUFACTURER, SERV_ACCESSORY_INFO)
+    MANUFACTURER, SERV_ACCESSORY_INFO)
 from homeassistant.const import (
     __version__, ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL, ATTR_ENTITY_ID,
     ATTR_SERVICE, ATTR_NOW, EVENT_TIME_CHANGED)
@@ -107,9 +107,7 @@ async def test_battery_service(hass, hk_driver, caplog):
     hass.states.async_set(entity_id, None, {ATTR_BATTERY_LEVEL: 50})
     await hass.async_block_till_done()
 
-    acc = HomeAccessory(hass, hk_driver, 'Battery Service', entity_id, 2,
-                        {CONF_LOW_BATTERY_THRESHOLD:
-                         DEFAULT_LOW_BATTERY_THRESHOLD})
+    acc = HomeAccessory(hass, hk_driver, 'Battery Service', entity_id, 2, None)
     acc.update_state = lambda x: None
     assert acc._char_battery.value == 0
     assert acc._char_low_battery.value == 0
@@ -139,9 +137,7 @@ async def test_battery_service(hass, hk_driver, caplog):
         ATTR_BATTERY_LEVEL: 10, ATTR_BATTERY_CHARGING: True})
     await hass.async_block_till_done()
 
-    acc = HomeAccessory(hass, hk_driver, 'Battery Service', entity_id, 2,
-                        {CONF_LOW_BATTERY_THRESHOLD:
-                         DEFAULT_LOW_BATTERY_THRESHOLD})
+    acc = HomeAccessory(hass, hk_driver, 'Battery Service', entity_id, 2, None)
     acc.update_state = lambda x: None
     assert acc._char_battery.value == 0
     assert acc._char_low_battery.value == 0
@@ -170,9 +166,7 @@ async def test_linked_battery_sensor(hass, hk_driver, caplog):
     await hass.async_block_till_done()
 
     acc = HomeAccessory(hass, hk_driver, 'Battery Service', entity_id, 2,
-                        {CONF_LINKED_BATTERY_SENSOR: linked_battery,
-                         CONF_LOW_BATTERY_THRESHOLD:
-                         DEFAULT_LOW_BATTERY_THRESHOLD})
+                        {CONF_LINKED_BATTERY_SENSOR: linked_battery})
     acc.update_state = lambda x: None
     assert acc.linked_battery_sensor == linked_battery
 


### PR DESCRIPTION
## Description:
Fix issue that occurred if entity supports battery levels, but no specific `entity_config` was given.
Originally added with: #23363 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been altered to verify that the new code works.

---
CC: @adrum 