### PR TITLE
WS: Improve service calling errors

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -168,8 +168,14 @@ class ScriptEntity(ToggleEntity):
             ATTR_NAME: self.script.name,
             ATTR_ENTITY_ID: self.entity_id,
         }, context=context)
-        await self.script.async_run(
-            kwargs.get(ATTR_VARIABLES), context)
+        try:
+            await self.script.async_run(
+                kwargs.get(ATTR_VARIABLES), context)
+        except Exception as err:  # pylint: disable=broad-except
+            self.script.async_log_exception(
+                _LOGGER, "Error executing script {}".format(self.entity_id),
+                err)
+            raise err
 
     async def async_turn_off(self, **kwargs):
         """Turn script off."""

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -120,17 +120,21 @@ async def handle_call_service(hass, connection, msg):
             msg['domain'], msg['service'], msg.get('service_data'), blocking,
             connection.context(msg))
         connection.send_message(messages.result_message(msg['id']))
-    except ServiceNotFound:
-        connection.send_message(messages.error_message(
-            msg['id'], const.ERR_NOT_FOUND, 'Service not found.'))
+    except ServiceNotFound as err:
+        if err.domain == msg['domain'] and err.service == msg['service']:
+            connection.send_message(messages.error_message(
+                msg['id'], const.ERR_NOT_FOUND, 'Service not found.'))
+        else:
+            connection.send_message(messages.error_message(
+                msg['id'], const.ERR_HOME_ASSISTANT_ERROR, str(err)))
     except HomeAssistantError as err:
         connection.logger.exception(err)
         connection.send_message(messages.error_message(
-            msg['id'], const.ERR_HOME_ASSISTANT_ERROR, '{}'.format(err)))
+            msg['id'], const.ERR_HOME_ASSISTANT_ERROR, str(err)))
     except Exception as err:  # pylint: disable=broad-except
         connection.logger.exception(err)
         connection.send_message(messages.error_message(
-            msg['id'], const.ERR_UNKNOWN_ERROR, '{}'.format(err)))
+            msg['id'], const.ERR_UNKNOWN_ERROR, str(err)))
 
 
 @callback

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -76,6 +76,6 @@ class ServiceNotFound(HomeAssistantError):
         self.domain = domain
         self.service = service
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return string representation."""
         return "Unable to find service {}/{}".format(self.domain, self.service)

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -77,5 +77,5 @@ class ServiceNotFound(HomeAssistantError):
         self.service = service
 
     def __str__(self):
-        """String representation."""
+        """Return string representation."""
         return "Unable to find service {}/{}".format(self.domain, self.service)

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -75,3 +75,7 @@ class ServiceNotFound(HomeAssistantError):
             self, "Service {}.{} not found".format(domain, service))
         self.domain = domain
         self.service = service
+
+    def __str__(self):
+        """String representation."""
+        return "Unable to find service {}/{}".format(self.domain, self.service)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -893,4 +893,4 @@ async def test_automation_with_error_in_script(hass, caplog):
 
     hass.bus.async_fire('test_event')
     await hass.async_block_till_done()
-    assert 'Service test.automation not found' in caplog.text
+    assert 'Service not found' in caplog.text


### PR DESCRIPTION
## Description:
While creating https://github.com/home-assistant/home-assistant-polymer/pull/3192 I noticed that we would incorrectly attribute the ServiceNotFound error that propagated up from running a script to report to the user that the script service was not found.

This fixes that and adds some better error reporting.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
