### PR TITLE
Add incomfort sensor and binary_sensor

### DIFF
--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -44,7 +44,7 @@ async def async_setup(hass, hass_config):
             exc_info=True)
         return False
 
-    for platform in ['water_heater', 'climate']:
+    for platform in ['water_heater', 'binary_sensor', 'sensor']:
         hass.async_create_task(async_load_platform(
             hass, platform, DOMAIN, {}, hass_config))
 

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -44,7 +44,7 @@ async def async_setup(hass, hass_config):
             exc_info=True)
         return False
 
-    for platform in ['water_heater', 'binary_sensor', 'sensor']:
+    for platform in ['water_heater', 'binary_sensor', 'sensor', 'climate']:
         hass.async_create_task(async_load_platform(
             hass, platform, DOMAIN, {}, hass_config))
 

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -37,9 +37,9 @@ async def async_setup(hass, hass_config):
 
     try:
         heater = incomfort_data['heater'] = list(await client.heaters)[0]
-    except ClientResponseError as exc:
+    except ClientResponseError as err:
         _LOGGER.warning(
-            "Setup failed, check your configuration, message is: %s", exc)
+            "Setup failed, check your configuration, message is: %s", err)
         return False
 
     await heater.update()

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -37,8 +37,9 @@ async def async_setup(hass, hass_config):
 
     try:
         heater = incomfort_data['heater'] = list(await client.heaters)[0]
-    except ClientResponseError as e:
-        _LOGGER.warning("Setup failed, check your configuration, hint: %s", e)
+    except ClientResponseError as exc:
+        _LOGGER.warning(
+            "Setup failed, check your configuration, message is: %s", exc)
         return False
 
     await heater.update()

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -1,6 +1,7 @@
 """Support for an Intergas boiler via an InComfort/Intouch Lan2RF gateway."""
 import logging
 
+from aiohttp import ClientResponseError
 import voluptuous as vol
 from incomfortclient import Gateway as InComfortGateway
 
@@ -30,19 +31,17 @@ async def async_setup(hass, hass_config):
     credentials = dict(hass_config[DOMAIN])
     hostname = credentials.pop(CONF_HOST)
 
+    client = incomfort_data['client'] = InComfortGateway(
+        hostname, **credentials, session=async_get_clientsession(hass)
+    )
+
     try:
-        client = incomfort_data['client'] = InComfortGateway(
-            hostname, **credentials, session=async_get_clientsession(hass)
-        )
-
         heater = incomfort_data['heater'] = list(await client.heaters)[0]
-        await heater.update()
-
-    except AssertionError:  # assert response.status == HTTP_OK
-        _LOGGER.warning(
-            "Setup failed, check your configuration.",
-            exc_info=True)
+    except ClientResponseError as e:
+        _LOGGER.warning("Setup failed, check your configuration, hint: %s", e)
         return False
