### PR TITLE
WIP Ps4 Convert entity to Async / Fix entity name changing

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -18,6 +18,7 @@ class PS4Data():
     def __init__(self):
         """Init Class."""
         self.devices = []
+        self.handler = None
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -27,7 +27,7 @@ async def async_setup(hass, config):
     hass.data[PS4_DATA] = PS4Data()
 
     """Initialize PS4 Handler.
-    Handler manages listeners which are threads 
+    Handler manages listeners which are threads
     which queues synchronous network IO
     with low-level sockets, such as status updates over UDP,
     as well as manages TCP connections and tasks/commands.

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -14,6 +14,9 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass, config):
     """Set up the PS4 Component."""
+    from pyps4_homeassistant.client import PS4Client
+    hass.data[PS4_DATA] = PS4Data()
+    hass.data[PS4_DATA].handler = PS4Client()
     return True
 
 

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -25,6 +25,12 @@ async def async_setup(hass, config):
     """Set up the PS4 Component."""
     from pyps4_homeassistant.client import PS4Client
     hass.data[PS4_DATA] = PS4Data()
+    
+    """Initialize PS4 Handler.
+    Handler is a thread which queues synchronous network IO
+    with low-level sockets, such as status updates over UDP,
+    as well as manages TCP connections and tasks.
+    """
     hass.data[PS4_DATA].handler = PS4Client()
     return True
 

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -25,11 +25,12 @@ async def async_setup(hass, config):
     """Set up the PS4 Component."""
     from pyps4_homeassistant.client import PS4Client
     hass.data[PS4_DATA] = PS4Data()
-    
+
     """Initialize PS4 Handler.
-    Handler is a thread which queues synchronous network IO
+    Handler manages listeners which are threads 
+    which queues synchronous network IO
     with low-level sockets, such as status updates over UDP,
-    as well as manages TCP connections and tasks.
+    as well as manages TCP connections and tasks/commands.
     """
     hass.data[PS4_DATA].handler = PS4Client()
     return True

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -12,6 +12,14 @@ from .const import DOMAIN  # noqa: pylint: disable=unused-import
 _LOGGER = logging.getLogger(__name__)
 
 
+class PS4Data():
+    """Init Data Class."""
+
+    def __init__(self):
+        """Init Class."""
+        self.devices = []
+
+
 async def async_setup(hass, config):
     """Set up the PS4 Component."""
     from pyps4_homeassistant.client import PS4Client

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.helpers import entity_registry
 from homeassistant.util import location
 
 from .config_flow import PlayStation4FlowHandler  # noqa: pylint: disable=unused-import
-from .const import DOMAIN  # noqa: pylint: disable=unused-import
+from .const import DOMAIN, PS4_DATA  # noqa: pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -18,21 +18,18 @@ class PS4Data():
     def __init__(self):
         """Init Class."""
         self.devices = []
-        self.handler = None
+        self.protocol = None
 
 
 async def async_setup(hass, config):
     """Set up the PS4 Component."""
-    from pyps4_homeassistant.client import PS4Client
+    from pyps4_homeassistant.ddp import async_create_ddp_endpoint
+
     hass.data[PS4_DATA] = PS4Data()
 
-    """Initialize PS4 Handler.
-    Handler manages listeners which are threads
-    which queues synchronous network IO
-    with low-level sockets, such as status updates over UDP,
-    as well as manages TCP connections and tasks/commands.
-    """
-    hass.data[PS4_DATA].handler = PS4Client()
+    transport, protocol = await async_create_ddp_endpoint()
+    hass.data[PS4_DATA].protocol = protocol
+    _LOGGER.debug("PS4 DDP endpoint created: %s, %s", transport, protocol)
     return True
 
 

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
     CONF_CODE, CONF_HOST, CONF_IP_ADDRESS, CONF_NAME, CONF_REGION, CONF_TOKEN)
 from homeassistant.util import location
 
-from .const import DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_ALIAS, DEFAULT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             self.host = user_input[CONF_IP_ADDRESS]
 
             is_ready, is_login = await self.hass.async_add_executor_job(
-                self.helper.link, self.host, self.creds, self.pin)
+                self.helper.link, self.host, self.creds, self.pin, DEFAULT_ALIAS)
 
             if is_ready is False:
                 errors['base'] = 'not_ready'

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -143,7 +143,8 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
             self.host = user_input[CONF_IP_ADDRESS]
 
             is_ready, is_login = await self.hass.async_add_executor_job(
-                self.helper.link, self.host, self.creds, self.pin, DEFAULT_ALIAS)
+                self.helper.link, self.host,
+                self.creds, self.pin, DEFAULT_ALIAS)
 
             if is_ready is False:
                 errors['base'] = 'not_ready'

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -61,7 +61,7 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
         if user_input is not None:
             try:
                 self.creds = await self.hass.async_add_executor_job(
-                    self.helper.get_creds)
+                    self.helper.get_creds, DEFAULT_ALIAS)
                 if self.creds is not None:
                     return await self.async_step_mode()
                 return self.async_abort(reason='credential_error')

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -2,6 +2,7 @@
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
 DOMAIN = 'ps4'
+PS4_DATA = 'ps4_data'
 
 # Deprecated used for logger/backwards compatibility from 0.89
 REGIONS = ['R1', 'R2', 'R3', 'R4', 'R5']

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -1,6 +1,7 @@
 """Constants for PlayStation 4."""
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
+DEFAULT_ALIAS = 'Home-Assistant'
 DOMAIN = 'ps4'
 PS4_DATA = 'ps4_data'
 

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.7.3"
+    "pyps4-homeassistant==0.8.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.8.0"
+    "pyps4-homeassistant==0.8.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -130,6 +130,7 @@ class PS4Device(MediaPlayerDevice):
             self._ps4, self.status_callback)
 
     def check_region(self):
+        """Display logger msg if region is deprecated."""
         # Non-Breaking although data returned may be inaccurate.
         if self._region in deprecated_regions:
             _LOGGER.info("""Region: %s has been deprecated.

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -128,7 +128,7 @@ class PS4Device(MediaPlayerDevice):
         """Notify protocol to callback with update changes."""
         self.hass.data[PS4_DATA].protocol.add_callback(
             self._ps4, self.status_callback)
