### PR TITLE
Change PiLight to receive all codes

### DIFF
--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -55,7 +55,8 @@ def setup(hass, config):
         hass, config[DOMAIN][CONF_SEND_DELAY])
 
     try:
-        pilight_client = pilight.Client(host=host, port=port)
+        pilight_client = pilight.Client(host=host, port=port
+                                        , recv_codes_only=False)
     except (socket.error, socket.timeout) as err:
         _LOGGER.error(
             "Unable to connect to %s on port %s: %s", host, port, err)

--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -55,8 +55,8 @@ def setup(hass, config):
         hass, config[DOMAIN][CONF_SEND_DELAY])
 
     try:
-        pilight_client = pilight.Client(host=host, port=port
-                                        , recv_codes_only=False)
+        pilight_client = pilight.Client(
+            host=host, port=port, recv_codes_only=False)
     except (socket.error, socket.timeout) as err:
         _LOGGER.error(
             "Unable to connect to %s on port %s: %s", host, port, err)


### PR DESCRIPTION
pilight hub is filtering all events with "origin" parameter diferent from "receiver".

Pilight uses "origin": "sender" for devices defined "inside" the platform running pilight (i.e. generic switches, gpios, cpu_temp, DS18b20 temp sensors , etc.)

In order to get all events from pilight, you have to instance pilight_client from python piligh lib with recv_codes_only=False

By default recv_codes_only is True in pilight.py of python lib, so only RF codes are reported by pilight_client to HA.

To make gpio switch work I had to change “recv_codes_only=False” in instance of pilight_client, and now all events from pilight are been puted on HA bus!!!

The problem is that actually the pilight receive events, only work fine with RF external codes. It doesnt work with internal gpios,generic switches, etc.

Please, revise carefully as this is my first pull request.



## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