+
+    await heater.update()
 
     for platform in ['water_heater', 'binary_sensor', 'sensor', 'climate']:
         hass.async_create_task(async_load_platform(

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -9,25 +9,19 @@ from . import DOMAIN
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up an InComfort/InTouch binary_sensor device."""
-    client = hass.data[DOMAIN]['client']
-    heater = hass.data[DOMAIN]['heater']
-
     async_add_entities([
-        IncomfortFailed(client, heater)
+        IncomfortFailed(hass.data[DOMAIN]['client'],
+                        hass.data[DOMAIN]['heater'])
     ])
 
 
-class IncomfortBinarySensor(BinarySensorDevice):
-    """Representation of an InComfort/InTouch binary_sensor device."""
+class IncomfortFailed(IncomfortBinarySensor):
+    """Representation of an InComfort Failed sensor."""
 
     def __init__(self, client, boiler):
         """Initialize the binary sensor."""
         self._client = client
         self._boiler = boiler
-
-        self._name = None
-        self._is_on_key = None
-        self._other_key = None
 
     async def async_added_to_hass(self):
         """Set up a listener when this entity is added to HA."""
@@ -40,32 +34,20 @@ class IncomfortBinarySensor(BinarySensorDevice):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name
+        return 'Fault state'
 
     @property
     def is_on(self):
         """Return the status of the sensor."""
-        return self._boiler.status[self._is_on_key]
+        return self._boiler.status['is_failed']
 
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        value = self._boiler.status[self._other_key] if self.is_on else None
-        return {self._other_key: value}
+        return {'fault_code': self._boiler.status['fault_code']}
 
     @property
     def should_poll(self) -> bool:
         """Return False as this device should never be polled."""
         return False
 
-
-class IncomfortFailed(IncomfortBinarySensor):
-    """Representation of an InComfort Failed sensor."""
-
-    def __init__(self, client, boiler):
-        """Initialize the binary sensor."""
-        super().__init__(client, boiler)
-
-        self._name = 'Failed'
-        self._is_on_key = 'is_failed'
-        self._other_key = 'fault_code'

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -53,8 +53,6 @@ class IncomfortBinarySensor(BinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        if self._other_key is None:
-            return None
         value = self._boiler.status[self._other_key] if self.is_on else None
         return {self._other_key: value}
 

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -50,4 +50,3 @@ class IncomfortFailed(BinarySensorDevice):
     def should_poll(self) -> bool:
         """Return False as this device should never be polled."""
         return False
-

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -15,7 +15,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     ])
 
 
-class IncomfortFailed(IncomfortBinarySensor):
+class IncomfortFailed(BinarySensorDevice):
     """Representation of an InComfort Failed sensor."""
 
     def __init__(self, client, boiler):

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -1,0 +1,125 @@
+"""Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import DOMAIN
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up an InComfort/InTouch binary_sensor device."""
+    client = hass.data[DOMAIN]['client']
+    heater = hass.data[DOMAIN]['heater']
+
+    async_add_entities([
+        IncomfortBurning(client, heater),
+        IncomfortPumping(client, heater),
+        IncomfortTapping(client, heater),
+        IncomfortFailed(client, heater)
+    ])
+
+
+class IncomfortBinarySensor(BinarySensorDevice):
+    """Representation of an InComfort/InTouch binary_sensor device."""
+
+    def __init__(self, client, boiler):
+        """Initialize the binary sensor."""
+        self._client = client
+        self._boiler = boiler
+
+        self._name = None
+        self._is_on_key = None
+        self._other_key = None
+
+    async def async_added_to_hass(self):
+        """Set up a listener when this entity is added to HA."""
+        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
+
+    @callback
+    def _refresh(self):
+        self.async_schedule_update_ha_state(force_refresh=True)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the status of the sensor."""
+        return self._boiler.status[self._is_on_key]
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        if self._other_key is None:
+            return None
+        value = self._boiler.status[self._other_key] if self.is_on else None
+        return {self._other_key: value}
+
+    @property
+    def should_poll(self) -> bool:
+        """Return False as this device should never be polled."""
+        return False
+
+
+class IncomfortBurning(IncomfortBinarySensor):
+    """Representation of an InComfort Burning sensor."""
+
+    def __init__(self, client, boiler):
+        """Initialize the binary sensor."""
+        super().__init__(client, boiler)
+
+        self._name = 'Burning'
+        self._is_on_key = 'is_burning'
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        if self._boiler.status['is_pumping']:
+            value = self._boiler.status['heater_temp']
+        elif self._boiler.status['is_tapping']:
+            value = self._boiler.status['tap_temp']
+        else:
+            value = max(
+                self._boiler.status['heater_temp'],
+                self._boiler.status['tap_temp']
+            )
+        return {'water_temp': value}
+
+
+class IncomfortFailed(IncomfortBinarySensor):
+    """Representation of an InComfort Failed sensor."""
+
+    def __init__(self, client, boiler):
+        """Initialize the binary sensor."""
+        super().__init__(client, boiler)
+
+        self._name = 'Failed'
+        self._is_on_key = 'is_failed'
+        self._other_key = 'fault_code'
+
+
+class IncomfortPumping(IncomfortBinarySensor):
+    """Representation of an InComfort Pumping sensor."""
+
+    def __init__(self, client, boiler):
+        """Initialize the binary sensor."""
+        super().__init__(client, boiler)
+
+        self._name = 'Pumping'
+        self._is_on_key = 'is_pumping'
+        self._other_key = 'heater_temp'
+
+
+class IncomfortTapping(IncomfortBinarySensor):
+    """Representation of an InComfort Tapping sensor."""
+
+    def __init__(self, client, boiler):
+        """Initialize the binary sensor."""
+        super().__init__(client, boiler)
+
+        self._name = 'Tapping'
+        self._is_on_key = 'is_tapping'
+        self._other_key = 'tap_temp'

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -77,15 +77,10 @@ class IncomfortBurning(IncomfortBinarySensor):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        if self._boiler.status['is_pumping']:
-            value = self._boiler.status['heater_temp']
-        elif self._boiler.status['is_tapping']:
+        if self._boiler.status['is_tapping']:
             value = self._boiler.status['tap_temp']
         else:
-            value = max(
-                self._boiler.status['heater_temp'],
-                self._boiler.status['tap_temp']
-            )
+            value = self._boiler.status['heater_temp']
         return {'water_temp': value}
 
 

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -13,9 +13,6 @@ async def async_setup_platform(hass, config, async_add_entities,
     heater = hass.data[DOMAIN]['heater']
 
     async_add_entities([
-        IncomfortBurning(client, heater),
-        IncomfortPumping(client, heater),
-        IncomfortTapping(client, heater),
         IncomfortFailed(client, heater)
     ])
 
@@ -62,26 +59,6 @@ class IncomfortBinarySensor(BinarySensorDevice):
         return False
 
 
-class IncomfortBurning(IncomfortBinarySensor):
-    """Representation of an InComfort Burning sensor."""
-
-    def __init__(self, client, boiler):
-        """Initialize the binary sensor."""
-        super().__init__(client, boiler)
-
-        self._name = 'Burning'
-        self._is_on_key = 'is_burning'
-
-    @property
-    def device_state_attributes(self):
-        """Return the device state attributes."""
-        if self._boiler.status['is_tapping']:
-            value = self._boiler.status['tap_temp']
-        else:
-            value = self._boiler.status['heater_temp']
-        return {'water_temp': value}
-
-
 class IncomfortFailed(IncomfortBinarySensor):
     """Representation of an InComfort Failed sensor."""
 
@@ -92,27 +69,3 @@ class IncomfortFailed(IncomfortBinarySensor):
         self._name = 'Failed'
         self._is_on_key = 'is_failed'
         self._other_key = 'fault_code'
-
-
-class IncomfortPumping(IncomfortBinarySensor):
-    """Representation of an InComfort Pumping sensor."""
-
-    def __init__(self, client, boiler):
-        """Initialize the binary sensor."""
-        super().__init__(client, boiler)
-
-        self._name = 'Pumping'
-        self._is_on_key = 'is_pumping'
-        self._other_key = 'heater_temp'
-
-
-class IncomfortTapping(IncomfortBinarySensor):
-    """Representation of an InComfort Tapping sensor."""
-
-    def __init__(self, client, boiler):
-        """Initialize the binary sensor."""
-        super().__init__(client, boiler)
-
-        self._name = 'Tapping'
-        self._is_on_key = 'is_tapping'
-        self._other_key = 'tap_temp'

--- a/homeassistant/components/incomfort/manifest.json
+++ b/homeassistant/components/incomfort/manifest.json
@@ -3,7 +3,7 @@
   "name": "Intergas InComfort/Intouch Lan2RF gateway",
   "documentation": "https://www.home-assistant.io/components/incomfort",
   "requirements": [
-    "incomfort-client==0.2.9"
+    "incomfort-client==0.3.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -1,0 +1,111 @@
+"""Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
+import logging
+
+from homeassistant.const import (
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_SIGNAL_STRENGTH)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up an InComfort/InTouch sensor device."""
+    client = hass.data[DOMAIN]['client']
+    heater = hass.data[DOMAIN]['heater']
+
+    async_add_entities([
+        IncomfortSignal(client, heater),
+        IncomfortPressure(client, heater)
+    ])
+
+
+class IncomfortSensor(Entity):
+    """Representation of an InComfort/InTouch sensor device."""
+
+    def __init__(self, client, boiler):
+        """Initialize the sensor."""
+        self._client = client
+        self._boiler = boiler
+
+        self._name = None
+        self._device_class = None
+        self._unit_of_measurement = None
+
+    async def async_added_to_hass(self):
+        """Set up a listener when this entity is added to HA."""
+        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
+
+    @callback
+    def _refresh(self):
+        self.async_schedule_update_ha_state(force_refresh=True)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of the sensor."""
+        return self._unit_of_measurement
+
+    @property
+    def should_poll(self) -> bool:
+        """Return False as this device should never be polled."""
+        return False
+
+
+class IncomfortPressure(IncomfortSensor):
+    """Representation of an InTouch CV Pressure sensor."""
+
+    def __init__(self, client, boiler):
+        """Initialize the sensor."""
+        super().__init__(client, boiler)
+
+        self._name = 'CV Pressure'
+        self._device_class = DEVICE_CLASS_PRESSURE
+        self._unit_of_measurement = 'bar'
+
+    @property
+    def state(self):
+        """Return the state/value of the sensor."""
+        return self._boiler.status['pressure']
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        keys = ['is_pumping', 'heater_temp']
+        return {k: self._boiler.status[k] for k in keys}
+
+
+class IncomfortSignal(IncomfortSensor):
+    """Representation of an InTouch Signal strength sensor."""
+
+    def __init__(self, client, boiler):
+        """Initialize the signal strength sensor."""
+        super().__init__(client, boiler)
+
+        self._name = 'RF Signal'
+        self._device_class = DEVICE_CLASS_SIGNAL_STRENGTH
+        self._unit_of_measurement = 'dBm'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._boiler.status['rf_message_rssi']
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {k: self._boiler.status[k] for k in ['nodenr', 'rfstatus_cntr']}

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -1,7 +1,6 @@
 """Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
 from homeassistant.const import (
-    PRESSURE_BAR, TEMP_CELSIUS,
-    DEVICE_CLASS_PRESSURE, DEVICE_CLASS_TEMPERATURE)
+    PRESSURE_BAR, TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -25,7 +24,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     heater = hass.data[DOMAIN]['heater']
 
     async_add_entities([
-        IncomfortPressure(client, heater),
+        IncomfortPressure(client, heater, INTOUCH_PRESSURE),
         IncomfortTemperature(client, heater, INTOUCH_HEATER_TEMP),
         IncomfortTemperature(client, heater, INTOUCH_TAP_TEMP)
     ])
@@ -75,12 +74,11 @@ class IncomfortSensor(Entity):
 class IncomfortPressure(IncomfortSensor):
     """Representation of an InTouch CV Pressure sensor."""
 
-    def __init__(self, client, boiler):
+    def __init__(self, client, boiler, name):
         """Initialize the sensor."""
         super().__init__(client, boiler)
 
-        self._name = INTOUCH_PRESSURE
-        self._device_class = DEVICE_CLASS_PRESSURE
+        self._name = name
         self._unit_of_measurement = PRESSURE_BAR
 
     @property

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -1,6 +1,4 @@
 """Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
-import logging
-
 from homeassistant.const import (
     PRESSURE_BAR, TEMP_CELSIUS,
     DEVICE_CLASS_PRESSURE, DEVICE_CLASS_TEMPERATURE)
@@ -18,6 +16,7 @@ INTOUCH_MAP_ATTRS = {
     INTOUCH_HEATER_TEMP: ['heater_temp', 'is_pumping'],
     INTOUCH_TAP_TEMP: ['tap_temp', 'is_tapping'],
 }
+
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -17,8 +17,8 @@ HEATER_MIN_TEMP = 30.0
 
 HEATER_NAME = 'Boiler'
 HEATER_ATTRS = [
-    'display_code', 'display_text', 'fault_code', 'is_burning', 'is_failed',
-    'is_pumping', 'is_tapping', 'heater_temp', 'tap_temp', 'pressure']
+    'display_code', 'display_text', 'is_burning',
+    'rf_message_rssi', 'nodenr', 'rfstatus_cntr']
 
 
 async def async_setup_platform(hass, hass_config, async_add_entities,

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -28,17 +28,16 @@ async def async_setup_platform(hass, hass_config, async_add_entities,
     heater = hass.data[DOMAIN]['heater']
 
     async_add_entities([
-        IncomfortWaterHeater(hass, client, heater)], update_before_add=True)
+        IncomfortWaterHeater(client, heater)], update_before_add=True)
 
 
 class IncomfortWaterHeater(WaterHeaterDevice):
     """Representation of an InComfort/Intouch water_heater device."""
 
-    def __init__(self, hass, client, heater):
+    def __init__(self, client, heater):
         """Initialize the water_heater device."""
         self._client = client
         self._heater = heater
-        self._hass = hass
 
     @property
     def name(self):
@@ -97,4 +96,4 @@ class IncomfortWaterHeater(WaterHeaterDevice):
         except (AssertionError, asyncio.TimeoutError) as err:
             _LOGGER.warning("Update failed, message: %s", err)
 
-        async_dispatcher_send(self._hass, DOMAIN)
+        async_dispatcher_send(self.hass, DOMAIN)

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 
+from aiohttp import ClientResponseError
 from homeassistant.components.water_heater import WaterHeaterDevice
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -93,7 +94,7 @@ class IncomfortWaterHeater(WaterHeaterDevice):
         try:
             await self._heater.update()
 
-        except (AssertionError, asyncio.TimeoutError) as err:
-            _LOGGER.warning("Update failed, message: %s", err)
+        except (ClientResponseError, asyncio.TimeoutError) as err:
+            _LOGGER.warning("Update failed, message is: %s", err)
 
         async_dispatcher_send(self.hass, DOMAIN)

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -57,7 +57,9 @@ class IncomfortWaterHeater(WaterHeaterDevice):
         """Return the current temperature."""
         if self._heater.is_tapping:
             return self._heater.tap_temp
-        return self._heater.heater_temp
+        elif self._heater.is_pumping:
+            return self._heater.heater_temp
+        return max(self._heater.heater_temp, self._heater.tap_temp)
 
     @property
     def min_temp(self):

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -46,6 +46,11 @@ class IncomfortWaterHeater(WaterHeaterDevice):
         return HEATER_NAME
 
     @property
+    def icon(self):
+        """Return the icon of the water_heater device."""
+        return "mdi:oil-temperature"
+
+    @property
     def device_state_attributes(self):
         """Return the device state attributes."""
         state = {k: self._heater.status[k]

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -84,7 +84,7 @@ class IncomfortWaterHeater(WaterHeaterDevice):
     def current_operation(self):
         """Return the current operation mode."""
         if self._heater.is_failed:
-            return "Failed, fault code: {}".format(self._heater.fault_code)
+            return "Fault code: {}".format(self._heater.fault_code)
 
         return self._heater.display_text
 

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -56,7 +56,7 @@ class IncomfortWaterHeater(WaterHeaterDevice):
         """Return the current temperature."""
         if self._heater.is_tapping:
             return self._heater.tap_temp
-        elif self._heater.is_pumping:
+        if self._heater.is_pumping:
             return self._heater.heater_temp
         return max(self._heater.heater_temp, self._heater.tap_temp)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -346,6 +346,7 @@ LENGTH_MILES = 'mi'  # type: str
 # Pressure units
 PRESSURE_PA = 'Pa'  # type: str
 PRESSURE_HPA = 'hPa'  # type: str
+PRESSURE_BAR = 'bar'  # type: str
 PRESSURE_MBAR = 'mbar'  # type: str
 PRESSURE_INHG = 'inHg'  # type: str
 PRESSURE_PSI = 'psi'  # type: str

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -634,7 +634,7 @@ iglo==1.2.7
 ihcsdk==2.3.0
 
 # homeassistant.components.incomfort
-incomfort-client==0.2.9
+incomfort-client==0.3.0
 
 # homeassistant.components.influxdb
 influxdb==5.2.0


### PR DESCRIPTION
## Breaking Change:

Some `device_state_attributes` have been removed from the `water_heater` and converted to sensors, or attributes of those sensors:
 - `is_failed`, `fault_code`
 - `is_tapping`, `tap_temp`
 - `is_pumping`, `heater_temp`, and
 - `pressure`

The reason for this is so that very attribute appears only once across all entities of this integration.

## Description:

Adds `sensor`s (CV Pressure, CV Temp & Tap Temp), and `binary-sensor`s (is_failed) to the **incomfort** integration.

Bumps the client.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9654

## Example entry for `configuration.yaml` (if applicable):
N/A - Unchanged

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
