### PR TITLE
Add "soc-thermal 1" as CPU Temp label to Glances

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -178,7 +178,8 @@ class GlancesSensor(Entity):
                     if sensor['label'] in ['CPU', "CPU Temperature",
                                            "Package id 0", "Physical id 0",
                                            "cpu_thermal 1", "cpu-thermal 1",
-                                           "exynos-therm 1", "soc_thermal 1"]:
+                                           "exynos-therm 1", "soc_thermal 1",
+                                           "soc-thermal 1"]:
                         self._state = sensor['value']
             elif self.type == 'docker_active':
                 count = 0


### PR DESCRIPTION
## Description:

Add "soc-thermal 1" as CPU Temp label to Glances. 


## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: glances
    host: localhost
    version: 3
    resources: [ cpu_temp ]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
