### PR TITLE
Don't crash on first EAN without installations

### DIFF
--- a/homeassistant/components/essent/manifest.json
+++ b/homeassistant/components/essent/manifest.json
@@ -2,7 +2,7 @@
   "domain": "essent",
   "name": "Essent",
   "documentation": "https://www.home-assistant.io/components/essent",
-  "requirements": ["PyEssent==0.10"],
+  "requirements": ["PyEssent==0.12"],
   "dependencies": [],
   "codeowners": ["@TheLastProject"]
 }

--- a/homeassistant/components/essent/sensor.py
+++ b/homeassistant/components/essent/sensor.py
@@ -65,8 +65,9 @@ class EssentBase():
         essent = PyEssent(self._username, self._password)
         self._meters = essent.get_EANs()
         for meter in self._meters:
-            self._meter_data[meter] = essent.read_meter(
-                meter, only_last_meter_reading=True)
+            meter_data = essent.read_meter(meter, only_last_meter_reading=True)
+            if meter_data:
+                self._meter_data[meter] = meter_data
 
 
 class EssentMeter(Entity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -42,7 +42,7 @@ Mastodon.py==1.4.2
 OPi.GPIO==0.3.6
 
 # homeassistant.components.essent
-PyEssent==0.10
+PyEssent==0.12
 
 # homeassistant.components.github
 PyGithub==1.43.5


### PR DESCRIPTION
## Description:
It seems that some users have multiple "EANs" on their Essent account, possibly without any installations attached to them. This causes an AttributeError. This patch makes it so that it loops over every single EAN, ignoring those that failed.

I honestly do not know of all the possible effects this may cause (because this whole component is reverse engineering), but I can confirm that it doesn't cause any regressions for my setup.

**Related issue (if applicable):** (hopefully) fixes #24016. I sadly do not have enough information to make completely sure this will actually make meter info show up for these users but I am hopeful it may help and feel it is more likely to improve the situation than make it worse.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
