### PR TITLE
Set assumed_state property to True.

### DIFF
--- a/homeassistant/components/mcp23017/switch.py
+++ b/homeassistant/components/mcp23017/switch.py
@@ -79,6 +79,11 @@ class MCP23017Switch(ToggleEntity):
         """Return true if device is on."""
         return self._state
 
+    @property
+    def assumed_state(self):
+        """Return true if optimistic updates are used."""
+        return True
+
     def turn_on(self, **kwargs):
         """Turn the device on."""
         self._pin.value = not self._invert_logic


### PR DESCRIPTION
## Description:

Set assumed_state property to ```True``` since there is no feedback from the device before changing state.

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.
  - [ x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
