### PR TITLE
Fix discovering the same HomeKit device multiple times

### DIFF
--- a/homeassistant/components/homekit_controller/.translations/en.json
+++ b/homeassistant/components/homekit_controller/.translations/en.json
@@ -3,6 +3,7 @@
         "abort": {
             "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
             "already_configured": "Accessory is already configured with this controller.",
+            "already_in_progress": "Config flow for device is already in progress.",
             "already_paired": "This accessory is already paired to another device. Please reset the accessory and try again.",
             "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
             "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed.",

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -131,9 +131,16 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         paired = not status_flags & 0x01
 
         # pylint: disable=unsupported-assignment-operation
+        self.context['hkid'] = hkid
         self.context['title_placeholders'] = {
             'name': discovery_info['name'].replace('._hap._tcp.local.', ''),
         }
+
+        # If multiple HomekitControllerFlowHandler end up getting created
+        # for the same accessory dont  let duplicates hang around
+        active_flows = self._async_in_progress()
+        if any(hkid == flow['context']['hkid'] for flow in active_flows):
+            return self.async_abort(reason='already_in_progress')
 
         # The configuration number increases every time the characteristic map
         # needs updating. Some devices use a slightly off-spec name so handle

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -33,7 +33,8 @@
             "ignored_model": "HomeKit support for this model is blocked as a more feature complete native integration is available.",
             "already_configured": "Accessory is already configured with this controller.",
             "invalid_config_entry": "This device is showing as ready to pair but there is already a conflicting config entry for it in Home Assistant that must first be removed.",
-            "accessory_not_found_error": "Cannot add pairing as device can no longer be found."
+            "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
+            "already_in_progress": "Config flow for device is already in progress."
         }
     }
 }


### PR DESCRIPTION
## Description:

This fixes the behaviour i mentioned in https://github.com/home-assistant/home-assistant/pull/24042 where a unpaired device can be discovered multiple times.

CC @balloob @Kane610 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
