### PR TITLE
Update Hass.io when core config is updated

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -9,7 +9,8 @@ from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components.homeassistant import SERVICE_CHECK_CONFIG
 import homeassistant.config as conf_util
 from homeassistant.const import (
-    ATTR_NAME, SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP)
+    ATTR_NAME, SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP,
+    EVENT_CORE_CONFIG_UPDATE)
 from homeassistant.core import DOMAIN as HASS_DOMAIN, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
@@ -194,8 +195,13 @@ async def async_setup(hass, config):
 
     await hassio.update_hass_api(config.get('http', {}), refresh_token.token)
 
-    if 'homeassistant' in config:
-        await hassio.update_hass_timezone(config['homeassistant'])
+    async def push_config(_):
+        """Push core config to Hass.io."""
+        await hassio.update_hass_timezone(str(hass.config.time_zone))
+
+    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, push_config)
+
+    await push_config(None)
 
     async def async_service_handler(service):
         """Handle service calls for Hass.io."""

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -11,7 +11,7 @@ from homeassistant.components.http import (
     CONF_SERVER_PORT,
     CONF_SSL_CERTIFICATE,
 )
-from homeassistant.const import CONF_TIME_ZONE, SERVER_PORT
+from homeassistant.const import SERVER_PORT
 
 from .const import X_HASSIO
 

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -140,13 +140,13 @@ class HassIO:
                                        payload=options)
 
     @_api_bool
