### PR TITLE
Entity registry doesn't overwrite with None

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -127,8 +127,8 @@ class EntityRegistry:
         if entity_id:
             return self._async_update_entity(
                 entity_id,
-                config_entry_id=config_entry_id,
-                device_id=device_id,
+                config_entry_id=config_entry_id or _UNDEF,
+                device_id=device_id or _UNDEF,
                 # When we changed our slugify algorithm, we invalidated some
                 # stored entity IDs with either a __ or ending in _.
                 # Fix introduced in 0.86 (Jan 23, 2019). Next line can be


### PR DESCRIPTION
## Description:

Little patch to entity registry.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
