### PR TITLE
Ambiclimate test, mock

### DIFF
--- a/tests/components/ambiclimate/test_config_flow.py
+++ b/tests/components/ambiclimate/test_config_flow.py
@@ -86,12 +86,14 @@ async def test_full_flow_implementation(hass):
     assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
 
 
-async def test_abort_no_code(hass):
+async def test_abort_invalid_code(hass):
     """Test if no code is given to step_code."""
     config_flow.register_flow_implementation(hass, None, None)
     flow = await init_config_flow(hass)
 
-    result = await flow.async_step_code('invalid')
+    with patch('ambiclimate.AmbiclimateOAuth.get_access_token',
+               return_value=mock_coro(None)):
+        result = await flow.async_step_code('invalid')
     assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
     assert result['reason'] == 'access_token'
 


### PR DESCRIPTION
## Description:
Ambiclimate test, mock

**Related issue (if applicable):** fixes #24027

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.
