### PR TITLE
Support multiple Elk instances

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -12,8 +12,6 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType  # noqa
 
-REQUIREMENTS = ['elkm1-lib==0.7.14']
-
 DOMAIN = 'elkm1'
 
 CONF_AREA = 'area'

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -65,9 +65,10 @@ def _elk_range_validator(rng):
     end = start if len(vals) == 1 else _elk_value(vals[1])
     return (start, end)
 
+
 def _has_all_unique_prefixes(value):
     """Validate that each m1 configured has a unique prefix."""
-    prefixes = [ device.get(CONF_PREFIX) for device in value]
+    prefixes = [device.get(CONF_PREFIX) for device in value]
     schema = vol.Schema(vol.Unique())
     schema(prefixes)
     return value

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -109,7 +109,7 @@ def _get_mac_for(elk_host):
     digits_pattern = re.compile(r"^[0-9.]+$")
     hp_m = hostname_pattern.search(elk_host)
     if hp_m:
-        ip_host = m.group(1)
+        ip_host = hp_m.group(1)
         dp_m = digits_pattern.match(ip_host)
         if dp_m:
             mac_addr = get_mac_address(ip=ip_host)

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -140,7 +140,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 _LOGGER.error("Config item: %s; %s", item, err)
                 return False
 
-        prefix = conf.get(CONF_PREFIX, "")
+        prefix = conf.get[CONF_PREFIX]
         device = devices.get(prefix)
         if device is not None:
             if prefix == "":
@@ -173,22 +173,22 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
 
 def _create_elk_services(hass, elks):
     def _speak_word_service(service):
-        prefix = service.data.get('prefix', "")
+        prefix = service.data['prefix']
         elk = elks.get(prefix)
         if elk is None:
             _LOGGER.error("No elk m1 with prefix for speak_word: '%s'",
                           prefix)
-        else:
-            elk.panel.speak_word(service.data['number'])
+            return
+        elk.panel.speak_word(service.data['number'])
 
     def _speak_phrase_service(service):
-        prefix = service.data.get('prefix', "")
+        prefix = service.data['prefix']
         elk = elks.get(prefix)
         if elk is None:
             _LOGGER.error("No elk m1 with prefix for speak_phrase: '%s'",
                           prefix)
-        else:
-            elk.panel.speak_phrase(service.data['number'])
+            return
+        elk.panel.speak_phrase(service.data['number'])
 
     hass.services.async_register(
         DOMAIN, 'speak_word', _speak_word_service, SPEAK_SERVICE_SCHEMA)

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -98,7 +98,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     """Set up the Elk M1 platform."""
     from elkm1_lib.const import Max
@@ -152,12 +151,16 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
             else:
                 _LOGGER.error("Duplicate prefix on elk m1s: " + prefix)
         else:
