### PR TITLE
Add a TCP timeout of 5 seconds to ffmpeg

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -53,6 +53,7 @@ def request_stream(hass, stream_source, *, fmt='hls',
     if isinstance(stream_source, str) \
             and stream_source[:7] == 'rtsp://' and not options:
         options['rtsp_flags'] = 'prefer_tcp'
+        options['stimeout'] = '5000000'
 
     try:
         streams = hass.data[DOMAIN][ATTR_STREAMS]


### PR DESCRIPTION
Add a TCP timeout of 5 seconds to ffmpeg to fix stream getting stuck when network connectivity is lost
https://github.com/home-assistant/home-assistant/issues/22741


## Description:


fixes #22741



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
