### PR TITLE
Remove attribute lowBat for Homematic IP devices

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -23,6 +23,7 @@ from .device import ATTR_GROUP_MEMBER_UNREACHABLE
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_LOW_BATTERY = 'low_battery'
 ATTR_MOTIONDETECTED = 'motion detected'
 ATTR_PRESENCEDETECTED = 'presence detected'
 ATTR_POWERMAINSFAILURE = 'power mains failure'
@@ -312,7 +313,8 @@ class HomematicipSecuritySensorGroup(HomematicipSecurityZoneSensorGroup,
             attr[ATTR_MOISTUREDETECTED] = True
         if self._device.waterlevelDetected:
             attr[ATTR_WATERLEVELDETECTED] = True
-
+        if self._device.lowBat:
+            attr[ATTR_LOW_BATTERY] = True
         if self._device.smokeDetectorAlarmType is not None and \
                 self._device.smokeDetectorAlarmType != \
                 SmokeDetectorAlarmType.IDLE_OFF:

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_LOW_BATTERY = 'low_battery'
 ATTR_MODEL_TYPE = 'model_type'
 # RSSI HAP -> Device
 ATTR_RSSI_DEVICE = 'rssi_device'
@@ -96,8 +95,6 @@ class HomematicipGenericDevice(Entity):
     def device_state_attributes(self):
         """Return the state attributes of the generic device."""
         attr = {ATTR_MODEL_TYPE: self._device.modelType}
-        if hasattr(self._device, 'lowBat') and self._device.lowBat:
-            attr[ATTR_LOW_BATTERY] = self._device.lowBat
         if hasattr(self._device, 'sabotage') and self._device.sabotage:
             attr[ATTR_SABOTAGE] = self._device.sabotage
         if hasattr(self._device, 'rssiDeviceValue') and \


### PR DESCRIPTION
## Breaking Change:

The lowBat attribute has been removed from HmIP Devices.
Please use the battery binary_sensor (since 0.92.0) instead.

## Description:

The low_bat attribute of HmIP devices has been replaced by a battery sensor with HA 0.92.0.
The low_bat attribute is only needed for SecurityGroups.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
