### PR TITLE
Share snmp constants across all platforms

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -538,9 +538,7 @@ omit =
     homeassistant/components/smappee/*
     homeassistant/components/smtp/notify.py
     homeassistant/components/snapcast/media_player.py
-    homeassistant/components/snmp/device_tracker.py
-    homeassistant/components/snmp/sensor.py
-    homeassistant/components/snmp/switch.py
+    homeassistant/components/snmp/*
     homeassistant/components/sochain/sensor.py
     homeassistant/components/socialblade/sensor.py
     homeassistant/components/solaredge/sensor.py

--- a/homeassistant/components/snmp/const.py
+++ b/homeassistant/components/snmp/const.py
@@ -1,0 +1,43 @@
+"""SNMP constants."""
+CONF_ACCEPT_ERRORS = 'accept_errors'
+CONF_AUTH_KEY = 'auth_key'
+CONF_AUTH_PROTOCOL = 'auth_protocol'
+CONF_BASEOID = 'baseoid'
+CONF_COMMUNITY = 'community'
+CONF_DEFAULT_VALUE = 'default_value'
+CONF_PRIV_KEY = 'priv_key'
+CONF_PRIV_PROTOCOL = 'priv_protocol'
+CONF_VERSION = 'version'
+
+DEFAULT_AUTH_PROTOCOL = 'none'
+DEFAULT_COMMUNITY = 'public'
+DEFAULT_HOST = 'localhost'
+DEFAULT_NAME = 'SNMP'
+DEFAULT_PORT = '161'
+DEFAULT_PRIV_PROTOCOL = 'none'
+DEFAULT_VERSION = '1'
+
+SNMP_VERSIONS = {
+    '1': 0,
+    '2c': 1,
+    '3': None
+}
+
+MAP_AUTH_PROTOCOLS = {
+    'none': 'usmNoAuthProtocol',
+    'hmac-md5': 'usmHMACMD5AuthProtocol',
+    'hmac-sha': 'usmHMACSHAAuthProtocol',
+    'hmac128-sha224': 'usmHMAC128SHA224AuthProtocol',
+    'hmac192-sha256': 'usmHMAC192SHA256AuthProtocol',
+    'hmac256-sha384': 'usmHMAC256SHA384AuthProtocol',
+    'hmac384-sha512': 'usmHMAC384SHA512AuthProtocol',
+}
+
+MAP_PRIV_PROTOCOLS = {
+    'none': 'usmNoPrivProtocol',
+    'des': 'usmDESPrivProtocol',
+    '3des-ede': 'usm3DESEDEPrivProtocol',
+    'aes-cfb-128': 'usmAesCfb128Protocol',
+    'aes-cfb-192': 'usmAesCfb192Protocol',
+    'aes-cfb-256': 'usmAesCfb256Protocol',
+}

--- a/homeassistant/components/snmp/device_tracker.py
+++ b/homeassistant/components/snmp/device_tracker.py
@@ -4,26 +4,23 @@ import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    CONF_AUTH_KEY, CONF_BASEOID, CONF_COMMUNITY, CONF_PRIV_KEY,
+    DEFAULT_COMMUNITY)
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_AUTHKEY = 'authkey'
-CONF_BASEOID = 'baseoid'
-CONF_COMMUNITY = 'community'
-CONF_PRIVKEY = 'privkey'
-
-DEFAULT_COMMUNITY = 'public'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_BASEOID): cv.string,
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_COMMUNITY, default=DEFAULT_COMMUNITY): cv.string,
-    vol.Inclusive(CONF_AUTHKEY, 'keys'): cv.string,
-    vol.Inclusive(CONF_PRIVKEY, 'keys'): cv.string,
+    vol.Inclusive(CONF_AUTH_KEY, 'keys'): cv.string,
+    vol.Inclusive(CONF_PRIV_KEY, 'keys'): cv.string,
 })
 
 
@@ -44,13 +41,13 @@ class SnmpScanner(DeviceScanner):
         self.snmp = cmdgen.CommandGenerator()
 
         self.host = cmdgen.UdpTransportTarget((config[CONF_HOST], 161))
-        if CONF_AUTHKEY not in config or CONF_PRIVKEY not in config:
+        if CONF_AUTH_KEY not in config or CONF_PRIV_KEY not in config:
             self.auth = cmdgen.CommunityData(config[CONF_COMMUNITY])
         else:
             self.auth = cmdgen.UsmUserData(
                 config[CONF_COMMUNITY],
-                config[CONF_AUTHKEY],
-                config[CONF_PRIVKEY],
+                config[CONF_AUTH_KEY],
+                config[CONF_PRIV_KEY],
                 authProtocol=cfg.usmHMACSHAAuthProtocol,
                 privProtocol=cfg.usmAesCfb128Protocol
             )
@@ -108,7 +105,7 @@ class SnmpScanner(DeviceScanner):
                     mac = binascii.hexlify(val.asOctets()).decode('utf-8')
                 except AttributeError:
                     continue
-                _LOGGER.debug("Found MAC %s", mac)
+                _LOGGER.debug("Found MAC address: %s", mac)
                 mac = ':'.join([mac[i:i+2] for i in range(0, len(mac), 2)])
                 devices.append({'mac': mac})
         return devices

--- a/homeassistant/components/snmp/sensor.py
+++ b/homeassistant/components/snmp/sensor.py
@@ -1,60 +1,24 @@
 """Support for displaying collected data over SNMP."""
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT, STATE_UNKNOWN,
-    CONF_USERNAME, CONF_VALUE_TEMPLATE)
+    CONF_HOST, CONF_NAME, CONF_PORT, CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME,
+    CONF_VALUE_TEMPLATE, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+from .const import (
+    CONF_ACCEPT_ERRORS, CONF_AUTH_KEY, CONF_AUTH_PROTOCOL, CONF_BASEOID,
+    CONF_COMMUNITY, CONF_DEFAULT_VALUE, CONF_PRIV_KEY, CONF_PRIV_PROTOCOL,
+    CONF_VERSION, DEFAULT_AUTH_PROTOCOL, DEFAULT_COMMUNITY, DEFAULT_HOST,
+    DEFAULT_NAME, DEFAULT_PORT, DEFAULT_PRIV_PROTOCOL, DEFAULT_VERSION,
+    MAP_AUTH_PROTOCOLS, MAP_PRIV_PROTOCOLS, SNMP_VERSIONS)
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_BASEOID = 'baseoid'
-CONF_COMMUNITY = 'community'
-CONF_VERSION = 'version'
-CONF_AUTH_KEY = 'auth_key'
-CONF_AUTH_PROTOCOL = 'auth_protocol'
-CONF_PRIV_KEY = 'priv_key'
-CONF_PRIV_PROTOCOL = 'priv_protocol'
-CONF_ACCEPT_ERRORS = 'accept_errors'
-CONF_DEFAULT_VALUE = 'default_value'
-
-DEFAULT_COMMUNITY = 'public'
-DEFAULT_HOST = 'localhost'
-DEFAULT_NAME = 'SNMP'
-DEFAULT_PORT = '161'
-DEFAULT_VERSION = '1'
-DEFAULT_AUTH_PROTOCOL = 'none'
-DEFAULT_PRIV_PROTOCOL = 'none'
-
-SNMP_VERSIONS = {
-    '1': 0,
-    '2c': 1,
-    '3': None
-}
-
-MAP_AUTH_PROTOCOLS = {
-    'none': 'usmNoAuthProtocol',
-    'hmac-md5': 'usmHMACMD5AuthProtocol',
-    'hmac-sha': 'usmHMACSHAAuthProtocol',
-    'hmac128-sha224': 'usmHMAC128SHA224AuthProtocol',
-    'hmac192-sha256': 'usmHMAC192SHA256AuthProtocol',
-    'hmac256-sha384': 'usmHMAC256SHA384AuthProtocol',
-    'hmac384-sha512': 'usmHMAC384SHA512AuthProtocol',
-}
-
-MAP_PRIV_PROTOCOLS = {
-    'none': 'usmNoPrivProtocol',
-    'des': 'usmDESPrivProtocol',
-    '3des-ede': 'usm3DESEDEPrivProtocol',
-    'aes-cfb-128': 'usmAesCfb128Protocol',
-    'aes-cfb-192': 'usmAesCfb192Protocol',
-    'aes-cfb-256': 'usmAesCfb256Protocol',
-}
 
 SCAN_INTERVAL = timedelta(seconds=10)
 
@@ -194,7 +158,7 @@ class SnmpData:
 
     async def async_update(self):
         """Get the latest data from the remote SNMP capable host."""
-        from pysnmp.hlapi.asyncio import (getCmd, ObjectType, ObjectIdentity)
+        from pysnmp.hlapi.asyncio import getCmd, ObjectType, ObjectIdentity
 
         errindication, errstatus, errindex, restable = await getCmd(
             *self._request_args, ObjectType(ObjectIdentity(self._baseoid)))

--- a/homeassistant/components/snmp/switch.py
+++ b/homeassistant/components/snmp/switch.py
@@ -3,59 +3,27 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, CONF_PAYLOAD_ON, CONF_PAYLOAD_OFF,
+    CONF_HOST, CONF_NAME, CONF_PAYLOAD_OFF, CONF_PAYLOAD_ON, CONF_PORT,
     CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 
+from .const import (
+    CONF_AUTH_KEY, CONF_AUTH_PROTOCOL, CONF_BASEOID, CONF_COMMUNITY,
+    CONF_PRIV_KEY, CONF_PRIV_PROTOCOL, CONF_VERSION, DEFAULT_AUTH_PROTOCOL,
+    DEFAULT_HOST, DEFAULT_NAME, DEFAULT_PORT, DEFAULT_PRIV_PROTOCOL,
+    DEFAULT_VERSION, MAP_AUTH_PROTOCOLS, MAP_PRIV_PROTOCOLS, SNMP_VERSIONS)
+
 _LOGGER = logging.getLogger(__name__)
 
-CONF_BASEOID = 'baseoid'
 CONF_COMMAND_OID = 'command_oid'
-CONF_COMMAND_PAYLOAD_ON = 'command_payload_on'
 CONF_COMMAND_PAYLOAD_OFF = 'command_payload_off'
-CONF_COMMUNITY = 'community'
-CONF_VERSION = 'version'
-CONF_AUTH_KEY = 'auth_key'
-CONF_AUTH_PROTOCOL = 'auth_protocol'
-CONF_PRIV_KEY = 'priv_key'
-CONF_PRIV_PROTOCOL = 'priv_protocol'
+CONF_COMMAND_PAYLOAD_ON = 'command_payload_on'
 
-DEFAULT_NAME = 'SNMP Switch'
-DEFAULT_HOST = 'localhost'
-DEFAULT_PORT = '161'
 DEFAULT_COMMUNITY = 'private'
-DEFAULT_VERSION = '1'
-DEFAULT_AUTH_PROTOCOL = 'none'
-DEFAULT_PRIV_PROTOCOL = 'none'
-DEFAULT_PAYLOAD_ON = 1
 DEFAULT_PAYLOAD_OFF = 0
-
-SNMP_VERSIONS = {
-    '1': 0,
-    '2c': 1,
-    '3': None
-}
-
-MAP_AUTH_PROTOCOLS = {
-    'none': 'usmNoAuthProtocol',
-    'hmac-md5': 'usmHMACMD5AuthProtocol',
-    'hmac-sha': 'usmHMACSHAAuthProtocol',
-    'hmac128-sha224': 'usmHMAC128SHA224AuthProtocol',
-    'hmac192-sha256': 'usmHMAC192SHA256AuthProtocol',
-    'hmac256-sha384': 'usmHMAC256SHA384AuthProtocol',
-    'hmac384-sha512': 'usmHMAC384SHA512AuthProtocol',
-}
-
-MAP_PRIV_PROTOCOLS = {
-    'none': 'usmNoPrivProtocol',
-    'des': 'usmDESPrivProtocol',
-    '3des-ede': 'usm3DESEDEPrivProtocol',
-    'aes-cfb-128': 'usmAesCfb128Protocol',
-    'aes-cfb-192': 'usmAesCfb192Protocol',
-    'aes-cfb-256': 'usmAesCfb256Protocol',
-}
+DEFAULT_PAYLOAD_ON = 1
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_BASEOID): cv.string,
@@ -115,8 +83,8 @@ class SnmpSwitch(SwitchDevice):
                  command_payload_off):
         """Initialize the switch."""
         from pysnmp.hlapi.asyncio import (
-            CommunityData, ContextData, SnmpEngine,
-            UdpTransportTarget, UsmUserData)
+            CommunityData, ContextData, SnmpEngine, UdpTransportTarget,
+            UsmUserData)
 
         self._name = name
         self._baseoid = baseoid
@@ -172,8 +140,8 @@ class SnmpSwitch(SwitchDevice):
 
     async def async_update(self):
         """Update the state."""
-        from pysnmp.hlapi.asyncio import (getCmd, ObjectType, ObjectIdentity)
-        from pyasn1.type.univ import (Integer)
+        from pysnmp.hlapi.asyncio import getCmd, ObjectType, ObjectIdentity
+        from pyasn1.type.univ import Integer
 
         errindication, errstatus, errindex, restable = await getCmd(
             *self._request_args, ObjectType(ObjectIdentity(self._baseoid)))
@@ -203,7 +171,7 @@ class SnmpSwitch(SwitchDevice):
         return self._state
 
     async def _set(self, value):
-        from pysnmp.hlapi.asyncio import (setCmd, ObjectType, ObjectIdentity)
+        from pysnmp.hlapi.asyncio import setCmd, ObjectType, ObjectIdentity
 
         await setCmd(
             *self._request_args,


### PR DESCRIPTION
## Breaking Change:
The configuration of the SNMP device tracker was aligned with the other SNMP switch and the sensor configuration. If you are using authentication key and private key then change your configuration to `auth_key:` and `priv_key:`.

## Description:
Share constants across all platforms.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9381

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: snmp
    name: SNMP test
    host: 192.168.0.9
    baseoid: 1.3.6.1.4.1.2021.10.1.5.2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
