### PR TITLE
Reinstate passing loop to DSMR

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -187,7 +187,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     else:
         reader_factory = partial(
             create_dsmr_reader, config[CONF_PORT], config[CONF_DSMR_VERSION],
-            update_entities_telegram)
+            update_entities_telegram, loop=hass.loop)
 
     async def connect_and_reconnect():
         """Connect to DSMR and keep reconnecting until Home Assistant stops."""

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -183,7 +183,8 @@ async def async_setup_platform(hass, config, async_add_entities,
     if CONF_HOST in config:
         reader_factory = partial(
             create_tcp_dsmr_reader, config[CONF_HOST], config[CONF_PORT],
-            config[CONF_DSMR_VERSION], update_entities_telegram)
+            config[CONF_DSMR_VERSION], update_entities_telegram,
+            loop=hass.loop)
     else:
         reader_factory = partial(
             create_dsmr_reader, config[CONF_PORT], config[CONF_DSMR_VERSION],


### PR DESCRIPTION
## Description:
loop is optional for `create_dsmr_reader`  but looks like they don't call asyncio.get_event_loop() if it's None, and instead pass the loop variable on as-is. So make sure we pass a correct loop in. 

Reverts a change from #23984 noticed by @WoLpH in https://github.com/home-assistant/home-assistant/pull/23984#discussion_r287578225