### PR TITLE
Rename via_hub to via_device

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -69,7 +69,7 @@ def _entry_dict(entry):
         'name': entry.name,
         'sw_version': entry.sw_version,
         'id': entry.id,
-        'hub_device_id': entry.hub_device_id,
+        'via_device_id': entry.via_device_id,
         'area_id': entry.area_id,
         'name_by_user': entry.name_by_user,
     }

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -72,5 +72,5 @@ class DeconzDevice(Entity):
             'model': self._device.modelid,
             'name': self._device.name,
             'sw_version': self._device.swversion,
-            'via_hub': (DECONZ_DOMAIN, bridgeid),
+            'via_device': (DECONZ_DOMAIN, bridgeid),
         }

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -156,11 +156,12 @@ class HomeKitEntity(Entity):
             'sw_version': self._accessory_info.get('firmware.revision', ''),
         }
 
-        # Some devices only have a single accessory - we don't add a via_hub
-        # otherwise it would be self referential.
+        # Some devices only have a single accessory - we don't add a
+        # via_device otherwise it would be self referential.
         bridge_serial = self._accessory.connection_info['serial-number']
         if accessory_serial != bridge_serial:
-            device_info['via_hub'] = (DOMAIN, 'serial-number', bridge_serial)
+            device_info['via_device'] = (
+                DOMAIN, 'serial-number', bridge_serial)
 
         return device_info
 

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -45,7 +45,8 @@ class HomematicipGenericDevice(Entity):
                 'manufacturer': self._device.oem,
                 'model': self._device.modelType,
                 'sw_version': self._device.firmwareVersion,
-                'via_hub': (homematicip_cloud.DOMAIN, self._device.homeId),
+                'via_device': (
+                    homematicip_cloud.DOMAIN, self._device.homeId),
             }
         return None
 

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -334,7 +334,7 @@ class HueLight(Light):
             'model': self.light.productname or self.light.modelid,
             # Not yet exposed as properties in aiohue
             'sw_version': self.light.raw['swversion'],
-            'via_hub': (hue.DOMAIN, self.bridge.api.config.bridgeid),
+            'via_device': (hue.DOMAIN, self.bridge.api.config.bridgeid),
         }
 
     async def async_turn_on(self, **kwargs):

--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -269,7 +269,7 @@ class GenericHueSensor:
                 self.primary_sensor.productname or
                 self.primary_sensor.modelid),
             'sw_version': self.primary_sensor.swversion,
-            'via_hub': (hue.DOMAIN, self.bridge.api.config.bridgeid),
+            'via_device': (hue.DOMAIN, self.bridge.api.config.bridgeid),
         }
 
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -79,7 +79,8 @@ CONF_CONNECTIONS = 'connections'
 CONF_MANUFACTURER = 'manufacturer'
 CONF_MODEL = 'model'
 CONF_SW_VERSION = 'sw_version'
-CONF_VIA_HUB = 'via_hub'
+CONF_VIA_DEVICE = 'via_device'
+CONF_DEPRECATED_VIA_HUB = 'via_hub'
 
 PROTOCOL_31 = '3.1'
 PROTOCOL_311 = '3.1.1'
@@ -229,17 +230,20 @@ MQTT_AVAILABILITY_SCHEMA = vol.Schema({
                  default=DEFAULT_PAYLOAD_NOT_AVAILABLE): cv.string,
 })
 
-MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(vol.Schema({
-    vol.Optional(CONF_IDENTIFIERS, default=list):
-        vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional(CONF_CONNECTIONS, default=list):
-        vol.All(cv.ensure_list, [vol.All(vol.Length(2), [cv.string])]),
-    vol.Optional(CONF_MANUFACTURER): cv.string,
-    vol.Optional(CONF_MODEL): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_SW_VERSION): cv.string,
-    vol.Optional(CONF_VIA_HUB): cv.string,
-}), validate_device_has_at_least_one_identifier)
+MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(
+    cv.deprecated(CONF_DEPRECATED_VIA_HUB, CONF_VIA_DEVICE),
+    vol.Schema({
+        vol.Optional(CONF_IDENTIFIERS, default=list):
+            vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_CONNECTIONS, default=list):
+            vol.All(cv.ensure_list, [vol.All(vol.Length(2), [cv.string])]),
+        vol.Optional(CONF_MANUFACTURER): cv.string,
+        vol.Optional(CONF_MODEL): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_SW_VERSION): cv.string,
+        vol.Optional(CONF_VIA_DEVICE): cv.string,
+    }),
+    validate_device_has_at_least_one_identifier)
 
 MQTT_JSON_ATTRS_SCHEMA = vol.Schema({
     vol.Optional(CONF_JSON_ATTRS_TOPIC): valid_subscribe_topic,
@@ -1098,8 +1102,8 @@ class MqttEntityDeviceInfo(Entity):
         if CONF_SW_VERSION in self._device_config:
             info['sw_version'] = self._device_config[CONF_SW_VERSION]
 
-        if CONF_VIA_HUB in self._device_config:
-            info['via_hub'] = (DOMAIN, self._device_config[CONF_VIA_HUB])
+        if CONF_VIA_DEVICE in self._device_config:
+            info['via_device'] = (DOMAIN, self._device_config[CONF_VIA_DEVICE])
 
         return info
 

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -300,7 +300,7 @@ class MinutPointEntity(Entity):
             'model': 'Point v{}'.format(device['hardware_version']),
             'name': device['description'],
             'sw_version': device['firmware']['installed'],
-            'via_hub': (DOMAIN, device['home']),
+            'via_device': (DOMAIN, device['home']),
         }
 
     @property

--- a/homeassistant/components/tellduslive/entry.py
+++ b/homeassistant/components/tellduslive/entry.py
@@ -128,5 +128,5 @@ class TelldusLiveEntity(Entity):
             device_info['manufacturer'] = protocol.title()
         client = device.get('client')
         if client is not None:
-            device_info['via_hub'] = ('tellduslive', client)
+            device_info['via_device'] = ('tellduslive', client)
         return device_info

--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistantType,
         },
         manufacturer='Eneco',
         name="Meter Adapter",
-        via_hub=(DOMAIN, toon.agreement.id)
+        via_device=(DOMAIN, toon.agreement.id)
     )
 
     for component in 'binary_sensor', 'climate', 'sensor':
@@ -126,7 +126,7 @@ class ToonElectricityMeterDeviceEntity(ToonEntity):
             'identifiers': {
                 (DOMAIN, self.toon.agreement.id, 'electricity'),
             },
-            'via_hub': (DOMAIN, self.toon.agreement.id, 'meter_adapter'),
+            'via_device': (DOMAIN, self.toon.agreement.id, 'meter_adapter'),
         }
 
 
@@ -136,16 +136,16 @@ class ToonGasMeterDeviceEntity(ToonEntity):
     @property
     def device_info(self) -> Dict[str, Any]:
         """Return device information about this entity."""
-        via_hub = 'meter_adapter'
+        via_device = 'meter_adapter'
         if self.toon.gas.is_smart:
-            via_hub = 'electricity'
+            via_device = 'electricity'
 
         return {
             'name': 'Gas Meter',
             'identifiers': {
                 (DOMAIN, self.toon.agreement.id, 'gas'),
             },
-            'via_hub': (DOMAIN, self.toon.agreement.id, via_hub),
+            'via_device': (DOMAIN, self.toon.agreement.id, via_device),
         }
 
 
@@ -160,7 +160,7 @@ class ToonSolarDeviceEntity(ToonEntity):
             'identifiers': {
                 (DOMAIN, self.toon.agreement.id, 'solar'),
             },
-            'via_hub': (DOMAIN, self.toon.agreement.id, 'meter_adapter'),
+            'via_device': (DOMAIN, self.toon.agreement.id, 'meter_adapter'),
         }
 
 
