### PR TITLE
Hue : revert low lux for high lux

### DIFF
--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -34,13 +34,7 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
         """Return the state of the device."""
         if self.sensor.lightlevel is None:
             return None
-
-        # https://developers.meethue.com/develop/hue-api/supported-devices/#clip_zll_lightlevel
-        # Light level in 10000 log10 (lux) +1 measured by sensor. Logarithm
-        # scale used because the human eye adjusts to light levels and small
-        # changes at low lux levels are more noticeable than at high lux
-        # levels.
-        return 10 ** ((self.sensor.lightlevel - 1) / 10000)
+        return self.sensor.lightlevel
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Description:
I propose to go back on the calculation because the daylight and fark attribut thresholds are based on the light level

dark attribut is True if lightlevel <= threshold_dark
daylight attribut is True if threshold_dark + threshold_offset >= lightlevel

These values need to be consistent if we want to use them in triggering conditions

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
