### PR TITLE
Make broadlink switch restore its state

### DIFF
--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -133,7 +133,7 @@ class BroadlinkRMSwitch(SwitchDevice, RestoreEntity):
         await super().async_added_to_hass()
         state = await self.async_get_last_state()
         if state:
-          self._state = state.state == STATE_ON
+            self._state = state.state == STATE_ON
 
     @property
     def name(self):

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -10,9 +10,10 @@ from homeassistant.components.switch import (
     ENTITY_ID_FORMAT, PLATFORM_SCHEMA, SwitchDevice)
 from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_FRIENDLY_NAME, CONF_HOST, CONF_MAC,
-    CONF_SWITCHES, CONF_TIMEOUT, CONF_TYPE)
+    CONF_SWITCHES, CONF_TIMEOUT, CONF_TYPE, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, slugify
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import async_setup_service, data_packet
 
@@ -115,7 +116,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(switches)
 
 
-class BroadlinkRMSwitch(SwitchDevice):
+class BroadlinkRMSwitch(SwitchDevice, RestoreEntity):
     """Representation of an Broadlink switch."""
 
     def __init__(self, name, friendly_name, device, command_on, command_off):
@@ -126,6 +127,13 @@ class BroadlinkRMSwitch(SwitchDevice):
         self._command_on = command_on
         self._command_off = command_off
         self._device = device
+
+    async def async_added_to_hass(self):
+        """Call when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state:
+          self._state = state.state == STATE_ON
 
     @property
     def name(self):


### PR DESCRIPTION

## Breaking Change: 
This could break behavior for people relying on the switch to always start up in `off` state.
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Especially if we have a "toggle" switch (with same on/off commands), it is very useful to restore the state in home assistant. We can then guess the current state and actually switch the device on or off. This should also work after a HA restart. Which it didn't so far...

I copied the method to do so from pilight switch to broadlink switch. 

**Related issue (if applicable):** none.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** none


## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
- platform: broadlink
  host: !secret rmmini_host
  mac:  !secret rmmini_mac
  switches:
    receiver:
      friendly_name: "Receiver an/aus"
      command_on:    'JgBgAAABKJIVERQRFRAVNRU0FjQVEBY0FRAVEBYQFRAWEBUQFRAVERU0FhAVNBU1FDUWEBQRFDUVERU0FhAVEBURFDUUNhQRFAAFpAABKUcVAAw===='
      command_off:   'JgBgAAABKJIVERQRFRAVNRU0FjQVEBY0FRAVEBYQFRAWEBUQFRAVERU0FhAVNBU1FDUWEBQRFDUVERU0FhAVEBURFDUUNhQRFAAFpAABKUcVAAw===='
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
