### PR TITLE
Don't measure CPU temperatures in farenheit

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, CONF_USERNAME, CONF_PASSWORD, CONF_SSL,
-    CONF_VERIFY_SSL, CONF_RESOURCES, STATE_UNAVAILABLE, TEMP_CELSIUS)
+    CONF_VERIFY_SSL, CONF_RESOURCES, STATE_UNAVAILABLE)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -41,7 +41,7 @@ SENSOR_TYPES = {
     'process_thread': ['Thread', 'Count', 'mdi:memory'],
     'process_sleeping': ['Sleeping', 'Count', 'mdi:memory'],
     'cpu_use_percent': ['CPU used', '%', 'mdi:memory'],
-    'cpu_temp': ['CPU Temp', TEMP_CELSIUS, 'mdi:thermometer'],
+    'cpu_temp': ['CPU Temp', '°C', 'mdi:thermometer'],
     'docker_active': ['Containers active', '', 'mdi:docker'],
     'docker_cpu_use': ['Containers CPU used', '%', 'mdi:docker'],
     'docker_memory_use': ['Containers RAM used', 'MiB', 'mdi:docker'],

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -41,7 +41,7 @@ SENSOR_TYPES = {
     'process_thread': ['Thread', 'Count', 'mdi:memory'],
     'process_sleeping': ['Sleeping', 'Count', 'mdi:memory'],
     'cpu_use_percent': ['CPU used', '%', 'mdi:memory'],
-    'cpu_temp': ['CPU Temp', '°C', 'mdi:thermometer'],
+    'cpu_temp': ['CPU Temp', '', 'mdi:thermometer'],
     'docker_active': ['Containers active', '', 'mdi:docker'],
     'docker_cpu_use': ['Containers CPU used', '%', 'mdi:docker'],
     'docker_memory_use': ['Containers RAM used', 'MiB', 'mdi:docker'],
@@ -181,6 +181,7 @@ class GlancesSensor(Entity):
                                            "exynos-therm 1", "soc_thermal 1",
                                            "soc-thermal 1"]:
                         self._state = sensor['value']
+                        self._unit_of_measurement = sensor['unit']
             elif self.type == 'docker_active':
                 count = 0
                 try:


### PR DESCRIPTION
## Breaking Change:

The `unit_of_measurement` from Glance's `cpu_temperature` is changing from `preferred_unit` to whichever unit is included in the API response from the Glances endpoint (`C` or `F`)

## Description:

CPU temperatures are measured in Celsius, currently the Glances sensor measures the CPU temperatures in `preferred_units`, so if your `preferred_units` is Farenheit, the temperatures show up in Farenheit which is not ideal.

**Related issue (if applicable):** fixes #24098

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: glances
    host: !secret ip
    name: glances
    version: 3
    resources:
      - cpu_temp
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
