### PR TITLE
Upgraded libsoundtouch to 0.8.0 and implemented snapshot and restore

### DIFF
--- a/homeassistant/components/soundtouch/manifest.json
+++ b/homeassistant/components/soundtouch/manifest.json
@@ -3,7 +3,7 @@
   "name": "Soundtouch",
   "documentation": "https://www.home-assistant.io/components/soundtouch",
   "requirements": [
-    "libsoundtouch==0.7.2"
+    "libsoundtouch==0.8.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -74,6 +74,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Bose Soundtouch platform."""
     if DATA_SOUNDTOUCH not in hass.data:
@@ -147,10 +148,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                             str(entity_id))
             return
 
-        _LOGGER.debug("Found device with entity_id: %s",
-                        str(entity_id))
-
-        if  service.service == SERVICE_SNAPSHOT:
+        if service.service == SERVICE_SNAPSHOT:
             master.snapshot()
         elif service.service == SERVICE_RESTORE:
             master.restore()
@@ -300,13 +298,15 @@ class SoundTouchDevice(MediaPlayerDevice):
         """Restore a snapshot of this media player."""
         _LOGGER.debug("Restoring snapshot: %s", self._device._snapshot)
 
-        # Unable to use the self._device.restore() function as it used the Source Enum lacking TUNEIN support
+        # Unable to use the self._device.restore() function
+        # as it used the Source Enum lacking TUNEIN support
         try:
             if self._device._snapshot:
-                self._device.select_content_item(Source[self._device._snapshot.source],
-                                         self._device._snapshot.source_account,
-                                         self._device._snapshot.location,
-                                         self._device._snapshot.type)
+                self._device.select_content_item(
+                    Source[self._device._snapshot.source],
+                    self._device._snapshot.source_account,
+                    self._device._snapshot.location,
+                    self._device._snapshot.type)
 
             self._status = self._device.status()
         except (TypeError, AttributeError) as ex:
@@ -414,7 +414,8 @@ class SoundTouchDevice(MediaPlayerDevice):
                          self._device.config.name)
             self._device.add_zone_slave([slave.device for slave in slaves])
 
-#Overriding the official libsoundtouch Source Enum (it missed TUNEIN in version 0.8.0)
+
+# Overriding the official libsoundtouch Source Enum (it missed TUNEIN in version 0.8.0)
 class Source(Enum):
     """Music sources supported by the device."""
 

--- a/homeassistant/components/soundtouch/media_player.py
+++ b/homeassistant/components/soundtouch/media_player.py
@@ -415,7 +415,8 @@ class SoundTouchDevice(MediaPlayerDevice):
             self._device.add_zone_slave([slave.device for slave in slaves])
 
 
-# Overriding the official libsoundtouch Source Enum (it missed TUNEIN in version 0.8.0)
+# Overriding the official libsoundtouch Source Enum
+# (it missed TUNEIN in version 0.8.0)
 class Source(Enum):
     """Music sources supported by the device."""
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -641,7 +641,7 @@ libpyfoscam==1.0
 librouteros==2.2.0
 
 # homeassistant.components.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.8.0
 
 # homeassistant.components.lifx_legacy
 liffylights==0.9.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,7 +164,7 @@ jsonpath==0.75
 libpurecool==0.5.0
 
 # homeassistant.components.soundtouch
-libsoundtouch==0.7.2
+libsoundtouch==0.8.0
 
 # homeassistant.components.luftdaten
 luftdaten==0.3.4


### PR DESCRIPTION
## Description:

Upgraded libsoundtouch to 0.8.0
Implemented Snapshot and restore

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
