### PR TITLE
Add ATTR_FORECAST_PRECIPITATION option

### DIFF
--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -5,7 +5,8 @@ import voluptuous as vol
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION, ATTR_FORECAST_TEMP, ATTR_FORECAST_TEMP_LOW,
-    ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity)
+    ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity,
+    ATTR_FORECAST_PRECIPITATION)
 from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, TEMP_CELSIUS)
 from homeassistant.helpers import config_validation as cv
@@ -149,7 +150,7 @@ class BrWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        from buienradar.buienradar import (CONDITION, CONDCODE, DATETIME,
+        from buienradar.buienradar import (CONDITION, CONDCODE, RAIN, DATETIME,
                                            MIN_TEMP, MAX_TEMP)
 
         if self._forecast:
@@ -166,7 +167,8 @@ class BrWeather(WeatherEntity):
                     data_out[ATTR_FORECAST_CONDITION] = cond[condcode]
                     data_out[ATTR_FORECAST_TEMP_LOW] = data_in.get(MIN_TEMP)
                     data_out[ATTR_FORECAST_TEMP] = data_in.get(MAX_TEMP)
-
+                    data_out[ATTR_FORECAST_PRECIPITATION] = data_in.get(RAIN)
+                    
                     fcdata_out.append(data_out)
 
             return fcdata_out

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -168,7 +168,7 @@ class BrWeather(WeatherEntity):
                     data_out[ATTR_FORECAST_TEMP_LOW] = data_in.get(MIN_TEMP)
                     data_out[ATTR_FORECAST_TEMP] = data_in.get(MAX_TEMP)
                     data_out[ATTR_FORECAST_PRECIPITATION] = data_in.get(RAIN)
-                    
+
                     fcdata_out.append(data_out)
 
             return fcdata_out


### PR DESCRIPTION
## Description:

I have added the ATTR_FORECAST_PRECIPITATION option to the weather.py file from buienradar, because the pypi lib of buienradar is also supporting this.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
