### PR TITLE
Add ferienapidotde binary sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -190,6 +190,7 @@ omit =
     homeassistant/components/familyhub/camera.py
     homeassistant/components/fastdotcom/*
     homeassistant/components/fedex/sensor.py
+    homeassistant/components/ferienapidotde/binary_sensor.py
     homeassistant/components/ffmpeg/camera.py
     homeassistant/components/fibaro/*
     homeassistant/components/filesize/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,6 +79,7 @@ homeassistant/components/eq3btsmart/* @rytilahti
 homeassistant/components/esphome/* @OttoWinter
 homeassistant/components/essent/* @TheLastProject
 homeassistant/components/evohome/* @zxdavb
+homeassistant/components/ferienapidotde/* @HazardDede
 homeassistant/components/file/* @fabaff
 homeassistant/components/filter/* @dgomes
 homeassistant/components/fitbit/* @robbiet480

--- a/homeassistant/components/ferienapidotde/__init__.py
+++ b/homeassistant/components/ferienapidotde/__init__.py
@@ -1,0 +1,1 @@
+"""Binary sensor to indicate if today is a german vacation day or not."""

--- a/homeassistant/components/ferienapidotde/binary_sensor.py
+++ b/homeassistant/components/ferienapidotde/binary_sensor.py
@@ -1,0 +1,135 @@
+"""Binary sensor to indicate if today is a german vacation day or not."""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle, dt
+
+_LOGGER = logging.getLogger(__name__)
+
+ALL_STATE_CODES = [
+    "BW", "BY", "BE", "BB", "HB", "HH", "HE", "MV", "NI", "NW", "RP", "SL",
+    "SN", "ST", "SH", "TH"
+]
+
+ATTR_START = 'start'
+ATTR_END = 'end'
+ATTR_NEXT_START = 'next_start'
+ATTR_NEXT_END = 'next_end'
+ATTR_VACATION_NAME = 'vacation_name'
+
+CONF_STATE_CODE = 'state_code'
+
+DEFAULT_NAME = 'Vacation Sensor'
+
+# Don't rush the api. Every 12h should suffice.
+MIN_TIME_BETWEEN_UPDATES = timedelta(hours=12)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_STATE_CODE): vol.In(ALL_STATE_CODES),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
+
+SCAN_INTERVAL = timedelta(minutes=1)
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Setups the ferienapidotde platform."""
+    state_code = config[CONF_STATE_CODE]
+    name = config[CONF_NAME]
+
+    import aiohttp.client_exceptions as exc
+    try:
+        data_object = VacationData(state_code)
+        await data_object.async_update()
+    except exc.ClientError:
+        import traceback
+        _LOGGER.warning(traceback.format_exc())
+        raise PlatformNotReady()
+
+    async_add_entities([VacationSensor(name, data_object)], True)
+
+
+class VacationSensor(BinarySensorDevice):
+    """Implementation of the vacation sensor."""
+
+    def __init__(self, name, data_object):
+        """Initialize the vacation sensor."""
+        self._name = name
+        self.data_object = data_object
+        self._state = None
+        self._state_attrs = {}
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of this device."""
+        return self._state_attrs
+
+    async def async_update(self):
+        """Update the state and state attributes."""
+        import ferien
+        await self.data_object.async_update()
+        vacations = self.data_object.data
+        if vacations:  # Might be none in case of failure
+            current = ferien.current_vacation(vacs=vacations)
+            if current:
+                self._state = True
+                aligned_end = current.end - timedelta(seconds=1)
+                self._state_attrs = {
+                    ATTR_START: dt.as_utc(current.start).isoformat(),
+                    ATTR_END: dt.as_utc(aligned_end).isoformat(),
+                    ATTR_VACATION_NAME: current.name
+                }
+            else:
+                self._state = False
+                next_vacation = ferien.next_vacation(vacs=vacations)
+                if next_vacation:
+                    aligned_end = next_vacation.end - timedelta(seconds=1)
+                    self._state_attrs = {
+                        ATTR_NEXT_START:
+                            dt.as_utc(next_vacation.start).isoformat(),
+                        ATTR_NEXT_END: dt.as_utc(aligned_end).isoformat(),
+                        ATTR_VACATION_NAME: next_vacation.name
+                    }
+                else:
+                    self._state_attrs = {}
+
+
+class VacationData:
+    """Class for handling data retrieval."""
+
+    def __init__(self, state_code):
+        """Initializer."""
+        self.state_code = state_code
+        self.data = None
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    async def async_update(self):
+        """Update the publicly available data container."""
+        import aiohttp.client_exceptions as exc
+        try:
+            import ferien
+            self.data = await ferien.state_vacations_async(self.state_code)
+        except exc.ClientError:
+            import traceback
+            _LOGGER.error(
+                "Failed to update the vacation data from ferien-api.de: %s",
+                traceback.format_exc()
+            )

--- a/homeassistant/components/ferienapidotde/manifest.json
+++ b/homeassistant/components/ferienapidotde/manifest.json
@@ -1,0 +1,12 @@
+{
+    "domain": "ferienapidotde",
+    "name": "Ferienapidotde",
+    "documentation": "https://www.home-assistant.io/components/ferienapidotde",
+    "dependencies": [],
+    "codeowners": [
+        "@HazardDede"
+    ],
+    "requirements": [
+        "ferien-api==0.3.4"
+    ]
+  }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -452,6 +452,9 @@ fedexdeliverymanager==1.0.6
 # homeassistant.components.feedreader
 feedparser-homeassistant==5.2.2.dev1
 
+# homeassistant.components.ferienapidotde
+ferien-api==0.3.4
+
 # homeassistant.components.fibaro
 fiblary3==0.1.7
 


### PR DESCRIPTION
## Description:

Binary sensor to indicate if today is a german vacation day or not

This is a re-open from my messed up PR: https://github.com/home-assistant/home-assistant/pull/22361

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9021

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: ferienapidotde
    name: vaction_hh  # Optional
    state_code: HH
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
