### PR TITLE
Don't pass in loop

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -118,7 +118,7 @@ async def async_setup(hass, config):
 
     tasks = [alert.async_update_ha_state() for alert in entities]
     if tasks:
-        await asyncio.wait(tasks, loop=hass.loop)
+        await asyncio.wait(tasks)
 
     return True
 

--- a/homeassistant/components/alexa/auth.py
+++ b/homeassistant/components/alexa/auth.py
@@ -39,7 +39,7 @@ class Auth:
         self._prefs = None
         self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
 
-        self._get_token_lock = asyncio.Lock(loop=hass.loop)
+        self._get_token_lock = asyncio.Lock()
 
     async def async_do_auth(self, accept_grant_code):
         """Do authentication with an AcceptGrant code."""
@@ -97,7 +97,7 @@ class Auth:
 
         try:
             session = aiohttp_client.async_get_clientsession(self.hass)
-            with async_timeout.timeout(DEFAULT_TIMEOUT, loop=self.hass.loop):
+            with async_timeout.timeout(DEFAULT_TIMEOUT):
                 response = await session.post(LWA_TOKEN_URI,
                                               headers=LWA_HEADERS,
                                               data=lwa_params,

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1432,7 +1432,7 @@ async def async_send_changereport_message(hass, config, alexa_entity):
 
     try:
         session = aiohttp_client.async_get_clientsession(hass)
-        with async_timeout.timeout(DEFAULT_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(DEFAULT_TIMEOUT):
             response = await session.post(config.endpoint,
                                           headers=headers,
                                           json=message_serialized,

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -144,7 +144,7 @@ class AmcrestCam(Camera):
         from haffmpeg.camera import CameraMjpeg
 
         streaming_url = self._api.rtsp_url(typeno=self._resolution)
-        stream = CameraMjpeg(self._ffmpeg.binary, loop=self.hass.loop)
+        stream = CameraMjpeg(self._ffmpeg.binary)
         await stream.open_camera(
             streaming_url, extra_cmd=self._ffmpeg_arguments)
 

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -144,7 +144,7 @@ class AmcrestCam(Camera):
         from haffmpeg.camera import CameraMjpeg
 
         streaming_url = self._api.rtsp_url(typeno=self._resolution)
-        stream = CameraMjpeg(self._ffmpeg.binary)
+        stream = CameraMjpeg(self._ffmpeg.binary, loop=self.hass.loop)
         await stream.open_camera(
             streaming_url, extra_cmd=self._ffmpeg_arguments)
 

--- a/homeassistant/components/android_ip_webcam/__init__.py
+++ b/homeassistant/components/android_ip_webcam/__init__.py
@@ -233,7 +233,7 @@ async def async_setup(hass, config):
 
     tasks = [async_setup_ipcamera(conf) for conf in config[DOMAIN]]
     if tasks:
-        await asyncio.wait(tasks, loop=hass.loop)
+        await asyncio.wait(tasks)
 
     return True
 

--- a/homeassistant/components/anthemav/media_player.py
+++ b/homeassistant/components/anthemav/media_player.py
@@ -47,7 +47,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         hass.async_create_task(device.async_update_ha_state())
 
     avr = await anthemav.Connection.create(
-        host=host, port=port, loop=hass.loop,
+        host=host, port=port,
         update_callback=async_anthemav_update_callback)
 
     device = AnthemAVR(avr, name)

--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -82,7 +82,7 @@ class APIEventStream(HomeAssistantView):
             raise Unauthorized()
         hass = request.app['hass']
         stop_obj = object()
-        to_write = asyncio.Queue(loop=hass.loop)
+        to_write = asyncio.Queue()
 
         restrict = request.query.get('restrict')
         if restrict:
@@ -119,8 +119,7 @@ class APIEventStream(HomeAssistantView):
 
             while True:
                 try:
-                    with async_timeout.timeout(STREAM_PING_INTERVAL,
-                                               loop=hass.loop):
+                    with async_timeout.timeout(STREAM_PING_INTERVAL):
                         payload = await to_write.get()
 
                     if payload is stop_obj:

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -167,7 +167,7 @@ async def async_setup(hass, config):
 
     tasks = [_setup_atv(hass, config, conf) for conf in config.get(DOMAIN, [])]
     if tasks:
-        await asyncio.wait(tasks, loop=hass.loop)
+        await asyncio.wait(tasks)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SCAN, async_service_handler,

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -124,7 +124,7 @@ async def async_setup(hass, config):
                 context=service_call.context))
 
         if tasks:
-            await asyncio.wait(tasks, loop=hass.loop)
+            await asyncio.wait(tasks)
 
     async def turn_onoff_service_handler(service_call):
         """Handle automation turn on/off service calls."""
@@ -134,7 +134,7 @@ async def async_setup(hass, config):
             tasks.append(getattr(entity, method)())
 
         if tasks:
-            await asyncio.wait(tasks, loop=hass.loop)
+            await asyncio.wait(tasks)
 
     async def toggle_service_handler(service_call):
         """Handle automation toggle service calls."""
@@ -146,7 +146,7 @@ async def async_setup(hass, config):
                 tasks.append(entity.async_turn_on())
 
         if tasks:
-            await asyncio.wait(tasks, loop=hass.loop)
+            await asyncio.wait(tasks)
 
     async def reload_service_handler(service_call):
         """Remove all automations and load new ones from config."""

--- a/homeassistant/components/aws/__init__.py
+++ b/homeassistant/components/aws/__init__.py
@@ -166,14 +166,14 @@ async def _validate_aws_credentials(hass, credential):
     profile = aws_config.get(CONF_PROFILE_NAME)
 
     if profile is not None:
-        session = aiobotocore.AioSession(profile=profile, loop=hass.loop)
+        session = aiobotocore.AioSession(profile=profile)
         del aws_config[CONF_PROFILE_NAME]
         if CONF_ACCESS_KEY_ID in aws_config:
             del aws_config[CONF_ACCESS_KEY_ID]
         if CONF_SECRET_ACCESS_KEY in aws_config:
             del aws_config[CONF_SECRET_ACCESS_KEY]
     else:
-        session = aiobotocore.AioSession(loop=hass.loop)
+        session = aiobotocore.AioSession()
 
     if credential[CONF_VALIDATE]:
         async with session.create_client("iam", **aws_config) as client:

--- a/homeassistant/components/aws/notify.py
+++ b/homeassistant/components/aws/notify.py
@@ -94,10 +94,10 @@ async def async_get_service(hass, config, discovery_info=None):
     if session is None:
         profile = aws_config.get(CONF_PROFILE_NAME)
         if profile is not None:
-            session = aiobotocore.AioSession(profile=profile, loop=hass.loop)
+            session = aiobotocore.AioSession(profile=profile)
             del aws_config[CONF_PROFILE_NAME]
         else:
-            session = aiobotocore.AioSession(loop=hass.loop)
+            session = aiobotocore.AioSession()
 
     aws_config[CONF_REGION] = region_name
 

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -190,7 +190,7 @@ async def get_device(hass, config):
     import axis
 
     device = axis.AxisDevice(
-        loop=hass.loop, host=config[CONF_HOST],
+        host=config[CONF_HOST],
         username=config[CONF_USERNAME],
         password=config[CONF_PASSWORD],
         port=config[CONF_PORT], web_proto='http')

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -190,7 +190,7 @@ async def get_device(hass, config):
     import axis
 
     device = axis.AxisDevice(
-        host=config[CONF_HOST],
+        loop=hass.loop, host=config[CONF_HOST],
         username=config[CONF_USERNAME],
         password=config[CONF_PASSWORD],
         port=config[CONF_PORT], web_proto='http')

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -255,7 +255,7 @@ class BluesoundPlayer(MediaPlayerDevice):
                 BluesoundPlayer._TimeoutException):
             _LOGGER.info("Node %s is offline, retrying later", self._name)
             await asyncio.sleep(
-                NODE_OFFLINE_CHECK_TIMEOUT, loop=self._hass.loop)
+                NODE_OFFLINE_CHECK_TIMEOUT)
             self.start_polling()
 
         except CancelledError:
@@ -318,7 +318,7 @@ class BluesoundPlayer(MediaPlayerDevice):
 
         try:
             websession = async_get_clientsession(self._hass)
-            with async_timeout.timeout(10, loop=self._hass.loop):
+            with async_timeout.timeout(10):
                 response = await websession.get(url)
 
             if response.status == 200:
@@ -361,7 +361,7 @@ class BluesoundPlayer(MediaPlayerDevice):
 
         try:
 
