### PR TITLE
Plex Media Content Type Workaround

### DIFF
--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -9,7 +9,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_SEEK, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF,
-    STATE_PAUSED, STATE_PLAYING, STATE_STANDBY)
+    STATE_PAUSED, STATE_PLAYING, STATE_STANDBY, STATE_UNKNOWN)
 from homeassistant.core import callback
 import homeassistant.util.dt as dt_util
 
@@ -144,14 +144,16 @@ class AppleTvDevice(MediaPlayerDevice):
         from pyatv import const
         media_type = self._playing.media_type
         if self._playing and media_type == const.MEDIA_TYPE_MUSIC:
+            media_type_result = STATE_UNKNOWN
             title = self._playing.title
             artist = self._playing.artist
             if PLEX_TVSHOW_REGEX.search(title):
-                return MEDIA_TYPE_TVSHOW
+                media_type_result = MEDIA_TYPE_TVSHOW
             elif not artist:
-                return MEDIA_TYPE_VIDEO
+                media_type_result = MEDIA_TYPE_VIDEO
             else:
-                return MEDIA_TYPE_MUSIC
+                media_type_result = MEDIA_TYPE_MUSIC
+            return media_type_result
 
     @property
     def media_duration(self):

--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -1,5 +1,6 @@
 """Support for Apple TV media player."""
 import logging
+import re
 
 from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
@@ -20,7 +21,7 @@ SUPPORT_APPLE_TV = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA | \
                    SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SEEK | \
                    SUPPORT_STOP | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
 
-PLEX_TVSHOW_REGEX = '^S\d+\s.\sE\d+.*$'
+PLEX_TVSHOW_REGEX = re.compile('^S\d+\s.\sE\d+.*$')
 
 
 async def async_setup_platform(
@@ -136,6 +137,7 @@ class AppleTvDevice(MediaPlayerDevice):
                 return self._plex_media_content_type
             if media_type == const.MEDIA_TYPE_TV:
                 return MEDIA_TYPE_TVSHOW
+
     @property
     def _plex_media_content_type(self):
         """Content type hack for Plex which always shows as music."""
@@ -144,7 +146,7 @@ class AppleTvDevice(MediaPlayerDevice):
         if self._playing and media_type == const.MEDIA_TYPE_MUSIC:
             title = self._playing.title
             artist = self._playing.artist
-            if re.search(PLEX_TV_REGEX, title):
+            if PLEX_TVSHOW_REGEX.search(title):
                 return MEDIA_TYPE_TVSHOW
             elif not artist:
                 return MEDIA_TYPE_VIDEO

--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -21,7 +21,7 @@ SUPPORT_APPLE_TV = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PLAY_MEDIA | \
                    SUPPORT_PAUSE | SUPPORT_PLAY | SUPPORT_SEEK | \
                    SUPPORT_STOP | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
 
-PLEX_TVSHOW_REGEX = re.compile('^S\d+\s.\sE\d+.*$')
+PLEX_TVSHOW_REGEX = re.compile(r'^S\d+\s.\sE\d+.*$')
 
 
 async def async_setup_platform(


### PR DESCRIPTION
Plex does not conform to the media content type pattern and always returns `music`

## Description:
Plex on AppleTV always returns `music` as media_content_type - this is a hack to work around that to determine if it's a video or tv-show. Tested against 10 different TV series and 10 different movies on 3 Plex Servers.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