@@ -176,7 +176,7 @@ class ToonBoilerModuleDeviceEntity(ToonEntity):
             'identifiers': {
                 (DOMAIN, self.toon.agreement.id, 'boiler_module'),
             },
-            'via_hub': (DOMAIN, self.toon.agreement.id),
+            'via_device': (DOMAIN, self.toon.agreement.id),
         }
 
 
@@ -191,5 +191,5 @@ class ToonBoilerDeviceEntity(ToonEntity):
             'identifiers': {
                 (DOMAIN, self.toon.agreement.id, 'boiler'),
             },
-            'via_hub': (DOMAIN, self.toon.agreement.id, 'boiler_module'),
+            'via_device': (DOMAIN, self.toon.agreement.id, 'boiler_module'),
         }

--- a/homeassistant/components/tradfri/light.py
+++ b/homeassistant/components/tradfri/light.py
@@ -175,7 +175,7 @@ class TradfriLight(Light):
             'manufacturer': info.manufacturer,
             'model': info.model_number,
             'sw_version': info.firmware_version,
-            'via_hub': (TRADFRI_DOMAIN, self._gateway_id),
+            'via_device': (TRADFRI_DOMAIN, self._gateway_id),
         }
 
     @property

--- a/homeassistant/components/tradfri/switch.py
+++ b/homeassistant/components/tradfri/switch.py
@@ -61,7 +61,7 @@ class TradfriSwitch(SwitchDevice):
             'manufacturer': info.manufacturer,
             'model': info.model_number,
             'sw_version': info.firmware_version,
-            'via_hub': (TRADFRI_DOMAIN, self._gateway_id),
+            'via_device': (TRADFRI_DOMAIN, self._gateway_id),
         }
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -109,7 +109,8 @@ class ZhaEntity(RestoreEntity, entity.Entity):
             ATTR_MANUFACTURER: zha_device_info[ATTR_MANUFACTURER],
             MODEL: zha_device_info[MODEL],
             NAME: zha_device_info[NAME],
-            'via_hub': (DOMAIN, self.hass.data[DATA_ZHA][DATA_ZHA_BRIDGE_ID]),
+            'via_device': (
+                DOMAIN, self.hass.data[DATA_ZHA][DATA_ZHA_BRIDGE_ID]),
         }
 
     @property

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -1079,14 +1079,14 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
             info['identifiers'] = {
                 (DOMAIN, self.node_id, self.values.primary.instance, ),
             }
-            info['via_hub'] = (DOMAIN, self.node_id, )
+            info['via_device'] = (DOMAIN, self.node_id, )
         else:
             info['name'] = node_name(self.node)
             info['identifiers'] = {
                 (DOMAIN, self.node_id),
             }
             if self.node_id > 1:
-                info['via_hub'] = (DOMAIN, 1, )
+                info['via_device'] = (DOMAIN, 1, )
         return info
 
     @property

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -133,7 +133,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             'name': node_name(self.node)
         }
         if self.node_id > 1:
-            info['via_hub'] = (DOMAIN, 1)
+            info['via_device'] = (DOMAIN, 1)
         return info
 
     def network_node_changed(self, node=None, value=None, args=None):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -38,7 +38,7 @@ class DeviceEntry:
     model = attr.ib(type=str, default=None)
     name = attr.ib(type=str, default=None)
     sw_version = attr.ib(type=str, default=None)
-    hub_device_id = attr.ib(type=str, default=None)
+    via_device_id = attr.ib(type=str, default=None)
     area_id = attr.ib(type=str, default=None)
     name_by_user = attr.ib(type=str, default=None)
     id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
@@ -93,7 +93,7 @@ class DeviceRegistry:
     def async_get_or_create(self, *, config_entry_id, connections=None,
                             identifiers=None, manufacturer=_UNDEF,
                             model=_UNDEF, name=_UNDEF, sw_version=_UNDEF,
-                            via_hub=None):
+                            via_device=None):
         """Get device. Create if it doesn't exist."""
         if not identifiers and not connections:
             return None