-            elk = elkm1.Elk({'url': conf[CONF_HOST], 'userid': conf[CONF_USERNAME],
+            elk = elkm1.Elk({'url': conf[CONF_HOST], 'userid':
+                             conf[CONF_USERNAME],
                              'password': conf[CONF_PASSWORD]})
             elk.connect()
 
             devices[prefix] = elk
-            elk_datas[prefix] = {'elk': elk, 'prefix': prefix, 'config': config, 'keypads': {}}
+            elk_datas[prefix] = {'elk': elk,
+                                 'prefix': prefix,
+                                 'config': config,
+                                 'keypads': {}}
 
     _create_elk_services(hass, devices)
 
@@ -174,11 +177,11 @@ def _create_elk_services(hass, elks):
     def _speak_word_service(service):
         elk = elks.get('', None)
         elk.panel.speak_word(service.data.get('number'))
-        
+
     def _speak_phrase_service(service):
         prefix = service.data.get('prefix', "")
         elk = elks.get(prefix, None)
-        if elk == None:
+        if elk is None:
             _LOGGER.error("no elk m1 with prefix: '" + prefix + "'")
         else:
             elk.panel.speak_phrase(service.data.get('number'))
@@ -189,7 +192,8 @@ def _create_elk_services(hass, elks):
         DOMAIN, 'speak_phrase', _speak_phrase_service, SPEAK_SERVICE_SCHEMA)
 
 
-def create_elk_entities(elk_data, elk_elements, element_type, class_, entities):
+def create_elk_entities(elk_data, elk_elements, element_type,
+                        class_, entities):
     """Create the ElkM1 devices of a particular class."""
     if elk_data['config'][element_type]['enabled']:
         elk = elk_data['elk']

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -141,7 +141,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 return False
 
         prefix = conf[CONF_PREFIX]
-        device = devices[prefix]
+        device = devices.get(prefix)
         if device is not None:
             if prefix == "":
                 _LOGGER.error("At most one elk m1 configuration may skip " +

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -64,6 +64,13 @@ def _elk_range_validator(rng):
     end = start if len(vals) == 1 else _elk_value(vals[1])
     return (start, end)
 
+def _has_all_unique_prefixes(value):
+    """Validate that each m1 configured has a unique prefix."""
+    prefixes = [ device.get(CONF_PREFIX) for device in value]
+    schema = vol.Schema(vol.Unique())
+    schema(prefixes)
+    return value
+
 
 DEVICE_SCHEMA_SUBDOMAIN = vol.Schema({
     vol.Optional(CONF_ENABLED, default=True): cv.boolean,
@@ -90,7 +97,8 @@ DEVICE_SCHEMA = vol.Schema({
 }, _host_validator)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(cv.ensure_list, [DEVICE_SCHEMA])
+    DOMAIN: vol.All(cv.ensure_list, _has_all_unique_prefixes,
+                    [DEVICE_SCHEMA])
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -140,8 +140,8 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 _LOGGER.error("Config item: %s; %s", item, err)
                 return False
 
-        prefix = conf.get[CONF_PREFIX]
-        device = devices.get(prefix)
+        prefix = conf[CONF_PREFIX]
+        device = devices[prefix]
         if device is not None:
             if prefix == "":
                 _LOGGER.error("At most one elk m1 configuration may skip " +

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -121,6 +121,7 @@ def _get_mac_for(elk_host):
     else:
         return None
 
+    
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     """Set up the Elk M1 platform."""
     from elkm1_lib.const import Max
@@ -166,7 +167,6 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 return False
 
         prefix = conf[CONF_PREFIX]
-        device = devices.get(prefix)
         elk = elkm1.Elk({'url': conf[CONF_HOST], 'userid':
                          conf[CONF_USERNAME],
                          'password': conf[CONF_PASSWORD]})

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -149,7 +149,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 _LOGGER.error("Need to use a prefix configuration command " +
                               "on second and later elk m1s")
             else:
-                _LOGGER.error("Duplicate prefix on elk prefix: %s", m1s)
+                _LOGGER.error("Duplicate prefix on elk m1, prefix: %s", prefix)
         else:
             elk = elkm1.Elk({'url': conf[CONF_HOST], 'userid':
                              conf[CONF_USERNAME],

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -219,7 +219,7 @@ def create_elk_entities(elk_data, elk_elements, element_type,
     """Create the ElkM1 devices of a particular class."""
     if elk_data['config'][element_type]['enabled']:
         elk = elk_data['elk']
-        _LOGGER.debug("create_elk_entities for %s", elk)
+        _LOGGER.debug("Creating elk entities for %s", elk)
         for element in elk_elements:
             if elk_data['config'][element_type]['included'][element.index]:
                 entities.append(class_(element, elk, elk_data))
@@ -235,14 +235,14 @@ class ElkEntity(Entity):
         self._element = element
         self._prefix = elk_data['prefix']
         self._temperature_unit = elk_data['config']['temperature_unit']
-        self._unique_id = 'elkm1_{}'.format(
-            elk.mac_address.lower() + '_' +
-            self._element.default_name('_').lower())
+        self._unique_id = 'elkm1_{mac}_{name}'.format(
+            mac = elk.mac_address,
+            name = self._element.default_name('_')).lower()
 
     @property
     def name(self):
         """Name of the element."""
-        return self._prefix + self._element.name
+        return "{p}{n}".format(p=self._prefix,n=self._element.name)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -121,7 +121,7 @@ def _get_mac_for(elk_host):
     else:
         return None
 
-    
+
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     """Set up the Elk M1 platform."""
     from elkm1_lib.const import Max

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -125,7 +125,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
             values[rng[0]-1:rng[1]] = [set_to] * (rng[1] - rng[0] + 1)
 
     for index, conf in enumerate(hass_config[DOMAIN][CONF_DEVICES]):
-        _LOGGER.debug("Setting up elkm1 #" + str(index) + " - " + conf['host'])
+        _LOGGER.debug("Setting up elkm1 #%d - %s", index, conf['host'])
 
         config = {'temperature_unit': conf[CONF_TEMPERATURE_UNIT]}
         config['panel'] = {'enabled': True, 'included': [True]}
@@ -149,7 +149,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 _LOGGER.error("Need to use a prefix configuration command " +
                               "on second and later elk m1s")
             else:
-                _LOGGER.error("Duplicate prefix on elk m1s: " + prefix)
+                _LOGGER.error("Duplicate prefix on elk prefix: %s", m1s)
         else:
             elk = elkm1.Elk({'url': conf[CONF_HOST], 'userid':
                              conf[CONF_USERNAME],
@@ -182,7 +182,7 @@ def _create_elk_services(hass, elks):
         prefix = service.data.get('prefix', "")
         elk = elks.get(prefix, None)
         if elk is None:
-            _LOGGER.error("no elk m1 with prefix: '" + prefix + "'")
+            _LOGGER.error("no elk m1 with prefix: '%s'", prefix)
         else:
             elk.panel.speak_phrase(service.data.get('number'))
 
@@ -197,11 +197,10 @@ def create_elk_entities(elk_data, elk_elements, element_type,
     """Create the ElkM1 devices of a particular class."""
     if elk_data['config'][element_type]['enabled']:
         elk = elk_data['elk']
-        _LOGGER.debug("create_elk_entities for " + str(elk))
+        _LOGGER.debug("create_elk_entities for %s", elk)
         for element in elk_elements:
             if elk_data['config'][element_type]['included'][element.index]:
-                e = class_(element, elk, elk_data)
-                entities.append(e)
+                entities.append(class_(element, elk, elk_data))
     return entities
 
 

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -12,6 +12,8 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType  # noqa
 
+REQUIREMENTS = ['elkm1-lib==0.7.14']
+
 DOMAIN = 'elkm1'
 
 CONF_AREA = 'area'
@@ -133,17 +135,20 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
             config[item] = {'enabled': conf[item][CONF_ENABLED],
                             'included': [not conf[item]['include']] * max_}
             try:
-                _included(conf[item]['include'], True, config[item]['included'])
-                _included(conf[item]['exclude'], False, config[item]['included'])
+                _included(conf[item]['include'], True,
+                          config[item]['included'])
+                _included(conf[item]['exclude'], False,
+                          config[item]['included'])
             except (ValueError, vol.Invalid) as err:
                 _LOGGER.error("Config item: %s; %s", item, err)
                 return False
 
-        prefix = conf.get(CONF_PREFIX,"")
+        prefix = conf.get(CONF_PREFIX, "")
         device = devices.get(prefix, None)
-        if device != None:
+        if device is not None:
             if prefix != "":
-                _LOGGER.error("Need to use a prefix configuration command on second and later elk m1s")
+                _LOGGER.error("Need to use a prefix configuration command " +
+                              "on second and later elk m1s")
             else:
                 _LOGGER.error("Duplicate prefix on elk m1s: " + prefix)
         else:

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -144,7 +144,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
         device = devices.get(prefix)
         if device is not None:
             if prefix == "":
-                _LOGGER.error("At most one elk m1 configuration may skip " +
+                _LOGGER.error("At most one elk m1 configuration may skip "
                               "the prefix; more than one did.")
             else:
                 _LOGGER.error("Duplicate prefix on elk m1, prefix: %s", prefix)

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -236,13 +236,13 @@ class ElkEntity(Entity):
         self._prefix = elk_data['prefix']
         self._temperature_unit = elk_data['config']['temperature_unit']
         self._unique_id = 'elkm1_{mac}_{name}'.format(
-            mac = elk.mac_address,
-            name = self._element.default_name('_')).lower()
+            mac=elk.mac_address,
+            name=self._element.default_name('_')).lower()
 
     @property
     def name(self):
         """Name of the element."""
-        return "{p}{n}".format(p=self._prefix,n=self._element.name)
+        return "{p}{n}".format(p=self._prefix, n=self._element.name)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -26,7 +26,6 @@ CONF_SETTING = 'setting'
 CONF_TASK = 'task'
 CONF_THERMOSTAT = 'thermostat'
 CONF_ZONE = 'zone'
-CONF_DEVICES = 'devices'
 CONF_PREFIX = 'prefix'
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,9 +91,7 @@ DEVICE_SCHEMA = vol.Schema({
 }, _host_validator)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_DEVICES): vol.All(cv.ensure_list, [DEVICE_SCHEMA])
-    }),
+    DOMAIN: vol.All(cv.ensure_list, [DEVICE_SCHEMA])
 }, extra=vol.ALLOW_EXTRA)
 
 
@@ -124,7 +121,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 raise vol.Invalid("Invalid range {}".format(rng))
             values[rng[0]-1:rng[1]] = [set_to] * (rng[1] - rng[0] + 1)
 
-    for index, conf in enumerate(hass_config[DOMAIN][CONF_DEVICES]):
+    for index, conf in enumerate(hass_config[DOMAIN]):
         _LOGGER.debug("Setting up elkm1 #%d - %s", index, conf['host'])
 
         config = {'temperature_unit': conf[CONF_TEMPERATURE_UNIT]}

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -66,8 +66,10 @@ def _elk_range_validator(rng):
 
 
 def _has_all_unique_prefixes(value):
-    """Validate that each m1 configured has a unique,
-    case-independent prefix."""
+    """Validate that each m1 configured has a unique prefix.
+
+    Uniqueness is determined case-independently.
+    """
     prefixes = [device[CONF_PREFIX] for device in value]
     schema = vol.Schema(vol.Unique())
     schema(prefixes)

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -219,8 +219,20 @@ class ElkEntity(Entity):
         self._element = element
         self._prefix = elk_data['prefix']
         self._temperature_unit = elk_data['config']['temperature_unit']
-        self._unique_id = 'elkm1_{prefix}_{name}'.format(
-            prefix=self._prefix,
+        # unique_id starts with elkm1_ iff there is no prefix
+        # it starts with elkm1m_{prefix} iff there is a prefix
+        # this is to avoid a conflict between
+        # prefix=foo, name=bar  (which would be elkm1_foo_bar)
+        # and
+        # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
+        # we could have used elkm1__foo_bar for the latter, but that
+        # would have been a breaking change
+        if self._prefix != "":
+            uid_start = 'elkm1m_{prefix}'.format(prefix=self._prefix)
+        else:
+            uid_start = 'elkm1'
+        self._unique_id = '{uid_start}_{name}'.format(
+            uid_start=uid_start,
             name=self._element.default_name('_')).lower()
 
     @property

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -67,7 +67,7 @@ def _elk_range_validator(rng):
 
 def _has_all_unique_prefixes(value):
     """Validate that each m1 configured has a unique prefix."""
-    prefixes = [device.get(CONF_PREFIX) for device in value]
+    prefixes = [device.get(CONF_PREFIX, "").lower() for device in value]
     schema = vol.Schema(vol.Unique())
     schema(prefixes)
     return value
@@ -98,8 +98,8 @@ DEVICE_SCHEMA = vol.Schema({
 }, _host_validator)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(cv.ensure_list, _has_all_unique_prefixes,
-                    [DEVICE_SCHEMA])
+    DOMAIN: vol.All(cv.ensure_list, [DEVICE_SCHEMA],
+                    _has_all_unique_prefixes)
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -223,7 +223,7 @@ class ElkEntity(Entity):
         # it starts with elkm1m_{prefix} iff there is a prefix
         # this is to avoid a conflict between
         # prefix=foo, name=bar  (which would be elkm1_foo_bar)
-        # and
+        #   - and -
         # prefix="", name="foo bar" (which would be elkm1_foo_bar also)
         # we could have used elkm1__foo_bar for the latter, but that
         # would have been a breaking change

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -66,8 +66,9 @@ def _elk_range_validator(rng):
 
 
 def _has_all_unique_prefixes(value):
-    """Validate that each m1 configured has a unique prefix."""
-    prefixes = [device.get(CONF_PREFIX, "").lower() for device in value]
+    """Validate that each m1 configured has a unique,
+    case-independent prefix."""
+    prefixes = [device[CONF_PREFIX] for device in value]
     schema = vol.Schema(vol.Unique())
     schema(prefixes)
     return value
@@ -81,7 +82,7 @@ DEVICE_SCHEMA_SUBDOMAIN = vol.Schema({
 
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_PREFIX, default=''): cv.string,
+    vol.Optional(CONF_PREFIX, default=''): vol.All(cv.string, vol.Lower),
     vol.Optional(CONF_USERNAME, default=''): cv.string,
     vol.Optional(CONF_PASSWORD, default=''): cv.string,
     vol.Optional(CONF_TEMPERATURE_UNIT, default='F'):

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType  # noqa
 
-REQUIREMENTS = ['elkm1-lib==0.7.13']
+REQUIREMENTS = ['elkm1-lib==0.7.14']
 
 DOMAIN = 'elkm1'
 
@@ -135,17 +135,20 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
             config[item] = {'enabled': conf[item][CONF_ENABLED],
                             'included': [not conf[item]['include']] * max_}
             try:
-                _included(conf[item]['include'], True, config[item]['included'])
-                _included(conf[item]['exclude'], False, config[item]['included'])
+                _included(conf[item]['include'], True,
+                          config[item]['included'])
+                _included(conf[item]['exclude'], False,
+                          config[item]['included'])
             except (ValueError, vol.Invalid) as err:
                 _LOGGER.error("Config item: %s; %s", item, err)
                 return False
 
-        prefix = conf.get(CONF_PREFIX,"")
+        prefix = conf.get(CONF_PREFIX, "")
         device = devices.get(prefix, None)
-        if device != None:
+        if device is not None:
             if prefix != "":
-                _LOGGER.error("Need to use a prefix configuration command on second and later elk m1s")
+                _LOGGER.error("Need to use a prefix configuration command " +
+                              "on second and later elk m1s")
             else:
                 _LOGGER.error("Duplicate prefix on elk m1s: " + prefix)
         else:

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -26,6 +26,8 @@ CONF_SETTING = 'setting'
 CONF_TASK = 'task'
 CONF_THERMOSTAT = 'thermostat'
 CONF_ZONE = 'zone'
+CONF_DEVICES = 'devices'
+CONF_PREFIX = 'prefix'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,39 +67,45 @@ def _elk_range_validator(rng):
     return (start, end)
 
 
-CONFIG_SCHEMA_SUBDOMAIN = vol.Schema({
+DEVICE_SCHEMA_SUBDOMAIN = vol.Schema({
     vol.Optional(CONF_ENABLED, default=True): cv.boolean,
     vol.Optional(CONF_INCLUDE, default=[]): [_elk_range_validator],
     vol.Optional(CONF_EXCLUDE, default=[]): [_elk_range_validator],
 })
 
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PREFIX, default=''): cv.string,
+    vol.Optional(CONF_USERNAME, default=''): cv.string,
+    vol.Optional(CONF_PASSWORD, default=''): cv.string,
+    vol.Optional(CONF_TEMPERATURE_UNIT, default='F'):
+    cv.temperature_unit,
+    vol.Optional(CONF_AREA, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_COUNTER, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_KEYPAD, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_OUTPUT, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_PLC, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_SETTING, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_TASK, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_THERMOSTAT, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+    vol.Optional(CONF_ZONE, default={}): DEVICE_SCHEMA_SUBDOMAIN,
+}, _host_validator)
+
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema(
-        {
-            vol.Required(CONF_HOST): cv.string,
-            vol.Optional(CONF_USERNAME, default=''): cv.string,
-            vol.Optional(CONF_PASSWORD, default=''): cv.string,
-            vol.Optional(CONF_TEMPERATURE_UNIT, default='F'):
-                cv.temperature_unit,
-            vol.Optional(CONF_AREA, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_COUNTER, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_KEYPAD, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_OUTPUT, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_PLC, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_SETTING, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_TASK, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_THERMOSTAT, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_ZONE, default={}): CONFIG_SCHEMA_SUBDOMAIN,
-        },
-        _host_validator,
-    )
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DEVICES): vol.All(cv.ensure_list, [DEVICE_SCHEMA])
+    }),
 }, extra=vol.ALLOW_EXTRA)
+
 
 
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     """Set up the Elk M1 platform."""
     from elkm1_lib.const import Max
     import elkm1_lib as elkm1
+
+    devices = {}
+    elk_datas = {}
 
     configs = {
         CONF_AREA: Max.AREAS.value,
@@ -117,27 +125,40 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
                 raise vol.Invalid("Invalid range {}".format(rng))
             values[rng[0]-1:rng[1]] = [set_to] * (rng[1] - rng[0] + 1)
 
-    conf = hass_config[DOMAIN]
-    config = {'temperature_unit': conf[CONF_TEMPERATURE_UNIT]}
-    config['panel'] = {'enabled': True, 'included': [True]}
+    for index, conf in enumerate(hass_config[DOMAIN][CONF_DEVICES]):
+        _LOGGER.debug("Setting up elkm1 #" + str(index) + " - " + conf['host'])
 
-    for item, max_ in configs.items():
-        config[item] = {'enabled': conf[item][CONF_ENABLED],
-                        'included': [not conf[item]['include']] * max_}
-        try:
-            _included(conf[item]['include'], True, config[item]['included'])
-            _included(conf[item]['exclude'], False, config[item]['included'])
-        except (ValueError, vol.Invalid) as err:
-            _LOGGER.error("Config item: %s; %s", item, err)
-            return False
+        config = {'temperature_unit': conf[CONF_TEMPERATURE_UNIT]}
+        config['panel'] = {'enabled': True, 'included': [True]}
 
-    elk = elkm1.Elk({'url': conf[CONF_HOST], 'userid': conf[CONF_USERNAME],
-                     'password': conf[CONF_PASSWORD]})
-    elk.connect()
+        for item, max_ in configs.items():
+            config[item] = {'enabled': conf[item][CONF_ENABLED],
+                            'included': [not conf[item]['include']] * max_}
+            try:
+                _included(conf[item]['include'], True, config[item]['included'])
+                _included(conf[item]['exclude'], False, config[item]['included'])
+            except (ValueError, vol.Invalid) as err:
+                _LOGGER.error("Config item: %s; %s", item, err)
+                return False
 
-    _create_elk_services(hass, elk)
+        prefix = conf.get(CONF_PREFIX,"")
+        device = devices.get(prefix, None)
+        if device != None:
+            if prefix != "":
+                _LOGGER.error("Need to use a prefix configuration command on second and later elk m1s")
+            else:
+                _LOGGER.error("Duplicate prefix on elk m1s: " + prefix)
+        else:
+            elk = elkm1.Elk({'url': conf[CONF_HOST], 'userid': conf[CONF_USERNAME],
+                             'password': conf[CONF_PASSWORD]})
+            elk.connect()
 
-    hass.data[DOMAIN] = {'elk': elk, 'config': config, 'keypads': {}}
+            devices[prefix] = elk
+            elk_datas[prefix] = {'elk': elk, 'prefix': prefix, 'config': config, 'keypads': {}}
+
+    _create_elk_services(hass, devices)
+
+    hass.data[DOMAIN] = elk_datas
     for component in SUPPORTED_DOMAINS:
         hass.async_create_task(
             discovery.async_load_platform(hass, component, DOMAIN, {},
@@ -146,12 +167,18 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     return True
 
 
-def _create_elk_services(hass, elk):
+def _create_elk_services(hass, elks):
     def _speak_word_service(service):
+        elk = elks.get('', None)
         elk.panel.speak_word(service.data.get('number'))
-
+        
     def _speak_phrase_service(service):
-        elk.panel.speak_phrase(service.data.get('number'))
+        prefix = service.data.get('prefix', "")
+        elk = elks.get(prefix, None)
+        if elk == None:
+            _LOGGER.error("no elk m1 with prefix: '" + prefix + "'")
+        else:
+            elk.panel.speak_phrase(service.data.get('number'))
 
     hass.services.async_register(
         DOMAIN, 'speak_word', _speak_word_service, SPEAK_SERVICE_SCHEMA)
@@ -159,14 +186,15 @@ def _create_elk_services(hass, elk):
         DOMAIN, 'speak_phrase', _speak_phrase_service, SPEAK_SERVICE_SCHEMA)
 
 
-def create_elk_entities(hass, elk_elements, element_type, class_, entities):
+def create_elk_entities(elk_data, elk_elements, element_type, class_, entities):
     """Create the ElkM1 devices of a particular class."""
-    elk_data = hass.data[DOMAIN]
     if elk_data['config'][element_type]['enabled']:
         elk = elk_data['elk']
+        _LOGGER.debug("create_elk_entities for " + str(elk))
         for element in elk_elements:
             if elk_data['config'][element_type]['included'][element.index]:
-                entities.append(class_(element, elk, elk_data))
+                e = class_(element, elk, elk_data)
+                entities.append(e)
     return entities
 
 
@@ -177,14 +205,15 @@ class ElkEntity(Entity):
         """Initialize the base of all Elk devices."""
         self._elk = elk
         self._element = element
+        self._prefix = elk_data['prefix']
         self._temperature_unit = elk_data['config']['temperature_unit']
         self._unique_id = 'elkm1_{}'.format(
-            self._element.default_name('_').lower())
+            self._prefix + self._element.default_name('_').lower())
 
     @property
     def name(self):
         """Name of the element."""
-        return self._element.name
+        return self._prefix + self._element.name
 
     @property
     def unique_id(self):

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -37,7 +37,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.areas,
                                        'area', ElkArea, [])

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -38,7 +38,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.areas,
                                        'area', ElkArea, entities)

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -36,9 +36,11 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None:
         return
 
-    elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(hass, elk.areas, 'area', ElkArea, [])
-    async_add_entities(entities, True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        entities = create_elk_entities(elk_data, elk.areas, 'area', ElkArea, [])
+        async_add_entities(entities, True)
 
     def _dispatch(signal, entity_ids, *args):
         for entity_id in entity_ids:
@@ -103,7 +105,7 @@ class ElkArea(ElkEntity, alarm.AlarmControlPanel):
             return
         if changeset.get('last_user') is not None:
             self._changed_by_entity_id = self.hass.data[
-                ELK_DOMAIN]['keypads'].get(keypad.index, '')
+                ELK_DOMAIN][self._prefix]['keypads'].get(keypad.index, '')
             self.async_schedule_update_ha_state(True)
 
     @property

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -37,11 +37,12 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.areas,
-                                       'area', ElkArea, [])
-        async_add_entities(entities, True)
+                                       'area', ElkArea, entities)
+    async_add_entities(entities, True)
 
     def _dispatch(signal, entity_ids, *args):
         for entity_id in entity_ids:

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -39,7 +39,8 @@ async def async_setup_platform(hass, config, async_add_entities,
     elk_datas = hass.data[ELK_DOMAIN]
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        entities = create_elk_entities(elk_data, elk.areas, 'area', ElkArea, [])
+        entities = create_elk_entities(elk_data, elk.areas,
+                                       'area', ElkArea, [])
         async_add_entities(entities, True)
 
     def _dispatch(signal, entity_ids, *args):

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -25,7 +25,7 @@ DISPLAY_MESSAGE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional('clear', default=2): vol.All(vol.Coerce(int),
                                               vol.In([0, 1, 2])),
     vol.Optional('beep', default=False): cv.boolean,
-    vol.Optional('timeout', default=0): vol.All(vol.coerce(int),
+    vol.Optional('timeout', default=0): vol.All(vol.Coerce(int),
                                                 vol.Range(min=0, max=65535)),
     vol.Optional('line1', default=''): cv.string,
     vol.Optional('line2', default=''): cv.string,

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -22,7 +22,8 @@ ELK_ALARM_SERVICE_SCHEMA = vol.Schema({
 
 DISPLAY_MESSAGE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID, default=[]): cv.entity_ids,
-    vol.Optional('clear', default=2): vol.All(vol.Coerce(int), vol.In([0, 1, 2])),
+    vol.Optional('clear', default=2): vol.All(vol.Coerce(int),
+                                              vol.In([0, 1, 2])),
     vol.Optional('beep', default=False): cv.boolean,
     vol.Optional('timeout', default=0): vol.All(vol.coerce(int),
                                                 vol.Range(min=0, max=65535)),

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -22,9 +22,10 @@ ELK_ALARM_SERVICE_SCHEMA = vol.Schema({
 
 DISPLAY_MESSAGE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID, default=[]): cv.entity_ids,
-    vol.Optional('clear', default=2): vol.In([0, 1, 2]),
+    vol.Optional('clear', default=2): vol.All(vol.Coerce(int), vol.In([0, 1, 2])),
     vol.Optional('beep', default=False): cv.boolean,
-    vol.Optional('timeout', default=0): vol.Range(min=0, max=65535),
+    vol.Optional('timeout', default=0): vol.All(vol.coerce(int),
+                                                vol.Range(min=0, max=65535)),
     vol.Optional('line1', default=''): cv.string,
     vol.Optional('line2', default=''): cv.string,
 })

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -40,7 +40,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.areas,
                                        'area', ElkArea, entities)

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -41,7 +41,8 @@ async def async_setup_platform(hass, config, async_add_entities,
     elk_datas = hass.data[ELK_DOMAIN]
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        entities = create_elk_entities(elk_data, elk.areas, 'area', ElkArea, [])
+        entities = create_elk_entities(elk_data, elk.areas,
+                                       'area', ElkArea, [])
         async_add_entities(entities, True)
 
     def _dispatch(signal, entity_ids, *args):

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -39,7 +39,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.areas,
                                        'area', ElkArea, [])

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -38,9 +38,11 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None:
         return
 
-    elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(hass, elk.areas, 'area', ElkArea, [])
-    async_add_entities(entities, True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        entities = create_elk_entities(elk_data, elk.areas, 'area', ElkArea, [])
+        async_add_entities(entities, True)
 
     def _dispatch(signal, entity_ids, *args):
         for entity_id in entity_ids:
@@ -105,7 +107,7 @@ class ElkArea(ElkEntity, alarm.AlarmControlPanel):
             return
         if changeset.get('last_user') is not None:
             self._changed_by_entity_id = self.hass.data[
-                ELK_DOMAIN]['keypads'].get(keypad.index, '')
+                ELK_DOMAIN][self._prefix]['keypads'].get(keypad.index, '')
             self.async_schedule_update_ha_state(True)
 
     @property

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -39,11 +39,12 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.areas,
-                                       'area', ElkArea, [])
-        async_add_entities(entities, True)
+                                       'area', ElkArea, entities)
+    async_add_entities(entities, True)
 
     def _dispatch(signal, entity_ids, *args):
         for entity_id in entity_ids:

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -17,7 +17,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         async_add_entities(create_elk_entities(
             elk_data, elk.thermostats, 'thermostat', ElkThermostat, []), True)

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -16,9 +16,11 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None:
         return
 
