### PR TITLE
Split devices of nodes with multiple instances

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -1057,13 +1057,20 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
     @property
     def device_info(self):
         """Return device information."""
+        ident = self.node_id
+        name = node_name(self.node)
+        if self.values.primary.instance > 1:
+            ident = '{}_{}'.format(
+                self.node_id, self.values.primary.instance)
+            name = '{} ({})'.format(
+                name, self.values.primary.instance)
         return {
             'identifiers': {
-                (DOMAIN, self.node_id)
+                (DOMAIN, ident)
             },
             'manufacturer': self.node.manufacturer_name,
             'model': self.node.product_name,
-            'name': node_name(self.node),
+            'name': name,
         }
 
     @property

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -124,7 +124,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
     @property
     def device_info(self):
         """Return device information."""
-        return {
+        info = {
             'identifiers': {
                 (DOMAIN, self.node_id)
             },
@@ -132,6 +132,9 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             'model': self.node.product_name,
             'name': node_name(self.node)
         }
+        if self.node_id > 1:
+            info['via_hub'] = (DOMAIN, 1)
+        return info
 
     def network_node_changed(self, node=None, value=None, args=None):
         """Handle a changed node on the network."""


### PR DESCRIPTION
## Breaking Change:

I've deliberately used a device ID of the first (1) instance that is compatible with the old way so as not to introduce a breaking change that requires removing old devices.

## Description:

Z-Wave devices such as the aeotech Dual Nano Switch that have more than one instance are all being put under the same device. This means that if different instances are in different areas it doesn't work too well. This splits the devices out per-instance.

**Related issue (if applicable):** relates to #23995

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
