### PR TITLE
Fix bug when IQVIA API fails to return data

### DIFF
--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -158,10 +158,6 @@ class IQVIAData:
 
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)
 
-        # IQVIA sites require a bit more complicated error handling, given that
-        # they sometimes have parts (but not the whole thing) go down:
-        #   1. If `InvalidZipError` is thrown, quit everything immediately.
-        #   2. If a single request throws any other error, try the others.
         for key, result in zip(tasks, results):
             if isinstance(result, IQVIAError):
                 _LOGGER.error('Unable to get %s data: %s', key, result)

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -11,7 +11,6 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS
 from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, async_dispatcher_send)
@@ -87,9 +86,6 @@ async def async_setup_entry(hass, config_entry):
         _LOGGER.error(
             'Invalid ZIP code provided: %s', config_entry.data[CONF_ZIP_CODE])
         return False
-    except IQVIAError as err:
-        _LOGGER.error('Unable to set up IQVIA: %s', err)
-        raise ConfigEntryNotReady
 
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = iqvia
 

--- a/homeassistant/components/iqvia/config_flow.py
+++ b/homeassistant/components/iqvia/config_flow.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import voluptuous as vol
 
 from pyiqvia import Client
-from pyiqvia.errors import IQVIAError
+from pyiqvia.errors import InvalidZipError
 
 from homeassistant import config_entries
 from homeassistant.core import callback
@@ -54,11 +54,10 @@ class IQVIAFlowHandler(config_entries.ConfigFlow):
             return await self._show_form({CONF_ZIP_CODE: 'identifier_exists'})
 
         websession = aiohttp_client.async_get_clientsession(self.hass)
-        client = Client(user_input[CONF_ZIP_CODE], websession)
 
         try:
-            await client.allergens.current()
-        except IQVIAError:
+            client = Client(user_input[CONF_ZIP_CODE], websession)
+        except InvalidZipError:
             return await self._show_form({CONF_ZIP_CODE: 'invalid_zip_code'})
 
         return self.async_create_entry(

--- a/homeassistant/components/iqvia/config_flow.py
+++ b/homeassistant/components/iqvia/config_flow.py
@@ -56,7 +56,7 @@ class IQVIAFlowHandler(config_entries.ConfigFlow):
         websession = aiohttp_client.async_get_clientsession(self.hass)
 
         try:
-            client = Client(user_input[CONF_ZIP_CODE], websession)
+            Client(user_input[CONF_ZIP_CODE], websession)
         except InvalidZipError:
             return await self._show_form({CONF_ZIP_CODE: 'invalid_zip_code'})
 

--- a/homeassistant/components/iqvia/manifest.json
+++ b/homeassistant/components/iqvia/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/components/iqvia",
   "requirements": [
     "numpy==1.16.3",
-    "pyiqvia==0.2.0"
+    "pyiqvia==0.2.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -106,8 +106,8 @@ class ForecastSensor(IQVIAEntity):
         if not self._iqvia.data:
             return
 
-        data = self._iqvia.data[self._type].get('Location')
-        if not data:
+        data = self._iqvia.data[self._type]['Location']
+        if not data.get('periods'):
             return
 
         indices = [p['Index'] for p in data['periods']]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1130,7 +1130,7 @@ pyicloud==0.9.1
 pyipma==1.2.1
 
 # homeassistant.components.iqvia
-pyiqvia==0.2.0
+pyiqvia==0.2.1
 
 # homeassistant.components.irish_rail_transport
 pyirishrail==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -235,7 +235,7 @@ pyheos==0.5.2
 pyhomematic==0.1.58
 
 # homeassistant.components.iqvia
-pyiqvia==0.2.0
+pyiqvia==0.2.1
 
 # homeassistant.components.litejet
 pylitejet==0.1

--- a/tests/components/iqvia/test_config_flow.py
+++ b/tests/components/iqvia/test_config_flow.py
@@ -9,17 +9,9 @@ from tests.common import MockConfigEntry, MockDependency, mock_coro
 
 
 @pytest.fixture
-def allergens_current_response():
-    """Define a fixture for a successful allergens.current response."""
-    return mock_coro()
-
-
-@pytest.fixture
-def mock_pyiqvia(allergens_current_response):
+def mock_pyiqvia():
     """Mock the pyiqvia library."""
     with MockDependency('pyiqvia') as mock_pyiqvia_:
-        mock_pyiqvia_.Client().allergens.current.return_value = (
-            allergens_current_response)
         yield mock_pyiqvia_
 
 
@@ -37,8 +29,6 @@ async def test_duplicate_error(hass):
     assert result['errors'] == {CONF_ZIP_CODE: 'identifier_exists'}
 
 
-@pytest.mark.parametrize(
-    'allergens_current_response', [mock_coro(exception=IQVIAError)])
 async def test_invalid_zip_code(hass, mock_pyiqvia):
     """Test that an invalid ZIP code key throws an error."""
     conf = {

--- a/tests/components/iqvia/test_config_flow.py
+++ b/tests/components/iqvia/test_config_flow.py
@@ -1,11 +1,10 @@
 """Define tests for the IQVIA config flow."""
-from pyiqvia.errors import IQVIAError
 import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.iqvia import CONF_ZIP_CODE, DOMAIN, config_flow
 
-from tests.common import MockConfigEntry, MockDependency, mock_coro
+from tests.common import MockConfigEntry, MockDependency
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description:

A situation arose where individual IQVIA APIs would return valid responses (including `200` statuses), but the response data would be empty. Combined with some erroneous ZIP code validation logic, this created a condition where the integration would error out on startup. This PR fixes the issue.

Marking as 0.93.1 since the integration fails to load properly without this fix.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/23910

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
iqvia:
  zip_code: "10752"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
