### PR TITLE
Add for option to template triggers

### DIFF
--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -4,8 +4,10 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM
-from homeassistant.helpers.event import async_track_template
+from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM, CONF_FOR
+from homeassistant.helpers import condition
+from homeassistant.helpers.event import (
+    async_track_same_state, async_track_template)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -13,6 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 TRIGGER_SCHEMA = IF_ACTION_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'template',
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
 })
 
 
@@ -20,17 +23,44 @@ async def async_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
     value_template.hass = hass
+    time_delta = config.get(CONF_FOR)
+    unsub_track_same = None
 
     @callback
     def template_listener(entity_id, from_s, to_s):
         """Listen for state changes and calls action."""
-        hass.async_run_job(action({
-            'trigger': {
-                'platform': 'template',
-                'entity_id': entity_id,
-                'from_state': from_s,
-                'to_state': to_s,
-            },
-        }, context=(to_s.context if to_s else None)))
+        nonlocal unsub_track_same
 
-    return async_track_template(hass, value_template, template_listener)
+        @callback
+        def call_action():
+            """Call action with right context."""
+            hass.async_run_job(action({
+                'trigger': {
+                    'platform': 'template',
+                    'entity_id': entity_id,
+                    'from_state': from_s,
+                    'to_state': to_s,
+                },
+            }, context=(to_s.context if to_s else None)))
+
+        if not time_delta:
+            call_action()
+            return
+
+        unsub_track_same = async_track_same_state(
+            hass, time_delta, call_action,
+            lambda _, _2, _3: condition.async_template(hass, value_template),
+            value_template.extract_entities())
+
+    unsub = async_track_template(
+        hass, value_template, template_listener)
+
+    @callback
+    def async_remove():
+        """Remove state listeners async."""
+        unsub()
+        if unsub_track_same:
+            # pylint: disable=not-callable
+            unsub_track_same()
+
+    return async_remove


### PR DESCRIPTION
## Description:
Add option to use `for:` with template triggers.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9572

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  - alias: Template trigger with for option
    trigger:
      platform: template
      value_template: "{{ is_state('sensor.abc', '123') }}"
      for:
        minutes: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
