### PR TITLE
homekit_controller: don't throw on routine transient encryption errors

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -95,7 +95,8 @@ class HomeKitEntity(Entity):
         """Obtain a HomeKit device's state."""
         # pylint: disable=import-error
         from homekit.exceptions import (
-            AccessoryDisconnectedError, AccessoryNotFoundError)
+            AccessoryDisconnectedError, AccessoryNotFoundError,
+            EncryptionError)
 
         try:
             new_values_dict = await self._accessory.get_characteristics(
@@ -106,7 +107,7 @@ class HomeKitEntity(Entity):
             # visible on the network.
             self._available = False
             return
-        except AccessoryDisconnectedError:
+        except (AccessoryDisconnectedError, EncryptionError):
             # Temporary connection failure. Device is still available but our
             # connection was dropped.
             return


### PR DESCRIPTION
## Description:

After this change homekt_controller will catch `EncryptionError` errors and won't fill the logs with them. These are transient and happen when a device closes its TCP connection on us abruptly. They are harmless but can be blamed when debugging other issues.

There is already a test that the code recovers from an `EncryptionError`.

Can this go in 0.94?

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
