### PR TITLE
Pubnub to 1.0.6 (Wink)

### DIFF
--- a/homeassistant/components/wink/manifest.json
+++ b/homeassistant/components/wink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Wink",
   "documentation": "https://www.home-assistant.io/components/wink",
   "requirements": [
-    "pubnubsub-handler==1.0.5",
+    "pubnubsub-handler==1.0.6",
     "python-wink==1.10.5"
   ],
   "dependencies": ["configurator"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -921,7 +921,7 @@ psutil==5.6.2
 ptvsd==4.2.8
 
 # homeassistant.components.wink
-pubnubsub-handler==1.0.5
+pubnubsub-handler==1.0.6
 
 # homeassistant.components.pushbullet
 pushbullet.py==0.11.0


### PR DESCRIPTION
## Description:

There is was defect in 1.0.5 introduced by https://github.com/home-assistant/home-assistant/pull/24154 which causes the CPU usage to increase because a new pubnub was getting created for every 3 devices not 50. This fixes that and also the error below.

```
ERROR (EndpointThread-Subscribe-0) [pubnub] Exception in subscribe loop: HTTP Client Error (400): {"error":"Bad Request","message":"Client Error","statusCode":400}
```

Part of this update delays the pubnub subscription for 60 seconds after the Home Assistant started event is fired. This means some users may see things get out of sync if they change any Wink devices during that 60 seconds.

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/wink-pubnub-not-updating/114580/209

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
