### PR TITLE
Bump pyheos to 0.5.2

### DIFF
--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "heos",
-  "name": "Heos",
+  "name": "HEOS",
   "documentation": "https://www.home-assistant.io/components/heos",
   "requirements": [
-    "pyheos==0.5.1"
+    "pyheos==0.5.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1094,7 +1094,7 @@ pygtt==1.1.2
 pyhaversion==2.2.1
 
 # homeassistant.components.heos
-pyheos==0.5.1
+pyheos==0.5.2
 
 # homeassistant.components.hikvision
 pyhik==0.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -229,7 +229,7 @@ pydeconz==58
 pydispatcher==2.0.5
 
 # homeassistant.components.heos
-pyheos==0.5.1
+pyheos==0.5.2
 
 # homeassistant.components.homematic
 pyhomematic==0.1.58


### PR DESCRIPTION
## Description:
Update `pyheos` to latest version to fix an edge case identified in the referenced issue.

**Related issue (if applicable):** fixes #23640
 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
