### PR TITLE
Fix icons for homekit_controller sensors

### DIFF
--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -3,9 +3,9 @@ from homeassistant.const import TEMP_CELSIUS
 
 from . import KNOWN_DEVICES, HomeKitEntity
 
-HUMIDITY_ICON = 'mdi-water-percent'
-TEMP_C_ICON = "mdi-temperature-celsius"
-BRIGHTNESS_ICON = "mdi-brightness-6"
+HUMIDITY_ICON = 'mdi:water-percent'
+TEMP_C_ICON = "mdi:thermometer"
+BRIGHTNESS_ICON = "mdi:brightness-6"
 
 UNIT_PERCENT = "%"
 UNIT_LUX = "lux"


### PR DESCRIPTION
## Description:

Whilst testing #23874 I noticed temperature sensors in the device list didn't have icons. This turned out to be a typo in the icon names, which this PR fixes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
