### PR TITLE
Add a discovery config flow to Wemo

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -58,7 +58,6 @@ SERVICE_HANDLERS = {
     SERVICE_MOBILE_APP: ('mobile_app', None),
     SERVICE_HASS_IOS_APP: ('ios', None),
     SERVICE_NETGEAR: ('device_tracker', None),
-    SERVICE_WEMO: ('wemo', None),
     SERVICE_HASSIO: ('hassio', None),
     SERVICE_APPLE_TV: ('apple_tv', None),
     SERVICE_ENIGMA2: ('media_player', 'enigma2'),
@@ -94,19 +93,20 @@ OPTIONAL_SERVICE_HANDLERS = {
     SERVICE_DLNA_DMR: ('media_player', 'dlna_dmr'),
 }
 
-MIGRATED_SERVICE_HANDLERS = {
-    'axis': None,
-    'deconz': None,
-    'esphome': None,
-    'ikea_tradfri': None,
-    'homekit': None,
-    'philips_hue': None
-}
+MIGRATED_SERVICE_HANDLERS = [
+    'axis',
+    'deconz',
+    'esphome',
+    'ikea_tradfri',
+    'homekit',
+    'philips_hue',
+    SERVICE_WEMO,
+]
 
 DEFAULT_ENABLED = list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS) + \
-    list(MIGRATED_SERVICE_HANDLERS)
+    MIGRATED_SERVICE_HANDLERS
 DEFAULT_DISABLED = list(OPTIONAL_SERVICE_HANDLERS) + \
-    list(MIGRATED_SERVICE_HANDLERS)
+    MIGRATED_SERVICE_HANDLERS
 
 CONF_IGNORE = 'ignore'
 CONF_ENABLE = 'enable'

--- a/homeassistant/components/wemo/config_flow.py
+++ b/homeassistant/components/wemo/config_flow.py
@@ -1,0 +1,15 @@
+"""Config flow for Wemo."""
+from homeassistant.helpers import config_entry_flow
+from homeassistant import config_entries
+from . import DOMAIN
+
+
+async def _async_has_devices(hass):
+    """Return if there are devices that can be discovered."""
+    import pywemo
+
+    return bool(pywemo.discover_devices())
+
+
+config_entry_flow.register_discovery_flow(
+    DOMAIN, 'Wemo', _async_has_devices, config_entries.CONN_CLASS_LOCAL_PUSH)

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -1,10 +1,16 @@
 {
   "domain": "wemo",
   "name": "Wemo",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/wemo",
   "requirements": [
     "pywemo==0.4.34"
   ],
+  "ssdp": {
+    "manufacturer": [
+      "Belkin International Inc."
+    ]
+  },
   "dependencies": [],
   "codeowners": [
     "@sqldiablo"

--- a/homeassistant/components/wemo/strings.json
+++ b/homeassistant/components/wemo/strings.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "title": "Wemo",
+    "step": {
+      "confirm": {
+        "title": "Wemo",
+        "description": "Do you want to set up Wemo?"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of Wemo is possible.",
+      "no_devices_found": "No Wemo devices found on the network."
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -50,6 +50,7 @@ FLOWS = [
     "twilio",
     "unifi",
     "upnp",
+    "wemo",
     "zha",
     "zone",
     "zwave"

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -7,6 +7,9 @@ To update, run python3 -m script.hassfest
 SSDP = {
     "device_type": {},
     "manufacturer": {
+        "Belkin International Inc.": [
+            "wemo"
+        ],
         "Royal Philips Electronics": [
             "deconz",
             "hue"

--- a/script/hassfest/ssdp.py
+++ b/script/hassfest/ssdp.py
@@ -43,7 +43,9 @@ def generate_and_validate(integrations: Dict[str, Integration]):
 
         try:
             with open(str(integration.path / "config_flow.py")) as fp:
-                if ' async_step_ssdp(' not in fp.read():
+                content = fp.read()
+                if (' async_step_ssdp(' not in content and
+                        'register_discovery_flow' not in content):
                     integration.add_error(
                         'ssdp', 'Config flow has no async_step_ssdp')
                     continue


### PR DESCRIPTION
## Description:
Convert Wemo to use config flows and make it discoverable via SSDP integration. I have not touched the rest of the integration, which still uses discovery forwarding. That's for the future.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.
