### PR TITLE
deCONZ - proper comparison of discovered and configured gateways

### DIFF
--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -1,5 +1,5 @@
 """Tests for deCONZ config flow."""
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import asyncio
 
@@ -177,7 +177,8 @@ async def test_bridge_ssdp_discovery(hass):
             config_flow.CONF_PORT: 80,
             config_flow.ATTR_SERIAL: 'id',
             config_flow.ATTR_MANUFACTURERURL:
-                config_flow.DECONZ_MANUFACTURERURL
+                config_flow.DECONZ_MANUFACTURERURL,
+            config_flow.ATTR_UUID: 'uuid:1234'
         },
         context={'source': 'ssdp'}
     )
@@ -207,13 +208,19 @@ async def test_bridge_discovery_update_existing_entry(hass):
     })
     entry.add_to_hass(hass)
 
+    gateway = Mock()
+    gateway.config_entry = entry
+    gateway.api.config.uuid = '1234'
+    hass.data[config_flow.DOMAIN] = {'id': gateway}
+
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         data={
             config_flow.CONF_HOST: 'mock-deconz',
             config_flow.ATTR_SERIAL: 'id',
             config_flow.ATTR_MANUFACTURERURL:
-                config_flow.DECONZ_MANUFACTURERURL
+                config_flow.DECONZ_MANUFACTURERURL,
+            config_flow.ATTR_UUID: 'uuid:1234'
         },
         context={'source': 'ssdp'}
     )


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Apparently the bridgeid differ between what is received from UPnP discovery and deCONZ Rest API. This change compares the UPnP UUID instead.

I am awaiting feedback from deCONZ developers if there is a way to compare the bridgeid instead, as to minimise this fix as much as possible. https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1575

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html