### PR TITLE
Add media_type_app to media_player

### DIFF
--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -39,6 +39,7 @@ MEDIA_TYPE_PLAYLIST = 'playlist'
 MEDIA_TYPE_IMAGE = 'image'
 MEDIA_TYPE_URL = 'url'
 MEDIA_TYPE_GAME = 'game'
+MEDIA_TYPE_APP = 'app'
 
 SERVICE_CLEAR_PLAYLIST = 'clear_playlist'
 SERVICE_PLAY_MEDIA = 'play_media'

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -3,7 +3,7 @@
   "name": "Ps4",
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.7.2"
+    "pyps4-homeassistant==0.7.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -7,8 +7,8 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     ENTITY_IMAGE_URL, MediaPlayerDevice)
 from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_GAME, SUPPORT_SELECT_SOURCE, SUPPORT_STOP, SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON)
+    MEDIA_TYPE_GAME, MEDIA_TYPE_APP, SUPPORT_SELECT_SOURCE,
+    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
 from homeassistant.components.ps4 import format_unique_id
 from homeassistant.const import (
     ATTR_COMMAND, ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_REGION,
@@ -222,7 +222,10 @@ class PS4Device(MediaPlayerDevice):
             self._media_title = app_name or name
             self._source = self._media_title
             self._media_image = art
-            self._media_type = MEDIA_TYPE_GAME
+            if title.game_type == 'App'
+                self._media_type = MEDIA_TYPE_APP
+            else:
+                self._media_type = MEDIA_TYPE_GAME
             self.update_list()
 
     def update_list(self):

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -222,7 +222,7 @@ class PS4Device(MediaPlayerDevice):
             self._media_title = app_name or name
             self._source = self._media_title
             self._media_image = art
-            if title.game_type == 'App'
+            if title.game_type == 'App':
                 self._media_type = MEDIA_TYPE_APP
             else:
                 self._media_type = MEDIA_TYPE_GAME

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1246,7 +1246,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.7.2
+pyps4-homeassistant==0.7.3
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -252,7 +252,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.7.2
+pyps4-homeassistant==0.7.3
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93


### PR DESCRIPTION
## Description:
Continuation/completion of PR #22459
PS4 component now can distinguish between game and app types. An app example would be the PS4 Netflix app.

**Pull request in [developers.home-assistant](https://github.com/home-assistant/developers.home-assistant) with documentation (if applicable):** home-assistant/developers.home-assistant#248

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [developers.home-assistant](https://github.com/home-assistant/developers.home-assistant)

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
