### PR TITLE
Entity Component to no longer generate automatic groups

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -125,9 +125,7 @@ def is_on(hass, entity_id):
 
 async def async_setup(hass, config):
     """Set up the automation."""
-    component = EntityComponent(
-        _LOGGER, DOMAIN, hass, group_name=GROUP_NAME_ALL_AUTOMATIONS
-    )
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     await _async_process_config(hass, config, component)
 

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -29,7 +29,7 @@ SCAN_INTERVAL = timedelta(seconds=60)
 async def async_setup(hass, config):
     """Track states and offer events for calendars."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, DOMAIN
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
     )
 
     hass.http.register_view(CalendarListView(component))

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
@@ -37,9 +36,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "cover"
 SCAN_INTERVAL = timedelta(seconds=15)
-
-GROUP_NAME_ALL_COVERS = "all covers"
-ENTITY_ID_ALL_COVERS = group.ENTITY_ID_FORMAT.format("all_covers")
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
@@ -82,16 +78,15 @@ ATTR_TILT_POSITION = "tilt_position"
 
 
 @bind_hass
-def is_closed(hass, entity_id=None):
+def is_closed(hass, entity_id):
     """Return if the cover is closed based on the statemachine."""
-    entity_id = entity_id or ENTITY_ID_ALL_COVERS
     return hass.states.is_state(entity_id, STATE_CLOSED)
 
 
 async def async_setup(hass, config):
     """Track states and offer events for covers."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_COVERS
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
     )
 
     await component.async_setup(config)

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -3,7 +3,6 @@ import asyncio
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
@@ -42,8 +41,6 @@ from .const import (
     SOURCE_TYPE_ROUTER,
 )
 from .legacy import DeviceScanner  # noqa: F401 pylint: disable=unused-import
-
-ENTITY_ID_ALL_DEVICES = group.ENTITY_ID_FORMAT.format("all_devices")
 
 SERVICE_SEE = "see"
 
