### PR TITLE
Fix ZHA battery when readings produce an unknown value

### DIFF
--- a/homeassistant/components/zha/device_entity.py
+++ b/homeassistant/components/zha/device_entity.py
@@ -142,11 +142,8 @@ class ZhaDeviceEntity(ZhaEntity):
         """Get the latest battery reading from channels cache."""
         battery = await self._battery_channel.get_attribute_value(
             'battery_percentage_remaining')
-        if battery is not None:
-            # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
-            if battery == -1:
-                battery = UNKNOWN
-            else:
-                battery = battery / 2
-                battery = int(round(battery))
+        # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
+        if battery is not None and battery != -1:
+            battery = battery / 2
+            battery = int(round(battery))
             self._device_state_attributes['battery_level'] = battery

--- a/homeassistant/components/zha/device_entity.py
+++ b/homeassistant/components/zha/device_entity.py
@@ -6,7 +6,7 @@ import time
 from homeassistant.core import callback
 from homeassistant.util import slugify
 from .entity import ZhaEntity
-from .const import POWER_CONFIGURATION_CHANNEL, SIGNAL_STATE_ATTR, UNKNOWN
+from .const import POWER_CONFIGURATION_CHANNEL, SIGNAL_STATE_ATTR
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zha/device_entity.py
+++ b/homeassistant/components/zha/device_entity.py
@@ -6,7 +6,7 @@ import time
 from homeassistant.core import callback
 from homeassistant.util import slugify
 from .entity import ZhaEntity
-from .const import POWER_CONFIGURATION_CHANNEL, SIGNAL_STATE_ATTR
+from .const import POWER_CONFIGURATION_CHANNEL, SIGNAL_STATE_ATTR, UNKNOWN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,6 +144,9 @@ class ZhaDeviceEntity(ZhaEntity):
             'battery_percentage_remaining')
         if battery is not None:
             # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
-            battery = battery / 2
-            battery = int(round(battery))
+            if battery == -1:
+                battery = UNKNOWN
+            else:
+                battery = battery / 2
+                battery = int(round(battery))
             self._device_state_attributes['battery_level'] = battery


### PR DESCRIPTION
## Description:
Fixes an issue with ZHA battery readings when the device returns 0 or 255 for the battery reading. Fixes: #23827

## Depends on: #23855

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]