### PR TITLE
Fix iterating over NoneType exception

### DIFF
--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -103,7 +103,7 @@ class DarkSkyWeather(WeatherEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        if self._dark_sky is None:
+        if self._dark_sky.units is None:
             return None
         return TEMP_FAHRENHEIT if 'us' in self._dark_sky.units \
             else TEMP_CELSIUS

--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -103,6 +103,8 @@ class DarkSkyWeather(WeatherEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
+        if self._dark_sky is None:
+            return None
         return TEMP_FAHRENHEIT if 'us' in self._dark_sky.units \
             else TEMP_CELSIUS
 


### PR DESCRIPTION
## Breaking Change:

N/A

## Description:

When `self._dark_sky` is `None`, don't try to return `self._dark_sky.units`. 

This should fix the following stacktrace seen in the below issue:
```
2019-04-20 03:04:53 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity.py", line 225, in async_update_ha_state
    self._async_write_ha_state()
  File "/usr/src/app/homeassistant/helpers/entity.py", line 255, in _async_write_ha_state
    attr = self.state_attributes or {}
  File "/usr/src/app/homeassistant/components/weather/__init__.py", line 121, in state_attributes
    self.hass, self.temperature, self.temperature_unit,
  File "/usr/src/app/homeassistant/components/darksky/weather.py", line 108, in temperature_unit
    return TEMP_FAHRENHEIT if 'us' in self._dark_sky.units \
TypeError: argument of type 'NoneType' is not iterable
```

Similar to https://github.com/home-assistant/home-assistant/pull/22101 but in a different function call

**Related issue (if applicable):** fixes #16898

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: darksky
    api_key: !secret darksky_api
    mode: hourly
    name: "Hourly Forecast"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
