### PR TITLE
Revert Zeroconf back to previously used library

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -1,5 +1,4 @@
 """Support for exposing Home Assistant via Zeroconf."""
-from __future__ import absolute_import
 import logging
 
 import ipaddress

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -1,4 +1,5 @@
 """Support for exposing Home Assistant via Zeroconf."""
+from __future__ import absolute_import
 import logging
 
 import ipaddress

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -1,4 +1,7 @@
 """Support for exposing Home Assistant via Zeroconf."""
+# PyLint bug confuses absolute/relative imports
+# https://github.com/PyCQA/pylint/issues/1931
+# pylint: disable=no-name-in-module
 import logging
 
 import ipaddress

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -45,22 +45,7 @@ def setup(hass, config):
 
     zeroconf.register_service(info)
 
-<<<<<<< HEAD
-    async def new_service(service_type, name):
-        """Signal new service discovered."""
-        service_info = await zeroconf.get_service_info(service_type, name)
-        info = info_from_service(service_info)
-        _LOGGER.debug("Discovered new device %s %s", name, info)
-
-        for domain in zeroconf_manifest.SERVICE_TYPES[service_type]:
-            await hass.config_entries.flow.async_init(
-                domain, context={'source': DOMAIN}, data=info
-            )
-
-    def service_update(_, service_type, name, state_change):
-=======
     def service_update(zeroconf, service_type, name, state_change):
->>>>>>> Revert back to previously used library
         """Service state changed."""
         if state_change is ServiceStateChange.Added:
             service_info = zeroconf.get_service_info(service_type, name)

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zeroconf",
   "documentation": "https://www.home-assistant.io/components/zeroconf",
   "requirements": [
-    "aiozeroconf==0.1.8"
+    "zeroconf==0.22.0"
   ],
   "dependencies": [
     "api"

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -4,7 +4,7 @@ To update, run python3 -m hassfest
 """
 
 
-SERVICE_TYPES = {
+ZEROCONF = {
     "_axis-video._tcp.local.": [
         "axis"
     ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -162,9 +162,6 @@ aioswitcher==2019.3.21
 # homeassistant.components.unifi
 aiounifi==4
 
-# homeassistant.components.zeroconf
-aiozeroconf==0.1.8
-
 # homeassistant.components.aladdin_connect
 aladdin_connect==0.3
 
@@ -1876,6 +1873,9 @@ youtube_dl==2019.05.11
 
 # homeassistant.components.zengge
 zengge==0.2
+
+# homeassistant.components.zeroconf
+zeroconf==0.22.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -60,9 +60,6 @@ aioswitcher==2019.3.21
 # homeassistant.components.unifi
 aiounifi==4
 
-# homeassistant.components.zeroconf
-aiozeroconf==0.1.8
-
 # homeassistant.components.ambiclimate
 ambiclimate==0.1.2
 
@@ -353,6 +350,9 @@ vultr==0.1.2
 # homeassistant.components.samsungtv
 # homeassistant.components.wake_on_lan
 wakeonlan==1.1.6
+
+# homeassistant.components.zeroconf
+zeroconf==0.22.0
 
 # homeassistant.components.zha
 zigpy-homeassistant==0.3.3

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -51,7 +51,6 @@ TEST_REQUIREMENTS = (
     'aiohue',
     'aiounifi',
     'aioswitcher',
-    'aiozeroconf',
     'apns2',
     'av',
     'axis',
@@ -150,6 +149,7 @@ TEST_REQUIREMENTS = (
     'vultr',
     'YesssSMS',
     'ruamel.yaml',
+    'zeroconf',
     'zigpy-homeassistant',
     'bellows-homeassistant',
 )

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -12,7 +12,7 @@ To update, run python3 -m hassfest
 \"\"\"
 
 
-SERVICE_TYPES = {}
+ZEROCONF = {}
 """.strip()
 
 

--- a/tests/components/default_config/test_init.py
+++ b/tests/components/default_config/test_init.py
@@ -9,9 +9,9 @@ from tests.common import MockDependency, mock_coro
 
 
 @pytest.fixture(autouse=True)
-def aiozeroconf_mock():
-    """Mock aiozeroconf."""
-    with MockDependency('aiozeroconf') as mocked_zeroconf:
+def zeroconf_mock():
+    """Mock zeroconf."""
+    with MockDependency('zeroconf') as mocked_zeroconf:
         mocked_zeroconf.Zeroconf.return_value.register_service \
             .return_value = mock_coro(True)
         yield

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from zeroconf import ServiceInfo, ServiceStateChange
 
 from homeassistant.generated import zeroconf as zc_gen
-from homeassistant.setup import async_setup_component, setup_component
+from homeassistant.setup import async_setup_component
 from homeassistant.components import zeroconf
 
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,21 +1,21 @@
 """Test Zeroconf component setup process."""
 from unittest.mock import patch
 
-from aiozeroconf import ServiceInfo, ServiceStateChange
+from zeroconf import ServiceInfo, ServiceStateChange
 
 from homeassistant.generated import zeroconf as zc_gen
-from homeassistant.setup import async_setup_component
+from homeassistant.setup import async_setup_component, setup_component
 from homeassistant.components import zeroconf
 
 
 def service_update_mock(zeroconf, service, handlers):
     """Call service update handler."""
     handlers[0](
-        None, service, '{}.{}'.format('name', service),
+        zeroconf, service, '{}.{}'.format('name', service),
         ServiceStateChange.Added)
 
 
-async def get_service_info_mock(service_type, name):
+def get_service_info_mock(service_type, name):
     """Return service info for get_service_info."""
     return ServiceInfo(
         service_type, name, address=b'\n\x00\x00\x14', port=80, weight=0,
@@ -35,7 +35,6 @@ async def test_setup(hass):
 
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
-        await hass.async_block_till_done()
 
-    assert len(MockServiceBrowser.mock_calls) == len(zc_gen.SERVICE_TYPES)
-    assert len(mock_config_flow.mock_calls) == len(zc_gen.SERVICE_TYPES)
+    assert len(MockServiceBrowser.mock_calls) == len(zc_gen.ZEROCONF)
+    assert len(mock_config_flow.mock_calls) == len(zc_gen.ZEROCONF)

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -37,4 +37,4 @@ async def test_setup(hass):
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(MockServiceBrowser.mock_calls) == len(zc_gen.ZEROCONF)
-    assert len(mock_config_flow.mock_calls) == len(zc_gen.ZEROCONF)
+    assert len(mock_config_flow.mock_calls) == len(zc_gen.ZEROCONF) * 2


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/24115 https://github.com/home-assistant/architecture/issues/198

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html