### PR TITLE
Fix Netatmo thermostat out of range

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -140,7 +140,7 @@ class NetatmoThermostat(ClimateDevice):
             _LOGGER.error("Thermostat in %s not available", room_id)
 
         if self._module_type == NA_THERM:
-            self._operation_list = list(DICT_NETATMO_TO_HA)
+            self._operation_list = list(DICT_HA_TO_NETATMO)
             self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
 
     @property

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -122,7 +122,7 @@ class NetatmoThermostat(ClimateDevice):
         self._operation_mode = None
         self.update_without_throttle = False
         self._module_type = None
-        self._support_flags = None
+        self._support_flags = SUPPORT_FLAGS
 
         _LOGGER.debug(
             "Setting up thermostat %s in %s (%s).",
@@ -139,7 +139,6 @@ class NetatmoThermostat(ClimateDevice):
                 DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
                 DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
                 DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
-            self._support_flags = SUPPORT_FLAGS
         elif self._module_type == NA_THERM:
             self._operation_list = [
                 DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -131,23 +131,16 @@ class NetatmoThermostat(ClimateDevice):
         ]
 
         _LOGGER.debug(
-            "Setting up thermostat %s in %s (%s).",
+            "Setting up thermostat %s in %s (%s)",
             self._name, self._room_name, self._room_id
         )
         try:
             self._module_type = self._data.room_status[room_id]['module_type']
         except KeyError:
-            _LOGGER.error("Thermostat in %s not available.", room_id)
+            _LOGGER.error("Thermostat in %s not available", room_id)
 
         if self._module_type == NA_THERM:
-            self._operation_list = [
-                DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_OFF],
-            ]
+            self._operation_list = list(DICT_NETATMO_TO_HA)
             self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
 
     @property
@@ -178,6 +171,7 @@ class NetatmoThermostat(ClimateDevice):
                 self._room_name,
                 self._room_id
             )
+        return None
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -111,36 +111,40 @@ class NetatmoThermostat(ClimateDevice):
 
     def __init__(self, data, room_id):
         """Initialize the sensor."""
+        self._data = data
+        self._state = None
+        self._room_id = room_id
+        self._room_name = self._data.homedata.rooms[
+            self._data.home][room_id]['name']
+        self._name = 'netatmo_{}'.format(self._room_name)
+        self._target_temperature = None
+        self._away = None
+        self._operation_mode = None
+        self.update_without_throttle = False
+        self._module_type = None
+        self._support_flags = None
+
         try:
-            self._data = data
-            self._state = None
-            self._room_id = room_id
-            self._room_name = self._data.homedata.rooms[
-                self._data.home][room_id]['name']
-            self._name = 'netatmo_{}'.format(self._room_name)
-            self._target_temperature = None
-            self._away = None
             self._module_type = self._data.room_status[room_id]['module_type']
