### PR TITLE
Add websocket API for updating core config

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,7 +83,7 @@ homeassistant/components/flock/* @fabaff
 homeassistant/components/flunearyou/* @bachya
 homeassistant/components/foursquare/* @robbiet480
 homeassistant/components/freebox/* @snoof85
-homeassistant/components/frontend/* @home-assistant/core
+homeassistant/components/frontend/* @home-assistant/frontend
 homeassistant/components/gearbest/* @HerrHofrat
 homeassistant/components/geniushub/* @zxdavb
 homeassistant/components/gitter/* @fabaff
@@ -138,7 +138,7 @@ homeassistant/components/linux_battery/* @fabaff
 homeassistant/components/liveboxplaytv/* @pschmitt
 homeassistant/components/logger/* @home-assistant/core
 homeassistant/components/logi_circle/* @evanjd
-homeassistant/components/lovelace/* @home-assistant/core
+homeassistant/components/lovelace/* @home-assistant/frontend
 homeassistant/components/luci/* @fbradyirl
 homeassistant/components/luftdaten/* @fabaff
 homeassistant/components/mastodon/* @fabaff
@@ -173,8 +173,8 @@ homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff
 homeassistant/components/orangepi_gpio/* @pascallj
 homeassistant/components/owlet/* @oblogic7
-homeassistant/components/panel_custom/* @home-assistant/core
-homeassistant/components/panel_iframe/* @home-assistant/core
+homeassistant/components/panel_custom/* @home-assistant/frontend
+homeassistant/components/panel_iframe/* @home-assistant/frontend
 homeassistant/components/persistent_notification/* @home-assistant/core
 homeassistant/components/philips_js/* @elupus
 homeassistant/components/pi_hole/* @fabaff

--- a/homeassistant/components/config/core.py
+++ b/homeassistant/components/config/core.py
@@ -1,12 +1,16 @@
 """Component to interact with Hassbian tools."""
 
+import voluptuous as vol
+
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config import async_check_ha_config_file
+from homeassistant.components import websocket_api
 
 
 async def async_setup(hass):
     """Set up the Hassbian config."""
     hass.http.register_view(CheckConfigView)
+    hass.components.websocket_api.async_register_command(websocket_core_update)
     return True
 
 
@@ -26,3 +30,23 @@ class CheckConfigView(HomeAssistantView):
             "result": state,
             "errors": errors,
         })
+
+
+@websocket_api.require_admin
+@websocket_api.async_response
+@websocket_api.websocket_command({
+    vol.Required('type'): 'config/core/update',
+    vol.Optional('latitude'): vol.Coerce(float),
+    vol.Optional('longitude'): vol.Coerce(float),
+    vol.Optional('elevation'): vol.Coerce(int),
+    vol.Optional('unit_system'): vol.Coerce(str),
+    vol.Optional('location_name'): vol.Coerce(str),
+    vol.Optional('time_zone'): vol.Coerce(str),
+})
+async def websocket_core_update(hass, connection, msg):
+    """Handle request for account info."""
+    data = dict(msg)
+    data.pop('id')
+    data.pop('type')
+    await hass.config.update(**data)
+    connection.send_result(msg['id'])

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -4,35 +4,96 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
+from homeassistant.components.websocket_api.const import TYPE_RESULT
 from tests.common import mock_coro
 
 
-@asyncio.coroutine
-def test_validate_config_ok(hass, hass_client):
+async def test_validate_config_ok(hass, hass_client):
     """Test checking config."""
     with patch.object(config, 'SECTIONS', ['core']):
-        yield from async_setup_component(hass, 'config', {})
+        await async_setup_component(hass, 'config', {})
 
-    yield from asyncio.sleep(0.1, loop=hass.loop)
+    await asyncio.sleep(0.1, loop=hass.loop)
 
-    client = yield from hass_client()
+    client = await hass_client()
 
     with patch(
         'homeassistant.components.config.core.async_check_ha_config_file',
             return_value=mock_coro()):
-        resp = yield from client.post('/api/config/core/check_config')
+        resp = await client.post('/api/config/core/check_config')
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert result['result'] == 'valid'
     assert result['errors'] is None
 
     with patch(
         'homeassistant.components.config.core.async_check_ha_config_file',
             return_value=mock_coro('beer')):
-        resp = yield from client.post('/api/config/core/check_config')
+        resp = await client.post('/api/config/core/check_config')
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert result['result'] == 'invalid'
     assert result['errors'] == 'beer'
+
+
+async def test_websocket_core_update(hass, hass_ws_client):
+    """Test core config update websocket command."""
+    with patch.object(config, 'SECTIONS', ['core']):
+        await async_setup_component(hass, 'config', {})
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        'id': 5,
+        'type': 'config/core/update',
+        'latitude': 123,
+    })
+
+    msg = await client.receive_json()
+
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+
+
+async def test_websocket_core_update_not_admin(
+        hass, hass_ws_client, hass_admin_user):
+    """Test core config fails for non admin."""
+    hass_admin_user.groups = []
+    with patch.object(config, 'SECTIONS', ['core']):
+        await async_setup_component(hass, 'config', {})
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        'id': 6,
+        'type': 'config/core/update',
+        'latitude': 123,
+    })
+
+    msg = await client.receive_json()
+
+    assert msg['id'] == 6
+    assert msg['type'] == TYPE_RESULT
+    assert not msg['success']
+    assert msg['error']['code'] == 'unauthorized'
+
+
+async def test_websocket_bad_core_update(hass, hass_ws_client):
+    """Test core config update fails with bad parameters."""
+    with patch.object(config, 'SECTIONS', ['core']):
+        await async_setup_component(hass, 'config', {})
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        'id': 7,
+        'type': 'config/core/update',
+        'latituude': 123,
+    })
+
+    msg = await client.receive_json()
+
+    assert msg['id'] == 7
+    assert msg['type'] == TYPE_RESULT
+    assert not msg['success']
+    assert msg['error']['code'] == 'invalid_format'

--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -6,7 +6,10 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import CONF_UNIT_SYSTEM, CONF_UNIT_SYSTEM_IMPERIAL
+import homeassistant.util.dt as dt_util
 from tests.common import mock_coro
+
+ORIG_TIME_ZONE = dt_util.DEFAULT_TIME_ZONE
 
 
 async def test_validate_config_ok(hass, hass_client):
@@ -74,6 +77,8 @@ async def test_websocket_core_update(hass, hass_ws_client):
     assert hass.config.location_name == 'Huis'
     assert hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL
     assert hass.config.time_zone.zone == 'America/New_York'
+
+    dt_util.set_default_time_zone(ORIG_TIME_ZONE)
 
 
 async def test_websocket_core_update_not_admin(


### PR DESCRIPTION
## Description:
Add new websocket API for updating core config

This is a follow-up to: #23872, #23922

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
