### PR TITLE
Update requests to 2.22.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,7 +11,7 @@ pip>=8.0.3
 python-slugify==3.0.2
 pytz>=2019.01
 pyyaml>=3.13,<4
-requests==2.21.0
+requests==2.22.0
 ruamel.yaml==0.15.94
 voluptuous==0.11.5
 voluptuous-serialize==2.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -12,7 +12,7 @@ pip>=8.0.3
 python-slugify==3.0.2
 pytz>=2019.01
 pyyaml>=3.13,<4
-requests==2.21.0
+requests==2.22.0
 ruamel.yaml==0.15.94
 voluptuous==0.11.5
 voluptuous-serialize==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ REQUIRES = [
     'python-slugify==3.0.2',
     'pytz>=2019.01',
     'pyyaml>=3.13,<4',
-    'requests==2.21.0',
+    'requests==2.22.0',
     'ruamel.yaml==0.15.94',
     'voluptuous==0.11.5',
     'voluptuous-serialize==2.1.0',


### PR DESCRIPTION
## Description:

Update requests to 2.22.0, which supports urllib3 1.25.2 as there is fixed CVE-2019-11324 and compliant for RFC 3986.

Even requests shouldn't be used anywhere in Home Assistant as said in #23685 , it is still in setup requirement. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
