### PR TITLE
Fix unexpected error thrown if instance_domain is not set

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -122,6 +122,9 @@ def async_remote_ui_url(hass) -> str:
     if not async_is_logged_in(hass):
         raise CloudNotAvailable
 
+    if not hass.data[DOMAIN].remote.instance_domain:
+        raise CloudNotAvailable
+
     return "https://" + hass.data[DOMAIN].remote.instance_domain
 
 


### PR DESCRIPTION
Fixes this error that `mobile_app` users that don't use cloud are getting, which causes a 500 and registration to fail:

```
Log Details (ERROR)
Wed May 01 2019 21:32:02 GMT-0400 (Eastern Daylight Time)
Error handling request
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/http/real_ip.py", line 33, in real_ip_middleware
    return await handler(request)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/http/ban.py", line 68, in ban_middleware
    return await handler(request)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/http/auth.py", line 216, in auth_middleware
    return await handler(request)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/http/view.py", line 115, in handle
    result = await result
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/http/data_validator.py", line 46, in wrapper
    result = await method(view, request, *args, **kwargs)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/mobile_app/http_api.py", line 57, in post
    remote_ui_url = async_remote_ui_url(hass)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/cloud/__init__.py", line 125, in async_remote_ui_url
    return "https://" + hass.data[DOMAIN].remote.instance_domain
TypeError: must be str, not NoneType
```

Thanks to @arsaboo

https://github.com/home-assistant/home-assistant-iOS/issues/299