### PR TITLE
Merge UniFi device tracker to config entry

### DIFF
--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -1,8 +1,7 @@
 """Code to set up a device tracker platform using a config entry."""
 from typing import Optional
 
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.components import zone
 from homeassistant.const import (
     STATE_NOT_HOME,
     STATE_HOME,
@@ -11,7 +10,8 @@ from homeassistant.const import (
     ATTR_LONGITUDE,
     ATTR_BATTERY_LEVEL,
 )
-from homeassistant.components import zone
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
 
 from .const import (
     ATTR_SOURCE_TYPE,

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -11,21 +11,30 @@ from .const import (
     CONTROLLER_ID, DOMAIN, UNIFI_CONFIG)
 from .controller import UniFiController
 
+CONF_CONTROLLERS = 'controllers'
+
+CONTROLLER_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_SITE_ID): cv.string,
+    vol.Optional(CONF_DETECTION_TIME): vol.All(
+        cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
+})
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_DETECTION_TIME): vol.All(
-            cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
+        vol.Required(CONF_CONTROLLERS):
+            vol.All(cv.ensure_list, [CONTROLLER_SCHEMA]),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):
     """Component doesn't support configuration through configuration.yaml."""
-    hass.data[UNIFI_CONFIG] = {}
+    hass.data[UNIFI_CONFIG] = []
 
     if DOMAIN in config:
-        hass.data[UNIFI_CONFIG] = config[DOMAIN]
+        hass.data[UNIFI_CONFIG] = config[DOMAIN][CONF_CONTROLLERS]
 
     return True
 

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -1,9 +1,6 @@
 """Support for devices connected to UniFi POE."""
-from datetime import timedelta
-
 import voluptuous as vol
 
-from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -22,7 +22,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Component doesn't support configuration through configuration.yaml."""
-    hass.data[UNIFI_CONFIG] = []
+    hass.data[UNIFI_CONFIG] = {}
 
     if DOMAIN in config:
         hass.data[UNIFI_CONFIG] = config[DOMAIN]

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -6,7 +6,8 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from .const import (
     CONF_CONTROLLER, CONF_SITE_ID, CONTROLLER_ID, DOMAIN, UNIFI_CONFIG)
 from .controller import UniFiController
-from .device_tracker import PLATFORM_SCHEMA as DEVICE_TRACKER_SCHEMA
+from .device_tracker import (
+    CONF_DT_SITE_ID, PLATFORM_SCHEMA as DEVICE_TRACKER_SCHEMA)
 
 
 async def async_setup(hass, config):
@@ -20,8 +21,17 @@ async def async_setup(hass, config):
 
     hass.data[UNIFI_CONFIG] = unifi_config
 
-    if not hass.config_entries.async_entries(DOMAIN):
-        for unifi in unifi_config:
+    for unifi in unifi_config:
+        exist = False
+
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if unifi[CONF_HOST] == entry.data[CONF_CONTROLLER][CONF_HOST] and \
+                    unifi[CONF_DT_SITE_ID] == \
+                        entry.data[CONF_CONTROLLER][CONF_SITE_ID]:
+                exist = True
+                break
+
+        if not exist:
             hass.async_create_task(hass.config_entries.flow.async_init(
                 DOMAIN, context={'source': config_entries.SOURCE_IMPORT},
                 data=unifi

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -79,7 +79,6 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
         errors = {}
 
         if user_input is not None:
-
             try:
                 desc = user_input.get(CONF_SITE_ID, self.desc)
 
@@ -110,6 +109,12 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
             self.desc = next(iter(self.sites.values()))['desc']
             return await self.async_step_site(user_input={})
 
+        if self.desc is not None:
+            for site in self.sites.values():
+                if self.desc == site['name']:
+                    self.desc = site['desc']
+                    return await self.async_step_site(user_input={})
+
         sites = []
         for site in self.sites.values():
             sites.append(site['desc'])
@@ -121,3 +126,17 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
             }),
             errors=errors,
         )
+
+    async def async_step_import(self, import_config):
+        """Import from UniFi device tracker config."""
+        config = {
+            CONF_HOST: import_config[CONF_HOST],
+            CONF_USERNAME: import_config[CONF_USERNAME],
+            CONF_PASSWORD: import_config[CONF_PASSWORD],
+            CONF_PORT: import_config.get(CONF_PORT),
+            CONF_VERIFY_SSL: import_config.get(CONF_VERIFY_SSL),
+        }
+
+        self.desc = import_config[CONF_SITE_ID]
+
+        return await self.async_step_user(user_input=config)

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -6,10 +6,8 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME, CONF_VERIFY_SSL)
 
 from .const import CONF_CONTROLLER, CONF_SITE_ID, DOMAIN, LOGGER
-from .device_tracker import CONF_DT_SITE_ID
 from .controller import get_controller
 from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
-
 
 DEFAULT_PORT = 8443
 DEFAULT_SITE_ID = 'default'
@@ -112,12 +110,6 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
             self.desc = next(iter(self.sites.values()))['desc']
             return await self.async_step_site(user_input={})
 
-        if self.desc is not None:
-            for site in self.sites.values():
-                if self.desc == site['name']:
-                    self.desc = site['desc']
-                    return await self.async_step_site(user_input={})
-
         sites = []
         for site in self.sites.values():
             sites.append(site['desc'])
@@ -129,17 +121,3 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
             }),
             errors=errors,
         )
