### PR TITLE
Fixes issue with multiple alerts

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -290,4 +290,3 @@ class Alert(ToggleEntity):
         if self._ack:
             return await self.async_turn_on()
         return await self.async_turn_off()
-        

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -1,7 +1,7 @@
 """Support for repeating alerts when conditions are met."""
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import voluptuous as vol
 
@@ -13,6 +13,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE, ATTR_ENTITY_ID)
 from homeassistant.helpers import service, event
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.util.dt import now
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -222,7 +223,7 @@ class Alert(ToggleEntity):
     async def _schedule_notify(self):
         """Schedule a notification."""
         delay = self._delay[self._next_delay]
-        next_msg = datetime.now() + delay
+        next_msg = now() + delay
         self._cancel = \
             event.async_track_point_in_time(self.hass, self._notify, next_msg)
         self._next_delay = min(self._next_delay + 1, len(self._delay) - 1)

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -290,3 +290,4 @@ class Alert(ToggleEntity):
         if self._ack:
             return await self.async_turn_on()
         return await self.async_turn_off()
+        


### PR DESCRIPTION
## Description:

When the OS time and the configured TZ for HA differ, the alert component will send one notification every second.

This change forces it to use the defined TZ, and with that, it only sends notifications when they are expected.

**Related issue (if applicable):** fixes #21860

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9474

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  time_zone: America/Los_Angeles

alert:
  garage_door:
    name: Garage is open
    done_message: Garage is closed
    entity_id: input_boolean.garage_door
    state: 'on'
    repeat: 5
    can_acknowledge: true
    skip_first: true
    notifiers:
      - pushbullet
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
<!--
If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.
-->
If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
