### PR TITLE
Axis handle Vapix error messages

### DIFF
--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/axis",
-  "requirements": ["axis==23"],
+  "requirements": ["axis==24"],
   "dependencies": [],
   "zeroconf": ["_axis-video._tcp.local."],
   "codeowners": ["@kane610"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -212,7 +212,7 @@ av==6.1.2
 # avion==0.10
 
 # homeassistant.components.axis
-axis==23
+axis==24
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -70,7 +70,7 @@ apns2==0.3.0
 av==6.1.2
 
 # homeassistant.components.axis
-axis==23
+axis==24
 
 # homeassistant.components.zha
 bellows-homeassistant==0.7.3


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Small improvement to handle Vapix errors identified by beta users.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html