### PR TITLE
Axis discovery MAC filter

### DIFF
--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -14,6 +14,8 @@ from .const import CONF_MODEL, DOMAIN
 from .device import get_device
 from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
 
+AXIS_OUI = {'00408C', 'ACCC8E'}
+
 CONFIG_FILE = 'axis.conf'
 
 EVENT_TYPES = ['motion', 'vmd3', 'pir', 'sound',
@@ -151,10 +153,15 @@ class AxisFlowHandler(config_entries.ConfigFlow):
 
         This flow is triggered by the discovery component.
         """
+        serialnumber = discovery_info['properties']['macaddress']
+        print(serialnumber)
+        if serialnumber[:6] not in AXIS_OUI:
+            print('NOT')
+            return self.async_abort(reason='link_local_address')
+
         if discovery_info[CONF_HOST].startswith('169.254'):
             return self.async_abort(reason='link_local_address')
 
-        serialnumber = discovery_info['properties']['macaddress']
         # pylint: disable=unsupported-assignment-operation
         self.context['macaddress'] = serialnumber
 

--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -14,7 +14,7 @@ from .const import CONF_MODEL, DOMAIN
 from .device import get_device
 from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
 
-AXIS_OUI = {'00408C', 'ACCC8E'}
+AXIS_OUI = {'00408C', 'ACCC8E', 'B8A44F'}
 
 CONFIG_FILE = 'axis.conf'
 
@@ -154,10 +154,9 @@ class AxisFlowHandler(config_entries.ConfigFlow):
         This flow is triggered by the discovery component.
         """
         serialnumber = discovery_info['properties']['macaddress']
-        print(serialnumber)
+
         if serialnumber[:6] not in AXIS_OUI:
-            print('NOT')
-            return self.async_abort(reason='link_local_address')
+            return self.async_abort(reason='not_axis_device')
 
         if discovery_info[CONF_HOST].startswith('169.254'):
             return self.async_abort(reason='link_local_address')

--- a/homeassistant/components/axis/strings.json
+++ b/homeassistant/components/axis/strings.json
@@ -21,7 +21,8 @@
         "abort": {
             "already_configured": "Device is already configured",
             "bad_config_file": "Bad data from config file",
-            "link_local_address": "Link local addresses are not supported"
+            "link_local_address": "Link local addresses are not supported",
+            "not_axis_device": "Discovered device not a Axis device"
         }
     }
 }

--- a/homeassistant/components/axis/strings.json
+++ b/homeassistant/components/axis/strings.json
@@ -22,7 +22,7 @@
             "already_configured": "Device is already configured",
             "bad_config_file": "Bad data from config file",
             "link_local_address": "Link local addresses are not supported",
-            "not_axis_device": "Discovered device not a Axis device"
+            "not_axis_device": "Discovered device not an Axis device"
         }
     }
 }

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -169,7 +169,7 @@ async def test_zeroconf_flow(hass):
             data={
                 config_flow.CONF_HOST: '1.2.3.4',
                 config_flow.CONF_PORT: 80,
-                'properties': {'macaddress': '1234'}
+                'properties': {'macaddress': '00408C12345'}
             },
             context={'source': 'zeroconf'}
         )
@@ -184,7 +184,7 @@ async def test_zeroconf_flow_known_device(hass):
     This is legacy support from devices registered with configurator.
     """
     with patch('homeassistant.components.axis.config_flow.load_json',
-               return_value={'1234ABCD': {
+               return_value={'00408C12345': {
                    config_flow.CONF_HOST: '2.3.4.5',
                    config_flow.CONF_USERNAME: 'user',
                    config_flow.CONF_PASSWORD: 'pass',
@@ -208,7 +208,7 @@ async def test_zeroconf_flow_known_device(hass):
                 config_flow.CONF_HOST: '1.2.3.4',
                 config_flow.CONF_PORT: 80,
                 'hostname': 'name',
-                'properties': {'macaddress': '1234ABCD'}
+                'properties': {'macaddress': '00408C12345'}
             },
             context={'source': 'zeroconf'}
         )
@@ -221,7 +221,7 @@ async def test_zeroconf_flow_already_configured(hass):
     entry = MockConfigEntry(
         domain=axis.DOMAIN,
         data={axis.CONF_DEVICE: {axis.config_flow.CONF_HOST: '1.2.3.4'},
-              axis.config_flow.CONF_MAC: '1234ABCD'}
+              axis.config_flow.CONF_MAC: '00408C12345'}
     )
     entry.add_to_hass(hass)
 
@@ -233,7 +233,7 @@ async def test_zeroconf_flow_already_configured(hass):
             config_flow.CONF_PASSWORD: 'pass',
             config_flow.CONF_PORT: 80,
             'hostname': 'name',
-            'properties': {'macaddress': '1234ABCD'}
+            'properties': {'macaddress': '00408C12345'}
         },
         context={'source': 'zeroconf'}
     )
@@ -242,11 +242,29 @@ async def test_zeroconf_flow_already_configured(hass):
     assert result['reason'] == 'already_configured'
 
 
+async def test_zeroconf_flow_ignore_non_axis_device(hass):
+    """Test that zeroconf doesn't setup devices with link local addresses."""
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        data={
+            config_flow.CONF_HOST: '169.254.3.4',
+            'properties': {'macaddress': '01234567890'}
+        },
+        context={'source': 'zeroconf'}
+    )
+
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'not_axis_device'
+
+
 async def test_zeroconf_flow_ignore_link_local_address(hass):
     """Test that zeroconf doesn't setup devices with link local addresses."""
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        data={config_flow.CONF_HOST: '169.254.3.4'},
+        data={
+            config_flow.CONF_HOST: '169.254.3.4',
+            'properties': {'macaddress': '00408C12345'}
+        },
         context={'source': 'zeroconf'}
     )
 
@@ -257,7 +275,7 @@ async def test_zeroconf_flow_ignore_link_local_address(hass):
 async def test_zeroconf_flow_bad_config_file(hass):
     """Test that zeroconf discovery with bad config files abort."""
     with patch('homeassistant.components.axis.config_flow.load_json',
-               return_value={'1234ABCD': {
+               return_value={'00408C12345': {
                    config_flow.CONF_HOST: '2.3.4.5',
                    config_flow.CONF_USERNAME: 'user',
                    config_flow.CONF_PASSWORD: 'pass',
@@ -268,7 +286,7 @@ async def test_zeroconf_flow_bad_config_file(hass):
             config_flow.DOMAIN,
             data={
                 config_flow.CONF_HOST: '1.2.3.4',
-                'properties': {'macaddress': '1234ABCD'}
+                'properties': {'macaddress': '00408C12345'}
             },
             context={'source': 'zeroconf'}
         )


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Axis config flow ignores OUI that is not registered by Axis communications

**Related issue (if applicable):** fixes #24411, #19837

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
