### PR TITLE
Add sensitivity attribut for binary sensor and add dark & daylight for lightlevel sensor for Hue

### DIFF
--- a/homeassistant/components/hue/binary_sensor.py
+++ b/homeassistant/components/hue/binary_sensor.py
@@ -26,3 +26,11 @@ class HuePresence(GenericZLLSensor, BinarySensorDevice):
     def is_on(self):
         """Return true if the binary sensor is on."""
         return self.sensor.presence
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = super().device_state_attributes
+        if 'sensitivity' in self.sensor.config: attributes.update({"sensitivity":self.sensor.config['sensitivity']})
+        if 'sensitivitymax' in self.sensor.config: attributes.update({"sensitivity_max":self.sensor.config['sensitivitymax']})
+        return attributes

--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -49,6 +49,8 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
         attributes.update({
             "threshold_dark": self.sensor.tholddark,
             "threshold_offset": self.sensor.tholdoffset,
+            "dark": self.sensor.dark,
+            "daylight": self.sensor.daylight,
         })
         return attributes
 


### PR DESCRIPTION
## Description:
Add sensitivity attribut for binarysensor 
Add dark & daylight for lightlevel sensor
These attributes are important because the sensor sends the brightness level every 5 minutes.
The dark and daylight attributes can be used to condition the automata

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
