### PR TITLE
Don't load last_checkpoint if shipment is pending

### DIFF
--- a/homeassistant/components/aftership/sensor.py
+++ b/homeassistant/components/aftership/sensor.py
@@ -177,6 +177,11 @@ class AfterShipSensor(Entity):
                 if track['title'] is None
                 else track['title']
             )
+            last_checkpoint = (
+                "Shipment pending"
+                if track['tag'] == "Pending"
+                else track['checkpoints'][-1]
+            )
             status_counts[status] = status_counts.get(status, 0) + 1
             trackings.append({
                 'name': name,
@@ -187,7 +192,7 @@ class AfterShipSensor(Entity):
                 'last_update': track['updated_at'],
                 'expected_delivery': track['expected_delivery'],
                 'status': track['tag'],
-                'last_checkpoint': track['checkpoints'][-1]
+                'last_checkpoint': last_checkpoint
             })
 
             if status not in status_to_ignore:


### PR DESCRIPTION
## Description:

If a shipment is pending, it won't have a dictionary that includes its ``last_checkpoint``. Prior to this change, the component would crash on startup if any packages were in pending state. 

**Related issue (if applicable):** fixes #23554

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
