### PR TITLE
Ensure sun conditions are using the right date

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -318,23 +318,26 @@ def sun(
     """Test if current time matches sun requirements."""
     utcnow = dt_util.utcnow()
     today = dt_util.as_local(utcnow).date()
-    tomorrow = dt_util.as_local(utcnow + timedelta(days=1)).date()
     before_offset = before_offset or timedelta(0)
     after_offset = after_offset or timedelta(0)
 
     sunrise_today = get_astral_event_date(hass, SUN_EVENT_SUNRISE, today)
     sunset_today = get_astral_event_date(hass, SUN_EVENT_SUNSET, today)
-    sunrise_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNRISE, tomorrow)
-    sunset_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNSET, tomorrow)
 
     sunrise = sunrise_today
     sunset = sunset_today
-    if (today > dt_util.as_local(cast(datetime, sunrise_today)).date() and
-            SUN_EVENT_SUNRISE in (before, after)):
+    if today > dt_util.as_local(
+        cast(datetime, sunrise_today)
+    ).date() and SUN_EVENT_SUNRISE in (before, after):
+        tomorrow = dt_util.as_local(utcnow + timedelta(days=1)).date()
+        sunrise_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNRISE, tomorrow)
         sunrise = sunrise_tomorrow
 
-    if (today > dt_util.as_local(cast(datetime, sunset_today)).date() and
-            SUN_EVENT_SUNSET in (before, after)):
+    if today > dt_util.as_local(
+        cast(datetime, sunset_today)
+    ).date() and SUN_EVENT_SUNSET in (before, after):
+        tomorrow = dt_util.as_local(utcnow + timedelta(days=1)).date()
+        sunset_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNSET, tomorrow)
         sunset = sunset_tomorrow
 
     if sunrise is None and SUN_EVENT_SUNRISE in (before, after):
@@ -344,31 +347,6 @@ def sun(
     if sunset is None and SUN_EVENT_SUNSET in (before, after):
         # There is no sunset today
         return False
-
-    if before == SUN_EVENT_SUNRISE and utcnow > cast(datetime, sunrise) + before_offset:
-    _LOGGER.warning("---------------------------------")
-    _LOGGER.warning("now: local %s, UTC: %s", dt_util.as_local(utcnow), utcnow)
-    _LOGGER.warning("today: %s",
-                    today)
-    _LOGGER.warning("  local: sunrise: %s, sunset: %s",
-                    dt_util.as_local(cast(datetime, sunrise_today)),
-                    dt_util.as_local(cast(datetime, sunset_today)))
-    _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
-                    sunrise_today, sunset_today)
-    _LOGGER.warning("tomorrow: %s",
-                    tomorrow)
-    _LOGGER.warning("  local: sunrise: %s, sunset: %s",
-                    dt_util.as_local(cast(datetime, sunrise_tomorrow)),
-                    dt_util.as_local(cast(datetime, sunset_tomorrow)))
-    _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
-                    sunrise_tomorrow, sunset_tomorrow)
-    _LOGGER.warning("used:")
-    _LOGGER.warning("  local: sunrise: %s, sunset: %s",
-                    dt_util.as_local(cast(datetime, sunrise)),
-                    dt_util.as_local(cast(datetime, sunset)))
-    _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
-                    sunrise, sunset)
-    _LOGGER.warning("---------------------------------")
 
     if before == SUN_EVENT_SUNRISE and utcnow > cast(datetime, sunrise) + before_offset:
         return False

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -329,8 +329,12 @@ def sun(
 
     sunrise = sunrise_today
     sunset = sunset_today
-    if today > dt_util.as_local(cast(datetime, sunrise_today)).date():
+    if (today > dt_util.as_local(cast(datetime, sunrise_today)).date() and
+            SUN_EVENT_SUNRISE in (before, after)):
         sunrise = sunrise_tomorrow
+
+    if (today > dt_util.as_local(cast(datetime, sunset_today)).date() and
+            SUN_EVENT_SUNSET in (before, after)):
         sunset = sunset_tomorrow
 
     if sunrise is None and SUN_EVENT_SUNRISE in (before, after):

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -318,11 +318,20 @@ def sun(
     """Test if current time matches sun requirements."""
     utcnow = dt_util.utcnow()
     today = dt_util.as_local(utcnow).date()
+    tomorrow = dt_util.as_local(utcnow + timedelta(days=1)).date()
     before_offset = before_offset or timedelta(0)
     after_offset = after_offset or timedelta(0)
 
     sunrise = get_astral_event_date(hass, SUN_EVENT_SUNRISE, today)
     sunset = get_astral_event_date(hass, SUN_EVENT_SUNSET, today)
+    midnight = get_astral_event_date(hass, 'solar_midnight', today)
+    sunrise_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNRISE, tomorrow)
+    sunset_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNSET, tomorrow)
+    midnight_tomorrow = get_astral_event_date(hass, 'solar_midnight', tomorrow)
+
+    if utcnow > midnight_tomorrow:
+        sunrise = sunrise_tomorrow
+        sunset = sunset_tomorrow
 
     if sunrise is None and SUN_EVENT_SUNRISE in (before, after):
         # There is no sunrise today