-            with async_timeout.timeout(125, loop=self._hass.loop):
+            with async_timeout.timeout(125):
                 response = await self._polling_session.get(
                     url, headers={CONNECTION: KEEP_ALIVE})
 
@@ -378,7 +378,7 @@ class BluesoundPlayer(MediaPlayerDevice):
                     self._group_name = group_name
                     # the sleep is needed to make sure that the
                     # devices is synced
-                    await asyncio.sleep(1, loop=self._hass.loop)
+                    await asyncio.sleep(1)
                     await self.async_trigger_sync_on_all()
                 elif self.is_grouped:
                     # when player is grouped we need to fetch volume from

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -388,7 +388,7 @@ class BrData:
                     tasks.append(dev.async_update_ha_state())
 
             if tasks:
-                await asyncio.wait(tasks, loop=self.hass.loop)
+                await asyncio.wait(tasks)
 
     async def schedule_update(self, minute=1):
         """Schedule an update after minute minutes."""
@@ -407,7 +407,7 @@ class BrData:
         resp = None
         try:
             websession = async_get_clientsession(self.hass)
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 resp = await websession.get(url)
 
                 result[STATUS_CODE] = resp.status

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -121,7 +121,7 @@ async def async_get_image(hass, entity_id, timeout=10):
     camera = _get_camera_from_entity_id(hass, entity_id)
 
     with suppress(asyncio.CancelledError, asyncio.TimeoutError):
-        with async_timeout.timeout(timeout, loop=hass.loop):
+        with async_timeout.timeout(timeout):
             image = await camera.async_camera_image()
 
             if image:
@@ -481,7 +481,7 @@ class CameraImageView(CameraView):
     async def handle(self, request, camera):
         """Serve camera image."""
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
-            with async_timeout.timeout(10, loop=request.app['hass'].loop):
+            with async_timeout.timeout(10):
                 image = await camera.async_camera_image()
 
             if image:

--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -79,7 +79,7 @@ class CanaryCamera(Camera):
         image = await asyncio.shield(ffmpeg.get_image(
             self._live_stream_session.live_stream_url,
             output_format=IMAGE_JPEG,
-            extra_cmd=self._ffmpeg_arguments), loop=self.hass.loop)
+            extra_cmd=self._ffmpeg_arguments))
         return image
 
     async def handle_async_mjpeg_stream(self, request):
@@ -88,7 +88,7 @@ class CanaryCamera(Camera):
             return
 
         from haffmpeg.camera import CameraMjpeg
-        stream = CameraMjpeg(self._ffmpeg.binary, loop=self.hass.loop)
+        stream = CameraMjpeg(self._ffmpeg.binary)
         await stream.open_camera(
             self._live_stream_session.live_stream_url,
             extra_cmd=self._ffmpeg_arguments)

--- a/homeassistant/components/canary/camera.py
+++ b/homeassistant/components/canary/camera.py
@@ -88,7 +88,7 @@ class CanaryCamera(Camera):
             return
 
         from haffmpeg.camera import CameraMjpeg
-        stream = CameraMjpeg(self._ffmpeg.binary)
+        stream = CameraMjpeg(self._ffmpeg.binary, loop=self.hass.loop)
         await stream.open_camera(
             self._live_stream_session.live_stream_url,
             extra_cmd=self._ffmpeg_arguments)

--- a/homeassistant/components/citybikes/sensor.py
+++ b/homeassistant/components/citybikes/sensor.py
@@ -106,7 +106,7 @@ async def async_citybikes_request(hass, uri, schema):
     try:
         session = async_get_clientsession(hass)
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             req = await session.get(DEFAULT_ENDPOINT.format(uri=uri))
 
         json_response = await req.json()
@@ -181,7 +181,7 @@ class CityBikesNetworks:
         """Initialize the networks instance."""
         self.hass = hass
         self.networks = None
-        self.networks_loading = asyncio.Condition(loop=hass.loop)
+        self.networks_loading = asyncio.Condition()
 
     async def get_closest_network_id(self, latitude, longitude):
         """Return the id of the network closest to provided location."""
@@ -217,7 +217,7 @@ class CityBikesNetwork:
         self.hass = hass
         self.network_id = network_id
         self.stations = []
-        self.ready = asyncio.Event(loop=hass.loop)
+        self.ready = asyncio.Event()
 
     async def async_refresh(self, now=None):
         """Refresh the state of the network."""

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -164,10 +164,10 @@ class GoogleActionsSyncView(HomeAssistantView):
         cloud = hass.data[DOMAIN]
         websession = hass.helpers.aiohttp_client.async_get_clientsession()
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             await hass.async_add_job(cloud.auth.check_token)
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             req = await websession.post(
                 cloud.google_actions_sync_url, headers={
                     'authorization': cloud.id_token
@@ -192,7 +192,7 @@ class CloudLoginView(HomeAssistantView):
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             await hass.async_add_job(cloud.auth.login, data['email'],
                                      data['password'])
 
@@ -212,7 +212,7 @@ class CloudLogoutView(HomeAssistantView):
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             await cloud.logout()
 
         return self.json_message('ok')
@@ -234,7 +234,7 @@ class CloudRegisterView(HomeAssistantView):
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             await hass.async_add_job(
                 cloud.auth.register, data['email'], data['password'])
 
@@ -256,7 +256,7 @@ class CloudResendConfirmView(HomeAssistantView):
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             await hass.async_add_job(
                 cloud.auth.resend_email_confirm, data['email'])
 
@@ -278,7 +278,7 @@ class CloudForgotPasswordView(HomeAssistantView):
         hass = request.app['hass']
         cloud = hass.data[DOMAIN]
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             await hass.async_add_job(
                 cloud.auth.forgot_password, data['email'])
 
@@ -320,7 +320,7 @@ async def websocket_subscription(hass, connection, msg):
     from hass_nabucasa.const import STATE_DISCONNECTED
     cloud = hass.data[DOMAIN]
 
-    with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+    with async_timeout.timeout(REQUEST_TIMEOUT):
         response = await cloud.fetch_subscription_info()
 
     if response.status != 200:

--- a/homeassistant/components/comed_hourly_pricing/sensor.py
+++ b/homeassistant/components/comed_hourly_pricing/sensor.py
@@ -106,7 +106,7 @@ class ComedHourlyPricingSensor(Entity):
                 else:
                     url_string += '?type=currenthouraverage'
 
-                with async_timeout.timeout(60, loop=self.loop):
+                with async_timeout.timeout(60):
                     response = await self.websession.get(url_string)
                     # The API responds with MIME type 'text/html'
                     text = await response.text()

--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -62,7 +62,7 @@ async def async_setup(hass, config):
             tasks.append(setup_panel(panel_name))
 
     if tasks:
-        await asyncio.wait(tasks, loop=hass.loop)
+        await asyncio.wait(tasks)
 
     return True
 

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -144,7 +144,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
         }))
 
     if setup_tasks:
-        await asyncio.wait(setup_tasks, loop=hass.loop)
+        await asyncio.wait(setup_tasks)
 
     tracker.async_setup_group()
 

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -82,7 +82,7 @@ class DeviceTracker:
             else defaults.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
         self.defaults = defaults
         self.group = None
-        self._is_updating = asyncio.Lock(loop=hass.loop)
+        self._is_updating = asyncio.Lock()
 
         for dev in devices:
             if self.devices[dev.dev_id] is not dev:
@@ -229,7 +229,7 @@ class DeviceTracker:
                     async_init_single_device(device)))
 
         if tasks:
-            await asyncio.wait(tasks, loop=self.hass.loop)
+            await asyncio.wait(tasks)
 
 
 class Device(RestoreEntity):

