### PR TITLE
Quiet the chatty sun.sun

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -183,13 +183,12 @@ class Sun(Entity):
     @callback
     def update_sun_position(self, utc_point_in_time):
         """Calculate the position of the sun."""
-        # Round azimuth to nearest 0.5
         self.solar_azimuth = round(
             self.location.solar_azimuth(utc_point_in_time), 2)
         self.solar_elevation = round(
             self.location.solar_elevation(utc_point_in_time), 2)
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "sun position_update@%s: elevation=%s azimuth=%s",
             utc_point_in_time.isoformat(),
             self.solar_elevation, self.solar_azimuth

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -6,10 +6,9 @@ from homeassistant.const import (
     CONF_ELEVATION, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import (
-    async_track_point_in_utc_time, async_track_utc_time_change)
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.sun import (
-    get_astral_location, get_astral_event_next)
+    get_astral_location, get_location_astral_event_next)
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,12 +22,33 @@ STATE_BELOW_HORIZON = 'below_horizon'
 
 STATE_ATTR_AZIMUTH = 'azimuth'
 STATE_ATTR_ELEVATION = 'elevation'
+STATE_ATTR_RISING = 'rising'
 STATE_ATTR_NEXT_DAWN = 'next_dawn'
 STATE_ATTR_NEXT_DUSK = 'next_dusk'
 STATE_ATTR_NEXT_MIDNIGHT = 'next_midnight'
 STATE_ATTR_NEXT_NOON = 'next_noon'
 STATE_ATTR_NEXT_RISING = 'next_rising'
 STATE_ATTR_NEXT_SETTING = 'next_setting'
+STATE_ATTR_PHASE = 'phase'
+
+PHASE_NIGHT = 'night'
+PHASE_ASTRONOMICAL_TWILIGHT = 'astronomical_twilight'
+PHASE_NAUTICAL_TWILIGHT = 'nautical_twilight'
+PHASE_TWILIGHT = 'twilight'
+PHASE_SMALL_DAY = 'small_day'
+PHASE_DAY = 'day'
+
+# 4 mins is one degree of arc change of the sun on its circle.
+# During the night and the middle of the day we don't update
+# that much since it's not important.
+_PHASE_UPDATES = {
+    PHASE_NIGHT: timedelta(minutes=4*5),
+    PHASE_ASTRONOMICAL_TWILIGHT: timedelta(minutes=4*2),
+    PHASE_NAUTICAL_TWILIGHT: timedelta(minutes=4*2),
+    PHASE_TWILIGHT: timedelta(minutes=4),
+    PHASE_SMALL_DAY: timedelta(minutes=2),
+    PHASE_DAY: timedelta(minutes=4),
+}
 
 
 async def async_setup(hass, config):
@@ -37,10 +57,7 @@ async def async_setup(hass, config):
         _LOGGER.warning(
             "Elevation is now configured in home assistant core. "
             "See https://home-assistant.io/docs/configuration/basic/")
-
-    sun = Sun(hass, get_astral_location(hass))
-    sun.point_in_time_listener(dt_util.utcnow())
-
+    Sun(hass, get_astral_location(hass))
     return True
 
 
@@ -57,8 +74,10 @@ class Sun(Entity):
         self.next_dawn = self.next_dusk = None
         self.next_midnight = self.next_noon = None
         self.solar_elevation = self.solar_azimuth = None
+        self.rising = self.phase = None
 
-        async_track_utc_time_change(hass, self.timer_update, second=30)
+        self._next_change = None
+        self.update_events(dt_util.utcnow())
 
     @property
     def name(self):
@@ -83,57 +102,105 @@ class Sun(Entity):
             STATE_ATTR_NEXT_NOON: self.next_noon.isoformat(),
             STATE_ATTR_NEXT_RISING: self.next_rising.isoformat(),
             STATE_ATTR_NEXT_SETTING: self.next_setting.isoformat(),
-            STATE_ATTR_ELEVATION: round(self.solar_elevation, 2),
-            STATE_ATTR_AZIMUTH: round(self.solar_azimuth, 2)
+            STATE_ATTR_ELEVATION: self.solar_elevation,
+            STATE_ATTR_AZIMUTH: self.solar_azimuth,
+            STATE_ATTR_RISING: self.rising,
         }
 