@@ -331,6 +340,27 @@ def sun(
     if sunset is None and SUN_EVENT_SUNSET in (before, after):
         # There is no sunset today
         return False
+
+    if before == SUN_EVENT_SUNRISE and utcnow > cast(datetime, sunrise) + before_offset:
+    _LOGGER.warning("---------------------------------")
+    _LOGGER.warning("today: %s",
+                    today)
+    _LOGGER.warning("  local: %s, sunrise: %s, sunset: %s, midnight: %s",
+                    dt_util.as_local(utcnow), dt_util.as_local(sunrise),
+                    dt_util.as_local(sunset), dt_util.as_local(midnight))
+    _LOGGER.warning("  UTC: %s, sunrise: %s, sunset: %s, midnight: %s",
+                    utcnow, sunrise, sunset, midnight)
+    _LOGGER.warning("tomorrow: %s",
+                    tomorrow)
+    _LOGGER.warning("  local: %s, sunrise: %s, sunset: %s, midnight: %s",
+                    dt_util.as_local(utcnow),
+                    dt_util.as_local(sunrise_tomorrow),
+                    dt_util.as_local(sunset_tomorrow),
+                    dt_util.as_local(midnight_tomorrow))
+    _LOGGER.warning("  UTC: %s, sunrise: %s, sunset: %s, midnight UTC: %s",
+                    utcnow, sunrise_tomorrow, sunset_tomorrow,
+                    midnight_tomorrow)
+    _LOGGER.warning("---------------------------------")
 
     if before == SUN_EVENT_SUNRISE and utcnow > cast(datetime, sunrise) + before_offset:
         return False

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -322,14 +322,14 @@ def sun(
     before_offset = before_offset or timedelta(0)
     after_offset = after_offset or timedelta(0)
 
-    sunrise = get_astral_event_date(hass, SUN_EVENT_SUNRISE, today)
-    sunset = get_astral_event_date(hass, SUN_EVENT_SUNSET, today)
-    midnight = get_astral_event_date(hass, 'solar_midnight', today)
+    sunrise_today = get_astral_event_date(hass, SUN_EVENT_SUNRISE, today)
+    sunset_today = get_astral_event_date(hass, SUN_EVENT_SUNSET, today)
     sunrise_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNRISE, tomorrow)
     sunset_tomorrow = get_astral_event_date(hass, SUN_EVENT_SUNSET, tomorrow)
-    midnight_tomorrow = get_astral_event_date(hass, 'solar_midnight', tomorrow)
 
-    if utcnow > midnight_tomorrow:
+    sunrise = sunrise_today
+    sunset = sunset_today
+    if today > dt_util.as_local(sunrise_today).date():
         sunrise = sunrise_tomorrow
         sunset = sunset_tomorrow
 
@@ -343,23 +343,27 @@ def sun(
 
     if before == SUN_EVENT_SUNRISE and utcnow > cast(datetime, sunrise) + before_offset:
     _LOGGER.warning("---------------------------------")
+    _LOGGER.warning("now: local %s, UTC: %s", dt_util.as_local(utcnow), utcnow)
     _LOGGER.warning("today: %s",
                     today)
-    _LOGGER.warning("  local: %s, sunrise: %s, sunset: %s, midnight: %s",
-                    dt_util.as_local(utcnow), dt_util.as_local(sunrise),
-                    dt_util.as_local(sunset), dt_util.as_local(midnight))
-    _LOGGER.warning("  UTC: %s, sunrise: %s, sunset: %s, midnight: %s",
-                    utcnow, sunrise, sunset, midnight)
+    _LOGGER.warning("  local: sunrise: %s, sunset: %s",
+                    dt_util.as_local(sunrise_today),
+                    dt_util.as_local(sunset_today))
+    _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
+                    sunrise_today, sunset_today)
     _LOGGER.warning("tomorrow: %s",
                     tomorrow)
-    _LOGGER.warning("  local: %s, sunrise: %s, sunset: %s, midnight: %s",
-                    dt_util.as_local(utcnow),
+    _LOGGER.warning("  local: sunrise: %s, sunset: %s",
                     dt_util.as_local(sunrise_tomorrow),
-                    dt_util.as_local(sunset_tomorrow),
-                    dt_util.as_local(midnight_tomorrow))
-    _LOGGER.warning("  UTC: %s, sunrise: %s, sunset: %s, midnight UTC: %s",
-                    utcnow, sunrise_tomorrow, sunset_tomorrow,
-                    midnight_tomorrow)
+                    dt_util.as_local(sunset_tomorrow))
+    _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
+                    sunrise_tomorrow, sunset_tomorrow)
+    _LOGGER.warning("used:")
+    _LOGGER.warning("  local: sunrise: %s, sunset: %s",
+                    dt_util.as_local(sunrise),
+                    dt_util.as_local(sunset))
+    _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
+                    sunrise, sunset)
     _LOGGER.warning("---------------------------------")
 
     if before == SUN_EVENT_SUNRISE and utcnow > cast(datetime, sunrise) + before_offset:

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -329,7 +329,7 @@ def sun(
 
     sunrise = sunrise_today
     sunset = sunset_today
-    if today > dt_util.as_local(sunrise_today).date():
+    if today > dt_util.as_local(cast(datetime, sunrise_today)).date():
         sunrise = sunrise_tomorrow
         sunset = sunset_tomorrow
 
@@ -347,21 +347,21 @@ def sun(
     _LOGGER.warning("today: %s",
                     today)
     _LOGGER.warning("  local: sunrise: %s, sunset: %s",
-                    dt_util.as_local(sunrise_today),
-                    dt_util.as_local(sunset_today))
+                    dt_util.as_local(cast(datetime, sunrise_today)),
+                    dt_util.as_local(cast(datetime, sunset_today)))
     _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
                     sunrise_today, sunset_today)
     _LOGGER.warning("tomorrow: %s",
                     tomorrow)
     _LOGGER.warning("  local: sunrise: %s, sunset: %s",
-                    dt_util.as_local(sunrise_tomorrow),
-                    dt_util.as_local(sunset_tomorrow))
+                    dt_util.as_local(cast(datetime, sunrise_tomorrow)),
+                    dt_util.as_local(cast(datetime, sunset_tomorrow)))
     _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
                     sunrise_tomorrow, sunset_tomorrow)
     _LOGGER.warning("used:")
     _LOGGER.warning("  local: sunrise: %s, sunset: %s",
-                    dt_util.as_local(sunrise),
-                    dt_util.as_local(sunset))
+                    dt_util.as_local(cast(datetime, sunrise)),
+                    dt_util.as_local(cast(datetime, sunset)))
     _LOGGER.warning("  UTC: sunrise: %s, sunset: %s",
                     sunrise, sunset)
     _LOGGER.warning("---------------------------------")

