### PR TITLE
Zeroconf - replace library

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -23,10 +23,8 @@ CONFIG_SCHEMA = vol.Schema({
 async def async_setup(hass, config):
     """Set up Zeroconf and make Home Assistant discoverable."""
     from aiozeroconf import Zeroconf, ServiceInfo
-    import asyncio
-    zeroconf = Zeroconf(hass.loop)
 
-    await asyncio.sleep(5)
+    zeroconf = Zeroconf(hass.loop)
 
     zeroconf_name = '{}.{}'.format(hass.config.location_name, ZEROCONF_TYPE)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -50,14 +50,10 @@ async def async_setup(hass, config):
 
     await zeroconf.register_service(info)
 
-    @callback
-    def stop_zeroconf(event):
+    async def stop_zeroconf(event):
         """Stop Zeroconf."""
-        async def stop():
-            """Stop Zeroconf."""
-            await zeroconf.unregister_service(info)
-            await zeroconf.close()
-        hass.async_create_task(stop())
+        await zeroconf.unregister_service(info)
+        await zeroconf.close()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_zeroconf)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
-from homeassistant.core import callback
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zeroconf",
   "documentation": "https://www.home-assistant.io/components/zeroconf",
   "requirements": [
-    "zeroconf==0.22.0"
+    "aiozeroconf==0.1.8"
   ],
   "dependencies": [
     "api"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -154,6 +154,9 @@ aioswitcher==2019.3.21
 # homeassistant.components.unifi
 aiounifi==4
 
+# homeassistant.components.zeroconf
+aiozeroconf==0.1.8
+
 # homeassistant.components.aladdin_connect
 aladdin_connect==0.3
 
@@ -1849,9 +1852,6 @@ youtube_dl==2019.05.11
 
 # homeassistant.components.zengge
 zengge==0.2
-
-# homeassistant.components.zeroconf
-zeroconf==0.22.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.12

--- a/tests/components/default_config/test_init.py
+++ b/tests/components/default_config/test_init.py
@@ -5,7 +5,16 @@ from homeassistant.setup import async_setup_component
 
 import pytest
 
-from tests.common import MockDependency
+from tests.common import MockDependency, mock_coro
+
+
+@pytest.fixture(autouse=True)
+def aiozeroconf_mock():
+    """Mock aiozeroconf."""
+    with MockDependency('aiozeroconf') as mocked_zeroconf:
+        mocked_zeroconf.Zeroconf.return_value.register_service \
+            .return_value = mock_coro(True)
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Replace zeroconf library with aiozeroconf in preparation for https://github.com/home-assistant/architecture/issues/198

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html