### PR TITLE
Bump pyotgw to 0.4b4

### DIFF
--- a/homeassistant/components/opentherm_gw/manifest.json
+++ b/homeassistant/components/opentherm_gw/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "opentherm_gw",
-  "name": "Opentherm gw",
+  "name": "Opentherm Gateway",
   "documentation": "https://www.home-assistant.io/components/opentherm_gw",
   "requirements": [
-    "pyotgw==0.4b3"
+    "pyotgw==0.4b4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1232,7 +1232,7 @@ pyoppleio==1.0.5
 pyota==2.0.5
 
 # homeassistant.components.opentherm_gw
-pyotgw==0.4b3
+pyotgw==0.4b4
 
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp


### PR DESCRIPTION
## Description:
Bump pyotgw to 0.4b4. Fixes bug in disconnect handling (thanks @aequitas)
Correct Opentherm Gateway name in manifest.json.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
