### PR TITLE
Synchronize Sonos service calls

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -1,4 +1,5 @@
 """Support to embed Sonos."""
+import asyncio
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -80,12 +81,15 @@ SONOS_SET_OPTION_SCHEMA = vol.Schema({
     vol.Optional(ATTR_SPEECH_ENHANCE): cv.boolean,
 })
 
+DATA_SERVICE_EVENT ='sonos_service_running'
+
 
 async def async_setup(hass, config):
     """Set up the Sonos component."""
     conf = config.get(DOMAIN)
 
     hass.data[DOMAIN] = conf or {}
+    hass.data[DATA_SERVICE_EVENT] = asyncio.Event()
 
     if conf is not None:
         hass.async_create_task(hass.config_entries.flow.async_init(
@@ -93,7 +97,9 @@ async def async_setup(hass, config):
 
     async def service_handle(service):
         """Dispatch a service call."""
+        hass.data[DATA_SERVICE_EVENT].clear()
         async_dispatcher_send(hass, DOMAIN, service.service, service.data)
+        await hass.data[DATA_SERVICE_EVENT].wait()
 
     hass.services.async_register(
         DOMAIN, SERVICE_JOIN, service_handle,

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -81,7 +81,7 @@ SONOS_SET_OPTION_SCHEMA = vol.Schema({
     vol.Optional(ATTR_SPEECH_ENHANCE): cv.boolean,
 })
 
-DATA_SERVICE_EVENT ='sonos_service_running'
+DATA_SERVICE_EVENT = 'sonos_service_running'
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -81,7 +81,7 @@ SONOS_SET_OPTION_SCHEMA = vol.Schema({
     vol.Optional(ATTR_SPEECH_ENHANCE): cv.boolean,
 })
 
-DATA_SERVICE_EVENT = 'sonos_service_running'
+DATA_SERVICE_EVENT = 'sonos_service_idle'
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -25,7 +25,7 @@ from homeassistant.util.dt import utcnow
 
 from . import (
     CONF_ADVERTISE_ADDR, CONF_HOSTS, CONF_INTERFACE_ADDR,
-    DOMAIN as SONOS_DOMAIN,
+    DATA_SERVICE_EVENT, DOMAIN as SONOS_DOMAIN,
     ATTR_ALARM_ID, ATTR_ENABLED, ATTR_INCLUDE_LINKED_ZONES, ATTR_MASTER,
     ATTR_NIGHT_SOUND, ATTR_SLEEP_TIME, ATTR_SPEECH_ENHANCE, ATTR_TIME,
     ATTR_VOLUME, ATTR_WITH_GROUP,
@@ -154,6 +154,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     call = entity.set_option
 
                 hass.async_add_executor_job(call, data)
+
+        # We are ready for the next service call
+        hass.data[DATA_SERVICE_EVENT].set()
 
     async_dispatcher_connect(hass, SONOS_DOMAIN, async_service_handle)
 


### PR DESCRIPTION
## Description:

I moved Sonos services in #23670, using the dispatcher to connect the Sonos component with its media_player platform. However, I did not consider that the dispatcher is adding tasks that all run simultaneously. This breaks announcement scripts that are supposed to pause for speaker regrouping.

The fix in this PR is to make the component wait for an event that each service call has completed.

CC @MartinHjelmare since you suggested the dispatcher. Is this a reasonable fix?

**Related issue (if applicable):** fixes #23783

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  sonos_dance:
    sequence:
      - service: sonos.snapshot
      - service: sonos.join
        data:
          master: media_player.kitchen
      - service: sonos.unjoin
      - service: sonos.restore
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
