### PR TITLE
Zestimate: Fix for issue #23739.  Added unique_id property

### DIFF
--- a/homeassistant/components/zestimate/sensor.py
+++ b/homeassistant/components/zestimate/sensor.py
@@ -66,6 +66,11 @@ class ZestimateDataSensor(Entity):
         self.data = None
         self.address = None
         self._state = None
+ 
+    @property
+    def unique_id(self):
+        """Return the ZPID."""
+        return self.params['zpid']
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
Added unique_id property so that entities will always get mapped to the same
property ZPID code.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
fixes #23739 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
