### PR TITLE
fix gitlab_ci sad icon

### DIFF
--- a/homeassistant/components/gitlab_ci/sensor.py
+++ b/homeassistant/components/gitlab_ci/sensor.py
@@ -30,7 +30,7 @@ DEFAULT_URL = 'https://gitlab.com'
 
 ICON_HAPPY = 'mdi:emoticon-happy'
 ICON_OTHER = 'mdi:git'
-ICON_SAD = 'mdi:emoticon-happy'
+ICON_SAD = 'mdi:emoticon-sad'
 
 SCAN_INTERVAL = timedelta(seconds=300)
 


### PR DESCRIPTION
## Description:
Change the sad icon to an actually sad icon

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
