### PR TITLE
Add support for boost mode in Homematicip climate

### DIFF
--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -115,7 +115,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
             return
         await self._device.set_point_temperature(temperature)
 
-     async def async_set_operation_mode(self, operation_mode):
+    async def async_set_operation_mode(self, operation_mode):
         """Set operation mode."""
         _LOGGER.error("KAROL: %s", operation_mode)
         if operation_mode == STATE_BOOST:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -118,7 +118,6 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     async def async_set_operation_mode(self, operation_mode):
         """Set operation mode."""
-        _LOGGER.error("KAROL: %s", operation_mode)
         if operation_mode == STATE_BOOST:
             await self._device.set_boost()
         else:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -5,6 +5,7 @@ from homematicip.aio.device import (
     AsyncHeatingThermostat, AsyncHeatingThermostatCompact)
 from homematicip.aio.group import AsyncHeatingGroup
 from homematicip.aio.home import AsyncHome
+from homematicip.base.enums import ClimateControlMode
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
@@ -122,8 +123,10 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
             await self._device.set_boost()
         else:
             await self._device.set_boost(False)
-            await self._device.set_control_mode(HA_STATE_TO_HMIP[operation_mode])
+            await self._device.set_control_mode(
+                HA_STATE_TO_HMIP[operation_mode])
         self.schedule_update_ha_state()
+
 
 def _get_first_heating_thermostat(heating_group: AsyncHeatingGroup):
     """Return the first HeatingThermostat from a HeatingGroup."""

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -8,7 +8,8 @@ from homematicip.aio.home import AsyncHome
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    STATE_AUTO, STATE_MANUAL, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
+    STATE_AUTO, STATE_MANUAL, SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_OPERATION_MODE)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
@@ -113,7 +114,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         if temperature is None:
             return
         await self._device.set_point_temperature(temperature)
-        
+
      async def async_set_operation_mode(self, operation_mode):
         """Set operation mode."""
         _LOGGER.error("KAROL: %s", operation_mode)


### PR DESCRIPTION
## Description:
Homematic IP Cloud component misses support for boost mode that allows to quickly heaten up the room.
This PR presents an implementation for this function.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