-
-    async def async_step_import(self, import_config):
-        """Import from UniFi device tracker config."""
-        config = {
-            CONF_HOST: import_config[CONF_HOST],
-            CONF_USERNAME: import_config[CONF_USERNAME],
-            CONF_PASSWORD: import_config[CONF_PASSWORD],
-            CONF_PORT: import_config.get(CONF_PORT),
-            CONF_VERIFY_SSL: import_config.get(CONF_VERIFY_SSL),
-        }
-
-        self.desc = import_config.get(CONF_DT_SITE_ID)
-
-        return await self.async_step_user(user_input=config)

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -8,8 +8,7 @@ from homeassistant.const import (
 from .const import CONF_CONTROLLER, CONF_SITE_ID, DOMAIN, LOGGER
 from .device_tracker import CONF_DT_SITE_ID
 from .controller import get_controller
-from .errors import (
-    AlreadyConfigured, AuthenticationRequired, CannotConnect, UserLevel)
+from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
 
 
 DEFAULT_PORT = 8443
@@ -85,11 +84,9 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
 
             try:
                 desc = user_input.get(CONF_SITE_ID, self.desc)
-                print(self.sites)
+
                 for site in self.sites.values():
                     if desc == site['desc']:
-                        if site['role'] != 'admin':
-                            raise UserLevel
                         self.config[CONF_SITE_ID] = site['name']
                         break
 
@@ -110,9 +107,6 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
 
             except AlreadyConfigured:
                 return self.async_abort(reason='already_configured')
-
-            except UserLevel:
-                return self.async_abort(reason='user_privilege')
 
         if len(self.sites) == 1:
             self.desc = next(iter(self.sites.values()))['desc']

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -8,3 +8,5 @@ CONTROLLER_ID = '{host}-{site}'
 
 CONF_CONTROLLER = 'controller'
 CONF_SITE_ID = 'site'
+
+UNIFI_CONFIG = 'unifi_config'

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -10,3 +10,6 @@ CONF_CONTROLLER = 'controller'
 CONF_SITE_ID = 'site'
 
 UNIFI_CONFIG = 'unifi_config'
+
+CONF_DETECTION_TIME = 'detection_time'
+CONF_SSID_FILTER = 'ssid_filter'

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -107,9 +107,10 @@ class UniFiController:
                 'Unknown error connecting with UniFi controller.')
             return False
 
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(
-                self.config_entry, 'switch'))
+        for component in ['device_tracker', 'switch']:
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(
+                    self.config_entry, component))
 
         return True
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -12,9 +12,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import (
-    CONF_CONTROLLER, CONF_SITE_ID, CONTROLLER_ID, LOGGER, UNIFI_CONFIG)
-from .device_tracker import CONF_DT_SITE_ID
+from .const import CONF_CONTROLLER, CONF_SITE_ID, CONTROLLER_ID, LOGGER
 from .errors import AuthenticationRequired, CannotConnect
 
 
@@ -29,13 +27,6 @@ class UniFiController:
         self.api = None
         self.progress = None
         self.site_role = None
-        self.unifi_config = {}
-
-        for unifi_config in hass.data[UNIFI_CONFIG]:
-            if unifi_config[CONF_HOST] == self.host and \
-                    unifi_config[CONF_DT_SITE_ID] == self.site:
-                self.unifi_config = unifi_config
-                break
 
     @property
     def host(self):

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -28,7 +28,7 @@ class UniFiController:
         self.available = True
         self.api = None
         self.progress = None
-        self.sites = None
+        self.site_role = None
         self.unifi_config = {}
 
         for unifi_config in hass.data[UNIFI_CONFIG]:
@@ -111,7 +111,12 @@ class UniFiController:
             self.api = await get_controller(
                 self.hass, **self.config_entry.data[CONF_CONTROLLER])
             await self.api.initialize()
-            self.sites = await self.api.sites()
+
+            sites = await self.api.sites()
+            for site in sites.values():
+                if self.site == site['name']:
+                    self.site_role = site['role']
+                    break
 
         except CannotConnect:
             raise ConfigEntryNotReady
@@ -139,7 +144,7 @@ class UniFiController:
             return True
 
         for platform in ['device_tracker', 'switch']:
-            await self.hass.config_entries.async_forward_entry_setup(
+            await self.hass.config_entries.async_forward_entry_unload(
                 self.config_entry, platform)
 
         return True

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -11,8 +11,7 @@ from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL,
-    CONF_MONITORED_CONDITIONS)
+    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL)
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -51,10 +50,9 @@ async def async_setup_scanner(hass, config, sync_see, discovery_info):
     exist = False
 
     for entry in hass.config_entries.async_entries(UNIFI_DOMAIN):
-        print('ENTER')
         if config[CONF_HOST] == entry.data[CONF_CONTROLLER][CONF_HOST] and \
                 config[CONF_SITE_ID] == \
-                    entry.data[CONF_CONTROLLER][CONF_SITE_ID]:
+                entry.data[CONF_CONTROLLER][CONF_SITE_ID]:
             exist = True
             break
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -128,7 +128,7 @@ class UniFiClientTracker(ScannerEntity):
 
     @property
     def source_type(self):
-        """Return the source type, eg gps or router, of the device."""
+        """Return the source type of the device."""
         return SOURCE_TYPE_ROUTER
 
     @property
@@ -138,8 +138,8 @@ class UniFiClientTracker(ScannerEntity):
 
     @property
     def unique_id(self) -> str:
-        """Return a unique identifier for this switch."""
-        return 'unifi-dt-{}'.format(self.client.mac)
+        """Return a unique identifier for this client."""
+        return '{}-{}'.format(self.client.mac, self.controller.site)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -11,7 +11,7 @@ from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL)
+    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_VERIFY_SSL)
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -24,7 +24,6 @@ from .const import (
 
 LOGGER = logging.getLogger(__name__)
 
-CONF_PORT = 'port'
 CONF_DT_SITE_ID = 'site_id'
 
 DEFAULT_HOST = 'localhost'

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -20,7 +20,7 @@ import homeassistant.util.dt as dt_util
 
 from .const import (
     CONF_CONTROLLER, CONF_DETECTION_TIME, CONF_SITE_ID, CONF_SSID_FILTER,
-    CONTROLLER_ID, DOMAIN as UNIFI_DOMAIN, UNIFI_CONFIG)
+    CONTROLLER_ID, DOMAIN as UNIFI_DOMAIN)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -24,6 +24,13 @@ from .const import (
 
 LOGGER = logging.getLogger(__name__)
 
+DEVICE_ATTRIBUTES = [
+    '_is_guest_by_uap', 'ap_mac', 'authorized', 'bssid', 'ccq',
+    'channel', 'essid', 'hostname', 'ip', 'is_11r', 'is_guest', 'is_wired',
+    'mac', 'name', 'noise', 'noted', 'oui', 'qos_policy_applied', 'radio',
+    'radio_proto', 'rssi', 'signal', 'site_id', 'vlan'
+]
+
 CONF_DT_SITE_ID = 'site_id'
 
 DEFAULT_HOST = 'localhost'
@@ -161,3 +168,14 @@ class UniFiClientTracker(ScannerEntity):
         return {
             'connections': {(CONNECTION_NETWORK_MAC, self.client.mac)}
         }
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+
+        for variable in DEVICE_ATTRIBUTES:
+            if variable in self.client.raw:
+                attributes[variable] = self.client.raw[variable]
+
+        return attributes

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -58,7 +58,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.boolean, cv.isfile),
     vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
         cv.time_period, cv.positive_timedelta),
