### PR TITLE
Updated Hangout Component's manifest.json file with correct version of hangups.

### DIFF
--- a/homeassistant/components/hangouts/manifest.json
+++ b/homeassistant/components/hangouts/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hangouts",
   "documentation": "https://www.home-assistant.io/components/hangouts",
   "requirements": [
-    "hangups==0.4.6"
+    "hangups==0.4.9"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -524,7 +524,7 @@ ha-philipsjs==0.0.8
 habitipy==0.2.0
 
 # homeassistant.components.hangouts
-hangups==0.4.6
+hangups==0.4.9
 
 # homeassistant.components.cloud
 hass-nabucasa==0.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -127,7 +127,7 @@ google-api-python-client==1.6.4
 ha-ffmpeg==2.0
 
 # homeassistant.components.hangouts
-hangups==0.4.6
+hangups==0.4.9
 
 # homeassistant.components.cloud
 hass-nabucasa==0.12


### PR DESCRIPTION
## Description:
Updated the `manifest.json` file for the Hangout Component and ran `script/gen_all_requirements.txt` to update `requirements_all.txt`.

**Related issue (if applicable):** fixes #<#23392>

## Checklist:
  - [*] The code change is tested and works locally.
  - [* ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [* ] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [*] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [*] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [*] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
