### PR TITLE
ZHA requirements version bump.

### DIFF
--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -116,6 +116,8 @@ class ZHAGateway:
 
     def raw_device_initialized(self, device):
         """Handle a device initialization without quirks loaded."""
+        if device.nwk == 0x0000:
+            return
         endpoint_ids = device.endpoints.keys()
         ept_id = next((ept_id for ept_id in endpoint_ids if ept_id != 0), None)
         manufacturer = 'Unknown'
@@ -259,6 +261,9 @@ class ZHAGateway:
 
     async def async_device_initialized(self, device, is_new_join):
         """Handle device joined and basic information discovered (async)."""
+        if device.nwk == 0x0000:
+            return
+
         zha_device = self._async_get_or_create_device(device, is_new_join)
 
         is_rejoin = False

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/components/zha",
   "requirements": [
     "bellows-homeassistant==0.8.0",
-    "zha-quirks==0.0.13",
+    "zha-quirks==0.0.14",
     "zigpy-deconz==0.1.4",
     "zigpy-homeassistant==0.4.2",
     "zigpy-xbee-homeassistant==0.3.0"

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,11 +4,11 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/zha",
   "requirements": [
-    "bellows-homeassistant==0.7.3",
+    "bellows-homeassistant==0.8.0",
     "zha-quirks==0.0.13",
     "zigpy-deconz==0.1.4",
-    "zigpy-homeassistant==0.3.3",
-    "zigpy-xbee-homeassistant==0.2.1"
+    "zigpy-homeassistant==0.4.2",
+    "zigpy-xbee-homeassistant==0.3.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -235,7 +235,7 @@ batinfo==0.4.2
 beautifulsoup4==4.7.1
 
 # homeassistant.components.zha
-bellows-homeassistant==0.7.3
+bellows-homeassistant==0.8.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.5.3
@@ -1890,10 +1890,10 @@ ziggo-mediabox-xl==1.1.0
 zigpy-deconz==0.1.4
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.3.3
+zigpy-homeassistant==0.4.2
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.2.1
+zigpy-xbee-homeassistant==0.3.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1878,7 +1878,7 @@ zengge==0.2
 zeroconf==0.22.0
 
 # homeassistant.components.zha
-zha-quirks==0.0.13
+zha-quirks==0.0.14
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -73,7 +73,7 @@ av==6.1.2
 axis==23
 
 # homeassistant.components.zha
-bellows-homeassistant==0.7.3
+bellows-homeassistant==0.8.0
 
 # homeassistant.components.caldav
 caldav==0.6.1
@@ -355,4 +355,4 @@ wakeonlan==1.1.6
 zeroconf==0.22.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.3.3
+zigpy-homeassistant==0.4.2


### PR DESCRIPTION
## Description:
Bump ZHA component requirements.
Skip Coordinator Zigpy device.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
