### PR TITLE
Add geniushub sensor and binary_sensor

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -56,7 +56,7 @@ async def async_setup(hass, hass_config):
 
     async_track_time_interval(hass, data.async_update, SCAN_INTERVAL)
 
-    for platform in ['climate', 'water_heater']:
+    for platform in ['climate', 'water_heater', 'sensor', 'binary_sensor']:
         hass.async_create_task(async_load_platform(
             hass, platform, DOMAIN, {}, hass_config))
 

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -60,7 +60,7 @@ async def async_setup(hass, hass_config):
         hass.async_create_task(async_load_platform(
             hass, platform, DOMAIN, {}, hass_config))
 
-    if not data._client._api_v1:
+    if not data._client._api_v1  # pylint: disable=protected-access
         for platform in ['sensor', 'binary_sensor']:
             hass.async_create_task(async_load_platform(
                 hass, platform, DOMAIN, {}, hass_config))

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -60,7 +60,7 @@ async def async_setup(hass, hass_config):
         hass.async_create_task(async_load_platform(
             hass, platform, DOMAIN, {}, hass_config))
 
-    if not data._client._api_v1  # pylint: disable=protected-access
+    if not data._client._api_v1:  # pylint: disable=protected-access
         for platform in ['sensor', 'binary_sensor']:
             hass.async_create_task(async_load_platform(
                 hass, platform, DOMAIN, {}, hass_config))

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -56,9 +56,14 @@ async def async_setup(hass, hass_config):
 
     async_track_time_interval(hass, data.async_update, SCAN_INTERVAL)
 
-    for platform in ['climate', 'water_heater', 'sensor', 'binary_sensor']:
+    for platform in ['climate', 'water_heater']:
         hass.async_create_task(async_load_platform(
             hass, platform, DOMAIN, {}, hass_config))
+
+    if not data._client._api_v1:
+        for platform in ['sensor', 'binary_sensor']:
+            hass.async_create_task(async_load_platform(
+                hass, platform, DOMAIN, {}, hass_config))
 
     return True
 

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for Genius Hub binary_sensor devices."""
+from datetime import datetime
 import logging
-from time import (localtime, strftime)
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
@@ -11,8 +11,6 @@ from . import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 GH_IS_SWITCH = ['Dual Channel Receiver', 'Electric Switch', 'Smart Plug']
-
-GH_STATE_ATTRS = ['measuredTemperature']
 
 
 async def async_setup_platform(hass, config, async_add_entities,
@@ -66,14 +64,11 @@ class GeniusSwitch(BinarySensorDevice):
     def device_state_attributes(self):
         """Return the device state attributes."""
         attrs = {}
-        attrs['location'] = self._device.assignedZones[0]['name']
+        attrs['assignedZone'] = self._device.assignedZones[0]['name']
 
         last_comms = self._device._info_raw['childValues']['lastComms']['val']  # noqa; pylint: disable=protected-access
         if last_comms != 0:
-            last_comms = strftime('%Y-%m-%d %H:%M:%S', localtime(last_comms))
-            attrs['lastCommunication'] = last_comms
+            attrs['lastCommunication'] = datetime.utcfromtimestamp(
+                last_comms).isoformat()
 
-        state = {k: v for k, v in self._device.state.items()
-                 if k in GH_STATE_ATTRS}
-
-        return {**attrs, **state}
+        return {**attrs}

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Support for Genius Hub binary_sensor devices ."""
+"""Support for Genius Hub binary_sensor devices."""
 import logging
 from time import (localtime, strftime)
 

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -1,11 +1,10 @@
 """Support for Genius Hub binary_sensor devices."""
 import logging
+from time import (localtime, strftime)
 
-from homeassistant.components.binary_sensor import (
-    BinarySensorDevice, DEVICE_CLASS_POWER)
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
 
 from . import DOMAIN
 
@@ -68,7 +67,11 @@ class GeniusSwitch(BinarySensorDevice):
         """Return the device state attributes."""
         attrs = {}
         attrs['location'] = self._device.assignedZones[0]['name']
