### PR TITLE
Bump pyteleloisirs version

### DIFF
--- a/homeassistant/components/liveboxplaytv/manifest.json
+++ b/homeassistant/components/liveboxplaytv/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/components/liveboxplaytv",
   "requirements": [
     "liveboxplaytv==2.0.2",
-    "pyteleloisirs==3.4"
+    "pyteleloisirs==3.5"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1318,7 +1318,7 @@ pysyncthru==0.4.2
 pytautulli==0.5.0
 
 # homeassistant.components.liveboxplaytv
-pyteleloisirs==3.4
+pyteleloisirs==3.5
 
 # homeassistant.components.tfiac
 pytfiac==0.3


### PR DESCRIPTION
## Description:
Bump pyteleloisirs version to 3.5

**Related issue (if applicable):** fixes #23619 

**See :** pschmitt/pyteleloisirs#2

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


