### PR TITLE
Fix OwnTracks race condition

### DIFF
--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -192,6 +192,7 @@ class OwnTracksContext:
         self.region_mapping = region_mapping
         self.events_only = events_only
         self.mqtt_topic = mqtt_topic
+        self._pending_msg = []
 
     @callback
     def async_valid_accuracy(self, message):
@@ -223,9 +224,17 @@ class OwnTracksContext:
         return True
 
     @callback
+    def set_async_see(self, func):
+        """Set a new async_see function."""
+        self.async_see = func
+        for msg in self._pending_msg:
+            func(**msg)
+        self._pending_msg.clear()
+
+    @callback
     def async_see(self, **data):
         """Send a see message to the device tracker."""
-        raise NotImplementedError
+        self._pending_msg.append(data)
 
     @callback
     def async_see_beacons(self, hass, dev_id, kwargs_param):

--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -231,6 +231,7 @@ class OwnTracksContext:
             func(**msg)
         self._pending_msg.clear()
 
+    # pylint: disable=method-hidden
     @callback
     def async_see(self, **data):
         """Send a see message to the device tracker."""

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         )
         async_add_entities([entity])
 
-    hass.data[OT_DOMAIN]['context'].async_see = _receive_data
+    hass.data[OT_DOMAIN]['context'].set_async_see(_receive_data)
 
     # Restore previously loaded devices
     dev_reg = await device_registry.async_get_registry(hass)

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 
 from homeassistant.setup import async_setup_component
-
+from homeassistant.components import owntracks
 from tests.common import mock_component, MockConfigEntry
 
 MINIMAL_LOCATION_MESSAGE = {
@@ -160,3 +160,24 @@ def test_returns_error_missing_device(mock_client):
 
     json = yield from resp.json()
     assert json == []
+
+
+def test_context_delivers_pending_msg():
+    """Test that context is able to hold pending messages while being init."""
+    context = owntracks.OwnTracksContext(
+        None, None, None, None, None, None, None, None
+    )
+    context.async_see(hello='world')
+    context.async_see(world='hello')
+    received = []
+
+    context.set_async_see(lambda **data: received.append(data))
+
+    assert len(received) == 2
+    assert received[0] == {'hello': 'world'}
+    assert received[1] == {'world': 'hello'}
+
+    received.clear()
+
+    context.set_async_see(lambda **data: received.append(data))
+    assert len(received) == 0


### PR DESCRIPTION
## Description:
When OwnTracks is set up using MQTT and the OwnTracks messages have the retain flag on, it is possible for messages to be processed before the device tracker platform has been set up.

With this PR, those messages will now get processed when the device tracker platform has been initialized.

**Related issue (if applicable):** fixes issue reported on Discord #beta

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
