### PR TITLE
Entity Cleanup on Z-Wave node removal

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -382,13 +382,15 @@ async def async_setup_entry(hass, config_entry):
         _LOGGER.info("Node Removed: %s",
                      hass.data[DATA_DEVICES][node_key])
         for key in list(hass.data[DATA_DEVICES]):
-            if '{}-'.format(node_id) in key:
-                entity = hass.data[DATA_DEVICES][key]
-                _LOGGER.info('Removing Entity - value: %s - entity_id: %s',
-                             key, entity.entity_id)
-                asyncio.run_coroutine_threadsafe(entity.node_removed(),
-                                                 hass.loop)
-                del hass.data[DATA_DEVICES][key]
+            if not key.startswith('{}-'.format(node_id)):
+                continue
+
+            entity = hass.data[DATA_DEVICES][key]
+            _LOGGER.info('Removing Entity - value: %s - entity_id: %s',
+                         key, entity.entity_id)
+            asyncio.run_coroutine_threadsafe(entity.node_removed(),
+                                             hass.loop)
+            del hass.data[DATA_DEVICES][key]
 
         entity = hass.data[DATA_DEVICES][node_key]
         asyncio.run_coroutine_threadsafe(entity.node_removed(), hass.loop)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -388,12 +388,11 @@ async def async_setup_entry(hass, config_entry):
             entity = hass.data[DATA_DEVICES][key]
             _LOGGER.info('Removing Entity - value: %s - entity_id: %s',
                          key, entity.entity_id)
-            asyncio.run_coroutine_threadsafe(entity.node_removed(),
-                                             hass.loop)
+            hass.add_job(entity.node_removed())
             del hass.data[DATA_DEVICES][key]
 
         entity = hass.data[DATA_DEVICES][node_key]
-        asyncio.run_coroutine_threadsafe(entity.node_removed(), hass.loop)
+        hass.add_job(entity.node_removed())
         del hass.data[DATA_DEVICES][node_key]
 
     def network_ready():

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -780,6 +780,25 @@ async def async_setup_entry(hass, config_entry):
                                test_node,
                                schema=TEST_NODE_SCHEMA)
 
+    async def node_removed():
+        # node_id = service.data.get('node')
+        node_id = 14
+        entities = hass.data[DATA_DEVICES]
+        node_key = 'node-{}'.format(node_id)
+        _LOGGER.info("Node Removed: %s",
+                     hass.data[DATA_DEVICES][node_key])
+        for key in entities:
+            if '{}-'.format(node_id) in key:
+                entity = hass.data[DATA_DEVICES][key]
+                _LOGGER.info('Removing Entity - value: %s - entity_id: %s',
+                             key, entity.entity_id)
+                await entity.node_removed()
+                del hass.data[DATA_DEVICES][key]
+
+        entity = hass.data[DATA_DEVICES][node_key]
+        await entity.node_removed()
+        del hass.data[DATA_DEVICES][node_key]
+
     # Setup autoheal
     if autoheal:
         _LOGGER.info("Z-Wave network autoheal is enabled")

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -82,8 +82,6 @@ class ZWaveBaseEntity(Entity):
             return
 
         registry.async_remove(self.entity_id)
-        _LOGGER.info('removed entity from entity_registry: %s', self.entity_id)
-
         await self.async_remove()
 
 

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -76,7 +76,7 @@ class ZWaveBaseEntity(Entity):
             self.hass.add_job(_async_remove_and_add)
 
     async def node_removed(self):
-        """Called when a node is removed from the Z-Wave network."""
+        """Call when a node is removed from the Z-Wave network."""
         registry = await async_get_registry(self.hass)
         if self.entity_id not in registry.entities:
             return

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -77,12 +77,13 @@ class ZWaveBaseEntity(Entity):
 
     async def node_removed(self):
         """Call when a node is removed from the Z-Wave network."""
+        await self.async_remove()
+
         registry = await async_get_registry(self.hass)
         if self.entity_id not in registry.entities:
             return
 
         registry.async_remove(self.entity_id)
-        await self.async_remove()
 
 
 class ZWaveNodeEntity(ZWaveBaseEntity):

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -3,6 +3,7 @@ import logging
 
 from homeassistant.core import callback
 from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_WAKEUP, ATTR_ENTITY_ID
+from homeassistant.helpers.entity_registry import async_get_registry
 from homeassistant.helpers.entity import Entity
 
 from .const import (
@@ -73,6 +74,17 @@ class ZWaveBaseEntity(Entity):
             await self.platform.async_add_entities([self])
         if self.hass and self.platform:
             self.hass.add_job(_async_remove_and_add)
+
+    async def node_removed(self):
+        """Called when a node is removed from the Z-Wave network."""
+        registry = await async_get_registry(self.hass)
+        if self.entity_id not in registry.entities:
+            return
+
+        registry.async_remove(self.entity_id)
+        _LOGGER.info('removed entity from entity_registry: %s', self.entity_id)
+
+        await self.async_remove()
 
 
 class ZWaveNodeEntity(ZWaveBaseEntity):


### PR DESCRIPTION
## Description:
Currently, when a Z-Wave node is removed, entities are left in Home Assistant until a restart, and entries are left orphaned in the entity registry and must be manually cleaned up.

This PR will update the node removal process so that when a node is removed, all entities associated with that node are removed, and their entries are purged from the entity registry.

**Related issue (if applicable):** fixes #18795

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
