### PR TITLE
Add 'adb_response' attribute to Android TV / Fire TV

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -156,8 +156,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for target_device in target_devices:
             output = target_device.adb_command(cmd)
 
-            # log the output if there is any
-            if output.strip():
+            # log the output, if there is any
+            if output:
                 _LOGGER.info("Output of command '%s' from '%s': %s",
                              cmd, target_device.entity_id, output)
 
@@ -311,15 +311,19 @@ class ADBDevice(MediaPlayerDevice):
         key = self._keys.get(cmd)
         if key:
             self.aftv.adb_shell('input keyevent {}'.format(key))
-            self._adb_response = ''
-            return self._adb_response
+            self._adb_response = None
+            return
 
         if cmd == 'GET_PROPERTIES':
             self._adb_response = str(self.aftv.get_properties_dict())
             return self._adb_response
 
         response = self.aftv.adb_shell(cmd)
-        self._adb_response = str(response) if response else ''
+        if isinstance(response, str) and response.strip():
+            self._adb_response = response.strip()
+        else:
+            self._adb_response = None
+
         return self._adb_response
 
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -312,10 +312,12 @@ class ADBDevice(MediaPlayerDevice):
         if key:
             self.aftv.adb_shell('input keyevent {}'.format(key))
             self._adb_response = None
+            self.schedule_update_ha_state()
             return
 
         if cmd == 'GET_PROPERTIES':
             self._adb_response = str(self.aftv.get_properties_dict())
+            self.schedule_update_ha_state()
             return self._adb_response
 
         response = self.aftv.adb_shell(cmd)
@@ -324,6 +326,7 @@ class ADBDevice(MediaPlayerDevice):
         else:
             self._adb_response = None
 
+        self.schedule_update_ha_state()
         return self._adb_response
 
 

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -224,7 +224,7 @@ class ADBDevice(MediaPlayerDevice):
             self.exceptions = (ConnectionResetError, RuntimeError)
 
         # Property attributes
-        self._adb_response = ''
+        self._adb_response = None
         self._available = self.aftv.available
         self._current_app = None
         self._state = None


### PR DESCRIPTION
## Description:

This stores the output, if any, of the `androidtv.adb_command` service in a state attribute -- `'adb_response'` -- so that it can be used in automations / scripts. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]