### PR TITLE
OctoPrint improvements

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -157,14 +157,14 @@ def setup(hass, config):
         octoprint_api.post('job', "{\"command\": \"cancel\"}")
 
     def handle_command(call):
-        """Sends a command to the printer."""
+        """Sends a command."""
         json_string = "{\"command\": \""
         json_string += call.data.get(ATTR_COMMAND)
         json_string += "\"}"
         octoprint_api.post('printer/command', json_string)
 
     def handle_connect(call):
-        """Connects to the printer."""
+        """Connects the printer."""
         port = call.data.get(ATTR_PORT)
         baudrate = call.data.get(ATTR_BAUDRATE)
         printer_profile = call.data.get(ATTR_PRINTER_PROFILE)
@@ -182,7 +182,7 @@ def setup(hass, config):
         octoprint_api.post('connection', json_string)
 
     def handle_disconnect(call):
-        """Disconnects from the printer."""
+        """Disconnects the printer."""
         octoprint_api.post('connection', "{\"command\": \"disconnect\"}")
 
     def handle_pause_job(call):
@@ -196,7 +196,7 @@ def setup(hass, config):
             'job', "{\"command\": \"pause\",\"action\": \"resume\"}")
 
     def handle_target_temperature(call):
-        """Sets the target temperature for a tool or the bed."""
+        """Sets the target temperature."""
         name = call.data.get(ATTR_NAME)
         temperature = call.data.get(ATTR_TEMPERATURE)
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -80,7 +80,7 @@ SENSOR_TYPES = {
                      'seconds', 'mdi:clock-start'],
     "Job File": ['job', ['job', 'file', 'display'],
                  None, 'mdi:file'],
