### PR TITLE
Convert frontend to do client-side modern JS detection

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import pathlib
-from urllib.parse import urlparse
 
 from aiohttp import web
 import voluptuous as vol
@@ -28,8 +27,6 @@ CONF_EXTRA_HTML_URL = 'extra_html_url'
 CONF_EXTRA_HTML_URL_ES5 = 'extra_html_url_es5'
 CONF_FRONTEND_REPO = 'development_repo'
 CONF_JS_VERSION = 'javascript_version'
-JS_DEFAULT_OPTION = 'auto'
-JS_OPTIONS = ['es5', 'latest', 'auto']
 
 DEFAULT_THEME_COLOR = '#03A9F4'
 
@@ -74,10 +71,9 @@ CONFIG_SCHEMA = vol.Schema({
         }),
         vol.Optional(CONF_EXTRA_HTML_URL):
             vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_EXTRA_HTML_URL_ES5):
-            vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_JS_VERSION, default=JS_DEFAULT_OPTION):
-            vol.In(JS_OPTIONS)
+        # We no longer use these options.
+        vol.Optional(CONF_EXTRA_HTML_URL_ES5): cv.match_all,
+        vol.Optional(CONF_JS_VERSION):  cv.match_all,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -217,7 +213,6 @@ async def async_setup(hass, config):
 
     repo_path = conf.get(CONF_FRONTEND_REPO)
     is_dev = repo_path is not None
