### PR TITLE
Updated pubnubsub-handler to 1.0.7 to fix crash on slow startup

### DIFF
--- a/homeassistant/components/wink/manifest.json
+++ b/homeassistant/components/wink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Wink",
   "documentation": "https://www.home-assistant.io/components/wink",
   "requirements": [
-    "pubnubsub-handler==1.0.6",
+    "pubnubsub-handler==1.0.7",
     "python-wink==1.10.5"
   ],
   "dependencies": ["configurator"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -930,7 +930,7 @@ psutil==5.6.2
 ptvsd==4.2.8
 
 # homeassistant.components.wink
-pubnubsub-handler==1.0.6
+pubnubsub-handler==1.0.7
 
 # homeassistant.components.pushbullet
 pushbullet.py==0.11.0


### PR DESCRIPTION
## Description:
Creates a default pubnub instance if subscribe hasn't been called by the time Home Assistant start is fired.

**Related issue (if applicable):** fixes #24349 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
