### PR TITLE
Add Hue Dimmer and Hue Tap sensors for Hue integration

### DIFF
--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -41,15 +41,15 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
         # scale used because the human eye adjusts to light levels and small
         # changes at low lux levels are more noticeable than at high lux
         # levels.
-        return 10 ** ((self.sensor.lightlevel - 1) / 10000)
+        return self.sensor.lightlevel
 
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
         attributes = super().device_state_attributes
         attributes.update({
-            "threshold_dark": self.sensor.tholddark,
-            "threshold_offset": self.sensor.tholdoffset,
+            "dark": self.sensor.dark,
+            "daylight": self.sensor.daylight,
         })
         return attributes
 

--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -1,6 +1,6 @@
 """Hue sensor entities."""
 from homeassistant.const import (
-    DEVICE_CLASS_ILLUMINANCE, DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS)
+    DEVICE_CLASS_ILLUMINANCE, DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, DEVICE_CLASS_SWITCH)
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.hue.sensor_base import (
     GenericZLLSensor, async_setup_entry as shared_async_setup_entry)
@@ -8,6 +8,7 @@ from homeassistant.components.hue.sensor_base import (
 
 LIGHT_LEVEL_NAME_FORMAT = "{} light level"
 TEMPERATURE_NAME_FORMAT = "{} temperature"
+BUTTON_EVENT_NAME_FORMAT = "{}"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -66,3 +67,25 @@ class HueTemperature(GenericHueGaugeSensorEntity):
             return None
 
         return self.sensor.temperature / 100
+
+class HueSwitch(GenericHueGaugeSensorEntity):
+    """The dimmer sensor entity for a Hue sensor device."""
+
+    device_class = DEVICE_CLASS_SWITCH
+
+    @property
+    def state(self):
+        BUTTONS = {
+                    34: "1_click", 16: "2_click", 17: "3_click", 18: "4_click",
+                    1000: "1_click", 2000: "2_click", 3000: "3_click", 4000: "4_click",
+                    1001: "1_hold", 2001: "2_hold", 3001: "3_hold", 4001: "4_hold",
+                    1002: "1_click_up", 2002: "2_click_up", 3002: "3_click_up", 4002: "4_click_up",
+                    1003: "1_hold_up", 2003: "2_hold_up", 3003: "3_hold_up", 4003: "4_hold_up",
+        }
+        """Return the state of the device."""
+        return BUTTONS[self.sensor.buttonevent]
+
+    @property
+    def icon(self) -> str:
+        """Icon to use in the frontend, if any."""
+        return 'mdi:remote'

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -55,8 +55,8 @@ class SensorManager:
         import aiohue
         from .binary_sensor import HuePresence, PRESENCE_NAME_FORMAT
         from .sensor import (
-            HueLightLevel, HueTemperature, LIGHT_LEVEL_NAME_FORMAT,
-            TEMPERATURE_NAME_FORMAT)
+            HueLightLevel, HueTemperature, HueSwitch, LIGHT_LEVEL_NAME_FORMAT,
+            TEMPERATURE_NAME_FORMAT, BUTTON_EVENT_NAME_FORMAT)
 
         self.hass = hass
         self.bridge = bridge
@@ -78,6 +78,16 @@ class SensorManager:
                 "binary": True,
                 "name_format": PRESENCE_NAME_FORMAT,
                 "class": HuePresence,
+            },
+            aiohue.sensors.TYPE_ZLL_SWITCH: {
+                "binary": False,
+                "name_format": BUTTON_EVENT_NAME_FORMAT,
+                "class": HueSwitch,
+            },
+            aiohue.sensors.TYPE_ZGP_SWITCH: {
+                "binary": False,
+                "name_format": BUTTON_EVENT_NAME_FORMAT,
+                "class": HueSwitch,
             },
         })
 
@@ -279,5 +289,6 @@ class GenericZLLSensor(GenericHueSensor):
     def device_state_attributes(self):
         """Return the device state attributes."""
         return {
-            "battery_level": self.sensor.battery
+            "battery_level": self.sensor.battery,
+            "last_updated": self.sensor.lastupdated
         }

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -47,7 +47,7 @@ class SensorManager:
     Intended to be a singleton.
     """
 
-    SCAN_INTERVAL = timedelta(seconds=5)
+    SCAN_INTERVAL = timedelta(seconds=0.1)
     sensor_config_map = {}
 
     def __init__(self, hass, bridge):
@@ -288,7 +288,12 @@ class GenericZLLSensor(GenericHueSensor):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        return {
-            "battery_level": self.sensor.battery,
-            "last_updated": self.sensor.lastupdated
-        }
+        attributes = dict()
+        attributes.update(self.sensor.config)
+        """ Removing unnecessary values."""
+        if 'pending' in attributes: del attributes['pending']
+        if 'reachable' in attributes: del attributes['reachable']
+        if 'alert' in attributes: del attributes['alert']
+        if 'ledindication' in attributes: del attributes['ledindication']
+        if 'usertest' in attributes: del attributes['usertest']
+        return attributes

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -185,6 +185,7 @@ DEVICE_CLASS_TEMPERATURE = 'temperature'
 DEVICE_CLASS_TIMESTAMP = 'timestamp'
 DEVICE_CLASS_PRESSURE = 'pressure'
 DEVICE_CLASS_POWER = 'power'
+DEVICE_CLASS_SWITCH = 'switch'
 
 # #### STATES ####
 STATE_ON = 'on'


### PR DESCRIPTION
## Description:

Add Hue Dimmer and Hue Tap sensors for Hue integration

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
