### PR TITLE
Allow discovery flows to be discovered via zeroconf/ssdp

### DIFF
--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -81,6 +81,9 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
         return await self.async_step_confirm()
 
+    async_step_zeroconf = async_step_discovery
+    async_step_ssdp = async_step_discovery
+
     async def async_step_import(self, _):
         """Handle a flow initialized by import."""
         if self._async_in_progress() or self._async_current_entries():

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -75,24 +75,26 @@ async def test_user_has_confirmation(hass, discovery_flow_conf):
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
 
 
-async def test_discovery_single_instance(hass, discovery_flow_conf):
-    """Test we ask for confirmation via discovery."""
+@pytest.mark.parametrize('source', ['discovery', 'ssdp', 'zeroconf'])
+async def test_discovery_single_instance(hass, discovery_flow_conf, source):
+    """Test we not allow duplicates."""
     flow = config_entries.HANDLERS['test']()
     flow.hass = hass
 
     MockConfigEntry(domain='test').add_to_hass(hass)
-    result = await flow.async_step_discovery({})
+    result = await getattr(flow, "async_step_{}".format(source))({})
 
     assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
     assert result['reason'] == 'single_instance_allowed'
 
 
-async def test_discovery_confirmation(hass, discovery_flow_conf):
+@pytest.mark.parametrize('source', ['discovery', 'ssdp', 'zeroconf'])
+async def test_discovery_confirmation(hass, discovery_flow_conf, source):
     """Test we ask for confirmation via discovery."""
     flow = config_entries.HANDLERS['test']()
     flow.hass = hass
 
-    result = await flow.async_step_discovery({})
+    result = await getattr(flow, "async_step_{}".format(source))({})
 
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert result['step_id'] == 'confirm'


### PR DESCRIPTION
## Description:
Allow discovery flows to be discovered via zeroconf/ssdp.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
