### PR TITLE
Netatmo, handle offline device

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -523,9 +523,9 @@ class NetatmoData:
             _LOGGER.debug("%s detected!", str(self.data_class.__name__))
             return station_data
         except NoDevice:
-            _LOGGER.warning("No Weather or HomeCoach devices found for %s", str(
-                self.station
-                ))
+            _LOGGER.warning("No Weather or HomeCoach devices found for %s",
+                            str(self.station)
+                            )
             raise
 
     def update(self):

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -523,7 +523,7 @@ class NetatmoData:
             _LOGGER.debug("%s detected!", str(self.data_class.__name__))
             return station_data
         except NoDevice:
-            _LOGGER.error("No Weather or HomeCoach devices found for %s", str(
+            _LOGGER.warning("No Weather or HomeCoach devices found for %s", str(
                 self.station
                 ))
             raise
@@ -547,10 +547,14 @@ class NetatmoData:
 
         try:
             if self.station is not None:
-                self.data = self.station_data.lastData(
+                data = self.station_data.lastData(
                     station=self.station, exclude=3600)
             else:
-                self.data = self.station_data.lastData(exclude=3600)
+                data = self.station_data.lastData(exclude=3600)
+            if not data:
+                self._next_update = time() + NETATMO_UPDATE_INTERVAL
+                return
+            self.data = data
 
             newinterval = 0
             try:


### PR DESCRIPTION
## Description:
Netatmo, handle offline device

And change error to warning

**Related issue (if applicable):** fixes #23897 and  #23865

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
