### PR TITLE
0.93.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
       git config --global user.email "pvizeli@syshack.ch"
       git config --global credential.helper store
 
-      echo "https://$(githubToken):x-oauth-basic@github.com" > $HOME\.git-credentials
+      echo "https://$(githubToken):x-oauth-basic@github.com" > $HOME/.git-credentials
     displayName: 'Install requirements'
   - script: |
       set -e

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -1,7 +1,7 @@
 """Support for repeating alerts when conditions are met."""
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import voluptuous as vol
 
@@ -13,6 +13,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE, ATTR_ENTITY_ID)
 from homeassistant.helpers import service, event
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.util.dt import now
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -222,7 +223,7 @@ class Alert(ToggleEntity):
     async def _schedule_notify(self):
         """Schedule a notification."""
         delay = self._delay[self._next_delay]
-        next_msg = datetime.now() + delay
+        next_msg = now() + delay
         self._cancel = \
             event.async_track_point_in_time(self.hass, self._notify, next_msg)
         self._next_delay = min(self._next_delay + 1, len(self._delay) - 1)

--- a/homeassistant/components/broadlink/manifest.json
+++ b/homeassistant/components/broadlink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Broadlink",
   "documentation": "https://www.home-assistant.io/components/broadlink",
   "requirements": [
-    "broadlink==0.9.0"
+    "broadlink==0.10.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/discord/notify.py
+++ b/homeassistant/components/discord/notify.py
@@ -53,21 +53,20 @@ class DiscordNotificationService(BaseNotificationService):
             _LOGGER.error("No target specified")
             return None
 
-        if ATTR_DATA in kwargs:
-            data = kwargs.get(ATTR_DATA)
+        data = kwargs.get(ATTR_DATA) or {}
 
-            if ATTR_IMAGES in data:
-                images = list()
+        if ATTR_IMAGES in data:
+            images = list()
 
-                for image in data.get(ATTR_IMAGES):
-                    image_exists = await self.hass.async_add_executor_job(
-                        self.file_exists,
-                        image)
+            for image in data.get(ATTR_IMAGES):
+                image_exists = await self.hass.async_add_executor_job(
+                    self.file_exists,
+                    image)
 
-                    if image_exists:
-                        images.append(image)
-                    else:
-                        _LOGGER.warning("Image not found: %s", image)
+                if image_exists:
+                    images.append(image)
+                else:
+                    _LOGGER.warning("Image not found: %s", image)
 
         # pylint: disable=unused-variable
         @discord_bot.event

--- a/homeassistant/components/traccar/manifest.json
+++ b/homeassistant/components/traccar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Traccar",
   "documentation": "https://www.home-assistant.io/components/traccar",
   "requirements": [
-    "pytraccar==0.8.0",
+    "pytraccar==0.9.0",
     "stringcase==1.2.0"
   ],
   "dependencies": [],

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 93
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -338,17 +338,17 @@ async def check_ha_config_file(hass):
             result.add_error("Integration not found: {}".format(domain))
             continue
 
-        try:
-            component = integration.get_component()
-        except ImportError:
-            result.add_error("Component not found: {}".format(domain))
-            continue
-
         if (not hass.config.skip_pip and integration.requirements and
                 not await requirements.async_process_requirements(
                     hass, integration.domain, integration.requirements)):
             result.add_error("Unable to install all requirements: {}".format(
                 ', '.join(integration.requirements)))
+            continue
+
+        try:
+            component = integration.get_component()
+        except ImportError:
+            result.add_error("Component not found: {}".format(domain))
             continue
 
         if hasattr(component, 'CONFIG_SCHEMA'):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -261,7 +261,7 @@ boto3==1.9.16
 braviarc-homeassistant==0.3.7.dev0
 
 # homeassistant.components.broadlink
-broadlink==0.9.0
+broadlink==0.10.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1450,7 +1450,7 @@ pytile==2.0.6
 pytouchline==0.7
 
 # homeassistant.components.traccar
-pytraccar==0.8.0
+pytraccar==0.9.0
 
 # homeassistant.components.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
- Fix auto version update Hass.io ([@pvizeli] - [#23935])
- Bump pytraccar ([@ludeeus] - [#23939]) ([traccar docs])
- Fixes issue with multiple alerts ([@ludeeus] - [#23945]) ([alert docs])
- Setup integration dependencies before loading it ([@aerialls] - [#23957])
- Make Discord payload data key not required ([@cyrosy] - [#23964]) ([discord docs])
- upgrade broadlink library ([@Danielhiversen] - [#23966]) ([broadlink docs])

[#23935]: https://github.com/home-assistant/home-assistant/pull/23935
[#23939]: https://github.com/home-assistant/home-assistant/pull/23939
[#23945]: https://github.com/home-assistant/home-assistant/pull/23945
[#23957]: https://github.com/home-assistant/home-assistant/pull/23957
[#23964]: https://github.com/home-assistant/home-assistant/pull/23964
[#23966]: https://github.com/home-assistant/home-assistant/pull/23966
[@Danielhiversen]: https://github.com/Danielhiversen
[@aerialls]: https://github.com/aerialls
[@cyrosy]: https://github.com/cyrosy
[@ludeeus]: https://github.com/ludeeus
[@pvizeli]: https://github.com/pvizeli
[alert docs]: https://www.home-assistant.io/components/alert/
[broadlink docs]: https://www.home-assistant.io/components/broadlink/
[discord docs]: https://www.home-assistant.io/components/discord/
[traccar docs]: https://www.home-assistant.io/components/traccar/