### PR TITLE
Use resource for index routing

### DIFF
--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -8,8 +8,7 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
     DOMAIN, CONF_JS_VERSION, CONF_THEMES, CONF_EXTRA_HTML_URL,
-    CONF_EXTRA_HTML_URL_ES5, generate_negative_index_regex,
-    EVENT_PANELS_UPDATED)
+    CONF_EXTRA_HTML_URL_ES5, EVENT_PANELS_UPDATED)
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 
 from tests.common import mock_coro, async_capture_events
@@ -348,43 +347,3 @@ async def test_auth_authorize(mock_http_client):
     resp = await mock_http_client.get(authorizejs.groups(0)[0])
     assert resp.status == 200
     assert 'public' in resp.headers.get('cache-control')
-
-
-def test_index_regex():
-    """Test the index regex."""
-    pattern = re.compile('/' + generate_negative_index_regex())
-
-    for should_match in (
-            '/',
-            '/lovelace',
-            '/lovelace/default_view',
-            '/map',
-            '/config',
-    ):
-        assert pattern.match(should_match), should_match
-
-    for should_not_match in (
-            '/service_worker.js',
-            '/manifest.json',
-            '/onboarding.html',
-            '/manifest.json',
-            'static',
-            'static/',
-            'static/index.html',
-            'frontend_latest',
-            'frontend_latest/',
-            'frontend_latest/index.html',
-            'frontend_es5',
-            'frontend_es5/',
-            'frontend_es5/index.html',
-            'local',
-            'local/',
-            'local/index.html',
-            'auth',
-            'auth/',
-            'auth/index.html',
-            '/api',
-            '/api/',
-            '/api/logbook',
-    ):
-        assert not pattern.match(should_not_match), should_not_match


### PR DESCRIPTION
## Description:
When I migrated how we routed the index page, I did not foresee custom integrations registering extra static paths. Oh boy was I wrong ;-) I broke the custom card updater. This fixes it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
