### PR TITLE
Update PyYAML to 5.1

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,7 +10,7 @@ cryptography==2.6.1
 pip>=8.0.3
 python-slugify==3.0.2
 pytz>=2019.01
-pyyaml>=3.13,<4
+pyyaml==5.1
 requests==2.21.0
 ruamel.yaml==0.15.94
 voluptuous==0.11.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ cryptography==2.6.1
 pip>=8.0.3
 python-slugify==3.0.2
 pytz>=2019.01
-pyyaml>=3.13,<4
+pyyaml==5.1
 requests==2.21.0
 ruamel.yaml==0.15.94
 voluptuous==0.11.5

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ REQUIRES = [
     'pip>=8.0.3',
     'python-slugify==3.0.2',
     'pytz>=2019.01',
-    'pyyaml>=3.13,<4',
+    'pyyaml==5.1',
     'requests==2.21.0',
     'ruamel.yaml==0.15.94',
     'voluptuous==0.11.5',


### PR DESCRIPTION
## Breaking Change:

- Deprecate yaml.load and add FullLoader and UnsafeLoader classes
- Make default_flow_style=False

The **Deprecate yaml.load** is just related to tests, otherwise, in Home Assistant, there is used SafeLineLoader. 

https://github.com/home-assistant/home-assistant/blob/a52f96b23abcdcdec12608834698af425e2ff43a/homeassistant/util/yaml.py#L95

## Description:

Update pyyaml to version 5.1.
- Fixes [CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342)

Changelog: https://raw.githubusercontent.com/yaml/pyyaml/master/CHANGES

**Related issue (if applicable):** Fixes #23195

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html