### PR TITLE
Only update media icon when necessary

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -272,6 +272,9 @@ class LgWebOSDevice(MediaPlayerDevice):
             icon = self._app_list[self._current_source_id]['largeIcon']
             if not icon.startswith('http'):
                 icon = self._app_list[self._current_source_id]['icon']
+
+            # 'icon' holds a URL with a transient key. Avoid unnecessary
+            # updates by returning the same URL until the image changes.
             if self._last_icon and \
                     (icon.split('/')[-1] == self._last_icon.split('/')[-1]):
                 return self._last_icon

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -275,9 +275,8 @@ class LgWebOSDevice(MediaPlayerDevice):
             if self._last_icon and \
                     (icon.split('/')[-1] == self._last_icon.split('/')[-1]):
                 return self._last_icon
-            else:
-                self._last_icon = icon
-                return icon
+            self._last_icon = icon
+            return icon
         return None
 
     @property

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -167,6 +167,7 @@ class LgWebOSDevice(MediaPlayerDevice):
         self._source_list = {}
         self._app_list = {}
         self._channel = None
+        self._last_icon = None
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
@@ -271,7 +272,12 @@ class LgWebOSDevice(MediaPlayerDevice):
             icon = self._app_list[self._current_source_id]['largeIcon']
             if not icon.startswith('http'):
                 icon = self._app_list[self._current_source_id]['icon']
-            return icon
+            if self._last_icon and \
+                    (icon.split('/')[-1] == self._last_icon.split('/')[-1]):
+                return self._last_icon
+            else:
+                self._last_icon = icon
+                return icon
         return None
 
     @property


### PR DESCRIPTION
## Description:

The WebOS `media_player` media icon contains a transient key in the URL which caused the `entity_icon` attribute to update on every poll of the entity. This PR continues to send the last matching icon to reduce database writes.

**Related issue (if applicable):** fixes #21585

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: webostv
  host: 10.0.1.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html