### PR TITLE
Hue -Fix config values  and scan_interval

### DIFF
--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -47,8 +47,8 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
         """Return the device state attributes."""
         attributes = super().device_state_attributes
         attributes.update({
-            "threshold_dark": self.sensor.tholddark,
-            "threshold_offset": self.sensor.tholdoffset,
+            "dark": self.sensor.dark,
+            "daylight": self.sensor.daylight,
         })
         return attributes
 

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -47,7 +47,7 @@ class SensorManager:
     Intended to be a singleton.
     """
 
-    SCAN_INTERVAL = timedelta(seconds=5)
+    SCAN_INTERVAL = timedelta(seconds=0.1)
     sensor_config_map = {}
 
     def __init__(self, hass, bridge):
@@ -277,7 +277,13 @@ class GenericZLLSensor(GenericHueSensor):
 
     @property
     def device_state_attributes(self):
-        """Return the device state attributes."""
-        return {
-            "battery_level": self.sensor.battery
-        }
+        """Return the device state attributes."""                        
+        attributes = dict()                                              
+        attributes.update(self.sensor.config)                            
+        """ Removing unnecessary values."""                              
+        if 'pending' in attributes: del attributes['pending']            
+        if 'reachable' in attributes: del attributes['reachable']        
+        if 'alert' in attributes: del attributes['alert']                
+        if 'ledindication' in attributes: del attributes['ledindication']
+        if 'usertest' in attributes: del attributes['usertest']              
+        return attributes


### PR DESCRIPTION
## Description:

    Add all config values except unnecessary
    Change scan_interval to 0.1 (a lower value is used to intercept long presses on the switches)
    Remove threshold_dark , threshold_offset because because they are already present in the config values

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
