### PR TITLE
Make the HUE scan interval variable.

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -21,6 +21,9 @@ CONF_BRIDGES = "bridges"
 CONF_ALLOW_UNREACHABLE = 'allow_unreachable'
 DEFAULT_ALLOW_UNREACHABLE = False
 
+CONF_SCAN_INTERVAL = 'scan_interval'
+DEFAULT_SCAN_INTERVAL = 5.0
+
 DATA_CONFIGS = 'hue_configs'
 
 PHUE_CONFIG_FILE = 'phue.conf'
@@ -37,6 +40,8 @@ BRIDGE_CONFIG_SCHEMA = vol.Schema({
                  default=DEFAULT_ALLOW_UNREACHABLE): cv.boolean,
     vol.Optional(CONF_ALLOW_HUE_GROUPS,
                  default=DEFAULT_ALLOW_HUE_GROUPS): cv.boolean,
+    vol.Optional(CONF_SCAN_INTERVAL,
+                 default=DEFAULT_SCAN_INTERVAL): float,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -97,11 +102,14 @@ async def async_setup_entry(hass, entry):
     if config is None:
         allow_unreachable = DEFAULT_ALLOW_UNREACHABLE
         allow_groups = DEFAULT_ALLOW_HUE_GROUPS
+        scan_interval = DEFAULT_SCAN_INTERVAL
     else:
         allow_unreachable = config[CONF_ALLOW_UNREACHABLE]
         allow_groups = config[CONF_ALLOW_HUE_GROUPS]
+        scan_interval = config[CONF_SCAN_INTERVAL]
 
-    bridge = HueBridge(hass, entry, allow_unreachable, allow_groups)
+    bridge = HueBridge(hass, entry, allow_unreachable, allow_groups,
+                       scan_interval)
 
     if not await bridge.async_setup():
         return False

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -1,6 +1,7 @@
 """Code to handle a Hue bridge."""
 import asyncio
 
+from datetime import timedelta
 import aiohue
 import async_timeout
 import voluptuous as vol
@@ -24,12 +25,14 @@ SCENE_SCHEMA = vol.Schema({
 class HueBridge:
     """Manages a single Hue bridge."""
 
-    def __init__(self, hass, config_entry, allow_unreachable, allow_groups):
+    def __init__(self, hass, config_entry, allow_unreachable, allow_groups,
+                 scan_interval):
         """Initialize the system."""
         self.config_entry = config_entry
         self.hass = hass
         self.allow_unreachable = allow_unreachable
         self.allow_groups = allow_groups
+        self.scan_interval = timedelta(seconds=scan_interval)
         self.available = True
         self.api = None
 

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -1,6 +1,5 @@
 """Support for the Philips Hue sensors as a platform."""
 import asyncio
-from datetime import timedelta
 import logging
 from time import monotonic
 
@@ -48,7 +47,6 @@ class SensorManager:
     Intended to be a singleton.
     """
 
-    SCAN_INTERVAL = timedelta(seconds=5)
     sensor_config_map = {}
 
     def __init__(self, hass, bridge):
@@ -95,14 +93,15 @@ class SensorManager:
 
         self._started = True
         _LOGGER.info('Starting sensor polling loop with %s second interval',
-                     self.SCAN_INTERVAL.total_seconds())
+                     self.bridge.scan_interval.total_seconds())
 
         async def async_update_bridge(now):
             """Will update sensors from the bridge."""
             await self.async_update_items()
 
             async_track_point_in_utc_time(
-                self.hass, async_update_bridge, utcnow() + self.SCAN_INTERVAL)
+                self.hass, async_update_bridge,
+                utcnow() + self.bridge.scan_interval)
 
         await async_update_bridge(None)
 

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -15,7 +15,7 @@ async def test_bridge_setup():
     entry = Mock()
     api = Mock()
     entry.data = {'host': '1.2.3.4', 'username': 'mock-username'}
-    hue_bridge = bridge.HueBridge(hass, entry, False, False)
+    hue_bridge = bridge.HueBridge(hass, entry, False, False, 5)
 
     with patch.object(bridge, 'get_bridge', return_value=mock_coro(api)):
         assert await hue_bridge.async_setup() is True
@@ -35,7 +35,7 @@ async def test_bridge_setup_invalid_username():
     hass = Mock()
     entry = Mock()
     entry.data = {'host': '1.2.3.4', 'username': 'mock-username'}
-    hue_bridge = bridge.HueBridge(hass, entry, False, False)
+    hue_bridge = bridge.HueBridge(hass, entry, False, False, 5)
 
     with patch.object(bridge, 'get_bridge',
                       side_effect=errors.AuthenticationRequired):
@@ -53,7 +53,7 @@ async def test_bridge_setup_timeout(hass):
     hass = Mock()
     entry = Mock()
     entry.data = {'host': '1.2.3.4', 'username': 'mock-username'}
-    hue_bridge = bridge.HueBridge(hass, entry, False, False)
+    hue_bridge = bridge.HueBridge(hass, entry, False, False, 5)
 
     with patch.object(
             bridge, 'get_bridge', side_effect=errors.CannotConnect
@@ -66,7 +66,7 @@ async def test_reset_if_entry_had_wrong_auth():
     hass = Mock()
     entry = Mock()
     entry.data = {'host': '1.2.3.4', 'username': 'mock-username'}
-    hue_bridge = bridge.HueBridge(hass, entry, False, False)
+    hue_bridge = bridge.HueBridge(hass, entry, False, False, 5)
 
     with patch.object(bridge, 'get_bridge',
                       side_effect=errors.AuthenticationRequired):
@@ -82,7 +82,7 @@ async def test_reset_unloads_entry_if_setup():
     hass = Mock()
     entry = Mock()
     entry.data = {'host': '1.2.3.4', 'username': 'mock-username'}
-    hue_bridge = bridge.HueBridge(hass, entry, False, False)
+    hue_bridge = bridge.HueBridge(hass, entry, False, False, 5)
 
     with patch.object(bridge, 'get_bridge', return_value=mock_coro(Mock())):
         assert await hue_bridge.async_setup() is True

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -30,7 +30,8 @@ async def test_setup_defined_hosts_known_auth(hass):
                     hue.CONF_HOST: '0.0.0.0',
                     hue.CONF_FILENAME: 'bla.conf',
                     hue.CONF_ALLOW_HUE_GROUPS: False,
-                    hue.CONF_ALLOW_UNREACHABLE: True
+                    hue.CONF_ALLOW_UNREACHABLE: True,
+                    hue.CONF_SCAN_INTERVAL: 5.0
                 }
             }
         }) is True
@@ -44,7 +45,8 @@ async def test_setup_defined_hosts_known_auth(hass):
             hue.CONF_HOST: '0.0.0.0',
             hue.CONF_FILENAME: 'bla.conf',
             hue.CONF_ALLOW_HUE_GROUPS: False,
-            hue.CONF_ALLOW_UNREACHABLE: True
+            hue.CONF_ALLOW_UNREACHABLE: True,
+            hue.CONF_SCAN_INTERVAL: 5.0
         }
     }
 
@@ -60,7 +62,8 @@ async def test_setup_defined_hosts_no_known_auth(hass):
                     hue.CONF_HOST: '0.0.0.0',
                     hue.CONF_FILENAME: 'bla.conf',
                     hue.CONF_ALLOW_HUE_GROUPS: False,
-                    hue.CONF_ALLOW_UNREACHABLE: True
+                    hue.CONF_ALLOW_UNREACHABLE: True,
+                    hue.CONF_SCAN_INTERVAL: 5.0
                 }
             }
         }) is True
@@ -78,7 +81,8 @@ async def test_setup_defined_hosts_no_known_auth(hass):
             hue.CONF_HOST: '0.0.0.0',
             hue.CONF_FILENAME: 'bla.conf',
             hue.CONF_ALLOW_HUE_GROUPS: False,
-            hue.CONF_ALLOW_UNREACHABLE: True
+            hue.CONF_ALLOW_UNREACHABLE: True,
+            hue.CONF_SCAN_INTERVAL: 5.0
         }
     }
 
@@ -108,19 +112,21 @@ async def test_config_passed_to_config_entry(hass):
                     hue.CONF_HOST: '0.0.0.0',
                     hue.CONF_FILENAME: 'bla.conf',
                     hue.CONF_ALLOW_HUE_GROUPS: False,
-                    hue.CONF_ALLOW_UNREACHABLE: True
+                    hue.CONF_ALLOW_UNREACHABLE: True,
+                    hue.CONF_SCAN_INTERVAL: 1.0
                 }
             }
         }) is True
 
     assert len(mock_bridge.mock_calls) == 2
-    p_hass, p_entry, p_allow_unreachable, p_allow_groups = \
+    p_hass, p_entry, p_allow_unreachable, p_allow_groups, p_scan_interval = \
         mock_bridge.mock_calls[0][1]
 
     assert p_hass is hass
     assert p_entry is entry
     assert p_allow_unreachable is True
     assert p_allow_groups is False
+    assert p_scan_interval == 1.0
 
     assert len(mock_registry.mock_calls) == 1
     assert mock_registry.mock_calls[0][2] == {

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -222,6 +222,7 @@ def mock_bridge(hass):
         available=True,
         allow_unreachable=False,
         allow_groups=False,
+        scan_interval=5,
         api=Mock(),
         spec=hue.HueBridge
     )

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -1,4 +1,5 @@
 """Philips Hue sensors platform tests."""
+from datetime import timedelta
 import asyncio
 from collections import deque
 import datetime
@@ -327,6 +328,7 @@ def create_mock_bridge():
         available=True,
         allow_unreachable=False,
         allow_groups=False,
+        scan_interval=timedelta(seconds=5),
         api=Mock(),
         spec=hue.HueBridge
     )
@@ -358,8 +360,9 @@ def mock_bridge(hass):
 
 @pytest.fixture
 def increase_scan_interval(hass):
-    """Increase the SCAN_INTERVAL to prevent unexpected scans during tests."""
-    hue_sensor_base.SensorManager.SCAN_INTERVAL = datetime.timedelta(days=365)
+    """Increase the scan_interval to prevent unexpected scans during tests."""
+    hue_sensor_base.SensorManager.bridge.scan_interval = datetime.timedelta(
+        days=365)
 
 
 async def setup_bridge(hass, mock_bridge, hostname=None):


### PR DESCRIPTION
The default is 5 seconds

## Description:


**Related issue (if applicable):** fixes #23502

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9523

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
  bridges:
    - scan_interval: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
