### PR TITLE
Update sensor_base.py

### DIFF
--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -47,7 +47,7 @@ class SensorManager:
     Intended to be a singleton.
     """
 
-    SCAN_INTERVAL = timedelta(seconds=5)
+    SCAN_INTERVAL = timedelta(seconds=0.1)
     sensor_config_map = {}
 
     def __init__(self, hass, bridge):
@@ -277,7 +277,13 @@ class GenericZLLSensor(GenericHueSensor):
 
     @property
     def device_state_attributes(self):
-        """Return the device state attributes."""
-        return {
-            "battery_level": self.sensor.battery
-        }
+        """Return the device state attributes."""                        
+        attributes = dict()                                              
+        attributes.update(self.sensor.config)                            
+        """ Removing unnecessary values."""                              
+        if 'pending' in attributes: del attributes['pending']            
+        if 'reachable' in attributes: del attributes['reachable']        
+        if 'alert' in attributes: del attributes['alert']                
+        if 'ledindication' in attributes: del attributes['ledindication']
+        if 'usertest' in attributes: del attributes['usertest']              
+        return attributes


### PR DESCRIPTION
Add all config values except unnecessary
Change scan_interval to 0.1 (a lower value is used to intercept long presses on the switches)

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
