### PR TITLE
Allow deletion of automations and scripts

### DIFF
--- a/tests/components/config/test_script.py
+++ b/tests/components/config/test_script.py
@@ -1,0 +1,41 @@
+"""Tests for config/script."""
+from unittest.mock import patch
+
+from homeassistant.bootstrap import async_setup_component
+from homeassistant.components import config
+
+
+async def test_delete_script(hass, hass_client):
+    """Test deleting a script."""
+    with patch.object(config, 'SECTIONS', ['script']):
+        await async_setup_component(hass, 'config', {})
+
+    client = await hass_client()
+
+    orig_data = {
+        'one': {},
+        'two': {},
+    }
+
+    def mock_read(path):
+        """Mock reading data."""
+        return orig_data
+
+    written = []
+
+    def mock_write(path, data):
+        """Mock writing data."""
+        written.append(data)
+
+    with patch('homeassistant.components.config._read', mock_read), \
+            patch('homeassistant.components.config._write', mock_write):
+        resp = await client.delete('/api/config/script/config/two')
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {'result': 'ok'}
+
+    assert len(written) == 1
+    assert written[0] == {
+      'one': {}
+    }


### PR DESCRIPTION
## Description:
Add API endpoint to delete automations and scripts from the UI.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
