### PR TITLE
typo for ambiclimate

### DIFF
--- a/homeassistant/components/ambiclimate/climate.py
+++ b/homeassistant/components/ambiclimate/climate.py
@@ -62,7 +62,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         return
 
     if _token_info:
-        await store.async_save(token_info)
+        await store.async_save(_token_info)
         token_info = _token_info
 
     data_connection = ambiclimate.AmbiclimateConnection(oauth,


### PR DESCRIPTION


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.
