### PR TITLE
Expose port 8123 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,8 @@ RUN pip3 install --no-cache-dir -r requirements_all.txt && \
 # Copy source
 COPY . .
 
+EXPOSE 8123
+EXPOSE 8300
+EXPOSE 51827
+
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -58,4 +58,8 @@ RUN tox -e py37 --notest
 # Copy source
 COPY . .
 
+EXPOSE 8123
+EXPOSE 8300
+EXPOSE 51827
+
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
## Description:

Adds the `EXPOSE` directive to `Dockerfile` and `virtualization/Docker/Dockerfile.dev` to document the fact the container listens on that port (by default). (see https://docs.docker.com/engine/reference/builder/#expose)

This change also has the added benefit of allowing the built docker image to be run via Docker Swarm using host networking. (see https://docs.docker.com/network/host/)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
