### PR TITLE
Add service to update core location

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import intent
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE,
     SERVICE_HOMEASSISTANT_STOP, SERVICE_HOMEASSISTANT_RESTART,
-    RESTART_EXIT_CODE)
+    RESTART_EXIT_CODE, ATTR_LATITUDE, ATTR_LONGITUDE)
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +22,7 @@ DOMAIN = ha.DOMAIN
 SERVICE_RELOAD_CORE_CONFIG = 'reload_core_config'
 SERVICE_CHECK_CONFIG = 'check_config'
 SERVICE_UPDATE_ENTITY = 'update_entity'
+SERVICE_SET_LOCATION = 'set_location'
 SCHEMA_UPDATE_ENTITY = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids
 })
@@ -131,7 +132,22 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
         await conf_util.async_process_ha_core_config(
             hass, conf.get(ha.DOMAIN) or {})
 
-    hass.services.async_register(
-        ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG, async_handle_reload_config)
+    hass.helpers.service.async_register_admin_service(
+        ha.DOMAIN, SERVICE_RELOAD_CORE_CONFIG, async_handle_reload_config
+    )
+
+    async def async_set_location(call):
+        """Service handler to set location."""
+        await hass.config.async_update(
+            latitude=call.data[ATTR_LATITUDE],
+            longitude=call.data[ATTR_LONGITUDE],
+        )
+
+    hass.helpers.service.async_register_admin_service(
+        ha.DOMAIN, SERVICE_SET_LOCATION, async_set_location, vol.Schema({
+            ATTR_LATITUDE: cv.latitude,
+            ATTR_LONGITUDE: cv.longitude,
+        })
+    )
 
     return True

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -10,7 +10,7 @@ from homeassistant import config
 from homeassistant.const import (
     ATTR_ENTITY_ID, STATE_ON, STATE_OFF, SERVICE_HOMEASSISTANT_RESTART,
     SERVICE_HOMEASSISTANT_STOP, SERVICE_TURN_ON, SERVICE_TURN_OFF,
-    SERVICE_TOGGLE)
+    SERVICE_TOGGLE, EVENT_CORE_CONFIG_UPDATE)
 import homeassistant.components as comps
 from homeassistant.setup import async_setup_component
 from homeassistant.components.homeassistant import (
@@ -22,7 +22,7 @@ from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from tests.common import (
     get_test_home_assistant, mock_service, patch_yaml_files, mock_coro,
-    async_mock_service)
+    async_mock_service, async_capture_events)
 
 
 def turn_on(hass, entity_id=None, **service_data):
@@ -371,3 +371,18 @@ async def test_entity_update(hass):
 
     assert len(mock_update.mock_calls) == 1
     assert mock_update.mock_calls[0][1][1] == 'light.kitchen'
+
+
+async def test_setting_location(hass):
+    """Test setting the location."""
+    await async_setup_component(hass, 'homeassistant', {})
+    events = async_capture_events(hass, EVENT_CORE_CONFIG_UPDATE)
+    assert hass.config.latitude != 10
+    assert hass.config.longitude != 20
+    await hass.services.async_call('homeassistant', 'set_location', {
+        'latitude': 30,
+        'longitude': 40,
+    }, blocking=True)
+    assert len(events) == 1
+    assert hass.config.latitude == 30
+    assert hass.config.longitude == 40

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -377,8 +377,9 @@ async def test_setting_location(hass):
     """Test setting the location."""
     await async_setup_component(hass, 'homeassistant', {})
     events = async_capture_events(hass, EVENT_CORE_CONFIG_UPDATE)
-    assert hass.config.latitude != 10
-    assert hass.config.longitude != 20
+    # Just to make sure that we are updating values.
+    assert hass.config.latitude != 30
+    assert hass.config.longitude != 40
     await hass.services.async_call('homeassistant', 'set_location', {
         'latitude': 30,
         'longitude': 40,


### PR DESCRIPTION
## Description:
Add a service to update the location of Home Assistant in the core config. This will make it easier to use Home Assistant in RVs.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
