### PR TITLE
Update pysonos to 0.0.14

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.12"
+    "pysonos==0.0.14"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -374,7 +374,9 @@ class SonosEntity(MediaPlayerDevice):
 
     def _set_favorites(self):
         """Set available favorites."""
-        self._favorites = self.soco.music_library.get_sonos_favorites()
+        favorites = self.soco.music_library.get_sonos_favorites()
+        # Exclude favorites that are non-playable due to no linked resources
+        self._favorites = [f for f in favorites if f.reference.resources]
 
     def _radio_artwork(self, url):
         """Return the private URL with artwork for a radio stream."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1327,7 +1327,7 @@ pysmartthings==0.6.8
 pysnmp==4.4.9
 
 # homeassistant.components.sonos
-pysonos==0.0.12
+pysonos==0.0.14
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -274,7 +274,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.8
 
 # homeassistant.components.sonos
-pysonos==0.0.12
+pysonos==0.0.14
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

Update to pysonos 0.0.14 which mostly consists of a merge with the upstream SoCo 0.17 release.

Upstream handles invalid favorites a bit differently so we must now filter them out by hand.

There are no bug fixes so this should _not_ go into the beta.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