--- a/homeassistant/components/device_tracker/setup.py
+++ b/homeassistant/components/device_tracker/setup.py
@@ -147,7 +147,7 @@ def async_setup_scanner_platform(hass: HomeAssistantType, config: ConfigType,
     This method must be run in the event loop.
     """
     interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
-    update_lock = asyncio.Lock(loop=hass.loop)
+    update_lock = asyncio.Lock()
     scanner.hass = hass
 
     # Initial scan of each mac we also tell about host name for config

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -46,7 +46,7 @@ class DiscordNotificationService(BaseNotificationService):
         import discord
 
         discord.VoiceClient.warn_nacl = False
-        discord_bot = discord.Client(loop=self.hass.loop)
+        discord_bot = discord.Client()
         images = None
 
         if ATTR_TARGET not in kwargs:

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -103,7 +103,6 @@ async def async_start_event_handler(
         requester,
         listen_port=server_port,
         listen_host=server_host,
-        loop=hass.loop,
         callback_url=callback_url_override)
     await server.start_server()
     _LOGGER.info(

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -63,7 +63,7 @@ class WanIpSensor(Entity):
         self.hass = hass
         self._name = name
         self.hostname = hostname
-        self.resolver = aiodns.DNSResolver(loop=self.hass.loop)
+        self.resolver = aiodns.DNSResolver()
         self.resolver.nameservers = [resolver]
         self.querytype = 'AAAA' if ipv6 else 'A'
         self._state = None

--- a/homeassistant/components/doorbird/camera.py
+++ b/homeassistant/components/doorbird/camera.py
@@ -81,7 +81,7 @@ class DoorBirdCamera(Camera):
 
         try:
             websession = async_get_clientsession(self.hass)
-            with async_timeout.timeout(_TIMEOUT, loop=self.hass.loop):
+            with async_timeout.timeout(_TIMEOUT):
                 response = await websession.get(self._url)
 
             self._last_image = await response.read()

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -183,12 +183,11 @@ async def async_setup_platform(hass, config, async_add_entities,
     if CONF_HOST in config:
         reader_factory = partial(
             create_tcp_dsmr_reader, config[CONF_HOST], config[CONF_PORT],
-            config[CONF_DSMR_VERSION], update_entities_telegram,
-            loop=hass.loop)
+            config[CONF_DSMR_VERSION], update_entities_telegram)
     else:
         reader_factory = partial(
             create_dsmr_reader, config[CONF_PORT], config[CONF_DSMR_VERSION],
-            update_entities_telegram, loop=hass.loop)
+            update_entities_telegram)
 
     async def connect_and_reconnect():
         """Connect to DSMR and keep reconnecting until Home Assistant stops."""
@@ -223,8 +222,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                 update_entities_telegram({})
 
                 # throttle reconnect attempts
-                await asyncio.sleep(config[CONF_RECONNECT_INTERVAL],
-                                    loop=hass.loop)
+                await asyncio.sleep(config[CONF_RECONNECT_INTERVAL])
 
     # Can't be hass.async_add_job because job runs forever
     hass.loop.create_task(connect_and_reconnect())

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -106,7 +106,7 @@ async def async_setup(hass, config):
     zones = conf.get(CONF_ZONES)
     partitions = conf.get(CONF_PARTITIONS)
     connection_timeout = conf.get(CONF_TIMEOUT)
-    sync_connect = asyncio.Future(loop=hass.loop)
+    sync_connect = asyncio.Future()
 
     controller = EnvisalinkAlarmPanel(
         host, port, panel_type, version, user, password, zone_dump,

--- a/homeassistant/components/ffmpeg/camera.py
+++ b/homeassistant/components/ffmpeg/camera.py
@@ -59,7 +59,7 @@ class FFmpegCamera(Camera):
 
         image = await asyncio.shield(ffmpeg.get_image(
             self._input, output_format=IMAGE_JPEG,
-            extra_cmd=self._extra_arguments), loop=self.hass.loop)
+            extra_cmd=self._extra_arguments))
         return image
 
     async def handle_async_mjpeg_stream(self, request):

--- a/homeassistant/components/flock/notify.py
+++ b/homeassistant/components/flock/notify.py
@@ -26,15 +26,14 @@ async def get_service(hass, config, discovery_info=None):
     url = '{}{}'.format(_RESOURCE, access_token)
     session = async_get_clientsession(hass)
 
-    return FlockNotificationService(url, session, hass.loop)
+    return FlockNotificationService(url, session)
 
 
 class FlockNotificationService(BaseNotificationService):
     """Implement the notification service for Flock."""
 
-    def __init__(self, url, session, loop):
+    def __init__(self, url, session):
         """Initialize the Flock notification service."""
-        self._loop = loop
         self._url = url
         self._session = session
 
@@ -45,7 +44,7 @@ class FlockNotificationService(BaseNotificationService):
         _LOGGER.debug("Attempting to call Flock at %s", self._url)
 
         try:
-            with async_timeout.timeout(10, loop=self._loop):
+            with async_timeout.timeout(10):
                 response = await self._session.post(self._url, json=payload)
                 result = await response.json()
 

--- a/homeassistant/components/freedns/__init__.py
+++ b/homeassistant/components/freedns/__init__.py
@@ -68,7 +68,7 @@ async def _update_freedns(hass, session, url, auth_token):
         params[auth_token] = ""
 
     try:
-        with async_timeout.timeout(TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(TIMEOUT):
             resp = await session.get(url, params=params)
             body = await resp.text()
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -243,11 +243,11 @@ async def async_setup(hass, config):
 
     await asyncio.wait(
         [async_register_built_in_panel(hass, panel) for panel in (
-            'kiosk', 'states', 'profile')], loop=hass.loop)
+            'kiosk', 'states', 'profile')])
     await asyncio.wait(
         [async_register_built_in_panel(hass, panel, require_admin=True)
          for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
-                       'dev-template', 'dev-mqtt')], loop=hass.loop)
+                       'dev-template', 'dev-mqtt')])
 
     hass.data[DATA_FINALIZE_PANEL] = async_finalize_panel
 

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -127,7 +127,7 @@ class GenericCamera(Camera):
             try:
                 websession = async_get_clientsession(
                     self.hass, verify_ssl=self.verify_ssl)
-                with async_timeout.timeout(10, loop=self.hass.loop):
+                with async_timeout.timeout(10):
                     response = await websession.get(
                         url, auth=self._auth)
                 self._last_image = await response.read()

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -65,7 +65,7 @@ async def async_setup(hass: HomeAssistant, yaml_config: Dict[str, Any]):
         """Handle request sync service calls."""
         websession = async_get_clientsession(hass)
         try:
-            with async_timeout.timeout(15, loop=hass.loop):
+            with async_timeout.timeout(15):
                 agent_user_id = call.data.get('agent_user_id') or \
                                 call.context.user_id
                 res = await websession.post(

--- a/homeassistant/components/google_domains/__init__.py
+++ b/homeassistant/components/google_domains/__init__.py
@@ -67,7 +67,7 @@ async def _update_google_domains(
     }
 
     try:
-        with async_timeout.timeout(timeout, loop=hass.loop):
+        with async_timeout.timeout(timeout):
             resp = await session.get(url, params=params)
             body = await resp.text()
 

--- a/homeassistant/components/google_translate/tts.py
+++ b/homeassistant/components/google_translate/tts.py
@@ -87,7 +87,7 @@ class GoogleProvider(Provider):
             }
 
             try:
-                with async_timeout.timeout(10, loop=self.hass.loop):
+                with async_timeout.timeout(10):
                     request = await websession.get(
                         GOOGLE_SPEECH_URL, params=url_param,
                         headers=self.headers

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -306,7 +306,7 @@ async def async_setup(hass, config):
             tasks.append(group.async_update_ha_state())
 
         if tasks:
-            await asyncio.wait(tasks, loop=hass.loop)
+            await asyncio.wait(tasks)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_VISIBILITY, visibility_service_handler,

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -65,4 +65,4 @@ class GroupNotifyPlatform(BaseNotificationService):
                 DOMAIN, entity.get(ATTR_SERVICE), sending_payload))
 
         if tasks:
-            await asyncio.wait(tasks, loop=self.hass.loop)
+            await asyncio.wait(tasks)

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -156,7 +156,7 @@ class HassIO:
         This method is a coroutine.
         """
         try:
-            with async_timeout.timeout(timeout, loop=self.loop):
+            with async_timeout.timeout(timeout):
                 request = await self.websession.request(
                     method, "http://{}{}".format(self._ip, command),
                     json=payload, headers={

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -77,7 +77,7 @@ class HassIOView(HomeAssistantView):
         headers = _init_header(request)
 
         try:
-            with async_timeout.timeout(10, loop=hass.loop):
+            with async_timeout.timeout(10):
                 data = await request.read()
 
             method = getattr(self._websession, request.method.lower())

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -71,8 +71,6 @@ class HassIOView(HomeAssistantView):
         This method is a coroutine.
         """
         read_timeout = _get_timeout(path)
-        hass = request.app['hass']
-
         data = None
         headers = _init_header(request)
 

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -172,7 +172,7 @@ def setup(hass: HomeAssistant, base_config):
         adapter = TcpAdapter(host, name=display_name, activate_source=False)
     else:
         adapter = CecAdapter(name=display_name[:12], activate_source=False)
-    hdmi_network = HDMINetwork(adapter, loop=loop)
+    hdmi_network = HDMINetwork(adapter, loop)
 
     def _volume(call):
         """Increase/decrease volume and mute/unmute system."""

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -172,7 +172,7 @@ def setup(hass: HomeAssistant, base_config):
         adapter = TcpAdapter(host, name=display_name, activate_source=False)
     else:
         adapter = CecAdapter(name=display_name[:12], activate_source=False)
-    hdmi_network = HDMINetwork(adapter, loop)
+    hdmi_network = HDMINetwork(adapter, loop=loop)
 
     def _volume(call):
         """Increase/decrease volume and mute/unmute system."""

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -64,7 +64,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
             tasks.append(hass.services.async_call(
                 domain, service.service, data, blocking))
 
-        await asyncio.wait(tasks, loop=hass.loop)
+        await asyncio.wait(tasks)
 
     hass.services.async_register(
         ha.DOMAIN, SERVICE_TURN_OFF, async_handle_turn_service)

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -79,7 +79,7 @@ class HKDevice():
 
         # There are multiple entities sharing a single connection - only
         # allow one entity to use pairing at once.
-        self.pairing_lock = asyncio.Lock(loop=hass.loop)
+        self.pairing_lock = asyncio.Lock()
 
     async def async_setup(self):
         """Prepare to use a paired HomeKit device in homeassistant."""

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -180,7 +180,7 @@ class HomematicipHAP:
 
             try:
                 self._retry_task = self.hass.async_create_task(asyncio.sleep(
-                    retry_delay, loop=self.hass.loop))
+                    retry_delay))
                 await self._retry_task
             except asyncio.CancelledError:
                 break

--- a/homeassistant/components/hook/switch.py
+++ b/homeassistant/components/hook/switch.py
@@ -36,7 +36,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     # If password is set in config, prefer it over token
     if username is not None and password is not None:
         try:
-            with async_timeout.timeout(TIMEOUT, loop=hass.loop):
+            with async_timeout.timeout(TIMEOUT):
                 response = await websession.post(
                     '{}{}'.format(HOOK_ENDPOINT, 'user/login'),
                     data={
@@ -56,7 +56,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             return False
 
     try:
-        with async_timeout.timeout(TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(TIMEOUT):
             response = await websession.get(
                 '{}{}'.format(HOOK_ENDPOINT, 'device'),
                 params={"token": token})
@@ -103,7 +103,7 @@ class HookSmartHome(SwitchDevice):
         try:
             _LOGGER.debug("Sending: %s", url)
             websession = async_get_clientsession(self.hass)
-            with async_timeout.timeout(TIMEOUT, loop=self.hass.loop):
+            with async_timeout.timeout(TIMEOUT):
                 response = await websession.get(
                     url, params={"token": self._token})
             data = await response.json(content_type=None)

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -77,7 +77,7 @@ async def async_setup(hass, config):
                 entity.async_update_ha_state(True))
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SCAN, async_scan_service,

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -82,7 +82,7 @@ async def async_get_station(hass, latitude, longitude):
     from pyipma import Station
 
     websession = async_get_clientsession(hass)
-    with async_timeout.timeout(10, loop=hass.loop):
+    with async_timeout.timeout(10):
         station = await Station.get(websession, float(latitude),
                                     float(longitude))
 
@@ -106,7 +106,7 @@ class IPMAWeather(WeatherEntity):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Update Condition and Forecast."""
-        with async_timeout.timeout(10, loop=self.hass.loop):
+        with async_timeout.timeout(10):
             _new_condition = await self._station.observation()
             if _new_condition is None:
                 _LOGGER.warning("Could not update weather conditions")

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -231,7 +231,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                 update_tasks.append(update_coro)
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     if hass.services.has_service(DOMAIN, SERVICE_ADD_MEDIA):
         return

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -202,7 +202,7 @@ class LIFXManager:
         self.entities = {}
         self.hass = hass
         self.async_add_entities = async_add_entities
-        self.effects_conductor = aiolifx_effects().Conductor(loop=hass.loop)
+        self.effects_conductor = aiolifx_effects().Conductor()
         self.discoveries = []
         self.cleanup_unsub = self.hass.bus.async_listen(
             EVENT_HOMEASSISTANT_STOP,
@@ -253,7 +253,7 @@ class LIFXManager:
                     task = light.set_state(**service.data)
                 tasks.append(self.hass.async_create_task(task))
             if tasks:
-                await asyncio.wait(tasks, loop=self.hass.loop)
+                await asyncio.wait(tasks)
 
         self.hass.services.async_register(
             DOMAIN, SERVICE_LIFX_SET_STATE, service_handler,

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -202,7 +202,7 @@ class LIFXManager:
         self.entities = {}
         self.hass = hass
         self.async_add_entities = async_add_entities
-        self.effects_conductor = aiolifx_effects().Conductor()
+        self.effects_conductor = aiolifx_effects().Conductor(hass.loop)
         self.discoveries = []
         self.cleanup_unsub = self.hass.bus.async_listen(
             EVENT_HOMEASSISTANT_STOP,

--- a/homeassistant/components/lifx_cloud/scene.py
+++ b/homeassistant/components/lifx_cloud/scene.py
@@ -38,7 +38,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     try:
         httpsession = async_get_clientsession(hass)
-        with async_timeout.timeout(timeout, loop=hass.loop):
+        with async_timeout.timeout(timeout):
             scenes_resp = await httpsession.get(url, headers=headers)
 
     except (asyncio.TimeoutError, aiohttp.ClientError):
@@ -83,7 +83,7 @@ class LifxCloudScene(Scene):
 
         try:
             httpsession = async_get_clientsession(self.hass)
-            with async_timeout.timeout(self._timeout, loop=self.hass.loop):
+            with async_timeout.timeout(self._timeout):
                 await httpsession.put(url, headers=self._headers)
 
         except (asyncio.TimeoutError, aiohttp.ClientError):

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -303,7 +303,7 @@ async def async_setup(hass, config):
                 light.async_update_ha_state(True))
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     # Listen for light on and light off service calls.
     hass.services.async_register(

--- a/homeassistant/components/logi_circle/__init__.py
+++ b/homeassistant/components/logi_circle/__init__.py
@@ -118,7 +118,7 @@ async def async_setup_entry(hass, entry):
         return False
 
     try:
-        with async_timeout.timeout(_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(_TIMEOUT):
             # Ensure the cameras property returns the same Camera objects for
             # all devices. Performs implicit login and session validation.
             await logi_circle.synchronize_cameras()

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -160,7 +160,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
             cache_file=DEFAULT_CACHEDB)
 
         try:
-            with async_timeout.timeout(_TIMEOUT, loop=self.hass.loop):
+            with async_timeout.timeout(_TIMEOUT):
                 await logi_session.authorize(code)
         except AuthorizationFailed:
             (self.hass.data[DATA_FLOW_IMPL][DOMAIN]

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -241,7 +241,6 @@ class MailboxMediaView(MailboxView):
         """Retrieve media."""
         mailbox = self.get_mailbox(platform)
 
-        hass = request.app['hass']
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
             with async_timeout.timeout(10):
                 try:

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -82,7 +82,7 @@ async def async_setup(hass, config):
                    in config_per_platform(config, DOMAIN)]
 
     if setup_tasks:
-        await asyncio.wait(setup_tasks, loop=hass.loop)
+        await asyncio.wait(setup_tasks)
 
     async def async_platform_discovered(platform, info):
         """Handle for discovered platform."""
@@ -243,7 +243,7 @@ class MailboxMediaView(MailboxView):
 
         hass = request.app['hass']
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
-            with async_timeout.timeout(10, loop=hass.loop):
+            with async_timeout.timeout(10):
                 try:
                     stream = await mailbox.async_get_media(msgid)
                 except StreamError as err:

--- a/homeassistant/components/marytts/tts.py
+++ b/homeassistant/components/marytts/tts.py
@@ -75,7 +75,7 @@ class MaryTTSProvider(Provider):
         actual_language = re.sub('-', '_', language)
 
         try:
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 url = 'http://{}:{}/process?'.format(self._host, self._port)
 
                 audio = self._codec.upper()

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -777,7 +777,7 @@ async def _async_fetch_image(hass, url):
         url = hass.config.api.base_url + url
 
     if url not in cache_images:
-        cache_images[url] = {CACHE_LOCK: asyncio.Lock(loop=hass.loop)}
+        cache_images[url] = {CACHE_LOCK: asyncio.Lock()}
 
     async with cache_images[url][CACHE_LOCK]:
         if CACHE_CONTENT in cache_images[url]:
@@ -786,7 +786,7 @@ async def _async_fetch_image(hass, url):
         content, content_type = (None, None)
         websession = async_get_clientsession(hass)
         try:
-            with async_timeout.timeout(10, loop=hass.loop):
+            with async_timeout.timeout(10):
                 response = await websession.get(url)
 
                 if response.status == 200:

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -277,7 +277,7 @@ class MicrosoftFace:
             tasks.append(self._entities[g_id].async_update_ha_state())
 
         if tasks:
-            await asyncio.wait(tasks, loop=self.hass.loop)
+            await asyncio.wait(tasks)
 
     async def call_api(self, method, function, data=None, binary=False,
                        params=None):
@@ -297,7 +297,7 @@ class MicrosoftFace:
                 payload = None
 
         try:
-            with async_timeout.timeout(self.timeout, loop=self.hass.loop):
+            with async_timeout.timeout(self.timeout):
                 response = await getattr(self.websession, method)(
                     url, data=payload, headers=headers, params=params)
 

--- a/homeassistant/components/mjpeg/camera.py
+++ b/homeassistant/components/mjpeg/camera.py
@@ -112,7 +112,7 @@ class MjpegCamera(Camera):
             verify_ssl=self._verify_ssl
         )
         try:
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 response = await websession.get(
                     self._still_image_url, auth=self._auth)
 

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -115,7 +115,7 @@ class MobileAppNotificationService(BaseNotificationService):
             data['registration_info'] = reg_info
 
             try:
-                with async_timeout.timeout(10, loop=self.hass.loop):
+                with async_timeout.timeout(10):
                     response = await self._session.post(push_url, json=data)
                     result = await response.json()
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -651,7 +651,7 @@ class MQTT:
         self.birth_message = birth_message
         self.connected = False
         self._mqttc = None  # type: mqtt.Client
-        self._paho_lock = asyncio.Lock(loop=hass.loop)
+        self._paho_lock = asyncio.Lock()
 
         if protocol == PROTOCOL_31:
             proto = mqtt.MQTTv31  # type: int

--- a/homeassistant/components/mysensors/gateway.py
+++ b/homeassistant/components/mysensors/gateway.py
@@ -124,7 +124,7 @@ async def _get_gateway(hass, config, gateway_conf, persistence_file):
                 await hass.async_add_job(is_socket_address, device)
                 # valid ip address
                 gateway = mysensors.AsyncTCPGateway(
-                    device, port=tcp_port, event_callback=None, loop=hass.loop,
+                    device, port=tcp_port, loop=hass.loop, event_callback=None,
                     persistence=persistence, persistence_file=persistence_file,
                     protocol_version=version)
             except vol.Invalid:

--- a/homeassistant/components/mysensors/gateway.py
+++ b/homeassistant/components/mysensors/gateway.py
@@ -124,7 +124,7 @@ async def _get_gateway(hass, config, gateway_conf, persistence_file):
                 await hass.async_add_job(is_socket_address, device)
                 # valid ip address
                 gateway = mysensors.AsyncTCPGateway(
-                    device, port=tcp_port, loop=hass.loop, event_callback=None,
+                    device, port=tcp_port, event_callback=None, loop=hass.loop,
                     persistence=persistence, persistence_file=persistence_file,
                     protocol_version=version)
             except vol.Invalid:
@@ -151,9 +151,9 @@ async def finish_setup(hass, hass_config, gateways):
         start_tasks.append(_gw_start(hass, gateway))
     if discover_tasks:
         # Make sure all devices and platforms are loaded before gateway start.
-        await asyncio.wait(discover_tasks, loop=hass.loop)
+        await asyncio.wait(discover_tasks)
     if start_tasks:
-        await asyncio.wait(start_tasks, loop=hass.loop)
+        await asyncio.wait(start_tasks)
 
 
 async def _discover_persistent_devices(hass, hass_config, gateway):
@@ -172,7 +172,7 @@ async def _discover_persistent_devices(hass, hass_config, gateway):
         tasks.append(discover_mysensors_platform(
             hass, hass_config, platform, dev_ids))
     if tasks:
-        await asyncio.wait(tasks, loop=hass.loop)
+        await asyncio.wait(tasks)
 
 
 async def _gw_start(hass, gateway):
@@ -196,7 +196,7 @@ async def _gw_start(hass, gateway):
     hass.data[gateway_ready_key] = gateway_ready
 
     try:
-        with async_timeout.timeout(GATEWAY_READY_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(GATEWAY_READY_TIMEOUT):
             await gateway_ready
     except asyncio.TimeoutError:
         _LOGGER.warning(

--- a/homeassistant/components/no_ip/__init__.py
+++ b/homeassistant/components/no_ip/__init__.py
@@ -89,7 +89,7 @@ async def _update_no_ip(hass, session, domain, auth_str, timeout):
     }
 
     try:
-        with async_timeout.timeout(timeout, loop=hass.loop):
+        with async_timeout.timeout(timeout):
             resp = await session.get(url, params=params, headers=headers)
             body = await resp.text()
 

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -139,7 +139,7 @@ async def async_setup(hass, config):
                    in config_per_platform(config, DOMAIN)]
 
     if setup_tasks:
-        await asyncio.wait(setup_tasks, loop=hass.loop)
+        await asyncio.wait(setup_tasks)
 
     async def async_platform_discovered(platform, info):
         """Handle for discovered platform."""

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -308,7 +308,7 @@ class ONVIFHassCamera(Camera):
 
         image = await asyncio.shield(ffmpeg.get_image(
             self._input, output_format=IMAGE_JPEG,
-            extra_cmd=self._ffmpeg_arguments), loop=self.hass.loop)
+            extra_cmd=self._ffmpeg_arguments))
         return image
 
     async def handle_async_mjpeg_stream(self, request):

--- a/homeassistant/components/openalpr_cloud/image_processing.py
+++ b/homeassistant/components/openalpr_cloud/image_processing.py
@@ -108,7 +108,7 @@ class OpenAlprCloudEntity(ImageProcessingAlprEntity):
         }
 
         try:
-            with async_timeout.timeout(self.timeout, loop=self.hass.loop):
+            with async_timeout.timeout(self.timeout):
                 request = await websession.post(
                     OPENALPR_API_URL, params=params, data=body
                 )

--- a/homeassistant/components/prowl/notify.py
+++ b/homeassistant/components/prowl/notify.py
@@ -52,7 +52,7 @@ class ProwlNotificationService(BaseNotificationService):
         session = async_get_clientsession(self._hass)
 
         try:
-            with async_timeout.timeout(10, loop=self._hass.loop):
+            with async_timeout.timeout(10):
                 response = await session.post(url, data=payload)
                 result = await response.text()
 

--- a/homeassistant/components/push/camera.py
+++ b/homeassistant/components/push/camera.py
@@ -60,7 +60,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 async def handle_webhook(hass, webhook_id, request):
     """Handle incoming webhook POST with image files."""
     try:
-        with async_timeout.timeout(5, loop=hass.loop):
+        with async_timeout.timeout(5):
             data = dict(await request.post())
     except (asyncio.TimeoutError, aiohttp.web.HTTPException) as error:
         _LOGGER.error("Could not get information from POST <%s>", error)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -141,7 +141,7 @@ class Recorder(threading.Thread):
         self.queue = queue.Queue()  # type: Any
         self.recording_start = dt_util.utcnow()
         self.db_url = uri
-        self.async_db_ready = asyncio.Future(loop=hass.loop)
+        self.async_db_ready = asyncio.Future()
         self.engine = None  # type: Any
         self.run_info = None  # type: Any
 

--- a/homeassistant/components/recswitch/switch.py
+++ b/homeassistant/components/recswitch/switch.py
@@ -33,7 +33,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     if not hass.data.get(DATA_RSN):
         hass.data[DATA_RSN] = RSNetwork()
-        job = hass.data[DATA_RSN].create_datagram_endpoint(loop=hass.loop)
+        job = hass.data[DATA_RSN].create_datagram_endpoint()
         hass.async_create_task(job)
 
     device = hass.data[DATA_RSN].register_device(mac_address, host)

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -149,7 +149,7 @@ class RestSwitch(SwitchDevice):
         """Send a state update to the device."""
         websession = async_get_clientsession(self.hass, self._verify_ssl)
 
-        with async_timeout.timeout(self._timeout, loop=self.hass.loop):
+        with async_timeout.timeout(self._timeout):
             req = await getattr(websession, self._method)(
                 self._resource, auth=self._auth, data=bytes(body, 'utf-8'),
                 headers=self._headers)
@@ -168,7 +168,7 @@ class RestSwitch(SwitchDevice):
         """Get the latest data from REST API and update the state."""
         websession = async_get_clientsession(hass, self._verify_ssl)
 
-        with async_timeout.timeout(self._timeout, loop=hass.loop):
+        with async_timeout.timeout(self._timeout):
             req = await websession.get(self._resource, auth=self._auth,
                                        headers=self._headers)
             text = await req.text()

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -92,7 +92,7 @@ async def async_setup(hass, config):
                     'utf-8')
 
             try:
-                with async_timeout.timeout(timeout, loop=hass.loop):
+                with async_timeout.timeout(timeout):
                     request = await getattr(websession, method)(
                         template_url.async_render(variables=service.data),
                         data=payload,

--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -116,7 +116,7 @@ class RingCam(Camera):
 
         image = await asyncio.shield(ffmpeg.get_image(
             self._video_url, output_format=IMAGE_JPEG,
-            extra_cmd=self._ffmpeg_arguments), loop=self.hass.loop)
+            extra_cmd=self._ffmpeg_arguments))
         return image
 
     async def handle_async_mjpeg_stream(self, request):

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -70,7 +70,7 @@ async def async_setup(hass, config):
 
         tasks = [scene.async_activate() for scene in target_scenes]
         if tasks:
