### PR TITLE
Add unit of measurement to Tautulli sensor

### DIFF
--- a/homeassistant/components/tautulli/sensor.py
+++ b/homeassistant/components/tautulli/sensor.py
@@ -120,6 +120,11 @@ class TautulliSensor(Entity):
         return 'mdi:plex'
 
     @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return "Watching"
+
+    @property
     def device_state_attributes(self):
         """Return attributes for the sensor."""
         return self._attributes


### PR DESCRIPTION
Adds unit of measurement ("Watching") to sensor, so it can be graphed properly.
This is the same unit of measurement as the Plex sensor.

## Breaking Change:

I can't see a way that this would be a breaking change.

## Description:

Unit of measurement was added to sensor value to allow it to be displayed as a graph and not a series of states. This value should only ever be a numeric value 0 or above, and represents the number of users watching.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
No change from existing component.
```yaml
sensor:
  - platform: tautulli
    api_key: TAUTULLI_API_KEY
    host: TAUTULLI_HOST
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:

  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

Functionality of sensor unchanged, so no accompanying documentation.

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
