### PR TITLE
Add attributs and fix lightlevel inconsistency for LightLevel sensor

### DIFF
--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -40,14 +40,17 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
         # scale used because the human eye adjusts to light levels and small
         # changes at low lux levels are more noticeable than at high lux
         # levels.
-        return 10 ** ((self.sensor.lightlevel - 1) / 10000)
+        return round(float(10 ** ((self.sensor.lightlevel - 1) / 10000)), 2)
 
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
         attributes = super().device_state_attributes
         attributes.update({
-            "threshold_dark": self.sensor.tholddark,
+            "lightlevel": self.sensor.lightlevel,
+            "daylight": self.sensor.daylight,
+            "dark": self.sensor.dark,
+            "threshold_dark": self.sensor.tholddark,	    
             "threshold_offset": self.sensor.tholdoffset,
         })
         return attributes

--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -50,7 +50,7 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
             "lightlevel": self.sensor.lightlevel,
             "daylight": self.sensor.daylight,
             "dark": self.sensor.dark,
-            "threshold_dark": self.sensor.tholddark,    
+            "threshold_dark": self.sensor.tholddark,
             "threshold_offset": self.sensor.tholdoffset,
         })
         return attributes

--- a/homeassistant/components/hue/sensor.py
+++ b/homeassistant/components/hue/sensor.py
@@ -50,7 +50,7 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
             "lightlevel": self.sensor.lightlevel,
             "daylight": self.sensor.daylight,
             "dark": self.sensor.dark,
-            "threshold_dark": self.sensor.tholddark,	    
+            "threshold_dark": self.sensor.tholddark,    
             "threshold_offset": self.sensor.tholdoffset,
         })
         return attributes


### PR DESCRIPTION
## Description:

Add lightlevel , dark and daylight attributs
Fix lightlevel inconsistency

**Related issue (if applicable):** fixes #23503

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
