### PR TITLE
Remove discovery from initial config

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -59,9 +59,6 @@ default_config:
 # http:
 #   base_url: example.duckdns.org:8123
 
-# Discover some devices automatically
-discovery:
-
 # Sensors
 sensor:
   # Weather prediction


### PR DESCRIPTION
## Description:
Remove the discovery integration from the initial generated configuration. Users will still be able to add it to their configuration if they wish so. This will not impact existing installations.

Discovery is now done by the zeroconf and ssdp integrations.

