### PR TITLE
Catch thethingsnetwork TypeError

### DIFF
--- a/homeassistant/components/thethingsnetwork/sensor.py
+++ b/homeassistant/components/thethingsnetwork/sensor.py
@@ -45,7 +45,7 @@ async def async_setup_platform(
     success = await ttn_data_storage.async_update()
 
     if not success:
-        return False
+        return
 
     devices = []
     for value, unit_of_measurement in values.items():
@@ -78,7 +78,7 @@ class TtnDataSensor(Entity):
         if self._ttn_data_storage.data is not None:
             try:
                 return round(self._state[self._value], 1)
-            except KeyError:
+            except (KeyError, TypeError):
                 pass
 
     @property
@@ -124,32 +124,32 @@ class TtnDataStorage:
         try:
             session = async_get_clientsession(self._hass)
             with async_timeout.timeout(DEFAULT_TIMEOUT, loop=self._hass.loop):
-                req = await session.get(self._url, headers=self._headers)
+                response = await session.get(self._url, headers=self._headers)
 
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Error while accessing: %s", self._url)
-            return False
+            return
 
-        status = req.status
+        status = response.status
 
         if status == 204:
             _LOGGER.error("The device is not available: %s", self._device_id)
-            return False
+            return
 
         if status == 401:
             _LOGGER.error(
                 "Not authorized for Application ID: %s", self._app_id)
-            return False
+            return
 
         if status == 404:
             _LOGGER.error("Application ID is not available: %s", self._app_id)
-            return False
+            return
 
-        data = await req.json()
+        data = await response.json()
         self.data = data[-1]
 
         for value in self._values.items():
             if value[0] not in self.data.keys():
                 _LOGGER.warning("Value not available: %s", value[0])
 
-        return req
+        return response

--- a/homeassistant/components/thethingsnetwork/sensor.py
+++ b/homeassistant/components/thethingsnetwork/sensor.py
@@ -79,7 +79,7 @@ class TtnDataSensor(Entity):
             try:
                 return round(self._state[self._value], 1)
             except (KeyError, TypeError):
-                pass
+                return None
 
     @property
     def unit_of_measurement(self):
@@ -128,22 +128,22 @@ class TtnDataStorage:
 
         except (asyncio.TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Error while accessing: %s", self._url)
-            return
+            return None
 
         status = response.status
 
         if status == 204:
             _LOGGER.error("The device is not available: %s", self._device_id)
-            return
+            return None
 
         if status == 401:
             _LOGGER.error(
                 "Not authorized for Application ID: %s", self._app_id)
-            return
+            return None
 
         if status == 404:
             _LOGGER.error("Application ID is not available: %s", self._app_id)
-            return
+            return None
 
         data = await response.json()
         self.data = data[-1]

--- a/homeassistant/components/thethingsnetwork/sensor.py
+++ b/homeassistant/components/thethingsnetwork/sensor.py
@@ -80,6 +80,7 @@ class TtnDataSensor(Entity):
                 return round(self._state[self._value], 1)
             except (KeyError, TypeError):
                 return None
+        return None
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
## Description:
Strings can't be rounded.

**Related issue (if applicable):** fixes #23097

## Example entry for `configuration.yaml` (if applicable):
```yaml
thethingsnetwork:
  app_id: ha-connector
  access_key: ttn-account-v2.0W_xxxxxxxxxxxxxxxxx

sensor:
  - platform: thethingsnetwork
    device_id: sensor
    values:
      value: T
      voltage: V
      tempC: '°C'
      tDewC: '°C'
      rh: "%"
      p: mb
      lux: lx
      vBat: V
      vBus: V
      alpha: V
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

