### PR TITLE
Add default config to constraint file

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,21 +1,29 @@
+PyJWT==1.7.1
+PyNaCl==1.3.0
 aiohttp==3.5.4
+aiohttp_cors==0.7.0
 astral==1.10.1
 async_timeout==3.0.1
 attrs==19.1.0
 bcrypt==3.1.6
 certifi>=2018.04.16
+cryptography==2.6.1
+distro==1.4.0
+hass-nabucasa==0.13
+home-assistant-frontend==20190604.0
 importlib-metadata==0.15
 jinja2>=2.10
-PyJWT==1.7.1
-cryptography==2.6.1
+netdisco==2.6.0
 pip>=8.0.3
 python-slugify==3.0.2
 pytz>=2019.01
 pyyaml>=3.13,<4
 requests==2.22.0
 ruamel.yaml==0.15.97
-voluptuous==0.11.5
+sqlalchemy==1.3.3
 voluptuous-serialize==2.1.0
+voluptuous==0.11.5
+zeroconf==0.23.0
 
 pycryptodome>=3.6.6
 
@@ -27,7 +35,3 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
-
-# Newer version causes pylint to take forever
-# https://github.com/timothycrosley/isort/issues/848
-isort==4.3.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Generate an updated requirements_all.txt."""
-import fnmatch
 import importlib
 import os
 import pathlib
@@ -155,13 +154,6 @@ TEST_REQUIREMENTS = (
     'bellows-homeassistant',
 )
 
-IGNORE_PACKAGES = (
-    'homeassistant.components.hangouts.hangups_utils',
-    'homeassistant.components.cloud.client',
-    'homeassistant.components.homekit.*',
-    'homeassistant.components.recorder.models',
-)
-
 IGNORE_PIN = ('colorlog>2.1,<3', 'keyring>=9.3,<10.0', 'urllib3')
 
 IGNORE_REQ = (
@@ -185,10 +177,6 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
-
-# Newer version causes pylint to take forever
-# https://github.com/timothycrosley/isort/issues/848
-isort==4.3.4
 """
 
 
@@ -216,6 +204,22 @@ def core_requirements():
         reqs_raw = re.search(
             r'REQUIRES = \[(.*?)\]', inp.read(), re.S).group(1)
     return re.findall(r"'(.*?)'", reqs_raw)
+
+
+def gather_recursive_requirements(domain, seen=None):
+    """Recursively gather requirements from a module."""
+    if seen is None:
+        seen = set()
+
+    seen.add(domain)
+    integration = Integration(pathlib.Path(
+        'homeassistant/components/{}'.format(domain)
+    ))
+    integration.load_manifest()
+    reqs = set(integration.manifest['requirements'])
+    for dep_domain in integration.manifest['dependencies']:
+        reqs.update(gather_recursive_requirements(dep_domain, seen))
+    return reqs
 
 
 def comment_requirement(req):
@@ -274,12 +278,8 @@ def gather_requirements_from_modules(errors, reqs):
         try:
             module = importlib.import_module(package)
         except ImportError as err:
-            for pattern in IGNORE_PACKAGES:
-                if fnmatch.fnmatch(package, pattern):
-                    break
-            else:
-                print("{}: {}".format(package.replace('.', '/') + '.py', err))
-                errors.append(package)
+            print("{}: {}".format(package.replace('.', '/') + '.py', err))
+            errors.append(package)
             continue
 
         if getattr(module, 'REQUIREMENTS', None):
@@ -347,7 +347,8 @@ def requirements_test_output(reqs):
 
 def gather_constraints():
     """Construct output for constraint file."""
-    return '\n'.join(core_requirements() + [''])
+    return '\n'.join(sorted(core_requirements() + list(
+        gather_recursive_requirements('default_config'))) + [''])
 
 
 def write_requirements_file(data):


### PR DESCRIPTION
## Description:
We use a constraint file to guarantee that certain versions of certain packages are installed. This PR changes the content of this file from being limited to Home Assistant core, to also include the requirements from the default config.

**Related issue (if applicable):** fixes #24359

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
