### PR TITLE
Dynamic panels

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -36,7 +36,7 @@ async def async_setup(hass, config):
     hass.http.register_view(CalendarEventView(component))
 
     # Doesn't work in prod builds of the frontend: home-assistant-polymer#1289
-    # await hass.components.frontend.async_register_built_in_panel(
+    # hass.components.frontend.async_register_built_in_panel(
     #     'calendar', 'calendar', 'hass:calendar')
 
     await component.async_setup(config)

--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -30,7 +30,7 @@ ON_DEMAND = ('zwave',)
 
 async def async_setup(hass, config):
     """Set up the config component."""
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'config', 'config', 'hass:settings', require_admin=True)
 
     async def setup_panel(panel_name):

--- a/homeassistant/components/hassio/addon_panel.py
+++ b/homeassistant/components/hassio/addon_panel.py
@@ -61,7 +61,7 @@ class HassIOAddonPanel(HomeAssistantView):
 
     async def delete(self, request, addon):
         """Handle remove add-on panel requests."""
-        # Currently not supported by backend / frontend
+        self.hass.components.frontend.async_remove_panel(addon)
         return web.Response()
 
     async def get_panels(self):

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -252,7 +252,7 @@ async def async_setup(hass, config):
     use_include_order = conf.get(CONF_ORDER)
 
     hass.http.register_view(HistoryPeriodView(filters, use_include_order))
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'history', 'history', 'hass:poll-box')
 
     return True

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -102,7 +102,7 @@ async def async_setup(hass, config):
 
     hass.http.register_view(LogbookView(config.get(DOMAIN, {})))
 
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'logbook', 'logbook', 'hass:format-list-bulleted-type')
 
     hass.services.async_register(

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -53,7 +53,7 @@ async def async_setup(hass, config):
     # Pass in default to `get` because defaults not set if loaded as dep
     mode = config.get(DOMAIN, {}).get(CONF_MODE, MODE_STORAGE)
 
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         DOMAIN, config={
             'mode': mode
         })

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -30,7 +30,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 async def async_setup(hass, config):
     """Track states and offer events for mailboxes."""
     mailboxes = []
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'mailbox', 'mailbox', 'mdi:mailbox')
     hass.http.register_view(MailboxPlatformsView(mailboxes))
     hass.http.register_view(MailboxMessageView(mailboxes))

--- a/homeassistant/components/map/__init__.py
+++ b/homeassistant/components/map/__init__.py
@@ -4,6 +4,6 @@ DOMAIN = 'map'
 
 async def async_setup(hass, config):
     """Register the built-in map panel."""
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'map', 'map', 'hass:tooltip-account')
     return True

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -112,7 +112,7 @@ async def async_register_panel(
 
     config['_panel_custom'] = custom_panel_config
 
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         component_name='custom',
         sidebar_title=sidebar_title,
         sidebar_icon=sidebar_icon,

--- a/homeassistant/components/panel_iframe/__init__.py
+++ b/homeassistant/components/panel_iframe/__init__.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
 async def async_setup(hass, config):
     """Set up the iFrame frontend panels."""
     for url_path, info in config[DOMAIN].items():
-        await hass.components.frontend.async_register_built_in_panel(
+        hass.components.frontend.async_register_built_in_panel(
             'iframe', info.get(CONF_TITLE), info.get(CONF_ICON),
             url_path, {'url': info[CONF_URL]},
             require_admin=info[CONF_REQUIRE_ADMIN])

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -117,7 +117,7 @@ def async_setup(hass, config):
         'What is on my shopping list'
     ])
 
