### PR TITLE
Better logging of method used for ADB connection

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -90,20 +90,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if CONF_ADB_SERVER_IP not in config:
         # Use "python-adb" (Python ADB implementation)
+        adb_log = "using Python ADB implementation "
         if CONF_ADBKEY in config:
             aftv = setup(host, config[CONF_ADBKEY],
                          device_class=config[CONF_DEVICE_CLASS])
-            adb_log = " using adbkey='{0}'".format(config[CONF_ADBKEY])
+            adb_log += "with adbkey='{0}'".format(config[CONF_ADBKEY])
 
         else:
             aftv = setup(host, device_class=config[CONF_DEVICE_CLASS])
-            adb_log = ""
+            adb_log += "without adbkey authentication"
     else:
         # Use "pure-python-adb" (communicate with ADB server)
         aftv = setup(host, adb_server_ip=config[CONF_ADB_SERVER_IP],
                      adb_server_port=config[CONF_ADB_SERVER_PORT],
                      device_class=config[CONF_DEVICE_CLASS])
-        adb_log = " using ADB server at {0}:{1}".format(
+        adb_log = "using ADB server at {0}:{1}".format(
             config[CONF_ADB_SERVER_IP], config[CONF_ADB_SERVER_PORT])
 
     if not aftv.available:
@@ -117,7 +118,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         else:
             device_name = 'Android TV / Fire TV device'
 
-        _LOGGER.warning("Could not connect to %s at %s%s",
+        _LOGGER.warning("Could not connect to %s at %s %s",
                         device_name, host, adb_log)
         raise PlatformNotReady
 


### PR DESCRIPTION
## Description:

This makes it more clear to users which method HA is using for its ADB connection to the Android TV device (ADB server or Python ADB implementation with/without adbkey authentication). 

https://www.home-assistant.io/components/androidtv#adb-setup

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]