@@ -116,16 +116,16 @@ class DeviceRegistry:
             device = DeviceEntry(is_new=True)
             self.devices[device.id] = device
 
-        if via_hub is not None:
-            hub_device = self.async_get_device({via_hub}, set())
-            hub_device_id = hub_device.id if hub_device else _UNDEF
+        if via_device is not None:
+            via = self.async_get_device({via_device}, set())
+            via_device_id = via.id if via else _UNDEF
         else:
-            hub_device_id = _UNDEF
+            via_device_id = _UNDEF
 
         return self._async_update_device(
             device.id,
             add_config_entry_id=config_entry_id,
-            hub_device_id=hub_device_id,
+            via_device_id=via_device_id,
             merge_connections=connections or _UNDEF,
             merge_identifiers=identifiers or _UNDEF,
             manufacturer=manufacturer,
@@ -153,7 +153,7 @@ class DeviceRegistry:
                              model=_UNDEF,
                              name=_UNDEF,
                              sw_version=_UNDEF,
-                             hub_device_id=_UNDEF,
+                             via_device_id=_UNDEF,
                              area_id=_UNDEF,
                              name_by_user=_UNDEF):
         """Update device attributes."""
@@ -191,7 +191,7 @@ class DeviceRegistry:
                 ('model', model),
                 ('name', name),
                 ('sw_version', sw_version),
-                ('hub_device_id', hub_device_id),
+                ('via_device_id', via_device_id),
         ):
             if value is not _UNDEF and value != getattr(old, attr_name):
                 changes[attr_name] = value
@@ -247,7 +247,10 @@ class DeviceRegistry:
                     sw_version=device['sw_version'],
                     id=device['id'],
                     # Introduced in 0.79
-                    hub_device_id=device.get('hub_device_id'),
+                    # renamed in 0.95
+                    via_device_id=(
+                        device.get('via_device_id')
+                        or device.get('hub_device_id')),
                     # Introduced in 0.87
                     area_id=device.get('area_id'),
                     name_by_user=device.get('name_by_user')
@@ -275,7 +278,7 @@ class DeviceRegistry:
                 'name': entry.name,
                 'sw_version': entry.sw_version,
                 'id': entry.id,
-                'hub_device_id': entry.hub_device_id,
+                'via_device_id': entry.via_device_id,
                 'area_id': entry.area_id,
                 'name_by_user': entry.name_by_user
             } for entry in self.devices.values()

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -296,7 +296,7 @@ class EntityPlatform:
                         'model',
                         'name',
                         'sw_version',
-                        'via_hub',
+                        'via_device',
                 ):
                     if key in device_info:
                         processed_dev_info[key] = device_info[key]

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -47,7 +47,7 @@ async def test_list_devices(hass, client, registry):
             'model': 'model',
             'name': None,
             'sw_version': None,
-            'hub_device_id': None,
+            'via_device_id': None,
             'area_id': None,
             'name_by_user': None,
         },
@@ -58,7 +58,7 @@ async def test_list_devices(hass, client, registry):
             'model': 'model',
             'name': None,
             'sw_version': None,
-            'hub_device_id': dev1,
+            'via_device_id': dev1,
             'area_id': None,
             'name_by_user': None,
         }

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -29,7 +29,7 @@ async def test_list_devices(hass, client, registry):
         config_entry_id='1234',
         identifiers={('bridgeid', '1234')},
         manufacturer='manufacturer', model='model',
