### PR TITLE
Add incomfort climate and bump client

### DIFF
--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -44,7 +44,8 @@ async def async_setup(hass, hass_config):
             exc_info=True)
         return False
 
-    hass.async_create_task(async_load_platform(
-        hass, 'water_heater', DOMAIN, {}, hass_config))
+    for platform in ['water_heater', 'climate']:
+        hass.async_create_task(async_load_platform(
+            hass, platform, DOMAIN, {}, hass_config))
 
     return True

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -1,0 +1,93 @@
+"""Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
+from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate.const import SUPPORT_TARGET_TEMPERATURE
+from homeassistant.const import (ATTR_TEMPERATURE, TEMP_CELSIUS)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import DOMAIN
+
+INTOUCH_SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
+
+INTOUCH_MAX_TEMP = 30.0
+INTOUCH_MIN_TEMP = 5.0
+
+
+async def async_setup_platform(hass, hass_config, async_add_entities,
+                               discovery_info=None):
+    """Set up an InComfort/InTouch climate device."""
+    client = hass.data[DOMAIN]['client']
+    heater = hass.data[DOMAIN]['heater']
+
+    rooms = [InComfortClimate(client, r)
+             for r in heater.rooms if not r.room_temp]
+    if rooms:
+        async_add_entities(rooms)
+
+
+class InComfortClimate(ClimateDevice):
+    """Representation of an InComfort/InTouch climate device."""
+
+    def __init__(self, client, room):
+        """Initialize the climate device."""
+        self._client = client
+        self._room = room
+        self._name = 'Room {}'.format(room.room_no)
+
+    async def async_added_to_hass(self):
+        """Set up a listener when this entity is added to HA."""
+        async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
+
+    @callback
+    def _refresh(self):
+        self.async_schedule_update_ha_state(force_refresh=True)
+
+    @property
+    def name(self):
+        """Return the name of the climate device."""
+        return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {'status': self._room.status}
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._room.room_temp
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._room.override  # or: self._room.setpoint?
+
+    @property
+    def min_temp(self):
+        """Return max valid temperature that can be set."""
+        return INTOUCH_MIN_TEMP
+
+    @property
+    def max_temp(self):
+        """Return max valid temperature that can be set."""
+        return INTOUCH_MAX_TEMP
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return INTOUCH_SUPPORT_FLAGS
+
+    async def async_set_temperature(self, **kwargs):
+        """Set a new target temperature for this zone."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        await self._room.set_override(temperature)
+
+    @property
+    def should_poll(self) -> bool:
+        """Return False as this device should never be polled."""
+        return False

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -60,7 +60,7 @@ class InComfortClimate(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._room.override  # or: self._room.setpoint?
+        return self._room.override
 
     @property
     def min_temp(self):

--- a/homeassistant/components/incomfort/manifest.json
+++ b/homeassistant/components/incomfort/manifest.json
@@ -3,7 +3,7 @@
   "name": "Intergas InComfort/Intouch Lan2RF gateway",
   "documentation": "https://www.home-assistant.io/components/incomfort",
   "requirements": [
-    "incomfort-client==0.2.8"
+    "incomfort-client==0.2.9"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -602,7 +602,7 @@ iglo==1.2.7
 ihcsdk==2.3.0
 
 # homeassistant.components.incomfort
-incomfort-client==0.2.8
+incomfort-client==0.2.9
 
 # homeassistant.components.influxdb
 influxdb==5.2.0


### PR DESCRIPTION
## Breaking Change:

None known.

## Description:

Adds climate entities to the intouch platform.

**Related issue (if applicable):** bumps client to address a KeyError that becomes only apparent with climate entities.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):

Unchanged.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
