### PR TITLE
Bump regenmaschine to 1.5.1

### DIFF
--- a/homeassistant/components/rainmachine/manifest.json
+++ b/homeassistant/components/rainmachine/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/rainmachine",
   "requirements": [
-    "regenmaschine==1.4.0"
+    "regenmaschine==1.5.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1546,7 +1546,7 @@ raspyrfm-client==1.2.8
 recollect-waste==1.0.1
 
 # homeassistant.components.rainmachine
-regenmaschine==1.4.0
+regenmaschine==1.5.1
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -298,7 +298,7 @@ pytradfri[async]==6.0.1
 pywebpush==1.9.2
 
 # homeassistant.components.rainmachine
-regenmaschine==1.4.0
+regenmaschine==1.5.1
 
 # homeassistant.components.python_script
 restrictedpython==4.0b8


### PR DESCRIPTION
## Description:

1.5.1 changelog: https://github.com/bachya/regenmaschine/releases/tag/1.5.1

1.5.0 changelog: https://github.com/bachya/regenmaschine/releases/tag/1.5.0

**Related issue (if applicable):** fixes #23650

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_host
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
