### PR TITLE
Switch media player to SWITCH type

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -53,7 +53,6 @@ TYPE_SENSOR = PREFIX_TYPES + 'SENSOR'
 TYPE_DOOR = PREFIX_TYPES + 'DOOR'
 TYPE_TV = PREFIX_TYPES + 'TV'
 TYPE_SPEAKER = PREFIX_TYPES + 'SPEAKER'
-TYPE_MEDIA = PREFIX_TYPES + 'MEDIA'
 
 SERVICE_REQUEST_SYNC = 'request_sync'
 HOMEGRAPH_URL = 'https://homegraph.googleapis.com/'
@@ -89,7 +88,7 @@ DOMAIN_TO_GOOGLE_TYPES = {
     input_boolean.DOMAIN: TYPE_SWITCH,
     light.DOMAIN: TYPE_LIGHT,
     lock.DOMAIN: TYPE_LOCK,
-    media_player.DOMAIN: TYPE_MEDIA,
+    media_player.DOMAIN: TYPE_SWITCH,
     scene.DOMAIN: TYPE_SCENE,
     script.DOMAIN: TYPE_SCENE,
     switch.DOMAIN: TYPE_SWITCH,

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -147,7 +147,7 @@ DEMO_DEVICES = [{
             'action.devices.traits.Modes'
         ],
     'type':
-    'action.devices.types.MEDIA',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -162,7 +162,7 @@ DEMO_DEVICES = [{
             'action.devices.traits.Modes'
         ],
     'type':
-    'action.devices.types.MEDIA',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {
@@ -171,7 +171,7 @@ DEMO_DEVICES = [{
         'name': 'Lounge room'
     },
     'traits': ['action.devices.traits.OnOff', 'action.devices.traits.Modes'],
-    'type': 'action.devices.types.MEDIA',
+    'type': 'action.devices.types.SWITCH',
     'willReportState': False
 }, {
     'id':
@@ -182,7 +182,7 @@ DEMO_DEVICES = [{
     'traits':
     ['action.devices.traits.OnOff', 'action.devices.traits.Volume'],
     'type':
-    'action.devices.types.MEDIA',
+    'action.devices.types.SWITCH',
     'willReportState':
     False
 }, {

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -686,7 +686,7 @@ async def test_device_class_cover(hass, device_class, google_type):
 
 
 @pytest.mark.parametrize("device_class,google_type", [
-    ('non_existing_class', 'action.devices.types.MEDIA'),
+    ('non_existing_class', 'action.devices.types.SWITCH'),
     ('speaker', 'action.devices.types.SPEAKER'),
     ('tv', 'action.devices.types.TV'),
 ])


### PR DESCRIPTION
## Description:

MEDIA device type is being rejected by google now.

**Related issue (if applicable):** fixes #23891

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~[_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.~
  - [ ] ~New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.~
  - [ ] ~Untested files have been added to `.coveragerc`.~

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
