### PR TITLE
Fix invalid Hue response

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -453,7 +453,7 @@ def get_entity_state(config, entity):
     if cached_state is None:
         data[STATE_ON] = entity.state != STATE_OFF
         if data[STATE_ON]:
-            data[STATE_BRIGHTNESS] = entity.attributes.get(ATTR_BRIGHTNESS)
+            data[STATE_BRIGHTNESS] = entity.attributes.get(ATTR_BRIGHTNESS, 0)
             hue_sat = entity.attributes.get(ATTR_HS_COLOR, None)
             if hue_sat is not None:
                 hue = hue_sat[0]


### PR DESCRIPTION
## Description:
Based on the discoveries in issue #23514, the periodic lack of response from emulated hue was due to an invalid value (null) being returned. The fix for that issue is the change on line 456, but as an extra precaution, I added a method to entity_to_json to help catch any future issues like this from occuring.

Note: I haven't been able to repro this through unit tests, but 2 different people commented on the issue saying that this does fix the issue (I did cleaned up an unused variable between the commit they tested and this commit)

**Related issue (if applicable):** fixes #23514

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