-        via_hub=('bridgeid', '0123'))
+        via_device=('bridgeid', '0123'))
 
     await client.send_json({
         'id': 5,

--- a/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
@@ -51,4 +51,4 @@ async def test_aqara_gateway_setup(hass):
     assert device.name == 'Aqara Hub-1563'
     assert device.model == 'ZHWA11LM'
     assert device.sw_version == '1.4.7'
-    assert device.hub_device_id is None
+    assert device.via_device_id is None

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -74,7 +74,7 @@ async def test_ecobee3_setup(hass):
     assert climate_device.name == 'HomeW'
     assert climate_device.model == 'ecobee3'
     assert climate_device.sw_version == '4.2.394'
-    assert climate_device.hub_device_id is None
+    assert climate_device.via_device_id is None
 
     # Check that an attached sensor has its own device entity that
     # is linked to the bridge
@@ -83,7 +83,7 @@ async def test_ecobee3_setup(hass):
     assert sensor_device.name == 'Kitchen'
     assert sensor_device.model == 'REMOTE SENSOR'
     assert sensor_device.sw_version == '1.0.0'
-    assert sensor_device.hub_device_id == climate_device.id
+    assert sensor_device.via_device_id == climate_device.id
 
 
 async def test_ecobee3_setup_from_cache(hass, hass_storage):

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -45,7 +45,7 @@ async def test_koogeek_ls1_setup(hass):
     assert device.name == 'Koogeek-LS1-20833F'
     assert device.model == 'LS1'
     assert device.sw_version == '2.2.15'
-    assert device.hub_device_id is None
+    assert device.via_device_id is None
 
 
 @pytest.mark.parametrize('failure_cls', [

--- a/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
+++ b/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
@@ -38,4 +38,4 @@ async def test_lennox_e30_setup(hass):
 
     # The fixture contains a single accessory - so its a single device
     # and no bridge
-    assert device.hub_device_id is None
+    assert device.via_device_id is None

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -232,7 +232,7 @@ class TestMQTTComponent(unittest.TestCase):
             'model': 'Glass',
             'sw_version': '0.1-beta',
         })
-        # full device info with via_hub
+        # full device info with via_device
         mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA({
             'identifiers': ['helloworld', 'hello'],
             'connections': [
@@ -243,7 +243,7 @@ class TestMQTTComponent(unittest.TestCase):
             'name': 'Beer',
             'model': 'Glass',
             'sw_version': '0.1-beta',
-            'via_hub': 'test-hub',
+            'via_device': 'test-hub',
         })
         # no identifiers
         with pytest.raises(vol.Invalid):

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -693,7 +693,7 @@ async def test_entity_device_info_with_hub(hass, mqtt_mock):
         'state_topic': 'test-topic',
         'device': {
             'identifiers': ['helloworld'],
-            'via_hub': 'hub-id',
+            'via_device': 'hub-id',
         },
         'unique_id': 'veryunique'
     })

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -702,4 +702,4 @@ async def test_entity_device_info_with_hub(hass, mqtt_mock):
 
     device = registry.async_get_device({('mqtt', 'helloworld')}, set())
     assert device is not None
-    assert device.hub_device_id == hub.id
+    assert device.via_device_id == hub.id

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -250,71 +250,71 @@ async def test_removing_area_id(registry):
     assert entry_w_area != entry_wo_area
 
 
-async def test_specifying_hub_device_create(registry):
-    """Test specifying a hub and updating."""
-    hub = registry.async_get_or_create(
+async def test_specifying_via_device_create(registry):
+    """Test specifying a via_device and updating."""
+    via = registry.async_get_or_create(
         config_entry_id='123',
         connections={
             (device_registry.CONNECTION_NETWORK_MAC, '12:34:56:AB:CD:EF')
         },
         identifiers={('hue', '0123')},
-        manufacturer='manufacturer', model='hub')
+        manufacturer='manufacturer', model='via')
 
     light = registry.async_get_or_create(
         config_entry_id='456',
         connections=set(),
         identifiers={('hue', '456')},
         manufacturer='manufacturer', model='light',
-        via_hub=('hue', '0123'))
+        via_device=('hue', '0123'))
 
-    assert light.hub_device_id == hub.id
+    assert light.via_device_id == via.id
 
 
-async def test_specifying_hub_device_update(registry):
-    """Test specifying a hub and updating."""
+async def test_specifying_via_device_update(registry):
+    """Test specifying a via_device and updating."""
     light = registry.async_get_or_create(
         config_entry_id='456',
         connections=set(),
         identifiers={('hue', '456')},
         manufacturer='manufacturer', model='light',
-        via_hub=('hue', '0123'))
+        via_device=('hue', '0123'))
 