@@ -97,11 +94,9 @@ SERVICE_SEE_PAYLOAD_SCHEMA = vol.Schema(
 
 
 @bind_hass
-def is_on(hass: HomeAssistantType, entity_id: str = None):
+def is_on(hass: HomeAssistantType, entity_id: str):
     """Return the state if any or a specified device is home."""
-    entity = entity_id or ENTITY_ID_ALL_DEVICES
-
-    return hass.states.is_state(entity, STATE_HOME)
+    return hass.states.is_state(entity_id, STATE_HOME)
 
 
 def see(
@@ -147,8 +142,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 
     if setup_tasks:
         await asyncio.wait(setup_tasks)
-
-    tracker.async_setup_group()
 
     async def async_platform_discovered(p_type, info):
         """Load a platform."""

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -8,15 +8,6 @@ import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.components import zone
-from homeassistant.components.group import (
-    ATTR_ADD_ENTITIES,
-    ATTR_ENTITIES,
-    ATTR_OBJECT_ID,
-    ATTR_VISIBLE,
-    DOMAIN as DOMAIN_GROUP,
-    SERVICE_SET,
-)
-from homeassistant.components.zone import async_active_zone
 from homeassistant.config import async_log_exception, load_yaml_config_file
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -60,7 +51,6 @@ from .const import (
 )
 
 YAML_DEVICES = "known_devices.yaml"
-GROUP_NAME_ALL_DEVICES = "all devices"
 EVENT_NEW_DEVICE = "device_tracker_new_device"
 
 
@@ -104,7 +94,6 @@ class DeviceTracker:
             else defaults.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
         )
         self.defaults = defaults
-        self.group = None
         self._is_updating = asyncio.Lock()
 
         for dev in devices:
@@ -230,21 +219,6 @@ class DeviceTracker:
         if device.track:
             await device.async_update_ha_state()
 
-        # During init, we ignore the group
-        if self.group and self.track_new:
-            self.hass.async_create_task(
-                self.hass.async_call(
-                    DOMAIN_GROUP,
-                    SERVICE_SET,
-                    {
-                        ATTR_OBJECT_ID: util.slugify(GROUP_NAME_ALL_DEVICES),
-                        ATTR_VISIBLE: False,
-                        ATTR_NAME: GROUP_NAME_ALL_DEVICES,
-                        ATTR_ADD_ENTITIES: [device.entity_id],
-                    },
-                )
-            )
-
         self.hass.bus.async_fire(
             EVENT_NEW_DEVICE,
             {
@@ -270,27 +244,6 @@ class DeviceTracker:
             await self.hass.async_add_executor_job(
                 update_config, self.hass.config.path(YAML_DEVICES), dev_id, device
             )
-
-    @callback
-    def async_setup_group(self):
-        """Initialize group for all tracked devices.
-
-        This method must be run in the event loop.
-        """
-        entity_ids = [dev.entity_id for dev in self.devices.values() if dev.track]
-
-        self.hass.async_create_task(
-            self.hass.services.async_call(
-                DOMAIN_GROUP,
-                SERVICE_SET,
-                {
-                    ATTR_OBJECT_ID: util.slugify(GROUP_NAME_ALL_DEVICES),
-                    ATTR_VISIBLE: False,
-                    ATTR_NAME: GROUP_NAME_ALL_DEVICES,
-                    ATTR_ENTITIES: entity_ids,
-                },
-            )
-        )
 
     @callback
     def async_update_stale(self, now: dt_util.dt.datetime):
@@ -489,7 +442,7 @@ class Device(RestoreEntity):
         if self.location_name:
             self._state = self.location_name
         elif self.gps is not None and self.source_type == SOURCE_TYPE_GPS:
-            zone_state = async_active_zone(
+            zone_state = zone.async_active_zone(
                 self.hass, self.gps[0], self.gps[1], self.gps_accuracy
             )
             if zone_state is None:

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.const import SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
@@ -21,9 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "fan"
 SCAN_INTERVAL = timedelta(seconds=30)
-
-GROUP_NAME_ALL_FANS = "all fans"
-ENTITY_ID_ALL_FANS = group.ENTITY_ID_FORMAT.format(GROUP_NAME_ALL_FANS)
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
@@ -58,9 +54,8 @@ PROP_TO_ATTR = {
 
 
 @bind_hass
-def is_on(hass, entity_id: Optional[str] = None) -> bool:
+def is_on(hass, entity_id: str) -> bool:
     """Return if the fans are on based on the statemachine."""
-    entity_id = entity_id or ENTITY_ID_ALL_FANS
     state = hass.states.get(entity_id)
     return state.attributes[ATTR_SPEED] not in [SPEED_OFF, None]
 
@@ -68,7 +63,7 @@ def is_on(hass, entity_id: Optional[str] = None) -> bool:
 async def async_setup(hass, config: dict):
     """Expose fan control via statemachine and services."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_FANS
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
     )
 
     await component.async_setup(config)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -9,7 +9,6 @@ from typing import Dict, Optional, Tuple
 import voluptuous as vol
 
 from homeassistant.auth.permissions.const import POLICY_CONTROL
-from homeassistant.components.group import ENTITY_ID_FORMAT as GROUP_ENTITY_ID_FORMAT
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TOGGLE,
@@ -33,9 +32,6 @@ import homeassistant.util.color as color_util
 
 DOMAIN = "light"
 SCAN_INTERVAL = timedelta(seconds=30)
-
-GROUP_NAME_ALL_LIGHTS = "all lights"
-ENTITY_ID_ALL_LIGHTS = GROUP_ENTITY_ID_FORMAT.format("all_lights")
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
@@ -131,9 +127,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @bind_hass
-def is_on(hass, entity_id=None):
+def is_on(hass, entity_id):
     """Return if the lights are on based on the statemachine."""
-    entity_id = entity_id or ENTITY_ID_ALL_LIGHTS
     return hass.states.is_state(entity_id, STATE_ON)
 
 
@@ -183,7 +178,7 @@ def preprocess_turn_off(params):
 async def async_setup(hass, config):
     """Expose light control via state machine and services."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_LIGHTS
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
     )
     await component.async_setup(config)
 
@@ -336,7 +331,7 @@ class Profiles:
         name = entity_id + ".default"
         if name in cls._all:
             return name
-        name = ENTITY_ID_ALL_LIGHTS + ".default"
+        name = "group.all_lights.default"
         if name in cls._all:
             return name
         return None

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -5,7 +5,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_CODE_FORMAT,
@@ -32,10 +31,7 @@ ATTR_CHANGED_BY = "changed_by"
 DOMAIN = "lock"
 SCAN_INTERVAL = timedelta(seconds=30)
 
-ENTITY_ID_ALL_LOCKS = group.ENTITY_ID_FORMAT.format("all_locks")
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
-
-GROUP_NAME_ALL_LOCKS = "all locks"
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
@@ -50,16 +46,15 @@ PROP_TO_ATTR = {"changed_by": ATTR_CHANGED_BY, "code_format": ATTR_CODE_FORMAT}
 
 
 @bind_hass
-def is_locked(hass, entity_id=None):
+def is_locked(hass, entity_id):
     """Return if the lock is locked based on the statemachine."""
-    entity_id = entity_id or ENTITY_ID_ALL_LOCKS
     return hass.states.is_state(entity_id, STATE_LOCKED)
 
 
 async def async_setup(hass, config):
     """Track states and offer events for locks."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_LOCKS
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
     )
 
     await component.async_setup(config)

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -5,7 +5,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.components.recorder.models import States
 from homeassistant.components.recorder.util import execute, session_scope
 from homeassistant.const import (
@@ -101,8 +100,6 @@ PLANT_SCHEMA = vol.Schema(
 )
 
 DOMAIN = "plant"
-GROUP_NAME_ALL_PLANTS = "all plants"
-ENTITY_ID_ALL_PLANTS = group.ENTITY_ID_FORMAT.format("all_plants")
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: {cv.string: PLANT_SCHEMA}}, extra=vol.ALLOW_EXTRA)
 
@@ -114,7 +111,7 @@ ENABLE_LOAD_HISTORY = False
 
 async def async_setup(hass, config):
     """Set up the Plant component."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass, group_name=GROUP_NAME_ALL_PLANTS)
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     entities = []
     for plant_name, plant_config in config[DOMAIN].items():

--- a/homeassistant/components/remember_the_milk/__init__.py
+++ b/homeassistant/components/remember_the_milk/__init__.py
@@ -17,7 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "remember_the_milk"
 DEFAULT_NAME = DOMAIN
-GROUP_NAME_RTM = "remember the milk accounts"
 
 CONF_SHARED_SECRET = "shared_secret"
 CONF_ID_MAP = "id_map"
@@ -50,7 +49,7 @@ SERVICE_SCHEMA_COMPLETE_TASK = vol.Schema({vol.Required(CONF_ID): cv.string})
 
 def setup(hass, config):
     """Set up the Remember the milk component."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass, group_name=GROUP_NAME_RTM)
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     stored_rtm_config = RememberTheMilkConfiguration(hass)
     for rtm_config in config[DOMAIN]:

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -5,7 +5,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.const import (
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
@@ -38,10 +37,7 @@ ATTR_TIMEOUT = "timeout"
 DOMAIN = "remote"
 SCAN_INTERVAL = timedelta(seconds=30)
 
-ENTITY_ID_ALL_REMOTES = group.ENTITY_ID_FORMAT.format("all_remotes")
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
-
-GROUP_NAME_ALL_REMOTES = "all remotes"
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
@@ -61,17 +57,14 @@ REMOTE_SERVICE_ACTIVITY_SCHEMA = make_entity_service_schema(
 
 
 @bind_hass
-def is_on(hass, entity_id=None):
+def is_on(hass, entity_id):
     """Return if the remote is on based on the statemachine."""
-    entity_id = entity_id or ENTITY_ID_ALL_REMOTES
     return hass.states.is_state(entity_id, STATE_ON)
 
 
 async def async_setup(hass, config):
     """Track states and offer events for remotes."""
-    component = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_REMOTES
-    )
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
     await component.async_setup(config)
 
     component.async_register_entity_service(

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -38,8 +38,6 @@ CONF_SEQUENCE = "sequence"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
-GROUP_NAME_ALL_SCRIPTS = "all scripts"
-
 SCRIPT_ENTRY_SCHEMA = vol.Schema(
     {
         CONF_ALIAS: cv.string,
@@ -73,9 +71,7 @@ def is_on(hass, entity_id):
 
 async def async_setup(hass, config):
     """Load the scripts from the configuration."""
-    component = EntityComponent(
-        _LOGGER, DOMAIN, hass, group_name=GROUP_NAME_ALL_SCRIPTS
-    )
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     await _async_process_config(hass, config, component)
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -4,7 +4,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.const import (
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
@@ -23,9 +22,6 @@ from homeassistant.loader import bind_hass
 
 DOMAIN = "switch"
 SCAN_INTERVAL = timedelta(seconds=30)
-
-GROUP_NAME_ALL_SWITCHES = "all switches"
-ENTITY_ID_ALL_SWITCHES = group.ENTITY_ID_FORMAT.format("all_switches")
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
@@ -50,19 +46,18 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @bind_hass
-def is_on(hass, entity_id=None):
+def is_on(hass, entity_id):
     """Return if the switch is on based on the statemachine.
 
     Async friendly.
     """
-    entity_id = entity_id or ENTITY_ID_ALL_SWITCHES
     return hass.states.is_state(entity_id, STATE_ON)
 
 
 async def async_setup(hass, config):
     """Track states and offer events for switches."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_SWITCHES
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
     )
     await component.async_setup(config)
 

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -5,7 +5,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import group
 from homeassistant.const import (  # noqa: F401 # STATE_PAUSED/IDLE are API
     ATTR_BATTERY_LEVEL,
     ATTR_COMMAND,
@@ -33,9 +32,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "vacuum"
 SCAN_INTERVAL = timedelta(seconds=20)
-
-GROUP_NAME_ALL_VACUUMS = "all vacuum cleaners"
-ENTITY_ID_ALL_VACUUMS = group.ENTITY_ID_FORMAT.format("all_vacuum_cleaners")
 
 ATTR_BATTERY_ICON = "battery_icon"
 ATTR_CLEANED_AREA = "cleaned_area"
@@ -81,16 +77,15 @@ SUPPORT_START = 8192
 
 
 @bind_hass
-def is_on(hass, entity_id=None):
+def is_on(hass, entity_id):
     """Return if the vacuum is on based on the statemachine."""
-    entity_id = entity_id or ENTITY_ID_ALL_VACUUMS
     return hass.states.is_state(entity_id, STATE_ON)
 
 
 async def async_setup(hass, config):
     """Set up the vacuum component."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_VACUUMS
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
     )
 
     await component.async_setup(config)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -440,7 +440,6 @@ async def async_setup_entry(hass, config_entry):
         platform=None,
         scan_interval=DEFAULT_SCAN_INTERVAL,
         entity_namespace=None,
-        async_entities_added_callback=lambda: None,
     )
     platform.config_entry = config_entry
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.service import async_extract_entity_ids
 from homeassistant.loader import async_get_integration, bind_hass
 from homeassistant.setup import async_prepare_setup_platform
-from homeassistant.util import slugify
 
 from .entity_platform import EntityPlatform
 
@@ -59,19 +58,15 @@ class EntityComponent:
      - Process the configuration and set up a platform based component.
      - Manage the platforms and their entities.
      - Help extract the entities from a service call.
-     - Maintain a group that tracks all platform entities.
      - Listen for discovery events for platforms related to the domain.
     """
 
-    def __init__(
-        self, logger, domain, hass, scan_interval=DEFAULT_SCAN_INTERVAL, group_name=None
-    ):
+    def __init__(self, logger, domain, hass, scan_interval=DEFAULT_SCAN_INTERVAL):
         """Initialize an entity component."""
         self.logger = logger
         self.hass = hass
         self.domain = domain
         self.scan_interval = scan_interval
-        self.group_name = group_name
 
         self.config = None
 
@@ -237,35 +232,6 @@ class EntityComponent:
 
         await self._platforms[key].async_setup(platform_config, discovery_info)
 
-    @callback
-    def _async_update_group(self) -> None:
-        """Set up and/or update component group.
-
-        This method must be run in the event loop.
-        """
-        if self.group_name is None:
-            return
-
-        ids = [
-            entity.entity_id
-            for entity in sorted(
-                self.entities, key=lambda entity: entity.name or entity.entity_id
-            )
-        ]
-
-        self.hass.async_create_task(
-            self.hass.services.async_call(
-                "group",
-                "set",
-                dict(
-                    object_id=slugify(self.group_name),
-                    name=self.group_name,
-                    visible=False,
-                    entities=ids,
-                ),
-            )
-        )
-
     async def _async_reset(self) -> None:
         """Remove entities and reset the entity component to initial values.
 
@@ -278,11 +244,6 @@ class EntityComponent:
 
         self._platforms = {self.domain: self._platforms[self.domain]}
         self.config = None
-
-        if self.group_name is not None:
-            await self.hass.services.async_call(
-                "group", "remove", dict(object_id=slugify(self.group_name))
-            )
 
     async def async_remove_entity(self, entity_id: str) -> None:
         """Remove an entity managed by one of the platforms."""
@@ -329,5 +290,4 @@ class EntityComponent:
             platform=platform,
             scan_interval=scan_interval,
             entity_namespace=entity_namespace,
-            async_entities_added_callback=self._async_update_group,
         )

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -32,7 +32,6 @@ class EntityPlatform:
         platform,
         scan_interval,
         entity_namespace,
-        async_entities_added_callback,
     ):
         """Initialize the entity platform.
 
@@ -42,7 +41,6 @@ class EntityPlatform:
         platform_name: str
         scan_interval: timedelta
         entity_namespace: str
-        async_entities_added_callback: @callback method
         """
         self.hass = hass
         self.logger = logger
@@ -51,7 +49,6 @@ class EntityPlatform:
         self.platform = platform
         self.scan_interval = scan_interval
         self.entity_namespace = entity_namespace
-        self.async_entities_added_callback = async_entities_added_callback
         self.config_entry = None
         self.entities = {}
         self._tasks = []
@@ -250,7 +247,6 @@ class EntityPlatform:
             return
 
         await asyncio.wait(tasks)
-        self.async_entities_added_callback()
 
         if self._async_unsub_polling is not None or not any(
             entity.should_poll for entity in self.entities.values()

--- a/tests/common.py
+++ b/tests/common.py
@@ -584,7 +584,6 @@ class MockEntityPlatform(entity_platform.EntityPlatform):
         platform=None,
         scan_interval=timedelta(seconds=15),
         entity_namespace=None,
-        async_entities_added_callback=lambda: None,
     ):
         """Initialize a mock entity platform."""
         if logger is None:
@@ -602,7 +601,6 @@ class MockEntityPlatform(entity_platform.EntityPlatform):
             platform=platform,
             scan_interval=scan_interval,
             entity_namespace=entity_namespace,
-            async_entities_added_callback=async_entities_added_callback,
         )
 
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -80,10 +80,6 @@ async def test_service_specify_data(hass, calls):
     assert state is not None
     assert state.attributes.get("last_triggered") == time
 
-    state = hass.states.get("group.all_automations")
-    assert state is not None
-    assert state.attributes.get("entity_id") == ("automation.hello",)
-
 
 async def test_action_delay(hass, calls):
     """Test action delay."""
@@ -134,9 +130,6 @@ async def test_action_delay(hass, calls):
     state = hass.states.get("automation.hello")
     assert state is not None
     assert state.attributes.get("last_triggered") == time
-    state = hass.states.get("group.all_automations")
-    assert state is not None
-    assert state.attributes.get("entity_id") == ("automation.hello",)
 
 
 async def test_service_specify_entity_id(hass, calls):

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -62,7 +62,7 @@ async def test_cover(hass):
     assert "cover.level_controllable_cover" in gateway.deconz_ids
     assert "cover.window_covering_device" in gateway.deconz_ids
     assert "cover.unsupported_cover" not in gateway.deconz_ids
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 3
 
     level_controllable_cover = hass.states.get("cover.level_controllable_cover")
     assert level_controllable_cover.state == "open"
@@ -122,4 +122,4 @@ async def test_cover(hass):
 
     await gateway.async_reset()
 
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -91,8 +91,8 @@ async def test_lights_and_groups(hass):
     assert "light.light_group" in gateway.deconz_ids
     assert "light.empty_group" not in gateway.deconz_ids
     assert "light.on_off_switch" not in gateway.deconz_ids
-    # 4 entities + 2 groups (one for switches and one for lights)
-    assert len(hass.states.async_all()) == 6
+    # 4 entities
+    assert len(hass.states.async_all()) == 4
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light.state == "on"
@@ -200,7 +200,7 @@ async def test_lights_and_groups(hass):
 
     await gateway.async_reset()
 
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 0
 
 
 async def test_disable_light_groups(hass):
@@ -218,8 +218,8 @@ async def test_disable_light_groups(hass):
     assert "light.light_group" not in gateway.deconz_ids
     assert "light.empty_group" not in gateway.deconz_ids
     assert "light.on_off_switch" not in gateway.deconz_ids
-    # 4 entities + 2 groups (one for switches and one for lights)
-    assert len(hass.states.async_all()) == 5
+    # 3 entities
+    assert len(hass.states.async_all()) == 3
 
     rgb_light = hass.states.get("light.rgb_light")
     assert rgb_light is not None

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -68,7 +68,7 @@ async def test_switches(hass):
     assert "switch.smart_plug" in gateway.deconz_ids
     assert "switch.warning_device" in gateway.deconz_ids
     assert "switch.unsupported_switch" not in gateway.deconz_ids
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 4
 
     on_off_switch = hass.states.get("switch.on_off_switch")
     assert on_off_switch.state == "on"
@@ -161,4 +161,4 @@ async def test_switches(hass):
 
     await gateway.async_reset()
 
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 0

--- a/tests/components/demo/test_vacuum.py
+++ b/tests/components/demo/test_vacuum.py
@@ -19,7 +19,6 @@ from homeassistant.components.vacuum import (
     ATTR_PARAMS,
     ATTR_STATUS,
     DOMAIN,
-    ENTITY_ID_ALL_VACUUMS,
     SERVICE_SEND_COMMAND,
     SERVICE_SET_FAN_SPEED,
     STATE_CLEANING,
@@ -118,14 +117,6 @@ class TestVacuumDemo(unittest.TestCase):
         self.hass.states.set(ENTITY_VACUUM_BASIC, STATE_OFF)
         self.hass.block_till_done()
         assert not vacuum.is_on(self.hass, ENTITY_VACUUM_BASIC)
-
-        self.hass.states.set(ENTITY_ID_ALL_VACUUMS, STATE_ON)
-        self.hass.block_till_done()
-        assert vacuum.is_on(self.hass)
-
-        self.hass.states.set(ENTITY_ID_ALL_VACUUMS, STATE_OFF)
-        self.hass.block_till_done()
-        assert not vacuum.is_on(self.hass)
 
         common.turn_on(self.hass, ENTITY_VACUUM_COMPLETE)
         self.hass.block_till_done()

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -85,24 +85,31 @@ async def test_lights_on_when_sun_sets(hass, scanner):
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
 
-    assert light.is_on(hass)
+    assert all(
+        light.is_on(hass, ent_id) for ent_id in hass.states.async_entity_ids("light")
+    )
 
 
-async def test_lights_turn_off_when_everyone_leaves(hass, scanner):
+async def test_lights_turn_off_when_everyone_leaves(hass):
     """Test lights turn off when everyone leaves the house."""
+    assert await async_setup_component(
+        hass, "light", {light.DOMAIN: {CONF_PLATFORM: "test"}}
+    )
     await common_light.async_turn_on(hass)
+    hass.states.async_set("device_tracker.bla", STATE_HOME)
 
     assert await async_setup_component(
         hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
     )
 
-    assert light.is_on(hass)
-
-    hass.states.async_set(device_tracker.ENTITY_ID_ALL_DEVICES, STATE_NOT_HOME)
+    hass.states.async_set("device_tracker.bla", STATE_NOT_HOME)
 
     await hass.async_block_till_done()
 
-    assert not light.is_on(hass)
+    assert all(
+        not light.is_on(hass, ent_id)
+        for ent_id in hass.states.async_entity_ids("light")
+    )
 
 
 async def test_lights_turn_on_when_coming_home_after_sun_set(hass, scanner):
@@ -118,7 +125,10 @@ async def test_lights_turn_on_when_coming_home_after_sun_set(hass, scanner):
         hass.states.async_set(DT_ENTITY_ID_FORMAT.format("device_2"), STATE_HOME)
 
         await hass.async_block_till_done()
-    assert light.is_on(hass)
+
+    assert all(
+        light.is_on(hass, ent_id) for ent_id in hass.states.async_entity_ids("light")
+    )
 
 
 async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanner):
@@ -133,8 +143,10 @@ async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanne
         hass.states.async_set(device_2, STATE_NOT_HOME)
         await hass.async_block_till_done()
 
-        assert not light.is_on(hass)
-        assert hass.states.get(device_tracker.ENTITY_ID_ALL_DEVICES).state == "not_home"
+        assert all(
+            not light.is_on(hass, ent_id)
+            for ent_id in hass.states.async_entity_ids("light")
+        )
         assert hass.states.get(device_1).state == "not_home"
         assert hass.states.get(device_2).state == "not_home"
 
@@ -152,7 +164,10 @@ async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanne
             {device_sun_light_trigger.DOMAIN: {"device_group": "group.person_me"}},
         )
 
-        assert not light.is_on(hass)
+        assert all(
+            not light.is_on(hass, ent_id)
+            for ent_id in hass.states.async_entity_ids("light")
+        )
         assert hass.states.get(device_1).state == "not_home"
         assert hass.states.get(device_2).state == "not_home"
         assert hass.states.get("person.me").state == "not_home"
@@ -161,7 +176,10 @@ async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanne
         hass.states.async_set(device_2, STATE_HOME)
         await hass.async_block_till_done()
 
-        assert not light.is_on(hass)
+        assert all(
+            not light.is_on(hass, ent_id)
+            for ent_id in hass.states.async_entity_ids("light")
+        )
         assert hass.states.get(device_1).state == "not_home"
         assert hass.states.get(device_2).state == "home"
         assert hass.states.get("person.me").state == "not_home"
@@ -170,7 +188,10 @@ async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanne
         hass.states.async_set(device_1, STATE_HOME)
         await hass.async_block_till_done()
 
-        assert light.is_on(hass)
+        assert all(
+            light.is_on(hass, ent_id)
+            for ent_id in hass.states.async_entity_ids("light")
+        )
         assert hass.states.get(device_1).state == "home"
         assert hass.states.get(device_2).state == "home"
         assert hass.states.get("person.me").state == "home"

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -12,7 +12,6 @@ from homeassistant.components import zone
 import homeassistant.components.device_tracker as device_tracker
 from homeassistant.components.device_tracker import const, legacy
 from homeassistant.const import (
-    ATTR_ENTITY_ID,
     ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_GPS_ACCURACY,
@@ -319,29 +318,7 @@ async def test_device_hidden(hass, mock_device_tracker_conf):
     assert hass.states.get(entity_id).attributes.get(ATTR_HIDDEN)
 
 
-async def test_group_all_devices(hass, mock_device_tracker_conf):
-    """Test grouping of devices."""
-    devices = mock_device_tracker_conf
-    dev_id = "test_entity"
-    entity_id = const.ENTITY_ID_FORMAT.format(dev_id)
-    device = legacy.Device(
-        hass, timedelta(seconds=180), True, dev_id, None, hide_if_away=True
-    )
-    devices.append(device)
-    scanner = getattr(hass.components, "test.device_tracker").SCANNER
-    scanner.reset()
-
-    with assert_setup_component(1, device_tracker.DOMAIN):
-        assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
-        await hass.async_block_till_done()
-
-    state = hass.states.get(device_tracker.ENTITY_ID_ALL_DEVICES)
-    assert state is not None
-    assert STATE_NOT_HOME == state.state
-    assert (entity_id,) == state.attributes.get(ATTR_ENTITY_ID)
-
-
-@patch("homeassistant.components.device_tracker.legacy.DeviceTracker.async_see")
+@patch("homeassistant.components.device_tracker.legacy." "DeviceTracker.async_see")
 async def test_see_service(mock_see, hass):
     """Test the see service with a unicode dev_id and NO MAC."""
     with assert_setup_component(1, device_tracker.DOMAIN):

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -124,20 +124,6 @@ DEMO_DEVICES = [
         "willReportState": False,
     },
     {
-        "id": "group.all_lights",
-        "name": {"name": "all lights"},
-        "traits": ["action.devices.traits.OnOff"],
-        "type": "action.devices.types.SWITCH",
-        "willReportState": False,
-    },
-    {
-        "id": "group.all_switches",
-        "name": {"name": "all switches"},
-        "traits": ["action.devices.traits.OnOff"],
-        "type": "action.devices.types.SWITCH",
-        "willReportState": False,
-    },
-    {
         "id": "cover.living_room_window",
         "name": {"name": "Living Room Window"},
         "traits": ["action.devices.traits.OpenClose"],
@@ -163,13 +149,6 @@ DEMO_DEVICES = [
         "name": {"name": "Kitchen Window"},
         "traits": ["action.devices.traits.OpenClose"],
         "type": "action.devices.types.BLINDS",
-        "willReportState": False,
-    },
-    {
-        "id": "group.all_covers",
-        "name": {"name": "all covers"},
-        "traits": ["action.devices.traits.OnOff"],
-        "type": "action.devices.types.SWITCH",
         "willReportState": False,
     },
     {
@@ -224,13 +203,6 @@ DEMO_DEVICES = [
         "name": {"name": "Ceiling Fan"},
         "traits": ["action.devices.traits.FanSpeed", "action.devices.traits.OnOff"],
         "type": "action.devices.types.FAN",
-        "willReportState": False,
-    },
-    {
-        "id": "group.all_fans",
-        "name": {"name": "all fans"},
-        "traits": ["action.devices.traits.OnOff"],
-        "type": "action.devices.types.SWITCH",
         "willReportState": False,
     },
     {

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -258,8 +258,8 @@ async def test_lights(hass, mock_bridge):
     mock_bridge.mock_light_responses.append(LIGHT_RESPONSE)
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 1
-    # 1 All Lights group, 2 lights
-    assert len(hass.states.async_all()) == 3
+    # 2 lights
+    assert len(hass.states.async_all()) == 2
 
     lamp_1 = hass.states.get("light.hue_lamp_1")
     assert lamp_1 is not None
@@ -313,8 +313,8 @@ async def test_groups(hass, mock_bridge):
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 2
-    # 1 all lights group, 2 hue group lights
-    assert len(hass.states.async_all()) == 3
+    # 2 hue group lights
+    assert len(hass.states.async_all()) == 2
 
     lamp_1 = hass.states.get("light.group_1")
     assert lamp_1 is not None
@@ -335,7 +335,7 @@ async def test_new_group_discovered(hass, mock_bridge):
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 2
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     new_group_response = dict(GROUP_RESPONSE)
     new_group_response["3"] = {
@@ -365,7 +365,7 @@ async def test_new_group_discovered(hass, mock_bridge):
     )
     # 2x group update, 2x light update, 1 turn on request
     assert len(mock_bridge.mock_requests) == 5
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     new_group = hass.states.get("light.group_3")
     assert new_group is not None
@@ -380,7 +380,7 @@ async def test_new_light_discovered(hass, mock_bridge):
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 1
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     new_light_response = dict(LIGHT_RESPONSE)
     new_light_response["3"] = {
@@ -418,7 +418,7 @@ async def test_new_light_discovered(hass, mock_bridge):
     )
     # 2x light update, 1 turn on request
     assert len(mock_bridge.mock_requests) == 3
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     light = hass.states.get("light.hue_lamp_3")
     assert light is not None
@@ -433,7 +433,7 @@ async def test_group_removed(hass, mock_bridge):
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 2
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     mock_bridge.mock_light_responses.append({})
     mock_bridge.mock_group_responses.append({"1": GROUP_RESPONSE["1"]})
@@ -445,7 +445,7 @@ async def test_group_removed(hass, mock_bridge):
 
     # 2x group update, 2x light update, 1 turn on request
     assert len(mock_bridge.mock_requests) == 5
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     group = hass.states.get("light.group_1")
     assert group is not None
@@ -460,7 +460,7 @@ async def test_light_removed(hass, mock_bridge):
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 1
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     mock_bridge.mock_light_responses.clear()
     mock_bridge.mock_light_responses.append({"1": LIGHT_RESPONSE.get("1")})
@@ -472,7 +472,7 @@ async def test_light_removed(hass, mock_bridge):
 
     # 2x light update, 1 turn on request
     assert len(mock_bridge.mock_requests) == 3
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     light = hass.states.get("light.hue_lamp_1")
     assert light is not None
@@ -489,7 +489,7 @@ async def test_other_group_update(hass, mock_bridge):
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 2
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     group_2 = hass.states.get("light.group_2")
     assert group_2 is not None
@@ -526,7 +526,7 @@ async def test_other_group_update(hass, mock_bridge):
     )
     # 2x group update, 2x light update, 1 turn on request
     assert len(mock_bridge.mock_requests) == 5
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     group_2 = hass.states.get("light.group_2")
     assert group_2 is not None
@@ -540,7 +540,7 @@ async def test_other_light_update(hass, mock_bridge):
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 1
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     lamp_2 = hass.states.get("light.hue_lamp_2")
     assert lamp_2 is not None
@@ -583,7 +583,7 @@ async def test_other_light_update(hass, mock_bridge):
     )
     # 2x light update, 1 turn on request
     assert len(mock_bridge.mock_requests) == 3
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     lamp_2 = hass.states.get("light.hue_lamp_2")
     assert lamp_2 is not None
@@ -641,7 +641,7 @@ async def test_light_turn_on_service(hass, mock_bridge):
         "alert": "none",
     }
 
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     light = hass.states.get("light.hue_lamp_2")
     assert light is not None
@@ -685,7 +685,7 @@ async def test_light_turn_off_service(hass, mock_bridge):
 
     assert mock_bridge.mock_requests[1]["json"] == {"on": False, "alert": "none"}
 
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     light = hass.states.get("light.hue_lamp_1")
     assert light is not None

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -52,12 +52,6 @@ class TestLight(unittest.TestCase):
         self.hass.states.set("light.test", STATE_OFF)
         assert not light.is_on(self.hass, "light.test")
 
-        self.hass.states.set(light.ENTITY_ID_ALL_LIGHTS, STATE_ON)
-        assert light.is_on(self.hass)
-
-        self.hass.states.set(light.ENTITY_ID_ALL_LIGHTS, STATE_OFF)
-        assert not light.is_on(self.hass)
-
         # Test turn_on
         turn_on_calls = mock_service(self.hass, light.DOMAIN, SERVICE_TURN_ON)
 

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -707,8 +707,7 @@ async def test_unique_id(hass, mqtt_mock):
 
     async_fire_mqtt_message(hass, "test-topic", "payload")
 
-    assert len(hass.states.async_entity_ids()) == 2
-    # all vacuums group is 1, unique id created is 1
+    assert len(hass.states.async_entity_ids()) == 1
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):

--- a/tests/components/mqtt/test_state_vacuum.py
+++ b/tests/components/mqtt/test_state_vacuum.py
@@ -533,8 +533,7 @@ async def test_unique_id(hass, mqtt_mock):
 
     async_fire_mqtt_message(hass, "test-topic", "payload")
 
-    assert len(hass.states.async_entity_ids()) == 2
-    # all vacuums group is 1, unique id created is 1
+    assert len(hass.states.async_entity_ids()) == 1
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -391,8 +391,7 @@ async def test_unique_id(hass):
 
     async_fire_mqtt_message(hass, "test-topic", "payload")
 
-    assert len(hass.states.async_entity_ids()) == 2
-    # all switches group is 1, unique id created is 1
+    assert len(hass.states.async_entity_ids()) == 1
 
 
 async def test_discovery_removal_switch(hass, mqtt_mock, caplog):

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -42,12 +42,6 @@ class TestRemote(unittest.TestCase):
         self.hass.states.set("remote.test", STATE_OFF)
         assert not remote.is_on(self.hass, "remote.test")
 
-        self.hass.states.set(remote.ENTITY_ID_ALL_REMOTES, STATE_ON)
-        assert remote.is_on(self.hass)
-
-        self.hass.states.set(remote.ENTITY_ID_ALL_REMOTES, STATE_OFF)
-        assert not remote.is_on(self.hass)
-
     def test_turn_on(self):
         """Test turn_on."""
         turn_on_calls = mock_service(self.hass, remote.DOMAIN, SERVICE_TURN_ON)

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -135,10 +135,6 @@ class TestScriptComponent(unittest.TestCase):
         assert not script.is_on(self.hass, ENTITY_ID)
         assert 0 == len(events)
 
-        state = self.hass.states.get("group.all_scripts")
-        assert state is not None
-        assert state.attributes.get("entity_id") == (ENTITY_ID,)
-
     def test_toggle_service(self):
         """Test the toggling of a service."""
         event = "test_event"

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -4,7 +4,7 @@ import unittest
 
 from homeassistant import core
 from homeassistant.components import switch
-from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON
+from homeassistant.const import CONF_PLATFORM
 from homeassistant.setup import async_setup_component, setup_component
 
 from tests.common import get_test_home_assistant, mock_entity_platform
@@ -33,8 +33,6 @@ class TestSwitch(unittest.TestCase):
         assert setup_component(
             self.hass, switch.DOMAIN, {switch.DOMAIN: {CONF_PLATFORM: "test"}}
         )
-        assert switch.is_on(self.hass)
-        assert STATE_ON == self.hass.states.get(switch.ENTITY_ID_ALL_SWITCHES).state
         assert switch.is_on(self.hass, self.switch_1.entity_id)
         assert not switch.is_on(self.hass, self.switch_2.entity_id)
         assert not switch.is_on(self.hass, self.switch_3.entity_id)
@@ -44,7 +42,6 @@ class TestSwitch(unittest.TestCase):
 
         self.hass.block_till_done()
 
-        assert switch.is_on(self.hass)
         assert not switch.is_on(self.hass, self.switch_1.entity_id)
         assert switch.is_on(self.hass, self.switch_2.entity_id)
 
@@ -53,8 +50,6 @@ class TestSwitch(unittest.TestCase):
 
         self.hass.block_till_done()
 
-        assert not switch.is_on(self.hass)
-        assert STATE_OFF == self.hass.states.get(switch.ENTITY_ID_ALL_SWITCHES).state
         assert not switch.is_on(self.hass, self.switch_1.entity_id)
         assert not switch.is_on(self.hass, self.switch_2.entity_id)
         assert not switch.is_on(self.hass, self.switch_3.entity_id)
@@ -64,8 +59,6 @@ class TestSwitch(unittest.TestCase):
 
         self.hass.block_till_done()
 
-        assert switch.is_on(self.hass)
-        assert STATE_ON == self.hass.states.get(switch.ENTITY_ID_ALL_SWITCHES).state
         assert switch.is_on(self.hass, self.switch_1.entity_id)
         assert switch.is_on(self.hass, self.switch_2.entity_id)
         assert switch.is_on(self.hass, self.switch_3.entity_id)

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -97,7 +97,7 @@ async def test_no_clients(hass):
     """Test the update_clients function when no clients are found."""
     await setup_unifi_integration(hass)
 
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
 
 async def test_tracked_devices(hass):
@@ -112,7 +112,7 @@ async def test_tracked_devices(hass):
         devices_response=[DEVICE_1, DEVICE_2],
         known_wireless_clients=(CLIENT_4["mac"],),
     )
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 5
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -186,7 +186,7 @@ async def test_wireless_client_go_wired_issue(hass):
     client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
 
     controller = await setup_unifi_integration(hass, clients_response=[client_1_client])
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -262,7 +262,7 @@ async def test_restoring_client(hass):
         clients_response=[CLIENT_2],
         clients_all_response=[CLIENT_1],
     )
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 3
 
     device_1 = hass.states.get("device_tracker.client_1")
     assert device_1 is not None
@@ -276,7 +276,7 @@ async def test_dont_track_clients(hass):
         clients_response=[CLIENT_1],
         devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is None
@@ -294,7 +294,7 @@ async def test_dont_track_devices(hass):
         clients_response=[CLIENT_1],
         devices_response=[DEVICE_1],
     )
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None
@@ -311,7 +311,7 @@ async def test_dont_track_wired_clients(hass):
         options={unifi.controller.CONF_TRACK_WIRED_CLIENTS: False},
         clients_response=[CLIENT_1, CLIENT_2],
     )
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 2
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1 is not None

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -55,7 +55,7 @@ async def test_no_clients(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
 
 async def test_sensors(hass):
@@ -71,7 +71,7 @@ async def test_sensors(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 5
 
     wired_client_rx = hass.states.get("sensor.wired_client_name_rx")
     assert wired_client_rx.state == "1234.0"

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -208,7 +208,7 @@ async def test_no_clients(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
 
 async def test_controller_not_client(hass):
@@ -224,7 +224,7 @@ async def test_controller_not_client(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
     cloudkey = hass.states.get("switch.cloud_key")
     assert cloudkey is None
 
@@ -245,7 +245,7 @@ async def test_not_admin(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
 
 async def test_switches(hass):
@@ -263,7 +263,7 @@ async def test_switches(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 4
 
     switch_1 = hass.states.get("switch.poe_client_1")
     assert switch_1 is not None
@@ -298,7 +298,7 @@ async def test_new_client_discovered_on_block_control(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 2
 
     controller.mock_client_all_responses.append([BLOCKED])
 
@@ -307,7 +307,7 @@ async def test_new_client_discovered_on_block_control(hass):
         "switch", "turn_off", {"entity_id": "switch.block_client_1"}, blocking=True
     )
     assert len(controller.mock_requests) == 7
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 2
     assert controller.mock_requests[3] == {
         "json": {"mac": "00:00:00:00:01:01", "cmd": "block-sta"},
         "method": "post",
@@ -338,7 +338,7 @@ async def test_new_client_discovered_on_poe_control(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 2
 
     controller.mock_client_responses.append([CLIENT_1, CLIENT_2])
     controller.mock_device_responses.append([DEVICE_1])
@@ -348,7 +348,7 @@ async def test_new_client_discovered_on_poe_control(hass):
         "switch", "turn_off", {"entity_id": "switch.poe_client_1"}, blocking=True
     )
     assert len(controller.mock_requests) == 6
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 3
     assert controller.mock_requests[3] == {
         "json": {
             "port_overrides": [{"port_idx": 1, "portconf_id": "1a1", "poe_mode": "off"}]
@@ -387,7 +387,7 @@ async def test_ignore_multiple_poe_clients_on_same_port(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 4
 
     switch_1 = hass.states.get("switch.poe_client_1")
     switch_2 = hass.states.get("switch.poe_client_2")
@@ -438,7 +438,7 @@ async def test_restoring_client(hass):
     )
 
     assert len(controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 3
 
     device_1 = hass.states.get("switch.client_1")
     assert device_1 is not None

--- a/tests/components/verisure/test_lock.py
+++ b/tests/components/verisure/test_lock.py
@@ -74,8 +74,8 @@ async def setup_verisure_locks(hass, config):
     with mock_hub(config):
         await async_setup_component(hass, VERISURE_DOMAIN, config)
         await hass.async_block_till_done()
-        # lock.door_lock, group.all_locks, ethernet_status
-        assert len(hass.states.async_all()) == 3
+        # lock.door_lock, ethernet_status
+        assert len(hass.states.async_all()) == 2
 
 
 async def test_verisure_no_default_code(hass):

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -31,39 +31,6 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "test_domain"
 
 
-async def test_setting_up_group(hass):
-    """Set up the setting of a group."""
-    assert await async_setup_component(hass, "group", {"group": {}})
-    component = EntityComponent(_LOGGER, DOMAIN, hass, group_name="everyone")
-
-    # No group after setup
-    assert len(hass.states.async_entity_ids()) == 0
-
-    await component.async_add_entities([MockEntity()])
-    await hass.async_block_till_done()
-
-    # group exists
-    assert len(hass.states.async_entity_ids()) == 2
-    assert hass.states.async_entity_ids("group") == ["group.everyone"]
-
-    grp = hass.states.get("group.everyone")
-
-    assert grp.attributes.get("entity_id") == ("test_domain.unnamed_device",)
-
-    # group extended
-    await component.async_add_entities([MockEntity(name="goodbye")])
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_entity_ids()) == 3
-    grp = hass.states.get("group.everyone")
-
-    # Ordered in order of added to the group
-    assert grp.attributes.get("entity_id") == (
-        "test_domain.goodbye",
-        "test_domain.unnamed_device",
-    )
-
-
 async def test_setup_loads_platforms(hass):
     """Test the loading of the platforms."""
     component_setup = Mock(return_value=True)
@@ -424,7 +391,7 @@ async def test_set_service_race(hass):
     hass.loop.set_exception_handler(async_loop_exception_handler)
 
     await async_setup_component(hass, "group", {})
-    component = EntityComponent(_LOGGER, DOMAIN, hass, group_name="yo")
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     for _ in range(2):
         hass.async_create_task(component.async_add_entities([MockEntity()]))

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -251,8 +251,7 @@ async def test_remove_entry(hass, manager):
 
     # Check entity state got added
     assert hass.states.get("light.test_entity") is not None
-    # Group all_lights, light.test_entity
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 1
 
     # Check entity got added to entity registry
     ent_reg = await hass.helpers.entity_registry.async_get_registry()
@@ -275,8 +274,7 @@ async def test_remove_entry(hass, manager):
 
     # Check that entity state has been removed
     assert hass.states.get("light.test_entity") is None
-    # Just Group all_lights
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 0
 
     # Check that entity registry entry has been removed
     entity_entry_list = list(ent_reg.entities.values())


### PR DESCRIPTION
## Breaking Change:

Entity integrations will no longer automatically maintain the hidden groups with all of their entities. The following groups are no longer automatically created and maintained: 

 - `group.all_automations`
 - `group.calendar`
 - `group.all_covers`
 - `group.all_devices`
 - `group.all_fans`
 - `group.all_lights`
 - `group.all_locks`
 - `group.all_plants`
 - `group.remember_the_milk_accounts` (???)
 - `group.all_remotes`
 - `group.all_scripts`
 - `group.all_switches`
 - `group.all_vacuum_cleaners`

The automation and script config panels have been updated to show and manage all automations/scripts. If you want to show cards in your UI with all entities for a single domain, use the [auto-entities](https://github.com/thomasloven/lovelace-auto-entities) card. If you want to target all entities in a service call, use `'all'` as value for `entity_id`.

## Description:
Disable the automatic creation of "all groups". They were not visible in the UI, and for anyone having things spread out over multiple rooms they were holding too many entities, so being useless. 

Before merging this, we should:
 - [ ] ~~add an `all_person` group to track the person integration.~~
 - [x] add enable/disable toggles to automation config panel, show non-editable automations 
 - [x] show non-editable scripts on script config panel

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/177

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
