### PR TITLE
Adding filter support for splunk component.

### DIFF
--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -62,8 +62,8 @@ def setup(hass, config):
         """Listen for new messages on the bus and sends them to Splunk."""
         state = event.data.get('new_state')
 
+        """Skip empty states, and exclude filtered domains/entities."""
         if state is None or not entity_filter(state.entity_id):
-            """Skip empty states, and exclude filtered domains/entities."""
             return
 
         try:

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -62,8 +62,8 @@ def setup(hass, config):
         """Listen for new messages on the bus and sends them to Splunk."""
         state = event.data.get('new_state')
 
-        """Skip empty states, and exclude filtered domains/entities."""
         if state is None or not entity_filter(state.entity_id):
+            """Skip empty states, and exclude filtered domains/entities."""
             return
 
         try:

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -11,12 +11,10 @@ from homeassistant.const import (
     CONF_PORT, CONF_TOKEN, EVENT_STATE_CHANGED)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.helpers.json import JSONEncoder
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_FILTER = 'filter'
 DOMAIN = 'splunk'
 
 DEFAULT_HOST = 'localhost'
@@ -32,7 +30,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SSL, default=False): cv.boolean,
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_FILTER, default={}): FILTER_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -47,8 +44,6 @@ def setup(hass, config):
     verify_ssl = conf.get(CONF_VERIFY_SSL)
     name = conf.get(CONF_NAME)
 
-    entity_filter = conf[CONF_FILTER]
-
     if use_ssl:
         uri_scheme = 'https://'
     else:
@@ -62,8 +57,7 @@ def setup(hass, config):
         """Listen for new messages on the bus and sends them to Splunk."""
         state = event.data.get('new_state')
 
-        """Skip empty states, and exclude filtered domains/entities."""
-        if state is None or not entity_filter(state.entity_id):
+        if state is None:
             return
 
         try:

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -11,10 +11,12 @@ from homeassistant.const import (
     CONF_PORT, CONF_TOKEN, EVENT_STATE_CHANGED)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.helpers.json import JSONEncoder
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_FILTER = 'filter'
 DOMAIN = 'splunk'
 
 DEFAULT_HOST = 'localhost'
@@ -30,6 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SSL, default=False): cv.boolean,
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_FILTER, default={}): FILTER_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -44,6 +47,8 @@ def setup(hass, config):
     verify_ssl = conf.get(CONF_VERIFY_SSL)
     name = conf.get(CONF_NAME)
 
+    entity_filter = conf[CONF_FILTER]
+
     if use_ssl:
         uri_scheme = 'https://'
     else:
@@ -57,7 +62,8 @@ def setup(hass, config):
         """Listen for new messages on the bus and sends them to Splunk."""
         state = event.data.get('new_state')
 
-        if state is None:
+        """Skip empty states, and exclude filtered domains/entities."""
+        if state is None or not entity_filter(state.entity_id):
             return
 
         try:


### PR DESCRIPTION
## Description:
Adding "filter" support for the Splunk component.  Filter implementation is modeled after the current HomeKit component filter support.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9409

## Example entry for `configuration.yaml` (if applicable):
```yaml
splunk:
  token: XXXXXXXXXXX
  host: splunk.example.com
  port: 8088
  ssl: true
  verify_ssl: false
  name: homeassistant
  filter:
    exclude_domains:
      - automation
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
* No changes to communication code.

If the code does not interact with devices:
* Are there any tests for splunk component at all?  I didn't see them where I was looking (maybe looking in wrong place).

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html