### PR TITLE
Add control of Amcrest indicator light

### DIFF
--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 import logging
 
+from amcrest import AmcrestError
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, DEVICE_CLASS_MOTION)
 from homeassistant.const import CONF_NAME, CONF_BINARY_SENSORS
@@ -58,8 +60,6 @@ class AmcrestBinarySensor(BinarySensorDevice):
 
     def update(self):
         """Update entity."""
-        from amcrest import AmcrestError
-
         _LOGGER.debug('Pulling data from %s binary sensor', self._name)
 
         try:


### PR DESCRIPTION
## Description:

Automatically control the camera's indicator light, turning it on if the audio or video streams are enabled, and turning it off if both streams are disabled.

Enable feature by default but allow it to be disabled by `control_light: false` in config.

Get brand from camera instead of assuming Amcrest (since this works with other cameras, too.)

Retrieve RTSP URL in update method instead of in `stream_source` property and in `handle_async_mjpeg_stream` method.

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9486

## Example entry for `configuration.yaml` (if applicable):
```yaml
amcrest:
  - host: IP_ADDRESS_CAMERA
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
    control_light: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