--- a/homeassistant/helpers/sun.py
+++ b/homeassistant/helpers/sun.py
@@ -1,6 +1,5 @@
 """Helpers for sun events."""
 import datetime
-import logging
 from typing import Optional, Union, TYPE_CHECKING
 
 from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
@@ -13,8 +12,6 @@ if TYPE_CHECKING:
     import astral  # pylint: disable=unused-import
 
 DATA_LOCATION_CACHE = "astral_location_cache"
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @callback

--- a/homeassistant/helpers/sun.py
+++ b/homeassistant/helpers/sun.py
@@ -1,5 +1,6 @@
 """Helpers for sun events."""
 import datetime
+import logging
 from typing import Optional, Union, TYPE_CHECKING
 
 from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
@@ -12,6 +13,8 @@ if TYPE_CHECKING:
     import astral  # pylint: disable=unused-import
 
 DATA_LOCATION_CACHE = "astral_location_cache"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -628,57 +628,49 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(hass, calls):
     at 7 AM and sunset at 3AM during summer
     After sunrise is true from sunrise until midnight, local time.
     """
-    tz = dt_util.get_time_zone('America/Anchorage')
+    tz = dt_util.get_time_zone("America/Anchorage")
     dt_util.set_default_time_zone(tz)
     hass.config.latitude = 66.5
     hass.config.longitude = 162.4
-    await async_setup_component(hass, automation.DOMAIN, {
-        automation.DOMAIN: {
-            'trigger': {
-                'platform': 'event',
-                'event_type': 'test_event',
-            },
-            'condition': {
-                'condition': 'sun',
-                'before': SUN_EVENT_SUNRISE,
-            },
-            'action': {
-                'service': 'test.automation'
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "condition": {"condition": "sun", "before": SUN_EVENT_SUNRISE},
+                "action": {"service": "test.automation"},
             }
-        }
-    })
+        },
+    )
 
     # sunrise: 2015-07-24 07:17:24 local, sunset: 2015-07-25 03:16:27 local
     # sunrise: 2015-07-24 15:17:24 UTC,   sunset: 2015-07-25 11:16:27 UTC
     # now = sunrise + 1s -> 'before sunrise' not true
     now = datetime(2015, 7, 24, 15, 17, 25, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 0 == len(calls)
 
     # now = sunrise -> 'before sunrise' true
     now = datetime(2015, 7, 24, 15, 17, 24, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = local midnight -> 'before sunrise' true
     now = datetime(2015, 7, 24, 8, 0, 0, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 2 == len(calls)
 
     # now = local midnight - 1s -> 'before sunrise' not true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 2 == len(calls)
 
@@ -692,57 +684,49 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(hass, calls):
     at 7 AM and sunset at 3AM during summer
     Before sunrise is true from midnight until sunrise, local time.
     """
