### PR TITLE
Load the SSDP component only when it's needed

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -153,7 +153,8 @@ class DeconzFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered deCONZ bridge."""
-        from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
+        from homeassistant.components.ssdp import (
+            ATTR_MANUFACTURERURL, ATTR_SERIAL)
 
         if discovery_info[ATTR_MANUFACTURERURL] != DECONZ_MANUFACTURERURL:
             return self.async_abort(reason='not_deconz_bridge')

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -9,7 +9,6 @@ from pydeconz.utils import (
     async_discovery, async_get_api_key, async_get_bridgeid)
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -154,6 +153,8 @@ class DeconzFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered deCONZ bridge."""
+        from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
+
         if discovery_info[ATTR_MANUFACTURERURL] != DECONZ_MANUFACTURERURL:
             return self.async_abort(reason='not_deconz_bridge')
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -8,7 +8,6 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import ATTR_MANUFACTURERURL
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
@@ -146,6 +145,8 @@ class HueFlowHandler(config_entries.ConfigFlow):
         This flow is triggered by the SSDP component. It will check if the
         host is already configured and delegate to the import step if not.
         """
+        from homeassistant.components.ssdp import ATTR_MANUFACTURERURL
+
         if discovery_info[ATTR_MANUFACTURERURL] != HUE_MANUFACTURERURL:
             return self.async_abort(reason='not_hue_bridge')
 

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import asyncio
 
 from homeassistant.components.deconz import config_flow
+from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
 from tests.common import MockConfigEntry
 
 import pydeconz
@@ -175,8 +176,8 @@ async def test_bridge_ssdp_discovery(hass):
         data={
             config_flow.CONF_HOST: '1.2.3.4',
             config_flow.CONF_PORT: 80,
-            config_flow.ATTR_SERIAL: 'id',
-            config_flow.ATTR_MANUFACTURERURL:
+            ATTR_SERIAL: 'id',
+            ATTR_MANUFACTURERURL:
                 config_flow.DECONZ_MANUFACTURERURL,
             config_flow.ATTR_UUID: 'uuid:1234'
         },
@@ -192,7 +193,7 @@ async def test_bridge_ssdp_discovery_not_deconz_bridge(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         data={
-            config_flow.ATTR_MANUFACTURERURL: 'not deconz bridge'
+            ATTR_MANUFACTURERURL: 'not deconz bridge'
         },
         context={'source': 'ssdp'}
     )
@@ -217,8 +218,8 @@ async def test_bridge_discovery_update_existing_entry(hass):
         config_flow.DOMAIN,
         data={
             config_flow.CONF_HOST: 'mock-deconz',
-            config_flow.ATTR_SERIAL: 'id',
-            config_flow.ATTR_MANUFACTURERURL:
+            ATTR_SERIAL: 'id',
+            ATTR_MANUFACTURERURL:
                 config_flow.DECONZ_MANUFACTURERURL,
             config_flow.ATTR_UUID: 'uuid:1234'
         },


### PR DESCRIPTION
## Description:

Load the SSP module only when it's necessary. This change broke all Home-Assistant with the `hue` component without the discovery/ssdp.

**Related issue (if applicable):** fixes #24419

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