-#       attrs['lastCommunication'] = 0  # TODO: add this
+
+        last_comms = self._device._info_raw['childValues']['lastComms']['val']  # noqa; pylint: disable=protected-access
+        if last_comms != 0:
+            last_comms = strftime('%Y-%m-%d %H:%M:%S', localtime(last_comms))
+            attrs['lastCommunication'] = last_comms
 
         state = {k: v for k, v in self._device.state.items()
                  if k in GH_STATE_ATTRS}

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -18,13 +18,13 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the Genius Hub sensor entities."""
     client = hass.data[DOMAIN]['client']
 
-    switches = [GeniusSwitch(client, d)
+    switches = [GeniusBinarySensor(client, d)
                 for d in client.hub.device_objs if d.type[:21] in GH_IS_SWITCH]
 
     async_add_entities(switches)
 
 
-class GeniusSwitch(BinarySensorDevice):
+class GeniusBinarySensor(BinarySensorDevice):
     """Representation of a Genius Hub binary_sensor."""
 
     def __init__(self, client, device):

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Support for Genius Hub binary_sensor devices."""
+"""Support for Genius Hub binary_sensor devices ."""
 import logging
 from time import (localtime, strftime)
 

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -64,11 +64,11 @@ class GeniusSwitch(BinarySensorDevice):
     def device_state_attributes(self):
         """Return the device state attributes."""
         attrs = {}
-        attrs['assignedZone'] = self._device.assignedZones[0]['name']
+        attrs['assigned_zone'] = self._device.assignedZones[0]['name']
 
         last_comms = self._device._info_raw['childValues']['lastComms']['val']  # noqa; pylint: disable=protected-access
         if last_comms != 0:
-            attrs['lastCommunication'] = datetime.utcfromtimestamp(
+            attrs['last_comms'] = datetime.utcfromtimestamp(
                 last_comms).isoformat()
 
         return {**attrs}

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -1,0 +1,76 @@
+"""Support for Genius Hub binary_sensor devices."""
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, DEVICE_CLASS_POWER)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+GH_IS_SWITCH = ['Dual Channel Receiver', 'Electric Switch', 'Smart Plug']
+
+GH_STATE_ATTRS = ['measuredTemperature']
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the Genius Hub sensor entities."""
+    client = hass.data[DOMAIN]['client']
+
+    switches = [GeniusSwitch(client, d)
+                for d in client.hub.device_objs if d.type[:21] in GH_IS_SWITCH]
+
+    async_add_entities(switches)
+
+
+class GeniusSwitch(BinarySensorDevice):
+    """Representation of a Genius Hub binary_sensor."""
+
+    def __init__(self, client, device):
+        """Initialize the binary sensor."""
+        self._client = client
+        self._device = device
+
+        if device.type[:21] == 'Dual Channel Receiver':
+            self._name = 'Dual Channel Receiver {}'.format(device.id)
+        else:
+            self._name = '{} {}'.format(device.type, device.id)
+
+    async def async_added_to_hass(self):
+        """Set up a listener when this entity is added to HA."""
+        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
+
+    @callback
+    def _refresh(self):
+        self.async_schedule_update_ha_state(force_refresh=True)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self) -> bool:
+        """Return False as the geniushub devices should not be polled."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return the status of the sensor."""
+        return self._device.state['outputOnOff']
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attrs = {}
+        attrs['location'] = self._device.assignedZones[0]['name']
+#       attrs['lastCommunication'] = 0  # TODO: add this
+
+        state = {k: v for k, v in self._device.state.items()
+                 if k in GH_STATE_ATTRS}
+
+        return {**attrs, **state}

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.4.6"
+    "geniushub-client==0.4.7"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -1,8 +1,8 @@
 """Support for Genius Hub sensor devices."""
 import logging
+from time import (localtime, strftime)
 