-    tz = dt_util.get_time_zone('America/Anchorage')
+    tz = dt_util.get_time_zone("America/Anchorage")
     dt_util.set_default_time_zone(tz)
     hass.config.latitude = 66.5
     hass.config.longitude = 162.4
-    await async_setup_component(hass, automation.DOMAIN, {
-        automation.DOMAIN: {
-            'trigger': {
-                'platform': 'event',
-                'event_type': 'test_event',
-            },
-            'condition': {
-                'condition': 'sun',
-                'after': SUN_EVENT_SUNRISE,
-            },
-            'action': {
-                'service': 'test.automation'
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "condition": {"condition": "sun", "after": SUN_EVENT_SUNRISE},
+                "action": {"service": "test.automation"},
             }
-        }
-    })
+        },
+    )
 
     # sunrise: 2015-07-24 07:17:24 local, sunset: 2015-07-25 03:16:27 local
     # sunrise: 2015-07-24 15:17:24 UTC,   sunset: 2015-07-25 11:16:27 UTC
     # now = sunrise -> 'after sunrise' true
     now = datetime(2015, 7, 24, 15, 17, 24, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = sunrise - 1s -> 'after sunrise' not true
     now = datetime(2015, 7, 24, 15, 17, 23, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = local midnight -> 'after sunrise' not true
     now = datetime(2015, 7, 24, 8, 0, 1, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = local midnight - 1s -> 'after sunrise' true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 2 == len(calls)
 
@@ -756,57 +740,49 @@ async def test_if_action_before_sunset_no_offset_kotzebue(hass, calls):
     at 7 AM and sunset at 3AM during summer
     Before sunset is true from midnight until sunset, local time.
     """
-    tz = dt_util.get_time_zone('America/Anchorage')
+    tz = dt_util.get_time_zone("America/Anchorage")
     dt_util.set_default_time_zone(tz)
     hass.config.latitude = 66.5
     hass.config.longitude = 162.4
-    await async_setup_component(hass, automation.DOMAIN, {
-        automation.DOMAIN: {
-            'trigger': {
-                'platform': 'event',
-                'event_type': 'test_event',
-            },
-            'condition': {
-                'condition': 'sun',
-                'before': SUN_EVENT_SUNSET,
-            },
-            'action': {
-                'service': 'test.automation'
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "condition": {"condition": "sun", "before": SUN_EVENT_SUNSET},
+                "action": {"service": "test.automation"},
             }
-        }
-    })
+        },
+    )
 
     # sunrise: 2015-07-24 07:17:24 local, sunset: 2015-07-25 03:16:27 local
     # sunrise: 2015-07-24 15:17:24 UTC,   sunset: 2015-07-25 11:16:27 UTC
     # now = sunrise + 1s -> 'before sunrise' not true
     now = datetime(2015, 7, 25, 11, 16, 28, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 0 == len(calls)
 
     # now = sunrise -> 'before sunrise' true
     now = datetime(2015, 7, 25, 11, 16, 27, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = local midnight -> 'before sunrise' true
     now = datetime(2015, 7, 24, 8, 0, 0, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 2 == len(calls)
 
     # now = local midnight - 1s -> 'before sunrise' not true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 2 == len(calls)
 
@@ -820,56 +796,48 @@ async def test_if_action_after_sunset_no_offset_kotzebue(hass, calls):
     at 7 AM and sunset at 3AM during summer
     After sunset is true from sunset until midnight, local time.
     """
-    tz = dt_util.get_time_zone('America/Anchorage')
+    tz = dt_util.get_time_zone("America/Anchorage")
     dt_util.set_default_time_zone(tz)
     hass.config.latitude = 66.5
     hass.config.longitude = 162.4
-    await async_setup_component(hass, automation.DOMAIN, {
-        automation.DOMAIN: {
-            'trigger': {
-                'platform': 'event',
-                'event_type': 'test_event',
-            },
-            'condition': {
-                'condition': 'sun',
-                'after': SUN_EVENT_SUNSET,
-            },
-            'action': {
-                'service': 'test.automation'
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "condition": {"condition": "sun", "after": SUN_EVENT_SUNSET},
+                "action": {"service": "test.automation"},
             }
-        }
-    })
+        },
+    )
 
     # sunrise: 2015-07-24 07:17:24 local, sunset: 2015-07-25 03:16:27 local
     # sunrise: 2015-07-24 15:17:24 UTC,   sunset: 2015-07-25 11:16:27 UTC
     # now = sunset -> 'after sunset' true
     now = datetime(2015, 7, 25, 11, 16, 27, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = sunset - 1s -> 'after sunset' not true
     now = datetime(2015, 7, 25, 11, 16, 26, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = local midnight -> 'after sunset' not true
     now = datetime(2015, 7, 24, 8, 0, 1, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 1 == len(calls)
 
     # now = local midnight - 1s -> 'after sunset' true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with patch('homeassistant.util.dt.utcnow',
-               return_value=now):
-        hass.bus.async_fire('test_event')
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
         assert 2 == len(calls)

--- a/tests/components/automation/test_sun.py
+++ b/tests/components/automation/test_sun.py
@@ -626,7 +626,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(hass, calls):
     Local timezone: Alaska time
     Location: Kotzebue, which has a very skewed local timezone with sunrise
     at 7 AM and sunset at 3AM during summer
-    Before sunrise is true from midnight until sunset, local time.
+    After sunrise is true from sunrise until midnight, local time.
     """
     tz = dt_util.get_time_zone('America/Anchorage')
     dt_util.set_default_time_zone(tz)
@@ -690,7 +690,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(hass, calls):
     Local timezone: Alaska time
     Location: Kotzebue, which has a very skewed local timezone with sunrise
     at 7 AM and sunset at 3AM during summer
-    Before sunrise is true from midnight until sunset, local time.
+    Before sunrise is true from midnight until sunrise, local time.
     """
     tz = dt_util.get_time_zone('America/Anchorage')
     dt_util.set_default_time_zone(tz)
@@ -739,6 +739,134 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(hass, calls):
         assert 1 == len(calls)
 
     # now = local midnight - 1s -> 'after sunrise' true
+    now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 2 == len(calls)
+
+
+async def test_if_action_before_sunset_no_offset_kotzebue(hass, calls):
+    """
+    Test if action was before sunrise.
+
+    Local timezone: Alaska time
+    Location: Kotzebue, which has a very skewed local timezone with sunrise
+    at 7 AM and sunset at 3AM during summer
+    Before sunset is true from midnight until sunset, local time.
+    """
+    tz = dt_util.get_time_zone('America/Anchorage')
+    dt_util.set_default_time_zone(tz)
+    hass.config.latitude = 66.5
+    hass.config.longitude = 162.4
+    await async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'trigger': {
+                'platform': 'event',
+                'event_type': 'test_event',
+            },
+            'condition': {
+                'condition': 'sun',
+                'before': SUN_EVENT_SUNSET,
+            },
+            'action': {
+                'service': 'test.automation'
+            }
+        }
+    })
+
+    # sunrise: 2015-07-24 07:17:24 local, sunset: 2015-07-25 03:16:27 local
+    # sunrise: 2015-07-24 15:17:24 UTC,   sunset: 2015-07-25 11:16:27 UTC
+    # now = sunrise + 1s -> 'before sunrise' not true
+    now = datetime(2015, 7, 25, 11, 16, 28, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 0 == len(calls)
+
+    # now = sunrise -> 'before sunrise' true
+    now = datetime(2015, 7, 25, 11, 16, 27, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 1 == len(calls)
+
+    # now = local midnight -> 'before sunrise' true
+    now = datetime(2015, 7, 24, 8, 0, 0, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 2 == len(calls)
+
+    # now = local midnight - 1s -> 'before sunrise' not true
+    now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 2 == len(calls)
+
+
+async def test_if_action_after_sunset_no_offset_kotzebue(hass, calls):
+    """
+    Test if action was after sunrise.
+
+    Local timezone: Alaska time
+    Location: Kotzebue, which has a very skewed local timezone with sunrise
+    at 7 AM and sunset at 3AM during summer
+    After sunset is true from sunset until midnight, local time.
+    """
+    tz = dt_util.get_time_zone('America/Anchorage')
+    dt_util.set_default_time_zone(tz)
+    hass.config.latitude = 66.5
+    hass.config.longitude = 162.4
+    await async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'trigger': {
+                'platform': 'event',
+                'event_type': 'test_event',
+            },
+            'condition': {
+                'condition': 'sun',
+                'after': SUN_EVENT_SUNSET,
+            },
+            'action': {
+                'service': 'test.automation'
+            }
+        }
+    })
+
+    # sunrise: 2015-07-24 07:17:24 local, sunset: 2015-07-25 03:16:27 local
+    # sunrise: 2015-07-24 15:17:24 UTC,   sunset: 2015-07-25 11:16:27 UTC
+    # now = sunset -> 'after sunset' true
+    now = datetime(2015, 7, 25, 11, 16, 27, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 1 == len(calls)
+
+    # now = sunset - 1s -> 'after sunset' not true
+    now = datetime(2015, 7, 25, 11, 16, 26, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 1 == len(calls)
+
+    # now = local midnight -> 'after sunset' not true
+    now = datetime(2015, 7, 24, 8, 0, 1, tzinfo=dt_util.UTC)
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now):
+        hass.bus.async_fire('test_event')
+        await hass.async_block_till_done()
+        assert 1 == len(calls)
+
+    # now = local midnight - 1s -> 'after sunset' true
     now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
     with patch('homeassistant.util.dt.utcnow',
                return_value=now):


### PR DESCRIPTION
## Description:
When evaluating sun conditions, take care to ensure we are comparing current time with solar event times for the correct day.

The added test cases:
- `test_if_action_before_sunrise_no_offset_kotzebue`
- `test_if_action_after_sunrise_no_offset_kotzebue`
- `test_if_action_before_sunset_no_offset_kotzebue`
- `test_if_action_after_sunset_no_offset_kotzebue`

all fail without this patch because events from the wrong (already passed) day were compared with.
The added test cases test sun condition at summer in Kotzebue, which has an extremely skewed local time zone: https://en.wikipedia.org/wiki/Time_zone#Skewing_of_zones, with the sun setting at 3AM local time and rising at 7 AM local time during the summer as illustrated in this [chart](https://www.timeanddate.com/sun/usa/kotzebue).

Fix by testing if we got solar events from the previous local day, and if we do, use events for the next local day.

However, the sun conditions are still unintuitive with this change, `after_sunset` is for example true from 3 AM until midnight, whereas `after_sunrise` is true from 7 AM until midnight at summer in Kotzebue.

This means this condition will not work:
```yaml
condition:
    condition: or  # 'when dark' condition: either after sunset or before sunrise - equivalent to a state condition on `sun.sun` of `below_horizon`
    conditions:
      - condition: sun
        after: sunset
      - condition: sun
        before: sunrise
```

This is very much related to the solar events using midnight in _local time_ as a cutoff point instead of _solar_ midnight (https://www.home-assistant.io/docs/scripts/conditions/#sun-condition).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.