### PR TITLE
Bump venstarcolortouch to v0.7

### DIFF
--- a/homeassistant/components/venstar/manifest.json
+++ b/homeassistant/components/venstar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Venstar",
   "documentation": "https://www.home-assistant.io/components/venstar",
   "requirements": [
-    "venstarcolortouch==0.6"
+    "venstarcolortouch==0.7"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1761,7 +1761,7 @@ uscisstatus==0.1.1
 uvcclient==0.11.0
 
 # homeassistant.components.venstar
-venstarcolortouch==0.6
+venstarcolortouch==0.7
 
 # homeassistant.components.volkszaehler
 volkszaehler==0.1.2


### PR DESCRIPTION
## Description:

Bump venstar to v0.7 to fix bug with setting away mode.

**Related issue (if applicable):** fixes #23805 

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
