### PR TITLE
Replace pyunifi with aiounifi in UniFi device tracker

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -84,6 +84,7 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
 
             try:
                 desc = user_input.get(CONF_SITE_ID, self.desc)
+                print(self.sites)
                 for site in self.sites.values():
                     if desc == site['desc']:
                         if site['role'] != 'admin':

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -1,7 +1,7 @@
 """UniFi Controller abstraction."""
 import asyncio
-import async_timeout
 import ssl
+import async_timeout
 
 from aiohttp import CookieJar
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -1,6 +1,7 @@
 """UniFi Controller abstraction."""
 import asyncio
 import async_timeout
+import ssl
 
 from aiohttp import CookieJar
 
@@ -81,15 +82,19 @@ async def get_controller(
     """Create a controller object and verify authentication."""
     import aiounifi
 
+    sslcontext = None
+
     if verify_ssl:
         session = aiohttp_client.async_get_clientsession(hass)
+        if isinstance(verify_ssl, str):
+            sslcontext = ssl.create_default_context(cafile=verify_ssl)
     else:
         session = aiohttp_client.async_create_clientsession(
             hass, verify_ssl=verify_ssl, cookie_jar=CookieJar(unsafe=True))
 
     controller = aiounifi.Controller(
         host, username=username, password=password, port=port, site=site,
-        websession=session
+        websession=session, sslcontext=sslcontext
     )
 
     try:

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,8 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/unifi",
   "requirements": [
-    "aiounifi==4",
-    "pyunifi==2.16"
+    "aiounifi==5"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/unifi",
   "requirements": [
-    "aiounifi==5"
+    "aiounifi==6"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -160,7 +160,7 @@ aiopvapi==1.6.14
 aioswitcher==2019.3.21
 
 # homeassistant.components.unifi
-aiounifi==4
+aiounifi==5
 
 # homeassistant.components.aladdin_connect
 aladdin_connect==0.3
@@ -1484,9 +1484,6 @@ pytrafikverket==0.1.5.9
 
 # homeassistant.components.ubee
 pyubee==0.6
-
-# homeassistant.components.unifi
-pyunifi==2.16
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==0.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -160,7 +160,7 @@ aiopvapi==1.6.14
 aioswitcher==2019.3.21
 
 # homeassistant.components.unifi
-aiounifi==5
+aiounifi==6
 
 # homeassistant.components.aladdin_connect
 aladdin_connect==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -58,7 +58,7 @@ aiohue==1.9.1
 aioswitcher==2019.3.21
 
 # homeassistant.components.unifi
-aiounifi==4
+aiounifi==5
 
 # homeassistant.components.ambiclimate
 ambiclimate==0.1.2
@@ -290,9 +290,6 @@ python_awair==0.0.4
 
 # homeassistant.components.tradfri
 pytradfri[async]==6.0.1
-
-# homeassistant.components.unifi
-pyunifi==2.16
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -58,7 +58,7 @@ aiohue==1.9.1
 aioswitcher==2019.3.21
 
 # homeassistant.components.unifi
-aiounifi==5
+aiounifi==6
 
 # homeassistant.components.ambiclimate
 ambiclimate==0.1.2

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -1,8 +1,6 @@
 """The tests for the Unifi WAP device tracker platform."""
 from unittest import mock
 from datetime import datetime, timedelta
-from pyunifi.controller import APIError
-
 
 import pytest
 import voluptuous as vol
@@ -13,13 +11,20 @@ import homeassistant.components.unifi.device_tracker as unifi
 from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
                                  CONF_PLATFORM, CONF_VERIFY_SSL,
                                  CONF_MONITORED_CONDITIONS)
+
+from tests.common import mock_coro
+from asynctest import CoroutineMock
+from aiounifi.clients import Clients
+
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
 
 
 @pytest.fixture
 def mock_ctrl():
     """Mock pyunifi."""
-    with mock.patch('pyunifi.controller.Controller') as mock_control:
+    with mock.patch('aiounifi.Controller') as mock_control:
+        mock_control.return_value.login.return_value = mock_coro()
+        mock_control.return_value.initialize.return_value = mock_coro()
         yield mock_control
 
 
@@ -33,7 +38,7 @@ def mock_scanner():
 
 @mock.patch('os.access', return_value=True)
 @mock.patch('os.path.isfile', mock.Mock(return_value=True))
-def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
+async def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
     """Test the setup with a string for ssl_verify.
 
     Representing the absolute path to a CA certificate bundle.
@@ -46,12 +51,9 @@ def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
             CONF_VERIFY_SSL: "/tmp/unifi.crt"
         })
     }
-    result = unifi.get_scanner(hass, config)
+    result = await unifi.async_get_scanner(hass, config)
     assert mock_scanner.return_value == result
     assert mock_ctrl.call_count == 1
-    assert mock_ctrl.mock_calls[0] == \
-        mock.call('localhost', 'foo', 'password', 8443,
-                  version='v4', site_id='default', ssl_verify="/tmp/unifi.crt")
 
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
@@ -59,7 +61,7 @@ def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
                                                None, None)
 
 
-def test_config_minimal(hass, mock_scanner, mock_ctrl):
+async def test_config_minimal(hass, mock_scanner, mock_ctrl):
     """Test the setup with minimal configuration."""
     config = {
         DOMAIN: unifi.PLATFORM_SCHEMA({
@@ -68,12 +70,10 @@ def test_config_minimal(hass, mock_scanner, mock_ctrl):
             CONF_PASSWORD: 'password',
         })
     }
-    result = unifi.get_scanner(hass, config)
+
+    result = await unifi.async_get_scanner(hass, config)
     assert mock_scanner.return_value == result
     assert mock_ctrl.call_count == 1
-    assert mock_ctrl.mock_calls[0] == \
-        mock.call('localhost', 'foo', 'password', 8443,
-                  version='v4', site_id='default', ssl_verify=True)
 
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
@@ -81,7 +81,7 @@ def test_config_minimal(hass, mock_scanner, mock_ctrl):
                                                None, None)
 
 
-def test_config_full(hass, mock_scanner, mock_ctrl):
+async def test_config_full(hass, mock_scanner, mock_ctrl):
     """Test the setup with full configuration."""
     config = {
         DOMAIN: unifi.PLATFORM_SCHEMA({
@@ -96,12 +96,9 @@ def test_config_full(hass, mock_scanner, mock_ctrl):
             'detection_time': 300,
         })
     }
-    result = unifi.get_scanner(hass, config)
+    result = await unifi.async_get_scanner(hass, config)
     assert mock_scanner.return_value == result
     assert mock_ctrl.call_count == 1
-    assert mock_ctrl.call_args == \
-        mock.call('myhost', 'foo', 'password', 123,
-                  version='v4', site_id='abcdef01', ssl_verify=False)
 
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(
@@ -137,7 +134,7 @@ def test_config_error():
         })
 
 
-def test_config_controller_failed(hass, mock_ctrl, mock_scanner):
+async def test_config_controller_failed(hass, mock_ctrl, mock_scanner):
     """Test for controller failure."""
     config = {
         'device_tracker': {
@@ -146,13 +143,12 @@ def test_config_controller_failed(hass, mock_ctrl, mock_scanner):
             CONF_PASSWORD: 'password',
         }
     }
-    mock_ctrl.side_effect = APIError(
-        '/', 500, 'foo', {}, None)
-    result = unifi.get_scanner(hass, config)
+    mock_ctrl.side_effect = unifi.CannotConnect
+    result = await unifi.async_get_scanner(hass, config)
     assert result is False
 
 
-def test_scanner_update():
+async def test_scanner_update():
     """Test the scanner update."""
     ctrl = mock.MagicMock()
     fake_clients = [
@@ -161,21 +157,20 @@ def test_scanner_update():
         {'mac': '234', 'essid': 'barnet',
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
-    ctrl.get_clients.return_value = fake_clients
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
-    assert ctrl.get_clients.call_count == 1
-    assert ctrl.get_clients.call_args == mock.call()
+    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
+    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+    await scnr.async_update()
+    assert len(scnr._clients) == 2
 
 
 def test_scanner_update_error():
     """Test the scanner update for error."""
     ctrl = mock.MagicMock()
-    ctrl.get_clients.side_effect = APIError(
-        '/', 500, 'foo', {}, None)
+    ctrl.get_clients.side_effect = unifi.aiounifi.AiounifiException
     unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
 
 
-def test_scan_devices():
+async def test_scan_devices():
     """Test the scanning for devices."""
     ctrl = mock.MagicMock()
     fake_clients = [
@@ -184,12 +179,13 @@ def test_scan_devices():
         {'mac': '234', 'essid': 'barnet',
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
-    ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
-    assert set(scanner.scan_devices()) == set(['123', '234'])
+    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
+    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+    await scnr.async_update()
+    assert set(await scnr.async_scan_devices()) == set(['123', '234'])
 
 
-def test_scan_devices_filtered():
+async def test_scan_devices_filtered():
     """Test the scanning for devices based on SSID."""
     ctrl = mock.MagicMock()
     fake_clients = [
@@ -204,13 +200,13 @@ def test_scan_devices_filtered():
     ]
 
     ssid_filter = ['foonet', 'barnet']
-    ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter,
-                                 None)
-    assert set(scanner.scan_devices()) == set(['123', '234', '890'])
+    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
+    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter, None)
+    await scnr.async_update()
+    assert set(await scnr.async_scan_devices()) == set(['123', '234', '890'])
 
 
-def test_get_device_name():
+async def test_get_device_name():
     """Test the getting of device names."""
     ctrl = mock.MagicMock()
     fake_clients = [
@@ -226,15 +222,16 @@ def test_get_device_name():
          'essid': 'barnet',
          'last_seen': '1504786810'},
     ]
-    ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
-    assert scanner.get_device_name('123') == 'foobar'
-    assert scanner.get_device_name('234') == 'Nice Name'
-    assert scanner.get_device_name('456') is None
-    assert scanner.get_device_name('unknown') is None
+    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
+    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+    await scnr.async_update()
+    assert scnr.get_device_name('123') == 'foobar'
+    assert scnr.get_device_name('234') == 'Nice Name'
+    assert scnr.get_device_name('456') is None
+    assert scnr.get_device_name('unknown') is None
 
 
-def test_monitored_conditions():
+async def test_monitored_conditions():
     """Test the filtering of attributes."""
     ctrl = mock.MagicMock()
     fake_clients = [
@@ -254,16 +251,17 @@ def test_monitored_conditions():
          'essid': 'barnet',
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
-    ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
-                                 ['essid', 'signal', 'latest_assoc_time'])
-    assert scanner.get_extra_attributes('123') == {
+    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
+    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
+                              ['essid', 'signal', 'latest_assoc_time'])
+    await scnr.async_update()
+    assert scnr.get_extra_attributes('123') == {
         'essid': 'barnet',
         'signal': -60,
         'latest_assoc_time': datetime(2000, 1, 1, 0, 0, tzinfo=dt_util.UTC)
     }
-    assert scanner.get_extra_attributes('234') == {
+    assert scnr.get_extra_attributes('234') == {
         'essid': 'barnet',
         'signal': -42
     }
-    assert scanner.get_extra_attributes('456') == {'essid': 'barnet'}
+    assert scnr.get_extra_attributes('456') == {'essid': 'barnet'}

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -146,7 +146,8 @@ async def test_flow_works(hass, aioclient_mock):
     flow.hass = hass
 
     with patch('aiounifi.Controller') as mock_controller:
-        def mock_constructor(host, username, password, port, site, websession):
+        def mock_constructor(
+                host, username, password, port, site, websession, sslcontext):
             """Fake the controller constructor."""
             mock_controller.host = host
             mock_controller.username = username
@@ -254,7 +255,8 @@ async def test_user_permissions_low(hass, aioclient_mock):
     flow.hass = hass
 
     with patch('aiounifi.Controller') as mock_controller:
-        def mock_constructor(host, username, password, port, site, websession):
+        def mock_constructor(
+                host, username, password, port, site, websession, sslcontext):
             """Fake the controller constructor."""
             mock_controller.host = host
             mock_controller.username = username


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
First step towards making UniFi device tracker a part of the UniFi config entry.

**Related issue (if applicable):** should solve #23490

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
