### PR TITLE
Add De Lijn (Flemish Public Transport) component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -118,6 +118,7 @@ omit =
     homeassistant/components/ddwrt/device_tracker.py
     homeassistant/components/decora/light.py
     homeassistant/components/decora_wifi/light.py
+    homeassistant/components/delijn/*
     homeassistant/components/deluge/sensor.py
     homeassistant/components/deluge/switch.py
     homeassistant/components/denon/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -60,6 +60,7 @@ homeassistant/components/cups/* @fabaff
 homeassistant/components/daikin/* @fredrike @rofrantz
 homeassistant/components/darksky/* @fabaff
 homeassistant/components/deconz/* @kane610
+homeassistant/components/delijn/* @bollewolle
 homeassistant/components/demo/* @home-assistant/core
 homeassistant/components/digital_ocean/* @fabaff
 homeassistant/components/discogs/* @thibmaek

--- a/homeassistant/components/delijn/__init__.py
+++ b/homeassistant/components/delijn/__init__.py
@@ -1,0 +1,1 @@
+"""The delijn component."""

--- a/homeassistant/components/delijn/manifest.json
+++ b/homeassistant/components/delijn/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "delijn",
+  "name": "De Lijn",
+  "documentation": "https://www.home-assistant.io/components/delijn",
+  "dependencies": [],
+  "codeowners": ["@bollewolle"],
+  "requirements": ["pydelijn==0.4.0"]
+}

--- a/homeassistant/components/delijn/manifest.json
+++ b/homeassistant/components/delijn/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/components/delijn",
   "dependencies": [],
   "codeowners": ["@bollewolle"],
-  "requirements": ["pydelijn==0.4.0"]
+  "requirements": ["pydelijn==0.5.1"]
 }

--- a/homeassistant/components/delijn/sensor.py
+++ b/homeassistant/components/delijn/sensor.py
@@ -1,0 +1,107 @@
+"""Support for De Lijn (Flemish public transport) information."""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.exceptions import PlatformNotReady
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_NEXT_PASSAGE = 'nextpassage'
+CONF_STOP_ID = 'stop_id'
+CONF_SUB_KEY = 'sub_key'
+CONF_MAX_PASSAGES = 'max_passages'
+
+DEFAULT_NAME = 'De Lijn'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SUB_KEY): cv.string,
+    vol.Required(CONF_NEXT_PASSAGE): [{
+        vol.Required(CONF_STOP_ID): cv.string,
+        vol.Optional(CONF_MAX_PASSAGES, default=5): cv.positive_int}]
+})
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Create the sensor."""
+    from pydelijn.api import Passages
+
+    sub_key = config.get(CONF_SUB_KEY)
+    name = DEFAULT_NAME
+
+    session = async_get_clientsession(hass)
+
+    sensors = []
+    for nextpassage in config.get(CONF_NEXT_PASSAGE):
+        stop_id = nextpassage[CONF_STOP_ID]
+        max_passages = nextpassage[CONF_MAX_PASSAGES]
+        line = Passages(hass.loop, stop_id, max_passages, sub_key, session)
+        sensors.append(DeLijnPublicTransportSensor(line, name))
+
+    tasks = [sensor.async_update() for sensor in sensors]
+    if tasks:
+        await asyncio.wait(tasks)
+    if not all(sensor._attributes for sensor in sensors):
+        raise PlatformNotReady
+
+    async_add_entities(sensors, True)
+
+
+class DeLijnPublicTransportSensor(Entity):
+    """Representation of a Ruter sensor."""
+
+    def __init__(self, line, name):
+        """Initialize the sensor."""
+        self.line = line
+        self._attributes = {}
+        self._name = name
+        self._state = None
+
+    async def async_update(self):
+        """Get the latest data from the De Lijn API."""
+        await self.line.get_passages()
+        if self.line.passages is None:
+            _LOGGER.error("No data recieved from De Lijn.")
+            return
+        try:
+            attributes = {}
+            first = self.line.passages[0]
+            self._state = first['due_in_min']
+            self._name = first['stopname']
+            attributes['stopname'] = first['stopname']
+            attributes['line_number_public'] = first['line_number_public']
+            attributes['line_transport_type'] = first['line_transport_type']
+            attributes['final_destination'] = first['final_destination']
+            attributes['due_at_sch'] = first['due_at_sch']
+            attributes['due_at_rt'] = first['due_at_rt']
+            attributes['due_in_min'] = first['due_in_min']
+            attributes['next_passages'] = self.line.passages
+            self._attributes = attributes
+        except (KeyError, IndexError) as error:
+            _LOGGER.debug("Error getting data from De Lijn, %s", error)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return 'mdi:bus'
+
+    @property
+    def device_state_attributes(self):
+        """Return attributes for the sensor."""
+        return self._attributes

--- a/homeassistant/components/delijn/sensor.py
+++ b/homeassistant/components/delijn/sensor.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, CONF_API_KEY, DEVICE_CLASS_TIMESTAMP)
+    ATTR_ATTRIBUTION, DEVICE_CLASS_TIMESTAMP)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -43,7 +43,6 @@ def due_in_minutes(timestamp):
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create the sensor."""
-
     api_key = config[CONF_API_KEY]
     name = DEFAULT_NAME
 
@@ -53,7 +52,11 @@ async def async_setup_platform(
     for nextpassage in config[CONF_NEXT_DEPARTURE]:
         stop_id = nextpassage[CONF_STOP_ID]
         number_of_departures = nextpassage[CONF_NUMBER_OF_DEPARTURES]
-        line = Passages(hass.loop, stop_id, number_of_departures, api_key, session)
+        line = Passages(hass.loop,
+                        stop_id,
+                        number_of_departures,
+                        api_key,
+                        session)
         await line.get_passages()
         if line.passages is None:
             _LOGGER.error("No data recieved from De Lijn")
@@ -84,9 +87,11 @@ class DeLijnPublicTransportSensor(Entity):
             first = self.line.passages[0]
             local_timezone = pytz.timezone("Europe/Brussels")
             if first['due_at_rt'] is not None:
-                first_passage_naive = dt_util.parse_datetime(first['due_at_rt'])
+                first_passage_naive = dt_util.parse_datetime(
+                    first['due_at_rt'])
             else:
-                first_passage_naive = dt_util.parse_datetime(first['due_at_sch'])
+                first_passage_naive = dt_util.parse_datetime(
+                    first['due_at_sch'])
             first_passage_local = local_timezone.localize(first_passage_naive)
             first_passage_utc = dt_util.as_utc(first_passage_local)
             self._state = first_passage_utc.isoformat()

--- a/homeassistant/components/delijn/sensor.py
+++ b/homeassistant/components/delijn/sensor.py
@@ -80,7 +80,6 @@ class DeLijnPublicTransportSensor(Entity):
             else:
                 first_passage = first['due_at_schedule']
             self._state = first_passage
-
             self._name = first['stopname']
             self._attributes['stopname'] = first['stopname']
             self._attributes['line_number_public'] = first[
@@ -90,11 +89,9 @@ class DeLijnPublicTransportSensor(Entity):
             self._attributes['final_destination'] = first['final_destination']
             self._attributes['due_at_schedule'] = first['due_at_schedule']
             self._attributes['due_at_realtime'] = first['due_at_realtime']
-            self._attributes['due_in_min'] = first['due_in_min']
             self._attributes['next_passages'] = self.line.passages
-            self._attributes[ATTR_ATTRIBUTION] = ATTRIBUTION
         except (KeyError, IndexError) as error:
-            _LOGGER.debug("Error getting data from De Lijn, {}".format(error))
+            _LOGGER.debug("Error getting data from De Lijn: %s", error)
 
     @property
     def device_class(self):

--- a/homeassistant/components/delijn/sensor.py
+++ b/homeassistant/components/delijn/sensor.py
@@ -1,54 +1,64 @@
 """Support for De Lijn (Flemish public transport) information."""
-import asyncio
 import logging
 
+from pydelijn.api import Passages
+import pytz
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.exceptions import PlatformNotReady
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_API_KEY, DEVICE_CLASS_TIMESTAMP)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_NEXT_PASSAGE = 'nextpassage'
+ATTRIBUTION = "Data provided by data.delijn.be"
+
+CONF_NEXT_DEPARTURE = 'next_departure'
 CONF_STOP_ID = 'stop_id'
 CONF_API_KEY = 'api_key'
-CONF_MAX_PASSAGES = 'max_passages'
+CONF_NUMBER_OF_DEPARTURES = 'number_of_departures'
 
 DEFAULT_NAME = 'De Lijn'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Required(CONF_NEXT_PASSAGE): [{
+    vol.Required(CONF_NEXT_DEPARTURE): [{
         vol.Required(CONF_STOP_ID): cv.string,
-        vol.Optional(CONF_MAX_PASSAGES, default=5): cv.positive_int}]
+        vol.Optional(CONF_NUMBER_OF_DEPARTURES, default=5): cv.positive_int}]
 })
+
+
+def due_in_minutes(timestamp):
+    """Get the time in minutes from a timestamp."""
+    if timestamp is None:
+        return None
+    diff = timestamp - dt_util.now()
+    return int(diff.total_seconds() / 60)
 
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create the sensor."""
-    from pydelijn.api import Passages
 
-    api_key = config.get(CONF_API_KEY)
+    api_key = config[CONF_API_KEY]
     name = DEFAULT_NAME
 
     session = async_get_clientsession(hass)
 
     sensors = []
-    for nextpassage in config.get(CONF_NEXT_PASSAGE):
+    for nextpassage in config[CONF_NEXT_DEPARTURE]:
         stop_id = nextpassage[CONF_STOP_ID]
-        max_passages = nextpassage[CONF_MAX_PASSAGES]
-        line = Passages(hass.loop, stop_id, max_passages, api_key, session)
+        number_of_departures = nextpassage[CONF_NUMBER_OF_DEPARTURES]
+        line = Passages(hass.loop, stop_id, number_of_departures, api_key, session)
+        await line.get_passages()
+        if line.passages is None:
+            _LOGGER.error("No data recieved from De Lijn")
+            return
         sensors.append(DeLijnPublicTransportSensor(line, name))
-
-    tasks = [sensor.async_update() for sensor in sensors]
-    if tasks:
-        await asyncio.wait(tasks)
-    if not all(sensor._attributes for sensor in sensors):
-        raise PlatformNotReady
 
     async_add_entities(sensors, True)
 
@@ -72,19 +82,31 @@ class DeLijnPublicTransportSensor(Entity):
         try:
             attributes = {}
             first = self.line.passages[0]
-            self._state = first['due_in_min']
+            local_timezone = pytz.timezone("Europe/Brussels")
+            if first['due_at_rt'] is not None:
+                first_passage_naive = dt_util.parse_datetime(first['due_at_rt'])
+            else:
+                first_passage_naive = dt_util.parse_datetime(first['due_at_sch'])
+            first_passage_local = local_timezone.localize(first_passage_naive)
+            first_passage_utc = dt_util.as_utc(first_passage_local)
+            self._state = first_passage_utc.isoformat()
             self._name = first['stopname']
             attributes['stopname'] = first['stopname']
             attributes['line_number_public'] = first['line_number_public']
             attributes['line_transport_type'] = first['line_transport_type']
             attributes['final_destination'] = first['final_destination']
-            attributes['due_at_sch'] = first['due_at_sch']
-            attributes['due_at_rt'] = first['due_at_rt']
+            attributes['due_at_schedule'] = first['due_at_sch']
+            attributes['due_at_realtime'] = first['due_at_rt']
             attributes['due_in_min'] = first['due_in_min']
             attributes['next_passages'] = self.line.passages
             self._attributes = attributes
         except (KeyError, IndexError) as error:
-            _LOGGER.debug("Error getting data from De Lijn, %s", error)
+            _LOGGER.debug("Error getting data from De Lijn, {}".format(error))
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return DEVICE_CLASS_TIMESTAMP
 
     @property
     def name(self):
@@ -104,4 +126,5 @@ class DeLijnPublicTransportSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return attributes for the sensor."""
+        self._attributes[ATTR_ATTRIBUTION] = ATTRIBUTION
         return self._attributes

--- a/homeassistant/components/delijn/sensor.py
+++ b/homeassistant/components/delijn/sensor.py
@@ -63,10 +63,9 @@ class DeLijnPublicTransportSensor(Entity):
     def __init__(self, line, name):
         """Initialize the sensor."""
         self.line = line
-        self._attributes = {}
+        self._attributes = {ATTR_ATTRIBUTION: ATTRIBUTION}
         self._name = name
         self._state = None
-        self._attributes[ATTR_ATTRIBUTION] = ATTRIBUTION
 
     async def async_update(self):
         """Get the latest data from the De Lijn API."""
@@ -75,7 +74,6 @@ class DeLijnPublicTransportSensor(Entity):
             _LOGGER.warning("No data recieved from De Lijn")
             return
         try:
-            attributes = {}
             first = self.line.passages[0]
             if first['due_at_realtime'] is not None:
                 first_passage = first['due_at_realtime']
@@ -84,15 +82,15 @@ class DeLijnPublicTransportSensor(Entity):
             self._state = first_passage
 
             self._name = first['stopname']
-            attributes['stopname'] = first['stopname']
-            attributes['line_number_public'] = first['line_number_public']
-            attributes['line_transport_type'] = first['line_transport_type']
-            attributes['final_destination'] = first['final_destination']
-            attributes['due_at_schedule'] = first['due_at_schedule']
-            attributes['due_at_realtime'] = first['due_at_realtime']
-            attributes['due_in_min'] = first['due_in_min']
-            attributes['next_passages'] = self.line.passages
-            self._attributes = attributes
+            self._attributes['stopname'] = first['stopname']
+            self._attributes['line_number_public'] = first['line_number_public']
+            self._attributes['line_transport_type'] = first['line_transport_type']
+            self._attributes['final_destination'] = first['final_destination']
+            self._attributes['due_at_schedule'] = first['due_at_schedule']
+            self._attributes['due_at_realtime'] = first['due_at_realtime']
+            self._attributes['due_in_min'] = first['due_in_min']
+            self._attributes['next_passages'] = self.line.passages
+            self._attributes[ATTR_ATTRIBUTION] = ATTRIBUTION
         except (KeyError, IndexError) as error:
             _LOGGER.debug("Error getting data from De Lijn, {}".format(error))
 
@@ -119,5 +117,4 @@ class DeLijnPublicTransportSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return attributes for the sensor."""
-        self._attributes[ATTR_ATTRIBUTION] = ATTRIBUTION
         return self._attributes

--- a/homeassistant/components/delijn/sensor.py
+++ b/homeassistant/components/delijn/sensor.py
@@ -83,8 +83,10 @@ class DeLijnPublicTransportSensor(Entity):
 
             self._name = first['stopname']
             self._attributes['stopname'] = first['stopname']
-            self._attributes['line_number_public'] = first['line_number_public']
-            self._attributes['line_transport_type'] = first['line_transport_type']
+            self._attributes['line_number_public'] = first[
+                'line_number_public']
+            self._attributes['line_transport_type'] = first[
+                'line_transport_type']
             self._attributes['final_destination'] = first['final_destination']
             self._attributes['due_at_schedule'] = first['due_at_schedule']
             self._attributes['due_at_realtime'] = first['due_at_realtime']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1050,6 +1050,9 @@ pydanfossair==0.1.0
 # homeassistant.components.deconz
 pydeconz==59
 
+# homeassistant.components.delijn
+pydelijn==0.4.0
+
 # homeassistant.components.zwave
 pydispatcher==2.0.5
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1051,7 +1051,7 @@ pydanfossair==0.1.0
 pydeconz==59
 
 # homeassistant.components.delijn
-pydelijn==0.4.0
+pydelijn==0.5.1
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Breaking Change:

none

## Description:
Add [De Lijn](https://www.delijn.be) (the Flemish Public Transport agency) support. The use of the API's of De Lijn does require a subscription key that needs to be added to the configuration. You can register for a free developer account at https://data.delijn.be/ where you can find the subscription key.

Works best with the following custom lovelace card: https://github.com/bollewolle/delijn-card

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9507

## Example entry for `configuration.yaml`:
```yaml
sensor:
  # De Lijn public transport
  - platform: delijn
    sub_key: 'abcdefg'
    nextpassage:
    - stop_id: '200018'
      max_passages: 5
    - stop_id: '201169'
      max_passages: 20
```
Replace the abcdefg with the API subscription key of De Lijn.
Stop Id's are 6 digit number that can be found at each physical stop of De Lijn in Flanders, but can also be found on their site here: https://www.delijn.be/en/haltes/

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html