### PR TITLE
Bump loopenergy library version - catches runtime exception.

### DIFF
--- a/homeassistant/components/loopenergy/manifest.json
+++ b/homeassistant/components/loopenergy/manifest.json
@@ -3,7 +3,7 @@
   "name": "Loopenergy",
   "documentation": "https://www.home-assistant.io/components/loopenergy",
   "requirements": [
-    "pyloopenergy==0.1.2"
+    "pyloopenergy==0.1.3"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1172,7 +1172,7 @@ pylinky==0.3.3
 pylitejet==0.1
 
 # homeassistant.components.loopenergy
-pyloopenergy==0.1.2
+pyloopenergy==0.1.3
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.5.0


### PR DESCRIPTION
## Description:
Bump loop energy library. Catches an exception that is thrown by the new socket library on some network disconnects. This used to stop the monitoring thread - catching this exception allows the component to reconnect.

**Related issue (if applicable):** 
Related to some of the discussion here, although this does not fix the hass related issue discussed.
https://github.com/home-assistant/home-assistant/issues/22412

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
