### PR TITLE
Tado: Initiate websession inside event loop

### DIFF
--- a/homeassistant/components/tado/device_tracker.py
+++ b/homeassistant/components/tado/device_tracker.py
@@ -42,6 +42,7 @@ class TadoDeviceScanner(DeviceScanner):
 
     def __init__(self, hass, config):
         """Initialize the scanner."""
+        self.hass = hass
         self.last_results = []
 
         self.username = config[CONF_USERNAME]
@@ -60,8 +61,7 @@ class TadoDeviceScanner(DeviceScanner):
         # The API URL always needs a username and password
         self.tadoapiurl += '?username={username}&password={password}'
 
-        self.websession = async_create_clientsession(
-            hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
+        self.websession = None
 
         self.success_init = asyncio.run_coroutine_threadsafe(
             self._async_update_info(), hass.loop
@@ -91,6 +91,10 @@ class TadoDeviceScanner(DeviceScanner):
         Returns boolean if scanning successful.
         """
         _LOGGER.debug("Requesting Tado")
+
+        if self.websession is None:
+            self.websession = async_create_clientsession(
+                self.hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
 
         last_results = []
 


### PR DESCRIPTION
## Description:
Fixes:
```
Error setting up platform legacy
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/device_tracker/setup.py", line 69, in async_setup_legacy
    self.platform.get_scanner, hass, {DOMAIN: self.config})
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/tado/device_tracker.py", line 33, in get_scanner
    scanner = TadoDeviceScanner(hass, config[DOMAIN])
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/tado/device_tracker.py", line 64, in __init__
    hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/cookiejar.py", line 55, in __init__
    super().__init__(loop=loop)
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/abc.py", line 146, in __init__
    self._loop = get_running_loop(loop)
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/helpers.py", line 267, in get_running_loop
    loop = asyncio.get_event_loop()
  File "/usr/lib/python3.6/asyncio/events.py", line 694, in get_event_loop
    return get_event_loop_policy().get_event_loop()
  File "/usr/lib/python3.6/asyncio/events.py", line 602, in get_event_loop
    % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'SyncWorker_18'.
Error setting up platform legacy
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/device_tracker/setup.py", line 69, in async_setup_legacy
    self.platform.get_scanner, hass, {DOMAIN: self.config})
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/tado/device_tracker.py", line 33, in get_scanner
    scanner = TadoDeviceScanner(hass, config[DOMAIN])
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/tado/device_tracker.py", line 64, in __init__
    hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/cookiejar.py", line 55, in __init__
    super().__init__(loop=loop)
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/abc.py", line 146, in __init__
    self._loop = get_running_loop(loop)
  File "/srv/homeassistant/lib/python3.6/site-packages/aiohttp/helpers.py", line 267, in get_running_loop
    loop = asyncio.get_event_loop()
  File "/usr/lib/python3.6/asyncio/events.py", line 694, in get_event_loop
    return get_event_loop_policy().get_event_loop()
  File "/usr/lib/python3.6/asyncio/events.py", line 602, in get_event_loop
    % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'SyncWorker_18'.
```

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/0-94-smarthab-watson-tts-azure-event-hub/120228/15?u=balloob

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
