### PR TITLE
add a deprecation warning for tplink device_tracker

### DIFF
--- a/homeassistant/components/tplink/device_tracker.py
+++ b/homeassistant/components/tplink/device_tracker.py
@@ -44,8 +44,9 @@ def get_scanner(hass, config):
     _LOGGER.warning("TP-Link device tracker is unmaintained and will be "
                     "removed in the future releases if no maintainer is "
                     "found. If you have interest in this integration, "
-                    "feel free to create a pull request for 'tplink_router' "
-                    "integration using a pip-installable backend library.")
+                    "feel free to create a pull request to move this code "
+                    "to a new 'tplink_router' integration and refactoring "
+                    "the device-specific parts to the tplink library")
     for cls in [
             TplinkDeviceScanner, Tplink5DeviceScanner, Tplink4DeviceScanner,
             Tplink3DeviceScanner, Tplink2DeviceScanner, Tplink1DeviceScanner

--- a/homeassistant/components/tplink/device_tracker.py
+++ b/homeassistant/components/tplink/device_tracker.py
@@ -41,6 +41,11 @@ def get_scanner(hass, config):
     should be gradually migrated in the pypi package
 
     """
+    _LOGGER.warning("TP-Link device tracker is unmaintained and will be "
+                    "removed in the future releases if no maintainer is "
+                    "found. If you have interest in this integration, "
+                    "feel free to create a pull request for 'tplink_router' "
+                    "integration using a pip-installable backend library.")
     for cls in [
             TplinkDeviceScanner, Tplink5DeviceScanner, Tplink4DeviceScanner,
             Tplink3DeviceScanner, Tplink2DeviceScanner, Tplink1DeviceScanner


### PR DESCRIPTION
## Description:
As discussed on discord, this PR will add a warning to tplink's (misplaced) device_tracker platform in hope of getting someone to convert it to a separate integration separate from unrelated tplink smarthome integration (my proposal would be `tplink_router`).

I'm adding several related issues/PRs to raise awareness (again, hoping that someone will pick up the maintainership) of those who have reported/worked on this platform before.


**Related issue (if applicable):** #24091 #14641 #20769 #24140 #13991 #11827 #10575 #17371 #14801 #13525 #10506


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
