### PR TITLE
Use importlib metadata to check installed packages

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,6 +4,7 @@ async_timeout==3.0.1
 attrs==19.1.0
 bcrypt==3.1.6
 certifi>=2018.04.16
+importlib-metadata==0.15
 jinja2>=2.10
 PyJWT==1.7.1
 cryptography==2.6.1

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -3,11 +3,7 @@ import asyncio
 from functools import partial
 import logging
 import os
-import sys
 from typing import Any, Dict, List, Optional
-from urllib.parse import urlparse
-
-import pkg_resources
 
 import homeassistant.util.package as pkg_util
 from homeassistant.core import HomeAssistant
@@ -28,16 +24,12 @@ async def async_process_requirements(hass: HomeAssistant, name: str,
     if pip_lock is None:
         pip_lock = hass.data[DATA_PIP_LOCK] = asyncio.Lock()
 
-    pkg_cache = hass.data.get(DATA_PKG_CACHE)
-    if pkg_cache is None:
-        pkg_cache = hass.data[DATA_PKG_CACHE] = PackageLoadable(hass)
-
     pip_install = partial(pkg_util.install_package,
                           **pip_kwargs(hass.config.config_dir))
 
     async with pip_lock:
         for req in requirements:
-            if await pkg_cache.loadable(req):
+            if pkg_util.is_installed(req):
                 continue
 
             ret = await hass.async_add_executor_job(pip_install, req)
@@ -58,50 +50,3 @@ def pip_kwargs(config_dir: Optional[str]) -> Dict[str, Any]:
     if not (config_dir is None or pkg_util.is_virtual_env()):
         kwargs['target'] = os.path.join(config_dir, 'deps')
     return kwargs
-
-
-class PackageLoadable:
-    """Class to check if a package is loadable, with built-in cache."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the PackageLoadable class."""
-        self.dist_cache = {}  # type: Dict[str, pkg_resources.Distribution]
-        self.hass = hass
-
-    async def loadable(self, package: str) -> bool:
-        """Check if a package is what will be loaded when we import it.
-
-        Returns True when the requirement is met.
-        Returns False when the package is not installed or doesn't meet req.
-        """
-        dist_cache = self.dist_cache
-
-        try:
-            req = pkg_resources.Requirement.parse(package)
-        except ValueError:
-            # This is a zip file. We no longer use this in Home Assistant,
-            # leaving it in for custom components.
-            req = pkg_resources.Requirement.parse(urlparse(package).fragment)
-
-        req_proj_name = req.project_name.lower()
-        dist = dist_cache.get(req_proj_name)
-
-        if dist is not None:
-            return dist in req
-
-        for path in sys.path:
-            # We read the whole mount point as we're already here
-            # Caching it on first call makes subsequent calls a lot faster.
-            await self.hass.async_add_executor_job(self._fill_cache, path)
-
-            dist = dist_cache.get(req_proj_name)
-            if dist is not None:
-                return dist in req
-
-        return False
-
-    def _fill_cache(self, path: str) -> None:
-        """Add packages from a path to the cache."""
-        dist_cache = self.dist_cache
-        for dist in pkg_resources.find_distributions(path):
-            dist_cache.setdefault(dist.project_name.lower(), dist)

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -9,7 +9,6 @@ from typing import List
 
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
-from homeassistant.core import HomeAssistant
 from homeassistant.requirements import pip_kwargs
 from homeassistant.util.package import (
     install_package, is_virtual_env, is_installed)

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -10,8 +10,9 @@ from typing import List
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
 from homeassistant.core import HomeAssistant
-from homeassistant.requirements import pip_kwargs, PackageLoadable
-from homeassistant.util.package import install_package, is_virtual_env
+from homeassistant.requirements import pip_kwargs
+from homeassistant.util.package import (
+    install_package, is_virtual_env, is_installed)
 
 
 def run(args: List) -> int:
@@ -49,10 +50,8 @@ def run(args: List) -> int:
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-    hass = HomeAssistant(loop)
-    pkgload = PackageLoadable(hass)
     for req in getattr(script, 'REQUIREMENTS', []):
-        if loop.run_until_complete(pkgload.loadable(req)):
+        if is_installed(req):
             continue
 
         if not install_package(req, **_pip_kwargs):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,6 +5,7 @@ async_timeout==3.0.1
 attrs==19.1.0
 bcrypt==3.1.6
 certifi>=2018.04.16
+importlib-metadata==0.15
 jinja2>=2.10
 PyJWT==1.7.1
 cryptography==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ REQUIRES = [
     'attrs==19.1.0',
     'bcrypt==3.1.6',
     'certifi>=2018.04.16',
+    'importlib-metadata==0.15',
     'jinja2>=2.10',
     'PyJWT==1.7.1',
     # PyJWT has loose dependency. We want the latest one.

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -6,12 +6,19 @@ import sys
 from subprocess import PIPE
 from unittest.mock import MagicMock, call, patch
 
+import pkg_resources
 import pytest
 
 import homeassistant.util.package as package
 
 
+RESOURCE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'resources'))
+
 TEST_NEW_REQ = 'pyhelloworld3==1.0.0'
+
+TEST_ZIP_REQ = 'file://{}#{}' \
+    .format(os.path.join(RESOURCE_DIR, 'pyhelloworld3.zip'), TEST_NEW_REQ)
 
 
 @pytest.fixture
@@ -176,3 +183,14 @@ def test_async_get_user_site(mock_env_copy):
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
         env=env)
     assert ret == os.path.join(deps_dir, 'lib_dir')
+
+
+def test_check_package_global():
+    """Test for an installed package."""
+    installed_package = list(pkg_resources.working_set)[0].project_name
+    assert package.is_installed(installed_package)
+
+
+def test_check_package_zip():
+    """Test for an installed zip package."""
+    assert not package.is_installed(TEST_ZIP_REQ)


### PR DESCRIPTION
## Description:
I just saw [this tweet](https://twitter.com/pumpichank/status/1132302245997961216?s=09) with a new feature for Python 3.8: importlib.metadata. A module that gives information about packages that are installed. In the comments of the tweet I noticed that a version of that module is already available on PyPI, so I went ahead and migrated our own hackish implementation to the official one.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
