### PR TITLE
Bump zha-quirks version

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/components/zha",
   "requirements": [
     "bellows-homeassistant==0.7.3",
-    "zha-quirks==0.0.9",
+    "zha-quirks==0.0.12",
     "zigpy-deconz==0.1.4",
     "zigpy-homeassistant==0.3.3",
     "zigpy-xbee-homeassistant==0.2.1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1845,7 +1845,7 @@ zengge==0.2
 zeroconf==0.21.3
 
 # homeassistant.components.zha
-zha-quirks==0.0.9
+zha-quirks==0.0.12
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9


### PR DESCRIPTION
## Description:
Bump the version for zha-quirks

Fixes: #23628

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.