### PR TITLE
Loosen discovery config validation to avoid breaking changes

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -146,8 +146,8 @@ async def async_setup(hass, config):
     for platform in enabled_platforms:
         if platform in DEFAULT_ENABLED:
             logger.warning(
-                'Deprecated config for discovery: service %s is enabled by'
-                'default - ignoring',
+                "Please remove %s from your discovery.enable configuration "
+                "as it is now enabled by default.",
                 platform,
             )
 

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -147,7 +147,7 @@ async def async_setup(hass, config):
         if platform in DEFAULT_ENABLED:
             logger.warning(
                 "Please remove %s from your discovery.enable configuration "
-                "as it is now enabled by default.",
+                "as it is now enabled by default",
                 platform,
             )
 

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -105,16 +105,19 @@ OPTIONAL_SERVICE_HANDLERS = {
     SERVICE_DLNA_DMR: ('media_player', 'dlna_dmr'),
 }
 
+DEFAULT_ENABLED = list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS)
+DEFAULT_DISABLED = list(OPTIONAL_SERVICE_HANDLERS)
+
 CONF_IGNORE = 'ignore'
 CONF_ENABLE = 'enable'
 
 CONFIG_SCHEMA = vol.Schema({
     vol.Optional(DOMAIN): vol.Schema({
         vol.Optional(CONF_IGNORE, default=[]):
-            vol.All(cv.ensure_list, [
-                vol.In(list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS))]),
+            vol.All(cv.ensure_list, [vol.In(DEFAULT_ENABLED)]),
         vol.Optional(CONF_ENABLE, default=[]):
-            vol.All(cv.ensure_list, [vol.In(OPTIONAL_SERVICE_HANDLERS)])
+            vol.All(cv.ensure_list, [
+                vol.In(DEFAULT_DISABLED + DEFAULT_ENABLED)]),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -139,6 +142,14 @@ async def async_setup(hass, config):
     else:
         ignored_platforms = []
         enabled_platforms = []
+
+    for platform in enabled_platforms:
+        if platform in DEFAULT_ENABLED:
+            logger.warning(
+                'Deprecated config for discovery: service %s is enabled by'
+                'default - ignoring',
+                platform,
+            )
 
     async def new_service_found(service, info):
         """Handle a new service if one is found."""


### PR DESCRIPTION
## Description:

The purpose of this change is that as an integration develops it might change from having its discovery disabled by default to being enabled by default. That switch causes a breaking change as you aren't allowed to enable a discovery thats already enabled. I think a warning is more appropriate in this case.

Right now this change would be a no-op but as previously hinted at in in PR's @MartinHjelmare and @balloob have kindly reviewed for me i'm hoping to submit the last bit of the homekit_controller migration to config entries for inclusion in 0.94. So I hope to move homekit_controller from `OPTIONAL_SERVICE_HANDLERS` to `CONFIG_ENTRY_HANDLERS` which will cause exactly this kind of breaking change. I'd prefer not to break every homekit_controller user on the upgrade!

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
