### PR TITLE
Fix recorder defaults

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -62,7 +62,7 @@ FILTER_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: FILTER_SCHEMA.extend({
+    vol.Optional(DOMAIN, default=dict): FILTER_SCHEMA.extend({
         vol.Optional(CONF_PURGE_KEEP_DAYS, default=10):
             vol.All(vol.Coerce(int), vol.Range(min=1)),
         vol.Optional(CONF_PURGE_INTERVAL, default=1):
@@ -95,7 +95,7 @@ def run_information(hass, point_in_time: Optional[datetime] = None):
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the recorder."""
-    conf = config.get(DOMAIN, {})
+    conf = config[DOMAIN]
     keep_days = conf.get(CONF_PURGE_KEEP_DAYS)
     purge_interval = conf.get(CONF_PURGE_INTERVAL)
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -207,14 +207,18 @@ def test_recorder_setup_failure():
 
 async def test_defaults_set(hass):
     """Test the config defaults are set."""
+    recorder_config = None
+
     async def mock_setup(hass, config):
         """Mock setup."""
-        config = config['recorder']
-        assert config['purge_keep_days'] == 10
-        assert config['purge_interval'] == 1
+        nonlocal recorder_config
+        recorder_config = config['recorder']
         return True
 
     with patch('homeassistant.components.recorder.async_setup',
                side_effect=mock_setup):
         assert await async_setup_component(hass, 'history', {})
 
+    assert recorder_config is not None
+    assert recorder_config['purge_keep_days'] == 10
+    assert recorder_config['purge_interval'] == 1

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.core import callback
 from homeassistant.const import MATCH_ALL
+from homeassistant.setup import async_setup_component
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.const import DATA_INSTANCE
 from homeassistant.components.recorder.util import session_scope
@@ -202,3 +203,18 @@ def test_recorder_setup_failure():
         rec.join()
 
     hass.stop()
+
+
+async def test_defaults_set(hass):
+    """Test the config defaults are set."""
+    async def mock_setup(hass, config):
+        """Mock setup."""
+        config = config['recorder']
+        assert config['purge_keep_days'] == 10
+        assert config['purge_interval'] == 1
+        return True
+
+    with patch('homeassistant.components.recorder.async_setup',
+               side_effect=mock_setup):
+        assert await async_setup_component(hass, 'history', {})
+


### PR DESCRIPTION
## Breaking Change:

We used to have a bug that caused users that did not specify `recorder:` in their configuration (probably most of you), to not have their database automatically purged. This will start happening now as per the default settings. This might take a while the first time as it hasn't done any clean up in a while.

## Description:
If the recorder integration was loaded as a dependency of another integration, the default config was not being applied. This is probably the case for 95% of our users. 

This means that we never purged old DBs 🙈 

Adding breaking change to clarify what is going on.

**Related issue (if applicable):** fixes #24386

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
