### PR TITLE
Add LCN scene platform

### DIFF
--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -32,6 +32,10 @@ CONF_PCK = 'pck'
 CONF_CLIMATES = 'climates'
 CONF_MAX_TEMP = 'max_temp'
 CONF_MIN_TEMP = 'min_temp'
+CONF_SCENES = 'scenes'
+CONF_REGISTER = 'register'
+CONF_SCENE = 'scene'
+CONF_OUTPUTS = 'outputs'
 
 DIM_MODES = ['STEPS50', 'STEPS200']
 

--- a/homeassistant/components/lcn/scene.py
+++ b/homeassistant/components/lcn/scene.py
@@ -1,0 +1,66 @@
+"""Support for LCN scenes."""
+import pypck
+
+from homeassistant.components.scene import Scene
+from homeassistant.const import CONF_ADDRESS
+
+from . import LcnDevice
+from .const import (
+    CONF_CONNECTIONS, CONF_OUTPUTS, CONF_REGISTER, CONF_SCENE, CONF_TRANSITION,
+    DATA_LCN, OUTPUT_PORTS)
+from .helpers import get_connection
+
+
+async def async_setup_platform(hass, hass_config, async_add_entities,
+                               discovery_info=None):
+    """Set up the LCN scene platform."""
+    if discovery_info is None:
+        return
+
+    devices = []
+    for config in discovery_info:
+        address, connection_id = config[CONF_ADDRESS]
+        addr = pypck.lcn_addr.LcnAddr(*address)
+        connections = hass.data[DATA_LCN][CONF_CONNECTIONS]
+        connection = get_connection(connections, connection_id)
+        address_connection = connection.get_address_conn(addr)
+
+        devices.append(LcnScene(config, address_connection))
+
+    async_add_entities(devices)
+
+
+class LcnScene(LcnDevice, Scene):
+    """Representation of a LCN scene."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN scene."""
+        super().__init__(config, address_connection)
+
+        self.register_id = config[CONF_REGISTER]
+        self.scene_id = config[CONF_SCENE]
+        self.output_ports = []
+        self.relay_ports = []
+
+        for port in config[CONF_OUTPUTS]:
+            if port in OUTPUT_PORTS:
+                self.output_ports.append(pypck.lcn_defs.OutputPort[port])
+            else:  # in RELEAY_PORTS
+                self.relay_ports.append(pypck.lcn_defs.RelayPort[port])
+
+        if config[CONF_TRANSITION] is None:
+            self.transition = None
+        else:
+            self.transition = pypck.lcn_defs.time_to_ramp_value(
+                config[CONF_TRANSITION])
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+
+    async def async_activate(self):
+        """Activate scene."""
+        self.address_connection.activate_scene(self.register_id,
+                                               self.scene_id,
+                                               self.output_ports,
+                                               self.relay_ports,
+                                               self.transition)


### PR DESCRIPTION
## Description:
This adds the LCN scene platform. The implementation allows the activation of LCN scenes which have been properly programmed into the hardware modules.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9545

## Example entry for `configuration.yaml` (if applicable):
```yaml
lcn:
  connections:
    - name: myhome
      host: 192.168.2.41
      port: 4114
      username: !secret lcn_username
      password: !secret lcn_password

  scenes:
    - name: Romantic
      address: s0.m7
      register: 0
      scene: 0
      outputs: [output1, output2, relay1, relay3, relay5, relay8]
      transition: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
