### PR TITLE
Expose specific device_class for Velux covers

### DIFF
--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -60,8 +60,16 @@ class VeluxCover(CoverDevice):
 
     @property
     def device_class(self):
-        """Define this cover as a window."""
-        return 'window'
+        """Define this cover as either window, blind, awning or rollershutter.""" 
+        from pyvlx.opening_device import Blind, RollerShutter, Window, Awning
+        if isinstance(self.node, Window):
+            return 'window'
+        if isinstance(self.node, Blind):
+            return 'blind'
+        if isinstance(self.node, RollerShutter):
+            return 'shutter'
+        if isinstance(self.node, Awning):
+            return 'awning'
 
     @property
     def is_closed(self):

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -70,6 +70,7 @@ class VeluxCover(CoverDevice):
             return 'shutter'
         if isinstance(self.node, Awning):
             return 'awning'
+        return 'window'
 
     @property
     def is_closed(self):

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -60,7 +60,7 @@ class VeluxCover(CoverDevice):
 
     @property
     def device_class(self):
-        """Define this cover as either window/blind/awning/shutter"""
+        """Define this cover as either window/blind/awning/shutter."""
         from pyvlx.opening_device import Blind, RollerShutter, Window, Awning
         if isinstance(self.node, Window):
             return 'window'

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -60,7 +60,7 @@ class VeluxCover(CoverDevice):
 
     @property
     def device_class(self):
-        """Define this cover as either window, blind, awning or rollershutter.""" 
+        """Define this cover as either window/blind/awning/shutter"""
         from pyvlx.opening_device import Blind, RollerShutter, Window, Awning
         if isinstance(self.node, Window):
             return 'window'


### PR DESCRIPTION
Blinds, Rollingshutters and Awnings did not set their respective device_class attribute
Previously they would all appear as device_class "window"

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
