### PR TITLE
Fix entity id naming when not using first install

### DIFF
--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -6,7 +6,7 @@ import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 
-from . import CONF_ALARM, CONF_CODE_DIGITS, HUB as hub
+from . import CONF_ALARM, CONF_CODE_DIGITS, CONF_GIID, HUB as hub
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +45,12 @@ class VerisureAlarm(alarm.AlarmControlPanel):
     @property
     def name(self):
         """Return the name of the device."""
+        giid = hub.config.get(CONF_GIID)
+        if giid is not None:
+            return '{} alarm'.format(
+                    [i['alias'] for i in hub.session.installations if i['giid'] == giid][0]
+                    )
+
         return '{} alarm'.format(hub.session.installations[0]['alias'])
 
     @property

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -47,9 +47,11 @@ class VerisureAlarm(alarm.AlarmControlPanel):
         """Return the name of the device."""
         giid = hub.config.get(CONF_GIID)
         if giid is not None:
-            return '{} alarm'.format(
-                    [i['alias'] for i in hub.session.installations if i['giid'] == giid][0]
-                    )
+            d = {i['giid']: i['alias'] for i in hub.session.installations}
+            if giid in d.keys():
+                return '{} alarm'.format(d[giid])
+            else: 
+                _LOGGER.error('Verisure installation giid not found: %s', giid)
 
         return '{} alarm'.format(hub.session.installations[0]['alias'])
 

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -47,11 +47,11 @@ class VerisureAlarm(alarm.AlarmControlPanel):
         """Return the name of the device."""
         giid = hub.config.get(CONF_GIID)
         if giid is not None:
-            d = {i['giid']: i['alias'] for i in hub.session.installations}
-            if giid in d.keys():
-                return '{} alarm'.format(d[giid])
-            else:
-                _LOGGER.error('Verisure installation giid not found: %s', giid)
+            aliass = {i['giid']: i['alias'] for i in hub.session.installations}
+            if giid in aliass.keys():
+                return '{} alarm'.format(aliass[giid])
+
+            _LOGGER.error('Verisure installation giid not found: %s', giid)
 
         return '{} alarm'.format(hub.session.installations[0]['alias'])
 

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -50,7 +50,7 @@ class VerisureAlarm(alarm.AlarmControlPanel):
             d = {i['giid']: i['alias'] for i in hub.session.installations}
             if giid in d.keys():
                 return '{} alarm'.format(d[giid])
-            else: 
+            else:
                 _LOGGER.error('Verisure installation giid not found: %s', giid)
 
         return '{} alarm'.format(hub.session.installations[0]['alias'])


### PR DESCRIPTION
Currently, the Verisure component will use the alias of the first
installation to decide entity id of the alarm_control_panel even though
a different installation is configured through a specified giid. This
fixes that

## Breaking Change:
This is a breaking change as it will change entity_id of alarm_control_panel in cases where users is configuring an installation using giid that is not the first installation (based on enumerated list from underlying python library)

## Description:
Base entity_id of alarm_control_panel on alias of installation set by giid rather than first installation

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** HOW DO I DO THAT?
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) - NO CONFIGURATION VARIABLES ADDED

If the code communicates with devices, web services, or third-party tools - NOT APPLICABLE:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
