### PR TITLE
Fix for #23665 in acer_projector component

### DIFF
--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -160,7 +160,7 @@ class AcerSwitch(SwitchDevice):
             self._state = False
             self._available = True
         else:
-            _LOGGER.warn('Unknown status ' + awns)
+            _LOGGER.warning('Unknown status %s', awns)
             self._available = False
 
         if self._state and self._available:

--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -1,6 +1,5 @@
 """Use serial protocol of Acer projector to obtain state of the projector."""
 import logging
-import re
 import time
 
 import voluptuous as vol
@@ -40,7 +39,6 @@ CMD_DICT = {
     STATE_ON: '* 0 IR 001\r',
     STATE_OFF: '* 0 IR 002\r',
 }
-
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_FILENAME): cv.isdevice,
@@ -90,14 +88,13 @@ class AcerSwitch(SwitchDevice):
         try:
             if not self.ser.is_open:
                 self.ser.open()
-            else:    
+            else:
                 self.ser.flushInput()
                 self.ser.flushOutput()
-                
+
             msg = msg.encode('utf-8')
             self.ser.write(msg)
-            #Try to get a response a maximum of 5 times
-            #for x in range(0, 5):
+            # Try to get a response a maximum of 5 times
             time.sleep(1)
             if self.ser.inWaiting() > 0:
                 _LOGGER.debug('Number of characters to read %s', self.ser.inWaiting())
@@ -111,8 +108,6 @@ class AcerSwitch(SwitchDevice):
                 
             _LOGGER.debug('No response for %s', msg)
             self.ser.close()
-                
-                    
             
         except serial.SerialException:
             _LOGGER.error('Problem communicating with %s', self._serial_port)
@@ -120,7 +115,7 @@ class AcerSwitch(SwitchDevice):
     def _write_read_format(self, msg):
         """Write msg, obtain answer and format output."""
         # answers are formatted as ***\answer\r***
-        #Try 5 times to get a response
+        # Try 5 times to get a response
         for x in range(0, 5):
             lines = self._write_read(msg)
                     
@@ -131,7 +126,7 @@ class AcerSwitch(SwitchDevice):
                         return decodeLine
             time.sleep(1)
         
-        #If it gets to here something has gone wrong
+        # If it gets to here something has gone wrong
         _LOGGER.warn('Not able to get the relevant state for %s', msg)
         _LOGGER.warn(lines)
         return STATE_UNKNOWN

--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -97,7 +97,7 @@ class AcerSwitch(SwitchDevice):
             # Try to get a response a maximum of 5 times
             time.sleep(1)
             if self.ser.inWaiting() > 0:
-                _LOGGER.debug('Number of characters to read %s', self.ser.inWaiting())
+                _LOGGER.debug('Characters to read %s', self.ser.inWaiting())
                 # Changed to read number of waiting characters
                 test_list = self.ser.read(self.ser.inWaiting()).split(b'\r')
                 # Remove empty strings from the list
@@ -105,10 +105,10 @@ class AcerSwitch(SwitchDevice):
                 if len(ret) > 0:
                     self.ser.close()
                     return ret
-                
+
             _LOGGER.debug('No response for %s', msg)
             self.ser.close()
-            
+
         except serial.SerialException:
             _LOGGER.error('Problem communicating with %s', self._serial_port)
 
@@ -118,14 +118,14 @@ class AcerSwitch(SwitchDevice):
         # Try 5 times to get a response
         for x in range(0, 5):
             lines = self._write_read(msg)
-                    
+
             if (lines is not None):
                 for line in lines:
                     decodeLine = line.decode('utf-8')
                     if not decodeLine.startswith('*'):
                         return decodeLine
             time.sleep(1)
-        
+
         # If it gets to here something has gone wrong
         _LOGGER.warn('Not able to get the relevant state for %s', msg)
         _LOGGER.warn(lines)
@@ -155,7 +155,7 @@ class AcerSwitch(SwitchDevice):
         """Get the latest state from the projector."""
         msg = CMD_DICT[LAMP]
         awns = self._write_read_format(msg)
-        
+
         if awns == 'Lamp 1':
             self._state = True
             self._available = True

--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -102,7 +102,7 @@ class AcerSwitch(SwitchDevice):
                 test_list = self.ser.read(self.ser.inWaiting()).split(b'\r')
                 # Remove empty strings from the list
                 ret = [i for i in test_list if i]
-                if len(ret) > 0:
+                if ret:
                     self.ser.close()
                     return ret
 
@@ -116,19 +116,20 @@ class AcerSwitch(SwitchDevice):
         """Write msg, obtain answer and format output."""
         # answers are formatted as ***\answer\r***
         # Try 5 times to get a response
-        for x in range(0, 5):
+        for count in range(0, 5):
+            _LOGGER.debug('Attempt to get communicate %s times', count)
             lines = self._write_read(msg)
 
-            if (lines is not None):
+            if lines is not None:
                 for line in lines:
-                    decodeLine = line.decode('utf-8')
-                    if not decodeLine.startswith('*'):
-                        return decodeLine
+                    decode_line = line.decode('utf-8')
+                    if not decode_line.startswith('*'):
+                        return decode_line
             time.sleep(1)
 
         # If it gets to here something has gone wrong
-        _LOGGER.warn('Not able to get the relevant state for %s', msg)
-        _LOGGER.warn(lines)
+        _LOGGER.warning('Not able to get the relevant state for %s', msg)
+        _LOGGER.warning(lines)
         return STATE_UNKNOWN
 
     @property
@@ -163,7 +164,7 @@ class AcerSwitch(SwitchDevice):
             self._state = False
             self._available = True
         else:
-            _LOGGER.warn('Unknown status ' + awns)
+            _LOGGER.warning('Unknown status %s', awns)
             self._available = False
 
         if self._state and self._available:

--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -1,7 +1,5 @@
 """Use serial protocol of Acer projector to obtain state of the projector."""
 import logging
-import time
-
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)

--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -95,7 +95,6 @@ class AcerSwitch(SwitchDevice):
             msg = msg.encode('utf-8')
             self.ser.write(msg)
             # Try to get a response a maximum of 5 times
-            time.sleep(1)
             if self.ser.inWaiting() > 0:
                 _LOGGER.debug('Characters to read %s', self.ser.inWaiting())
                 # Changed to read number of waiting characters
@@ -125,7 +124,6 @@ class AcerSwitch(SwitchDevice):
                     decode_line = line.decode('utf-8')
                     if not decode_line.startswith('*'):
                         return decode_line
-            time.sleep(1)
 
         # If it gets to here something has gone wrong
         _LOGGER.warning('Not able to get the relevant state for %s', msg)
@@ -164,7 +162,7 @@ class AcerSwitch(SwitchDevice):
             self._state = False
             self._available = True
         else:
-            _LOGGER.warning('Unknown status %s', awns)
+            _LOGGER.warn('Unknown status ' + awns)
             self._available = False
 
         if self._state and self._available:

--- a/homeassistant/components/acer_projector/switch.py
+++ b/homeassistant/components/acer_projector/switch.py
@@ -116,8 +116,6 @@ class AcerSwitch(SwitchDevice):
             
         except serial.SerialException:
             _LOGGER.error('Problem communicating with %s', self._serial_port)
-        #self.ser.close()
-        #return ret
 
     def _write_read_format(self, msg):
         """Write msg, obtain answer and format output."""


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #23665

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x ] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [ x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [ x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x ] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_