-    @property
-    def next_change(self):
-        """Datetime when the next change to the state is."""
-        return min(self.next_dawn, self.next_dusk, self.next_midnight,
-                   self.next_noon, self.next_rising, self.next_setting)
+    def _check_event(self, utc_point_in_time, event, before):
+        next_utc = get_location_astral_event_next(
+            self.location, event, utc_point_in_time)
+        if next_utc < self._next_change:
+            self._next_change = next_utc
+            self.phase = before
+        return next_utc
 
     @callback
-    def update_as_of(self, utc_point_in_time):
+    def update_events(self, utc_point_in_time):
         """Update the attributes containing solar events."""
-        self.next_dawn = get_astral_event_next(
-            self.hass, 'dawn', utc_point_in_time)
-        self.next_dusk = get_astral_event_next(
-            self.hass, 'dusk', utc_point_in_time)
-        self.next_midnight = get_astral_event_next(
-            self.hass, 'solar_midnight', utc_point_in_time)
-        self.next_noon = get_astral_event_next(
-            self.hass, 'solar_noon', utc_point_in_time)
-        self.next_rising = get_astral_event_next(
-            self.hass, SUN_EVENT_SUNRISE, utc_point_in_time)
-        self.next_setting = get_astral_event_next(
-            self.hass, SUN_EVENT_SUNSET, utc_point_in_time)
+        self._next_change = utc_point_in_time + timedelta(days=400)
+
+        self.location.solar_depression = 'astronomical'
+        self._check_event(utc_point_in_time, 'dawn', PHASE_NIGHT)
+        self.location.solar_depression = 'nautical'
+        self._check_event(
+            utc_point_in_time, 'dawn', PHASE_ASTRONOMICAL_TWILIGHT)
+        self.location.solar_depression = 'civil'
+        self.next_dawn = self._check_event(
+            utc_point_in_time, 'dawn', PHASE_NAUTICAL_TWILIGHT)
+        self.next_rising = self._check_event(
+            utc_point_in_time, SUN_EVENT_SUNRISE, PHASE_TWILIGHT)
+        self.location.solar_depression = -10
+        self._check_event(utc_point_in_time, 'dawn', PHASE_SMALL_DAY)
+        self.next_noon = self._check_event(
+            utc_point_in_time, 'solar_noon', None)
+        self._check_event(utc_point_in_time, 'dusk', PHASE_DAY)
+        self.next_setting = self._check_event(
+            utc_point_in_time, SUN_EVENT_SUNSET, PHASE_SMALL_DAY)
+        self.location.solar_depression = 'civil'
+        self.next_dusk = self._check_event(
+            utc_point_in_time, 'dusk', PHASE_TWILIGHT)
+        self.location.solar_depression = 'nautical'
+        self._check_event(
+            utc_point_in_time, 'dusk', PHASE_NAUTICAL_TWILIGHT)
+        self.location.solar_depression = 'astronomical'
+        self._check_event(
+            utc_point_in_time, 'dusk', PHASE_ASTRONOMICAL_TWILIGHT)
+        self.next_midnight = self._check_event(
+            utc_point_in_time, 'solar_midnight', None)
+
+        # Need to calculate phase if next is noon or midnight
+        if self.phase is None:
+            elevation = self.location.solar_elevation(self._next_change)
+            if elevation >= 10:
+                self.phase = PHASE_DAY
+            elif elevation >= 0:
+                self.phase = PHASE_SMALL_DAY
+            elif elevation >= -6:
+                self.phase = PHASE_TWILIGHT
+            elif elevation >= -12:
+                self.phase = PHASE_NAUTICAL_TWILIGHT
+            elif elevation >= -18:
+                self.phase = PHASE_ASTRONOMICAL_TWILIGHT
+            else:
+                self.phase = PHASE_NIGHT
+
+        self.rising = self.next_noon < self.next_midnight
+
+        _LOGGER.info(
+            "sun phase_update@%s: phase=%s",
+            utc_point_in_time.isoformat(),
+            self.phase,
+        )
+        self.update_sun_position(utc_point_in_time)
+
+        # Set timer for the next solar event
+        async_track_point_in_utc_time(
+            self.hass, self.update_events,
+            self._next_change)
+        _LOGGER.debug("next time: %s", self._next_change)
 
     @callback
     def update_sun_position(self, utc_point_in_time):
         """Calculate the position of the sun."""
