### PR TITLE
Provide an option for the DD-WRT device tracker to include non-wireless devices

### DIFF
--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -103,7 +103,7 @@ class DdWrtDeviceScanner(DeviceScanner):
         """
         _LOGGER.info("Checking ARP")
 
-        url = '{}://{}/Status_Wireless.live.asp'.format(
+        url = '{}://{}/Status_Lan.live.asp'.format(
             self.protocol, self.host)
         data = self.get_ddwrt_data(url)
 
@@ -112,7 +112,7 @@ class DdWrtDeviceScanner(DeviceScanner):
 
         self.last_results = []
 
-        active_clients = data.get('active_wireless', None)
+        active_clients = data.get('arp_table', None)
         if not active_clients:
             return False
 

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -18,6 +18,8 @@ _MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
 
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
+CONF_WIRELESS_ONLY = 'wireless_only'
+DEFAULT_WIRELESS_ONLY = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -25,6 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+    vol.Optional(CONF_WIRELESS_ONLY, default=DEFAULT_WIRELESS_ONLY): cv.boolean
 })
 
 
@@ -46,6 +49,7 @@ class DdWrtDeviceScanner(DeviceScanner):
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
+        self.wireless_only = config[CONF_WIRELESS_ONLY]
 
         self.last_results = {}
         self.mac2name = {}
@@ -103,8 +107,9 @@ class DdWrtDeviceScanner(DeviceScanner):
         """
         _LOGGER.info("Checking ARP")
 
-        url = '{}://{}/Status_Lan.live.asp'.format(
-            self.protocol, self.host)
+        endpoint = 'Wireless' if self.wireless_only else 'Lan'
+        url = '{}://{}/Status_{}.live.asp'.format(
+            self.protocol, self.host, endpoint)
         data = self.get_ddwrt_data(url)
 
         if not data:
@@ -112,7 +117,10 @@ class DdWrtDeviceScanner(DeviceScanner):
 
         self.last_results = []
 
-        active_clients = data.get('arp_table', None)
+        if self.wireless_only:
+            active_clients = data.get('active_wireless', None)
+        else:
+            active_clients = data.get('arp_table', None)
         if not active_clients:
             return False
 


### PR DESCRIPTION
## Description:

Currently, the DD-WRT device tracker component checks the wireless client list. This results in a status of "not home" if the device is connected to a different access point or via Ethernet. This PR changes the component to offer an option to use the active client list (`wireless_only: false`), which contains devices that are currently connected via wireless or Ethernet, including those that are connected to a different access point. This is not a breaking change because the default value of this option (`wireless_only: true`) is consistent with the current behavior.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9555

**Example entry for configuration.yaml (if applicable):**
```yaml
device_tracker:
  - platform: ddwrt
    host: 192.168.2.1
    username: !secret router_username
    password: !secret router_password
    wireless_only: false # new
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:

  - [x] Documentation added/updated in home-assistant.io

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
