### PR TITLE
Load HA core config from storage

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -524,7 +524,6 @@ async def async_process_ha_core_config(
         time_zone = date_util.get_time_zone(time_zone_str)
 
         if time_zone:
-            hac.config_source = 'yaml'
             hac.time_zone = time_zone
             date_util.set_default_time_zone(time_zone)
         else:

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -499,19 +499,21 @@ async def async_load_ha_core_config(hass: HomeAssistant) -> None:
     store = hass.helpers.storage.Store(CORE_STORAGE_VERSION, CORE_STORAGE_KEY,
                                        private=True)
     data = await store.async_load()
-    if data:
-        hac = hass.config
-        hac.config_source = SOURCE_STORAGE
-        hac.latitude = data['latitude']
-        hac.longitude = data['longitude']
-        hac.elevation = data['elevation']
-        unit_system = data['unit_system']
-        if unit_system == CONF_UNIT_SYSTEM_IMPERIAL:
-            hac.units = IMPERIAL_SYSTEM
-        else:
-            hac.units = METRIC_SYSTEM
-        hac.location_name = data['location_name']
-        _set_time_zone(hass, data['time_zone'])
+    if not data:
+        return
+
+    hac = hass.config
+    hac.config_source = SOURCE_STORAGE
+    hac.latitude = data['latitude']
+    hac.longitude = data['longitude']
+    hac.elevation = data['elevation']
+    unit_system = data['unit_system']
+    if unit_system == CONF_UNIT_SYSTEM_IMPERIAL:
+        hac.units = IMPERIAL_SYSTEM
+    else:
+        hac.units = METRIC_SYSTEM
+    hac.location_name = data['location_name']
+    _set_time_zone(hass, data['time_zone'])
 
 
 async def async_process_ha_core_config(

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -50,8 +50,12 @@ FILE_MIGRATION = (
     ('ios.conf', '.ios.conf'),
 )
 
-CORE_STORAGE_KEY = 'homeassistant.storage'
+CORE_STORAGE_KEY = 'homeassistant.core_config'
 CORE_STORAGE_VERSION = 1
+
+SOURCE_DISCOVERED = 'discovered'
+SOURCE_STORAGE = 'storage'
+SOURCE_YAML = 'yaml'
 
 DEFAULT_CORE_CONFIG = (
     # Tuples (attribute, default, auto detect property, description)
@@ -476,6 +480,40 @@ def _format_config_error(ex: vol.Invalid, domain: str, config: Dict) -> str:
     return message
 
 
+def _set_time_zone(hass: HomeAssistant, time_zone_str: Optional[str]) -> None:
+    """Help to set the time zone."""
+    if time_zone_str is None:
+        return
+
+    time_zone = date_util.get_time_zone(time_zone_str)
+
+    if time_zone:
+        hass.config.time_zone = time_zone
+        date_util.set_default_time_zone(time_zone)
+    else:
+        _LOGGER.error("Received invalid time zone %s", time_zone_str)
+
+
+async def async_load_ha_core_config(hass: HomeAssistant) -> None:
+    """Store [homeassistant] core config."""
+    store = hass.helpers.storage.Store(CORE_STORAGE_VERSION, CORE_STORAGE_KEY,
+                                       private=True)
+    data = await store.async_load()
+    if data:
+        hac = hass.config
+        hac.config_source = SOURCE_STORAGE
+        hac.latitude = data['latitude']
+        hac.longitude = data['longitude']
+        hac.elevation = data['elevation']
+        unit_system = data['unit_system']
+        if unit_system == CONF_UNIT_SYSTEM_IMPERIAL:
+            hac.units = IMPERIAL_SYSTEM
+        else:
+            hac.units = METRIC_SYSTEM
+        hac.location_name = data['location_name']
+        _set_time_zone(hass, data['time_zone'])
+
+
 async def async_process_ha_core_config(
         hass: HomeAssistant, config: Dict,
         api_password: Optional[str] = None,
@@ -514,47 +552,23 @@ async def async_process_ha_core_config(
             auth_conf,
             mfa_conf))
 
+    await async_load_ha_core_config(hass)
+
     hac = hass.config
 
-    def set_time_zone(time_zone_str: Optional[str]) -> None:
-        """Help to set the time zone."""
-        if time_zone_str is None:
-            return
-
-        time_zone = date_util.get_time_zone(time_zone_str)
-
-        if time_zone:
-            hac.time_zone = time_zone
-            date_util.set_default_time_zone(time_zone)
-        else:
-            _LOGGER.error("Received invalid time zone %s", time_zone_str)
-
-    store = hass.helpers.storage.Store(CORE_STORAGE_VERSION, CORE_STORAGE_KEY,
-                                       private=True)
-    data = await store.async_load()
-    if data:
-        hac.config_source = 'storage'
-        hac.latitude = data.get('latitude')
-        hac.longitude = data.get('longitude')
-        hac.elevation = data.get('elevation')
-        unit_system = data.get('unit_system')
-        if unit_system:
-            if unit_system == CONF_UNIT_SYSTEM_IMPERIAL:
-                hac.units = IMPERIAL_SYSTEM
-            else:
-                hac.units = METRIC_SYSTEM
-        hac.location_name = data.get('location_name')
-        set_time_zone(data.get('time_zone'))
+    if any([k in config for k in [
+            CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, CONF_ELEVATION,
+            CONF_TIME_ZONE, CONF_UNIT_SYSTEM]]):
+        hac.config_source = SOURCE_YAML
 
     for key, attr in ((CONF_LATITUDE, 'latitude'),
                       (CONF_LONGITUDE, 'longitude'),
                       (CONF_NAME, 'location_name'),
                       (CONF_ELEVATION, 'elevation')):
         if key in config:
-            hac.config_source = 'yaml'
             setattr(hac, attr, config[key])
 
-    set_time_zone(config.get(CONF_TIME_ZONE))
+    _set_time_zone(hass, config.get(CONF_TIME_ZONE))
 
     # Init whitelist external dir
     hac.whitelist_external_dirs = {hass.config.path('www')}
@@ -587,13 +601,11 @@ async def async_process_ha_core_config(
         EntityValues(cust_exact, cust_domain, cust_glob)
 
     if CONF_UNIT_SYSTEM in config:
-        hac.config_source = 'yaml'
         if config[CONF_UNIT_SYSTEM] == CONF_UNIT_SYSTEM_IMPERIAL:
             hac.units = IMPERIAL_SYSTEM
         else:
             hac.units = METRIC_SYSTEM
     elif CONF_TEMPERATURE_UNIT in config:
-        hac.config_source = 'yaml'
         unit = config[CONF_TEMPERATURE_UNIT]
         if unit == TEMP_CELSIUS:
             hac.units = METRIC_SYSTEM
@@ -614,7 +626,7 @@ async def async_process_ha_core_config(
     # If we miss some of the needed values, auto detect them
     if None in (hac.latitude, hac.longitude, hac.units,
                 hac.time_zone):
-        hac.config_source = 'discovered'
+        hac.config_source = SOURCE_DISCOVERED
         info = await loc_util.async_detect_location_info(
             hass.helpers.aiohttp_client.async_get_clientsession()
         )
@@ -637,7 +649,7 @@ async def async_process_ha_core_config(
             discovered.append(('name', info.city))
 
         if hac.time_zone is None:
-            set_time_zone(info.time_zone)
+            _set_time_zone(hass, info.time_zone)
             discovered.append(('time_zone', info.time_zone))
 
     if hac.elevation is None and hac.latitude is not None and \
@@ -656,18 +668,15 @@ async def async_process_ha_core_config(
 
 async def async_store_ha_core_config(hass: HomeAssistant) -> None:
     """Store [homeassistant] core config."""
-    hac = hass.config
-    time_zone = date_util.UTC.zone
-    if hac.time_zone and getattr(hac.time_zone, 'zone'):
-        time_zone = getattr(hac.time_zone, 'zone')
+    config = hass.config.as_dict()
 
     data = {
-        'latitude': hac.latitude,
-        'longitude': hac.longitude,
-        'elevation': hac.elevation,
-        'unit_system': hac.units.name,
-        'location_name': hac.location_name,
-        'time_zone': time_zone,
+        'latitude': config['latitude'],
+        'longitude': config['longitude'],
+        'elevation': config['elevation'],
+        'unit_system': hass.config.units.name,
+        'location_name': config['location_name'],
+        'time_zone': config['time_zone'],
     }
 
     store = hass.helpers.storage.Store(CORE_STORAGE_VERSION, CORE_STORAGE_KEY,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1177,7 +1177,7 @@ class Config:
         self.time_zone = None  # type: Optional[datetime.tzinfo]
         self.units = METRIC_SYSTEM  # type: UnitSystem
 
-        self.config_source = None
+        self.config_source = None  # type: Optional[str]
 
         # If True, pip install is skipped for requirements on startup
         self.skip_pip = False  # type: bool
@@ -1253,7 +1253,8 @@ class Config:
             'components': self.components,
             'config_dir': self.config_dir,
             'whitelist_external_dirs': self.whitelist_external_dirs,
-            'version': __version__
+            'version': __version__,
+            'config_source': self.config_source
         }
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1177,6 +1177,8 @@ class Config:
         self.time_zone = None  # type: Optional[datetime.tzinfo]
         self.units = METRIC_SYSTEM  # type: UnitSystem
 
+        self.config_source = None
+
         # If True, pip install is skipped for requirements on startup
         self.skip_pip = False  # type: bool
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -416,7 +416,6 @@ def test_migrate_no_file_on_upgrade(mock_os, mock_shutil, hass):
 
 async def test_loading_configuration_from_storage(hass, hass_storage):
     """Test loading core config onto hass object."""
-    hass.config = mock.Mock()
     hass_storage["homeassistant.core_config"] = {
         'data': {
             'elevation': 10,
@@ -444,8 +443,7 @@ async def test_loading_configuration_from_storage(hass, hass_storage):
 
 
 async def test_override_stored_configuration(hass, hass_storage):
-    """Test loading core config onto hass object."""
-    hass.config = mock.Mock()
+    """Test loading core and YAML config onto hass object."""
     hass_storage["homeassistant.core_config"] = {
         'data': {
             'elevation': 10,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -418,18 +418,19 @@ async def test_loading_configuration_from_storage(hass, hass_storage):
     """Test loading core config onto hass object."""
     hass.config = mock.Mock()
     hass_storage["homeassistant.core_config"] = {
-    'data': {
-        'elevation': 10,
-        'latitude': 55,
-        'location_name': 'Home',
-        'longitude': 13,
-        'time_zone': 'Europe/Copenhagen',
-        'unit_system': 'metric'
-        },
-    'key': 'homeassistant.core_config',
-    'version': 1
+        'data': {
+            'elevation': 10,
+            'latitude': 55,
+            'location_name': 'Home',
+            'longitude': 13,
+            'time_zone': 'Europe/Copenhagen',
+            'unit_system': 'metric'
+            },
+        'key': 'homeassistant.core_config',
+        'version': 1
     }
-    await config_util.async_process_ha_core_config(hass, {'whitelist_external_dirs': '/tmp'})
+    await config_util.async_process_ha_core_config(
+        hass, {'whitelist_external_dirs': '/tmp'})
 
     assert hass.config.latitude == 55
     assert hass.config.longitude == 13
@@ -446,16 +447,16 @@ async def test_override_stored_configuration(hass, hass_storage):
     """Test loading core config onto hass object."""
     hass.config = mock.Mock()
     hass_storage["homeassistant.core_config"] = {
-    'data': {
-        'elevation': 10,
-        'latitude': 55,
-        'location_name': 'Home',
-        'longitude': 13,
-        'time_zone': 'Europe/Copenhagen',
-        'unit_system': 'metric'
-        },
-    'key': 'homeassistant.core_config',
-    'version': 1
+        'data': {
+            'elevation': 10,
+            'latitude': 55,
+            'location_name': 'Home',
+            'longitude': 13,
+            'time_zone': 'Europe/Copenhagen',
+            'unit_system': 'metric'
+            },
+        'key': 'homeassistant.core_config',
+        'version': 1
     }
     await config_util.async_process_ha_core_config(hass, {
         'latitude': 60,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -900,6 +900,7 @@ class TestConfig(unittest.TestCase):
             'config_dir': '/tmp/ha-config',
             'whitelist_external_dirs': set(),
             'version': __version__,
+            'config_source': None,
         }
 
         assert expected == self.config.as_dict()


### PR DESCRIPTION
## Description:
Initial steps of home-assistant/architecture#176:
- Load core config from storage
- Still support YAML, which will override config in storage

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
