### PR TITLE
WIP : Add configurable scan interval for worldtidesinfo

### DIFF
--- a/homeassistant/components/worldtidesinfo/sensor.py
+++ b/homeassistant/components/worldtidesinfo/sensor.py
@@ -18,15 +18,19 @@ ATTRIBUTION = "Data provided by WorldTides"
 
 DEFAULT_NAME = 'WorldTidesInfo'
 
-SCAN_INTERVAL = timedelta(seconds=3600)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=3600)
+
+CONF_SCAN_INTERVAL = 'interval_seconds'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Optional(CONF_LATITUDE): cv.latitude,
     vol.Optional(CONF_LONGITUDE): cv.longitude,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SCAN_INTERVAL): cv.time_period
 })
 
+SCAN_INTERVAL = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the WorldTidesInfo sensor."""


### PR DESCRIPTION
## Description:
Adding a config option to customize scan interval as API is billed.
This was asked as feature request.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here> TODO !

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: worldtidesinfo
    api_key: YOUR_API_KEY
    interval_seconds: 7200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) TODO

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
