### PR TITLE
Fix for LCN climate issue

### DIFF
--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -51,7 +51,7 @@ class LcnClimate(LcnDevice, ClimateDevice):
 
         self._current_temperature = None
         self._target_temperature = None
-        self._is_on = True
+        self._is_on = None
 
         self.support = const.SUPPORT_TARGET_TEMPERATURE
         if self.is_lockable:
@@ -130,10 +130,12 @@ class LcnClimate(LcnDevice, ClimateDevice):
             return
 
         if input_obj.get_var() == self.variable:
-            self._current_temperature = (
-                input_obj.get_value().to_var_unit(self.unit))
-        elif self._is_on and input_obj.get_var() == self.setpoint:
-            self._target_temperature = (
-                input_obj.get_value().to_var_unit(self.unit))
+            self._current_temperature = \
+                input_obj.get_value().to_var_unit(self.unit)
+        elif input_obj.get_var() == self.setpoint:
+            self._is_on = not input_obj.get_value().is_locked_regulator()
+            if self.is_on:
+                self._target_temperature = \
+                    input_obj.get_value().to_var_unit(self.unit)
 
         self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:

When LCN climate platform is turned off and Home Assistant gets restarted, the target temperature does not get fetched properly from the hardware modules.
This PR fixes this issue.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