-        
+
     def check_region(self):
         # Non-Breaking although data returned may be inaccurate.
         if self._region in deprecated_regions:

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -348,7 +348,7 @@ class PS4Device(MediaPlayerDevice):
 
     async def async_will_remove_from_hass(self):
         """Remove Entity from Hass."""
-        # Close TCP Socket, Stop listener.
+        # Close TCP Transport.
         if self._ps4.connected:
             await self._ps4.close()
         self.hass.data[PS4_DATA].devices.remove(self)

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -117,7 +117,6 @@ class PS4Device(MediaPlayerDevice):
     @callback
     def status_callback(self):
         """Handle status callback. Parse status."""
-        _LOGGER.warning("Status Changed for Ps4")
         self._parse_status()
 
     @callback

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -184,11 +184,11 @@ class PS4Device(MediaPlayerDevice):
                         asyncio.ensure_future(
                             self.async_get_title_data(title_id, name))
                 else:
-                    self.idle()
+                    if self._state != STATE_IDLE:
+                        self.idle()
             else:
-                self.state_off()
-
-            self.schedule_update()
+                if self._state != STATE_OFF:
+                    self.state_off()
 
         elif self._retry > 5:
             self.state_unknown()
@@ -199,11 +199,13 @@ class PS4Device(MediaPlayerDevice):
         """Set states for state idle."""
         self.reset_title()
         self._state = STATE_IDLE
+        self.schedule_update()
 
     def state_off(self):
         """Set states for state off."""
         self.reset_title()
         self._state = STATE_OFF
+        self.schedule_update()
 
     def state_unknown(self):
         """Set states for state unknown."""

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -162,7 +162,7 @@ class PS4Device(MediaPlayerDevice):
                 if self._info is None:
                     # Add entity to registry.
                     await self.async_get_device_info(self._ps4.status)
-                self._parse_status()
+        self._parse_status()
 
     def _parse_status(self):
         """Parse status."""
@@ -185,10 +185,10 @@ class PS4Device(MediaPlayerDevice):
                             self.async_get_title_data(title_id, name))
                 else:
                     self.idle()
-                    self.schedule_update()
             else:
                 self.state_off()
-                self.schedule_update()
+
+            self.schedule_update()
 
         elif self._retry > 5:
             self.state_unknown()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1261,7 +1261,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.7.3
+pyps4-homeassistant==0.8.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1261,7 +1261,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.0
+pyps4-homeassistant==0.8.2
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.7.3
+pyps4-homeassistant==0.8.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.0
+pyps4-homeassistant==0.8.2
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93


### PR DESCRIPTION
## Description:
- Media Player entity for PS4 is changed to Async. Faster updates can be achieved.
- Change to async allows for a proper fix for #22931.
- Package update adds the use of Asyncio Datagram and TCP, Protocols and Transports as requested to convert the integration to async.
- Handle no result for cover art better
- Search for cover art now uses aiohttp within library
 
**Related issue (if applicable):** fixes #22931, fixes #23987
Fix from PR #23556:
Entity gets unique_id/identifier from polling device. If PS4 is offline, ie. (fully powered down, no internet connection) at HA Startup then the identifier never gets set and a new entity_id is generated instead.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