-    vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(cv.ensure_list),
+    vol.Optional(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(AVAILABLE_ATTRS)]),
     vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
 })
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -34,18 +34,6 @@ DEFAULT_PORT = 8443
 DEFAULT_VERIFY_SSL = True
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
 
-AVAILABLE_ATTRS = [
-    '_id', '_is_guest_by_uap', '_last_seen_by_uap', '_uptime_by_uap',
-    'ap_mac', 'assoc_time', 'authorized', 'bssid', 'bytes-r', 'ccq',
-    'channel', 'essid', 'first_seen', 'hostname', 'idletime', 'ip',
-    'is_11r', 'is_guest', 'is_wired', 'last_seen', 'latest_assoc_time',
-    'mac', 'name', 'noise', 'noted', 'oui', 'powersave_enabled',
-    'qos_policy_applied', 'radio', 'radio_proto', 'rssi', 'rx_bytes',
-    'rx_bytes-r', 'rx_packets', 'rx_rate', 'signal', 'site_id',
-    'tx_bytes', 'tx_bytes-r', 'tx_packets', 'tx_power', 'tx_rate',
-    'uptime', 'user_id', 'usergroup_id', 'vlan'
-]
-
 TIMESTAMP_ATTRS = ['first_seen', 'last_seen', 'latest_assoc_time']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -59,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
         cv.time_period, cv.positive_timedelta),
     vol.Optional(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(AVAILABLE_ATTRS)]),
+        vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
 })
 
@@ -164,22 +152,3 @@ class UniFiClientTracker(ScannerEntity):
         return {
             'connections': {(CONNECTION_NETWORK_MAC, self.client.mac)}
         }
-
-    @property
-    def device_state_attributes(self):
-        """Return the extra attributes of the device."""
-        monitored_conditions = \
-            self.controller.unifi_config.get(CONF_MONITORED_CONDITIONS, {})
-
-        attributes = {}
-        for variable in monitored_conditions:
-
-            if variable in self.client.raw:
-                if variable in TIMESTAMP_ATTRS:
-                    attributes[variable] = dt_util.utc_from_timestamp(
-                        float(self.client.raw[variable])
-                    )
-                else:
-                    attributes[variable] = self.client.raw[variable]
-
-        return attributes

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -14,6 +14,10 @@ from homeassistant.const import (
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
+from homeassistant import config_entries
+from homeassistant.components import unifi
+from homeassistant.components.device_tracker.config_entry import (
+    NetworkDeviceTrackerEntity)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
@@ -54,8 +58,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.boolean, cv.isfile),
     vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
         cv.time_period, cv.positive_timedelta),
-    vol.Optional(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(AVAILABLE_ATTRS)]),
+    vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(cv.ensure_list),
     vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
 })
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -64,7 +64,7 @@ def update_items(controller, async_add_entities, tracked):
         if not client.is_wired and \
                 CONF_SSID_FILTER in controller.hass.data[UNIFI_CONFIG] and \
                 client.essid not in \
-                    controller.hass.data[UNIFI_CONFIG][CONF_SSID_FILTER]:
+                controller.hass.data[UNIFI_CONFIG][CONF_SSID_FILTER]:
             continue
 
         tracked[client_id] = UniFiClientTracker(client, controller)

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -92,7 +92,8 @@ def update_items(controller, async_add_entities, tracked):
 
         client = controller.api.clients[client_id]
 
-        if CONF_SSID_FILTER in controller.unifi_config and \
+        if not client.is_wired and \
+                CONF_SSID_FILTER in controller.unifi_config and \
                 client.essid not in controller.unifi_config[CONF_SSID_FILTER]:
             continue
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -100,9 +100,8 @@ def update_items(controller, async_add_entities, tracked):
         client = controller.api.clients[client_id]
 
         if not client.is_wired and \
-                CONF_SSID_FILTER in controller.hass.data[UNIFI_CONFIG] and \
-                client.essid not in \
-                controller.hass.data[UNIFI_CONFIG][CONF_SSID_FILTER]:
+                CONF_SSID_FILTER in controller.unifi_config and \
+                client.essid not in controller.unifi_config[CONF_SSID_FILTER]:
             continue
 
         tracked[client_id] = UniFiClientTracker(client, controller)
@@ -128,7 +127,7 @@ class UniFiClientTracker(ScannerEntity):
     @property
     def is_connected(self):
         """Return true if the device is connected to the network."""
-        detection_time = self.controller.hass.data[UNIFI_CONFIG].get(
+        detection_time = self.controller.unifi_config.get(
             CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
 
         if (dt_util.utcnow() - dt_util.utc_from_timestamp(float(

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -27,8 +27,6 @@ LOGGER = logging.getLogger(__name__)
 
 CONF_PORT = 'port'
 CONF_DT_SITE_ID = 'site_id'
-CONF_DETECTION_TIME = 'detection_time'
-CONF_SSID_FILTER = 'ssid_filter'
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8443
@@ -42,13 +40,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): vol.Any(
-        cv.boolean, cv.isfile),
-    vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
-        cv.time_period, cv.positive_timedelta),
-    vol.Optional(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
-})
+        cv.boolean, cv.isfile)
+}, extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup_scanner(hass, config, sync_see, discovery_info):

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -1,28 +1,76 @@
 """Support for Unifi WAP controllers."""
 from datetime import timedelta
-import logging
 
