### PR TITLE
Add stepped volume to demo

### DIFF
--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -125,16 +125,12 @@ class AbstractDemoPlayer(MediaPlayerDevice):
 
     def volume_up(self):
         """Increase volume."""
-        self._volume_level += 0.1
-        if self._volume_level > 1.0:
-            self._volume_level = 1.0
+        self._volume_level = min(1.0, self._volume_level + 0.1)
         self.schedule_update_ha_state()
 
     def volume_down(self):
         """Decrease volume."""
-        self._volume_level -= 0.1
-        if self._volume_level < 0.0:
-            self._volume_level = 0.0
+        self._volume_level = max(0.0, self._volume_level - 0.1)
         self.schedule_update_ha_state()
 
     def set_volume_level(self, volume):

--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -5,7 +5,8 @@ from homeassistant.components.media_player.const import (
     SUPPORT_CLEAR_PLAYLIST, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK,
     SUPPORT_SELECT_SOUND_MODE, SUPPORT_SELECT_SOURCE, SUPPORT_SHUFFLE_SET,
-    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET)
+    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_STEP)
 from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 import homeassistant.util.dt as dt_util
 
@@ -35,7 +36,7 @@ YOUTUBE_PLAYER_SUPPORT = \
 MUSIC_PLAYER_SUPPORT = \
     SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
     SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_CLEAR_PLAYLIST | \
-    SUPPORT_PLAY | SUPPORT_SHUFFLE_SET | \
+    SUPPORT_PLAY | SUPPORT_SHUFFLE_SET | SUPPORT_VOLUME_STEP | \
     SUPPORT_PREVIOUS_TRACK | SUPPORT_NEXT_TRACK | \
     SUPPORT_SELECT_SOUND_MODE
 
@@ -120,6 +121,20 @@ class AbstractDemoPlayer(MediaPlayerDevice):
     def mute_volume(self, mute):
         """Mute the volume."""
         self._volume_muted = mute
+        self.schedule_update_ha_state()
+
+    def volume_up(self):
+        """Increase volume."""
+        self._volume_level += 0.1
+        if self._volume_level > 1.0:
+            self._volume_level = 1.0
+        self.schedule_update_ha_state()
+
+    def volume_down(self):
+        """Decrease volume."""
+        self._volume_level -= 0.1
+        if self._volume_level < 0.0:
+            self._volume_level = 0.0
         self.schedule_update_ha_state()
 
     def set_volume_level(self, volume):


### PR DESCRIPTION
## Description:
Add ability to step volume on some of the media_player demos. It's nice to use for testing things out.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  playform: demo
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~[_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.~
  - [ ] ~New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.~
  - [ ] ~Untested files have been added to `.coveragerc`~

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