-    elk = hass.data[ELK_DOMAIN]['elk']
-    async_add_entities(create_elk_entities(
-        hass, elk.thermostats, 'thermostat', ElkThermostat, []), True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        async_add_entities(create_elk_entities(
+            elk_data, elk.thermostats, 'thermostat', ElkThermostat, []), True)
 
 
 class ElkThermostat(ElkEntity, ClimateDevice):

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -23,7 +23,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         entities = create_elk_entities(elk_data, elk.thermostats,
                                        'thermostat', ElkThermostat,
                                        entities)
-    async_add_entities(entities, True);
+    async_add_entities(entities, True)
 
 
 class ElkThermostat(ElkEntity, ClimateDevice):

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -18,7 +18,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.thermostats,
                                        'thermostat', ElkThermostat,

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -17,10 +17,13 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        async_add_entities(create_elk_entities(
-            elk_data, elk.thermostats, 'thermostat', ElkThermostat, []), True)
+        entities = create_elk_entities(elk_data, elk.thermostats,
+                                       'thermostat', ElkThermostat,
+                                       entities)
+    async_add_entities(entities, True);
 
 
 class ElkThermostat(ElkEntity, ClimateDevice):

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -25,7 +25,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         entities = create_elk_entities(elk_data, elk.thermostats,
                                        'thermostat', ElkThermostat,
                                        entities)
-    async_add_entities(entities, True);
+    async_add_entities(entities, True)
 
 
 class ElkThermostat(ElkEntity, ClimateDevice):

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -19,10 +19,13 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        async_add_entities(create_elk_entities(
-            elk_data, elk.thermostats, 'thermostat', ElkThermostat, []), True)
+        entities = create_elk_entities(elk_data, elk.thermostats,
+                                       'thermostat', ElkThermostat,
+                                       entities)
+    async_add_entities(entities, True);
 
 
 class ElkThermostat(ElkEntity, ClimateDevice):

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -18,9 +18,11 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None:
         return
 
-    elk = hass.data[ELK_DOMAIN]['elk']
-    async_add_entities(create_elk_entities(
-        hass, elk.thermostats, 'thermostat', ElkThermostat, []), True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        async_add_entities(create_elk_entities(
+            elk_data, elk.thermostats, 'thermostat', ElkThermostat, []), True)
 
 
 class ElkThermostat(ElkEntity, ClimateDevice):

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -19,7 +19,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         async_add_entities(create_elk_entities(
             elk_data, elk.thermostats, 'thermostat', ElkThermostat, []), True)

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -20,7 +20,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.thermostats,
                                        'thermostat', ElkThermostat,

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -18,6 +18,7 @@ async def async_setup_platform(
                             'plc', ElkLight, entities)
     async_add_entities(entities, True)
 
+
 class ElkLight(ElkEntity, Light):
     """Representation of an Elk lighting device."""
 

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -10,9 +10,11 @@ async def async_setup_platform(
     """Set up the Elk light platform."""
     if discovery_info is None:
         return
-    elk = hass.data[ELK_DOMAIN]['elk']
-    async_add_entities(
-        create_elk_entities(hass, elk.lights, 'plc', ElkLight, []), True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        async_add_entities(
+            create_elk_entities(elk_data, elk.lights, 'plc', ElkLight, []), True)
 
 
 class ElkLight(ElkEntity, Light):

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -12,7 +12,7 @@ async def async_setup_platform(
         return
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         create_elk_entities(elk_data, elk.lights,
                             'plc', ElkLight, entities)

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -14,7 +14,8 @@ async def async_setup_platform(
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
         async_add_entities(
-            create_elk_entities(elk_data, elk.lights, 'plc', ElkLight, []), True)
+            create_elk_entities(elk_data, elk.lights,
+                                'plc', ElkLight, []), True)
 
 
 class ElkLight(ElkEntity, Light):

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -11,7 +11,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         async_add_entities(
             create_elk_entities(elk_data, elk.lights,

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -11,12 +11,12 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        async_add_entities(
-            create_elk_entities(elk_data, elk.lights,
-                                'plc', ElkLight, []), True)
-
+        create_elk_entities(elk_data, elk.lights,
+                            'plc', ElkLight, entities)
+    async_add_entities(entities, True)
 
 class ElkLight(ElkEntity, Light):
     """Representation of an Elk lighting device."""

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -13,12 +13,12 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        async_add_entities(
-            create_elk_entities(elk_data, elk.lights,
-                                'plc', ElkLight, []), True)
-
+        create_elk_entities(elk_data, elk.lights,
+                            'plc', ElkLight, entities)
+    async_add_entities(entities, True)
 
 class ElkLight(ElkEntity, Light):
     """Representation of an Elk lighting device."""

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -12,9 +12,11 @@ async def async_setup_platform(
     """Set up the Elk light platform."""
     if discovery_info is None:
         return
-    elk = hass.data[ELK_DOMAIN]['elk']
-    async_add_entities(
-        create_elk_entities(hass, elk.lights, 'plc', ElkLight, []), True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        async_add_entities(
+            create_elk_entities(elk_data, elk.lights, 'plc', ElkLight, []), True)
 
 
 class ElkLight(ElkEntity, Light):

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -16,7 +16,8 @@ async def async_setup_platform(
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
         async_add_entities(
-            create_elk_entities(elk_data, elk.lights, 'plc', ElkLight, []), True)
+            create_elk_entities(elk_data, elk.lights,
+                                'plc', ElkLight, []), True)
 
 
 class ElkLight(ElkEntity, Light):

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -13,7 +13,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         async_add_entities(
             create_elk_entities(elk_data, elk.lights,

--- a/homeassistant/components/elkm1/light.py
+++ b/homeassistant/components/elkm1/light.py
@@ -14,7 +14,7 @@ async def async_setup_platform(
         return
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         create_elk_entities(elk_data, elk.lights,
                             'plc', ElkLight, entities)

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -3,7 +3,7 @@
   "name": "Elkm1",
   "documentation": "https://www.home-assistant.io/components/elkm1",
   "requirements": [
-    "elkm1-lib==0.7.13"
+    "elkm1-lib==0.7.14"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -3,8 +3,9 @@
   "name": "Elkm1",
   "documentation": "https://www.home-assistant.io/components/elkm1",
   "requirements": [
-    "elkm1-lib==0.7.14"
+    "elkm1-lib==0.7.14",
+    "getmac==0.8.1"
   ],
-  "dependencies": [ "getmac" ],
+  "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "elkm1-lib==0.7.14"
   ],
-  "dependencies": [],
+  "dependencies": [ "getmac" ],
   "codeowners": []
 }

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -4,7 +4,6 @@
   "documentation": "https://www.home-assistant.io/components/elkm1",
   "requirements": [
     "elkm1-lib==0.7.14",
-    "getmac==0.8.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -3,7 +3,7 @@
   "name": "Elkm1",
   "documentation": "https://www.home-assistant.io/components/elkm1",
   "requirements": [
-    "elkm1-lib==0.7.14",
+    "elkm1-lib==0.7.14"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/elkm1/manifest.json
+++ b/homeassistant/components/elkm1/manifest.json
@@ -3,7 +3,7 @@
   "name": "Elkm1",
   "documentation": "https://www.home-assistant.io/components/elkm1",
   "requirements": [
-    "elkm1-lib==0.7.14"
+    "elkm1-lib==0.7.15"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -10,11 +10,12 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.tasks,
-                                       'task', ElkTask, [])
-        async_add_entities(entities, True)
+                                       'task', ElkTask, entities)
+    async_add_entities(entities, True)
 
 
 class ElkTask(ElkEntity, Scene):

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -11,7 +11,7 @@ async def async_setup_platform(
         return
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.tasks,
                                        'task', ElkTask, entities)

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -10,7 +10,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.tasks,
                                        'task', ElkTask, [])

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -9,9 +9,11 @@ async def async_setup_platform(
     """Create the Elk-M1 scene platform."""
     if discovery_info is None:
         return
-    elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(hass, elk.tasks, 'task', ElkTask, [])
-    async_add_entities(entities, True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        entities = create_elk_entities(elk_data, elk.tasks, 'task', ElkTask, [])
+        async_add_entities(entities, True)
 
 
 class ElkTask(ElkEntity, Scene):

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -12,7 +12,8 @@ async def async_setup_platform(
     elk_datas = hass.data[ELK_DOMAIN]
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        entities = create_elk_entities(elk_data, elk.tasks, 'task', ElkTask, [])
+        entities = create_elk_entities(elk_data, elk.tasks,
+                                       'task', ElkTask, [])
         async_add_entities(entities, True)
 
 

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -12,7 +12,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.tasks,
                                        'task', ElkTask, [])

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -12,11 +12,12 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.tasks,
-                                       'task', ElkTask, [])
-        async_add_entities(entities, True)
+                                       'task', ElkTask, entities)
+    async_add_entities(entities, True)
 
 
 class ElkTask(ElkEntity, Scene):

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -14,7 +14,8 @@ async def async_setup_platform(
     elk_datas = hass.data[ELK_DOMAIN]
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        entities = create_elk_entities(elk_data, elk.tasks, 'task', ElkTask, [])
+        entities = create_elk_entities(elk_data, elk.tasks,
+                                       'task', ElkTask, [])
         async_add_entities(entities, True)
 
 

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -13,7 +13,7 @@ async def async_setup_platform(
         return
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.tasks,
                                        'task', ElkTask, entities)

--- a/homeassistant/components/elkm1/scene.py
+++ b/homeassistant/components/elkm1/scene.py
@@ -11,9 +11,11 @@ async def async_setup_platform(
     """Create the Elk-M1 scene platform."""
     if discovery_info is None:
         return
-    elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(hass, elk.tasks, 'task', ElkTask, [])
-    async_add_entities(entities, True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        entities = create_elk_entities(elk_data, elk.tasks, 'task', ElkTask, [])
+        async_add_entities(entities, True)
 
 
 class ElkTask(ElkEntity, Scene):

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -101,6 +101,7 @@ class ElkKeypad(ElkSensor):
         for _, elk_data in elk_datas.items():
             elk_data['keypads'][self._element.index] = self.entity_id
 
+
 class ElkPanel(ElkSensor):
     """Representation of an Elk-M1 Panel."""
 

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -3,6 +3,7 @@ from . import DOMAIN as ELK_DOMAIN, ElkEntity, create_elk_entities
 
 DEPENDENCIES = [ELK_DOMAIN]
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create the Elk-M1 sensor platform."""
@@ -11,7 +12,7 @@ async def async_setup_platform(
 
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(
             elk_data, elk.counters, 'counter', ElkCounter, entities)
@@ -97,9 +98,8 @@ class ElkKeypad(ElkSensor):
         """Register callback for ElkM1 changes and update entity state."""
         await super().async_added_to_hass()
         elk_datas = self.hass.data[ELK_DOMAIN]
-        for prefix, elk_data in elk_datas.items():
+        for _, elk_data in elk_datas.items():
             elk_data['keypads'][self._element.index] = self.entity_id
-
 
 class ElkPanel(ElkSensor):
     """Representation of an Elk-M1 Panel."""

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -1,5 +1,4 @@
 """Support for control of ElkM1 sensors."""
-import logging
 from . import DOMAIN as ELK_DOMAIN, ElkEntity, create_elk_entities
 
 DEPENDENCIES = [ELK_DOMAIN]

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -12,7 +12,7 @@ async def async_setup_platform(
 
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(
             elk_data, elk.counters, 'counter', ElkCounter, entities)

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -1,6 +1,7 @@
 """Support for control of ElkM1 sensors."""
 from . import DOMAIN as ELK_DOMAIN, ElkEntity, create_elk_entities
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create the Elk-M1 sensor platform."""

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -98,7 +98,7 @@ class ElkKeypad(ElkSensor):
         """Register callback for ElkM1 changes and update entity state."""
         await super().async_added_to_hass()
         elk_datas = self.hass.data[ELK_DOMAIN]
-        for _, elk_data in elk_datas.items():
+        for elk_data in elk_datas.values():
             elk_data['keypads'][self._element.index] = self.entity_id
 
 

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -1,9 +1,6 @@
 """Support for control of ElkM1 sensors."""
 from . import DOMAIN as ELK_DOMAIN, ElkEntity, create_elk_entities
 
-DEPENDENCIES = [ELK_DOMAIN]
-
-
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create the Elk-M1 sensor platform."""

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -1,8 +1,8 @@
 """Support for control of ElkM1 sensors."""
+import logging
 from . import DOMAIN as ELK_DOMAIN, ElkEntity, create_elk_entities
 
 DEPENDENCIES = [ELK_DOMAIN]
-
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -10,17 +10,20 @@ async def async_setup_platform(
     if discovery_info is None:
         return
 
-    elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(
-        hass, elk.counters, 'counter', ElkCounter, [])
-    entities = create_elk_entities(
-        hass, elk.keypads, 'keypad', ElkKeypad, entities)
-    entities = create_elk_entities(
-        hass, [elk.panel], 'panel', ElkPanel, entities)
-    entities = create_elk_entities(
-        hass, elk.settings, 'setting', ElkSetting, entities)
-    entities = create_elk_entities(
-        hass, elk.zones, 'zone', ElkZone, entities)
+    elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        entities = create_elk_entities(
+            elk_data, elk.counters, 'counter', ElkCounter, entities)
+        entities = create_elk_entities(
+            elk_data, elk.keypads, 'keypad', ElkKeypad, entities)
+        entities = create_elk_entities(
+            elk_data, [elk.panel], 'panel', ElkPanel, entities)
+        entities = create_elk_entities(
+            elk_data, elk.settings, 'setting', ElkSetting, entities)
+        entities = create_elk_entities(
+            elk_data, elk.zones, 'zone', ElkZone, entities)
     async_add_entities(entities, True)
 
 
@@ -94,8 +97,9 @@ class ElkKeypad(ElkSensor):
     async def async_added_to_hass(self):
         """Register callback for ElkM1 changes and update entity state."""
         await super().async_added_to_hass()
-        self.hass.data[ELK_DOMAIN]['keypads'][
-            self._element.index] = self.entity_id
+        elk_datas = self.hass.data[ELK_DOMAIN]
+        for prefix, elk_data in elk_datas.items():
+            elk_data['keypads'][self._element.index] = self.entity_id
 
 
 class ElkPanel(ElkSensor):

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -10,11 +10,12 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.outputs,
-                                       'output', ElkOutput, [])
-        async_add_entities(entities, True)
+                                       'output', ElkOutput, entities)
+    async_add_entities(entities, True)
 
 
 class ElkOutput(ElkEntity, SwitchDevice):

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -11,7 +11,7 @@ async def async_setup_platform(
         return
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.outputs,
                                        'output', ElkOutput, entities)

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -9,9 +9,11 @@ async def async_setup_platform(
     """Create the Elk-M1 switch platform."""
     if discovery_info is None:
         return
-    elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(hass, elk.outputs, 'output', ElkOutput, [])
-    async_add_entities(entities, True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        entities = create_elk_entities(elk_data, elk.outputs, 'output', ElkOutput, [])
+        async_add_entities(entities, True)
 
 
 class ElkOutput(ElkEntity, SwitchDevice):

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -12,7 +12,8 @@ async def async_setup_platform(
     elk_datas = hass.data[ELK_DOMAIN]
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        entities = create_elk_entities(elk_data, elk.outputs, 'output', ElkOutput, [])
+        entities = create_elk_entities(elk_data, elk.outputs,
+                                       'output', ElkOutput, [])
         async_add_entities(entities, True)
 
 

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -10,7 +10,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.outputs,
                                        'output', ElkOutput, [])

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -13,7 +13,7 @@ async def async_setup_platform(
         return
     elk_datas = hass.data[ELK_DOMAIN]
     entities = []
-    for _, elk_data in elk_datas.items():
+    for elk_data in elk_datas.values():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.outputs,
                                        'output', ElkOutput, entities)

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -12,11 +12,12 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
+    entities = []
     for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.outputs,
-                                       'output', ElkOutput, [])
-        async_add_entities(entities, True)
+                                       'output', ElkOutput, entities)
+    async_add_entities(entities, True)
 
 
 class ElkOutput(ElkEntity, SwitchDevice):

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -12,7 +12,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
     elk_datas = hass.data[ELK_DOMAIN]
-    for prefix, elk_data in elk_datas.items():
+    for _, elk_data in elk_datas.items():
         elk = elk_data['elk']
         entities = create_elk_entities(elk_data, elk.outputs,
                                        'output', ElkOutput, [])

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -11,9 +11,11 @@ async def async_setup_platform(
     """Create the Elk-M1 switch platform."""
     if discovery_info is None:
         return
-    elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(hass, elk.outputs, 'output', ElkOutput, [])
-    async_add_entities(entities, True)
+    elk_datas = hass.data[ELK_DOMAIN]
+    for prefix, elk_data in elk_datas.items():
+        elk = elk_data['elk']
+        entities = create_elk_entities(elk_data, elk.outputs, 'output', ElkOutput, [])
+        async_add_entities(entities, True)
 
 
 class ElkOutput(ElkEntity, SwitchDevice):

--- a/homeassistant/components/elkm1/switch.py
+++ b/homeassistant/components/elkm1/switch.py
@@ -14,7 +14,8 @@ async def async_setup_platform(
     elk_datas = hass.data[ELK_DOMAIN]
     for prefix, elk_data in elk_datas.items():
         elk = elk_data['elk']
-        entities = create_elk_entities(elk_data, elk.outputs, 'output', ElkOutput, [])
+        entities = create_elk_entities(elk_data, elk.outputs,
+                                       'output', ElkOutput, [])
         async_add_entities(entities, True)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -487,6 +487,9 @@ georss_generic_client==0.2
 # homeassistant.components.ign_sismologia
 georss_ign_sismologia_client==0.2
 
+# homeassistant.components.elkm1
+getmac==0.8.1
+
 # homeassistant.components.gitter
 gitterpy==0.1.7
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -386,7 +386,7 @@ eebrightbox==0.0.4
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==0.7.13
+elkm1-lib==0.7.14
 
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -386,7 +386,7 @@ eebrightbox==0.0.4
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==0.7.14
+elkm1-lib==0.7.15
 
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -487,9 +487,6 @@ georss_generic_client==0.2
 # homeassistant.components.ign_sismologia
 georss_ign_sismologia_client==0.2
 
-# homeassistant.components.elkm1
-getmac==0.8.1
-
 # homeassistant.components.gitter
 gitterpy==0.1.7
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -383,7 +383,7 @@ eebrightbox==0.0.4
 eliqonline==1.2.2
 
 # homeassistant.components.elkm1
-elkm1-lib==0.7.13
+elkm1-lib==0.7.14
 
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.8


### PR DESCRIPTION
* Allow more than one Elk M1 alarm system to be integrated into a single hass instance.

* Introduces new "devices" schema at the top level, each of which has
  the prior configuration schema.

* Requires new version of elkm1, 0.7.14, that gwww and I just updated (thanks Glen!)

* Changes to the docs are in a separate PR (#9441) on that repo.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9441

## Example entry for `configuration.yaml` (if applicable):
```
elkm1:
     - host: elk://192.168.0.2:2101/
     ....
     - host: elk://192.168.0.3:2101/
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
