### PR TITLE
Fix additional IQVIA data KeyError

### DIFF
--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -106,8 +106,8 @@ class ForecastSensor(IQVIAEntity):
         if not self._iqvia.data:
             return
 
-        data = self._iqvia.data[self._type]['Location']
-        if not data.get('periods'):
+        data = self._iqvia.data[self._type].get('Location')
+        if not data or not data.get('periods'):
             return
 
         indices = [p['Index'] for p in data['periods']]


### PR DESCRIPTION
## Description:

Fix a small nit I introduced in https://github.com/home-assistant/home-assistant/pull/23916.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
iqvia:
  zip_code: "10751"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
