### PR TITLE
Add min and max brightness to template.light

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -152,7 +152,6 @@ class LightTemplate(Light):
 
         self._brightness_min = brightness_min
         self._brightness_max = brightness_max
-        self._use_zero = 0
 
         brightness_interval = len(range(brightness_min, brightness_max))
 

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -25,6 +25,11 @@ CONF_ON_ACTION = 'turn_on'
 CONF_OFF_ACTION = 'turn_off'
 CONF_LEVEL_ACTION = 'set_level'
 CONF_LEVEL_TEMPLATE = 'level_template'
+CONF_LEVEL_BRIGHTNESS_MIN = 'brightness_min'
+CONF_LEVEL_BRIGHTNESS_MAX = 'brightness_max'
+
+DEFAULT_BRIGHTNESS_MIN = 0
+DEFAULT_BRIGHTNESS_MAX = 255
 
 LIGHT_SCHEMA = vol.Schema({
     vol.Required(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
@@ -35,7 +40,11 @@ LIGHT_SCHEMA = vol.Schema({
     vol.Optional(CONF_LEVEL_ACTION): cv.SCRIPT_SCHEMA,
     vol.Optional(CONF_LEVEL_TEMPLATE): cv.template,
     vol.Optional(CONF_FRIENDLY_NAME): cv.string,
-    vol.Optional(CONF_ENTITY_ID): cv.entity_ids
+    vol.Optional(CONF_ENTITY_ID): cv.entity_ids,
+    vol.Optional(CONF_LEVEL_BRIGHTNESS_MIN, default=DEFAULT_BRIGHTNESS_MIN):
+        vol.All(vol.Coerce(int), vol.Range(min=-1001)),
+    vol.Optional(CONF_LEVEL_BRIGHTNESS_MAX, default=DEFAULT_BRIGHTNESS_MAX):
+        vol.All(vol.Coerce(int), vol.Range(min=-1000))
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -58,6 +67,8 @@ async def async_setup_platform(hass, config, async_add_entities,
         off_action = device_config[CONF_OFF_ACTION]
         level_action = device_config.get(CONF_LEVEL_ACTION)
         level_template = device_config.get(CONF_LEVEL_TEMPLATE)
+        brightness_min = device_config.get(CONF_LEVEL_BRIGHTNESS_MIN)
+        brightness_max = device_config.get(CONF_LEVEL_BRIGHTNESS_MAX)
 
         template_entity_ids = set()
 
@@ -90,7 +101,8 @@ async def async_setup_platform(hass, config, async_add_entities,
             LightTemplate(
                 hass, device, friendly_name, state_template,
                 icon_template, entity_picture_template, on_action,
-                off_action, level_action, level_template, entity_ids)
+                off_action, level_action, level_template, entity_ids,
+                brightness_min, brightness_max)
         )
 
     if not lights:
@@ -106,7 +118,8 @@ class LightTemplate(Light):
 
     def __init__(self, hass, device_id, friendly_name, state_template,
                  icon_template, entity_picture_template, on_action,
-                 off_action, level_action, level_template, entity_ids):
+                 off_action, level_action, level_template, entity_ids,
+                 brightness_min, brightness_max):
         """Initialize the light."""
         self.hass = hass
         self.entity_id = async_generate_entity_id(
@@ -136,6 +149,19 @@ class LightTemplate(Light):
             self._icon_template.hass = self.hass
         if self._entity_picture_template is not None:
             self._entity_picture_template.hass = self.hass
+
+        self._brightness_min = brightness_min
+        self._brightness_max = brightness_max
+        self._use_zero = 0
+
+        brightness_interval = len(range(brightness_min, brightness_max))
+
+        self._brightness_max += \
+            (brightness_interval % DEFAULT_BRIGHTNESS_MAX) // \
+            DEFAULT_BRIGHTNESS_MAX
+
+        self._brightness_div = DEFAULT_BRIGHTNESS_MAX / \
+            (brightness_interval)
 
     @property
     def brightness(self):
@@ -205,13 +231,19 @@ class LightTemplate(Light):
 
         if self._level_template is None and ATTR_BRIGHTNESS in kwargs:
             _LOGGER.info("Optimistically setting brightness to %s",
-                         kwargs[ATTR_BRIGHTNESS])
-            self._brightness = kwargs[ATTR_BRIGHTNESS]
+                         int(kwargs[ATTR_BRIGHTNESS] / self._brightness_div)
+                         + (self._brightness_min))
+            self._brightness = \
+                int(kwargs[ATTR_BRIGHTNESS] / self._brightness_div) +\
+                self._brightness_min
             optimistic_set = True
 
         if ATTR_BRIGHTNESS in kwargs and self._level_script:
             await self._level_script.async_run(
-                {"brightness": kwargs[ATTR_BRIGHTNESS]}, context=self._context)
+                {"brightness":
+                 int(int(kwargs[ATTR_BRIGHTNESS] / self._brightness_div) +
+                     (self._brightness_min))},
+                context=self._context)
         else:
             await self._on_script.async_run()
 
@@ -249,12 +281,16 @@ class LightTemplate(Light):
                 _LOGGER.error(ex)
                 self._state = None
 
-            if 0 <= int(brightness) <= 255:
-                self._brightness = int(brightness)
+            if self._brightness_min <= int(brightness) <= self._brightness_max:
+                self._brightness = \
+                    (int(brightness) - self._brightness_min) *\
+                    self._brightness_div
             else:
                 _LOGGER.error(
-                    'Received invalid brightness : %s. Expected: 0-255',
-                    brightness)
+                    'Received invalid brightness : %s. Expected: %s-%s',
+                    brightness,
+                    str(self._brightness_min),
+                    str(self._brightness_max))
                 self._brightness = None
 
         for property_name, template in (


### PR DESCRIPTION
## Description:
Make it possible to set own min and max values for template light.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example 1, entry for `configuration.yaml` (if applicable):
```yaml
light: 
  - platform: template
    test_light:
        friendly_name: "test_light"
        value_template: "{{ states('input_number.test_brightness') | int > -257 }}"
        level_template: "{{ states('input_number.test_brightness') | int }}"
        turn_on:
          service: input_number.set_value
          data:
            entity_id: input_number.test_brightness
            value: 255
        turn_off:
          service: input_number.set_value
          data:
            entity_id: input_number.test_brightness
            value: -257
        set_level:
          - service: input_number.set_value
            data_template:
              entity_id: input_number.test_brightness
              value: "{{ brightness }}"
        brightness_min: -257
        brightness_max: 255

input_number:
  test_brightness:
    name: 'brightness'
    initial: -257
    min: -257
    max: 255
    step: 1
```
## Example 2
```yaml
light: 
  - platform: template
    lights:
        test_light:
        friendly_name: "test_light"
        value_template: "{{ states('input_number.test_brightness') | int > 500 }}"
        level_template: "{{ states('input_number.test_brightness') | int }}"
        turn_on:
          service: input_number.set_value
          data:
            entity_id: input_number.test_brightness
            value: 1000
        turn_off:
          service: input_number.set_value
          data:
            entity_id: input_number.test_brightness  
            value: 500
        set_level:
          - service: input_number.set_value
            data_template:
              entity_id: input_number.test_brightness
              value: "{{ brightness }}"
        brightness_min: 500
        brightness_max: 1000

input_number:
  test_brightness:
    name: 'brightness'
    initial: 500
    min: 500
    max: 1000
    step: 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

<!--
If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.
-->
If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html