### PR TITLE
Remove badges from README [skipci]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Home Assistant |Build Status| |CI Status| |Coverage Status| |Chat Status|
+Home Assistant |Chat Status|
 =================================================================================
 
 Home Assistant is a home automation platform running on Python 3. It is able to track and control all devices at home and offer a platform for automating control.
@@ -27,12 +27,6 @@ components <https://developers.home-assistant.io/docs/en/creating_component_inde
 If you run into issues while using Home Assistant or during development
 of a component, check the `Home Assistant help section <https://home-assistant.io/help/>`__ of our website for further help and information.
 
-.. |Build Status| image:: https://travis-ci.org/home-assistant/home-assistant.svg?branch=dev
-   :target: https://travis-ci.org/home-assistant/home-assistant
-.. |CI Status| image:: https://circleci.com/gh/home-assistant/home-assistant.svg?style=shield
-   :target: https://circleci.com/gh/home-assistant/home-assistant
-.. |Coverage Status| image:: https://img.shields.io/coveralls/home-assistant/home-assistant.svg
-   :target: https://coveralls.io/r/home-assistant/home-assistant?branch=master
 .. |Chat Status| image:: https://img.shields.io/discord/330944238910963714.svg
    :target: https://discord.gg/c5DvZ4e
 .. |screenshot-states| image:: https://raw.github.com/home-assistant/home-assistant/master/docs/screenshots.png


### PR DESCRIPTION
## Description:
Remove build status from badges. It's not adding any value. Leaving the chat one there, it's good.

Also note to self, the skip ci tag needs a space to be picked up 🤷‍♂ 