-            await asyncio.wait(tasks, loop=hass.loop)
+            await asyncio.wait(tasks)
 
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_ON, async_handle_scene_service,

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -82,7 +82,7 @@ async def async_setup(hass, config):
         await asyncio.wait([
             script.async_turn_off() for script
             in await component.async_extract_from_service(service)
-        ], loop=hass.loop)
+        ])
 
     async def toggle_service(service):
         """Toggle a script."""

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -101,7 +101,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                 update_tasks.append(climate.async_update_ha_state(True))
 
             if update_tasks:
-                await asyncio.wait(update_tasks, loop=hass.loop)
+                await asyncio.wait(update_tasks)
         hass.services.async_register(
             DOMAIN, SERVICE_ASSUME_STATE, async_assume_state,
             schema=ASSUME_STATE_SCHEMA)

--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -141,7 +141,7 @@ async def async_setup_platform(
             if task:
                 tasks.append(task)
         if tasks:
-            await asyncio.wait(tasks, loop=hass.loop)
+            await asyncio.wait(tasks)
 
     interval = config.get(CONF_SCAN_INTERVAL) or timedelta(seconds=5)
     async_track_time_interval(hass, async_sma, interval)

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -107,7 +107,7 @@ class SmhiWeather(WeatherEntity):
                     RETRY_TIMEOUT, self.retry_update())
 
         try:
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 self._forecasts = await self.get_weather_forecast()
                 self._fail_count = 0
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -63,7 +63,7 @@ class SonosData:
     def __init__(self, hass):
         """Initialize the data."""
         self.entities = []
