### PR TITLE
Downgrade Hue warning

### DIFF
--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -60,6 +60,7 @@ class HueBridge:
             return False
 
         except CannotConnect:
+            LOGGER.error("Error connecting to the Hue bridge at %s", host)
             raise ConfigEntryNotReady
 
         except Exception:  # pylint: disable=broad-except
@@ -161,10 +162,8 @@ async def get_bridge(hass, host, username=None):
 
         return bridge
     except (aiohue.LinkButtonNotPressed, aiohue.Unauthorized):
-        LOGGER.warning("Connected to Hue at %s but not registered.", host)
         raise AuthenticationRequired
     except (asyncio.TimeoutError, aiohue.RequestError):
-        LOGGER.error("Error connecting to the Hue bridge at %s", host)
         raise CannotConnect
     except aiohue.AiohueException:
         LOGGER.exception('Unknown Hue linking error occurred')


### PR DESCRIPTION
## Description:
The Hue `get_bridge` method should not print logs, but instead this should be appropriately handled by the caller of get_bridge.

```
2019-05-21 19:30:22 WARNING (MainThread) [homeassistant.components.hue] Connected to Hue at 192.168.1.142 but not registered.
```

This will fix it being added to the error log, confusing users.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
