### PR TITLE
Bump pytraccar

### DIFF
--- a/homeassistant/components/traccar/manifest.json
+++ b/homeassistant/components/traccar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Traccar",
   "documentation": "https://www.home-assistant.io/components/traccar",
   "requirements": [
-    "pytraccar==0.8.0",
+    "pytraccar==0.9.0",
     "stringcase==1.2.0"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1453,7 +1453,7 @@ pytile==2.0.6
 pytouchline==0.7
 
 # homeassistant.components.traccar
-pytraccar==0.8.0
+pytraccar==0.9.0
 
 # homeassistant.components.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
## Description:

- Bump pytraccar from `0.8.0` to `0.9.0`
- Changelog: https://github.com/ludeeus/pytraccar/compare/0.8.0...0.9.0

- This fixes #23904 (lat/long attribute errors).
- This version of the lib includes tests so this will not happen again...

**Related issue (if applicable):** fixes #23904

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: traccar
    username: admin
    password: admin
    host: 192.168.2.105
    port: 8072
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