-        self.topology_condition = asyncio.Condition(loop=hass.loop)
+        self.topology_condition = asyncio.Condition()
 
 
 async def async_setup_platform(hass,

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -128,7 +128,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             update_tasks.append(player.async_update_ha_state(True))
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     for service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[service]['schema']
@@ -179,7 +179,7 @@ class LogitechMediaServer:
 
         try:
             websession = async_get_clientsession(self.hass)
-            with async_timeout.timeout(TIMEOUT, loop=self.hass.loop):
+            with async_timeout.timeout(TIMEOUT):
                 response = await websession.post(
                     url,
                     data=data,

--- a/homeassistant/components/startca/sensor.py
+++ b/homeassistant/components/startca/sensor.py
@@ -138,7 +138,7 @@ class StartcaData:
         _LOGGER.debug("Updating Start.ca usage data")
         url = 'https://www.start.ca/support/usage/api?key=' + \
               self.api_key
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=self.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             req = await self.websession.get(url)
         if req.status != 200:
             _LOGGER.error("Request failed with status: %u", req.status)

--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -62,8 +62,7 @@ async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
         EVENT_HOMEASSISTANT_STOP, async_stop_bridge))
 
     try:
-        device_data = await wait_for(
-            v2bridge.queue.get(), timeout=10.0, loop=hass.loop)
+        device_data = await wait_for(v2bridge.queue.get(), timeout=10.0)
     except (Asyncio_TimeoutError, RuntimeError):
         _LOGGER.exception("failed to get response from device")
         await v2bridge.stop()

