### PR TITLE
Better handle file not found when loading YAML

### DIFF
--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -149,7 +149,8 @@ class ApnsNotificationService(BaseNotificationService):
         self.devices = {}
         self.device_states = {}
         self.topic = topic
-        if os.path.isfile(self.yaml_path):
+
+        try:
             self.devices = {
                 str(key): ApnsDevice(
                     str(key),
@@ -160,6 +161,8 @@ class ApnsNotificationService(BaseNotificationService):
                 for (key, value) in
                 load_yaml_config_file(self.yaml_path).items()
             }
+        except FileNotFoundError:
+            pass
 
         tracking_ids = [
             device.full_tracking_device_id

--- a/homeassistant/components/apns/notify.py
+++ b/homeassistant/components/apns/notify.py
@@ -1,6 +1,5 @@
 """APNS Notification platform."""
 import logging
-import os
 
 import voluptuous as vol
 

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -155,11 +155,10 @@ async def async_load_ip_bans_config(hass: HomeAssistant, path: str):
     """Load list of banned IPs from config file."""
     ip_list = []
 
-    if not os.path.isfile(path):
-        return ip_list
-
     try:
         list_ = await hass.async_add_executor_job(load_yaml_config_file, path)
+    except FileNotFoundError:
+        return ip_list
     except HomeAssistantError as err:
         _LOGGER.error('Unable to load %s: %s', path, str(err))
         return ip_list

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from datetime import datetime
 from ipaddress import ip_address
 import logging
-import os
 
 from aiohttp.web import middleware
 from aiohttp.web_exceptions import HTTPForbidden, HTTPUnauthorized

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -363,13 +363,11 @@ def find_config_file(config_dir: Optional[str]) -> Optional[str]:
 def load_yaml_config_file(config_path: str) -> Dict[Any, Any]:
     """Parse a YAML configuration file.
 
+    Raises FileNotFoundError or HomeAssistantError.
+
     This method needs to run in an executor.
     """
-    try:
-        conf_dict = load_yaml(config_path)
-    except FileNotFoundError as err:
-        raise HomeAssistantError("Config file not found: {}".format(
-            getattr(err, 'filename', err)))
+    conf_dict = load_yaml(config_path)
 
     if not isinstance(conf_dict, dict):
         msg = "The configuration file {} does not contain a dictionary".format(

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -312,6 +312,8 @@ async def check_ha_config_file(hass):
             return result.add_error("File configuration.yaml not found.")
         config = await hass.async_add_executor_job(
             load_yaml_config_file, config_path)
+    except FileNotFoundError:
+        return result.add_error("File not found: {}".format(config_path))
     except HomeAssistantError as err:
         return result.add_error(
             "Error loading {}: {}".format(config_path, err))


### PR DESCRIPTION
## Description:
FileNotFound errors were converted to HomeAssistantError, making it so that callers of the function were unable to differentiate between an invalid YAML file and a file not found. This caused new installations to have "Cannot find known_devices.yaml" in their logs.

This allows `FileNotFoundError` to propagate and updates all places that call that function.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