-    assert light.hub_device_id is None
+    assert light.via_device_id is None
 
-    hub = registry.async_get_or_create(
+    via = registry.async_get_or_create(
         config_entry_id='123',
         connections={
             (device_registry.CONNECTION_NETWORK_MAC, '12:34:56:AB:CD:EF')
         },
         identifiers={('hue', '0123')},
-        manufacturer='manufacturer', model='hub')
+        manufacturer='manufacturer', model='via')
 
     light = registry.async_get_or_create(
         config_entry_id='456',
         connections=set(),
         identifiers={('hue', '456')},
         manufacturer='manufacturer', model='light',
-        via_hub=('hue', '0123'))
+        via_device=('hue', '0123'))
 
-    assert light.hub_device_id == hub.id
+    assert light.via_device_id == via.id
 
 
 async def test_loading_saving_data(hass, registry):
     """Test that we load/save data correctly."""
-    orig_hub = registry.async_get_or_create(
+    orig_via = registry.async_get_or_create(
         config_entry_id='123',
         connections={
             (device_registry.CONNECTION_NETWORK_MAC, '12:34:56:AB:CD:EF')
         },
         identifiers={('hue', '0123')},
-        manufacturer='manufacturer', model='hub')
+        manufacturer='manufacturer', model='via')
 
     orig_light = registry.async_get_or_create(
         config_entry_id='456',
         connections=set(),
         identifiers={('hue', '456')},
         manufacturer='manufacturer', model='light',
-        via_hub=('hue', '0123'))
+        via_device=('hue', '0123'))
 
     assert len(registry.devices) == 2
 
@@ -326,10 +326,10 @@ async def test_loading_saving_data(hass, registry):
     # Ensure same order
     assert list(registry.devices) == list(registry2.devices)
 
-    new_hub = registry2.async_get_device({('hue', '0123')}, set())
+    new_via = registry2.async_get_device({('hue', '0123')}, set())
     new_light = registry2.async_get_device({('hue', '456')}, set())
 
-    assert orig_hub == new_hub
+    assert orig_via == new_via
     assert orig_light == new_light
 
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -706,11 +706,11 @@ async def test_entity_registry_updates_invalid_entity_id(hass):
 async def test_device_info_called(hass):
     """Test device info is forwarded correctly."""
     registry = await hass.helpers.device_registry.async_get_registry()
-    hub = registry.async_get_or_create(
+    via = registry.async_get_or_create(
         config_entry_id='123',
         connections=set(),
-        identifiers={('hue', 'hub-id')},
-        manufacturer='manufacturer', model='hub'
+        identifiers={('hue', 'via-id')},
+        manufacturer='manufacturer', model='via'
     )
 
     async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -726,7 +726,7 @@ async def test_device_info_called(hass):
                 'model': 'test-model',
                 'name': 'test-name',
                 'sw_version': 'test-sw',
-                'via_hub': ('hue', 'hub-id'),
+                'via_device': ('hue', 'via-id'),
             }),
         ])
         return True
@@ -754,7 +754,7 @@ async def test_device_info_called(hass):
     assert device.model == 'test-model'
     assert device.name == 'test-name'
     assert device.sw_version == 'test-sw'
-    assert device.hub_device_id == hub.id
+    assert device.via_device_id == via.id
 
 
 async def test_device_info_not_overrides(hass):


### PR DESCRIPTION
## Breaking Change:

The breaking change is that via_hub is renamed to via_device. Since custom components can't access this at this stage it should in theory not be an issue.

## Description:

As discussed in the arch issue, via_hub doesn't make that much sense as a name anymore since it's not strictly speaking actually a hub. This renames the variable.

**Related issue (if applicable):** fixes home-assistant/architecture#212

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been ~~added~~ modified to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