-        self.solar_azimuth = self.location.solar_azimuth(utc_point_in_time)
-        self.solar_elevation = self.location.solar_elevation(utc_point_in_time)
+        # Round azimuth to nearest 0.5
+        self.solar_azimuth = round(
+            self.location.solar_azimuth(utc_point_in_time), 2)
+        self.solar_elevation = round(
+            self.location.solar_elevation(utc_point_in_time), 2)
 
-    @callback
-    def point_in_time_listener(self, now):
-        """Run when the state of the sun has changed."""
-        self.update_sun_position(now)
-        self.update_as_of(now)
+        _LOGGER.info(
+            "sun position_update@%s: elevation=%s azimuth=%s",
+            utc_point_in_time.isoformat(),
+            self.solar_elevation, self.solar_azimuth
+        )
         self.async_write_ha_state()
-        _LOGGER.debug("sun point_in_time_listener@%s: %s, %s",
-                      now, self.state, self.state_attributes)
 
-        # Schedule next update at next_change+1 second so sun state has changed
+        next_update = utc_point_in_time + _PHASE_UPDATES[self.phase]
+        # if the next update is within 30 seconds of a change
+        # the next change will pick it up.
+        if next_update + timedelta(seconds=30) > self._next_change:
+            return
         async_track_point_in_utc_time(
-            self.hass, self.point_in_time_listener,
-            self.next_change + timedelta(seconds=1))
-        _LOGGER.debug("next time: %s", self.next_change + timedelta(seconds=1))
-
-    @callback
-    def timer_update(self, time):
-        """Needed to update solar elevation and azimuth."""
-        self.update_sun_position(time)
-        self.async_write_ha_state()
-        _LOGGER.debug("sun timer_update@%s: %s, %s",
-                      time, self.state, self.state_attributes)
+            self.hass, self.update_sun_position,
+            next_update)

--- a/homeassistant/helpers/sun.py
+++ b/homeassistant/helpers/sun.py
@@ -43,9 +43,18 @@ def get_astral_event_next(
         utc_point_in_time: Optional[datetime.datetime] = None,
         offset: Optional[datetime.timedelta] = None) -> datetime.datetime:
     """Calculate the next specified solar event."""
-    from astral import AstralError
-
     location = get_astral_location(hass)
+    return get_location_astral_event_next(
+        location, event, utc_point_in_time, offset)
+
+
+@callback
+def get_location_astral_event_next(
+        location: 'astral.Location', event: str,
+        utc_point_in_time: Optional[datetime.datetime] = None,
+        offset: Optional[datetime.timedelta] = None) -> datetime.datetime:
+    """Calculate the next specified solar event."""
+    from astral import AstralError
 
     if offset is None:
         offset = datetime.timedelta()

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -167,11 +167,11 @@ async def test_state_change_count(hass):
     hass.bus.async_listen(EVENT_STATE_CHANGED, state_change_listener)
     await hass.async_block_till_done()
 
-    for _ in range(24*60*6):
-        now += timedelta(seconds=10)
+    for _ in range(24*60*60):
+        now += timedelta(seconds=1)
         hass.bus.async_fire(
             ha.EVENT_TIME_CHANGED,
             {ha.ATTR_NOW: now})
         await hass.async_block_till_done()
 
-    assert len(events) < 600
+    assert len(events) < 721

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -1,153 +1,177 @@
 """The tests for the Sun component."""
-# pylint: disable=protected-access
-import unittest
+from datetime import datetime, timedelta
 from unittest.mock import patch
-from datetime import timedelta, datetime
 
-from homeassistant.setup import setup_component
+from pytest import mark
+
+import homeassistant.components.sun as sun
 import homeassistant.core as ha
 import homeassistant.util.dt as dt_util
-import homeassistant.components.sun as sun
+from homeassistant.const import EVENT_STATE_CHANGED
+from homeassistant.setup import async_setup_component
 
