### PR TITLE
Improve SSDP error handling

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -135,15 +135,15 @@ class Scanner:
             if not xml:
                 resp = await session.get(xml_location, timeout=5)
                 xml = await resp.text()
-        except aiohttp.ClientError as err:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             _LOGGER.debug("Error fetching %s: %s", xml_location, err)
-            return None
+            return {}
 
         try:
             tree = ElementTree.fromstring(xml)
         except ElementTree.ParseError as err:
             _LOGGER.debug("Error parsing %s: %s", xml_location, err)
-            return None
+            return {}
 
         return util.etree_to_dict(tree).get('root', {}).get('device', {})
 


### PR DESCRIPTION
## Description:
Improve SSDP error handling. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
