### PR TITLE
Change meteoalertapi to version 0.1.3

### DIFF
--- a/homeassistant/components/meteoalarm/manifest.json
+++ b/homeassistant/components/meteoalarm/manifest.json
@@ -3,7 +3,7 @@
   "name": "meteoalarm",
   "documentation": "https://www.home-assistant.io/components/meteoalarm",
   "requirements": [
-    "meteoalertapi==0.0.8"
+    "meteoalertapi==0.1.3"
   ],
   "dependencies": [],
   "codeowners": ["@rolfberkenbosch"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -730,7 +730,7 @@ mbddns==0.1.2
 messagebird==1.2.0
 
 # homeassistant.components.meteoalarm
-meteoalertapi==0.0.8
+meteoalertapi==0.1.3
 
 # homeassistant.components.meteo_france
 meteofrance==0.3.4


### PR DESCRIPTION
## Description:

This will fix the issue with the languages for meteoalarm component

**Related issue (if applicable):** fixes #24255, fixes #24172

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
