### PR TITLE
Upgrade defusedxml to 0.6.0

### DIFF
--- a/homeassistant/components/ihc/manifest.json
+++ b/homeassistant/components/ihc/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ihc",
   "documentation": "https://www.home-assistant.io/components/ihc",
   "requirements": [
-    "defusedxml==0.5.0",
+    "defusedxml==0.6.0",
     "ihcsdk==2.3.0"
   ],
   "dependencies": [],

--- a/homeassistant/components/namecheapdns/manifest.json
+++ b/homeassistant/components/namecheapdns/manifest.json
@@ -3,7 +3,7 @@
   "name": "Namecheapdns",
   "documentation": "https://www.home-assistant.io/components/namecheapdns",
   "requirements": [
-    "defusedxml==0.5.0"
+    "defusedxml==0.6.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/ohmconnect/manifest.json
+++ b/homeassistant/components/ohmconnect/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ohmconnect",
   "documentation": "https://www.home-assistant.io/components/ohmconnect",
   "requirements": [
-    "defusedxml==0.5.0"
+    "defusedxml==0.6.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/upc_connect/manifest.json
+++ b/homeassistant/components/upc_connect/manifest.json
@@ -3,7 +3,7 @@
   "name": "Upc connect",
   "documentation": "https://www.home-assistant.io/components/upc_connect",
   "requirements": [
-    "defusedxml==0.5.0"
+    "defusedxml==0.6.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -332,7 +332,7 @@ datapoint==0.4.3
 # homeassistant.components.namecheapdns
 # homeassistant.components.ohmconnect
 # homeassistant.components.upc_connect
-defusedxml==0.5.0
+defusedxml==0.6.0
 
 # homeassistant.components.deluge
 deluge-client==1.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -82,7 +82,7 @@ coinmarketcap==5.0.3
 # homeassistant.components.namecheapdns
 # homeassistant.components.ohmconnect
 # homeassistant.components.upc_connect
-defusedxml==0.5.0
+defusedxml==0.6.0
 
 # homeassistant.components.dsmr
 dsmr_parser==0.12


### PR DESCRIPTION
## Description:

https://github.com/tiran/defusedxml/blob/master/CHANGES.txt

Should be backwards compatible, contains Python 3.7+ fixes. Not tested beyond test suite, so mainainers of affected components should check it out.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ ] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
