### PR TITLE
Fix Home Assistant being discoverable

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -3,12 +3,14 @@
 # https://github.com/PyCQA/pylint/issues/1931
 # pylint: disable=no-name-in-module
 import logging
+import socket
 
 import ipaddress
 import voluptuous as vol
 
 from zeroconf import ServiceBrowser, ServiceInfo, ServiceStateChange, Zeroconf
 
+from homeassistant import util
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
 from homeassistant.generated.zeroconf import ZEROCONF, HOMEKIT
 
@@ -42,8 +44,16 @@ def setup(hass, config):
         'requires_api_password': True,
     }
 
-    info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name,
-                       port=hass.http.server_port, properties=params)
+    host_ip = util.get_local_ip()
+
+    try:
+        host_ip_pton = socket.inet_pton(socket.AF_INET, host_ip)
+    except socket.error:
+        host_ip_pton = socket.inet_pton(socket.AF_INET6, host_ip)
+
+    info = ServiceInfo(ZEROCONF_TYPE, zeroconf_name, None,
+                       addresses=[host_ip_pton], port=hass.http.server_port,
+                       properties=params)
 
     zeroconf = Zeroconf()
 


### PR DESCRIPTION
## Description:
This worked with aiozeroconf so never verified it when reverting back to python-zeroconf. But it seems we can't let zeroconf be smart about what addresses to broadcast on.

**Related issue (if applicable): Fix Home Assistant being discoverable by mobile app

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
