### PR TITLE
Add GPSLogger device_info and unique_id

### DIFF
--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -45,6 +45,7 @@ class GPSLoggerEntity(DeviceTrackerEntity):
         self._battery = battery
         self._location = location
         self._unsub_dispatcher = None
+        self._unique_id = device
 
     @property
     def battery_level(self):
@@ -80,6 +81,19 @@ class GPSLoggerEntity(DeviceTrackerEntity):
     def should_poll(self):
         """No polling needed."""
         return False
+
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return self._unique_id
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'name': self._name,
+            'identifiers': {(GPL_DOMAIN, self._unique_id)},
+        }
 
     @property
     def source_type(self):

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -140,6 +140,12 @@ async def test_enter_and_exit(hass, gpslogger_client, webhook_id):
                                                 data['device'])).state
     assert STATE_NOT_HOME == state_name
 
+    dev_reg = await hass.helpers.device_registry.async_get_registry()
+    assert len(dev_reg.devices) == 1
+
+    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    assert len(ent_reg.entities) == 1
+
 
 async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
     """Test when additional attributes are present."""
@@ -171,6 +177,33 @@ async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
     assert state.attributes['altitude'] == 102.0
     assert state.attributes['provider'] == 'gps'
     assert state.attributes['activity'] == 'running'
+
+    data = {
+        'latitude': HOME_LATITUDE,
+        'longitude': HOME_LONGITUDE,
+        'device': '123',
+        'accuracy': 123,
+        'battery': 23,
+        'speed': 23,
+        'direction': 123,
+        'altitude': 123,
+        'provider': 'gps',
+        'activity': 'idle'
+    }
+
+    req = await gpslogger_client.post(url, data=data)
+    await hass.async_block_till_done()
+    assert req.status == HTTP_OK
+    state = hass.states.get('{}.{}'.format(DEVICE_TRACKER_DOMAIN,
+                                           data['device']))
+    assert state.state == STATE_HOME
+    assert state.attributes['gps_accuracy'] == 123
+    assert state.attributes['battery_level'] == 23
+    assert state.attributes['speed'] == 23
+    assert state.attributes['direction'] == 123
+    assert state.attributes['altitude'] == 123
+    assert state.attributes['provider'] == 'gps'
+    assert state.attributes['activity'] == 'idle'
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## Description:
When we migrated 4 device tracker platforms to use config entries and entity base class, we didn't give them a unique ID and device info, which made it so that users are unable to change the name/entity_id, and so are losing some functionality compared to `known_devices.yaml` (which no longer works for these).

## Checklist:


If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