-    hass.data[DATA_JS_VERSION] = js_version = conf.get(CONF_JS_VERSION)
     root_path = _frontend_root(repo_path)
 
     for path, should_cache in (
@@ -238,7 +233,7 @@ async def async_setup(hass, config):
     if os.path.isdir(local):
         hass.http.register_static_path("/local", local, not is_dev)
 
-    index_view = IndexView(repo_path, js_version)
+    index_view = IndexView(repo_path)
     hass.http.register_view(index_view)
 
     @callback
@@ -263,13 +258,9 @@ async def async_setup(hass, config):
 
     if DATA_EXTRA_HTML_URL not in hass.data:
         hass.data[DATA_EXTRA_HTML_URL] = set()
-    if DATA_EXTRA_HTML_URL_ES5 not in hass.data:
-        hass.data[DATA_EXTRA_HTML_URL_ES5] = set()
 
     for url in conf.get(CONF_EXTRA_HTML_URL, []):
         add_extra_html_url(hass, url, False)
-    for url in conf.get(CONF_EXTRA_HTML_URL_ES5, []):
-        add_extra_html_url(hass, url, True)
 
     _async_setup_themes(hass, conf.get(CONF_THEMES))
 
@@ -334,13 +325,12 @@ class IndexView(HomeAssistantView):
     name = 'frontend:index'
     requires_auth = False
 
-    def __init__(self, repo_path, js_option):
+    def __init__(self, repo_path):
         """Initialize the frontend view."""
         self.repo_path = repo_path
-        self.js_option = js_option
         self._template_cache = None
 
-    def get_template(self, latest):
+    def get_template(self):
         """Get template."""
         tpl = self._template_cache
         if tpl is None:
@@ -358,32 +348,24 @@ class IndexView(HomeAssistantView):
     async def get(self, request, extra=None):
         """Serve the index view."""
         hass = request.app['hass']
-        latest = self.repo_path is not None or \
-            _is_latest(self.js_option, request)
 
         if not hass.components.onboarding.async_is_onboarded():
             return web.Response(status=302, headers={
                 'location': '/onboarding.html'
             })
 
-        no_auth = '1'
-        if not request[KEY_AUTHENTICATED]:
-            # do not try to auto connect on load
-            no_auth = '0'
+        template = self._template_cache
 
-        template = await hass.async_add_job(self.get_template, latest)
+        if template is not None:
+            template = await hass.async_add_executor_job(self.get_template)
 
-        extra_key = DATA_EXTRA_HTML_URL if latest else DATA_EXTRA_HTML_URL_ES5
-
-        template_params = dict(
-            no_auth=no_auth,
-            theme_color=MANIFEST_JSON['theme_color'],
-            extra_urls=hass.data[extra_key],
-            use_oauth='1'
+        return web.Response(
+            text=template.render(
+                theme_color=MANIFEST_JSON['theme_color'],
+                extra_urls=hass.data[DATA_EXTRA_HTML_URL],
+            ),
+            content_type='text/html'
         )
-
-        return web.Response(text=template.render(**template_params),
-                            content_type='text/html')
 
 
 class ManifestJSONView(HomeAssistantView):
@@ -398,38 +380,6 @@ class ManifestJSONView(HomeAssistantView):
         """Return the manifest.json."""
         msg = json.dumps(MANIFEST_JSON, sort_keys=True)
         return web.Response(text=msg, content_type="application/manifest+json")
-
-
-def _is_latest(js_option, request):
-    """
-    Return whether we should serve latest untranspiled code.
-
-    Set according to user's preference and URL override.
-    """
-    import hass_frontend
-
-    if request is None:
-        return js_option == 'latest'
-
-    # latest in query
-    if 'latest' in request.query or (
-            request.headers.get('Referer') and
-            'latest' in urlparse(request.headers['Referer']).query):
-        return True
-
-    # es5 in query
-    if 'es5' in request.query or (
-            request.headers.get('Referer') and
-            'es5' in urlparse(request.headers['Referer']).query):
-        return False
-
-    # non-auto option in config
-    if js_option != 'auto':
-        return js_option == 'latest'
-
-    useragent = request.headers.get('User-Agent')
-
-    return useragent and hass_frontend.version(useragent)
 
 
 @callback

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -356,7 +356,7 @@ class IndexView(HomeAssistantView):
 
         template = self._template_cache
 
-        if template is not None:
+        if template is None:
             template = await hass.async_add_executor_job(self.get_template)
 
         return web.Response(

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -11,7 +11,6 @@ import jinja2
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.http.view import HomeAssistantView
-from homeassistant.components.http.const import KEY_AUTHENTICATED
 from homeassistant.components import websocket_api
 from homeassistant.config import find_config_file, load_yaml_config_file
 from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -31,7 +31,8 @@ DEFAULT_THEME_COLOR = '#03A9F4'
 
 MANIFEST_JSON = {
     'background_color': '#FFFFFF',
-    'description': 'Open-source home automation platform running on Python 3.',
+    'description':
+    'Home automation platform that puts local control and privacy first.',
     'dir': 'ltr',
     'display': 'standalone',
     'icons': [],

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/components/frontend",
   "requirements": [
-    "home-assistant-frontend==20190427.0"
+    "home-assistant-frontend==20190502.0"
   ],
   "dependencies": [
     "api",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -560,7 +560,7 @@ hole==0.3.0
 holidays==0.9.10
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190427.0
+home-assistant-frontend==20190502.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -145,7 +145,7 @@ hdate==0.8.7
 holidays==0.9.10
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190427.0
+home-assistant-frontend==20190502.0
 
 # homeassistant.components.homekit_controller
 homekit[IP]==0.14.0

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -232,15 +232,6 @@ def test_extra_urls(mock_http_client_with_urls, mock_onboarded):
     assert text.find('href="https://domain.com/my_extra_url.html"') >= 0
 
 
-@asyncio.coroutine
-def test_extra_urls_es5(mock_http_client_with_urls, mock_onboarded):
-    """Test that es5 extra urls are loaded."""
-    resp = yield from mock_http_client_with_urls.get('/states?es5')
-    assert resp.status == 200
-    text = yield from resp.text()
-    assert text.find('href="https://domain.com/my_extra_url_es5.html"') >= 0
-
-
 async def test_get_panels(hass, hass_ws_client):
     """Test get_panels command."""
     await async_setup_component(hass, 'frontend', {})

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -89,10 +89,6 @@ def test_frontend_and_static(mock_http_client, mock_onboarded):
 @asyncio.coroutine
 def test_dont_cache_service_worker(mock_http_client):
     """Test that we don't cache the service worker."""
-    resp = yield from mock_http_client.get('/service_worker_es5.js')
-    assert resp.status == 200
-    assert 'cache-control' not in resp.headers
-
     resp = yield from mock_http_client.get('/service_worker.js')
     assert resp.status == 200
     assert 'cache-control' not in resp.headers
@@ -233,7 +229,7 @@ def test_extra_urls(mock_http_client_with_urls, mock_onboarded):
     resp = yield from mock_http_client_with_urls.get('/states?latest')
     assert resp.status == 200
     text = yield from resp.text()
-    assert text.find("href='https://domain.com/my_extra_url.html'") >= 0
+    assert text.find('href="https://domain.com/my_extra_url.html"') >= 0
 
 
 @asyncio.coroutine
@@ -242,7 +238,7 @@ def test_extra_urls_es5(mock_http_client_with_urls, mock_onboarded):
     resp = yield from mock_http_client_with_urls.get('/states?es5')
     assert resp.status == 200
     text = yield from resp.text()
-    assert text.find("href='https://domain.com/my_extra_url_es5.html'") >= 0
+    assert text.find('href="https://domain.com/my_extra_url_es5.html"') >= 0
 
 
 async def test_get_panels(hass, hass_ws_client):
@@ -330,15 +326,17 @@ async def test_auth_authorize(mock_http_client):
     resp = await mock_http_client.get(
         '/auth/authorize?response_type=code&client_id=https://localhost/&'
         'redirect_uri=https://localhost/&state=123%23456')
+    assert resp.status == 200
+    # No caching of auth page.
+    assert 'cache-control' not in resp.headers
 
-    assert str(resp.url.relative()) == (
-        '/frontend_es5/authorize.html?response_type=code&client_id='
-        'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
+    text = await resp.text()
 
-    resp = await mock_http_client.get(
-        '/auth/authorize?latest&response_type=code&client_id='
-        'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
+    # Test we can retrieve authorize.js
+    authorizejs = re.search(
+        r'(?P<app>\/frontend_latest\/authorize.[A-Za-z0-9]{8}.js)', text)
 
-    assert str(resp.url.relative()) == (
-        '/frontend_latest/authorize.html?latest&response_type=code&client_id='
-        'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
+    assert authorizejs is not None, text
+    resp = await mock_http_client.get(authorizejs.groups(0)[0])
+    assert resp.status == 200
+    assert 'public' in resp.headers.get('cache-control')


### PR DESCRIPTION
## Breaking Change:

It is no longer possible to force the frontend version that is shown to a browser by specifying a `javascript_version` option. Instead, we use feature detection to  make sure that each browser receives the latest supported version. Because of feature detection, we no longer have ES5 specific index pages, which means the option `extra_html_url_es5` no longer does anything. All usages of `extra_html_url` should be migrated to use Lovelace imports.

## Description:
Update the frontend to do modern JS feature detection client-side, simplifying the frontend integration. 

Frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/3145

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
