### PR TITLE
Fix aiohttp response serialize

### DIFF
--- a/homeassistant/components/cloud/utils.py
+++ b/homeassistant/components/cloud/utils.py
@@ -11,6 +11,8 @@ def aiohttp_serialize_response(response: web.Response) -> Dict[str, Any]:
     if isinstance(body, payload.StringPayload):
         # pylint: disable=protected-access
         body = body._value.decode(body.encoding)
+    elif isinstance(body, bytes):
+        body = body.decode(response.charset or 'utf-8')
     else:
         raise ValueError("Unknown payload encoding")
 

--- a/homeassistant/components/cloud/utils.py
+++ b/homeassistant/components/cloud/utils.py
@@ -1,13 +1,21 @@
 """Helper functions for cloud components."""
 from typing import Any, Dict
 
-from aiohttp import web
+from aiohttp import web, payload
 
 
 def aiohttp_serialize_response(response: web.Response) -> Dict[str, Any]:
     """Serialize an aiohttp response to a dictionary."""
+    body = response.body
+
+    if isinstance(body, payload.StringPayload):
+        # pylint: disable=protected-access
+        body = body._value.decode(body.encoding)
+    else:
+        raise ValueError("Unknown payload encoding")
+
     return {
         'status': response.status,
-        'body': response.text,
+        'body': body,
         'headers': dict(response.headers),
     }

--- a/homeassistant/components/cloud/utils.py
+++ b/homeassistant/components/cloud/utils.py
@@ -8,7 +8,9 @@ def aiohttp_serialize_response(response: web.Response) -> Dict[str, Any]:
     """Serialize an aiohttp response to a dictionary."""
     body = response.body
 
-    if isinstance(body, payload.StringPayload):
+    if body is None:
+        pass
+    elif isinstance(body, payload.StringPayload):
         # pylint: disable=protected-access
         body = body._value.decode(body.encoding)
     elif isinstance(body, bytes):

--- a/tests/components/cloud/test_utils.py
+++ b/tests/components/cloud/test_utils.py
@@ -27,6 +27,17 @@ def test_serialize_body_str():
     }
 
 
+def test_serialize_body_None():
+    """Test serializing a response with a str as body."""
+    response = web.Response(status=201, body=None)
+    assert utils.aiohttp_serialize_response(response) == {
+        'status': 201,
+        'body': None,
+        'headers': {
+        },
+    }
+
+
 def test_serialize_body_bytes():
     """Test serializing a response with a str as body."""
     response = web.Response(status=201, body=b'Hello')

--- a/tests/components/cloud/test_utils.py
+++ b/tests/components/cloud/test_utils.py
@@ -14,7 +14,7 @@ def test_serialize_text():
     }
 
 
-def test_serialize_body():
+def test_serialize_body_str():
     """Test serializing a response with a str as body."""
     response = web.Response(status=201, body='Hello')
     assert utils.aiohttp_serialize_response(response) == {
@@ -24,6 +24,16 @@ def test_serialize_body():
             'Content-Length': '5',
             'Content-Type': 'text/plain; charset=utf-8'
         },
+    }
+
+
+def test_serialize_body_bytes():
+    """Test serializing a response with a str as body."""
+    response = web.Response(status=201, body=b'Hello')
+    assert utils.aiohttp_serialize_response(response) == {
+        'status': 201,
+        'body': 'Hello',
+        'headers': {},
     }
 
 

--- a/tests/components/cloud/test_utils.py
+++ b/tests/components/cloud/test_utils.py
@@ -14,6 +14,19 @@ def test_serialize_text():
     }
 
 
+def test_serialize_body():
+    """Test serializing a response with a str as body."""
+    response = web.Response(status=201, body='Hello')
+    assert utils.aiohttp_serialize_response(response) == {
+        'status': 201,
+        'body': 'Hello',
+        'headers': {
+            'Content-Length': '5',
+            'Content-Type': 'text/plain; charset=utf-8'
+        },
+    }
+
+
 def test_serialize_json():
     """Test serializing a JSON response."""
     response = web.json_response({"how": "what"})


### PR DESCRIPTION
## Description:
The body attribute for aiohttp is typed to only take in bytes. However, it will also work with strings. In that case, it will use a `StringPayload` class. This happened [a few times](https://github.com/home-assistant/home-assistant/pull/23857), breaking cloudhooks.

This should make the serialization better.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
