### PR TITLE
Round Awair sensor values

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@ homeassistant/components/asuswrt/* @kennedyshead
 homeassistant/components/auth/* @home-assistant/core
 homeassistant/components/automatic/* @armills
 homeassistant/components/automation/* @home-assistant/core
+homeassistant/components/awair/* @danielsjf
 homeassistant/components/aws/* @awarecan @robbiet480
 homeassistant/components/axis/* @kane610
 homeassistant/components/azure_event_hub/* @eavanvalkenburg

--- a/homeassistant/components/awair/manifest.json
+++ b/homeassistant/components/awair/manifest.json
@@ -6,5 +6,7 @@
     "python_awair==0.0.4"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@danielsjf"
+  ]
 }

--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -219,6 +219,6 @@ class AwairData:
         # The air_data_latest call only returns one item, so this should
         # be safe to only process one entry.
         for sensor in resp[0][ATTR_SENSORS]:
-            self.data[sensor[ATTR_COMPONENT]] = sensor[ATTR_VALUE]
+            self.data[sensor[ATTR_COMPONENT]] = round(sensor[ATTR_VALUE], 1)
 
         _LOGGER.debug("Got Awair Data for %s: %s", self._uuid, self.data)

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -178,7 +178,7 @@ async def test_awair_humid(hass):
     await setup_awair(hass)
 
     sensor = hass.states.get("sensor.awair_humidity")
-    assert sensor.state == "32.73"
+    assert sensor.state == "32.7"
     assert sensor.attributes["device_class"] == DEVICE_CLASS_HUMIDITY
     assert sensor.attributes["unit_of_measurement"] == "%"
 
@@ -291,7 +291,7 @@ async def test_async_update(hass):
     assert score_sensor.state == "79"
 
     assert hass.states.get("sensor.awair_temperature").state == "23.4"
-    assert hass.states.get("sensor.awair_humidity").state == "33.73"
+    assert hass.states.get("sensor.awair_humidity").state == "33.7"
     assert hass.states.get("sensor.awair_co2").state == "613"
     assert hass.states.get("sensor.awair_voc").state == "1013"
     assert hass.states.get("sensor.awair_pm2_5").state == "7.2"


### PR DESCRIPTION
## Description:

Currently the sensor reports about 10 figures after the comma which isn't useful in the overview (numbers end in ...). This PR rounds it to one figure after the comma instead which is around the sensor precision anyway.

Should fix #20034

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
