### PR TITLE
Homekit controller component to use zeroconf discovery

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -31,7 +31,6 @@ SERVICE_ENIGMA2 = 'enigma2'
 SERVICE_FREEBOX = 'freebox'
 SERVICE_HASS_IOS_APP = 'hass_ios'
 SERVICE_HASSIO = 'hassio'
-SERVICE_HOMEKIT = 'homekit'
 SERVICE_HEOS = 'heos'
 SERVICE_HUE = 'philips_hue'
 SERVICE_IGD = 'igd'
@@ -59,7 +58,6 @@ CONFIG_ENTRY_HANDLERS = {
     SERVICE_IKEA_TRADFRI: 'tradfri',
     'sonos': 'sonos',
     SERVICE_IGD: 'upnp',
-    SERVICE_HOMEKIT: 'homekit_controller',
 }
 
 SERVICE_HANDLERS = {

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -109,7 +109,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
             })
         )
 
-    async def async_step_discovery(self, discovery_info):
+    async def async_step_zeroconf(self, discovery_info):
         """Handle a discovered HomeKit accessory.
 
         This flow is triggered by the discovery component.
@@ -132,7 +132,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         # pylint: disable=unsupported-assignment-operation
         self.context['title_placeholders'] = {
-            'name': discovery_info['name'],
+            'name': discovery_info['name'].replace('._hap._tcp.local.', ''),
         }
 
         # The configuration number increases every time the characteristic map

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -7,6 +7,7 @@
     "homekit[IP]==0.14.0"
   ],
   "dependencies": [],
+  "zeroconf": ["_hap._tcp.local."],
   "codeowners": [
     "@Jc2k"
   ]

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -10,5 +10,8 @@ SERVICE_TYPES = {
     ],
     "_esphomelib._tcp.local.": [
         "esphome"
+    ],
+    "_hap._tcp.local.": [
+        "homekit_controller"
     ]
 }

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -277,7 +277,7 @@ async def device_config_changed(hass, accessories):
     flow = config_flow.HomekitControllerFlowHandler()
     flow.hass = hass
     flow.context = {}
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_configured'
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -64,7 +64,7 @@ async def test_discovery_works(hass):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -119,7 +119,7 @@ async def test_discovery_works_upper_case(hass):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -172,7 +172,7 @@ async def test_discovery_works_missing_csharp(hass):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -226,7 +226,7 @@ async def test_pair_already_paired_1(hass):
 
     flow = _setup_flow_handler(hass)
 
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_paired'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -248,7 +248,7 @@ async def test_discovery_ignored_model(hass):
 
     flow = _setup_flow_handler(hass)
 
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'ignored_model'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -277,7 +277,7 @@ async def test_discovery_invalid_config_entry(hass):
 
     flow = _setup_flow_handler(hass)
 
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -311,7 +311,7 @@ async def test_discovery_already_configured(hass):
 
     flow = _setup_flow_handler(hass)
 
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_configured'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -341,7 +341,7 @@ async def test_discovery_already_configured_config_change(hass):
 
     flow = _setup_flow_handler(hass)
 
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_configured'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -366,7 +366,7 @@ async def test_pair_unable_to_pair(hass):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -403,7 +403,7 @@ async def test_pair_abort_errors_on_start(hass, exception, expected):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -436,7 +436,7 @@ async def test_pair_form_errors_on_start(hass, exception, expected):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -469,7 +469,7 @@ async def test_pair_abort_errors_on_finish(hass, exception, expected):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -508,7 +508,7 @@ async def test_pair_form_errors_on_finish(hass, exception, expected):
     flow = _setup_flow_handler(hass)
 
     # Device is discovered
-    result = await flow.async_step_discovery(discovery_info)
+    result = await flow.async_step_zeroconf(discovery_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'pair'
     assert flow.context == {'title_placeholders': {'name': 'TestDevice'}}
@@ -738,7 +738,7 @@ async def test_parse_new_homekit_json(hass):
         pairing_cls.return_value = pairing
         with mock.patch('builtins.open', mock_open):
             with mock.patch('os.path', mock_path):
-                result = await flow.async_step_discovery(discovery_info)
+                result = await flow.async_step_zeroconf(discovery_info)
 
     assert result['type'] == 'create_entry'
     assert result['title'] == 'TestDevice'
@@ -796,7 +796,7 @@ async def test_parse_old_homekit_json(hass):
         with mock.patch('builtins.open', mock_open):
             with mock.patch('os.path', mock_path):
                 with mock.patch('os.listdir', mock_listdir):
-                    result = await flow.async_step_discovery(discovery_info)
+                    result = await flow.async_step_zeroconf(discovery_info)
 
     assert result['type'] == 'create_entry'
     assert result['title'] == 'TestDevice'
@@ -865,7 +865,7 @@ async def test_parse_overlapping_homekit_json(hass):
         with mock.patch('builtins.open', side_effect=side_effects):
             with mock.patch('os.path', mock_path):
                 with mock.patch('os.listdir', mock_listdir):
-                    result = await flow.async_step_discovery(discovery_info)
+                    result = await flow.async_step_zeroconf(discovery_info)
 
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/198#event-2330901207
https://github.com/home-assistant/home-assistant.io/pull/9506

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html