### PR TITLE
Fix problem with cameras that don't support time

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -164,27 +164,28 @@ class ONVIFHassCamera(Camera):
 
             system_date = dt_util.utcnow()
             device_time = await devicemgmt.GetSystemDateAndTime()
-            cdate = device_time.UTCDateTime
-            cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month,
-                                   cdate.Date.Day, cdate.Time.Hour,
-                                   cdate.Time.Minute, cdate.Time.Second,
-                                   0, dt_util.UTC)
+            if device_time:
+                cdate = device_time.UTCDateTime
+                cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month,
+                                       cdate.Date.Day, cdate.Time.Hour,
+                                       cdate.Time.Minute, cdate.Time.Second,
+                                       0, dt_util.UTC)
 
-            _LOGGER.debug("Camera date/time: %s",
-                          cam_date)
+                _LOGGER.debug("Camera date/time: %s",
+                              cam_date)
 
-            _LOGGER.debug("System date/time: %s",
-                          system_date)
+                _LOGGER.debug("System date/time: %s",
+                              system_date)
 
-            dt_diff = cam_date - system_date
-            dt_diff_seconds = dt_diff.total_seconds()
+                dt_diff = cam_date - system_date
+                dt_diff_seconds = dt_diff.total_seconds()
 
-            if dt_diff_seconds > 5:
-                _LOGGER.warning("The date/time on the camera is '%s', "
-                                "which is different from the system '%s', "
-                                "this could lead to authentication issues",
-                                cam_date,
-                                system_date)
+                if dt_diff_seconds > 5:
+                    _LOGGER.warning("The date/time on the camera is '%s', "
+                                    "which is different from the system '%s', "
+                                    "this could lead to authentication issues",
+                                    cam_date,
+                                    system_date)
 
             _LOGGER.debug("Obtaining input uri")
 


### PR DESCRIPTION
## Description:
Some onvif cameras don't support Date management. In that case None is returned and script crashes when trying to obtain date

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
