### PR TITLE
Fix typo in integration component

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -40,7 +40,7 @@ UNIT_TIME = {'s': 1,
              'h': 60*60,
              'd': 24*60*60}
 
-ICON = 'mdi:char-histogram'
+ICON = 'mdi:chart-histogram'
 
 DEFAULT_ROUND = 3
 


### PR DESCRIPTION
## Description:
Fix a typo in ICON, char-histogram does not exists, I assume it should have been chart-histogram.

**Related issue (if applicable):** Same as #24217, but a new pull request because Github shows wrong commits.



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
