### PR TITLE
Upgrade Zeroconf to 0.23

### DIFF
--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -3,7 +3,7 @@
   "name": "Zeroconf",
   "documentation": "https://www.home-assistant.io/components/zeroconf",
   "requirements": [
-    "zeroconf==0.22.0"
+    "zeroconf==0.23.0"
   ],
   "dependencies": [
     "api"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1875,7 +1875,7 @@ youtube_dl==2019.05.11
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.22.0
+zeroconf==0.23.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -352,7 +352,7 @@ vultr==0.1.2
 wakeonlan==1.1.6
 
 # homeassistant.components.zeroconf
-zeroconf==0.22.0
+zeroconf==0.23.0
 
 # homeassistant.components.zha
 zigpy-homeassistant==0.4.2


### PR DESCRIPTION
## Description:
Zeroconf 0.23 will no longer cause stacktraces if it discovers itself on a loopback network.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
