### PR TITLE
Add integration step to onboarding

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -97,8 +97,7 @@ class AuthProvidersView(HomeAssistantView):
     async def get(self, request):
         """Get available auth providers."""
         hass = request.app['hass']
-
-        if not hass.components.onboarding.async_is_onboarded():
+        if not hass.components.onboarding.async_is_user_onboarded():
             return self.json_message(
                 message='Onboarding not finished',
                 status_code=400,

--- a/homeassistant/components/onboarding/.translations/en.json
+++ b/homeassistant/components/onboarding/.translations/en.json
@@ -1,0 +1,7 @@
+{
+    "area": {
+        "bedroom": "Bedroom",
+        "kitchen": "Kitchen",
+        "living_room": "Living Room"
+    }
+}

--- a/homeassistant/components/onboarding/__init__.py
+++ b/homeassistant/components/onboarding/__init__.py
@@ -1,24 +1,42 @@
 """Support to help onboard new users."""
 from homeassistant.core import callback
 from homeassistant.loader import bind_hass
+from homeassistant.helpers.storage import Store
 
-from .const import DOMAIN, STEP_USER, STEPS
+from .const import DOMAIN, STEP_USER, STEPS, STEP_INTEGRATION
 
 STORAGE_KEY = DOMAIN
-STORAGE_VERSION = 1
+STORAGE_VERSION = 2
+
+
+class OnboadingStorage(Store):
+    """Store onboarding data."""
+
+    async def _async_migrate_func(self, old_version, old_data):
+        """Migrate to the new version."""
+        # From version 1 -> 2, we automatically mark the integration step done
+        old_data['done'].append(STEP_INTEGRATION)
+        return old_data
 
 
 @bind_hass
 @callback
 def async_is_onboarded(hass):
     """Return if Home Assistant has been onboarded."""
-    return hass.data.get(DOMAIN, True)
+    data = hass.data.get(DOMAIN)
+    return data is None or data is True
+
+
+@bind_hass
+@callback
+def async_is_user_onboarded(hass):
+    """Return if a user has been created as part of onboarding."""
+    return async_is_onboarded(hass) or STEP_USER in hass.data[DOMAIN]['done']
 
 
 async def async_setup(hass, config):
     """Set up the onboarding component."""
-    store = hass.helpers.storage.Store(
-        STORAGE_VERSION, STORAGE_KEY, private=True)
+    store = OnboadingStorage(hass, STORAGE_VERSION, STORAGE_KEY, private=True)
     data = await store.async_load()
 
     if data is None:
@@ -43,7 +61,7 @@ async def async_setup(hass, config):
     if set(data['done']) == set(STEPS):
         return True
 
-    hass.data[DOMAIN] = False
+    hass.data[DOMAIN] = data
 
     from . import views
 

--- a/homeassistant/components/onboarding/const.py
+++ b/homeassistant/components/onboarding/const.py
@@ -1,9 +1,11 @@
 """Constants for the onboarding component."""
 DOMAIN = 'onboarding'
 STEP_USER = 'user'
+STEP_INTEGRATION = 'integration'
 
 STEPS = [
-    STEP_USER
+    STEP_USER,
+    STEP_INTEGRATION,
 ]
 
 DEFAULT_AREAS = (

--- a/homeassistant/components/onboarding/const.py
+++ b/homeassistant/components/onboarding/const.py
@@ -5,3 +5,9 @@ STEP_USER = 'user'
 STEPS = [
     STEP_USER
 ]
+
+DEFAULT_AREAS = (
+    'living_room',
+    'kitchen',
+    'bedroom',
+)

--- a/homeassistant/components/onboarding/strings.json
+++ b/homeassistant/components/onboarding/strings.json
@@ -1,0 +1,7 @@
+{
+  "area": {
+    "living_room": "Living Room",
+    "bedroom": "Bedroom",
+    "kitchen": "Kitchen"
+  }
+}

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -3,7 +3,6 @@ import asyncio
 
 import voluptuous as vol
 
-from homeassistant.exceptions import Unauthorized
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import callback

--- a/homeassistant/components/onboarding/views.py
+++ b/homeassistant/components/onboarding/views.py
@@ -7,7 +7,7 @@ from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import callback
 
-from .const import DOMAIN, STEP_USER, STEPS
+from .const import DOMAIN, STEP_USER, STEPS, DEFAULT_AREAS
 
 
 async def async_setup(hass, data, store):
@@ -109,7 +109,7 @@ class UserOnboardingView(_BaseOnboardingView):
             area_registry = \
                 await hass.helpers.area_registry.async_get_registry()
 
-            for area in ('living_room', 'bedroom', 'kitchen'):
+            for area in DEFAULT_AREAS:
                 area_registry.async_create(
                     translations['component.onboarding.area.{}'.format(area)]
                 )

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -21,7 +21,7 @@ async def test_fetch_auth_providers(hass, aiohttp_client):
 async def test_fetch_auth_providers_onboarding(hass, aiohttp_client):
     """Test fetching auth providers."""
     client = await async_setup_auth(hass, aiohttp_client)
-    with patch('homeassistant.components.onboarding.async_is_onboarded',
+    with patch('homeassistant.components.onboarding.async_is_user_onboarded',
                return_value=False):
         resp = await client.get('/auth/providers')
     assert resp.status == 400

--- a/tests/components/onboarding/test_init.py
+++ b/tests/components/onboarding/test_init.py
@@ -51,8 +51,26 @@ async def test_is_onboarded():
     hass.data[onboarding.DOMAIN] = True
     assert onboarding.async_is_onboarded(hass)
 
-    hass.data[onboarding.DOMAIN] = False
+    hass.data[onboarding.DOMAIN] = {
+        'done': []
+    }
     assert not onboarding.async_is_onboarded(hass)
+
+
+async def test_is_user_onboarded():
+    """Test the is onboarded function."""
+    hass = Mock()
+    hass.data = {}
+
+    assert onboarding.async_is_user_onboarded(hass)
+
+    hass.data[onboarding.DOMAIN] = True
+    assert onboarding.async_is_user_onboarded(hass)
+
+    hass.data[onboarding.DOMAIN] = {
+        'done': []
+    }
+    assert not onboarding.async_is_user_onboarded(hass)
 
 
 async def test_having_owner_finishes_user_step(hass, hass_storage):
@@ -70,3 +88,22 @@ async def test_having_owner_finishes_user_step(hass, hass_storage):
 
     done = hass_storage[onboarding.STORAGE_KEY]['data']['done']
     assert onboarding.STEP_USER in done
+
+
+async def test_migration(hass, hass_storage):
+    """Test migrating onboarding to new version."""
+    hass_storage[onboarding.STORAGE_KEY] = {
+        'version': 1,
+        'data': {
+            'done': ["user"]
+        }
+    }
+    assert await async_setup_component(hass, 'onboarding', {})
+
+    hass_storage[onboarding.STORAGE_KEY] = {
+        'version': 2,
+        'data': {
+            'done': ["user", "integration"]
+        }
+    }
+    assert onboarding.async_is_onboarded(hass)

--- a/tests/components/onboarding/test_init.py
+++ b/tests/components/onboarding/test_init.py
@@ -99,11 +99,4 @@ async def test_migration(hass, hass_storage):
         }
     }
     assert await async_setup_component(hass, 'onboarding', {})
-
-    hass_storage[onboarding.STORAGE_KEY] = {
-        'version': 2,
-        'data': {
-            'done': ["user", "integration"]
-        }
-    }
     assert onboarding.async_is_onboarded(hass)

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -201,6 +201,7 @@ async def test_onboarding_integration(hass, hass_storage, hass_client):
     })
 
     assert resp.status == 200
