### PR TITLE
Log a debug message when polling a ZHA light.

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -246,6 +246,7 @@ class Light(ZhaEntity, light.Light):
 
     async def async_get_state(self, from_cache=True):
         """Attempt to retrieve on off state from the light."""
+        self.debug("polling current state")
         if self._on_off_channel:
             self._state = await self._on_off_channel.get_attribute_value(
                 'on_off', from_cache=from_cache)


### PR DESCRIPTION
## Description:
Log a debug message when polling a ZHA light. This is in effort to aid troubleshooting of lights going offline.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