-from tests.common import get_test_home_assistant
+
+async def test_setting_rising(hass):
+    """Test retrieving sun setting and rising."""
+    utc_now = datetime(2016, 11, 1, 8, 0, 0, tzinfo=dt_util.UTC)
+    with patch('homeassistant.helpers.condition.dt_util.utcnow',
+               return_value=utc_now):
+        await async_setup_component(hass, sun.DOMAIN, {
+            sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
+
+    await hass.async_block_till_done()
+    state = hass.states.get(sun.ENTITY_ID)
+
+    from astral import Astral
+
+    astral = Astral()
+    utc_today = utc_now.date()
+
+    latitude = hass.config.latitude
+    longitude = hass.config.longitude
+
+    mod = -1
+    while True:
+        next_dawn = (astral.dawn_utc(
+            utc_today + timedelta(days=mod), latitude, longitude))
+        if next_dawn > utc_now:
+            break
+        mod += 1
+
+    mod = -1
+    while True:
+        next_dusk = (astral.dusk_utc(
+            utc_today + timedelta(days=mod), latitude, longitude))
+        if next_dusk > utc_now:
+            break
+        mod += 1
+
+    mod = -1
+    while True:
+        next_midnight = (astral.solar_midnight_utc(
+            utc_today + timedelta(days=mod), longitude))
+        if next_midnight > utc_now:
+            break
+        mod += 1
+
+    mod = -1
+    while True:
+        next_noon = (astral.solar_noon_utc(
+            utc_today + timedelta(days=mod), longitude))
+        if next_noon > utc_now:
+            break
+        mod += 1
+
+    mod = -1
+    while True:
+        next_rising = (astral.sunrise_utc(
+            utc_today + timedelta(days=mod), latitude, longitude))
+        if next_rising > utc_now:
+            break
+        mod += 1
+
+    mod = -1
+    while True:
+        next_setting = (astral.sunset_utc(
+            utc_today + timedelta(days=mod), latitude, longitude))
+        if next_setting > utc_now:
+            break
+        mod += 1
+
+    assert next_dawn == dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_DAWN])
+    assert next_dusk == dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_DUSK])
+    assert next_midnight == dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_MIDNIGHT])
+    assert next_noon == dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_NOON])
+    assert next_rising == dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_RISING])
+    assert next_setting == dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_SETTING])
 
 
-# pylint: disable=invalid-name
-class TestSun(unittest.TestCase):
-    """Test the sun module."""
+async def test_state_change(hass):
+    """Test if the state changes at next setting/rising."""
+    now = datetime(2016, 6, 1, 8, 0, 0, tzinfo=dt_util.UTC)
+    with patch('homeassistant.helpers.condition.dt_util.utcnow',
+               return_value=now):
+        await async_setup_component(hass, sun.DOMAIN, {
+            sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
+    await hass.async_block_till_done()
 
-    def tearDown(self):
-        """Stop everything that was started."""
-        self.hass.stop()
+    test_time = dt_util.parse_datetime(
+        hass.states.get(sun.ENTITY_ID)
+        .attributes[sun.STATE_ATTR_NEXT_RISING])
+    assert test_time is not None
 
-    def test_setting_rising(self):
-        """Test retrieving sun setting and rising."""
-        utc_now = datetime(2016, 11, 1, 8, 0, 0, tzinfo=dt_util.UTC)
-        with patch('homeassistant.helpers.condition.dt_util.utcnow',
-                   return_value=utc_now):
-            setup_component(self.hass, sun.DOMAIN, {
-                sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
+    assert sun.STATE_BELOW_HORIZON == \
+        hass.states.get(sun.ENTITY_ID).state
 
-        self.hass.block_till_done()
-        state = self.hass.states.get(sun.ENTITY_ID)
+    hass.bus.async_fire(
+        ha.EVENT_TIME_CHANGED,
+        {ha.ATTR_NOW: test_time + timedelta(seconds=5)})
 
-        from astral import Astral
+    await hass.async_block_till_done()
 
-        astral = Astral()
-        utc_today = utc_now.date()
+    assert sun.STATE_ABOVE_HORIZON == \
+        hass.states.get(sun.ENTITY_ID).state
 
-        latitude = self.hass.config.latitude
-        longitude = self.hass.config.longitude
 
-        mod = -1
-        while True:
-            next_dawn = (astral.dawn_utc(
-                utc_today + timedelta(days=mod), latitude, longitude))
-            if next_dawn > utc_now:
-                break
-            mod += 1
+async def test_norway_in_june(hass):
+    """Test location in Norway where the sun doesn't set in summer."""
+    hass.config.latitude = 69.6
+    hass.config.longitude = 18.8
 
-        mod = -1
-        while True:
-            next_dusk = (astral.dusk_utc(
-                utc_today + timedelta(days=mod), latitude, longitude))
-            if next_dusk > utc_now:
-                break
-            mod += 1
+    june = datetime(2016, 6, 1, tzinfo=dt_util.UTC)
 
-        mod = -1
-        while True:
-            next_midnight = (astral.solar_midnight_utc(
-                utc_today + timedelta(days=mod), longitude))
-            if next_midnight > utc_now:
-                break
-            mod += 1
+    with patch('homeassistant.helpers.condition.dt_util.utcnow',
+               return_value=june):
+        assert await async_setup_component(hass, sun.DOMAIN, {
+            sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
 
-        mod = -1
-        while True:
-            next_noon = (astral.solar_noon_utc(
-                utc_today + timedelta(days=mod), longitude))
-            if next_noon > utc_now:
-                break
-            mod += 1
+    state = hass.states.get(sun.ENTITY_ID)
+    assert state is not None
 
-        mod = -1
-        while True:
-            next_rising = (astral.sunrise_utc(
-                utc_today + timedelta(days=mod), latitude, longitude))
-            if next_rising > utc_now:
-                break
-            mod += 1
+    assert dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_RISING]) == \
+        datetime(2016, 7, 25, 23, 23, 39, tzinfo=dt_util.UTC)
+    assert dt_util.parse_datetime(
+        state.attributes[sun.STATE_ATTR_NEXT_SETTING]) == \
+        datetime(2016, 7, 26, 22, 19, 1, tzinfo=dt_util.UTC)
 
-        mod = -1
-        while True:
-            next_setting = (astral.sunset_utc(
-                utc_today + timedelta(days=mod), latitude, longitude))
-            if next_setting > utc_now:
-                break
-            mod += 1
 
-        assert next_dawn == dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_DAWN])
-        assert next_dusk == dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_DUSK])
-        assert next_midnight == dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_MIDNIGHT])
-        assert next_noon == dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_NOON])
-        assert next_rising == dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_RISING])
-        assert next_setting == dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_SETTING])
+@mark.skip
+async def test_state_change_count(hass):
+    """Count the number of state change events in a location."""
+    # Skipped because it's a bit slow. Has been validated with
+    # multiple lattitudes and dates
+    hass.config.latitude = 10
+    hass.config.longitude = 0
 
