### PR TITLE
Added new sensor meteoalarm to get weather alerts in Europe

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -347,6 +347,7 @@ omit =
     homeassistant/components/message_bird/notify.py
     homeassistant/components/met/weather.py
     homeassistant/components/meteo_france/*
+    homeassistant/components/meteoalarm/sensor.py
     homeassistant/components/metoffice/sensor.py
     homeassistant/components/metoffice/weather.py
     homeassistant/components/microsoft/tts.py

--- a/homeassistant/components/meteoalarm/__init__.py
+++ b/homeassistant/components/meteoalarm/__init__.py
@@ -1,0 +1,1 @@
+"""The meteoalarm component."""

--- a/homeassistant/components/meteoalarm/manifest.json
+++ b/homeassistant/components/meteoalarm/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "meteoalarm",
+  "name": "meteoalarm",
+  "documentation": "https://www.home-assistant.io/components/meteoalarm",
+  "requirements": [
+    "meteoalertapi==0.0.8"
+  ],
+  "dependencies": [],
+  "codeowners": []
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -703,6 +703,9 @@ mbddns==0.1.2
 # homeassistant.components.message_bird
 messagebird==1.2.0
 
+# homeassistant.components.meteoalarm
+meteoalertapi==0.0.8
+
 # homeassistant.components.meteo_france
 meteofrance==0.3.4
 


### PR DESCRIPTION
## Description:
The `MeteoAlarm` platform allows one to watch for weather alerts in europe from [MeteoAlarm](https://www.meteoalarm.eu) (EUMETNET).

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9375

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: meteoalarm
    country: "NL"
    province: "Groningen"
    language: 'nl'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
