### PR TITLE
Lifx allow homekit discovery

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -17,12 +17,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def test_homekit_zeroconf(discovery_info, exclude_models):
-    """Test if info belongs to a HK device that is not part of given models."""
+    """Test if info belongs to a HK device that is not part of given models.
+
+    Models are tested by testing if model starts with any of the given models.
+    """
     if not discovery_info.get('name', '').endswith('._hap._tcp.local.'):
         return False
 
     props = normalize_zeroconf_props(discovery_info.get('properties', {}))
-    return props.get('md') not in exclude_models
+    return not props.get('md', '').startswith(tuple(exclude_models))
 
 
 def escape_characteristic_name(char_name):

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -5,8 +5,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
-# We need an import from .config_flow, without it .config_flow is never loaded.
-from .config_flow import HomekitControllerFlowHandler  # noqa: F401
+from .config_flow import normalize_zeroconf_props
 from .connection import get_accessory_information, HKDevice
 from .const import (
     CONTROLLER, ENTITY_MAP, KNOWN_DEVICES
@@ -15,6 +14,15 @@ from .const import DOMAIN   # noqa: pylint: disable=unused-import
 from .storage import EntityMapStorage
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def test_homekit_zeroconf(discovery_info, exclude_models):
+    """Test if info belongs to a HK device that is not part of given models."""
+    if not discovery_info.get('name', '').endswith('._hap._tcp.local.'):
+        return False
+
+    props = normalize_zeroconf_props(discovery_info.get('properties', {}))
+    return props.get('md') not in exclude_models
 
 
 def escape_characteristic_name(char_name):

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -12,11 +12,12 @@ from .const import DOMAIN, KNOWN_DEVICES
 from .connection import get_bridge_information, get_accessory_name
 
 
-HOMEKIT_IGNORE = [
+HOMEKIT_IGNORE = (
     'BSB002',
     'Home Assistant Bridge',
     'TRADFRI gateway',
-]
+    'LIFX',
+)
 HOMEKIT_DIR = '.homekit'
 PAIRING_FILE = 'pairing.json'
 
@@ -190,7 +191,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         # Devices in HOMEKIT_IGNORE have native local integrations - users
         # should be encouraged to use native integration and not confused
         # by alternative HK API.
-        if model in HOMEKIT_IGNORE:
+        if model.startswith(HOMEKIT_IGNORE):
             return self.async_abort(reason='ignored_model')
 
         # Device isn't paired with us or anyone else.

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -57,6 +57,14 @@ def find_existing_host(hass, serial):
             return entry
 
 
+def normalize_zeroconf_props(properties):
+    """Normalize zeroconf properties."""
+    return {
+        key.lower(): value
+        for (key, value) in properties.items()
+    }
+
+
 @config_entries.HANDLERS.register(DOMAIN)
 class HomekitControllerFlowHandler(config_entries.ConfigFlow):
     """Handle a HomeKit config flow."""
@@ -117,10 +125,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         # Normalize properties from discovery
         # homekit_python has code to do this, but not in a form we can
         # easily use, so do the bare minimum ourselves here instead.
-        properties = {
-            key.lower(): value
-            for (key, value) in discovery_info['properties'].items()
-        }
+        properties = normalize_zeroconf_props(discovery_info['properties'])
 
         # The hkid is a unique random number that looks like a pairing code.
         # It changes if a device is factory reset.

--- a/homeassistant/components/lifx/config_flow.py
+++ b/homeassistant/components/lifx/config_flow.py
@@ -13,4 +13,5 @@ async def _async_has_devices(hass):
 
 
 config_entry_flow.register_discovery_flow(
-    DOMAIN, 'LIFX', _async_has_devices, config_entries.CONN_CLASS_LOCAL_POLL)
+    DOMAIN, 'LIFX', _async_has_devices, config_entries.CONN_CLASS_LOCAL_POLL,
+    homekit_models=['LIFX'])

--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -8,6 +8,7 @@
     "aiolifx_effects==0.2.2"
   ],
   "dependencies": [],
+  "zeroconf": ["_hap._tcp.local."],
   "codeowners": [
     "@amelchio"
   ]

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -79,6 +79,12 @@ class FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_zeroconf(self, user_input):
         """Handle zeroconf discovery."""
+        # If it's a zeroconf discovery, we want to exclude it unless the model
+        # is one of ours.
+        if self.hass.components.homekit_controller.test_homekit_zeroconf(
+                user_input, ['TRADFRI gateway']):
+            return self.async_abort(reason='not_supported')
+
         host = user_input['host']
 
         if any(flow['context']['host'] == host

--- a/homeassistant/components/tradfri/manifest.json
+++ b/homeassistant/components/tradfri/manifest.json
@@ -7,7 +7,7 @@
     "pytradfri[async]==6.0.1"
   ],
   "dependencies": [],
-  "zeroconf": ["_coap._udp.local."],
+  "zeroconf": ["_coap._udp.local.", "_hap._tcp.local."],
   "codeowners": [
     "@ggravlingen"
   ]

--- a/homeassistant/components/tradfri/strings.json
+++ b/homeassistant/components/tradfri/strings.json
@@ -17,7 +17,8 @@
       "timeout": "Timeout validating the code."
     },
     "abort": {
-      "already_configured": "Bridge is already configured"
+      "already_configured": "Bridge is already configured",
+      "already_in_progress": "There is already a flow setting up this bridge."
     }
   }
 }

