### PR TITLE
Meteofrance fix 24244

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -151,6 +151,7 @@ homeassistant/components/mcp23017/* @jardiamj
 homeassistant/components/mediaroom/* @dgomes
 homeassistant/components/melissa/* @kennedyshead
 homeassistant/components/met/* @danielhiversen
+homeassistant/components/meteo_france/* @victorcerutti
 homeassistant/components/meteoalarm/* @rolfberkenbosch
 homeassistant/components/miflora/* @danielhiversen @ChristianKuehnel
 homeassistant/components/mill/* @danielhiversen

--- a/homeassistant/components/meteo_france/manifest.json
+++ b/homeassistant/components/meteo_france/manifest.json
@@ -6,5 +6,7 @@
     "meteofrance==0.3.7"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@victorcerutti"
+  ]
 }

--- a/homeassistant/components/meteo_france/manifest.json
+++ b/homeassistant/components/meteo_france/manifest.json
@@ -3,7 +3,7 @@
   "name": "Meteo france",
   "documentation": "https://www.home-assistant.io/components/meteo_france",
   "requirements": [
-    "meteofrance==0.3.4"
+    "meteofrance==0.3.7"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -733,7 +733,7 @@ messagebird==1.2.0
 meteoalertapi==0.1.3
 
 # homeassistant.components.meteo_france
-meteofrance==0.3.4
+meteofrance==0.3.7
 
 # homeassistant.components.mfi
 mficlient==0.3.0


### PR DESCRIPTION
## Description:

Some elements went missing on meteo-france website, I corrected the package
**Related issue :** fixes #24244

## Example entry for `configuration.yaml` (if applicable):
```yaml
meteo_france:
  - city: 'Rouen'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
