### PR TITLE
Adjust logging

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -226,8 +226,8 @@ async def async_prepare_setup_platform(hass: core.HomeAssistant,
 
     try:
         platform = integration.get_platform(domain)
-    except ImportError:
-        log_error("Platform not found.")
+    except ImportError as exc:
+        log_error("Platform not found ({}).".format(exc))
         return None
 
     # Already loaded
@@ -239,8 +239,8 @@ async def async_prepare_setup_platform(hass: core.HomeAssistant,
     if integration.domain not in hass.config.components:
         try:
             component = integration.get_component()
-        except ImportError:
-            log_error("Unable to import the component")
+        except ImportError as exc:
+            log_error("Unable to import the component ({}).".format(exc))
             return None
 
         if (hasattr(component, 'setup')

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -207,7 +207,7 @@ async def async_prepare_setup_platform(hass: core.HomeAssistant,
     def log_error(msg: str) -> None:
         """Log helper."""
         _LOGGER.error("Unable to prepare setup for platform %s: %s",
-                      platform_name, msg)
+                      platform_path, msg)
         async_notify_setup_error(hass, platform_path)
 
     try:


### PR DESCRIPTION
## Description:
When platforms are prepared they are imported. Any import error inside a platform file would be logged by a generic error. It was almost impossible to find why the import of a component was failing.

This becomes most problematic for custom components with perhaps low test coverage.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
