### PR TITLE
Enable Homematic IP cloud climate device with HeatingThermostat only

### DIFF
--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -50,6 +50,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
     def __init__(self, home: AsyncHome, device) -> None:
         """Initialize heating group."""
         device.modelType = 'Group-Heating'
+        self._simple_heating = None
         if device.actualTemperature is None:
             self._simple_heating = _get_first_heating_thermostat(device)
         super().__init__(home, device)
@@ -72,7 +73,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
     @property
     def current_temperature(self) -> float:
         """Return the current temperature."""
-        if hasattr(self, '_simple_heating') and self._simple_heating:
+        if self._simple_heating:
             return self._simple_heating.valveActualTemperature
         return self._device.actualTemperature
 
@@ -110,3 +111,4 @@ def _get_first_heating_thermostat(heating_group: AsyncHeatingGroup):
         if isinstance(device, (AsyncHeatingThermostat,
                                AsyncHeatingThermostatCompact)):
             return device
+    return None


### PR DESCRIPTION
## Description:
Current Situation:
If you create a room in Homematic IP that does not contain a wall thermostat, then the corresponding climate entity in HA will not have a current temperature.

Solution in this PR:
If a HmIP HeatingGroup has no currentTemperature then take the valveActualTemperature from the **first** HeatingThermostat that belongs to this group.  

**Related issue (if applicable):** fixes #23773

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
