### PR TITLE
Allow homekit to forward discovery

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -144,9 +144,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         if model in HOMEKIT_IGNORE:
             return self.async_abort(reason='ignored_model')
 
-        # Devices in HOMEKIT_IGNORE have native local integrations - users
-        # should be encouraged to use native integration and not confused
-        # by alternative HK API.
         if model in HOMEKIT_FORWARD_ZEROCONF:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -150,7 +150,6 @@ class FlowHandler(config_entries.ConfigFlow):
         self._host = host
 
 
-
 async def authenticate(hass, host, security_code):
     """Authenticate with a Tradfri hub."""
     from pytradfri.api.aiocoap_api import APIFactory

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -7,6 +7,7 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.core import callback
 
 from .const import (
     CONF_IMPORT_GROUPS, CONF_IDENTITY, CONF_HOST, CONF_KEY, CONF_GATEWAY_ID)
@@ -78,13 +79,19 @@ class FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_zeroconf(self, user_input):
         """Handle zeroconf discovery."""
+        host = user_input['host']
+
+        if any(flow['context']['host'] == host
+               for flow in self._async_in_progress()):
+            return self.async_abort(reason='already_in_progress')
+
         for entry in self._async_current_entries():
-            if entry.data[CONF_HOST] == user_input['host']:
+            if entry.data[CONF_HOST] == host:
                 return self.async_abort(
                     reason='already_configured'
                 )
 
-        self._host = user_input['host']
+        self._set_host(host)
         return await self.async_step_auth()
 
     async def async_step_import(self, user_input):
@@ -97,7 +104,7 @@ class FlowHandler(config_entries.ConfigFlow):
 
         # Happens if user has host directly in configuration.yaml
         if 'key' not in user_input:
-            self._host = user_input['host']
+            self._set_host(user_input['host'])
             self._import_groups = user_input[CONF_IMPORT_GROUPS]
             return await self.async_step_auth()
 
@@ -113,7 +120,7 @@ class FlowHandler(config_entries.ConfigFlow):
             return await self._entry_from_data(data)
         except AuthError:
             # If we fail to connect, just pass it on to discovery
-            self._host = user_input['host']
+            self._set_host(user_input['host'])
             return await self.async_step_auth()
 
     async def _entry_from_data(self, data):
@@ -134,6 +141,14 @@ class FlowHandler(config_entries.ConfigFlow):
             title=host,
             data=data
         )
+
+    @callback
+    def _set_host(self, host):
+        """Set the host."""
+        # pylint: disable=unsupported-assignment-operation
+        self.context['host'] = host
+        self._host = host
+
 
 
 async def authenticate(hass, host, security_code):

--- a/homeassistant/components/tradfri/strings.json
+++ b/homeassistant/components/tradfri/strings.json
@@ -17,7 +17,8 @@
       "timeout": "Timeout validating the code."
     },
     "abort": {
-      "already_configured": "Bridge is already configured"
+      "already_configured": "Bridge is already configured",
+      "already_in_progress": "There is already a flow setting up this bridge."
     }
   }
 }

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -81,6 +81,9 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
         return await self.async_step_confirm()
 
+    async_step_zeroconf = async_step_discovery
+    async_step_ssdp = async_step_discovery
+
     async def async_step_import(self, _):
         """Handle a flow initialized by import."""
         if self._async_in_progress() or self._async_current_entries():

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -993,4 +993,3 @@ async def test_parse_overlapping_homekit_json(hass):
         'hkid': '00:00:00:00:00:00',
         'title_placeholders': {'name': 'TestDevice'}
     }
-

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -301,6 +301,34 @@ async def test_discovery_ignored_model(hass):
     }
 
 
+async def test_discovery_forward_discovery(hass):
+    """Forward discovery."""
+    discovery_info = {
+        'name': 'TestDevice',
+        'host': '127.0.0.1',
+        'port': 8080,
+        'properties': {
+            'md': 'TRADFRI gateway',
+            'id': '00:00:00:00:00:00',
+            'c#': 1,
+            'sf': 1,
+        }
+    }
+
+    flow = _setup_flow_handler(hass)
+
+    with mock.patch.object(hass.config_entries.flow, 'async_init') as mock_ini:
+        result = await flow.async_step_zeroconf(discovery_info)
+
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'ignored_model'
+
+    assert len(mock_ini.mock_calls) == 1
+    assert mock_ini.mock_calls[0][1][0] == 'tradfri'
+    assert mock_ini.mock_calls[0][2]['context'] == {'source': 'zeroconf'}
+    assert mock_ini.mock_calls[0][2]['data'] == discovery_info
+
+
 async def test_discovery_invalid_config_entry(hass):
     """There is already a config entry for the pairing id but its invalid."""
     MockConfigEntry(domain='homekit_controller', data={
@@ -965,3 +993,4 @@ async def test_parse_overlapping_homekit_json(hass):
         'hkid': '00:00:00:00:00:00',
         'title_placeholders': {'name': 'TestDevice'}
     }
+

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -40,7 +40,7 @@ async def test_config_yaml_host_imported(hass):
     progress = hass.config_entries.flow.async_progress()
     assert len(progress) == 1
     assert progress[0]['handler'] == 'tradfri'
-    assert progress[0]['context'] == {'source': 'import'}
+    assert progress[0]['context'] == {'source': 'import', 'host': 'mock-host'}
 
 
 async def test_config_json_host_not_imported(hass):

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -75,24 +75,26 @@ async def test_user_has_confirmation(hass, discovery_flow_conf):
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
 
 
-async def test_discovery_single_instance(hass, discovery_flow_conf):
-    """Test we ask for confirmation via discovery."""
+@pytest.mark.parametrize('source', ['discovery', 'ssdp', 'zeroconf'])
+async def test_discovery_single_instance(hass, discovery_flow_conf, source):
+    """Test we not allow duplicates."""
     flow = config_entries.HANDLERS['test']()
     flow.hass = hass
 
     MockConfigEntry(domain='test').add_to_hass(hass)
-    result = await flow.async_step_discovery({})
+    result = await getattr(flow, "async_step_{}".format(source))({})
 
     assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
     assert result['reason'] == 'single_instance_allowed'
 
 
-async def test_discovery_confirmation(hass, discovery_flow_conf):
+@pytest.mark.parametrize('source', ['discovery', 'ssdp', 'zeroconf'])
+async def test_discovery_confirmation(hass, discovery_flow_conf, source):
     """Test we ask for confirmation via discovery."""
     flow = config_entries.HANDLERS['test']()
     flow.hass = hass
 
-    result = await flow.async_step_discovery({})
+    result = await getattr(flow, "async_step_{}".format(source))({})
 
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'confirm'


### PR DESCRIPTION
## Description:
Allow the HomeKit controller config flow forward certain zeroconf discoveries to their respective integrations that will be able to handle it.

Next step is to find out the LIFX bulbs models so we can forward those.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
