### PR TITLE
Remove custom entity_id naming

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -26,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
 
+NAME_FORMAT = 'Plex {}'
 PLEX_CONFIG_FILE = 'plex.conf'
 PLEX_DATA = 'plex'
 
@@ -358,8 +359,8 @@ class PlexClient(MediaPlayerDevice):
                 self._device.proxyThroughServer()
             self._session = None
             self._machine_identifier = self._device.machineIdentifier
-            self._name = '{} {}'.format('Plex', self._device.title or
-                                        DEVICE_DEFAULT_NAME)
+            self._name = NAME_FORMAT.format(self._device.title or
+                                            DEVICE_DEFAULT_NAME)
             self._device_protocol_capabilities = (
                 self._device.protocolCapabilities)
 
@@ -376,7 +377,7 @@ class PlexClient(MediaPlayerDevice):
                 self._player = [p for p in self._session.players
                                 if p.machineIdentifier ==
                                 self._device.machineIdentifier][0]
-                self._name = '{} {}'.format('Plex', self._player.title)
+                self._name = NAME_FORMAT.format(self._player.title)
                 self._player_state = self._player.state
                 self._session_username = self._session.usernames[0]
                 self._make = self._player.device

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -317,6 +317,8 @@ class PlexClient(MediaPlayerDevice):
 
         self.refresh(device, session)
 
+        self.entity_id = "{}.{}_{}".format('media_player', 'plex', self.name)
+
     def _clear_media_details(self):
         """Set all Media Items to None."""
         # General

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -317,8 +317,6 @@ class PlexClient(MediaPlayerDevice):
 
         self.refresh(device, session)
 
-        self.entity_id = "{}.{}_{}".format('media_player', 'plex', self.name)
-
     def _clear_media_details(self):
         """Set all Media Items to None."""
         # General
@@ -360,7 +358,8 @@ class PlexClient(MediaPlayerDevice):
                 self._device.proxyThroughServer()
             self._session = None
             self._machine_identifier = self._device.machineIdentifier
-            self._name = self._device.title or DEVICE_DEFAULT_NAME
+            self._name = '{} {}'.format('Plex', self._device.title or \
+                    DEVICE_DEFAULT_NAME)
             self._device_protocol_capabilities = (
                 self._device.protocolCapabilities)
 
@@ -377,7 +376,7 @@ class PlexClient(MediaPlayerDevice):
                 self._player = [p for p in self._session.players
                                 if p.machineIdentifier ==
                                 self._device.machineIdentifier][0]
-                self._name = self._player.title
+                self._name = '{} {}'.format('Plex', self._player.title)
                 self._player_state = self._player.state
                 self._session_username = self._session.usernames[0]
                 self._make = self._player.device

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -30,14 +30,12 @@ PLEX_CONFIG_FILE = 'plex.conf'
 PLEX_DATA = 'plex'
 
 CONF_USE_EPISODE_ART = 'use_episode_art'
-CONF_USE_CUSTOM_ENTITY_IDS = 'use_custom_entity_ids'
 CONF_SHOW_ALL_CONTROLS = 'show_all_controls'
 CONF_REMOVE_UNAVAILABLE_CLIENTS = 'remove_unavailable_clients'
 CONF_CLIENT_REMOVE_INTERVAL = 'client_remove_interval'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
-    vol.Optional(CONF_USE_CUSTOM_ENTITY_IDS, default=False): cv.boolean,
     vol.Optional(CONF_SHOW_ALL_CONTROLS, default=False): cv.boolean,
     vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True): cv.boolean,
     vol.Optional(CONF_CLIENT_REMOVE_INTERVAL, default=timedelta(seconds=600)):
@@ -318,24 +316,6 @@ class PlexClient(MediaPlayerDevice):
         self._media_series_title = None
 
         self.refresh(device, session)
-
-        # Assign custom entity ID if desired
-        if self.config.get(CONF_USE_CUSTOM_ENTITY_IDS):
-            prefix = ''
-            # allow for namespace prefixing when using custom entity names
-            if config.get("entity_namespace"):
-                prefix = config.get("entity_namespace") + '_'
-
-            # rename the entity id
-            if self.machine_identifier:
-                self.entity_id = "%s.%s%s" % (
-                    'media_player', prefix,
-                    self.machine_identifier.lower().replace('-', '_'))
-            else:
-                if self.name:
-                    self.entity_id = "%s.%s%s" % (
-                        'media_player', prefix,
-                        self.name.lower().replace('-', '_'))
 
     def _clear_media_details(self):
         """Set all Media Items to None."""

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -358,8 +358,8 @@ class PlexClient(MediaPlayerDevice):
                 self._device.proxyThroughServer()
             self._session = None
             self._machine_identifier = self._device.machineIdentifier
-            self._name = '{} {}'.format('Plex', self._device.title or \
-                    DEVICE_DEFAULT_NAME)
+            self._name = '{} {}'.format('Plex', self._device.title or
+                                        DEVICE_DEFAULT_NAME)
             self._device_protocol_capabilities = (
                 self._device.protocolCapabilities)
 


### PR DESCRIPTION
## Breaking Change:

Config options `use_custom_entity_ids` and `entity_namespace` have been removed.
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

As mentioned in https://github.com/home-assistant/home-assistant/issues/13607#issuecomment-476197902, components should no longer attempt to set `entity_id` but allow the Entity Registry to do its thing.

This PR will prepend the display name (and therefore the default `entity_id`) of each newly created entity with 'Plex' for easy identification. Users may customize each display name and `entity_id` as desired via the Entity Registry. Entities created before this PR will not be affected as the `unique_id` remains the same.

**Related issue (if applicable):** fixes #13607

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9510

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
    - platform: plex
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html