### PR TITLE
Bump pypck to 0.6.1

### DIFF
--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -3,7 +3,7 @@
   "name": "Lcn",
   "documentation": "https://www.home-assistant.io/components/lcn",
   "requirements": [
-    "pypck==0.6.0"
+    "pypck==0.6.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1270,7 +1270,7 @@ pyowlet==1.0.2
 pyowm==2.10.0
 
 # homeassistant.components.lcn
-pypck==0.6.0
+pypck==0.6.1
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.0


### PR DESCRIPTION
## Description:
Bump to pypck==0.6.1
This is used by the LCN component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
