### PR TITLE
Deprecate Python 3.5.3

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -94,6 +94,13 @@ async def async_from_config_dict(config: Dict[str, Any],
     stop = time()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop-start)
 
+    if sys.version_info[:3] < (3, 6, 0):
+        hass.components.persistent_notification.async_create(
+            "Python 3.5 support is deprecated and will "
+            "be removed in the first release after August 1. Please "
+            "upgrade Python.", "Python version", "python_version"
+        )
+
     # TEMP: warn users for invalid slugs
     # Remove after 0.94 or 1.0
     if cv.INVALID_SLUGS_FOUND or cv.INVALID_ENTITY_IDS_FOUND:


### PR DESCRIPTION
## Breaking Change:

Python 3.5.3 support will be removed in the first release after August 1, 2019. This release will print a warning if a soon to be unsupported Python version is used.

## Description:
Create a notification if Home Assistant is run under 3.6.0.

