### PR TITLE
Add last_updated and id for ZLLSensor

### DIFF
--- a/homeassistant/components/hue/sensor_base.py
+++ b/homeassistant/components/hue/sensor_base.py
@@ -280,5 +280,7 @@ class GenericZLLSensor(GenericHueSensor):
     def device_state_attributes(self):
         """Return the device state attributes."""
         return {
-            "battery_level": self.sensor.battery
+            "battery_level": self.sensor.battery,
+            "last_updated": self.sensor.state['lastupdated'],
+            "hue_id": self.sensor.id
         }


### PR DESCRIPTION
## Description:
Add last_updated and id attributs for Generic ZLLSensor
the hue ID is used to execute rest commands from Home Assistant scripts or automata

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
