### PR TITLE
Do not add coordinator to the ZHA entities.

### DIFF
--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -93,6 +93,8 @@ class ZHAGateway:
 
         init_tasks = []
         for device in self.application_controller.devices.values():
+            if device.nwk == 0x0000:
+                continue
             init_tasks.append(self.async_device_initialized(device, False))
         await asyncio.gather(*init_tasks)
 


### PR DESCRIPTION
## Description:
Do not expose Zigbee coordinator device as a ZHA Entity, so users are not tempted to remove it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
