### PR TITLE
Fix Hue bridge timeout

### DIFF
--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -153,7 +153,7 @@ async def get_bridge(hass, host, username=None):
     )
 
     try:
-        with async_timeout.timeout(5):
+        with async_timeout.timeout(10):
             # Create username if we don't have one
             if not username:
                 await bridge.create_user('home-assistant')


### PR DESCRIPTION
## Description:
* Change timeout from 5 seconds to 10 seconds
Underpowered platforms timeout during configuration/discovery of a Hue bridge on a new install. Increasing this timeout fixes this.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
