### PR TITLE
Fix upnp logger name

### DIFF
--- a/homeassistant/components/axis/const.py
+++ b/homeassistant/components/axis/const.py
@@ -1,7 +1,7 @@
 """Constants for the Axis component."""
 import logging
 
-LOGGER = logging.getLogger('homeassistant.components.axis')
+LOGGER = logging.getLogger(__package__)
 
 DOMAIN = 'axis'
 

--- a/homeassistant/components/emulated_roku/binding.py
+++ b/homeassistant/components/emulated_roku/binding.py
@@ -5,7 +5,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import CoreState, EventOrigin
 
-LOGGER = logging.getLogger('.')
+LOGGER = logging.getLogger(__package__)
 
 EVENT_ROKU_COMMAND = 'roku_command'
 

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -1,6 +1,6 @@
 """Constants for the Hue component."""
 import logging
 
-LOGGER = logging.getLogger('.')
+LOGGER = logging.getLogger(__package__)
 DOMAIN = "hue"
 API_NUPNP = 'https://www.meethue.com/api/nupnp'

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 import logging
 
-LOGGER = logging.getLogger('.')
+LOGGER = logging.getLogger(__package__)
 
 DOMAIN = 'rainmachine'
 

--- a/homeassistant/components/smhi/const.py
+++ b/homeassistant/components/smhi/const.py
@@ -13,4 +13,4 @@ ENTITY_ID_SENSOR_FORMAT = WEATHER_DOMAIN + ".smhi_{}"
 ENTITY_ID_SENSOR_FORMAT_HOME = ENTITY_ID_SENSOR_FORMAT.format(
     HOME_LOCATION_NAME)
 
-LOGGER = logging.getLogger('.')
+LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -1,7 +1,7 @@
 """Constants for the UniFi component."""
 import logging
 
-LOGGER = logging.getLogger('.')
+LOGGER = logging.getLogger(__package__)
 DOMAIN = 'unifi'
 
 CONTROLLER_ID = '{host}-{site}'

--- a/homeassistant/components/upnp/const.py
+++ b/homeassistant/components/upnp/const.py
@@ -7,5 +7,5 @@ CONF_HASS = 'hass'
 CONF_LOCAL_IP = 'local_ip'
 CONF_PORTS = 'ports'
 DOMAIN = 'upnp'
-LOGGER = logging.getLogger('.')
+LOGGER = logging.getLogger(__package__)
 SIGNAL_REMOVE_SENSOR = 'upnp_remove_sensor'


### PR DESCRIPTION
## Description:

Fix logger name for `upnp`-component. Currently it is `.`, which should be `homeassistant.components.upnp`

**Related issue (if applicable):** fixes #22787 (though already closed)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly ([example][ex-manifest]).
  - [x] New dependencies have been added to `requirements` in the manifest ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
