### PR TITLE
Make Discord payload data key not required

### DIFF
--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -53,21 +53,20 @@ class DiscordNotificationService(BaseNotificationService):
             _LOGGER.error("No target specified")
             return None
 
-        if ATTR_DATA in kwargs:
-            data = kwargs.get(ATTR_DATA)
+        data = kwargs.get(ATTR_DATA) or {}
 
-            if ATTR_IMAGES in data:
-                images = list()
+        if ATTR_IMAGES in data:
+            images = list()
 
-                for image in data.get(ATTR_IMAGES):
-                    image_exists = await self.hass.async_add_executor_job(
-                        self.file_exists,
-                        image)
+            for image in data.get(ATTR_IMAGES):
+                image_exists = await self.hass.async_add_executor_job(
+                    self.file_exists,
+                    image)
 
-                    if image_exists:
-                        images.append(image)
-                    else:
-                        _LOGGER.warning("Image not found: %s", image)
+                if image_exists:
+                    images.append(image)
+                else:
+                    _LOGGER.warning("Image not found: %s", image)
 
         # pylint: disable=unused-variable
         @discord_bot.event


### PR DESCRIPTION
## Description:
My previous work in #23523 introduced a BC as noted by @Villhellm : a payload sent to Discord notify component would require an empty "data" object in its strucure.
This has now been fixed.

**Related issue (if applicable):** fixes #23948

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
