### PR TITLE
fix two times creating JWT headers in Push Notifications

### DIFF
--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -484,15 +484,6 @@ class HTML5NotificationService(BaseNotificationService):
             payload[ATTR_DATA][ATTR_JWT] = add_jwt(
                 timestamp, target, payload[ATTR_TAG],
                 info[ATTR_SUBSCRIPTION][ATTR_KEYS][ATTR_AUTH])
-            import jwt
-            jwt_secret = info[ATTR_SUBSCRIPTION][ATTR_KEYS][ATTR_AUTH]
-            jwt_exp = (datetime.fromtimestamp(timestamp) +
-                       timedelta(days=JWT_VALID_DAYS))
-            jwt_claims = {'exp': jwt_exp, 'nbf': timestamp,
-                          'iat': timestamp, ATTR_TARGET: target,
-                          ATTR_TAG: payload[ATTR_TAG]}
-            jwt_token = jwt.encode(jwt_claims, jwt_secret).decode('utf-8')
-            payload[ATTR_DATA][ATTR_JWT] = jwt_token
             webpusher = WebPusher(info[ATTR_SUBSCRIPTION])
             if self._vapid_prv and self._vapid_email:
                 vapid_headers = create_vapid_headers(


### PR DESCRIPTION
I found bug in my PR: https://github.com/home-assistant/home-assistant/pull/22988
Two times creating JWT headers.
First time in the method, second time in the code.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
