### PR TITLE
Remove extraneous update call in SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -119,8 +119,6 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
         """Update alarm status."""
         from simplipy.system import SystemStates
 
-        await self._system.update()
-
         self._attrs[ATTR_ALARM_ACTIVE] = self._system.alarm_going_off
         if self._system.temperature:
             self._attrs[ATTR_TEMPERATURE] = self._system.temperature


### PR DESCRIPTION
## Description:

This PR removes an extra call to `system.update()` in SimpliSafe. In addition to removing a redundancy, this also (a) removes a place where a possible exception can occur and (b) eliminates possible access token destruction due to overlapping calls.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/23669

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