-    def update_hass_timezone(self, core_config):
+    def update_hass_timezone(self, timezone):
         """Update Home-Assistant timezone data on Hass.io.
 
         This method return a coroutine.
         """
         return self.send_command("/supervisor/options", payload={
-            'timezone': core_config.get(CONF_TIME_ZONE)
+            'timezone': timezone
         })
 
     async def send_command(self, command, method="post", payload=None,

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -30,10 +30,11 @@ def hassio_env():
 def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
     """Create mock hassio http client."""
     with patch('homeassistant.components.hassio.HassIO.update_hass_api',
-               Mock(return_value=mock_coro({"result": "ok"}))), \
-            patch('homeassistant.components.hassio.HassIO.'
-                  'get_homeassistant_info',
-                  Mock(side_effect=HassioAPIError())):
+               return_value=mock_coro({"result": "ok"})
+    ), patch('homeassistant.components.hassio.HassIO.update_hass_timezone',
+             return_value=mock_coro({"result": "ok"})
+    ), patch('homeassistant.components.hassio.HassIO.get_homeassistant_info',
+             side_effect=HassioAPIError()):
         hass.state = CoreState.starting
         hass.loop.run_until_complete(async_setup_component(hass, 'hassio', {
             'http': {

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -29,12 +29,16 @@ def hassio_env():
 @pytest.fixture
 def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
     """Create mock hassio http client."""
-    with patch('homeassistant.components.hassio.HassIO.update_hass_api',
-               return_value=mock_coro({"result": "ok"})
-    ), patch('homeassistant.components.hassio.HassIO.update_hass_timezone',
-             return_value=mock_coro({"result": "ok"})
-    ), patch('homeassistant.components.hassio.HassIO.get_homeassistant_info',
-             side_effect=HassioAPIError()):
+    with patch(
+            'homeassistant.components.hassio.HassIO.update_hass_api',
+            return_value=mock_coro({"result": "ok"})
+    ), patch(
+        'homeassistant.components.hassio.HassIO.update_hass_timezone',
+        return_value=mock_coro({"result": "ok"})
+    ), patch(
+        'homeassistant.components.hassio.HassIO.get_homeassistant_info',
+        side_effect=HassioAPIError()
+    ):
         hass.state = CoreState.starting
         hass.loop.run_until_complete(async_setup_component(hass, 'hassio', {
             'http': {

--- a/tests/components/hassio/test_addon_panel.py
+++ b/tests/components/hassio/test_addon_panel.py
@@ -56,7 +56,7 @@ async def test_hassio_addon_panel_startup(hass, aioclient_mock, hassio_env):
         })
         await hass.async_block_till_done()
 
-        assert aioclient_mock.call_count == 2
+        assert aioclient_mock.call_count == 3
         assert mock_panel.called
         mock_panel.assert_called_with(
             hass, 'test1', {
@@ -98,7 +98,7 @@ async def test_hassio_addon_panel_api(hass, aioclient_mock, hassio_env,
         })
         await hass.async_block_till_done()
 
-        assert aioclient_mock.call_count == 2
+        assert aioclient_mock.call_count == 3
         assert mock_panel.called
         mock_panel.assert_called_with(
             hass, 'test1', {

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -43,7 +43,7 @@ def test_setup_api_ping(hass, aioclient_mock):
         result = yield from async_setup_component(hass, 'hassio', {})
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert hass.components.hassio.get_homeassistant_version() == "10.0"
     assert hass.components.hassio.is_hassio()
 
@@ -82,7 +82,7 @@ def test_setup_api_push_api_data(hass, aioclient_mock):
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 9999
     assert aioclient_mock.mock_calls[1][2]['watchdog']
@@ -101,7 +101,7 @@ def test_setup_api_push_api_data_server_host(hass, aioclient_mock):
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 9999
     assert not aioclient_mock.mock_calls[1][2]['watchdog']
@@ -117,7 +117,7 @@ async def test_setup_api_push_api_data_default(hass, aioclient_mock,
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 8123
     refresh_token = aioclient_mock.mock_calls[1][2]['refresh_token']
@@ -177,26 +177,28 @@ async def test_setup_api_existing_hassio_user(hass, aioclient_mock,
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 8123
     assert aioclient_mock.mock_calls[1][2]['refresh_token'] == token.token
 
 
-@asyncio.coroutine
-def test_setup_core_push_timezone(hass, aioclient_mock):
+async def test_setup_core_push_timezone(hass, aioclient_mock):
     """Test setup with API push default data."""
+    hass.config.time_zone = 'testzone'
+
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = yield from async_setup_component(hass, 'hassio', {
+        result = await async_setup_component(hass, 'hassio', {
             'hassio': {},
-            'homeassistant': {
-                'time_zone': 'testzone',
-            },
         })
         assert result
 
     assert aioclient_mock.call_count == 5
     assert aioclient_mock.mock_calls[2][2]['timezone'] == "testzone"
+
+    await hass.config.async_update(time_zone='America/New_York')
+    await hass.async_block_till_done()
+    assert aioclient_mock.mock_calls[-1][2]['timezone'] == "America/New_York"
 
 
 @asyncio.coroutine
@@ -209,7 +211,7 @@ def test_setup_hassio_no_additional_data(hass, aioclient_mock):
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert aioclient_mock.mock_calls[-1][3]['X-Hassio-Key'] == "123456"
 
 
@@ -288,14 +290,14 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
         'hassio', 'addon_stdin', {'addon': 'test', 'input': 'test'})
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 6
+    assert aioclient_mock.call_count == 7
     assert aioclient_mock.mock_calls[-1][2] == 'test'
 
     yield from hass.services.async_call('hassio', 'host_shutdown', {})
     yield from hass.services.async_call('hassio', 'host_reboot', {})
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 8
+    assert aioclient_mock.call_count == 9
 
     yield from hass.services.async_call('hassio', 'snapshot_full', {})
     yield from hass.services.async_call('hassio', 'snapshot_partial', {
@@ -305,7 +307,7 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
     })
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 11
     assert aioclient_mock.mock_calls[-1][2] == {
         'addons': ['test'], 'folders': ['ssl'], 'password': "123456"}
 
@@ -321,7 +323,7 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
     })
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 12
+    assert aioclient_mock.call_count == 13
     assert aioclient_mock.mock_calls[-1][2] == {
         'addons': ['test'], 'folders': ['ssl'], 'homeassistant': False,
         'password': "123456"
@@ -341,12 +343,12 @@ def test_service_calls_core(hassio_env, hass, aioclient_mock):
     yield from hass.services.async_call('homeassistant', 'stop')
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 3
+    assert aioclient_mock.call_count == 4
 
     yield from hass.services.async_call('homeassistant', 'check_config')
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 3
+    assert aioclient_mock.call_count == 4
 
     with patch(
         'homeassistant.config.async_check_ha_config_file',
@@ -356,4 +358,4 @@ def test_service_calls_core(hassio_env, hass, aioclient_mock):
         yield from hass.async_block_till_done()
         assert mock_check_config.called
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5


### PR DESCRIPTION
## Description:
Hass.io will now read the core config from the hass object and it will update Hass.io when the core config changes.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
