### PR TITLE
GeoFency unique ID and device info

### DIFF
--- a/homeassistant/components/geofency/device_tracker.py
+++ b/homeassistant/components/geofency/device_tracker.py
@@ -43,6 +43,7 @@ class GeofencyEntity(DeviceTrackerEntity):
         self._location_name = location_name
         self._gps = gps
         self._unsub_dispatcher = None
+        self._unique_id = device
 
     @property
     def device_state_attributes(self):
@@ -73,6 +74,19 @@ class GeofencyEntity(DeviceTrackerEntity):
     def should_poll(self):
         """No polling needed."""
         return False
+
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return self._unique_id
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'name': self._name,
+            'identifiers': {(GF_DOMAIN, self._unique_id)},
+        }
 
     @property
     def source_type(self):

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -217,6 +217,12 @@ async def test_gps_enter_and_exit_home(hass, geofency_client, webhook_id):
         'device_tracker', device_name)).attributes['longitude']
     assert NOT_HOME_LONGITUDE == current_longitude
 
+    dev_reg = await hass.helpers.device_registry.async_get_registry()
+    assert len(dev_reg.devices) == 1
+
+    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    assert len(ent_reg.entities) == 1
+
 
 async def test_beacon_enter_and_exit_home(hass, geofency_client, webhook_id):
     """Test iBeacon based zone enter and exit - a.k.a stationary iBeacon."""


### PR DESCRIPTION
## Description:
When we migrated 4 device tracker platforms to use config entries and entity base class, we didn't give them a unique ID and device info, which made it so that users are unable to change the name/entity_id, and so are losing some functionality compared to `known_devices.yaml` (which no longer works for these).

## Checklist:
If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