-    def test_state_change(self):
-        """Test if the state changes at next setting/rising."""
-        now = datetime(2016, 6, 1, 8, 0, 0, tzinfo=dt_util.UTC)
-        with patch('homeassistant.helpers.condition.dt_util.utcnow',
-                   return_value=now):
-            setup_component(self.hass, sun.DOMAIN, {
-                sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
+    now = datetime(2016, 6, 1, tzinfo=dt_util.UTC)
 
-        self.hass.block_till_done()
+    with patch(
+            'homeassistant.helpers.condition.dt_util.utcnow',
+            return_value=now):
+        assert await async_setup_component(hass, sun.DOMAIN, {
+            sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
 
-        test_time = dt_util.parse_datetime(
-            self.hass.states.get(sun.ENTITY_ID)
-            .attributes[sun.STATE_ATTR_NEXT_RISING])
-        assert test_time is not None
+    events = []
+    @ha.callback
+    def state_change_listener(event):
+        if event.data.get('entity_id') == 'sun.sun':
+            events.append(event)
+    hass.bus.async_listen(EVENT_STATE_CHANGED, state_change_listener)
+    await hass.async_block_till_done()
 
-        assert sun.STATE_BELOW_HORIZON == \
-            self.hass.states.get(sun.ENTITY_ID).state
+    for _ in range(24*60*6):
+        now += timedelta(seconds=10)
+        hass.bus.async_fire(
+            ha.EVENT_TIME_CHANGED,
+            {ha.ATTR_NOW: now})
+        await hass.async_block_till_done()
 
-        self.hass.bus.fire(ha.EVENT_TIME_CHANGED,
-                           {ha.ATTR_NOW: test_time + timedelta(seconds=5)})
-
-        self.hass.block_till_done()
-
-        assert sun.STATE_ABOVE_HORIZON == \
-            self.hass.states.get(sun.ENTITY_ID).state
-
-    def test_norway_in_june(self):
-        """Test location in Norway where the sun doesn't set in summer."""
-        self.hass.config.latitude = 69.6
-        self.hass.config.longitude = 18.8
-
-        june = datetime(2016, 6, 1, tzinfo=dt_util.UTC)
-
-        with patch('homeassistant.helpers.condition.dt_util.utcnow',
-                   return_value=june):
-            assert setup_component(self.hass, sun.DOMAIN, {
-                sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
-
-        state = self.hass.states.get(sun.ENTITY_ID)
-        assert state is not None
-
-        assert dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_RISING]) == \
-            datetime(2016, 7, 25, 23, 23, 39, tzinfo=dt_util.UTC)
-        assert dt_util.parse_datetime(
-            state.attributes[sun.STATE_ATTR_NEXT_SETTING]) == \
-            datetime(2016, 7, 26, 22, 19, 1, tzinfo=dt_util.UTC)
+    assert len(events) < 600


### PR DESCRIPTION
## Breaking Change:

This might be a breaking change to some, the sun's location updates less frequently. 

## Description

After [this report](https://www.reddit.com/r/homeassistant/comments/bm62hl/sunsun_chatty_sensor_psa/) on reddit, I have tuned the sun.sun sensor so it doesn't update nearly so frequently.

Previously the sun.sun sensor was updating every 30 seconds, day and night.

The Sun moves along its path by 1° of arc for every 4 mins.

With reference to [Twilight states](https://en.wikipedia.org/wiki/Twilight) I have tuned the sun.sun senor to update depending on the solar elevation:

phase | Angle | Frequency
----|----|----
Night | < -18° | 5° = 20 min
Astronomical Twilight | < -12° | 2° = 8 min
Nautical Twilight | <-6° | 2° = 8 min
Civil Twilight | < 0° | 1° = 4 min
Morning/Evening | < 10° | 0.5° = 2 min
Daytime | > 10° | 1° = 4 min

The total effect of this is that in equatoral areas the sun.sun device goes from generating 1441 events daily, to just 272, which is far more reasonable. It will generate more during some times of the year in polar areas, up to 720 around the equinox where the sun stays low on the horizon, but this will average out over the year and still be a lot less. Hopefully we can save Santa's SD card! :grin:

I haven't documented this at this point, happy to contribute it though. There's nothing too much to document though really, for the most part the change is opaque.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9460
## Discussion

I'll explain this a different way, it took me a bit to get my head around :grin:

So the Sun moves in the sky by 1° of arc for every four minutes. It doesn't matter what time of the day or night it is, this is happening everywhere on the Earth. This vector can be either perpendicular to parallel to the horizon. 

For reference, the disk of the sun takes up approximately 0.5° in the sky, so a shift of less than 0.5° is pretty meaningless since the light will cast more-or-less the same shadows and brightness.

The old code updated the sun's position every 30 seconds, which is just 0.125° of arc. This is a pretty meaningless amount of movement for the most purposes, and we can see that it's causing more issues than benefits since it's flooding the update log.

My first approach focused entirely on the movement with respect to the horizon, and just updated the Sun's position when it moved up or down with respect to it. This isn't so great however because at the poles the Sun moves quite parallel with the horizon, and might not change its elevation all day but in the mean time the light and shadow will change quite a lot. I realised it's really the arc change that matters. I also tried rounding out the elevation and azimuth (the bearing from North of the Sun), but near noon the Sun's azimuth changes rapidly and so you end up with a bunch of useless updates around Noon.

So, angular movement matters. First I cut down the update frequency to 1° of arc, so every 4 mins, but there are times of the day when you care more about where the Sun is. You really don't care much at all during the night, a bit more during twilight, quite a lot as the Sun is low on the horizon, and less during the middle of the day. The outcome of all of this is the update frequency changes depending on where the Sun is in the sky and throws away a lot of the useless position updates during the night and the middle of the day, and concentrates them on the times when the Sun is close to the horizon.

The other thing the PR does is makes sure that the timer for the 'next update' resets when the Sun crosses the horizon, or a few other important elevations, and the position is calculated. As soon as the Sun hits the horizon for example, the sun.sun sensor will update. You have to be careful with solar noon and solar midnight, naively we'd expect solar midnight to be at night, but in the polar winter it isn't.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sun:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
