### PR TITLE
Use the URL provided by the Wink API for subscriptions.

### DIFF
--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -329,8 +329,10 @@ def setup(hass, config):
             return True
 
     pywink.set_user_agent(USER_AGENT)
+    sub_details = pywink.get_subscription_details()
     hass.data[DOMAIN]['pubnub'] = PubNubSubscriptionHandler(
-        pywink.get_subscription_key())
+        sub_details[0],
+        origin=sub_details[1])
 
     def _subscribe():
         hass.data[DOMAIN]['pubnub'].subscribe()

--- a/homeassistant/components/wink/manifest.json
+++ b/homeassistant/components/wink/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/components/wink",
   "requirements": [
     "pubnubsub-handler==1.0.4",
-    "python-wink==1.10.4"
+    "python-wink==1.10.5"
   ],
   "dependencies": ["configurator"],
   "codeowners": []

--- a/homeassistant/components/wink/manifest.json
+++ b/homeassistant/components/wink/manifest.json
@@ -3,8 +3,8 @@
   "name": "Wink",
   "documentation": "https://www.home-assistant.io/components/wink",
   "requirements": [
-    "pubnubsub-handler==1.0.3",
-    "python-wink==1.10.3"
+    "pubnubsub-handler==1.0.4",
+    "python-wink==1.10.4"
   ],
   "dependencies": ["configurator"],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1426,7 +1426,7 @@ python-vlc==1.1.2
 python-whois==0.7.1
 
 # homeassistant.components.wink
-python-wink==1.10.4
+python-wink==1.10.5
 
 # homeassistant.components.awair
 python_awair==0.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -894,7 +894,7 @@ psutil==5.6.2
 ptvsd==4.2.8
 
 # homeassistant.components.wink
-pubnubsub-handler==1.0.3
+pubnubsub-handler==1.0.4
 
 # homeassistant.components.pushbullet
 pushbullet.py==0.11.0
@@ -1426,7 +1426,7 @@ python-vlc==1.1.2
 python-whois==0.7.1
 
 # homeassistant.components.wink
-python-wink==1.10.3
+python-wink==1.10.4
 
 # homeassistant.components.awair
 python_awair==0.0.4


### PR DESCRIPTION
## Description:

Wink no longer uses PubNub hosted servers for their push updates. All pushes now come from notifier.wink.com this update is mostly changes to the libraries used by HA to talk with Wink. 

The URL for the subscription now comes from Wink's API so if they change it again, things hopefully will keep working with this without additional changes.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/wink-pubnub-not-updating/114580/42

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
