### PR TITLE
Fix patching right import

### DIFF
--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -130,7 +130,7 @@ async def test_flow_timeout_discovery(hass):
     flow = config_flow.HueFlowHandler()
     flow.hass = hass
 
-    with patch('aiohue.discovery.discover_nupnp',
+    with patch('homeassistant.components.hue.config_flow.discover_nupnp',
                side_effect=asyncio.TimeoutError):
         result = await flow.async_step_init()
 


### PR DESCRIPTION
## Description:
When we moved imports for Hue around, this patch wasn't updated. It means that we were doing a nupnp query each test run, oops. This fixes it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
