### PR TITLE
Minor improvements to automation test suite

### DIFF
--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -9,8 +9,7 @@ import homeassistant.components.automation as automation
 from tests.common import async_mock_service, mock_coro
 
 
-@asyncio.coroutine
-def test_if_fires_on_hass_start(hass):
+async def test_if_fires_on_hass_start(hass):
     """Test the firing when HASS starts."""
     calls = async_mock_service(hass, 'test', 'automation')
     hass.state = CoreState.not_running
@@ -27,31 +26,29 @@ def test_if_fires_on_hass_start(hass):
         }
     }
 
-    res = yield from async_setup_component(hass, automation.DOMAIN, config)
-    assert res
+    assert await async_setup_component(hass, automation.DOMAIN, config)
     assert automation.is_on(hass, 'automation.hello')
     assert len(calls) == 0
 
-    yield from hass.async_start()
+    await hass.async_start()
     assert automation.is_on(hass, 'automation.hello')
     assert len(calls) == 1
 
     with patch('homeassistant.config.async_hass_config_yaml',
                Mock(return_value=mock_coro(config))):
-        yield from hass.services.async_call(
+        await hass.services.async_call(
             automation.DOMAIN, automation.SERVICE_RELOAD, blocking=True)
 
     assert automation.is_on(hass, 'automation.hello')
     assert len(calls) == 1
 
 
-@asyncio.coroutine
-def test_if_fires_on_hass_shutdown(hass):
+async def test_if_fires_on_hass_shutdown(hass):
     """Test the firing when HASS starts."""
     calls = async_mock_service(hass, 'test', 'automation')
     hass.state = CoreState.not_running
 
-    res = yield from async_setup_component(hass, automation.DOMAIN, {
+    assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'trigger': {
@@ -63,22 +60,13 @@ def test_if_fires_on_hass_shutdown(hass):
             }
         }
     })
-    assert res
     assert automation.is_on(hass, 'automation.hello')
     assert len(calls) == 0
 
-    yield from hass.async_start()
+    await hass.async_start()
     assert automation.is_on(hass, 'automation.hello')
     assert len(calls) == 0
 
     with patch.object(hass.loop, 'stop'):
-        yield from hass.async_stop()
+        await hass.async_stop()
     assert len(calls) == 1
-
-    # with patch('homeassistant.config.async_hass_config_yaml',
-    #            Mock(return_value=mock_coro(config))):
-    #     yield from hass.services.async_call(
-    #         automation.DOMAIN, automation.SERVICE_RELOAD, blocking=True)
-
-    # assert automation.is_on(hass, 'automation.hello')
-    # assert len(calls) == 1

--- a/tests/components/automation/test_homeassistant.py
+++ b/tests/components/automation/test_homeassistant.py
@@ -1,5 +1,4 @@
 """The tests for the Event automation."""
-import asyncio
 from unittest.mock import patch, Mock
 
 from homeassistant.core import CoreState

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -616,8 +616,7 @@ async def test_reload_config_handles_load_fails(hass, calls):
     assert len(calls) == 2
 
 
-@asyncio.coroutine
-def test_automation_restore_state(hass):
+async def test_automation_restore_state(hass):
     """Ensure states are restored on startup."""
     time = dt_util.utcnow()
 
@@ -642,39 +641,39 @@ def test_automation_restore_state(hass):
         'action': {'service': 'test.automation'}
     }]}
 
-    assert (yield from async_setup_component(hass, automation.DOMAIN, config))
+    assert await async_setup_component(hass, automation.DOMAIN, config)
 
     state = hass.states.get('automation.hello')
     assert state
     assert state.state == STATE_ON
+    assert state.attributes['last_triggered'] is None
 
     state = hass.states.get('automation.bye')
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get('last_triggered') == time
+    assert state.attributes['last_triggered'] == time
 
     calls = async_mock_service(hass, 'test', 'automation')
 
     assert automation.is_on(hass, 'automation.bye') is False
 
     hass.bus.async_fire('test_event_bye')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(calls) == 0
 
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event_hello')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(calls) == 1
 
 
-@asyncio.coroutine
-def test_initial_value_off(hass):
+async def test_initial_value_off(hass):
     """Test initial value off."""
     calls = async_mock_service(hass, 'test', 'automation')
 
