### PR TITLE
Remove device and entity registry entries when removing a ZHA device

### DIFF
--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -312,7 +312,8 @@ class ZHADevice:
                 ex
             )
 
-    async def async_unsub_dispatcher(self):
+    @callback
+    def async_unsub_dispatcher(self):
         """Unsubscribe the dispatcher."""
         if self._unsub:
             self._unsub()

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -160,8 +160,8 @@ class ZHAGateway:
         self._device_registry.pop(device.ieee, None)
         if zha_device is not None:
             device_info = async_get_device_info(self._hass, zha_device)
-            self._hass.async_create_task(zha_device.async_unsub_dispatcher())
-            self._hass.async_create_task(self._async_remove_device(zha_device))
+            zha_device.async_unsub_dispatcher()
+            asyncio.ensure_future(self._async_remove_device(zha_device))
             async_dispatcher_send(
                 self._hass,
                 "{}_{}".format(SIGNAL_REMOVE, str(zha_device.ieee))

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -219,7 +219,8 @@ class DeviceRegistry:
 
         return new
 
-    def _async_remove_device(self, device_id):
+    def async_remove_device(self, device_id):
+        """Remove a device from the device registry."""
         del self.devices[device_id]
         self.hass.bus.async_fire(EVENT_DEVICE_REGISTRY_UPDATED, {
             'action': 'remove',
@@ -297,7 +298,7 @@ class DeviceRegistry:
                 self._async_update_device(
                     dev_id, remove_config_entry_id=config_entry_id)
         for dev_id in remove:
-            self._async_remove_device(dev_id)
+            self.async_remove_device(dev_id)
 
     @callback
     def async_clear_area_id(self, area_id: str) -> None:


### PR DESCRIPTION
## Description:
This PR does the following:

- Make `async_remove_device` in the device registry public
- Listen to device removal event in the entity registry and remove entries associated to the device
- implements device / entity registry cleanup in ZHA

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]
