### PR TITLE
Use loose version to check for version upgrades

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1,7 +1,7 @@
 """Module to help with parsing and generating configuration files."""
 from collections import OrderedDict
 # pylint: disable=no-name-in-module
-from distutils.version import StrictVersion  # pylint: disable=import-error
+from distutils.version import LooseVersion  # pylint: disable=import-error
 import logging
 import os
 import re
@@ -334,15 +334,15 @@ def process_ha_config_upgrade(hass: HomeAssistant) -> None:
     _LOGGER.info("Upgrading configuration directory from %s to %s",
                  conf_version, __version__)
 
-    version_obj = StrictVersion(conf_version)
+    version_obj = LooseVersion(conf_version)
 
-    if version_obj < StrictVersion('0.50'):
+    if version_obj < LooseVersion('0.50'):
         # 0.50 introduced persistent deps dir.
         lib_path = hass.config.path('deps')
         if os.path.isdir(lib_path):
             shutil.rmtree(lib_path)
 
-    if version_obj < StrictVersion('0.92'):
+    if version_obj < LooseVersion('0.92'):
         # 0.92 moved google/tts.py to google_translate/tts.py
         config_path = find_config_file(hass.config.config_dir)
         assert config_path is not None
@@ -360,7 +360,7 @@ def process_ha_config_upgrade(hass: HomeAssistant) -> None:
                 _LOGGER.exception("Migrating to google_translate tts failed")
                 pass
 
-    if version_obj < StrictVersion('0.94.0b6') and is_docker_env():
+    if version_obj < LooseVersion('0.94') and is_docker_env():
         # In 0.94 we no longer install packages inside the deps folder when
         # running inside a Docker container.
         lib_path = hass.config.path('deps')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -281,7 +281,7 @@ def test_remove_lib_on_upgrade(mock_docker, mock_os, mock_shutil, hass):
 @mock.patch('homeassistant.config.is_docker_env', return_value=True)
 def test_remove_lib_on_upgrade_94(mock_docker, mock_os, mock_shutil, hass):
     """Test removal of library on upgrade from before 0.94 and in Docker."""
-    ha_version = '0.94.0b5'
+    ha_version = '0.93.0.dev0'
     mock_os.path.isdir = mock.Mock(return_value=True)
     mock_open = mock.mock_open()
     with mock.patch('homeassistant.config.open', mock_open, create=True):


### PR DESCRIPTION
## Description:
During the beta, I migrated to use `StrictVersion`  for version checks. However, that is unable to parse our dev tags, which are valid according to the PEP.

So this changes it back to the LooseVersion. Anyone that is on Docker and upgrading from a beta will now not have their deps cleared. This fix will only ship with 95, so I think that all beta users will have upgraded to 94 final by then.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