+import logging
+import voluptuous as vol
+
+from homeassistant import config_entries
 from homeassistant.components import unifi
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.core import callback
-from homeassistant.const import CONF_HOST
+from homeassistant.const import (
+    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL,
+    CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
+import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
 from .const import (
     CONF_CONTROLLER, CONF_DETECTION_TIME, CONF_SITE_ID, CONF_SSID_FILTER,
-    CONTROLLER_ID, UNIFI_CONFIG)
+    CONTROLLER_ID, DOMAIN as UNIFI_DOMAIN, UNIFI_CONFIG)
 
 LOGGER = logging.getLogger(__name__)
 
+CONF_PORT = 'port'
+CONF_DT_SITE_ID = 'site_id'
+CONF_DETECTION_TIME = 'detection_time'
+CONF_SSID_FILTER = 'ssid_filter'
+
+DEFAULT_HOST = 'localhost'
+DEFAULT_PORT = 8443
+DEFAULT_VERIFY_SSL = True
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_DT_SITE_ID, default='default'): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): vol.Any(
+        cv.boolean, cv.isfile),
+    vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
+        cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
+})
 
 
 async def async_setup_scanner(hass, config, sync_see, discovery_info):
     """Set up the Unifi integration."""
+    config[CONF_SITE_ID] = config.pop(CONF_DT_SITE_ID)  # Current from legacy
+
+    exist = False
+
+    for entry in hass.config_entries.async_entries(UNIFI_DOMAIN):
+        print('ENTER')
+        if config[CONF_HOST] == entry.data[CONF_CONTROLLER][CONF_HOST] and \
+                config[CONF_SITE_ID] == \
+                    entry.data[CONF_CONTROLLER][CONF_SITE_ID]:
+            exist = True
+            break
+
+    if not exist:
+        hass.async_create_task(hass.config_entries.flow.async_init(
+            UNIFI_DOMAIN, context={'source': config_entries.SOURCE_IMPORT},
+            data=config
+        ))
+
     return True
 
 

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -24,6 +24,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     Switches are controlling network switch ports with Poe.
     """
+    return True
     controller_id = CONTROLLER_ID.format(
         host=config_entry.data[CONF_CONTROLLER][CONF_HOST],
         site=config_entry.data[CONF_CONTROLLER][CONF_SITE_ID],

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -30,11 +30,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
     controller = hass.data[unifi.DOMAIN][controller_id]
 
-    for site in controller.sites.values():
-        if controller.site == site['name']:
-            if site['role'] != 'admin':
-                return
-            break
+    if controller.site_role != 'admin':
+        return
 
     switches = {}
 

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -1,5 +1,4 @@
 """Support for devices connected to UniFi POE."""
-from datetime import timedelta
 import logging
 
 from homeassistant.components import unifi
@@ -10,8 +9,6 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import CONF_CONTROLLER, CONF_SITE_ID, CONTROLLER_ID
-
-SCAN_INTERVAL = timedelta(seconds=15)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,12 +24,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     Switches are controlling network switch ports with Poe.
     """
-    return True
     controller_id = CONTROLLER_ID.format(
         host=config_entry.data[CONF_CONTROLLER][CONF_HOST],
         site=config_entry.data[CONF_CONTROLLER][CONF_SITE_ID],
     )
     controller = hass.data[unifi.DOMAIN][controller_id]
+
+    for site in controller.sites.values():
+        if controller.site == site['name']:
+            if site['role'] != 'admin':
+                return
+            break
+
     switches = {}
 
     @callback

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -27,6 +27,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     Switches are controlling network switch ports with Poe.
     """
+    return True
     controller_id = CONTROLLER_ID.format(
         host=config_entry.data[CONF_CONTROLLER][CONF_HOST],
         site=config_entry.data[CONF_CONTROLLER][CONF_SITE_ID],

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -24,7 +24,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     Switches are controlling network switch ports with Poe.
     """
