### PR TITLE
Sort discovered entries by 'st' to ensure getting the same device

### DIFF
--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -1,5 +1,6 @@
 """Open ports in your router for Home Assistant and provide statistics."""
 from ipaddress import ip_address
+from operator import itemgetter
 
 import voluptuous as vol
 
@@ -88,6 +89,8 @@ async def async_discover_and_construct(hass, udn=None) -> Device:
             _LOGGER.warning('Wanted UPnP/IGD device with UDN "%s" not found, '
                             'aborting', udn)
             return None
+        # ensure we're always taking the latest
+        filtered = sorted(filtered, key=itemgetter('st'), reverse=True)
         discovery_info = filtered[0]
     else:
         # get the first/any


### PR DESCRIPTION
## Description:

Some devices report themselves multiple times during discovery, but with a slightly different name. Ensure the same discovery-entry is taken each time.

**Related issue (if applicable):** fixes #23735

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
