### PR TITLE
Fix for sun issues

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -3,7 +3,8 @@ import logging
 from datetime import timedelta
 
 from homeassistant.const import (
-    CONF_ELEVATION, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+    CONF_ELEVATION, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET,
+    EVENT_CORE_CONFIG_UPDATE)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
@@ -70,7 +71,7 @@ async def async_setup(hass, config):
         _LOGGER.warning(
             "Elevation is now configured in home assistant core. "
             "See https://home-assistant.io/docs/configuration/basic/")
-    Sun(hass, get_astral_location(hass))
+    Sun(hass)
     return True
 
 
@@ -79,18 +80,23 @@ class Sun(Entity):
 
     entity_id = ENTITY_ID
 
-    def __init__(self, hass, location):
+    def __init__(self, hass):
         """Initialize the sun."""
         self.hass = hass
-        self.location = location
+        self.location = None
         self._state = self.next_rising = self.next_setting = None
         self.next_dawn = self.next_dusk = None
         self.next_midnight = self.next_noon = None
         self.solar_elevation = self.solar_azimuth = None
         self.rising = self.phase = None
-
         self._next_change = None
-        self.update_events(dt_util.utcnow())
+
+        def update_location(event):
+            self.location = get_astral_location(self.hass)
+            self.update_events(dt_util.utcnow())
+        update_location(None)
+        self.hass.bus.async_listen(
+            EVENT_CORE_CONFIG_UPDATE, update_location)
 
     @property
     def name(self):
@@ -100,7 +106,8 @@ class Sun(Entity):
     @property
     def state(self):
         """Return the state of the sun."""
-        if self.next_rising > self.next_setting:
+        # 0.8333 is the same value as astral uses
+        if self.solar_elevation > -0.833:
             return STATE_ABOVE_HORIZON
 
         return STATE_BELOW_HORIZON

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -119,6 +119,14 @@ async def test_state_change(hass):
     assert sun.STATE_ABOVE_HORIZON == \
         hass.states.get(sun.ENTITY_ID).state
 
+    with patch('homeassistant.helpers.condition.dt_util.utcnow',
+               return_value=now):
+        await hass.config.async_update(longitude=hass.config.longitude+90)
+        await hass.async_block_till_done()
+
+    assert sun.STATE_ABOVE_HORIZON == \
+        hass.states.get(sun.ENTITY_ID).state
+
 
 async def test_norway_in_june(hass):
     """Test location in Norway where the sun doesn't set in summer."""
@@ -141,6 +149,8 @@ async def test_norway_in_june(hass):
     assert dt_util.parse_datetime(
         state.attributes[sun.STATE_ATTR_NEXT_SETTING]) == \
         datetime(2016, 7, 26, 22, 19, 1, tzinfo=dt_util.UTC)
+
+    assert state.state == sun.STATE_ABOVE_HORIZON
 
 
 @mark.skip


### PR DESCRIPTION
## Description:

This fixes #24291.

It's only a partial fix for #24271, the issue is the underlying library is returning stuff that doesn't make sense. The bug has been there for some time. It's even in the test case.

I've changed the 'above_horizon' condition to be an elevation > -0.833, which is consistent with what astral uses. This doesn't take into account altitude because the underlying library doesn't use this in the elevation calculation, and differs from the sunrise / sunset calculation times by sometimes even a few mins. The underlying library needs to be fixed, but I don't really understand the maths.

**Related issue (if applicable):** fixes #24291 #24271

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