-    yield from hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'shopping-list', 'shopping_list', 'mdi:cart')
 
     hass.components.websocket_api.async_register_command(

--- a/homeassistant/components/websocket_api/permissions.py
+++ b/homeassistant/components/websocket_api/permissions.py
@@ -14,11 +14,13 @@ from homeassistant.components.lovelace import EVENT_LOVELACE_UPDATED
 from homeassistant.helpers.area_registry import EVENT_AREA_REGISTRY_UPDATED
 from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
+from homeassistant.components.frontend import EVENT_PANELS_UPDATED
 
 # These are events that do not contain any sensitive data
 # Except for state_changed, which is handled accordingly.
 SUBSCRIBE_WHITELIST = {
     EVENT_COMPONENT_LOADED,
+    EVENT_PANELS_UPDATED,
     EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
     EVENT_SERVICE_REGISTERED,
     EVENT_SERVICE_REMOVED,

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -8,10 +8,11 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
     DOMAIN, CONF_JS_VERSION, CONF_THEMES, CONF_EXTRA_HTML_URL,
-    CONF_EXTRA_HTML_URL_ES5, generate_negative_index_regex)
+    CONF_EXTRA_HTML_URL_ES5, generate_negative_index_regex,
+    EVENT_PANELS_UPDATED)
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 
-from tests.common import mock_coro
+from tests.common import mock_coro, async_capture_events
 
 
 CONFIG_THEMES = {
@@ -232,11 +233,20 @@ def test_extra_urls(mock_http_client_with_urls, mock_onboarded):
     assert text.find('href="https://domain.com/my_extra_url.html"') >= 0
 
 
-async def test_get_panels(hass, hass_ws_client):
+async def test_get_panels(hass, hass_ws_client, mock_http_client):
     """Test get_panels command."""
-    await async_setup_component(hass, 'frontend', {})
-    await hass.components.frontend.async_register_built_in_panel(
+    events = async_capture_events(hass, EVENT_PANELS_UPDATED)
+
+    resp = await mock_http_client.get('/map')
+    assert resp.status == 404
+
+    hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:tooltip-account', require_admin=True)
+
+    resp = await mock_http_client.get('/map')
+    assert resp.status == 200
+
+    assert len(events) == 1
 
     client = await hass_ws_client(hass)
     await client.send_json({
@@ -255,14 +265,21 @@ async def test_get_panels(hass, hass_ws_client):
     assert msg['result']['map']['title'] == 'Map'
     assert msg['result']['map']['require_admin'] is True
 
+    hass.components.frontend.async_remove_panel('map')
+
+    resp = await mock_http_client.get('/map')
+    assert resp.status == 404
+
+    assert len(events) == 2
+
 
 async def test_get_panels_non_admin(hass, hass_ws_client, hass_admin_user):
     """Test get_panels command."""
     hass_admin_user.groups = []
     await async_setup_component(hass, 'frontend', {})
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:tooltip-account', require_admin=True)
-    await hass.components.frontend.async_register_built_in_panel(
+    hass.components.frontend.async_register_built_in_panel(
         'history', 'History', 'mdi:history')
 
     client = await hass_ws_client(hass)

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
     DOMAIN, CONF_JS_VERSION, CONF_THEMES, CONF_EXTRA_HTML_URL,
-    CONF_EXTRA_HTML_URL_ES5)
+    CONF_EXTRA_HTML_URL_ES5, generate_negative_index_regex)
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 
 from tests.common import mock_coro
@@ -331,3 +331,43 @@ async def test_auth_authorize(mock_http_client):
     resp = await mock_http_client.get(authorizejs.groups(0)[0])
     assert resp.status == 200
     assert 'public' in resp.headers.get('cache-control')
+
+
+def test_index_regex():
+    """Test the index regex."""
+    pattern = re.compile('/' + generate_negative_index_regex())
+
+    for should_match in (
+            '/',
+            '/lovelace',
+            '/lovelace/default_view',
+            '/map',
+            '/config',
+    ):
+        assert pattern.match(should_match), should_match
+
+    for should_not_match in (
+            '/service_worker.js',
+            '/manifest.json',
+            '/onboarding.html',
+            '/manifest.json',
+            'static',
+            'static/',
+            'static/index.html',
+            'frontend_latest',
+            'frontend_latest/',
+            'frontend_latest/index.html',
+            'frontend_es5',
+            'frontend_es5/',
+            'frontend_es5/index.html',
+            'local',
+            'local/',
+            'local/index.html',
+            'auth',
+            'auth/',
+            'auth/index.html',
+            '/api',
+            '/api/',
+            '/api/logbook',
+    ):
+        assert not pattern.match(should_not_match), should_not_match


### PR DESCRIPTION
## Breaking Change

Developers only: `hass.components.frontend.async_register_built_in_panel` is no longer an async function.

## Description:
 - Allow removing panels from the frontend on the fly
 - Fire an event when panels are added/removed so the frontend knows when to reload

Successor of #23175

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
