### PR TITLE
Introduce a special warm-white mode

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -298,14 +298,14 @@ class FluxLight(Light):
         if hs_color is not None:
             # Special case warm-white mode
             if hs_color == (29.6, 58.824):
-                white = 100 if brightness is None else (self.brightness / 255 * 100)
+                white = 255 if brightness is None else self.brightness
             else:
                 if brightness is None:
                     brightness = self.brightness
                 color = (hs_color[0], hs_color[1], brightness / 255 * 100)
         elif brightness is not None:
             if self._color == (0.0, 0.0, 0.0) and self._white_value > 0:
-                white = brightness / 255 * 100
+                white = brightness
             else:
                 color = (self._color[0], self._color[1],
                         brightness / 255 * 100)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -309,7 +309,7 @@ class FluxLight(Light):
                 white = brightness
             else:
                 color = (self._color[0], self._color[1],
-                        brightness / 255 * 100)
+                         brightness / 255 * 100)
         # handle RGBW mode
         if self._mode == MODE_RGBW:
             if white is not None:

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -210,6 +210,7 @@ class FluxLight(Light):
             return self._white_value
 
         return int(self._color[2] / 100 * 255)
+        return int(self._color[2] / 100 * 255) or self._white_value
 
     @property
     def hs_color(self):

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -208,8 +208,6 @@ class FluxLight(Light):
         """Return the brightness of this light between 0..255."""
         if self._mode == MODE_WHITE:
             return self._white_value
-
-        return int(self._color[2] / 100 * 255)
         return int(self._color[2] / 100 * 255) or self._white_value
 
     @property


### PR DESCRIPTION
## Description:
flux_led component does not properly support all available modes that Flux Led Lights can operate in. In particular: warm-white mode (when controlled from a smart assistants Alexa/Google Home) and cool-white mode (cannot be set from Homeassistant at all). In this PR, I'm improving the logic for warm-white mode when it is controlled by smart assistants.

**Related issue (if applicable):** fixes #23704

## Checklist:
  - [✓ ] The code change is tested and works locally.
  - [✓ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ✓] There is no commented out code in this PR.

If the code does not interact with devices:
  - [✓ ] Tests have been added to verify that the new code works.
