### PR TITLE
Bump aioesphomeapi to 2.1.0

### DIFF
--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/esphome",
   "requirements": [
-    "aioesphomeapi==2.0.1"
+    "aioesphomeapi==2.1.0"
   ],
   "dependencies": [],
   "zeroconf": ["_esphomelib._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -129,7 +129,7 @@ aiobotocore==0.10.2
 aiodns==2.0.0
 
 # homeassistant.components.esphome
-aioesphomeapi==2.0.1
+aioesphomeapi==2.1.0
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -48,7 +48,7 @@ aioautomatic==0.6.5
 aiobotocore==0.10.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.0.1
+aioesphomeapi==2.1.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

Update aioesphomeapi to 2.1.0 - contains one small update:

.local names are no longer resolved with DNS first, but with zeroconf first.

Reason is: apparently many people have DNS setups that for some reason are happy to resolve .local names to some IP address (most oftem themself, no matter what string is passed in).

This makes sure the more accurate built-in zc is used first. If that fails, DNS is used as before.

https://github.com/esphome/aioesphomeapi/compare/v2.0.1...v2.1.0

Related: https://github.com/esphome/issues/issues/392

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the development checklist
