### PR TITLE
Homematic: Added possibility to define the data type for set_device_value

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -1,5 +1,5 @@
 """Support for HomeMatic devices."""
-from datetime import timedelta
+from datetime import timedelta, datetime
 from functools import partial
 import logging
 
@@ -34,6 +34,7 @@ ATTR_PARAM = 'param'
 ATTR_CHANNEL = 'channel'
 ATTR_ADDRESS = 'address'
 ATTR_VALUE = 'value'
+ATTR_VALUE_TYPE = 'value_type'
 ATTR_INTERFACE = 'interface'
 ATTR_ERRORCODE = 'error'
 ATTR_MESSAGE = 'message'
@@ -235,6 +236,7 @@ SCHEMA_SERVICE_SET_DEVICE_VALUE = vol.Schema({
     vol.Required(ATTR_CHANNEL): vol.Coerce(int),
     vol.Required(ATTR_PARAM): vol.All(cv.string, vol.Upper),
     vol.Required(ATTR_VALUE): cv.match_all,
+    vol.Optional(ATTR_VALUE_TYPE): vol.In(['boolean', 'dateTime.iso8601', 'double', 'int', 'string']),
     vol.Optional(ATTR_INTERFACE): cv.string,
 })
 
@@ -379,6 +381,22 @@ def setup(hass, config):
         channel = service.data.get(ATTR_CHANNEL)
         param = service.data.get(ATTR_PARAM)
         value = service.data.get(ATTR_VALUE)
+        valueType = service.data.get(ATTR_VALUE_TYPE)
+
+        # Convert value into correct XML-RPC Type.
+        # https://docs.python.org/3/library/xmlrpc.client.html#xmlrpc.client.ServerProxy - XML-RPC type 
+        if valueType:
+            if valueType == 'int':
+                value = int(value)
+            elif valueType == 'double':
+                value = float(value)
+            elif valueType == 'boolean':
+                value = bool(value)
+            elif valueType == 'dateTime.iso8601':
+                value = datetime.strptime(value, '%Y%m%dT%H:%M:%S')
+            else:
+                # Default is 'string'
+                value = str(value)
 
         # Device not found
         hmdevice = _device_from_servicecall(hass, service)


### PR DESCRIPTION
## Description:

The Homematic CCU needs that we send the correct XML-RPC Data Type for setValue, but parsing the yaml will always return a string.

This example request will be ignored by CCU:

```
<?xml version="1.0"?>
<methodCall>
	<methodName>setValue</methodName>
	<params>
		<param>
			<value><string>INT0000001:1</string></value>
		</param>
		<param>
			<value><string>ACTIVE_PROFILE</string></value>
		</param>
		<param>
			<value><string>2</string></value>
		</param>
	</params>
</methodCall>
```
the value should be a **int**:

```
<?xml version="1.0"?>
<methodCall>
	<methodName>setValue</methodName>
	<params>
		<param>
			<value><string>INT0000001:1</string></value>
		</param>
		<param>
			<value><string>ACTIVE_PROFILE</string></value>
		</param>
		<param>
			<value><int>2</int></value>
		</param>
	</params>
</methodCall>
```
Homematic component uses pyhomematic and pyhomematic uses xmlrpc.client.ServerProxy, an as stated under https://docs.python.org/3/library/xmlrpc.client.html#xmlrpc.client.ServerProxy, python data types are converted into the correct XML-RPC Type.

I added an optional _value_type_ parameter where you are able to define the desired data type. Supported data types are (I just used the same naming as XML-RPC Types):

- boolean
- dateTime.iso8601
- double
- int
- string

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9512

## Example entry for `automation.yaml`:
```yaml
- alias: changeProfile
  trigger:
    - platform: time
      at: '00:00:05'
  action:
    - service: homematic.set_device_value
      data_template:
        address: 'INT0000001'
        channel: 1
        param: 'ACTIVE_PROFILE'
        interface: groups
        value_type: 'int'
        value: >
          {% if ((states('sensor.week_number')|default(0)|int) % 2) == 0 %}
          1
          {% else %}
          2
          {% endif %}
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
