### PR TITLE
Bump pyheos to 0.5.1

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -195,7 +195,7 @@ class SourceManager:
                                       exc_info=isinstance(error, CommandError))
                         return
 
-        async def update_sources(event):
+        async def update_sources(event, data):
             if event in (const.EVENT_SOURCES_CHANGED,
                          const.EVENT_USER_CHANGED):
                 sources = await get_sources()

--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Heos",
   "documentation": "https://www.home-assistant.io/components/heos",
   "requirements": [
-    "pyheos==0.4.1"
+    "pyheos==0.5.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -79,7 +79,7 @@ class HeosMediaPlayer(MediaPlayerDevice):
             const.CONTROL_PLAY_NEXT: SUPPORT_NEXT_TRACK
         }
 
-    async def _controller_event(self, event):
+    async def _controller_event(self, event, data):
         """Handle controller event."""
         from pyheos import const
         if event == const.EVENT_PLAYERS_CHANGED:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1091,7 +1091,7 @@ pygtt==1.1.2
 pyhaversion==2.2.1
 
 # homeassistant.components.heos
-pyheos==0.4.1
+pyheos==0.5.1
 
 # homeassistant.components.hikvision
 pyhik==0.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -229,7 +229,7 @@ pydeconz==55
 pydispatcher==2.0.5
 
 # homeassistant.components.heos
-pyheos==0.4.1
+pyheos==0.5.1
 
 # homeassistant.components.homematic
 pyhomematic==0.1.58

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -161,7 +161,7 @@ async def test_update_sources_retry(hass, config_entry, config, controller,
     source_manager.max_retry_attempts = 1
     controller.get_favorites.side_effect = CommandError("Test", "test", 0)
     controller.dispatcher.send(
-        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_SOURCES_CHANGED)
+        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_SOURCES_CHANGED, {})
     # Wait until it's finished
     while "Unable to update sources" not in caplog.text:
         await asyncio.sleep(0.1)

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -104,7 +104,7 @@ async def test_updates_start_from_signals(
     # Test controller player change updates
     player.available = False
     player.heos.dispatcher.send(
-        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_PLAYERS_CHANGED)
+        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_PLAYERS_CHANGED, {})
     await hass.async_block_till_done()
     state = hass.states.get('media_player.test_player')
     assert state.state == STATE_UNAVAILABLE
@@ -159,7 +159,7 @@ async def test_updates_from_sources_updated(
 
     input_sources.clear()
     player.heos.dispatcher.send(
-        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_SOURCES_CHANGED)
+        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_SOURCES_CHANGED, {})
     await event.wait()
     source_list = hass.data[DOMAIN][DATA_SOURCE_MANAGER].source_list
     assert len(source_list) == 2
@@ -182,7 +182,7 @@ async def test_updates_from_user_changed(
     controller.is_signed_in = False
     controller.signed_in_username = None
     player.heos.dispatcher.send(
-        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_USER_CHANGED)
+        const.SIGNAL_CONTROLLER_EVENT, const.EVENT_USER_CHANGED, None)
     await event.wait()
     source_list = hass.data[DOMAIN][DATA_SOURCE_MANAGER].source_list
     assert len(source_list) == 1


### PR DESCRIPTION
## Description:
Updates `phyeos` to latest version to address issue #23557 where a HEOS returning a minimal payload breaks the integration.  `pyheos` 0.5.x adds a new parameter to one of the callbacks which accounts for the additional changes in this PR.

**Related issue (if applicable):** fixes #23557

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running 