### PR TITLE
Retrieve wire and wireless devices with the SRM device tracker

### DIFF
--- a/homeassistant/components/synology_srm/device_tracker.py
+++ b/homeassistant/components/synology_srm/device_tracker.py
@@ -80,7 +80,7 @@ class SynologySrmDeviceScanner(DeviceScanner):
         """Check the router for connected devices."""
         _LOGGER.debug("Scanning for connected devices")
 
-        devices = self.client.mesh.network_wifidevice()
+        devices = self.client.core.network_nsm_device({'is_online': True})
         last_results = []
 
         for device in devices:

--- a/homeassistant/components/synology_srm/manifest.json
+++ b/homeassistant/components/synology_srm/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "synology_srm",
-  "name": "Synology srm",
+  "name": "Synology SRM",
   "documentation": "https://www.home-assistant.io/components/synology_srm",
   "requirements": [
-    "synology-srm==0.0.6"
+    "synology-srm==0.0.7"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1699,7 +1699,7 @@ sucks==0.9.4
 swisshydrodata==0.0.3
 
 # homeassistant.components.synology_srm
-synology-srm==0.0.6
+synology-srm==0.0.7
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.14


### PR DESCRIPTION
## Description:

Before this change, only device connected to the Wi-Fi were retrieved. Now we have wire and wireless devices.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