-            if self._module_type == NA_VALVE:
-                self._operation_list = [
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
-                self._support_flags = SUPPORT_FLAGS
-            elif self._module_type == NA_THERM:
-                self._operation_list = [
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
-                    DICT_NETATMO_TO_HA[STATE_NETATMO_OFF]]
-                self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
-            self._operation_mode = None
-            self.update_without_throttle = False
         except KeyError:
             _LOGGER.error("Thermostat in %s not available.", room_id)
+
+        if self._module_type == NA_VALVE:
+            self._operation_list = [
+                DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
+            self._support_flags = SUPPORT_FLAGS
+        elif self._module_type == NA_THERM:
+            self._operation_list = [
+                DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_OFF]]
+            self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
 
     @property
     def supported_features(self):

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -174,7 +174,7 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._data.room_status[self._room_id]['target_temperature']
+        return self._target_temperature
 
     @property
     def current_operation(self):

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -140,7 +140,7 @@ class NetatmoThermostat(ClimateDevice):
             self._operation_mode = None
             self.update_without_throttle = False
         except KeyError:
-            _LOGGER.error("Thermostat in %s (%s) not available.", room_id)
+            _LOGGER.error("Thermostat in %s not available.", room_id)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -123,6 +123,11 @@ class NetatmoThermostat(ClimateDevice):
         self.update_without_throttle = False
         self._module_type = None
         self._support_flags = SUPPORT_FLAGS
+        self._operation_list = [
+                DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
+                DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
 
         _LOGGER.debug(
             "Setting up thermostat %s in %s (%s).",
@@ -133,13 +138,7 @@ class NetatmoThermostat(ClimateDevice):
         except KeyError:
             _LOGGER.error("Thermostat in %s not available.", room_id)
 
-        if self._module_type == NA_VALVE:
-            self._operation_list = [
-                DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
-        elif self._module_type == NA_THERM:
+        if self._module_type == NA_THERM:
             self._operation_list = [
                 DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
                 DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -124,6 +124,10 @@ class NetatmoThermostat(ClimateDevice):
         self._module_type = None
         self._support_flags = None
 
+        _LOGGER.debug(
+            "Setting up thermostat %s in %s (%s).",
+            self._name, self._room_name, self._room_id
+        )
         try:
             self._module_type = self._data.room_status[room_id]['module_type']
         except KeyError:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -197,7 +197,9 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        module_type = self._data.room_status[self._room_id]['module_type']
+        if self._room_id not in self._data.room_status:
+            return {}
+        module_type = self._data.room_status[self._room_id].get('module_type')
         if module_type not in (NA_THERM, NA_VALVE):
             return {}
         state_attributes = {

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_HOMES = 'homes'
 CONF_ROOMS = 'rooms'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
 
 HOME_CONFIG_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
@@ -227,7 +227,7 @@ class NetatmoThermostat(ClimateDevice):
         """Return true if on."""
         if self.target_temperature:
             return self.target_temperature > 0
-        return None
+        return False
 
     def turn_away_mode_on(self):
         """Turn away on."""

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -115,9 +115,9 @@ class NetatmoThermostat(ClimateDevice):
             self._data = data
             self._state = None
             self._room_id = room_id
-            room_name = self._data.homedata.rooms[
+            self._room_name = self._data.homedata.rooms[
                 self._data.home][room_id]['name']
-            self._name = 'netatmo_{}'.format(room_name)
+            self._name = 'netatmo_{}'.format(self._room_name)
             self._target_temperature = None
             self._away = None
             self._module_type = self._data.room_status[room_id]['module_type']
@@ -140,8 +140,7 @@ class NetatmoThermostat(ClimateDevice):
             self._operation_mode = None
             self.update_without_throttle = False
         except KeyError:
-            _LOGGER.error("Thermostat in %s (%s) not available.",
-                          room_name, room_id)
+            _LOGGER.error("Thermostat in %s (%s) not available.", room_id)
 
     @property
     def supported_features(self):
@@ -161,7 +160,16 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._data.room_status[self._room_id]['current_temperature']
+        try:
+            return self._data.room_status[self._room_id]['current_temperature']
+        except KeyError:
+            _LOGGER.error(
+                "Current temperature could not be retrieved "
+                "for %s in %s (%s)",
+                self._name,
+                self._room_name,
+                self._room_id
+            )
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -124,10 +124,11 @@ class NetatmoThermostat(ClimateDevice):
         self._module_type = None
         self._support_flags = SUPPORT_FLAGS
         self._operation_list = [
-                DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
+            DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
+            DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
+            DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
+            DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
+        ]
 
         _LOGGER.debug(
             "Setting up thermostat %s in %s (%s).",
@@ -145,7 +146,8 @@ class NetatmoThermostat(ClimateDevice):
                 DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
                 DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
                 DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
-                DICT_NETATMO_TO_HA[STATE_NETATMO_OFF]]
+                DICT_NETATMO_TO_HA[STATE_NETATMO_OFF],
+            ]
             self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
 
     @property

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -299,12 +299,18 @@ class NetatmoThermostat(ClimateDevice):
             _LOGGER.error("NetatmoThermostat::update() "
                           "got exception.")
             return
-        self._target_temperature = \
-            self._data.room_status[self._room_id]['target_temperature']
-        self._operation_mode = DICT_NETATMO_TO_HA[
-            self._data.room_status[self._room_id]['setpoint_mode']]
-        self._away = self._operation_mode == DICT_NETATMO_TO_HA[
-            STATE_NETATMO_AWAY]
+        try:
+            self._target_temperature = \
+                self._data.room_status[self._room_id]['target_temperature']
+            self._operation_mode = DICT_NETATMO_TO_HA[
+                self._data.room_status[self._room_id]['setpoint_mode']]
+            self._away = self._operation_mode == DICT_NETATMO_TO_HA[
+                STATE_NETATMO_AWAY]
+        except KeyError:
+            _LOGGER.error(
+                "The thermostat in room %s seems to be out of reach.",
+                self._room_id
+            )
 
 
 class HomeData:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -225,7 +225,9 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def is_on(self):
         """Return true if on."""
-        return self.target_temperature > 0
+        if self.target_temperature:
+            return self.target_temperature > 0
+        return None
 
     def turn_away_mode_on(self):
         """Turn away on."""

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -111,30 +111,37 @@ class NetatmoThermostat(ClimateDevice):
 
     def __init__(self, data, room_id):
         """Initialize the sensor."""
-        self._data = data
-        self._state = None
-        self._room_id = room_id
-        room_name = self._data.homedata.rooms[self._data.home][room_id]['name']
-        self._name = 'netatmo_{}'.format(room_name)
-        self._target_temperature = None
-        self._away = None
-        self._module_type = self._data.room_status[room_id]['module_type']
-        if self._module_type == NA_VALVE:
-            self._operation_list = [DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
-            self._support_flags = SUPPORT_FLAGS
-        elif self._module_type == NA_THERM:
-            self._operation_list = [DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_OFF]]
-            self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
-        self._operation_mode = None
-        self.update_without_throttle = False
+        try:
+            self._data = data
+            self._state = None
+            self._room_id = room_id
+            room_name = self._data.homedata.rooms[
+                self._data.home][room_id]['name']
+            self._name = 'netatmo_{}'.format(room_name)
+            self._target_temperature = None
+            self._away = None
+            self._module_type = self._data.room_status[room_id]['module_type']
+            if self._module_type == NA_VALVE:
+                self._operation_list = [
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
+                self._support_flags = SUPPORT_FLAGS
+            elif self._module_type == NA_THERM:
+                self._operation_list = [
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
+                    DICT_NETATMO_TO_HA[STATE_NETATMO_OFF]]
+                self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
+            self._operation_mode = None
+            self.update_without_throttle = False
+        except KeyError:
+            _LOGGER.error("Thermostat in %s (%s) not available.",
+                          room_name, room_id)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -199,7 +199,8 @@ class NetatmoThermostat(ClimateDevice):
         """Return device specific state attributes."""
         if self._room_id not in self._data.room_status:
             return {}
-        module_type = self._data.room_status[self._room_id].get('module_type')
+        room_status = self._data.room_status[self._room_id]
+        module_type = room_status.get('module_type')
         if module_type not in (NA_THERM, NA_VALVE):
             return {}
         state_attributes = {
@@ -210,13 +211,13 @@ class NetatmoThermostat(ClimateDevice):
             "hg_temperature": self._data.hg_temperature,
             "operation_mode": self._operation_mode,
             "module_type": module_type,
-            "module_id": self._data.room_status[self._room_id]['module_id']
+            "module_id": room_status['module_id']
         }
         if module_type == NA_THERM:
             state_attributes["boiler_status"] = self._data.boilerstatus
         elif module_type == NA_VALVE:
             state_attributes["heating_power_request"] = \
-                self._data.room_status[self._room_id]['heating_power_request']
+                room_status['heating_power_request']
         return state_attributes
 
     @property

--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/components/netatmo",
   "requirements": [
-    "pyatmo==2.0.0"
+    "pyatmo==2.0.1"
   ],
   "dependencies": [
     "webhook"

--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/components/netatmo",
   "requirements": [
-    "pyatmo==2.0.1"
+    "pyatmo==2.1.0"
   ],
   "dependencies": [
     "webhook"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ pyalarmdotcom==0.3.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==2.0.1
+pyatmo==2.1.0
 
 # homeassistant.components.apple_tv
 pyatv==0.3.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ pyalarmdotcom==0.3.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==2.0.0
+pyatmo==2.0.1
 
 # homeassistant.components.apple_tv
 pyatv==0.3.12


### PR DESCRIPTION
## Description:
Catch KeyError when thermostat is out of network range.

**Related issue (if applicable):** fixes #24380

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
