### PR TITLE
Fix homekit basic tv test assert when there are no messages

### DIFF
--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -311,4 +311,4 @@ async def test_media_player_television_basic(hass, hk_driver, events, caplog):
     await hass.async_block_till_done()
     assert acc.char_active.value == 1
 
-    assert 'Error' not in caplog.messages[-1]
+    assert not caplog.messages or 'Error' not in caplog.messages[-1]


### PR DESCRIPTION
## Description:

Not sure if this is the best fix, but as it stands all my builds at Travis fail with:

```
=================================== FAILURES ===================================
__________________ test_media_player_television_basic[pyloop] __________________
hass = <homeassistant.core.HomeAssistant object at 0x7fa2d5c8e5c0>
hk_driver = <pyhap.accessory_driver.AccessoryDriver object at 0x7fa2d62fb5f8>
events = []
caplog = <_pytest.logging.LogCaptureFixture object at 0x7fa2d5c8ab70>
    async def test_media_player_television_basic(hass, hk_driver, events, caplog):
        """Test if basic television accessory and HA are updated accordingly."""
        entity_id = 'media_player.television'
    
        # Supports turn_on', 'turn_off'
        hass.states.async_set(entity_id, None, {
            ATTR_DEVICE_CLASS: DEVICE_CLASS_TV, ATTR_SUPPORTED_FEATURES: 384})
        await hass.async_block_till_done()
        acc = TelevisionMediaPlayer(hass, hk_driver, 'MediaPlayer', entity_id, 2,
                                    None)
        await hass.async_add_job(acc.run)
    
        assert acc.chars_tv == []
        assert acc.chars_speaker == []
        assert acc.support_select_source is False
    
        hass.states.async_set(entity_id, STATE_ON, {ATTR_MEDIA_VOLUME_MUTED: True})
        await hass.async_block_till_done()
        assert acc.char_active.value == 1
    
        hass.states.async_set(entity_id, STATE_OFF)
        await hass.async_block_till_done()
        assert acc.char_active.value == 0
    
        hass.states.async_set(entity_id, STATE_ON, {ATTR_INPUT_SOURCE: 'HDMI 3'})
        await hass.async_block_till_done()
        assert acc.char_active.value == 1
    
>       assert 'Error' not in caplog.messages[-1]
E       IndexError: list index out of range
tests/components/homekit/test_type_media_players.py:314: IndexError
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
