### PR TITLE
Bump simplipy to 3.4.2

### DIFF
--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/simplisafe",
   "requirements": [
-    "simplisafe-python==3.4.1"
+    "simplisafe-python==3.4.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1618,7 +1618,7 @@ shodan==1.13.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.4.1
+simplisafe-python==3.4.2
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -313,7 +313,7 @@ ring_doorbell==0.2.3
 rxv==0.6.0
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.4.1
+simplisafe-python==3.4.2
 
 # homeassistant.components.sleepiq
 sleepyq==0.6


### PR DESCRIPTION
## Description:

Changelog: https://github.com/bachya/simplisafe-python/releases/tag/3.4.2

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
