### PR TITLE
Setup integration dependencies before loading it

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -343,17 +343,17 @@ async def check_ha_config_file(hass):
             result.add_error("Integration not found: {}".format(domain))
             continue
 
-        try:
-            component = integration.get_component()
-        except ImportError:
-            result.add_error("Component not found: {}".format(domain))
-            continue
-
         if (not hass.config.skip_pip and integration.requirements and
                 not await requirements.async_process_requirements(
                     hass, integration.domain, integration.requirements)):
             result.add_error("Unable to install all requirements: {}".format(
                 ', '.join(integration.requirements)))
+            continue
+
+        try:
+            component = integration.get_component()
+        except ImportError:
+            result.add_error("Component not found: {}".format(domain))
             continue
 
         if hasattr(component, 'CONFIG_SCHEMA'):


### PR DESCRIPTION
## Description:

The PR is fixing the situation when you are using the `check_config` script with components using top-level imports (like `hue` - [example here)](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/hue/light.py#L8). 

The component was loaded before the dependencies were setup. The component cannot be loaded if an `import` statement from an (yet) unknown package was present.

**Related issue (if applicable):** fixes #23488

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
```

```bash
$ hass -c . --script check_config
Testing configuration at /Users/aerialls/Projects/ha-dependencies-bug/.
Failed config
  General Errors:
    - Component not found: hue

Successful config (partial)
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
