### PR TITLE
Instantiate lock inside entity platform in event loop

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -45,7 +45,7 @@ class EntityPlatform:
         self._async_unsub_polling = None
         # Method to cancel the retry of setup
         self._async_cancel_retry_setup = None
-        self._process_updates = asyncio.Lock()
+        self._process_updates = None
 
         # Platform is None for the EntityComponent "catch-all" EntityPlatform
         # which powers entity_component.add_entities
@@ -404,6 +404,8 @@ class EntityPlatform:
 
         This method must be run in the event loop.
         """
+        if self._process_updates is None:
+            self._process_updates = asyncio.Lock()
         if self._process_updates.locked():
             self.logger.warning(
                 "Updating %s %s took longer than the scheduled update "


### PR DESCRIPTION
## Description:
It is possible for an EntityComponent class to be instantiated inside a thread (ie Wink, Dominos). This will cause an EntityPlatform to be created, which creates an asyncio.Lock. Locks can only be instantiated outside of the event loop by passing in a loop, but this is going away. So now we instantiate the lock only when we need it.