### PR TITLE
Fix cors on the index view

### DIFF
--- a/homeassistant/components/http/cors.py
+++ b/homeassistant/components/http/cors.py
@@ -1,4 +1,5 @@
 """Provide CORS support for the HTTP component."""
+from aiohttp.web_urldispatcher import Resource, ResourceRoute
 from aiohttp.hdrs import ACCEPT, CONTENT_TYPE, ORIGIN, AUTHORIZATION
 
 from homeassistant.const import (
@@ -8,6 +9,7 @@ from homeassistant.core import callback
 ALLOWED_CORS_HEADERS = [
     ORIGIN, ACCEPT, HTTP_HEADER_X_REQUESTED_WITH, CONTENT_TYPE,
     HTTP_HEADER_HA_AUTH, AUTHORIZATION]
+VALID_CORS_TYPES = (Resource, ResourceRoute)
 
 
 @callback
@@ -30,6 +32,9 @@ def setup_cors(app, origins):
             path = route.resource
         else:
             path = route
+
+        if not isinstance(path, VALID_CORS_TYPES):
+            return
 
         path = path.canonical
 

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -140,3 +140,15 @@ async def test_cors_middleware_with_cors_allowed_view(hass):
 
     hass.http.app._on_startup.freeze()
     await hass.http.app.startup()
+
+
+async def test_cors_works_with_frontend(hass, hass_client):
+    """Test CORS works with the frontend."""
+    assert await async_setup_component(hass, 'frontend', {
+        'http': {
+            'cors_allowed_origins': ['http://home-assistant.io']
+        }
+    })
+    client = await hass_client()
+    resp = await client.get('/')
+    assert resp.status == 200


### PR DESCRIPTION
## Description:
CORS does not work with classes derived from AbstractResource. Our index view is one. Fixes the issue and adds a test to keep it fixed.

**Related issue (if applicable):** fixes #24239

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
