### PR TITLE
Improve boolean validator

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -6,6 +6,7 @@ import re
 from datetime import (timedelta, datetime as datetime_sys,
                       time as time_sys, date as date_sys)
 from socket import _GLOBAL_DEFAULT_TIMEOUT
+from numbers import Number
 from typing import Any, Union, TypeVar, Callable, Sequence, Dict, Optional
 from urllib.parse import urlparse
 from uuid import UUID
@@ -81,14 +82,20 @@ def has_at_most_one_key(*keys: str) -> Callable:
 
 def boolean(value: Any) -> bool:
     """Validate and coerce a boolean value."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
     if isinstance(value, str):
-        value = value.lower()
+        value = value.lower().strip()
         if value in ('1', 'true', 'yes', 'on', 'enable'):
             return True
         if value in ('0', 'false', 'no', 'off', 'disable'):
             return False
         raise vol.Invalid('invalid boolean value {}'.format(value))
-    return bool(value)
+    if isinstance(value, Number):
+        return value != 0
+    raise vol.Invalid('invalid boolean value {}'.format(value))
 
 
 def isdevice(value):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -92,8 +92,7 @@ def boolean(value: Any) -> bool:
             return True
         if value in ('0', 'false', 'no', 'off', 'disable'):
             return False
-        raise vol.Invalid('invalid boolean value {}'.format(value))
-    if isinstance(value, Number):
+    elif isinstance(value, Number):
         return value != 0
     raise vol.Invalid('invalid boolean value {}'.format(value))
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -82,8 +82,6 @@ def has_at_most_one_key(*keys: str) -> Callable:
 
 def boolean(value: Any) -> bool:
     """Validate and coerce a boolean value."""
-    if value is None:
-        return False
     if isinstance(value, bool):
         return value
     if isinstance(value, str):

--- a/tests/components/demo/test_climate.py
+++ b/tests/components/demo/test_climate.py
@@ -203,7 +203,8 @@ class TestDemoClimate(unittest.TestCase):
         """Test setting the away mode without required attribute."""
         state = self.hass.states.get(ENTITY_CLIMATE)
         assert 'on' == state.attributes.get('away_mode')
-        common.set_away_mode(self.hass, None, ENTITY_CLIMATE)
+        with pytest.raises(vol.Invalid):
+            common.set_away_mode(self.hass, None, ENTITY_CLIMATE)
         self.hass.block_till_done()
         assert 'on' == state.attributes.get('away_mode')
 
@@ -246,7 +247,8 @@ class TestDemoClimate(unittest.TestCase):
         """Test setting the auxiliary heater without required attribute."""
         state = self.hass.states.get(ENTITY_CLIMATE)
         assert 'off' == state.attributes.get('aux_heat')
-        common.set_aux_heat(self.hass, None, ENTITY_CLIMATE)
+        with pytest.raises(vol.Invalid):
+            common.set_aux_heat(self.hass, None, ENTITY_CLIMATE)
         self.hass.block_till_done()
         assert 'off' == state.attributes.get('aux_heat')
 

--- a/tests/components/demo/test_media_player.py
+++ b/tests/components/demo/test_media_player.py
@@ -90,7 +90,8 @@ class TestDemoMediaPlayer(unittest.TestCase):
 
         assert False is state.attributes.get('is_volume_muted')
 
-        common.mute_volume(self.hass, None, entity_id)
+        with pytest.raises(vol.Invalid):
+            common.mute_volume(self.hass, None, entity_id)
         self.hass.block_till_done()
         state = self.hass.states.get(entity_id)
         assert False is state.attributes.get('is_volume_muted')

--- a/tests/components/demo/test_water_heater.py
+++ b/tests/components/demo/test_water_heater.py
@@ -95,7 +95,8 @@ class TestDemowater_heater(unittest.TestCase):
         """Test setting the away mode without required attribute."""
         state = self.hass.states.get(ENTITY_WATER_HEATER)
         assert 'off' == state.attributes.get('away_mode')
-        common.set_away_mode(self.hass, None, ENTITY_WATER_HEATER)
+        with pytest.raises(vol.Invalid):
+            common.set_away_mode(self.hass, None, ENTITY_WATER_HEATER)
         self.hass.block_till_done()
         assert 'off' == state.attributes.get('away_mode')
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -18,7 +18,7 @@ def test_boolean():
     schema = vol.Schema(cv.boolean)
 
     for value in (
-            'T', 'negative', 'lock', 'tr  ue',
+            None, 'T', 'negative', 'lock', 'tr  ue',
             [], [1, 2], {'one': 'two'}, test_boolean):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
@@ -27,7 +27,7 @@ def test_boolean():
                   'enable', 1, 50, True, 0.1):
         assert schema(value)
 
-    for value in (None, 'false', 'Off', '0', 'NO', 'disable', 0, False):
+    for value in ('false', 'Off', '0', 'NO', 'disable', 0, False):
         assert not schema(value)
 
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -17,14 +17,17 @@ def test_boolean():
     """Test boolean validation."""
     schema = vol.Schema(cv.boolean)
 
-    for value in ('T', 'negative', 'lock'):
+    for value in (
+            'T', 'negative', 'lock', 'tr  ue',
+            [], [1, 2], {'one': 'two'}, test_boolean):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
-    for value in ('true', 'On', '1', 'YES', 'enable', 1, True):
+    for value in ('true', 'On', '1', 'YES', '   true  ',
+                  'enable', 1, 50, True, 0.1):
         assert schema(value)
 
-    for value in ('false', 'Off', '0', 'NO', 'disable', 0, False):
+    for value in (None, 'false', 'Off', '0', 'NO', 'disable', 0, False):
         assert not schema(value)
 
 


### PR DESCRIPTION
## Description:

Improved the boolean validator to make it more robust. Picked out the important bits of #23293 

No longer allows non-boolean, non-number, non-string, non None types through (invalid value). Strips out surrounding white space. It seemed odd that `"  true"` would be an invalid value as would `"dog"`, but `[56]` would not and would validate to True. 

The core of the validator is unchanged in that strings are either explicitly true or false, or invalid, it's just more robust in the face of non-string types and whitespace.

It may be worth considering 'open' to be true and 'closed' to be false as well.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
