### PR TITLE
Run SSDP discovery in parallel

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -86,13 +86,16 @@ class Scanner:
         if not to_load:
             return
 
-        for entry, info, domains in to_load:
+        tasks = []
 
+        for entry, info, domains in to_load:
             for domain in domains:
                 _LOGGER.debug("Discovered %s at %s", domain, entry.location)
-                await self.hass.config_entries.flow.async_init(
+                tasks.append(self.hass.config_entries.flow.async_init(
                     domain, context={'source': DOMAIN}, data=info
-                )
+                ))
+
+        await asyncio.wait(tasks)
 
     async def _process_entry(self, entry):
         """Process a single entry."""


### PR DESCRIPTION
## Description:
When SSDP discovers integrations, initialize them in parallel. Otherwise we might wait for one integration installing a requirement while the next one would have been able to run right away.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
