### PR TITLE
Upgrade spotcrime to 1.0.4 (fixes #13189)

### DIFF
--- a/homeassistant/components/spotcrime/manifest.json
+++ b/homeassistant/components/spotcrime/manifest.json
@@ -3,7 +3,7 @@
   "name": "Spotcrime",
   "documentation": "https://www.home-assistant.io/components/spotcrime",
   "requirements": [
-    "spotcrime==1.0.3"
+    "spotcrime==1.0.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1641,7 +1641,7 @@ speedtest-cli==2.1.1
 spiderpy==1.3.1
 
 # homeassistant.components.spotcrime
-spotcrime==1.0.3
+spotcrime==1.0.4
 
 # homeassistant.components.spotify
 spotipy-homeassistant==2.4.4.dev1


### PR DESCRIPTION
## Description:
`requests` is no longer pinned by sportcrime. 

**Related issue (if applicable):** fixes #13189 (#21187 took care of crimereport)

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