-    "Printers Avaliable": ['connection', ['options', 'ports'],
+    "Printers Available": ['connection', ['options', 'ports'],
                            None, 'mdi:printer-3d'],
 }
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -69,7 +69,9 @@ SENSOR_TYPES = {
     "Time Remaining": ['job', ['progress', 'printTimeLeft'],
                        'seconds', 'mdi:clock-end'],
     "Time Elapsed": ['job', ['progress', 'printTime'],
-                     'seconds', 'mdi:clock-start']
+                     'seconds', 'mdi:clock-start'],
+    "Job File": ['job', ['job', 'file', 'display'],
+                         None, 'mdi:file'],
 }
 
 SENSOR_SCHEMA = vol.Schema({

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.discovery import SERVICE_OCTOPRINT
 from homeassistant.const import (
     CONF_API_KEY, CONF_HOST, CONTENT_TYPE_JSON, CONF_NAME, CONF_PATH,
     CONF_PORT, CONF_SSL, TEMP_CELSIUS, CONF_MONITORED_CONDITIONS, CONF_SENSORS,
-    CONF_BINARY_SENSORS, ATTR_NAME, ATTR_TEMPERATURE)
+    CONF_BINARY_SENSORS, ATTR_COMMAND, ATTR_NAME, ATTR_TEMPERATURE)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
@@ -29,6 +29,7 @@ ATTR_BAUDRATE = 'baudrate'
 ATTR_PRINTER_PROFILE = 'printer_profile'
 
 SERVICE_CANCEL_JOB = 'cancel_job'
+SERVICE_COMMAND = 'command'
 SERVICE_CONNECT = 'connect'
 SERVICE_DISCONNECT = 'disconnect'
 SERVICE_PAUSE_JOB = 'pause_job'
@@ -155,6 +156,13 @@ def setup(hass, config):
         """Aborts current job."""
         octoprint_api.post('job', "{\"command\": \"cancel\"}")
 
+    def handle_command(call):
+        """Sends a command to the printer."""
+        json_string = "{\"command\": \""
+        json_string += call.data.get(ATTR_COMMAND)
+        json_string += "\"}"
+        octoprint_api.post('printer/command', json_string)
+
     def handle_connect(call):
         """Connects to the printer."""
         port = call.data.get(ATTR_PORT)
@@ -206,6 +214,7 @@ def setup(hass, config):
             octoprint_api.post('printer/tool', json_string)
 
     hass.services.register(DOMAIN, SERVICE_CANCEL_JOB, handle_cancel_job)
+    hass.services.register(DOMAIN, SERVICE_COMMAND, handle_command)
     hass.services.register(DOMAIN, SERVICE_CONNECT, handle_connect)
     hass.services.register(DOMAIN, SERVICE_DISCONNECT, handle_disconnect)
     hass.services.register(DOMAIN, SERVICE_PAUSE_JOB, handle_pause_job)

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -164,7 +164,7 @@ def setup(hass, config):
         if port is not None:
             json_string += ", \"port\": \"{}\"".format(port)
         if baudrate is not None:
-            json_string += ", \"baudrate\": \"{}\"".format(baudrate)
+            json_string += ", \"baudrate\": {}".format(baudrate)
         if printer_profile is not None:
             json_string += ", \"printerProfile\": \"{}\"".format(
                 printer_profile)

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -24,7 +24,13 @@ CONF_NUMBER_OF_TOOLS = 'number_of_tools'
 DEFAULT_NAME = 'OctoPrint'
 DOMAIN = 'octoprint'
 
+ATTR_PORT = 'port'
+ATTR_BAUDRATE = 'baudrate'
+ATTR_PRINTER_PROFILE = 'printer_profile'
+
 SERVICE_CANCEL_JOB = 'cancel_job'
+SERVICE_CONNECT = 'connect'
+SERVICE_DISCONNECT = 'disconnect'
 SERVICE_PAUSE_JOB = 'pause_job'
 SERVICE_RESUME_JOB = 'resume_job'
 
@@ -146,6 +152,28 @@ def setup(hass, config):
         """Aborts current job."""
         octoprint_api.post('job', "{\"command\": \"cancel\"}")
 
+    def handle_connect(call):
+        """Connects to the printer."""
+        port = call.data.get(ATTR_PORT)
+        baudrate = call.data.get(ATTR_BAUDRATE)
+        printer_profile = call.data.get(ATTR_PRINTER_PROFILE)
+
+        json_string = "{\"command\": \"connect\""
+        if port is not None:
+            json_string += ", \"port\": \"{}\"".format(port)
+        if baudrate is not None:
+            json_string += ", \"baudrate\": \"{}\"".format(baudrate)
+        if printer_profile is not None:
+            json_string += ", \"printerProfile\": \"{}\"".format(
+                printer_profile)
+        json_string += "}"
+
+        octoprint_api.post('connection', json_string)
+
+    def handle_disconnect(call):
+        """Disconnects from the printer."""
+        octoprint_api.post('connection', "{\"command\": \"disconnect\"}")
+
     def handle_pause_job(call):
         """Pauses current job."""
         octoprint_api.post(
@@ -157,9 +185,9 @@ def setup(hass, config):
             'job', "{\"command\": \"pause\",\"action\": \"resume\"}")
 
     hass.services.register(DOMAIN, SERVICE_CANCEL_JOB, handle_cancel_job)
-
+    hass.services.register(DOMAIN, SERVICE_CONNECT, handle_connect)
+    hass.services.register(DOMAIN, SERVICE_DISCONNECT, handle_disconnect)
     hass.services.register(DOMAIN, SERVICE_PAUSE_JOB, handle_pause_job)
-
     hass.services.register(DOMAIN, SERVICE_RESUME_JOB, handle_resume_job)
 
     return success

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.discovery import SERVICE_OCTOPRINT
 from homeassistant.const import (
     CONF_API_KEY, CONF_HOST, CONTENT_TYPE_JSON, CONF_NAME, CONF_PATH,
     CONF_PORT, CONF_SSL, TEMP_CELSIUS, CONF_MONITORED_CONDITIONS, CONF_SENSORS,
-    CONF_BINARY_SENSORS, CONF_ENTITY_ID)
+    CONF_BINARY_SENSORS)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
@@ -71,7 +71,7 @@ SENSOR_TYPES = {
     "Time Elapsed": ['job', ['progress', 'printTime'],
                      'seconds', 'mdi:clock-start'],
     "Job File": ['job', ['job', 'file', 'display'],
-                         None, 'mdi:file'],
+                 None, 'mdi:file'],
 }
 
 SENSOR_SCHEMA = vol.Schema({

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -153,18 +153,18 @@ def setup(hass, config):
         success = True
 
     def handle_cancel_job(call):
-        """Aborts current job."""
+        """Abort the current job."""
         octoprint_api.post('job', "{\"command\": \"cancel\"}")
 
     def handle_command(call):
-        """Sends a command."""
+        """Send a command to the printer."""
         json_string = "{\"command\": \""
         json_string += call.data.get(ATTR_COMMAND)
         json_string += "\"}"
         octoprint_api.post('printer/command', json_string)
 
     def handle_connect(call):
-        """Connects the printer."""
+        """Connect to the printer."""
         port = call.data.get(ATTR_PORT)
         baudrate = call.data.get(ATTR_BAUDRATE)
         printer_profile = call.data.get(ATTR_PRINTER_PROFILE)
@@ -182,21 +182,21 @@ def setup(hass, config):
         octoprint_api.post('connection', json_string)
 
     def handle_disconnect(call):
-        """Disconnects the printer."""
+        """Disconnect from the printer."""
         octoprint_api.post('connection', "{\"command\": \"disconnect\"}")
 
     def handle_pause_job(call):
-        """Pauses current job."""
+        """Pause current job."""
         octoprint_api.post(
             'job', "{\"command\": \"pause\",\"action\": \"pause\"}")
 
     def handle_resume_job(call):
-        """Resumes current job."""
+        """Resume current job."""
         octoprint_api.post(
             'job', "{\"command\": \"pause\",\"action\": \"resume\"}")
 
     def handle_target_temperature(call):
-        """Sets the target temperature."""
+        """Set the target temperature."""
         name = call.data.get(ATTR_NAME)
         temperature = call.data.get(ATTR_TEMPERATURE)
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -78,6 +78,8 @@ SENSOR_TYPES = {
                      'seconds', 'mdi:clock-start'],
     "Job File": ['job', ['job', 'file', 'display'],
                  None, 'mdi:file'],
+    "Printers Avaliable": ['connection', ['options', 'ports'],
+                           None, 'mdi:printer-3d'],
 }
 
 SENSOR_SCHEMA = vol.Schema({

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -97,7 +97,11 @@ class OctoPrintSensor(Entity):
     def update(self):
         """Update state of sensor."""
         try:
-            self._state = self.api.update(self.api_endpoint, self.api_path)
+            data = self.api.update(self.api_endpoint, self.api_path)
+            if isinstance(data, list):
+                self._state = len(data)
+            else:
+                self._state = data
         except requests.exceptions.ConnectionError:
             # Error calling the api, already logged in api.update()
             return

--- a/homeassistant/components/octoprint/services.yaml
+++ b/homeassistant/components/octoprint/services.yaml
@@ -3,8 +3,15 @@
 cancel_job:
   description: Cancels current job.
 
+command:
+  description: Sends a command to the printer.
+  fields:
+    command:
+      description: The command. This is the same as inputting into the terminal.
+      example: G28
+
 connect:
-  description: Connects to the printer
+  description: Connects to the printer.
   fields:
     port:
       description: 'Optional: The port to connect to. Defaults to preferred or auto detection.'
@@ -17,7 +24,7 @@ connect:
       example: ender_3
 
 disconnect:
-  description: Disconnects from the printer
+  description: Disconnects from the printer.
 
 pause_job:
   description: Pauses current job.
@@ -26,11 +33,11 @@ resume_job:
   description: Resumes current job.
 
 target_temperature:
-  description: Sets temperature target for the given tool or bed
+  description: Sets temperature target for the given tool or bed.
   fields:
     name:
       description: The name. You can set tools or set 'bed' to set the bed temperature.
       example: tool0
     temperature: 
-      description: The target temperature for the tool or bed
+      description: The target temperature for the tool or bed.
       example: 200

--- a/homeassistant/components/octoprint/services.yaml
+++ b/homeassistant/components/octoprint/services.yaml
@@ -3,6 +3,22 @@
 cancel_job:
   description: Cancels current job.
 
+connect:
+  description: Connects to the printer
+  fields:
+    port:
+      description: 'Optional: The port to connect to. Defaults to preferred or auto detection.'
+      example: /dev/ttyUSB0
+    baudrate:
+      description: 'Optional: Specific baudrate to connect with. Defaults to preferred or auto detection.'
+      example: 115200
+    printer_profile:
+      description: 'Optional: Specific printer profile to use. Defaults to current profile.'
+      example: ender_3
+
+disconnect:
+  description: Disconnects from the printer
+
 pause_job:
   description: Pauses current job.
 

--- a/homeassistant/components/octoprint/services.yaml
+++ b/homeassistant/components/octoprint/services.yaml
@@ -24,3 +24,13 @@ pause_job:
 
 resume_job:
   description: Resumes current job.
+
+target_temperature:
+  description: Sets temperature target for the given tool or bed
+  fields:
+    name:
+      description: The name. You can set tools or set 'bed' to set the bed temperature.
+      example: tool0
+    temperature: 
+      description: The target temperature for the tool or bed
+      example: 200

--- a/homeassistant/components/octoprint/services.yaml
+++ b/homeassistant/components/octoprint/services.yaml
@@ -1,0 +1,10 @@
+# Describes the format for available octoprint services
+
+cancel_job:
+  description: Cancels current job.
+
+pause_job:
+  description: Pauses current job.
+
+resume_job:
+  description: Resumes current job.


### PR DESCRIPTION
## Breaking Change:

Users who use the binary sensors will need to change their automations to use the device classes instead of `on` or `off`. The Printing Error sensor now uses the `problem` device class and the Printing sensor now uses the `moving` device class.

## Description:

Improves upon the OctoPrint component, adding new sensors, services and rewriting some of the code to be more easily added unto.

- Adds services to pause, resume and cancel jobs
- Adds services to connect and disconnect from printer
- Adds Target Temperature service
- Adds command service (GCODE)
- Rewrites sensor and binary sensor to work with dynamic paths
- Adds job file sensor
- Adds printers available sensor

![image](https://user-images.githubusercontent.com/28114703/57488341-b351cc80-72aa-11e9-9b29-255d1e946020.png)

![image](https://user-images.githubusercontent.com/28114703/57488354-bf3d8e80-72aa-11e9-903d-4927cd844e84.png)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9424

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