--- a/homeassistant/components/tradfri/strings.json
+++ b/homeassistant/components/tradfri/strings.json
@@ -18,7 +18,8 @@
     },
     "abort": {
       "already_configured": "Bridge is already configured",
-      "already_in_progress": "There is already a flow setting up this bridge."
+      "already_in_progress": "There is already a flow setting up this bridge.",
+      "not_supported": "This discovery is not supported."
     }
   }
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -16,6 +16,7 @@ ZEROCONF = {
     ],
     "_hap._tcp.local.": [
         "homekit_controller",
+        "lifx",
         "tradfri"
     ]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -15,6 +15,7 @@ ZEROCONF = {
         "esphome"
     ],
     "_hap._tcp.local.": [
-        "homekit_controller"
+        "homekit_controller",
+        "tradfri"
     ]
 }

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -33,7 +33,9 @@ def generate_and_validate(integrations: Dict[str, Integration]):
 
         try:
             with open(str(integration.path / "config_flow.py")) as fp:
-                if ' async_step_zeroconf(' not in fp.read():
+                content = fp.read()
+                if (' async_step_zeroconf(' not in content and
+                        'register_discovery_flow' not in content):
                     integration.add_error(
                         'zeroconf', 'Config flow has no async_step_zeroconf')
                     continue

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -117,6 +117,35 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
     }
 
 
+async def test_discovery_filter_homekit(hass):
+    """Test a connection via homekit discovery filters non-tradfri devices."""
+    flow = await hass.config_entries.flow.async_init(
+        'tradfri', context={'source': 'zeroconf'}, data={
+            'name': 'tradfri._hap._tcp.local.',
+            'host': '123.123.123.123',
+            'properties': {
+                'md': "Not Tradfri"
+            }
+        })
+
+    assert flow['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert flow['reason'] == 'not_supported'
+
+
+async def test_discovery_allow_homekit(hass):
+    """Test a connection via homekit discovery."""
+    flow = await hass.config_entries.flow.async_init(
+        'tradfri', context={'source': 'zeroconf'}, data={
+            'name': 'tradfri._hap._tcp.local.',
+            'host': '123.123.123.123',
+            'properties': {
+                'md': "TRADFRI gateway"
+            }
+        })
+
+    assert flow['type'] == data_entry_flow.RESULT_TYPE_FORM
+
+
 async def test_import_connection(hass, mock_auth, mock_entry_setup):
     """Test a connection via import."""
     mock_auth.side_effect = lambda hass, host, code: mock_coro({

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -40,7 +40,7 @@ async def test_config_yaml_host_imported(hass):
     progress = hass.config_entries.flow.async_progress()
     assert len(progress) == 1
     assert progress[0]['handler'] == 'tradfri'
-    assert progress[0]['context'] == {'source': 'import'}
+    assert progress[0]['context'] == {'source': 'import', 'host': 'mock-host'}
 
 
 async def test_config_json_host_not_imported(hass):

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -26,9 +26,8 @@ def get_service_info_mock(service_type, name):
 async def test_setup(hass):
     """Test configured options for a device are loaded via config entry."""
     with patch.object(hass.config_entries, 'flow'), \
-            patch.object(zeroconf, 'ServiceBrowser'), \
-            patch.object(zeroconf.Zeroconf, 'get_service_info') as \
-            mock_get_service_info:
+            patch.object(zeroconf, 'ServiceBrowser') as MockServiceBrowser, \
+            patch.object(zeroconf.Zeroconf, 'get_service_info'):
 
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -37,4 +37,3 @@ async def test_setup(hass):
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 
     assert len(MockServiceBrowser.mock_calls) == len(zc_gen.ZEROCONF)
-    assert len(mock_config_flow.mock_calls) == len(zc_gen.ZEROCONF) * 2

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -25,8 +25,8 @@ def get_service_info_mock(service_type, name):
 
 async def test_setup(hass):
     """Test configured options for a device are loaded via config entry."""
-    with patch.object(hass.config_entries, 'flow') as mock_config_flow, \
-            patch.object(zeroconf, 'ServiceBrowser') as MockServiceBrowser, \
+    with patch.object(hass.config_entries, 'flow'), \
+            patch.object(zeroconf, 'ServiceBrowser'), \
             patch.object(zeroconf.Zeroconf, 'get_service_info') as \
             mock_get_service_info:
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -30,9 +30,6 @@ async def test_setup(hass):
             patch.object(zeroconf.Zeroconf, 'get_service_info') as \
             mock_get_service_info:
 
-        MockServiceBrowser.side_effect = service_update_mock
-        mock_get_service_info.side_effect = get_service_info_mock
-
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
 


### PR DESCRIPTION
## Description:
 - The discovery based config flow now supports homekit discovery
 - LIFX to specify homekit as a source of discovery
 - Homekit controller to ignore LIFX discovery

@Jc2k does this makes sense? One change I made for matching Homekit models is to allow specifying a 'startswith' for models. Not sure if this is appropriate?

This PR relies on changes to homekit controllers in #24198. Only last 2 commits are new. Will rebase PR once other is merged.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
