### PR TITLE
Add exception handling for Netatmo climate

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -344,8 +344,8 @@ class ThermostatData:
         """Return all module available on the API as a list."""
         if not self.setup():
             return []
-        for key in self.homestatus.rooms:
-            self.room_ids.append(key)
+        for room in self.homestatus.rooms:
+            self.room_ids.append(room)
         return self.room_ids
 
     def setup(self):
@@ -372,40 +372,52 @@ class ThermostatData:
             return
         _LOGGER.debug("Following is the debugging output for homestatus:")
         _LOGGER.debug(self.homestatus.rawData)
-        for key in self.homestatus.rooms:
-            roomstatus = {}
-            homestatus_room = self.homestatus.rooms[key]
-            homedata_room = self.homedata.rooms[self.home][key]
-            roomstatus['roomID'] = homestatus_room['id']
-            roomstatus['roomname'] = homedata_room['name']
-            roomstatus['target_temperature'] = \
-                homestatus_room['therm_setpoint_temperature']
-            roomstatus['setpoint_mode'] = \
-                homestatus_room['therm_setpoint_mode']
-            roomstatus['current_temperature'] = \
-                homestatus_room['therm_measured_temperature']
-            roomstatus['module_type'] = \
-                self.homestatus.thermostatType(self.home, key)
-            roomstatus['module_id'] = None
-            roomstatus['heating_status'] = None
-            roomstatus['heating_power_request'] = None
-            for module_id in homedata_room['module_ids']:
-                if self.homedata.modules[self.home][module_id]['type'] == \
-                   NA_THERM or roomstatus['module_id'] is None:
-                    roomstatus['module_id'] = module_id
-            if roomstatus['module_type'] == NA_THERM:
-                self.boilerstatus = self.homestatus.boilerStatus(
-                    rid=roomstatus['module_id'])
-                roomstatus['heating_status'] = self.boilerstatus
-            elif roomstatus['module_type'] == NA_VALVE:
-                roomstatus['heating_power_request'] = \
-                    homestatus_room['heating_power_request']
-                roomstatus['heating_status'] = \
-                    roomstatus['heating_power_request'] > 0
-                if self.boilerstatus is not None:
-                    roomstatus['heating_status'] = \
-                      self.boilerstatus and roomstatus['heating_status']
-            self.room_status[key] = roomstatus
+        for room in self.homestatus.rooms:
+            try:
+                roomstatus = {}
+                homestatus_room = self.homestatus.rooms[room]
+                homedata_room = self.homedata.rooms[self.home][room]
+                roomstatus["roomID"] = homestatus_room["id"]
+                roomstatus["roomname"] = homedata_room["name"]
+                roomstatus["target_temperature"] = homestatus_room[
+                    "therm_setpoint_temperature"
+                ]
+                roomstatus["setpoint_mode"] = (
+                    homestatus_room["therm_setpoint_mode"]
+                )
+                roomstatus["current_temperature"] = homestatus_room[
+                    "therm_measured_temperature"
+                ]
+                roomstatus["module_type"] = self.homestatus.thermostatType(
+                    self.home, room
+                )
+                roomstatus["module_id"] = None
+                roomstatus["heating_status"] = None
+                roomstatus["heating_power_request"] = None
+                for module_id in homedata_room["module_ids"]:
+                    if self.homedata.modules[self.home][module_id]["type"] == (
+                        NA_THERM or roomstatus["module_id"] is None
+                    ):
+                        roomstatus["module_id"] = module_id
+                if roomstatus["module_type"] == NA_THERM:
+                    self.boilerstatus = self.homestatus.boilerStatus(
+                        rid=roomstatus["module_id"]
+                    )
+                    roomstatus["heating_status"] = self.boilerstatus
+                elif roomstatus["module_type"] == NA_VALVE:
+                    roomstatus["heating_power_request"] = homestatus_room[
+                        "heating_power_request"
+                    ]
+                    roomstatus["heating_status"] = (
+                        roomstatus["heating_power_request"] > 0
+                    )
+                    if self.boilerstatus is not None:
+                        roomstatus["heating_status"] = (
+                            self.boilerstatus and roomstatus["heating_status"]
+                        )
+                self.room_status[room] = roomstatus
+            except KeyError as e:
+                _LOGGER.error("Update of room %s failed. Error: %s", room, e)
         self.away_temperature = self.homestatus.getAwaytemp(self.home)
         self.hg_temperature = self.homestatus.getHgtemp(self.home)
         self.setpoint_duration = self.homedata.setpoint_duration[self.home]

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -365,6 +365,7 @@ class ThermostatData:
     def update(self):
         """Call the NetAtmo API to update the data."""
         import pyatmo
+
         try:
             self.homestatus = pyatmo.HomeStatus(self.auth, home=self.home)
         except TypeError:
@@ -382,9 +383,9 @@ class ThermostatData:
                 roomstatus["target_temperature"] = homestatus_room[
                     "therm_setpoint_temperature"
                 ]
-                roomstatus["setpoint_mode"] = (
-                    homestatus_room["therm_setpoint_mode"]
-                )
+                roomstatus["setpoint_mode"] = homestatus_room[
+                    "therm_setpoint_mode"
+                ]
                 roomstatus["current_temperature"] = homestatus_room[
                     "therm_measured_temperature"
                 ]
@@ -395,9 +396,9 @@ class ThermostatData:
                 roomstatus["heating_status"] = None
                 roomstatus["heating_power_request"] = None
                 for module_id in homedata_room["module_ids"]:
-                    if self.homedata.modules[self.home][module_id]["type"] == (
-                        NA_THERM or roomstatus["module_id"] is None
-                    ):
+                    if (self.homedata.modules[self.home][module_id]["type"]
+                            == NA_THERM
+                            or roomstatus["module_id"] is None):
                         roomstatus["module_id"] = module_id
                 if roomstatus["module_type"] == NA_THERM:
                     self.boilerstatus = self.homestatus.boilerStatus(
@@ -416,8 +417,8 @@ class ThermostatData:
                             self.boilerstatus and roomstatus["heating_status"]
                         )
                 self.room_status[room] = roomstatus
-            except KeyError as e:
-                _LOGGER.error("Update of room %s failed. Error: %s", room, e)
+            except KeyError as err:
+                _LOGGER.error("Update of room %s failed. Error: %s", room, err)
         self.away_temperature = self.homestatus.getAwaytemp(self.home)
         self.hg_temperature = self.homestatus.getHgtemp(self.home)
         self.setpoint_duration = self.homedata.setpoint_duration[self.home]


### PR DESCRIPTION
## Description:
Try to catch when the update of rooms failes.

**Related issue (if applicable):** fixes #23990

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
