### PR TITLE
Handle icons for None sensor values gracefully of huawei_lte

### DIFF
--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -62,37 +62,37 @@ SENSOR_META = {
         name="RSRQ",
         # http://www.lte-anbieter.info/technik/rsrq.php
         icon=lambda x:
-        x >= -5 and "mdi:signal-cellular-3"
-        or x >= -8 and "mdi:signal-cellular-2"
-        or x >= -11 and "mdi:signal-cellular-1"
-        or "mdi:signal-cellular-outline"
+        (x is None or x < -11) and "mdi:signal-cellular-outline"
+        or x < -8 and "mdi:signal-cellular-1"
+        or x < -5 and "mdi:signal-cellular-2"
+        or "mdi:signal-cellular-3"
     ),
     "device_signal.rsrp": dict(
         name="RSRP",
         # http://www.lte-anbieter.info/technik/rsrp.php
         icon=lambda x:
-        x >= -80 and "mdi:signal-cellular-3"
-        or x >= -95 and "mdi:signal-cellular-2"
-        or x >= -110 and "mdi:signal-cellular-1"
-        or "mdi:signal-cellular-outline"
+        (x is None or x < -110) and "mdi:signal-cellular-outline"
+        or x < -95 and "mdi:signal-cellular-1"
+        or x < -80 and "mdi:signal-cellular-2"
+        or "mdi:signal-cellular-3"
     ),
     "device_signal.rssi": dict(
         name="RSSI",
         # https://eyesaas.com/wi-fi-signal-strength/
         icon=lambda x:
-        x >= -60 and "mdi:signal-cellular-3"
-        or x >= -70 and "mdi:signal-cellular-2"
-        or x >= -80 and "mdi:signal-cellular-1"
-        or "mdi:signal-cellular-outline"
+        (x is None or x < -80) and "mdi:signal-cellular-outline"
+        or x < -70 and "mdi:signal-cellular-1"
+        or x < -60 and "mdi:signal-cellular-2"
+        or "mdi:signal-cellular-3"
     ),
     "device_signal.sinr": dict(
         name="SINR",
         # http://www.lte-anbieter.info/technik/sinr.php
         icon=lambda x:
-        x >= 10 and "mdi:signal-cellular-3"
-        or x >= 5 and "mdi:signal-cellular-2"
-        or x >= 0 and "mdi:signal-cellular-1"
-        or "mdi:signal-cellular-outline"
+        (x is None or x < 0) and "mdi:signal-cellular-outline"
+        or x < 5 and "mdi:signal-cellular-1"
+        or x < 10 and "mdi:signal-cellular-2"
+        or "mdi:signal-cellular-3"
     ),
 }
 


### PR DESCRIPTION
## Description:

Avoid errors when trying to render icons for None values.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