-    res = yield from async_setup_component(hass, automation.DOMAIN, {
+    res = await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'initial_state': 'off',
@@ -692,7 +691,7 @@ def test_initial_value_off(hass):
     assert not automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(calls) == 0
 
 
@@ -753,15 +752,14 @@ async def test_initial_value_off_but_restore_on(hass):
     assert len(calls) == 0
 
 
-@asyncio.coroutine
-def test_initial_value_on_but_restore_off(hass):
+async def test_initial_value_on_but_restore_off(hass):
     """Test initial value on and restored state is turned off."""
     calls = async_mock_service(hass, 'test', 'automation')
     mock_restore_cache(hass, (
         State('automation.hello', STATE_OFF),
     ))
 
-    res = yield from async_setup_component(hass, automation.DOMAIN, {
+    res = await  async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'initial_state': 'on',
@@ -779,19 +777,18 @@ def test_initial_value_on_but_restore_off(hass):
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(calls) == 1
 
 
-@asyncio.coroutine
-def test_no_initial_value_and_restore_off(hass):
+async def test_no_initial_value_and_restore_off(hass):
     """Test initial value off and restored state is turned on."""
     calls = async_mock_service(hass, 'test', 'automation')
     mock_restore_cache(hass, (
         State('automation.hello', STATE_OFF),
     ))
 
-    res = yield from async_setup_component(hass, automation.DOMAIN, {
+    res = await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'trigger': {
@@ -808,16 +805,15 @@ def test_no_initial_value_and_restore_off(hass):
     assert not automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(calls) == 0
 
 
-@asyncio.coroutine
-def test_automation_is_on_if_no_initial_state_or_restore(hass):
+async def test_automation_is_on_if_no_initial_state_or_restore(hass):
     """Test initial value is on when no initial state or restored state."""
     calls = async_mock_service(hass, 'test', 'automation')
 
-    res = yield from async_setup_component(hass, automation.DOMAIN, {
+    res = await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'trigger': {
@@ -834,17 +830,16 @@ def test_automation_is_on_if_no_initial_state_or_restore(hass):
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(calls) == 1
 
 
-@asyncio.coroutine
-def test_automation_not_trigger_on_bootstrap(hass):
+async def test_automation_not_trigger_on_bootstrap(hass):
     """Test if automation is not trigger on bootstrap."""
     hass.state = CoreState.not_running
     calls = async_mock_service(hass, 'test', 'automation')
 
-    res = yield from async_setup_component(hass, automation.DOMAIN, {
+    res = await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'trigger': {
@@ -861,15 +856,15 @@ def test_automation_not_trigger_on_bootstrap(hass):
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(calls) == 0
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(calls) == 1
     assert ['hello.world'] == calls[0].data.get(ATTR_ENTITY_ID)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the automation component."""
-import asyncio
 from datetime import timedelta
 from unittest.mock import patch, Mock
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -672,7 +672,7 @@ async def test_initial_value_off(hass):
     """Test initial value off."""
     calls = async_mock_service(hass, 'test', 'automation')
 
-    res = await async_setup_component(hass, automation.DOMAIN, {
+    assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'initial_state': 'off',
@@ -686,7 +686,6 @@ async def test_initial_value_off(hass):
             }
         }
     })
-    assert res
     assert not automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
@@ -758,7 +757,7 @@ async def test_initial_value_on_but_restore_off(hass):
         State('automation.hello', STATE_OFF),
     ))
 
-    res = await  async_setup_component(hass, automation.DOMAIN, {
+    assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'initial_state': 'on',
@@ -772,7 +771,6 @@ async def test_initial_value_on_but_restore_off(hass):
             }
         }
     })
-    assert res
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
@@ -787,7 +785,7 @@ async def test_no_initial_value_and_restore_off(hass):
         State('automation.hello', STATE_OFF),
     ))
 
-    res = await async_setup_component(hass, automation.DOMAIN, {
+    assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'trigger': {
@@ -800,7 +798,6 @@ async def test_no_initial_value_and_restore_off(hass):
             }
         }
     })
-    assert res
     assert not automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
@@ -812,7 +809,7 @@ async def test_automation_is_on_if_no_initial_state_or_restore(hass):
     """Test initial value is on when no initial state or restored state."""
     calls = async_mock_service(hass, 'test', 'automation')
 
-    res = await async_setup_component(hass, automation.DOMAIN, {
+    assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'trigger': {
@@ -825,7 +822,6 @@ async def test_automation_is_on_if_no_initial_state_or_restore(hass):
             }
         }
     })
-    assert res
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')
@@ -838,7 +834,7 @@ async def test_automation_not_trigger_on_bootstrap(hass):
     hass.state = CoreState.not_running
     calls = async_mock_service(hass, 'test', 'automation')
 
-    res = await async_setup_component(hass, automation.DOMAIN, {
+    assert await async_setup_component(hass, automation.DOMAIN, {
         automation.DOMAIN: {
             'alias': 'hello',
             'trigger': {
@@ -851,7 +847,6 @@ async def test_automation_not_trigger_on_bootstrap(hass):
             }
         }
     })
-    assert res
     assert automation.is_on(hass, 'automation.hello')
 
     hass.bus.async_fire('test_event')


### PR DESCRIPTION
## Description:

Some minor improvements to the automation component test suite:

- Removed (2 year old) commented out code in test
- Converted all tests to async/await
- `test_automation_restore_state` stricter checking on `last_triggered` attribute, including extra assert to guarantee it didn't restore `last_triggered `attribute value.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
