### PR TITLE
Restore automation last_triggered with initial_state override

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -223,23 +223,25 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Startup with initial state or previous state."""
         await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state:
+            enable_automation = state.state == STATE_ON
+            self._last_triggered = state.attributes.get('last_triggered')
+            _LOGGER.debug("Loaded automation %s with state %s from state "
+                          " storage last state %s", self.entity_id,
+                          enable_automation, state)
+        else:
+            enable_automation = DEFAULT_INITIAL_STATE
+            _LOGGER.debug("Automation %s not in state storage, state %s from "
+                          "default is used.", self.entity_id,
+                          enable_automation)
+
         if self._initial_state is not None:
             enable_automation = self._initial_state
-            _LOGGER.debug("Automation %s initial state %s from config "
-                          "initial_state", self.entity_id, enable_automation)
-        else:
-            state = await self.async_get_last_state()
-            if state:
-                enable_automation = state.state == STATE_ON
-                self._last_triggered = state.attributes.get('last_triggered')
-                _LOGGER.debug("Automation %s initial state %s from recorder "
-                              "last state %s", self.entity_id,
-                              enable_automation, state)
-            else:
-                enable_automation = DEFAULT_INITIAL_STATE
-                _LOGGER.debug("Automation %s initial state %s from default "
-                              "initial state", self.entity_id,
-                              enable_automation)
+            _LOGGER.debug("Automation %s initial state %s overridden from "
+                          "config initial_state", self.entity_id,
+                          enable_automation)
 
         if enable_automation:
             await self.async_enable()

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -895,8 +895,7 @@ async def test_automation_with_error_in_script(hass, caplog):
     await hass.async_block_till_done()
     assert 'Service not found' in caplog.text
 
-@asyncio.coroutine
-def test_automation_restore_last_triggered_with_initial_state(hass):
+async def test_automation_restore_last_triggered_with_initial_state(hass):
     """Ensure last_triggered is restored, even when initial state is set."""
     time = dt_util.utcnow()
 
@@ -932,7 +931,7 @@ def test_automation_restore_last_triggered_with_initial_state(hass):
         'action': {'service': 'test.automation'}
     }]}
 
-    assert (yield from async_setup_component(hass, automation.DOMAIN, config))
+    await async_setup_component(hass, automation.DOMAIN, config)
 
     state = hass.states.get('automation.hello')
     assert state

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -895,6 +895,7 @@ async def test_automation_with_error_in_script(hass, caplog):
     await hass.async_block_till_done()
     assert 'Service not found' in caplog.text
 
+
 async def test_automation_restore_last_triggered_with_initial_state(hass):
     """Ensure last_triggered is restored, even when initial state is set."""
     time = dt_util.utcnow()

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -894,3 +894,57 @@ async def test_automation_with_error_in_script(hass, caplog):
     hass.bus.async_fire('test_event')
     await hass.async_block_till_done()
     assert 'Service not found' in caplog.text
+
+@asyncio.coroutine
+def test_automation_restore_last_triggered_with_initial_state(hass):
+    """Ensure last_triggered is restored, even when initial state is set."""
+    time = dt_util.utcnow()
+
+    mock_restore_cache(hass, (
+        State('automation.hello', STATE_ON),
+        State('automation.bye', STATE_ON, {'last_triggered': time}),
+        State('automation.solong', STATE_OFF, {'last_triggered': time}),
+    ))
+
+    config = {automation.DOMAIN: [{
+        'alias': 'hello',
+        'initial_state': 'off',
+        'trigger': {
+            'platform': 'event',
+            'event_type': 'test_event',
+        },
+        'action': {'service': 'test.automation'}
+    }, {
+        'alias': 'bye',
+        'initial_state': 'off',
+        'trigger': {
+            'platform': 'event',
+            'event_type': 'test_event',
+        },
+        'action': {'service': 'test.automation'}
+    }, {
+        'alias': 'solong',
+        'initial_state': 'on',
+        'trigger': {
+            'platform': 'event',
+            'event_type': 'test_event',
+        },
+        'action': {'service': 'test.automation'}
+    }]}
+
+    assert (yield from async_setup_component(hass, automation.DOMAIN, config))
+
+    state = hass.states.get('automation.hello')
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get('last_triggered') is None
+
+    state = hass.states.get('automation.bye')
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get('last_triggered') == time
+
+    state = hass.states.get('automation.solong')
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes.get('last_triggered') == time

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -937,14 +937,14 @@ async def test_automation_restore_last_triggered_with_initial_state(hass):
     state = hass.states.get('automation.hello')
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get('last_triggered') is None
+    assert state.attributes['last_triggered'] is None
 
     state = hass.states.get('automation.bye')
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get('last_triggered') == time
+    assert state.attributes['last_triggered'] == time
 
     state = hass.states.get('automation.solong')
     assert state
     assert state.state == STATE_ON
-    assert state.attributes.get('last_triggered') == time
+    assert state.attributes['last_triggered'] == time


### PR DESCRIPTION
## Breaking Change:

When setting the startup state of automation using the `initial_state` setting, it would also mean that the `last_triggered` attribute of the automation was lost. This behavior has been solved. It can potentially break automations if you rely on it being reset on startup.

## Description:

Automations are restored from the state storage only when `initial_state` isn't set.
However, the `last_triggered` is also restored from the state storage.

The current logic, makes the `last_triggered` vanish when the user has set an `initial_state`.

This PR changes this behavior, by first trying to load the previous state from the state storage and later apply the `initial_state` override. This preserves the `last_triggered` attribute.


**Related issue (if applicable):** fixes #12672 (old closed, never resolved).

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**  n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
