### PR TITLE
ESPHome component to use zeroconf discovery

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -52,7 +52,6 @@ SERVICE_XIAOMI_GW = 'xiaomi_gw'
 CONFIG_ENTRY_HANDLERS = {
     SERVICE_DAIKIN: 'daikin',
     SERVICE_DECONZ: 'deconz',
-    'esphome': 'esphome',
     'google_cast': 'cast',
     SERVICE_HEOS: 'heos',
     SERVICE_HUE: 'hue',

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -69,8 +69,8 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
             description_placeholders={'name': self._name},
         )
 
-    async def async_step_discovery(self, user_input: ConfigType):
-        """Handle discovery."""
+    async def async_step_zeroconf(self, user_input: ConfigType):
+        """Handle zeroconf discovery."""
         address = user_input['properties'].get(
             'address', user_input['hostname'][:-1])
         for entry in self._async_current_entries():

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -7,6 +7,7 @@
     "aioesphomeapi==2.0.1"
   ],
   "dependencies": [],
+  "zeroconf": ["_esphomelib._tcp.local."],
   "codeowners": [
     "@OttoWinter"
   ]

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -7,5 +7,8 @@ To update, run python3 -m hassfest
 SERVICE_TYPES = {
     "_axis-video._tcp.local.": [
         "axis"
+    ],
+    "_esphomelib._tcp.local.": [
+        "esphome"
     ]
 }

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -202,7 +202,7 @@ async def test_discovery_initiation(hass, mock_client):
     mock_client.device_info.return_value = mock_coro(
         MockDeviceInfo(False, "test8266"))
 
-    result = await flow.async_step_discovery(user_input=service_info)
+    result = await flow.async_step_zeroconf(user_input=service_info)
     assert result['type'] == 'form'
     assert result['step_id'] == 'discovery_confirm'
     assert result['description_placeholders']['name'] == 'test8266'
@@ -229,7 +229,7 @@ async def test_discovery_already_configured_hostname(hass, mock_client):
         'hostname': 'test8266.local.',
         'properties': {}
     }
-    result = await flow.async_step_discovery(user_input=service_info)
+    result = await flow.async_step_zeroconf(user_input=service_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_configured'
 
@@ -251,6 +251,6 @@ async def test_discovery_already_configured_ip(hass, mock_client):
             "address": "192.168.43.183"
         }
     }
-    result = await flow.async_step_discovery(user_input=service_info)
+    result = await flow.async_step_zeroconf(user_input=service_info)
     assert result['type'] == 'abort'
     assert result['reason'] == 'already_configured'

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -36,5 +36,5 @@ async def test_setup(hass):
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    assert len(MockServiceBrowser.mock_calls) == 1
-    assert len(mock_config_flow.mock_calls) == 1
+    assert len(MockServiceBrowser.mock_calls) == 2
+    assert len(mock_config_flow.mock_calls) == 2


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/198#event-2330901207
https://github.com/home-assistant/home-assistant.io/pull/9506

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html