### PR TITLE
Async register built in panel

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -36,7 +36,7 @@ async def async_setup(hass, config):
     hass.http.register_view(CalendarEventView(component))
 
     # Doesn't work in prod builds of the frontend: home-assistant-polymer#1289
-    # hass.components.frontend.async_register_built_in_panel(
+    # await hass.components.frontend.async_register_built_in_panel(
     #     'calendar', 'calendar', 'hass:calendar')
 
     await component.async_setup(config)

--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -30,7 +30,7 @@ ON_DEMAND = ('zwave',)
 
 async def async_setup(hass, config):
     """Set up the config component."""
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'config', 'config', 'hass:settings', require_admin=True)
 
     async def setup_panel(panel_name):

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -1,4 +1,5 @@
 """Handle the frontend for Home Assistant."""
+import asyncio
 import json
 import logging
 import os
@@ -257,12 +258,13 @@ async def async_setup(hass, config):
 
     hass.http.register_view(IndexView(repo_path))
 
-    for panel in ('kiosk', 'states', 'profile'):
-        async_register_built_in_panel(hass, panel)
-
-    for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
-                  'dev-template', 'dev-mqtt'):
-        async_register_built_in_panel(hass, panel, require_admin=True)
+    await asyncio.wait(
+        [async_register_built_in_panel(hass, panel) for panel in (
+            'kiosk', 'states', 'profile')])
+    await asyncio.wait(
+        [async_register_built_in_panel(hass, panel, require_admin=True)
+         for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
+                       'dev-template', 'dev-mqtt')])
 
     if DATA_EXTRA_HTML_URL not in hass.data:
         hass.data[DATA_EXTRA_HTML_URL] = set()

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -164,11 +164,10 @@ class Panel:
 
 
 @bind_hass
-@callback
-def async_register_built_in_panel(hass, component_name,
-                                  sidebar_title=None, sidebar_icon=None,
-                                  frontend_url_path=None, config=None,
-                                  require_admin=False):
+async def async_register_built_in_panel(hass, component_name,
+                                        sidebar_title=None, sidebar_icon=None,
+                                        frontend_url_path=None, config=None,
+                                        require_admin=False):
     """Register a built-in panel."""
     panel = Panel(component_name, sidebar_title, sidebar_icon,
                   frontend_url_path, config, require_admin)

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -252,7 +252,7 @@ async def async_setup(hass, config):
     use_include_order = conf.get(CONF_ORDER)
 
     hass.http.register_view(HistoryPeriodView(filters, use_include_order))
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'history', 'history', 'hass:poll-box')
 
     return True

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -102,7 +102,7 @@ async def async_setup(hass, config):
 
     hass.http.register_view(LogbookView(config.get(DOMAIN, {})))
 
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'logbook', 'logbook', 'hass:format-list-bulleted-type')
 
     hass.services.async_register(

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -53,7 +53,7 @@ async def async_setup(hass, config):
     # Pass in default to `get` because defaults not set if loaded as dep
     mode = config.get(DOMAIN, {}).get(CONF_MODE, MODE_STORAGE)
 
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         DOMAIN, config={
             'mode': mode
         })

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -30,7 +30,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 async def async_setup(hass, config):
     """Track states and offer events for mailboxes."""
     mailboxes = []
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'mailbox', 'mailbox', 'mdi:mailbox')
     hass.http.register_view(MailboxPlatformsView(mailboxes))
     hass.http.register_view(MailboxMessageView(mailboxes))

--- a/homeassistant/components/map/__init__.py
+++ b/homeassistant/components/map/__init__.py
@@ -4,6 +4,6 @@ DOMAIN = 'map'
 
 async def async_setup(hass, config):
     """Register the built-in map panel."""
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'map', 'map', 'hass:tooltip-account')
     return True

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -112,7 +112,7 @@ async def async_register_panel(
 
     config['_panel_custom'] = custom_panel_config
 
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         component_name='custom',
         sidebar_title=sidebar_title,
         sidebar_icon=sidebar_icon,

--- a/homeassistant/components/panel_iframe/__init__.py
+++ b/homeassistant/components/panel_iframe/__init__.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
 async def async_setup(hass, config):
     """Set up the iFrame frontend panels."""
     for url_path, info in config[DOMAIN].items():
-        hass.components.frontend.async_register_built_in_panel(
+        await hass.components.frontend.async_register_built_in_panel(
             'iframe', info.get(CONF_TITLE), info.get(CONF_ICON),
             url_path, {'url': info[CONF_URL]},
             require_admin=info[CONF_REQUIRE_ADMIN])

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -117,7 +117,7 @@ def async_setup(hass, config):
         'What is on my shopping list'
     ])
 
-    hass.components.frontend.async_register_built_in_panel(
+    yield from hass.components.frontend.async_register_built_in_panel(
         'shopping-list', 'shopping_list', 'mdi:cart')
 
     hass.components.websocket_api.async_register_command(

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -240,7 +240,7 @@ async def test_get_panels(hass, hass_ws_client, mock_http_client):
     resp = await mock_http_client.get('/map')
     assert resp.status == 404
 
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:tooltip-account', require_admin=True)
 
     resp = await mock_http_client.get('/map')
@@ -277,9 +277,9 @@ async def test_get_panels_non_admin(hass, hass_ws_client, hass_admin_user):
     """Test get_panels command."""
     hass_admin_user.groups = []
     await async_setup_component(hass, 'frontend', {})
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:tooltip-account', require_admin=True)
-    hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'history', 'History', 'mdi:history')
 
     client = await hass_ws_client(hass)


### PR DESCRIPTION
## Description:
I was assuming all registrations of built-in panels was done only in our code base. However, for iframe panels, custom integrations will call this method. This re-instates the method being async.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
