### PR TITLE
Speed up history `get_states`

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -157,7 +157,8 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None)
             most_recent_state_ids = (
                 session.query(States.state_id.label("max_state_id"))
                 .filter(
-                    (States.last_updated < utc_point_in_time)
+                    (States.last_updated >= run.start)
+                    & (States.last_updated < utc_point_in_time)
                     & (States.entity_id.in_(entity_ids))
                 )
                 .order_by(States.last_updated.desc())

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -156,13 +156,15 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None)
         if entity_ids and len(entity_ids) == 1:
             # Use an entirely different (and extremely fast) query if we only
             # have a single entity id
-            query = query.filter(
-                States.last_updated >= run.start,
-                States.last_updated < utc_point_in_time,
-                States.entity_id.in_(entity_ids)
-            ).order_by(
-                States.last_updated.desc()
-            ).limit(1)
+            query = (
+                query.filter(
+                    States.last_updated >= run.start,
+                    States.last_updated < utc_point_in_time,
+                    States.entity_id.in_(entity_ids),
+                )
+                .order_by(States.last_updated.desc())
+                .limit(1)
+            )
 
         else:
             # We have more than one entity to look at (most commonly we want
@@ -203,7 +205,7 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None)
 
             query = query.join(
                 most_recent_state_ids,
-                States.state_id == most_recent_state_ids.c.max_state_id
+                States.state_id == most_recent_state_ids.c.max_state_id,
             ).filter(~States.domain.in_(IGNORE_DOMAINS))
 
             if filters:

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -151,20 +151,18 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None)
     from sqlalchemy import and_, func
 
     with session_scope(hass=hass) as session:
+        query = session.query(States)
+
         if entity_ids and len(entity_ids) == 1:
             # Use an entirely different (and extremely fast) query if we only
             # have a single entity id
-            most_recent_state_ids = (
-                session.query(States.state_id.label("max_state_id"))
-                .filter(
-                    (States.last_updated >= run.start)
-                    & (States.last_updated < utc_point_in_time)
-                    & (States.entity_id.in_(entity_ids))
-                )
-                .order_by(States.last_updated.desc())
-            )
-
-            most_recent_state_ids = most_recent_state_ids.limit(1)
+            query = query.filter(
+                States.last_updated >= run.start,
+                States.last_updated < utc_point_in_time,
+                States.entity_id.in_(entity_ids)
+            ).order_by(
+                States.last_updated.desc()
+            ).limit(1)
 
         else:
             # We have more than one entity to look at (most commonly we want
@@ -201,19 +199,15 @@ def get_states(hass, utc_point_in_time, entity_ids=None, run=None, filters=None)
 
             most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
 
-        most_recent_state_ids = most_recent_state_ids.subquery()
+            most_recent_state_ids = most_recent_state_ids.subquery()
 
-        query = (
-            session.query(States)
-            .join(
+            query = query.join(
                 most_recent_state_ids,
-                States.state_id == most_recent_state_ids.c.max_state_id,
-            )
-            .filter((~States.domain.in_(IGNORE_DOMAINS)))
-        )
+                States.state_id == most_recent_state_ids.c.max_state_id
+            ).filter(~States.domain.in_(IGNORE_DOMAINS))
 
-        if filters:
-            query = filters.apply(query, entity_ids)
+            if filters:
+                query = filters.apply(query, entity_ids)
 
         return [
             state


### PR DESCRIPTION
## Description:

Adding a boundary of the start of the recorder run the point is in, significantly decreases the time of the query. This speeds up the fetching of the history of 1 entity.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
