### PR TITLE
Add templating to MQTT Cover tilt_status

### DIFF
--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -603,6 +603,39 @@ async def test_tilt_via_topic(hass, mqtt_mock):
     assert current_cover_tilt_position == 50
 
 
+async def test_tilt_via_topic_template(hass, mqtt_mock):
+    """Test tilt by updating status via MQTT and template."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'tilt_status_template': '{{ (value | multiply(0.01)) | int }}',
+            'tilt_opened_value': 400,
+            'tilt_closed_value': 125
+        }
+    })
+
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '99')
+
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert current_cover_tilt_position == 0
+
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '5000')
+
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert current_cover_tilt_position == 50
+
+
 async def test_tilt_via_topic_altered_range(hass, mqtt_mock):
     """Test tilt status via MQTT with altered tilt range."""
     assert await async_setup_component(hass, cover.DOMAIN, {
@@ -637,6 +670,47 @@ async def test_tilt_via_topic_altered_range(hass, mqtt_mock):
     assert current_cover_tilt_position == 100
 
     async_fire_mqtt_message(hass, 'tilt-status-topic', '25')
+
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert current_cover_tilt_position == 50
+
+
+async def test_tilt_via_topic_template_altered_range(hass, mqtt_mock):
+    """Test tilt status via MQTT and template with altered tilt range."""
+    assert await async_setup_component(hass, cover.DOMAIN, {
+        cover.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+            'state_topic': 'state-topic',
+            'command_topic': 'command-topic',
+            'qos': 0,
+            'payload_open': 'OPEN',
+            'payload_close': 'CLOSE',
+            'payload_stop': 'STOP',
+            'tilt_command_topic': 'tilt-command-topic',
+            'tilt_status_topic': 'tilt-status-topic',
+            'tilt_status_template': '{{ (value | multiply(0.01)) | int }}',
+            'tilt_opened_value': 400,
+            'tilt_closed_value': 125,
+            'tilt_min': 0,
+            'tilt_max': 50
+        }
+    })
+
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '99')
+
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert current_cover_tilt_position == 0
+
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '5000')
+
+    current_cover_tilt_position = hass.states.get(
+        'cover.test').attributes['current_tilt_position']
+    assert current_cover_tilt_position == 100
+
+    async_fire_mqtt_message(hass, 'tilt-status-topic', '2500')
 
     current_cover_tilt_position = hass.states.get(
         'cover.test').attributes['current_tilt_position']


### PR DESCRIPTION
## Description:
Add templating capabilities to MQTT Cover's 'tilt_status_topic' messages. 
(My first ever Pull Request)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9578

## Example entry for `configuration.yaml` (if applicable):
```yaml
tilt_status_template: '{{ value_json["PWM"]["PWM1"] }}'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