-    return True
     controller_id = CONTROLLER_ID.format(
         host=config_entry.data[CONF_CONTROLLER][CONF_HOST],
         site=config_entry.data[CONF_CONTROLLER][CONF_SITE_ID],

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -14,6 +14,7 @@ from tests.common import mock_coro
 
 CONTROLLER_SITES = {
     'site1': {
+        'desc': 'nice name',
         'name': 'site',
         'role': 'admin'
     }
@@ -82,6 +83,7 @@ async def test_controller_site():
 async def test_controller_mac():
     """Test that it is possible to identify controller mac."""
     hass = Mock()
+    hass.data = {UNIFI_CONFIG: {}}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     client = Mock()
@@ -104,6 +106,7 @@ async def test_controller_mac():
 async def test_controller_no_mac():
     """Test that it works to not find the controllers mac."""
     hass = Mock()
+    hass.data = {UNIFI_CONFIG: {}}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     client = Mock()
@@ -174,6 +177,7 @@ async def test_reset_if_entry_had_wrong_auth():
 async def test_reset_unloads_entry_if_setup():
     """Calling reset when the entry has been setup."""
     hass = Mock()
+    hass.data = {UNIFI_CONFIG: {}}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     api = Mock()

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.components.unifi.const import CONF_CONTROLLER, CONF_SITE_ID
+from homeassistant.components.unifi.const import (
+    CONF_CONTROLLER, CONF_SITE_ID, UNIFI_CONFIG)
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME, CONF_VERIFY_SSL)
 from homeassistant.components.unifi import controller, errors
@@ -35,7 +36,7 @@ ENTRY_CONFIG = {
 async def test_controller_setup():
     """Successful setup."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
+    hass.data = {UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     api = Mock()
@@ -59,7 +60,6 @@ async def test_controller_setup():
 async def test_controller_host():
     """Config entry host and controller host are the same."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
 
@@ -71,7 +71,6 @@ async def test_controller_host():
 async def test_controller_site():
     """Config entry site and controller site are the same."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
 
@@ -83,7 +82,6 @@ async def test_controller_site():
 async def test_controller_mac():
     """Test that it is possible to identify controller mac."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     client = Mock()
@@ -106,7 +104,6 @@ async def test_controller_mac():
 async def test_controller_no_mac():
     """Test that it works to not find the controllers mac."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     client = Mock()
@@ -128,7 +125,6 @@ async def test_controller_no_mac():
 async def test_controller_not_accessible():
     """Retry to login gets scheduled when connection fails."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     api = Mock()
@@ -145,7 +141,6 @@ async def test_controller_not_accessible():
 async def test_controller_unknown_error():
     """Unknown errors are handled."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     api = Mock()
@@ -162,7 +157,6 @@ async def test_controller_unknown_error():
 async def test_reset_if_entry_had_wrong_auth():
     """Calling reset when the entry contains wrong auth."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
 
@@ -180,7 +174,6 @@ async def test_reset_if_entry_had_wrong_auth():
 async def test_reset_unloads_entry_if_setup():
     """Calling reset when the entry has been setup."""
     hass = Mock()
-    hass.data = {controller.UNIFI_CONFIG: []}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     api = Mock()

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -36,7 +36,7 @@ ENTRY_CONFIG = {
 async def test_controller_setup():
     """Successful setup."""
     hass = Mock()
-    hass.data = {UNIFI_CONFIG: []}
+    hass.data = {UNIFI_CONFIG: {}}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     api = Mock()

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -130,10 +130,8 @@ async def test_no_clients(hass, mock_controller):
 
 async def test_tracked_devices(hass, mock_controller):
     """Test the update_items function with some clients."""
-    client_1 = copy(CLIENT_1)
-    client_1['last_seen'] = dt_util.as_timestamp(dt_util.utcnow())
     mock_controller.mock_client_responses.append(
-        [client_1, CLIENT_2, CLIENT_3])
+        [CLIENT_1, CLIENT_2, CLIENT_3])
     mock_controller.mock_device_responses.append({})
     hass.data[UNIFI_CONFIG] = {unifi_dt.CONF_SSID_FILTER: ['ssid']}
 
@@ -143,7 +141,7 @@ async def test_tracked_devices(hass, mock_controller):
 
     device_1 = hass.states.get('device_tracker.client_1')
     assert device_1 is not None
-    assert device_1.state == 'home'
+    assert device_1.state == 'not_home'
 
     device_2 = hass.states.get('device_tracker.wired_client')
     assert device_2 is not None
@@ -151,3 +149,13 @@ async def test_tracked_devices(hass, mock_controller):
 
     device_3 = hass.states.get('device_tracker.client_3')
     assert device_3 is None
+
+    client_1 = copy(CLIENT_1)
+    client_1['last_seen'] = dt_util.as_timestamp(dt_util.utcnow())
+    mock_controller.mock_client_responses.append([client_1])
+    mock_controller.mock_device_responses.append({})
+    await mock_controller.async_update()
+    await hass.async_block_till_done()
+
+    device_1 = hass.states.get('device_tracker.client_1')
+    assert device_1.state == 'home'

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -1,267 +1,154 @@
 """The tests for the Unifi WAP device tracker platform."""
-from unittest import mock
-from datetime import datetime, timedelta
+from collections import deque
+from copy import copy
+from unittest.mock import Mock
+from datetime import timedelta
 
 import pytest
-import voluptuous as vol
 
-import homeassistant.util.dt as dt_util
-from homeassistant.components.device_tracker import DOMAIN
-import homeassistant.components.unifi.device_tracker as unifi
-from homeassistant.const import (CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
-                                 CONF_PLATFORM, CONF_VERIFY_SSL,
-                                 CONF_MONITORED_CONDITIONS)
-
-from tests.common import mock_coro
-from asynctest import CoroutineMock
 from aiounifi.clients import Clients
+from aiounifi.devices import Devices
+
+from homeassistant import config_entries
+from homeassistant.components import unifi
+from homeassistant.components.unifi.const import (
+    CONF_CONTROLLER, CONF_SITE_ID, UNIFI_CONFIG)
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME, CONF_VERIFY_SSL)
+from homeassistant.setup import async_setup_component
+
+import homeassistant.components.device_tracker as device_tracker
+import homeassistant.components.unifi.device_tracker as unifi_dt
+import homeassistant.util.dt as dt_util
 
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
 
+CLIENT_1 = {
+    'essid': 'ssid',
+    'hostname': 'client_1',
+    'ip': '10.0.0.1',
+    'is_wired': False,
+    'last_seen': 1562600145,
+    'mac': '00:00:00:00:00:01',
+}
+CLIENT_2 = {
+    'hostname': 'client_2',
+    'ip': '10.0.0.2',
+    'is_wired': True,
+    'last_seen': 1562600145,
+    'mac': '00:00:00:00:00:02',
+    'name': 'Wired Client',
+}
+CLIENT_3 = {
+    'essid': 'ssid2',
+    'hostname': 'client_3',
+    'ip': '10.0.0.3',
+    'is_wired': False,
+    'last_seen': 1562600145,
+    'mac': '00:00:00:00:00:03',
+}
+
+
+CONTROLLER_DATA = {
+    CONF_HOST: 'mock-host',
+    CONF_USERNAME: 'mock-user',
+    CONF_PASSWORD: 'mock-pswd',
+    CONF_PORT: 1234,
+    CONF_SITE_ID: 'mock-site',
+    CONF_VERIFY_SSL: True
+}
+
+ENTRY_CONFIG = {
+    CONF_CONTROLLER: CONTROLLER_DATA
+}
+
+CONTROLLER_ID = unifi.CONTROLLER_ID.format(host='mock-host', site='mock-site')
+
 
 @pytest.fixture
-def mock_ctrl():
-    """Mock pyunifi."""
-    with mock.patch('aiounifi.Controller') as mock_control:
-        mock_control.return_value.login.return_value = mock_coro()
-        mock_control.return_value.initialize.return_value = mock_coro()
-        yield mock_control
+def mock_controller(hass):
+    """Mock a UniFi Controller."""
+    hass.data[UNIFI_CONFIG] = []
+    controller = unifi.UniFiController(hass, None)
+
+    controller.api = Mock()
+    controller.mock_requests = []
+
+    controller.mock_client_responses = deque()
+    controller.mock_device_responses = deque()
+
+    async def mock_request(method, path, **kwargs):
+        kwargs['method'] = method
+        kwargs['path'] = path
+        controller.mock_requests.append(kwargs)
+        if path == 's/{site}/stat/sta':
+            return controller.mock_client_responses.popleft()
+        if path == 's/{site}/stat/device':
+            return controller.mock_device_responses.popleft()
+        return None
+
+    controller.api.clients = Clients({}, mock_request)
+    controller.api.devices = Devices({}, mock_request)
+
+    return controller
 
 
-@pytest.fixture
-def mock_scanner():
-    """Mock UnifyScanner."""
-    with mock.patch('homeassistant.components.unifi.device_tracker'
-                    '.UnifiScanner') as scanner:
-        yield scanner
+async def setup_controller(hass, mock_controller):
+    """Load the UniFi switch platform with the provided controller."""
+    hass.config.components.add(unifi.DOMAIN)
+    hass.data[unifi.DOMAIN] = {CONTROLLER_ID: mock_controller}
+    config_entry = config_entries.ConfigEntry(
+        1, unifi.DOMAIN, 'Mock Title', ENTRY_CONFIG, 'test',
+        config_entries.CONN_CLASS_LOCAL_POLL)
+    mock_controller.config_entry = config_entry
+
+    await mock_controller.async_update()
+    await hass.config_entries.async_forward_entry_setup(
+        config_entry, device_tracker.DOMAIN)
+
+    await hass.async_block_till_done()
 
 
-@mock.patch('os.access', return_value=True)
-@mock.patch('os.path.isfile', mock.Mock(return_value=True))
-async def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
-    """Test the setup with a string for ssl_verify.
-
-    Representing the absolute path to a CA certificate bundle.
-    """
-    config = {
-        DOMAIN: unifi.PLATFORM_SCHEMA({
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_USERNAME: 'foo',
-            CONF_PASSWORD: 'password',
-            CONF_VERIFY_SSL: "/tmp/unifi.crt"
-        })
-    }
-    result = await unifi.async_get_scanner(hass, config)
-    assert mock_scanner.return_value == result
-    assert mock_ctrl.call_count == 1
-
-    assert mock_scanner.call_count == 1
-    assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
-                                               DEFAULT_DETECTION_TIME,
-                                               None, None)
-
-
-async def test_config_minimal(hass, mock_scanner, mock_ctrl):
-    """Test the setup with minimal configuration."""
-    config = {
-        DOMAIN: unifi.PLATFORM_SCHEMA({
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_USERNAME: 'foo',
-            CONF_PASSWORD: 'password',
-        })
-    }
-
-    result = await unifi.async_get_scanner(hass, config)
-    assert mock_scanner.return_value == result
-    assert mock_ctrl.call_count == 1
-
-    assert mock_scanner.call_count == 1
-    assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
-                                               DEFAULT_DETECTION_TIME,
-                                               None, None)
-
-
-async def test_config_full(hass, mock_scanner, mock_ctrl):
-    """Test the setup with full configuration."""
-    config = {
-        DOMAIN: unifi.PLATFORM_SCHEMA({
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_USERNAME: 'foo',
-            CONF_PASSWORD: 'password',
-            CONF_HOST: 'myhost',
-            CONF_VERIFY_SSL: False,
-            CONF_MONITORED_CONDITIONS: ['essid', 'signal'],
-            'port': 123,
-            'site_id': 'abcdef01',
-            'detection_time': 300,
-        })
-    }
-    result = await unifi.async_get_scanner(hass, config)
-    assert mock_scanner.return_value == result
-    assert mock_ctrl.call_count == 1
-
-    assert mock_scanner.call_count == 1
-    assert mock_scanner.call_args == mock.call(
-        mock_ctrl.return_value,
-        DEFAULT_DETECTION_TIME,
-        None,
-        config[DOMAIN][CONF_MONITORED_CONDITIONS])
-
-
-def test_config_error():
-    """Test for configuration errors."""
-    with pytest.raises(vol.Invalid):
-        unifi.PLATFORM_SCHEMA({
-            # no username
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_HOST: 'myhost',
-            'port': 123,
-        })
-    with pytest.raises(vol.Invalid):
-        unifi.PLATFORM_SCHEMA({
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_USERNAME: 'foo',
-            CONF_PASSWORD: 'password',
-            CONF_HOST: 'myhost',
-            'port': 'foo',  # bad port!
-        })
-    with pytest.raises(vol.Invalid):
-        unifi.PLATFORM_SCHEMA({
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_USERNAME: 'foo',
-            CONF_PASSWORD: 'password',
-            CONF_VERIFY_SSL: "dfdsfsdfsd",  # Invalid ssl_verify (no file)
-        })
-
-
-async def test_config_controller_failed(hass, mock_ctrl, mock_scanner):
-    """Test for controller failure."""
-    config = {
-        'device_tracker': {
-            CONF_PLATFORM: unifi.DOMAIN,
-            CONF_USERNAME: 'foo',
-            CONF_PASSWORD: 'password',
+async def test_platform_manually_configured(hass):
+    """Test that we do not discover anything or try to set up a bridge."""
+    assert await async_setup_component(hass, device_tracker.DOMAIN, {
+        device_tracker.DOMAIN: {
+            'platform': 'unifi'
         }
-    }
-    mock_ctrl.side_effect = unifi.CannotConnect
-    result = await unifi.async_get_scanner(hass, config)
-    assert result is False
+    }) is True
+    assert unifi.DOMAIN not in hass.data
 
 
-async def test_scanner_update():
-    """Test the scanner update."""
-    ctrl = mock.MagicMock()
-    fake_clients = [
-        {'mac': '123', 'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '234', 'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-    ]
-    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
-    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
-    await scnr.async_update()
-    assert len(scnr._clients) == 2
+async def test_no_clients(hass, mock_controller):
+    """Test the update_clients function when no clients are found."""
+    mock_controller.mock_client_responses.append({})
+    mock_controller.mock_device_responses.append({})
+    await setup_controller(hass, mock_controller)
+    assert len(mock_controller.mock_requests) == 2
+    assert len(hass.states.async_all()) == 2
 
 
-def test_scanner_update_error():
-    """Test the scanner update for error."""
-    ctrl = mock.MagicMock()
-    ctrl.get_clients.side_effect = unifi.aiounifi.AiounifiException
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+async def test_tracked_devices(hass, mock_controller):
+    """Test the update_items function with some clients."""
+    client_1 = copy(CLIENT_1)
+    client_1['last_seen'] = dt_util.as_timestamp(dt_util.utcnow())
+    mock_controller.mock_client_responses.append([client_1, CLIENT_2, CLIENT_3])
+    mock_controller.mock_device_responses.append({})
+    mock_controller.unifi_config[unifi_dt.CONF_DETECTION_TIME] = \
+        unifi_dt.DEFAULT_DETECTION_TIME
+    mock_controller.unifi_config[unifi_dt.CONF_SSID_FILTER] = ['ssid']
 
+    await setup_controller(hass, mock_controller)
+    assert len(mock_controller.mock_requests) == 2
+    assert len(hass.states.async_all()) == 4
 
-async def test_scan_devices():
-    """Test the scanning for devices."""
-    ctrl = mock.MagicMock()
-    fake_clients = [
-        {'mac': '123', 'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '234', 'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-    ]
-    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
-    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
-    await scnr.async_update()
-    assert set(await scnr.async_scan_devices()) == set(['123', '234'])
+    device_1 = hass.states.get('device_tracker.client_1')
+    assert device_1 is not None
+    assert device_1.state == 'home'
 
+    device_2 = hass.states.get('device_tracker.wired_client')
+    assert device_2 is not None
+    assert device_2.state == 'not_home'
 
-async def test_scan_devices_filtered():
-    """Test the scanning for devices based on SSID."""
-    ctrl = mock.MagicMock()
-    fake_clients = [
-        {'mac': '123', 'essid': 'foonet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '234', 'essid': 'foonet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '567', 'essid': 'notnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '890', 'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-    ]
-
-    ssid_filter = ['foonet', 'barnet']
-    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
-    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter, None)
-    await scnr.async_update()
-    assert set(await scnr.async_scan_devices()) == set(['123', '234', '890'])
-
-
-async def test_get_device_name():
-    """Test the getting of device names."""
-    ctrl = mock.MagicMock()
-    fake_clients = [
-        {'mac': '123',
-         'hostname': 'foobar',
-         'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '234',
-         'name': 'Nice Name',
-         'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '456',
-         'essid': 'barnet',
-         'last_seen': '1504786810'},
-    ]
-    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
-    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
-    await scnr.async_update()
-    assert scnr.get_device_name('123') == 'foobar'
-    assert scnr.get_device_name('234') == 'Nice Name'
-    assert scnr.get_device_name('456') is None
-    assert scnr.get_device_name('unknown') is None
-
-
-async def test_monitored_conditions():
-    """Test the filtering of attributes."""
-    ctrl = mock.MagicMock()
-    fake_clients = [
-        {'mac': '123',
-         'hostname': 'foobar',
-         'essid': 'barnet',
-         'signal': -60,
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow()),
-         'latest_assoc_time': 946684800.0},
-        {'mac': '234',
-         'name': 'Nice Name',
-         'essid': 'barnet',
-         'signal': -42,
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-        {'mac': '456',
-         'hostname': 'wired',
-         'essid': 'barnet',
-         'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
-    ]
-    ctrl.clients = Clients([], CoroutineMock(return_value=fake_clients))
-    scnr = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
-                              ['essid', 'signal', 'latest_assoc_time'])
-    await scnr.async_update()
-    assert scnr.get_extra_attributes('123') == {
-        'essid': 'barnet',
-        'signal': -60,
-        'latest_assoc_time': datetime(2000, 1, 1, 0, 0, tzinfo=dt_util.UTC)
-    }
-    assert scnr.get_extra_attributes('234') == {
-        'essid': 'barnet',
-        'signal': -42
-    }
-    assert scnr.get_extra_attributes('456') == {'essid': 'barnet'}
+    device_3 = hass.states.get('device_tracker.client_3')
+    assert device_3 is None

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -48,7 +48,6 @@ CLIENT_3 = {
     'mac': '00:00:00:00:00:03',
 }
 
-
 CONTROLLER_DATA = {
     CONF_HOST: 'mock-host',
     CONF_USERNAME: 'mock-user',
@@ -133,7 +132,7 @@ async def test_tracked_devices(hass, mock_controller):
     mock_controller.mock_client_responses.append(
         [CLIENT_1, CLIENT_2, CLIENT_3])
     mock_controller.mock_device_responses.append({})
-    hass.data[UNIFI_CONFIG] = {unifi_dt.CONF_SSID_FILTER: ['ssid']}
+    mock_controller.unifi_config = {unifi_dt.CONF_SSID_FILTER: ['ssid']}
 
     await setup_controller(hass, mock_controller)
     assert len(mock_controller.mock_requests) == 2

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -68,7 +68,7 @@ CONTROLLER_ID = unifi.CONTROLLER_ID.format(host='mock-host', site='mock-site')
 @pytest.fixture
 def mock_controller(hass):
     """Mock a UniFi Controller."""
-    hass.data[UNIFI_CONFIG] = []
+    hass.data[UNIFI_CONFIG] = {}
     controller = unifi.UniFiController(hass, None)
 
     controller.api = Mock()

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -132,11 +132,10 @@ async def test_tracked_devices(hass, mock_controller):
     """Test the update_items function with some clients."""
     client_1 = copy(CLIENT_1)
     client_1['last_seen'] = dt_util.as_timestamp(dt_util.utcnow())
-    mock_controller.mock_client_responses.append([client_1, CLIENT_2, CLIENT_3])
+    mock_controller.mock_client_responses.append(
+        [client_1, CLIENT_2, CLIENT_3])
     mock_controller.mock_device_responses.append({})
-    mock_controller.unifi_config[unifi_dt.CONF_DETECTION_TIME] = \
-        unifi_dt.DEFAULT_DETECTION_TIME
-    mock_controller.unifi_config[unifi_dt.CONF_SSID_FILTER] = ['ssid']
+    hass.data[UNIFI_CONFIG] = {unifi_dt.CONF_SSID_FILTER: ['ssid']}
 
     await setup_controller(hass, mock_controller)
     assert len(mock_controller.mock_requests) == 2

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -16,23 +16,29 @@ async def test_setup_with_no_config(hass):
     """Test that we do not discover anything or try to set up a bridge."""
     assert await async_setup_component(hass, unifi.DOMAIN, {}) is True
     assert unifi.DOMAIN not in hass.data
-    assert hass.data[unifi.UNIFI_CONFIG] == {}
+    assert hass.data[unifi.UNIFI_CONFIG] == []
 
 
 async def test_setup_with_config(hass):
     """Test that we do not discover anything or try to set up a bridge."""
     config = {
         unifi.DOMAIN: {
-            unifi.CONF_DETECTION_TIME: 3,
-            unifi.CONF_SSID_FILTER: ['ssid']
+            unifi.CONF_CONTROLLERS: {
+                unifi.CONF_HOST: '1.2.3.4',
+                unifi.CONF_SITE_ID: 'My site',
+                unifi.CONF_DETECTION_TIME: 3,
+                unifi.CONF_SSID_FILTER: ['ssid']
+            }
         }
     }
     assert await async_setup_component(hass, unifi.DOMAIN, config) is True
     assert unifi.DOMAIN not in hass.data
-    assert hass.data[unifi.UNIFI_CONFIG] == {
+    assert hass.data[unifi.UNIFI_CONFIG] == [{
+        unifi.CONF_HOST: '1.2.3.4',
+        unifi.CONF_SITE_ID: 'My site',
         unifi.CONF_DETECTION_TIME: timedelta(seconds=3),
         unifi.CONF_SSID_FILTER: ['ssid']
-    }
+    }]
 
 
 async def test_successful_config_entry(hass):

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -1,4 +1,5 @@
 """Test UniFi setup process."""
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from homeassistant.components import unifi
@@ -15,6 +16,23 @@ async def test_setup_with_no_config(hass):
     """Test that we do not discover anything or try to set up a bridge."""
     assert await async_setup_component(hass, unifi.DOMAIN, {}) is True
     assert unifi.DOMAIN not in hass.data
+    assert hass.data[unifi.UNIFI_CONFIG] == {}
+
+
+async def test_setup_with_config(hass):
+    """Test that we do not discover anything or try to set up a bridge."""
+    config = {
+        unifi.DOMAIN: {
+            unifi.CONF_DETECTION_TIME: 3,
+            unifi.CONF_SSID_FILTER: ['ssid']
+        }
+    }
+    assert await async_setup_component(hass, unifi.DOMAIN, config) is True
+    assert unifi.DOMAIN not in hass.data
+    assert hass.data[unifi.UNIFI_CONFIG] == {
+        unifi.CONF_DETECTION_TIME: timedelta(seconds=3),
+        unifi.CONF_SSID_FILTER: ['ssid']
+    }
 
 
 async def test_successful_config_entry(hass):

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -247,41 +247,6 @@ async def test_controller_site_already_configured(hass):
     assert result['type'] == 'abort'
 
 
-async def test_user_permissions_low(hass, aioclient_mock):
-    """Test config flow."""
-    flow = config_flow.UnifiFlowHandler()
-    flow.hass = hass
-
-    with patch('aiounifi.Controller') as mock_controller:
-        def mock_constructor(
-                host, username, password, port, site, websession, sslcontext):
-            """Fake the controller constructor."""
-            mock_controller.host = host
-            mock_controller.username = username
-            mock_controller.password = password
-            mock_controller.port = port
-            mock_controller.site = site
-            return mock_controller
-
-        mock_controller.side_effect = mock_constructor
-        mock_controller.login.return_value = mock_coro()
-        mock_controller.sites.return_value = mock_coro({
-            'site1': {'name': 'default', 'role': 'viewer', 'desc': 'site name'}
-        })
-
-        await flow.async_step_user(user_input={
-            CONF_HOST: '1.2.3.4',
-            CONF_USERNAME: 'username',
-            CONF_PASSWORD: 'password',
-            CONF_PORT: 1234,
-            CONF_VERIFY_SSL: True
-        })
-
-        result = await flow.async_step_site(user_input={})
-
-    assert result['type'] == 'abort'
-
-
 async def test_user_credentials_faulty(hass, aioclient_mock):
     """Test config flow."""
     flow = config_flow.UnifiFlowHandler()

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -189,7 +189,7 @@ CONTROLLER_ID = unifi.CONTROLLER_ID.format(host='mock-host', site='mock-site')
 @pytest.fixture
 def mock_controller(hass):
     """Mock a UniFi Controller."""
-    hass.data[UNIFI_CONFIG] = []
+    hass.data[UNIFI_CONFIG] = {}
     controller = unifi.UniFiController(hass, None)
 
     controller.site_role = 'admin'

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -192,7 +192,7 @@ def mock_controller(hass):
     hass.data[UNIFI_CONFIG] = {}
     controller = unifi.UniFiController(hass, None)
 
-    controller.site_role = 'admin'
+    controller._site_role = 'admin'
 
     controller.api = Mock()
     controller.mock_requests = []
@@ -266,7 +266,7 @@ async def test_not_admin(hass, mock_controller):
     mock_controller.mock_client_responses.append([CLIENT_1])
     mock_controller.mock_device_responses.append([])
 
-    mock_controller.site_role = 'viewer'
+    mock_controller._site_role = 'viewer'
 
     await setup_controller(hass, mock_controller)
     assert len(mock_controller.mock_requests) == 2


### PR DESCRIPTION
## Breaking Change:
Device tracker is now part of config entry. After initial import the unifi device tracker configuration is no longer needed. If configuring SSID filter or detection time you will need to use the new configuration from UniFi. See UniFi component documentation for details.

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Allows migrate device tracker unifi configuration to config entry
Removes requirement to have an admin level account, controls are moved to the switch platform
Additional configuration handled from unifi: level.

**Related issue (if applicable):** fixes #24895, #23490, #21636, #19301, #14663

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9847

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html