-from homeassistant.const import (
-    DEVICE_CLASS_BATTERY, DEVICE_CLASS_ILLUMINANCE)
+from homeassistant.const import DEVICE_CLASS_BATTERY
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -78,9 +78,12 @@ class GeniusBattery(Entity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
+        last_comms = self._device._info_raw['childValues']['lastComms']['val']  # noqa; pylint: disable=protected-access
+        last_comms = strftime('%Y-%m-%d %H:%M:%S', localtime(last_comms))
+
         attrs = {}
         attrs['location'] = self._device.assignedZones[0]['name']
-#       attrs['lastCommunication'] = 0  # TODO: add this
+        attrs['lastCommunication'] = last_comms
 
         state = {k: v for k, v in self._device.state.items()
                  if k in GH_STATE_ATTRS}

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -2,7 +2,7 @@
 import logging
 from time import (localtime, strftime)
 
-from homeassistant.const import DEVICE_CLASS_BATTERY
+from homeassistant.const import (DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -15,8 +15,7 @@ GH_HAS_BATTERY = [
     'Room Thermostat', 'Genius Valve', 'Room Sensor', 'Radiator Valve']
 
 GH_STATE_ATTRS = [
-    'setTemperature', 'measuredTemperature', 'luminance', 'occupancyTrigger',
-    'batteryLevel']
+    'setTemperature', 'luminance', 'occupancyTrigger', 'batteryLevel']
 
 
 async def async_setup_platform(hass, config, async_add_entities,
@@ -24,13 +23,13 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the Genius Hub sensor entities."""
     client = hass.data[DOMAIN]['client']
 
-    sensors = [GeniusBattery(client, d)
+    sensors = [GeniusDevice(client, d)
                for d in client.hub.device_objs if d.type in GH_HAS_BATTERY]
 
     async_add_entities(sensors)
 
 
-class GeniusBattery(Entity):
+class GeniusDevice(Entity):
     """Representation of a Genius Hub sensor."""
 
     def __init__(self, client, device):
@@ -39,8 +38,6 @@ class GeniusBattery(Entity):
         self._device = device
 
         self._name = '{} {}'.format(device.type, device.id)
-        self._device_class = DEVICE_CLASS_BATTERY
-        self._unit_of_measurement = '%'
 
     async def async_added_to_hass(self):
         """Set up a listener when this entity is added to HA."""
@@ -58,12 +55,12 @@ class GeniusBattery(Entity):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        return self._device_class
+        return DEVICE_CLASS_TEMPERATURE
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of the sensor."""
-        return self._unit_of_measurement
+        return TEMP_CELSIUS
 
     @property
     def should_poll(self) -> bool:
@@ -73,7 +70,7 @@ class GeniusBattery(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._device.state['batteryLevel']
+        return self._device.state.get('measuredTemperature')
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -73,10 +73,10 @@ class GeniusDevice(Entity):
     def device_state_attributes(self):
         """Return the device state attributes."""
         attrs = {}
-        attrs['assignedZone'] = self._device.assignedZones[0]['name']
+        attrs['assigned_zone'] = self._device.assignedZones[0]['name']
 
         last_comms = self._device._info_raw['childValues']['lastComms']['val']  # noqa; pylint: disable=protected-access
-        attrs['lastCommunication'] = datetime.utcfromtimestamp(
+        attrs['last_comms'] = datetime.utcfromtimestamp(
             last_comms).isoformat()
 
         return {**attrs}

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -1,0 +1,88 @@
+"""Support for Genius Hub sensor devices."""
+import logging
+
+from homeassistant.const import (
+    DEVICE_CLASS_BATTERY, DEVICE_CLASS_ILLUMINANCE)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+GH_HAS_BATTERY = [
+    'Room Thermostat', 'Genius Valve', 'Room Sensor', 'Radiator Valve']
+
+GH_STATE_ATTRS = [
+    'setTemperature', 'measuredTemperature', 'luminance', 'occupancyTrigger',
+    'batteryLevel']
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the Genius Hub sensor entities."""
+    client = hass.data[DOMAIN]['client']
+
+    sensors = [GeniusBattery(client, d)
+               for d in client.hub.device_objs if d.type in GH_HAS_BATTERY]
+
+    async_add_entities(sensors)
+
+
+class GeniusBattery(Entity):
+    """Representation of a Genius Hub sensor."""
+
+    def __init__(self, client, device):
+        """Initialize the signal strength sensor."""
+        self._client = client
+        self._device = device
+
+        self._name = '{} {}'.format(device.type, device.id)
+        self._device_class = DEVICE_CLASS_BATTERY
+        self._unit_of_measurement = '%'
+
+    async def async_added_to_hass(self):
+        """Set up a listener when this entity is added to HA."""
+        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
+
+    @callback
+    def _refresh(self):
+        self.async_schedule_update_ha_state(force_refresh=True)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of the sensor."""
+        return self._unit_of_measurement
+
+    @property
+    def should_poll(self) -> bool:
+        """Return False as the geniushub devices should not be polled."""
+        return False
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._device.state['batteryLevel']
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attrs = {}
+        attrs['location'] = self._device.assignedZones[0]['name']
+#       attrs['lastCommunication'] = 0  # TODO: add this
+
+        state = {k: v for k, v in self._device.state.items()
+                 if k in GH_STATE_ATTRS}
+
+        return {**attrs, **state}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -474,7 +474,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.4.6
+geniushub-client==0.4.7
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
## Breaking Change:

None known

## Description: 
The underlying devices that make up a genius hub system are either wireless (i.e. have a battery) or manage a switch (e.g. turn a immersion heater on/off, turn CH on/off).  

This PR exposed each individual device as one of a battery (sensor), or a switch (binary sensor).

Later, additional information will be exposed via `device_state_attributes`, such as last communication time, and issue logs.

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9456

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
