### PR TITLE
Restore state for mobile app device tracker

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from .const import (ATTR_DEVICE_ID, ATTR_DEVICE_NAME,
                     ATTR_MANUFACTURER, ATTR_MODEL, ATTR_OS_VERSION,
                     DATA_BINARY_SENSOR, DATA_CONFIG_ENTRIES, DATA_DELETED_IDS,
-                    DATA_DEVICES, DATA_DEVICE_TRACKER, DATA_SENSOR, DATA_STORE,
+                    DATA_DEVICES, DATA_SENSOR, DATA_STORE,
                     DOMAIN, STORAGE_KEY, STORAGE_VERSION)
 
 from .http_api import RegistrationsView
@@ -34,7 +34,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
         DATA_CONFIG_ENTRIES: {},
         DATA_DELETED_IDS: app_config.get(DATA_DELETED_IDS, []),
         DATA_DEVICES: {},
-        DATA_DEVICE_TRACKER: {},
         DATA_SENSOR: app_config.get(DATA_SENSOR, {}),
         DATA_STORE: store,
     }

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -25,7 +25,6 @@ DATA_BINARY_SENSOR = 'binary_sensor'
 DATA_CONFIG_ENTRIES = 'config_entries'
 DATA_DELETED_IDS = 'deleted_ids'
 DATA_DEVICES = 'devices'
-DATA_DEVICE_TRACKER = 'device_tracker'
 DATA_SENSOR = 'sensor'
 DATA_STORE = 'store'
 

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -22,7 +22,7 @@ async def test_sending_location(hass, create_registrations, webhook_client):
 
     assert resp.status == 200
     await hass.async_block_till_done()
-    state = hass.states.get('device_tracker.test_1')
+    state = hass.states.get('device_tracker.test_1_2')
     assert state is not None
     assert state.name == 'Test 1'
     assert state.state == 'bar'
@@ -54,7 +54,7 @@ async def test_sending_location(hass, create_registrations, webhook_client):
 
     assert resp.status == 200
     await hass.async_block_till_done()
-    state = hass.states.get('device_tracker.test_1')
+    state = hass.states.get('device_tracker.test_1_2')
     assert state is not None
     assert state.state == 'not_home'
     assert state.attributes['source_type'] == 'gps'
@@ -66,3 +66,51 @@ async def test_sending_location(hass, create_registrations, webhook_client):
     assert state.attributes['course'] == 6
     assert state.attributes['speed'] == 7
     assert state.attributes['vertical_accuracy'] == 8
+
+
+async def test_restoring_location(hass, create_registrations, webhook_client):
+    """Test sending a location via a webhook."""
+    resp = await webhook_client.post(
+        '/api/webhook/{}'.format(create_registrations[1]['webhook_id']),
+        json={
+            'type': 'update_location',
+            'data': {
+                'gps': [10, 20],
+                'gps_accuracy': 30,
+                'battery': 40,
+                'altitude': 50,
+                'course': 60,
+                'speed': 70,
+                'vertical_accuracy': 80,
+                'location_name': 'bar',
+            }
+        }
+    )
+
+    assert resp.status == 200
+    await hass.async_block_till_done()
+    state_1 = hass.states.get('device_tracker.test_1_2')
+    assert state_1 is not None
+
+    config_entry = hass.config_entries.async_entries('mobile_app')[1]
+
+    # mobile app doesn't support unloading, so we just reload device tracker
+    await hass.config_entries.async_forward_entry_unload(config_entry,
+                                                         'device_tracker')
+    await hass.config_entries.async_forward_entry_setup(config_entry,
+                                                        'device_tracker')
+
+    state_2 = hass.states.get('device_tracker.test_1_2')
+    assert state_2 is not None
+
+    assert state_1 is not state_2
+    assert state_2.name == 'Test 1'
+    assert state_2.attributes['source_type'] == 'gps'
+    assert state_2.attributes['latitude'] == 10
+    assert state_2.attributes['longitude'] == 20
+    assert state_2.attributes['gps_accuracy'] == 30
+    assert state_2.attributes['battery_level'] == 40
+    assert state_2.attributes['altitude'] == 50
+    assert state_2.attributes['course'] == 60
+    assert state_2.attributes['speed'] == 70
+    assert state_2.attributes['vertical_accuracy'] == 80


### PR DESCRIPTION
## Description:
Add support to the mobile app device tracker entities to restore their state.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
