### PR TITLE
Don't follow redirect on ingress itself

### DIFF
--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -133,6 +133,7 @@ class HassIOIngress(HomeAssistantView):
                     headers=headers,
                     status=result.status,
                     content_type=result.content_type,
+                    allow_redirects=False,
                     body=body
                 )
 

--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -119,8 +119,12 @@ class HassIOIngress(HomeAssistantView):
         source_header = _init_header(request, token)
 
         async with self._websession.request(
-                request.method, url, headers=source_header,
-                params=request.query, data=data
+                request.method,
+                url,
+                headers=source_header,
+                params=request.query,
+                allow_redirects=False,
+                data=data
         ) as result:
             headers = _response_header(result)
 
@@ -133,7 +137,6 @@ class HassIOIngress(HomeAssistantView):
                     headers=headers,
                     status=result.status,
                     content_type=result.content_type,
-                    allow_redirects=False,
                     body=body
                 )
 


### PR DESCRIPTION

## Description:

We should not follow redirections on ingress itself, that is a task for endpoint.

Hass.io: https://github.com/home-assistant/hassio/pull/1106

CC @OttoWinter 