### PR TITLE
Keep integrations in discovery

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -96,8 +96,15 @@ OPTIONAL_SERVICE_HANDLERS = {
     SERVICE_DLNA_DMR: ('media_player', 'dlna_dmr'),
 }
 
-DEFAULT_ENABLED = list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS)
-DEFAULT_DISABLED = list(OPTIONAL_SERVICE_HANDLERS)
+MIGRATED_SERVICE_HANDLERS = {
+    'axis': None,
+    'esphome': None
+}
+
+DEFAULT_ENABLED = list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS) + \
+    list(MIGRATED_SERVICE_HANDLERS)
+DEFAULT_DISABLED = list(OPTIONAL_SERVICE_HANDLERS) + \
+    list(MIGRATED_SERVICE_HANDLERS)
 
 CONF_IGNORE = 'ignore'
 CONF_ENABLE = 'enable'
@@ -144,6 +151,9 @@ async def async_setup(hass, config):
 
     async def new_service_found(service, info):
         """Handle a new service if one is found."""
+        if service in MIGRATED_SERVICE_HANDLERS:
+            return
+
         if service in ignored_platforms:
             logger.info("Ignoring service: %s %s", service, info)
             return

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -98,7 +98,10 @@ OPTIONAL_SERVICE_HANDLERS = {
 
 MIGRATED_SERVICE_HANDLERS = {
     'axis': None,
-    'esphome': None
+    'esphome': None,
+    'ikea_tradfri': None,
+    'homekit': None,
+    'philips_hue': None
 }
 
 DEFAULT_ENABLED = list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS) + \


### PR DESCRIPTION
But ignore them

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Related to https://github.com/home-assistant/architecture/issues/198 and https://github.com/home-assistant/home-assistant/pull/24090
We want to keep discovery working as to avoid breaking changes

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
