### PR TITLE
Fix russound_rio component in Python 3.7+

### DIFF
--- a/homeassistant/components/russound_rio/manifest.json
+++ b/homeassistant/components/russound_rio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Russound rio",
   "documentation": "https://www.home-assistant.io/components/russound_rio",
   "requirements": [
-    "russound_rio==0.1.4"
+    "russound_rio==0.1.7"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1564,7 +1564,7 @@ rova==0.1.0
 russound==0.1.9
 
 # homeassistant.components.russound_rio
-russound_rio==0.1.4
+russound_rio==0.1.7
 
 # homeassistant.components.yamaha
 rxv==0.6.0


### PR DESCRIPTION
## Description:
Changes to async broke the russound_rio module in python 3.7+. Version 0.1.7 of this module fixes the problem. Update the russound_rio requirement to 0.1.7.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
