### PR TITLE
geniushub: fix sensor battery level, and bump client

### DIFF
--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.4.9"
+    "geniushub-client==0.4.11"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -76,7 +76,8 @@ class GeniusDevice(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._device.state['batteryLevel']
+        level = self._device.state['batteryLevel']
+        return level if level != 255 else 0
 
     @property
     def device_state_attributes(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -484,7 +484,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.4.9
+geniushub-client==0.4.11
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
## Breaking Change:

None

## Description:
If battery is dead, the level is 255, and not 0.  This sets the level to 0, and improves the corresponding error message to include the name of the device that has the dead battery.

This requires a client bump.

```python
     @property
     def state(self):
         """Return the state of the sensor."""
         level = self._device.state['batteryLevel']
         return level if level != 255 else 0
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
No change

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