+    assert const.STEP_INTEGRATION in hass_storage[const.DOMAIN]['data']['done']
     tokens = await resp.json()
 
     assert (

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -72,10 +72,6 @@ async def test_onboarding_user_already_done(hass, hass_storage,
 async def test_onboarding_user(hass, hass_storage, aiohttp_client):
     """Test creating a new user."""
     assert await async_setup_component(hass, 'person', {})
-    mock_storage(hass_storage, {
-        'done': ['hello']
-    })
-
     assert await async_setup_component(hass, 'onboarding', {})
 
     client = await aiohttp_client(hass.http.app)
@@ -89,6 +85,8 @@ async def test_onboarding_user(hass, hass_storage, aiohttp_client):
     })
 
     assert resp.status == 200
+    assert const.STEP_USER in hass_storage[const.DOMAIN]['data']['done']
+
     data = await resp.json()
     assert 'auth_code' in data
 


### PR DESCRIPTION
## Description:
Add a new "integration" step to the onboarding. During this step , the onboarding page will set up a WebSocket connection and allow the user to configure integrations.

Frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/3163

Fixes https://github.com/home-assistant/architecture/issues/92

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-manifest]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mobile_app/manifest.json#L5
[manifest-docs]: https://developers.home-assistant.io/docs/en/development_checklist.html#_the-manifest-file_