--- a/homeassistant/components/tado/device_tracker.py
+++ b/homeassistant/components/tado/device_tracker.py
@@ -61,7 +61,7 @@ class TadoDeviceScanner(DeviceScanner):
         self.tadoapiurl += '?username={username}&password={password}'
 
         self.websession = async_create_clientsession(
-            hass, cookie_jar=aiohttp.CookieJar(unsafe=True, loop=hass.loop))
+            hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
 
         self.success_init = asyncio.run_coroutine_threadsafe(
             self._async_update_info(), hass.loop

--- a/homeassistant/components/teksavvy/sensor.py
+++ b/homeassistant/components/teksavvy/sensor.py
@@ -132,7 +132,7 @@ class TekSavvyData:
         _LOGGER.debug("Updating TekSavvy data")
         url = "https://api.teksavvy.com/"\
               "web/Usage/UsageSummaryRecords?$filter=IsCurrent%20eq%20true"
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=self.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             req = await self.websession.get(url, headers=headers)
         if req.status != 200:
             _LOGGER.error("Request failed with status: %u", req.status)

--- a/homeassistant/components/thethingsnetwork/sensor.py
+++ b/homeassistant/components/thethingsnetwork/sensor.py
@@ -124,7 +124,7 @@ class TtnDataStorage:
         """Get the current state from The Things Network Data Storage."""
         try:
             session = async_get_clientsession(self._hass)
-            with async_timeout.timeout(DEFAULT_TIMEOUT, loop=self._hass.loop):
+            with async_timeout.timeout(DEFAULT_TIMEOUT):
                 response = await session.get(self._url, headers=self._headers)
 
         except (asyncio.TimeoutError, aiohttp.ClientError):

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -143,7 +143,7 @@ async def authenticate(hass, host, security_code):
 
     identity = uuid4().hex
 
-    api_factory = APIFactory(host, psk_id=identity, loop=hass.loop)
+    api_factory = APIFactory(host, psk_id=identity)
 
     try:
         with async_timeout.timeout(5):

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -165,7 +165,7 @@ async def async_setup(hass, config):
                    in config_per_platform(config, DOMAIN)]
 
     if setup_tasks:
-        await asyncio.wait(setup_tasks, loop=hass.loop)
+        await asyncio.wait(setup_tasks)
 
     async def async_clear_cache_handle(service):
         """Handle clear cache service call."""

--- a/homeassistant/components/upc_connect/device_tracker.py
+++ b/homeassistant/components/upc_connect/device_tracker.py
@@ -81,7 +81,7 @@ class UPCDeviceScanner(DeviceScanner):
         """Get first token."""
         try:
             # get first token
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 response = await self.websession.get(
                     "http://{}/common_page/login.html".format(self.host),
                     headers=self.headers)
