### PR TITLE
Remember gpslogger entities across restarts (fixes #24432)

### DIFF
--- a/homeassistant/components/gpslogger/__init__.py
+++ b/homeassistant/components/gpslogger/__init__.py
@@ -11,19 +11,21 @@ from homeassistant.const import HTTP_UNPROCESSABLE_ENTITY, \
 from homeassistant.helpers import config_entry_flow
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    ATTR_ALTITUDE,
+    ATTR_ACCURACY,
+    ATTR_ACTIVITY,
+    ATTR_DEVICE,
+    ATTR_DIRECTION,
+    ATTR_PROVIDER,
+    ATTR_SPEED,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 TRACKER_UPDATE = '{}_tracker_update'.format(DOMAIN)
 
-ATTR_ALTITUDE = 'altitude'
-ATTR_ACCURACY = 'accuracy'
-ATTR_ACTIVITY = 'activity'
-ATTR_DEVICE = 'device'
-ATTR_DIRECTION = 'direction'
-ATTR_PROVIDER = 'provider'
-ATTR_SPEED = 'speed'
 
 DEFAULT_ACCURACY = 200
 DEFAULT_BATTERY = -1

--- a/homeassistant/components/gpslogger/const.py
+++ b/homeassistant/components/gpslogger/const.py
@@ -1,3 +1,11 @@
 """Const for GPSLogger."""
 
 DOMAIN = 'gpslogger'
+
+ATTR_ALTITUDE = 'altitude'
+ATTR_ACCURACY = 'accuracy'
+ATTR_ACTIVITY = 'activity'
+ATTR_DEVICE = 'device'
+ATTR_DIRECTION = 'direction'
+ATTR_PROVIDER = 'provider'
+ATTR_SPEED = 'speed'

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -2,14 +2,31 @@
 import logging
 
 from homeassistant.core import callback
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL,
+    ATTR_GPS_ACCURACY,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+)
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.components.device_tracker.config_entry import (
     DeviceTrackerEntity
 )
+from homeassistant.helpers import device_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as GPL_DOMAIN, TRACKER_UPDATE
+from .const import (
+    ATTR_ACCURACY,
+    ATTR_ACTIVITY,
+    ATTR_ALTITUDE,
+    ATTR_DEVICE,
+    ATTR_DIRECTION,
+    ATTR_PROVIDER,
+    ATTR_SPEED,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,8 +49,27 @@ async def async_setup_entry(hass: HomeAssistantType, entry,
     hass.data[GPL_DOMAIN]['unsub_device_tracker'][entry.entry_id] = \
         async_dispatcher_connect(hass, TRACKER_UPDATE, _receive_data)
 
+    # Restore previously loaded devices
+    dev_reg = await device_registry.async_get_registry(hass)
+    dev_ids = {
+        identifier[1]
+        for device in dev_reg.devices.values()
+        for identifier in device.identifiers
+        if identifier[0] == GPL_DOMAIN
+    }
+    if not dev_ids:
+        return
 
-class GPSLoggerEntity(DeviceTrackerEntity):
+    entities = []
+    for dev_id in dev_ids:
+        hass.data[GPL_DOMAIN]['devices'].add(dev_id)
+        entity = GPSLoggerEntity(dev_id, None, None, None, None)
+        entities.append(entity)
+
+    async_add_entities(entities)
+
+
+class GPSLoggerEntity(DeviceTrackerEntity, RestoreEntity):
     """Represent a tracked device."""
 
     def __init__(
@@ -102,11 +138,49 @@ class GPSLoggerEntity(DeviceTrackerEntity):
 
     async def async_added_to_hass(self):
         """Register state update callback."""
+        await super().async_added_to_hass()
         self._unsub_dispatcher = async_dispatcher_connect(
             self.hass, TRACKER_UPDATE, self._async_receive_data)
 
+        # don't restore if we got created with data
+        if self._location is not None:
+            return
+
+        state = await self.async_get_last_state()
+        if state is None:
+            # XXX: first restore after upgrade fill with dummy data;
+            # is there a better way to handle this?
+            self._location = (0, 0)
+            self._accuracy = 1e100
+            self._attributes = {
+                ATTR_ALTITUDE: None,
+                ATTR_ACTIVITY: None,
+                ATTR_DIRECTION: None,
+                ATTR_PROVIDER: None,
+                ATTR_SPEED: None,
+            }
+            self._battery = None
+            return
+
+        attr = state.attributes
+        self._location = (
+            attr.get(ATTR_LATITUDE),
+            attr.get(ATTR_LONGITUDE),
+        )
+        self._accuracy = attr.get(ATTR_GPS_ACCURACY)
+        self._attributes = {
+            ATTR_ALTITUDE: attr.get(ATTR_ALTITUDE),
+            ATTR_ACTIVITY: attr.get(ATTR_ACTIVITY),
+            ATTR_DIRECTION: attr.get(ATTR_DIRECTION),
+            ATTR_PROVIDER: attr.get(ATTR_PROVIDER),
+            ATTR_SPEED: attr.get(ATTR_SPEED),
+        }
+        self._battery = attr.get(ATTR_BATTERY_LEVEL)
+
+
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""
+        await super().async_will_remove_from_hass()
         self._unsub_dispatcher()
 
     @callback

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -19,10 +19,8 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 from . import DOMAIN as GPL_DOMAIN, TRACKER_UPDATE
 from .const import (
-    ATTR_ACCURACY,
     ATTR_ACTIVITY,
     ATTR_ALTITUDE,
-    ATTR_DEVICE,
     ATTR_DIRECTION,
     ATTR_PROVIDER,
     ATTR_SPEED,
@@ -151,7 +149,7 @@ class GPSLoggerEntity(DeviceTrackerEntity, RestoreEntity):
             # XXX: first restore after upgrade fill with dummy data;
             # is there a better way to handle this?
             self._location = (0, 0)
-            self._accuracy = 1e100
+            self._accuracy = 1
             self._attributes = {
                 ATTR_ALTITUDE: None,
                 ATTR_ACTIVITY: None,
@@ -176,7 +174,6 @@ class GPSLoggerEntity(DeviceTrackerEntity, RestoreEntity):
             ATTR_SPEED: attr.get(ATTR_SPEED),
         }
         self._battery = attr.get(ATTR_BATTERY_LEVEL)
-
 
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""

--- a/homeassistant/components/gpslogger/device_tracker.py
+++ b/homeassistant/components/gpslogger/device_tracker.py
@@ -146,10 +146,8 @@ class GPSLoggerEntity(DeviceTrackerEntity, RestoreEntity):
 
         state = await self.async_get_last_state()
         if state is None:
-            # XXX: first restore after upgrade fill with dummy data;
-            # is there a better way to handle this?
-            self._location = (0, 0)
-            self._accuracy = 1
+            self._location = (None, None)
+            self._accuracy = None
             self._attributes = {
                 ATTR_ALTITUDE: None,
                 ATTR_ACTIVITY: None,


### PR DESCRIPTION
## Breaking Change

For the first restart device trackers will have a bogus location, because... well I didn't know any better  ;-)
Maybe I'll have some more time tomorrow to investigate a bit further, but since this seems to affect other people I thought I'd just put it out there for people who are inclined to experiment

**Related issue (if applicable):** fixes #24432

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html

I hope it's ok to put out an unfinished/experimental PR, it should at least give people something to start from if they want to take a stab at the same issue