### PR TITLE
Fix Blink Motion Detection

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.helpers import (
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD, CONF_NAME, CONF_SCAN_INTERVAL,
     CONF_BINARY_SENSORS, CONF_SENSORS, CONF_FILENAME,
-    CONF_MONITORED_CONDITIONS, TEMP_FAHRENHEIT)
+    CONF_MONITORED_CONDITIONS, CONF_MODE, CONF_OFFSET, TEMP_FAHRENHEIT)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ BINARY_SENSORS = {
 
 SENSORS = {
     TYPE_TEMPERATURE: ['Temperature', TEMP_FAHRENHEIT, 'mdi:thermometer'],
-    TYPE_BATTERY: ['Battery', '%', 'mdi:battery-80'],
+    TYPE_BATTERY: ['Battery', '', 'mdi:battery-80'],
     TYPE_WIFI_STRENGTH: ['Wifi Signal', 'dBm', 'mdi:wifi-strength-2'],
 }
 
@@ -75,6 +75,8 @@ CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_BINARY_SENSORS, default={}):
                 BINARY_SENSOR_SCHEMA,
             vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
+            vol.Optional(CONF_OFFSET, default=1): int,
+            vol.Optional(CONF_MODE, default=''): cv.string,
         })
     },
     extra=vol.ALLOW_EXTRA)
@@ -87,8 +89,12 @@ def setup(hass, config):
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]
     scan_interval = conf[CONF_SCAN_INTERVAL]
+    is_legacy = bool(conf[CONF_MODE] == 'legacy')
+    motion_interval = conf[CONF_OFFSET]
     hass.data[BLINK_DATA] = blinkpy.Blink(username=username,
-                                          password=password)
+                                          password=password,
+                                          motion_interval=motion_interval,
+                                          legacy_subdomain=is_legacy)
     hass.data[BLINK_DATA].refresh_rate = scan_interval.total_seconds()
     hass.data[BLINK_DATA].start()
 

--- a/homeassistant/components/blink/manifest.json
+++ b/homeassistant/components/blink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Blink",
   "documentation": "https://www.home-assistant.io/components/blink",
   "requirements": [
-    "blinkpy==0.13.1"
+    "blinkpy==0.14.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -236,7 +236,7 @@ bimmer_connected==0.5.3
 bizkaibus==0.1.1
 
 # homeassistant.components.blink
-blinkpy==0.13.1
+blinkpy==0.14.0
 
 # homeassistant.components.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
**Note:** this is a new branch that implements the exact same behavior as #24069 but I was having CI trouble related to `zeroconf.py` that made no sense, so I just decided to nuke it and try again.
@fabaff 

EDIT - also, I think this should be added to the 0.93.3 milestone (given that it's a bug fix for broken motion detection with Blink)

## Description:
Updates to library fix broken motion detection
- API endpoint changed
- Internal throttling in library prevented multiple sync modules from working

Both are fixed with this update (also, battery status is now reported as a string rather than percentage.  Unrelated, but unavoidable, change)

Also, in the interest of adding some [CYA](https://en.wikipedia.org/wiki/Cover_your_ass) features, I added the ability to use older api endpoints and to manually set an offset for how far back in time to check for motion (see example yaml below).  Both of these are optional.

**Related issue (if applicable):** fixes #22119 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9508

## Example entry for `configuration.yaml` (if applicable):
```yaml
blink:
  ...
  mode: legacy    # enables legacy API endpoints
  offset: 1       # offset to motion detection in minutes (has motion been detected between [last_refresh + offset] and now?)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.