### PR TITLE
Life360: Fix config entry handling for imported accounts

### DIFF
--- a/homeassistant/components/life360/__init__.py
+++ b/homeassistant/components/life360/__init__.py
@@ -121,11 +121,36 @@ CONFIG_SCHEMA = vol.Schema({
 def setup(hass, config):
     """Set up integration."""
     conf = config.get(DOMAIN, LIFE360_SCHEMA({}))
-    hass.data[DOMAIN] = {'config': conf, 'apis': []}
+    hass.data[DOMAIN] = {'config': conf, 'apis': {}}
     discovery.load_platform(hass, DEVICE_TRACKER, DOMAIN, None, config)
 
-    if CONF_ACCOUNTS in conf:
+    if CONF_ACCOUNTS not in conf:
+        return True
+
+    # Check existing config entries. For any that correspond to an entry in
+    # configuration.yaml, and whose password has not changed, nothing needs to
+    # be done with that config entry or that account from configuration.yaml.
+    # But if the config entry was created by import and the account no longer
+    # exists in configuration.yaml, or if the password has changed, then delete
+    # that out-of-date config entry.
+    already_configured = []
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        # Find corresponding configuration.yaml entry and its password.
+        password = None
         for account in conf[CONF_ACCOUNTS]:
+            if account[CONF_USERNAME] == entry.data[CONF_USERNAME]:
+                password = account[CONF_PASSWORD]
+        if password == entry.data[CONF_PASSWORD]:
+            already_configured.append(entry.data[CONF_USERNAME])
+            continue
+        if (not password and entry.source == config_entries.SOURCE_IMPORT
+                or password and password != entry.data[CONF_PASSWORD]):
+            hass.async_create_task(hass.config_entries.async_remove(
+                entry.entry_id))
+
+    # Create config entries for accounts listed in configuration.
+    for account in conf[CONF_ACCOUNTS]:
+        if account[CONF_USERNAME] not in already_configured:
             hass.async_create_task(hass.config_entries.flow.async_init(
                 DOMAIN, context={'source': config_entries.SOURCE_IMPORT},
                 data=account))
@@ -134,6 +159,15 @@ def setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up config entry."""
-    hass.data[DOMAIN]['apis'].append(
-        get_api(entry.data[CONF_AUTHORIZATION]))
+    hass.data[DOMAIN]['apis'][entry.data[CONF_USERNAME]] = get_api(
+        entry.data[CONF_AUTHORIZATION])
     return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload config entry."""
+    try:
+        hass.data[DOMAIN]['apis'].pop(entry.data[CONF_USERNAME])
+        return True
+    except KeyError:
+        return False

--- a/homeassistant/components/life360/config_flow.py
+++ b/homeassistant/components/life360/config_flow.py
@@ -82,9 +82,6 @@ class Life360ConfigFlow(config_entries.ConfigFlow):
         """Import a config flow from configuration."""
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
-        if username in self.configured_usernames:
-            _LOGGER.warning('%s already configured', username)
-            return self.async_abort(reason='user_already_configured')
         try:
             authorization = self._api.get_authorization(username, password)
         except LoginError:

--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -305,7 +305,7 @@ class Life360Scanner:
         circles_updated = []
         members_updated = []
 
-        for api in self._apis:
+        for api in self._apis.values():
             err_key = 'get_circles'
             try:
                 circles = api.get_circles()


### PR DESCRIPTION
## Description:
When importing Life360 accounts from configuration.yaml not all scenarios were handled properly.

1. Was improperly generating a warning each restart for accounts entered in configuration.yaml.
1. Was not properly handling a password change in configuration.yaml.
1. Was not properly removing config entries for accounts removed from configuration.yaml.

Now will not bother to create a config entry for accounts in configuration.yaml that have not changed. Also, if an account's password has changed in configuration.yaml, or if an account is removed from configuration.yaml, then the corresponding config entry will be deleted (and recreated, with a freshly created authorization, when password is changed.)

**Related issue (if applicable):** none

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
life360:
  - accounts:
      username: LIFE360_USERNAME
      password: LIFE360_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
