### PR TITLE
Updated non-blocking timout to 10 seconds for fixing timeout issues.

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -63,7 +63,7 @@ async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
 
     try:
         device_data = await wait_for(
-            v2bridge.queue.get(), timeout=5.0, loop=hass.loop)
+            v2bridge.queue.get(), timeout=10.0, loop=hass.loop)
     except (Asyncio_TimeoutError, RuntimeError):
         _LOGGER.exception("failed to get response from device")
         await v2bridge.stop()

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -108,3 +108,25 @@ def mock_bridge_fixture() -> Generator[None, Any, None]:
 
     for patcher in patchers:
         patcher.stop()
+
+
+@fixture(name='mock_failed_bridge')
+def mock_failed_bridge_fixture() -> Generator[None, Any, None]:
+    """Fixture for mocking aioswitcher.bridge.SwitcherV2Bridge."""
+    async def mock_queue():
+        """Mock asyncio's Queue."""
+        raise RuntimeError
+
+    patchers = [
+        patch('aioswitcher.bridge.SwitcherV2Bridge.start', return_value=None),
+        patch('aioswitcher.bridge.SwitcherV2Bridge.stop', return_value=None),
+        patch('aioswitcher.bridge.SwitcherV2Bridge.queue', get=mock_queue)
+        ]
+
+    for patcher in patchers:
+        patcher.start()
+
+    yield
+
+    for patcher in patchers:
+        patcher.stop()

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -13,7 +13,9 @@ from .consts import (
     DUMMY_REMAINING_TIME, MANDATORY_CONFIGURATION)
 
 
-async def test_failed_config(hass: HomeAssistantType) -> None:
+async def test_failed_config(
+        hass: HomeAssistantType,
+        mock_failed_bridge: Generator[None, Any, None]) -> None:
     """Test failed configuration."""
     assert await async_setup_component(
         hass, DOMAIN, MANDATORY_CONFIGURATION) is False


### PR DESCRIPTION
## Description:
When the integration starts, it waits non-blocking for the device to send its initial state.
That can take up to 4 seconds, therefore a non-blocking timeout of 5 seconds was incorporated.
That works fine for most of the users...
In rare cases where there's some blocking code caused by an unrelated error or multiple prioritized tasks are waiting in the event loop, that 5 seconds timeout is too tight.

All day I've been working with users and in my own environment to test a fix for this issue.

After testing multiple scenarios on multiple environments, the tested fix of updating the timeout to 10 seconds works great.

**Related issue (if applicable):** fixes #23927

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
