### PR TITLE
Use a "check" icon if no actual meteoalarm alarms

### DIFF
--- a/homeassistant/components/meteoalarm/binary_sensor.py
+++ b/homeassistant/components/meteoalarm/binary_sensor.py
@@ -84,8 +84,7 @@ class MeteoAlertBinarySensor(BinarySensorDevice):
         """Icon to use in the frontend."""
         if self._state:
             return ICON_ALERT
-        else:
-            return ICON_OK
+        return ICON_OK
 
     @property
     def device_class(self):

--- a/homeassistant/components/meteoalarm/binary_sensor.py
+++ b/homeassistant/components/meteoalarm/binary_sensor.py
@@ -21,7 +21,8 @@ ATTRIBUTION = "Information provided by MeteoAlarm."
 DEFAULT_NAME = 'meteoalarm'
 DEFAULT_DEVICE_CLASS = 'safety'
 
-ICON = 'mdi:alert'
+ICON_ALERT = 'mdi:alert'
+ICON_OK = 'mdi:check'
 
 SCAN_INTERVAL = timedelta(minutes=30)
 
@@ -59,7 +60,7 @@ class MeteoAlertBinarySensor(BinarySensorDevice):
         """Initialize the MeteoAlert binary sensor."""
         self._name = name
         self._attributes = {}
-        self._state = None
+        self._state = False
         self._api = api
 
     @property
@@ -81,7 +82,10 @@ class MeteoAlertBinarySensor(BinarySensorDevice):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON
+        if self._state:
+            return ICON_ALERT
+        else:
+            return ICON_OK
 
     @property
     def device_class(self):


### PR DESCRIPTION
## Description:

Use a ✔️ icon if no actual alarms are in effect.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