@@ -99,7 +99,7 @@ class UPCDeviceScanner(DeviceScanner):
     async def _async_ws_function(self, function):
         """Execute a command on UPC firmware webservice."""
         try:
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 # The 'token' parameter has to be first, and 'fun' second
                 # or the UPC firmware will return an error
                 response = await self.websession.post(

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -136,7 +136,7 @@ async def get_newest_version(hass, huuid, include_components):
 
     session = async_get_clientsession(hass)
     try:
-        with async_timeout.timeout(5, loop=hass.loop):
+        with async_timeout.timeout(5):
             req = await session.post(UPDATER_URL, json=info_object)
         _LOGGER.info(("Submitted analytics to Home Assistant servers. "
                       "Information submitted includes %s"), info_object)

--- a/homeassistant/components/viaggiatreno/sensor.py
+++ b/homeassistant/components/viaggiatreno/sensor.py
@@ -67,7 +67,7 @@ async def async_http_request(hass, uri):
     """Perform actual request."""
     try:
         session = hass.helpers.aiohttp_client.async_get_clientsession(hass)
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             req = await session.get(uri)
         if req.status != 200:
             return {'error': req.status}

--- a/homeassistant/components/voicerss/tts.py
+++ b/homeassistant/components/voicerss/tts.py
@@ -116,7 +116,7 @@ class VoiceRSSProvider(Provider):
         form_data['hl'] = language
 
         try:
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 request = await websession.post(
                     VOICERSS_API_URL, data=form_data
                 )

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -40,7 +40,7 @@ class WebSocketHandler:
         self.hass = hass
         self.request = request
         self.wsock = None
-        self._to_write = asyncio.Queue(maxsize=MAX_PENDING_MSG, loop=hass.loop)
+        self._to_write = asyncio.Queue(maxsize=MAX_PENDING_MSG)
         self._handle_task = None
         self._writer_task = None
         self._logger = logging.getLogger(
@@ -101,7 +101,7 @@ class WebSocketHandler:
             # pylint: disable=no-member
             self._handle_task = asyncio.current_task()
         else:
-            self._handle_task = asyncio.Task.current_task(loop=self.hass.loop)
+            self._handle_task = asyncio.Task.current_task()
 
         @callback
         def handle_hass_stop(event):

--- a/homeassistant/components/worxlandroid/sensor.py
+++ b/homeassistant/components/worxlandroid/sensor.py
@@ -88,7 +88,7 @@ class WorxLandroidSensor(Entity):
 
         try:
             session = async_get_clientsession(self.hass)
-            with async_timeout.timeout(self.timeout, loop=self.hass.loop):
+            with async_timeout.timeout(self.timeout):
                 auth = aiohttp.helpers.BasicAuth('admin', self.pin)
                 mower_response = await session.get(self.url, auth=auth)
         except (asyncio.TimeoutError, aiohttp.ClientError):

--- a/homeassistant/components/wunderground/sensor.py
+++ b/homeassistant/components/wunderground/sensor.py
@@ -807,7 +807,7 @@ class WUndergroundData:
     async def async_update(self):
         """Get the latest data from WUnderground."""
         try:
-            with async_timeout.timeout(10, loop=self._hass.loop):
+            with async_timeout.timeout(10):
                 response = await self._session.get(self._build_url())
             result = await response.json()
             if "error" in result['response']:

--- a/homeassistant/components/xiaomi/camera.py
+++ b/homeassistant/components/xiaomi/camera.py
@@ -140,7 +140,7 @@ class XiaomiCamera(Camera):
             ffmpeg = ImageFrame(self._manager.binary, loop=self.hass.loop)
             self._last_image = await asyncio.shield(ffmpeg.get_image(
                 url, output_format=IMAGE_JPEG,
-                extra_cmd=self._extra_arguments), loop=self.hass.loop)
+                extra_cmd=self._extra_arguments))
             self._last_url = url
 
         return self._last_image

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -467,7 +467,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             update_tasks.append(device.async_update_ha_state(True))
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     for air_purifier_service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[air_purifier_service].get(

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -203,7 +203,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             update_tasks.append(target_device.async_update_ha_state(True))
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     for xiaomi_miio_service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[xiaomi_miio_service].get(

--- a/homeassistant/components/xiaomi_miio/remote.py
+++ b/homeassistant/components/xiaomi_miio/remote.py
@@ -142,7 +142,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                     message['error']['message'] == "learn timeout"):
                 await hass.async_add_executor_job(device.learn, slot)
 
-            await asyncio.sleep(1, loop=hass.loop)
+            await asyncio.sleep(1)
 
         _LOGGER.error("Timeout. No infrared command captured")
         hass.components.persistent_notification.async_create(

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -185,7 +185,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             update_tasks.append(device.async_update_ha_state(True))
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     for plug_service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[plug_service].get('schema', SERVICE_SCHEMA)

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -165,7 +165,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             update_tasks.append(update_coro)
 
         if update_tasks:
-            await asyncio.wait(update_tasks, loop=hass.loop)
+            await asyncio.wait(update_tasks)
 
     for vacuum_service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[vacuum_service].get(

--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -111,7 +111,7 @@ class YandexSpeechKitProvider(Provider):
         options = options or {}
 
         try:
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 url_param = {
                     'text': message,
                     'lang': actual_language,

--- a/homeassistant/components/yi/camera.py
+++ b/homeassistant/components/yi/camera.py
@@ -77,7 +77,7 @@ class YiCamera(Camera):
         """Retrieve the latest video file from the customized Yi FTP server."""
         from aioftp import Client, StatusCodeError
 
-        ftp = Client(loop=self.hass.loop)
+        ftp = Client()
         try:
             await ftp.connect(self.host)
             await ftp.login(self.user, self.passwd)

--- a/homeassistant/components/yr/sensor.py
+++ b/homeassistant/components/yr/sensor.py
@@ -160,7 +160,7 @@ class YrData:
             async_call_later(self.hass, minutes*60, self.fetching_data)
         try:
             websession = async_get_clientsession(self.hass)
-            with async_timeout.timeout(10, loop=self.hass.loop):
+            with async_timeout.timeout(10):
                 resp = await websession.get(
                     self._url, params=self._urlparams)
             if resp.status != 200:
@@ -247,4 +247,4 @@ class YrData:
                     tasks.append(dev.async_update_ha_state())
 
         if tasks:
-            await asyncio.wait(tasks, loop=self.hass.loop)
+            await asyncio.wait(tasks)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -715,7 +715,7 @@ async def async_setup_entry(hass, config_entry):
                         network.state_str)
                     break
                 else:
-                    await asyncio.sleep(1, loop=hass.loop)
+                    await asyncio.sleep(1)
 
             hass.async_add_job(_finalize_start)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -346,7 +346,7 @@ class HomeAssistant:
     def block_till_done(self) -> None:
         """Block till all pending work is done."""
         run_coroutine_threadsafe(
-            self.async_block_till_done()).result()
+            self.async_block_till_done(), self.loop).result()
 
     async def async_block_till_done(self) -> None:
         """Block till all pending work is done."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -346,7 +346,7 @@ class HomeAssistant:
     def block_till_done(self) -> None:
         """Block till all pending work is done."""
         run_coroutine_threadsafe(
-            self.async_block_till_done(), loop=self.loop).result()
+            self.async_block_till_done()).result()
 
     async def async_block_till_done(self) -> None:
         """Block till all pending work is done."""

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -80,7 +80,7 @@ async def async_aiohttp_proxy_web(
         timeout: int = 10) -> Optional[web.StreamResponse]:
     """Stream websession request to aiohttp web response."""
     try:
-        with async_timeout.timeout(timeout, loop=hass.loop):
+        with async_timeout.timeout(timeout):
             req = await web_coro
 
     except asyncio.CancelledError:
@@ -120,7 +120,7 @@ async def async_aiohttp_proxy_stream(hass: HomeAssistantType,
 
     try:
         while True:
-            with async_timeout.timeout(timeout, loop=hass.loop):
+            with async_timeout.timeout(timeout):
                 data = await stream.read(buffer_size)
 
             if not data:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -109,7 +109,7 @@ class EntityComponent:
             tasks.append(self._async_setup_platform(p_type, p_config))
 
         if tasks:
-            await asyncio.wait(tasks, loop=self.hass.loop)
+            await asyncio.wait(tasks)
 
         # Generic discovery listener for loading platform dynamically
         # Refer to: homeassistant.components.discovery.load_platform()
@@ -250,7 +250,7 @@ class EntityComponent:
                  in self._platforms.values()]
 
         if tasks:
-            await asyncio.wait(tasks, loop=self.hass.loop)
+            await asyncio.wait(tasks)
 
         self._platforms = {
             self.domain: self._platforms[self.domain]

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -45,7 +45,7 @@ class EntityPlatform:
         self._async_unsub_polling = None
         # Method to cancel the retry of setup
         self._async_cancel_retry_setup = None
-        self._process_updates = asyncio.Lock(loop=hass.loop)
+        self._process_updates = asyncio.Lock()
 
         # Platform is None for the EntityComponent "catch-all" EntityPlatform
         # which powers entity_component.add_entities
@@ -122,8 +122,8 @@ class EntityPlatform:
             task = async_create_setup_task()
 
             await asyncio.wait_for(
-                asyncio.shield(task, loop=hass.loop),
-                SLOW_SETUP_MAX_WAIT, loop=hass.loop)
+                asyncio.shield(task),
+                SLOW_SETUP_MAX_WAIT)
 
             # Block till all entities are done
             if self._tasks:
@@ -132,7 +132,7 @@ class EntityPlatform:
 
                 if pending:
                     await asyncio.wait(
-                        pending, loop=self.hass.loop)
+                        pending)
 
             hass.config.components.add(full_name)
             return True
@@ -218,7 +218,7 @@ class EntityPlatform:
         if not tasks:
             return
 
-        await asyncio.wait(tasks, loop=self.hass.loop)
+        await asyncio.wait(tasks)
         self.async_entities_added_callback()
 
         if self._async_unsub_polling is not None or \
@@ -379,7 +379,7 @@ class EntityPlatform:
         tasks = [self.async_remove_entity(entity_id)
                  for entity_id in self.entities]
 
-        await asyncio.wait(tasks, loop=self.hass.loop)
+        await asyncio.wait(tasks)
 
         if self._async_unsub_polling is not None:
             self._async_unsub_polling()
@@ -419,4 +419,4 @@ class EntityPlatform:
                 tasks.append(entity.async_update_ha_state(True))
 
             if tasks:
-                await asyncio.wait(tasks, loop=self.hass.loop)
+                await asyncio.wait(tasks)

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -209,7 +209,7 @@ async def async_reproduce_state_legacy(
         )
 
     if domain_tasks:
-        await asyncio.wait(domain_tasks, loop=hass.loop)
+        await asyncio.wait(domain_tasks)
 
 
 def state_as_number(state: State) -> float:

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -57,7 +57,7 @@ class Store:
         self._data = None
         self._unsub_delay_listener = None
         self._unsub_stop_listener = None
-        self._write_lock = asyncio.Lock(loop=hass.loop)
+        self._write_lock = asyncio.Lock()
         self._load_task = None
         self._encoder = encoder
 

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -26,7 +26,7 @@ async def async_process_requirements(hass: HomeAssistant, name: str,
     """
     pip_lock = hass.data.get(DATA_PIP_LOCK)
     if pip_lock is None:
-        pip_lock = hass.data[DATA_PIP_LOCK] = asyncio.Lock(loop=hass.loop)
+        pip_lock = hass.data[DATA_PIP_LOCK] = asyncio.Lock()
 
     pkg_cache = hass.data.get(DATA_PKG_CACHE)
     if pkg_cache is None:

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -54,7 +54,7 @@ async def async_million_events(hass):
     """Run a million events."""
     count = 0
     event_name = 'benchmark_event'
-    event = asyncio.Event(loop=hass.loop)
+    event = asyncio.Event()
 
     @core.callback
     def listener(_):
@@ -81,7 +81,7 @@ async def async_million_events(hass):
 async def async_million_time_changed_helper(hass):
     """Run a million events through time changed helper."""
     count = 0
-    event = asyncio.Event(loop=hass.loop)
+    event = asyncio.Event()
 
     @core.callback
     def listener(_):
@@ -112,7 +112,7 @@ async def async_million_state_changed_helper(hass):
     """Run a million events through state changed helper."""
     count = 0
     entity_id = 'light.kitchen'
-    event = asyncio.Event(loop=hass.loop)
+    event = asyncio.Event()
 
     @core.callback
     def listener(*args):

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -27,7 +27,7 @@ def setup_component(hass: core.HomeAssistant, domain: str,
                     config: Dict) -> bool:
     """Set up a component and all its dependencies."""
     return run_coroutine_threadsafe(  # type: ignore
-        async_setup_component(hass, domain, config), loop=hass.loop).result()
+        async_setup_component(hass, domain, config), hass.loop).result()
 
 
 async def async_setup_component(hass: core.HomeAssistant, domain: str,
@@ -69,7 +69,7 @@ async def _async_process_dependencies(
     if not tasks:
         return True
 
-    results = await asyncio.gather(*tasks, loop=hass.loop)
+    results = await asyncio.gather(*tasks)
 
     failed = [dependencies[idx] for idx, res
               in enumerate(results) if not res]

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -64,7 +64,7 @@ class AsyncHandler:
 
         if blocking:
             while self._thread.is_alive():
-                await asyncio.sleep(0, loop=self.loop)
+                await asyncio.sleep(0)
 
     def emit(self, record: Optional[logging.LogRecord]) -> None:
         """Process a record."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -102,7 +102,7 @@ def get_test_home_assistant():
 
     def start_hass(*mocks):
         """Start hass."""
-        run_coroutine_threadsafe(hass.async_start(), loop=hass.loop).result()
+        run_coroutine_threadsafe(hass.async_start()).result()
 
     def stop_hass():
         """Stop hass."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -87,6 +87,7 @@ def get_test_home_assistant():
     else:
         loop = asyncio.new_event_loop()
 
+    asyncio.set_event_loop(loop)
     hass = loop.run_until_complete(async_test_home_assistant(loop))
 
     stop_event = threading.Event()

--- a/tests/common.py
+++ b/tests/common.py
@@ -102,7 +102,7 @@ def get_test_home_assistant():
 
     def start_hass(*mocks):
         """Start hass."""
-        run_coroutine_threadsafe(hass.async_start()).result()
+        run_coroutine_threadsafe(hass.async_start(), loop).result()
 
     def stop_hass():
         """Stop hass."""

--- a/tests/components/automatic/test_device_tracker.py
+++ b/tests/components/automatic/test_device_tracker.py
@@ -99,7 +99,7 @@ def test_valid_credentials(
 
     @asyncio.coroutine
     def ws_connect():
-        return asyncio.Future(loop=hass.loop)
+        return asyncio.Future()
 
     mock_ws_connect.side_effect = ws_connect
 

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -78,7 +78,7 @@ def test_default_setup(hass, mock_connection_factory):
     telegram_callback(telegram)
 
     # after receiving telegram entities need to have the chance to update
-    yield from asyncio.sleep(0, loop=hass.loop)
+    yield from asyncio.sleep(0)
 
     # ensure entities have new state value after incoming telegram
     power_consumption = hass.states.get('sensor.power_consumption')
@@ -183,9 +183,9 @@ def test_reconnect(hass, monkeypatch, mock_connection_factory):
     }
 
     # mock waiting coroutine while connection lasts
-    closed = asyncio.Event(loop=hass.loop)
+    closed = asyncio.Event()
     # Handshake so that `hass.async_block_till_done()` doesn't cycle forever
-    closed2 = asyncio.Event(loop=hass.loop)
+    closed2 = asyncio.Event()
 
     @asyncio.coroutine
     def wait_closed():

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -158,7 +158,7 @@ async def test_subscribe_unsubscribe_events(hass, websocket_client):
     hass.bus.async_fire('test_event', {'hello': 'world'})
     hass.bus.async_fire('ignore_event')
 
-    with timeout(3, loop=hass.loop):
+    with timeout(3):
         msg = await websocket_client.receive_json()
 
     assert msg['id'] == 5
@@ -389,7 +389,7 @@ async def test_subscribe_unsubscribe_events_whitelist(
 
     hass.bus.async_fire('themes_updated')
 
-    with timeout(3, loop=hass.loop):
+    with timeout(3):
         msg = await websocket_client.receive_json()
 
     assert msg['id'] == 6

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -209,7 +209,7 @@ async def test_platform_error_slow_setup(hass, caplog):
 
         async def setup_platform(*args):
             called.append(1)
-            await asyncio.sleep(1, loop=hass.loop)
+            await asyncio.sleep(1)
 
         platform = MockPlatform(async_setup_platform=setup_platform)
         component = EntityComponent(_LOGGER, DOMAIN, hass)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -184,7 +184,7 @@ class TestHomeAssistant(unittest.TestCase):
             self.hass.add_job(test_coro())
 
         run_coroutine_threadsafe(
-            asyncio.wait(self.hass._pending_tasks, loop=self.hass.loop),
+            asyncio.wait(self.hass._pending_tasks),
             loop=self.hass.loop
         ).result()
 
@@ -206,8 +206,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            yield from asyncio.sleep(0, loop=self.hass.loop)
-            yield from asyncio.sleep(0, loop=self.hass.loop)
+            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
 
         run_coroutine_threadsafe(
             wait_finish_callback(), self.hass.loop).result()
@@ -227,8 +227,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            yield from asyncio.sleep(0, loop=self.hass.loop)
-            yield from asyncio.sleep(0, loop=self.hass.loop)
+            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
 
         for _ in range(2):
             self.hass.add_job(test_executor)
@@ -252,8 +252,8 @@ class TestHomeAssistant(unittest.TestCase):
         @asyncio.coroutine
         def wait_finish_callback():
             """Wait until all stuff is scheduled."""
-            yield from asyncio.sleep(0, loop=self.hass.loop)
-            yield from asyncio.sleep(0, loop=self.hass.loop)
+            yield from asyncio.sleep(0)
+            yield from asyncio.sleep(0)
 
         for _ in range(2):
             self.hass.add_job(test_callback)


### PR DESCRIPTION
## Description:
First pass removing passing loop around.

**Related issue (if applicable):** https://github.com/home-assistant/architecture/issues/238

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
