### PR TITLE
Fix ESPHome config flow with invalid config entry

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -94,7 +94,8 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
                 data = self.hass.data[DATA_KEY][
                     entry.entry_id]  # type: RuntimeEntryData
                 # Node names are unique in the network
-                already_configured = data.device_info.name == node_name
+                if data.device_info is not None:
+                    already_configured = data.device_info.name == node_name
 
             if already_configured:
                 return self.async_abort(


### PR DESCRIPTION
## Description:

Reported by @VDRainer in #beta discord chat.

This happens when there's a config entry that never connected to the node - I'm not sure how such a state is possible unless some .storage files were messed with or the node was disconnected right after the config flow was ready. 

Anyway, this patch stops other config flows from crashing in that case.

Depending on the cherry pick strategy option this can result in a failed cherry pick - best choose `theirs` as strategy option.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
