### PR TITLE
Add huawei LTE modem supports

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -162,4 +162,5 @@ def _setup_lte(hass, lte_config) -> None:
         """Clean up resources."""
         client.user.logout()
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+    if device_type == ATTR_ROUTER:
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -1,4 +1,5 @@
 """Support for device tracking of Huawei LTE routers."""
+import logging
 from typing import Any, Dict, List, Optional
 
 import attr
@@ -8,8 +9,11 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, DeviceScanner,
 )
+from homeassistant.components.huawei_lte import ATTR_MODEM
 from homeassistant.const import CONF_URL
 from . import DATA_KEY, RouterData
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_URL): cv.url,
@@ -21,6 +25,11 @@ HOSTS_PATH = "wlan_host_list.Hosts"
 def get_scanner(hass, config):
     """Get a Huawei LTE router scanner."""
     data = hass.data[DATA_KEY].get_data(config)
+
+    if data.device_type == ATTR_MODEM:
+        _LOGGER.error("Device tracker not supported for modems")
+        return None
+
     data.subscribe(HOSTS_PATH)
     return HuaweiLteScanner(data)
 

--- a/homeassistant/components/huawei_lte/manifest.json
+++ b/homeassistant/components/huawei_lte/manifest.json
@@ -3,7 +3,7 @@
   "name": "Huawei lte",
   "documentation": "https://www.home-assistant.io/components/huawei_lte",
   "requirements": [
-    "huawei-lte-api==1.1.5"
+    "huawei-lte-api==1.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -582,7 +582,7 @@ horimote==0.4.1
 httplib2==0.10.3
 
 # homeassistant.components.huawei_lte
-huawei-lte-api==1.1.5
+huawei-lte-api==1.2
 
 # homeassistant.components.hydrawise
 hydrawiser==0.1.1

--- a/tests/components/huawei_lte/test_init.py
+++ b/tests/components/huawei_lte/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.components import huawei_lte
 @pytest.fixture(autouse=True)
 def routerdata():
     """Set up a router data for testing."""
-    rd = huawei_lte.RouterData(Mock())
+    rd = huawei_lte.RouterData(Mock(), huawei_lte.ATTR_ROUTER)
     rd.device_information = {
         'SoftwareVersion': '1.0',
         'nested': {'foo': 'bar'},


### PR DESCRIPTION
## Description:
Added support for Huawei modems. Tested on e3372 Hilink version. Sensor and notifications are working as expected.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9435

## Example entry for `configuration.yaml` (if applicable):
Router:
```yaml
huawei_lte:
  - url: http://192.168.100.1/
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
```
Modem:
```yaml
huawei_lte:
  - url: http://192.168.100.1/
    device_type: modem
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.