### PR TITLE
Update to buienradar json api; and additional monitored_conditions 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,14 +51,14 @@ homeassistant/components/bt_smarthub/* @jxwolstenholme
 <<<<<<< HEAD
 homeassistant/components/buienradar/* @ties
 =======
-homeassistant/components/buienradar/* @mjj4791
+homeassistant/components/buienradar/* @mjj4791 @ties
 >>>>>>> Update to json api; and additional sensors
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/ciscospark/* @fbradyirl
 homeassistant/components/cloud/* @home-assistant/cloud
-homeassistant/components/cloudflare/* @ludeeus
+homeassistant/components/cloudflare/* :q@ludeeus@ludeeus
 homeassistant/components/config/* @home-assistant/core
 homeassistant/components/configurator/* @home-assistant/core
 homeassistant/components/conversation/* @home-assistant/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,7 +48,11 @@ homeassistant/components/braviatv/* @robbiet480
 homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
+<<<<<<< HEAD
 homeassistant/components/buienradar/* @ties
+=======
+homeassistant/components/buienradar/* @mjj4791
+>>>>>>> Update to json api; and additional sensors
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,23 +48,9 @@ homeassistant/components/braviatv/* @robbiet480
 homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-homeassistant/components/buienradar/* @ties
-=======
-homeassistant/components/buienradar/* @ties
->>>>>>> Update to json api; and additional sensors
-=======
 homeassistant/components/buienradar/camera @ties
 homeassistant/components/buienradar/sensor @mjj4791
 homeassistant/components/buienradar/weather @mjj4791
-=======
-homeassistant/components/buienradar/camera @ties
-homeassistant/components/buienradar/sensor @mjj4791
-homeassistant/components/buienradar/weather @mjj4791
->>>>>>> Update CODEOWNERS
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -70,7 +70,7 @@ homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/ciscospark/* @fbradyirl
 homeassistant/components/cloud/* @home-assistant/cloud
-homeassistant/components/cloudflare/* :q@ludeeus@ludeeus
+homeassistant/components/cloudflare/* @ludeeus@ludeeus
 homeassistant/components/config/* @home-assistant/core
 homeassistant/components/configurator/* @home-assistant/core
 homeassistant/components/conversation/* @home-assistant/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,9 +48,7 @@ homeassistant/components/braviatv/* @robbiet480
 homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
-homeassistant/components/buienradar/camera @ties
-homeassistant/components/buienradar/sensor @mjj4791
-homeassistant/components/buienradar/weather @mjj4791
+homeassistant/components/buienradar/* @mjj4791 @ties
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -70,7 +70,7 @@ homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl
 homeassistant/components/ciscospark/* @fbradyirl
 homeassistant/components/cloud/* @home-assistant/cloud
-homeassistant/components/cloudflare/* @ludeeus@ludeeus
+homeassistant/components/cloudflare/* @ludeeus
 homeassistant/components/config/* @home-assistant/core
 homeassistant/components/configurator/* @home-assistant/core
 homeassistant/components/conversation/* @home-assistant/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,6 +51,7 @@ homeassistant/components/bt_smarthub/* @jxwolstenholme
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 homeassistant/components/buienradar/* @ties
 =======
 homeassistant/components/buienradar/* @ties
@@ -59,6 +60,11 @@ homeassistant/components/buienradar/* @ties
 homeassistant/components/buienradar/camera @ties
 homeassistant/components/buienradar/sensor @mjj4791
 homeassistant/components/buienradar/weather @mjj4791
+=======
+homeassistant/components/buienradar/camera @ties
+homeassistant/components/buienradar/sensor @mjj4791
+homeassistant/components/buienradar/weather @mjj4791
+>>>>>>> Update CODEOWNERS
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -50,6 +50,7 @@ homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 homeassistant/components/buienradar/* @ties
 =======
 homeassistant/components/buienradar/* @ties
@@ -58,7 +59,6 @@ homeassistant/components/buienradar/* @ties
 homeassistant/components/buienradar/camera @ties
 homeassistant/components/buienradar/sensor @mjj4791
 homeassistant/components/buienradar/weather @mjj4791
->>>>>>> Update CODEOWNERS
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,10 +49,16 @@ homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
 <<<<<<< HEAD
+<<<<<<< HEAD
 homeassistant/components/buienradar/* @ties
 =======
-homeassistant/components/buienradar/* @mjj4791 @ties
+homeassistant/components/buienradar/* @ties
 >>>>>>> Update to json api; and additional sensors
+=======
+homeassistant/components/buienradar/camera @ties
+homeassistant/components/buienradar/sensor @mjj4791
+homeassistant/components/buienradar/weather @mjj4791
+>>>>>>> Update CODEOWNERS
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/homeassistant/components/buienradar/manifest.json
+++ b/homeassistant/components/buienradar/manifest.json
@@ -3,8 +3,14 @@
   "name": "Buienradar",
   "documentation": "https://www.home-assistant.io/components/buienradar",
   "requirements": [
-    "buienradar==0.91"
+    "buienradar==1.0.1"
   ],
   "dependencies": [],
+<<<<<<< HEAD
   "codeowners": ["@ties"]
+=======
+  "codeowners": [
+    "@mjj4791"
+  ]
+>>>>>>> Update to json api; and additional sensors
 }

--- a/homeassistant/components/buienradar/manifest.json
+++ b/homeassistant/components/buienradar/manifest.json
@@ -10,7 +10,7 @@
   "codeowners": ["@ties"]
 =======
   "codeowners": [
-    "@mjj4791"
+    "@mjj4791", "@ties"
   ]
 >>>>>>> Update to json api; and additional sensors
 }

--- a/homeassistant/components/buienradar/manifest.json
+++ b/homeassistant/components/buienradar/manifest.json
@@ -6,11 +6,7 @@
     "buienradar==1.0.1"
   ],
   "dependencies": [],
-<<<<<<< HEAD
-  "codeowners": ["@ties"]
-=======
   "codeowners": [
     "@mjj4791", "@ties"
   ]
->>>>>>> Update to json api; and additional sensors
 }

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -302,7 +302,7 @@ class BrSensor(Entity):
                 try:
                     self._state = data.get(FORECAST)[fcday].get(self.type[:-3])
                     if self._state is not None:
-                        self._state = round(self._state * 3.6, 1) 
+                        self._state = round(self._state * 3.6, 1)
                     return True
                 except IndexError:
                     _LOGGER.warning("No forecast for fcday=%s...", fcday)
@@ -353,14 +353,14 @@ class BrSensor(Entity):
             if self._state is not None:
                 self._state = round(data.get(self.type) * 3.6, 1)
             return True
-            
+
         if self.type == VISIBILITY:
             # hass wants visibility in km (not m), so convert:
             self._state = data.get(self.type)
             if self._state is not None:
                 self._state = round(self._state / 1000, 1)
             return True
-        
+
         # update all other sensors
         self._state = data.get(self.type)
         return True
@@ -625,4 +625,3 @@ class BrData:
         """Return the forecast data."""
         from buienradar.constants import FORECAST
         return self.data.get(FORECAST)
-

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -488,7 +488,7 @@ class BrData:
 
         # rounding coordinates prevents unnecessary redirects/calls
         lat = self.coordinates[CONF_LATITUDE]
-        lon = round(self.coordinates[CONF_LONGITUDE])
+        lon = self.coordinates[CONF_LONGITUDE]
         rainurl = json_precipitation_forecast_url(lat, lon)
         raincontent = await self.get_data(rainurl)
 

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -32,11 +32,19 @@ SCHEDULE_NOK = 2
 # Key: ['label', unit, icon]
 SENSOR_TYPES = {
     'stationname': ['Stationname', None, None],
+    # new in json api (>1.0.0):
+    'barometerfc': ['Barometer value', None, 'mdi:gauge'],
+    # new in json api (>1.0.0):
+    'barometerfcname': ['Barometer', None, 'mdi:gauge'],
+    # new in json api (>1.0.0):
+    'barometerfcnamenl': ['Barometer', None, 'mdi:gauge'],
     'condition': ['Condition', None, None],
     'conditioncode': ['Condition code', None, None],
     'conditiondetailed': ['Detailed condition', None, None],
     'conditionexact': ['Full condition', None, None],
     'symbol': ['Symbol', None, None],
+    # new in json api (>1.0.0):
+    'feeltemperature': ['Feel temperature', TEMP_CELSIUS, 'mdi:thermometer'],
     'humidity': ['Humidity', '%', 'mdi:water-percent'],
     'temperature': ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],
     'groundtemperature': ['Ground temperature', TEMP_CELSIUS,
@@ -54,6 +62,10 @@ SENSOR_TYPES = {
                                        'mm/h', 'mdi:weather-pouring'],
     'precipitation_forecast_total': ['Precipitation forecast total',
                                      'mm', 'mdi:weather-pouring'],
+    # new in json api (>1.0.0):
+    'rainlast24hour': ['Rain last 24h', 'mm', 'mdi:weather-pouring'],
+    # new in json api (>1.0.0):
+    'rainlasthour': ['Rain last hour', 'mm', 'mdi:weather-pouring'],
     'temperature_1d': ['Temperature 1d', TEMP_CELSIUS, 'mdi:thermometer'],
     'temperature_2d': ['Temperature 2d', TEMP_CELSIUS, 'mdi:thermometer'],
     'temperature_3d': ['Temperature 3d', TEMP_CELSIUS, 'mdi:thermometer'],
@@ -69,11 +81,18 @@ SENSOR_TYPES = {
     'rain_3d': ['Rain 3d', 'mm', 'mdi:weather-pouring'],
     'rain_4d': ['Rain 4d', 'mm', 'mdi:weather-pouring'],
     'rain_5d': ['Rain 5d', 'mm', 'mdi:weather-pouring'],
-    'snow_1d': ['Snow 1d', 'cm', 'mdi:snowflake'],
-    'snow_2d': ['Snow 2d', 'cm', 'mdi:snowflake'],
-    'snow_3d': ['Snow 3d', 'cm', 'mdi:snowflake'],
-    'snow_4d': ['Snow 4d', 'cm', 'mdi:snowflake'],
-    'snow_5d': ['Snow 5d', 'cm', 'mdi:snowflake'],
+    # new in json api (>1.0.0):
+    'minrain_1d': ['Minimum rain 1d', 'mm', 'mdi:weather-pouring'],
+    'minrain_2d': ['Minimum rain 2d', 'mm', 'mdi:weather-pouring'],
+    'minrain_3d': ['Minimum rain 3d', 'mm', 'mdi:weather-pouring'],
+    'minrain_4d': ['Minimum rain 4d', 'mm', 'mdi:weather-pouring'],
+    'minrain_5d': ['Minimum rain 5d', 'mm', 'mdi:weather-pouring'],
+    # new in json api (>1.0.0):
+    'maxrain_1d': ['Maximum rain 1d', 'mm', 'mdi:weather-pouring'],
+    'maxrain_2d': ['Maximum rain 2d', 'mm', 'mdi:weather-pouring'],
+    'maxrain_3d': ['Maximum rain 3d', 'mm', 'mdi:weather-pouring'],
+    'maxrain_4d': ['Maximum rain 4d', 'mm', 'mdi:weather-pouring'],
+    'maxrain_5d': ['Maximum rain 5d', 'mm', 'mdi:weather-pouring'],
     'rainchance_1d': ['Rainchance 1d', '%', 'mdi:weather-pouring'],
     'rainchance_2d': ['Rainchance 2d', '%', 'mdi:weather-pouring'],
     'rainchance_3d': ['Rainchance 3d', '%', 'mdi:weather-pouring'],
@@ -89,6 +108,26 @@ SENSOR_TYPES = {
     'windforce_3d': ['Wind force 3d', 'Bft', 'mdi:weather-windy'],
     'windforce_4d': ['Wind force 4d', 'Bft', 'mdi:weather-windy'],
     'windforce_5d': ['Wind force 5d', 'Bft', 'mdi:weather-windy'],
+    'windspeed_1d': ['Wind speed 1d', 'm/s', 'mdi:weather-windy'],
+    'windspeed_2d': ['Wind speed 2d', 'm/s', 'mdi:weather-windy'],
+    'windspeed_3d': ['Wind speed 3d', 'm/s', 'mdi:weather-windy'],
+    'windspeed_4d': ['Wind speed 4d', 'm/s', 'mdi:weather-windy'],
+    'windspeed_5d': ['Wind speed 5d', 'm/s', 'mdi:weather-windy'],
+    'winddirection_1d': ['Wind direction 1d', None, 'mdi:compass-outline'],
+    'winddirection_2d': ['Wind direction 2d', None, 'mdi:compass-outline'],
+    'winddirection_3d': ['Wind direction 3d', None, 'mdi:compass-outline'],
+    'winddirection_4d': ['Wind direction 4d', None, 'mdi:compass-outline'],
+    'winddirection_5d': ['Wind direction 5d', None, 'mdi:compass-outline'],
+    'windazimuth_1d': ['Wind direction azimuth 1d', '°',
+                       'mdi:compass-outline'],
+    'windazimuth_2d': ['Wind direction azimuth 2d', '°',
+                       'mdi:compass-outline'],
+    'windazimuth_3d': ['Wind direction azimuth 3d', '°',
+                       'mdi:compass-outline'],
+    'windazimuth_4d': ['Wind direction azimuth 4d', '°',
+                       'mdi:compass-outline'],
+    'windazimuth_5d': ['Wind direction azimuth 5d', '°',
+                       'mdi:compass-outline'],
     'condition_1d': ['Condition 1d', None, None],
     'condition_2d': ['Condition 2d', None, None],
     'condition_3d': ['Condition 3d', None, None],
@@ -113,7 +152,7 @@ SENSOR_TYPES = {
     'symbol_2d': ['Symbol 2d', None, None],
     'symbol_3d': ['Symbol 3d', None, None],
     'symbol_4d': ['Symbol 4d', None, None],
-    'symbol_5d': ['Symbol 5d', None, None],
+    'symbol_5d': ['Symbol 5d', None, None]
 }
 
 CONF_TIMEFRAME = 'timeframe'
@@ -168,7 +207,7 @@ class BrSensor(Entity):
 
     def __init__(self, sensor_type, client_name, coordinates):
         """Initialize the sensor."""
-        from buienradar.buienradar import (PRECIPITATION_FORECAST, CONDITION)
+        from buienradar.constants import (PRECIPITATION_FORECAST, CONDITION)
 
         self.client_name = client_name
         self._name = SENSOR_TYPES[sensor_type][0]
@@ -198,11 +237,11 @@ class BrSensor(Entity):
     def load_data(self, data):
         """Load the sensor with relevant data."""
         # Find sensor
-        from buienradar.buienradar import (ATTRIBUTION, CONDITION, CONDCODE,
-                                           DETAILED, EXACT, EXACTNL, FORECAST,
-                                           IMAGE, MEASURED,
-                                           PRECIPITATION_FORECAST, STATIONNAME,
-                                           TIMEFRAME)
+        from buienradar.constants import (ATTRIBUTION, CONDITION, CONDCODE,
+                                          DETAILED, EXACT, EXACTNL, FORECAST,
+                                          IMAGE, MEASURED,
+                                          PRECIPITATION_FORECAST, STATIONNAME,
+                                          TIMEFRAME)
 
         # Check if we have a new measurement,
         # otherwise we do not have to update the sensor
@@ -219,6 +258,7 @@ class BrSensor(Entity):
            self.type.endswith('_4d') or \
            self.type.endswith('_5d'):
 
+            # update forcasting sensors:
             fcday = 0
             if self.type.endswith('_2d'):
                 fcday = 1
@@ -229,7 +269,7 @@ class BrSensor(Entity):
             if self.type.endswith('_5d'):
                 fcday = 4
 
-            # update all other sensors
+            # update weather symbol & status text
             if self.type.startswith(SYMBOL) or self.type.startswith(CONDITION):
                 try:
                     condition = data.get(FORECAST)[fcday].get(CONDITION)
@@ -256,6 +296,7 @@ class BrSensor(Entity):
                         return True
                 return False
 
+            # update all other sensors
             try:
                 self._state = data.get(FORECAST)[fcday].get(self.type[:-3])
                 return True
@@ -331,7 +372,7 @@ class BrSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        from buienradar.buienradar import (PRECIPITATION_FORECAST)
+        from buienradar.constants import (PRECIPITATION_FORECAST)
 
         if self.type.startswith(PRECIPITATION_FORECAST):
             result = {ATTR_ATTRIBUTION: self._attribution}
@@ -399,8 +440,8 @@ class BrData:
 
     async def get_data(self, url):
         """Load data from specified url."""
-        from buienradar.buienradar import (CONTENT,
-                                           MESSAGE, STATUS_CODE, SUCCESS)
+        from buienradar.constants import (CONTENT,
+                                          MESSAGE, STATUS_CODE, SUCCESS)
 
         _LOGGER.debug("Calling url: %s...", url)
         result = {SUCCESS: False, MESSAGE: None}
@@ -427,16 +468,17 @@ class BrData:
 
     async def async_update(self, *_):
         """Update the data from buienradar."""
-        from buienradar.buienradar import (parse_data, CONTENT,
-                                           DATA, MESSAGE, STATUS_CODE, SUCCESS)
+        from buienradar.constants import (CONTENT, DATA, MESSAGE,
+                                          STATUS_CODE, SUCCESS)
+        from buienradar.buienradar import (parse_data)
+        from buienradar.urls import (JSON_FEED_URL,
+                                     json_precipitation_forecast_url)
 
-        content = await self.get_data('http://xml.buienradar.nl')
-        if not content.get(SUCCESS, False):
-            content = await self.get_data('http://api.buienradar.nl')
+        content = await self.get_data(JSON_FEED_URL)
 
         if content.get(SUCCESS) is not True:
             # unable to get the data
-            _LOGGER.warning("Unable to retrieve xml data from Buienradar."
+            _LOGGER.warning("Unable to retrieve json data from Buienradar."
                             "(Msg: %s, status: %s,)",
                             content.get(MESSAGE),
                             content.get(STATUS_CODE),)
@@ -445,11 +487,9 @@ class BrData:
             return
 
         # rounding coordinates prevents unnecessary redirects/calls
-        rainurl = 'http://gadgets.buienradar.nl/data/raintext/?lat={}&lon={}'
-        rainurl = rainurl.format(
-            round(self.coordinates[CONF_LATITUDE], 2),
-            round(self.coordinates[CONF_LONGITUDE], 2)
-            )
+        lat = self.coordinates[CONF_LATITUDE]
+        lon = round(self.coordinates[CONF_LONGITUDE])
+        rainurl = json_precipitation_forecast_url(lat, lon)
         raincontent = await self.get_data(rainurl)
 
         if raincontent.get(SUCCESS) is not True:
@@ -466,7 +506,8 @@ class BrData:
                             raincontent.get(CONTENT),
                             self.coordinates[CONF_LATITUDE],
                             self.coordinates[CONF_LONGITUDE],
-                            self.timeframe)
+                            self.timeframe,
+                            False)
 
         _LOGGER.debug("Buienradar parsed data: %s", result)
         if result.get(SUCCESS) is not True:
@@ -484,25 +525,25 @@ class BrData:
     @property
     def attribution(self):
         """Return the attribution."""
-        from buienradar.buienradar import ATTRIBUTION
+        from buienradar.constants import ATTRIBUTION
         return self.data.get(ATTRIBUTION)
 
     @property
     def stationname(self):
         """Return the name of the selected weatherstation."""
-        from buienradar.buienradar import STATIONNAME
+        from buienradar.constants import STATIONNAME
         return self.data.get(STATIONNAME)
 
     @property
     def condition(self):
         """Return the condition."""
-        from buienradar.buienradar import CONDITION
+        from buienradar.constants import CONDITION
         return self.data.get(CONDITION)
 
     @property
     def temperature(self):
         """Return the temperature, or None."""
-        from buienradar.buienradar import TEMPERATURE
+        from buienradar.constants import TEMPERATURE
         try:
             return float(self.data.get(TEMPERATURE))
         except (ValueError, TypeError):
@@ -511,7 +552,7 @@ class BrData:
     @property
     def pressure(self):
         """Return the pressure, or None."""
-        from buienradar.buienradar import PRESSURE
+        from buienradar.constants import PRESSURE
         try:
             return float(self.data.get(PRESSURE))
         except (ValueError, TypeError):
@@ -520,7 +561,7 @@ class BrData:
     @property
     def humidity(self):
         """Return the humidity, or None."""
-        from buienradar.buienradar import HUMIDITY
+        from buienradar.constants import HUMIDITY
         try:
             return int(self.data.get(HUMIDITY))
         except (ValueError, TypeError):
@@ -529,7 +570,7 @@ class BrData:
     @property
     def visibility(self):
         """Return the visibility, or None."""
-        from buienradar.buienradar import VISIBILITY
+        from buienradar.constants import VISIBILITY
         try:
             return int(self.data.get(VISIBILITY))
         except (ValueError, TypeError):
@@ -538,7 +579,7 @@ class BrData:
     @property
     def wind_speed(self):
         """Return the windspeed, or None."""
-        from buienradar.buienradar import WINDSPEED
+        from buienradar.constants import WINDSPEED
         try:
             return float(self.data.get(WINDSPEED))
         except (ValueError, TypeError):
@@ -547,7 +588,7 @@ class BrData:
     @property
     def wind_bearing(self):
         """Return the wind bearing, or None."""
-        from buienradar.buienradar import WINDAZIMUTH
+        from buienradar.constants import WINDAZIMUTH
         try:
             return int(self.data.get(WINDAZIMUTH))
         except (ValueError, TypeError):
@@ -556,5 +597,5 @@ class BrData:
     @property
     def forecast(self):
         """Return the forecast data."""
-        from buienradar.buienradar import FORECAST
+        from buienradar.constants import FORECAST
         return self.data.get(FORECAST)

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -157,27 +157,27 @@ class BrWeather(WeatherEntity):
                                           WINDSPEED)
 
         if not self._forecast:
-            return
+            return None
 
         fcdata_out = []
         cond = self.hass.data[DATA_CONDITION]
 
         if not self._data.forecast:
-            return
+            return None
 
         for data_in in self._data.forecast:
             # remap keys from external library to
             # keys understood by the weather component:
-            data_out = {}
             condcode = data_in.get(CONDITION, []).get(CONDCODE)
-
-            data_out[ATTR_FORECAST_TIME] = data_in.get(DATETIME)
-            data_out[ATTR_FORECAST_CONDITION] = cond[condcode]
-            data_out[ATTR_FORECAST_TEMP_LOW] = data_in.get(MIN_TEMP)
-            data_out[ATTR_FORECAST_TEMP] = data_in.get(MAX_TEMP)
-            data_out[ATTR_FORECAST_PRECIPITATION] = data_in.get(RAIN)
-            data_out[ATTR_FORECAST_WIND_BEARING] = data_in.get(WINDAZIMUTH)
-            data_out[ATTR_FORECAST_WIND_SPEED] = data_in.get(WINDSPEED)
+            data_out = {
+                ATTR_FORECAST_TIME: data_in.get(DATETIME),
+                ATTR_FORECAST_CONDITION: cond[condcode],
+                ATTR_FORECAST_TEMP_LOW: data_in.get(MIN_TEMP),
+                ATTR_FORECAST_TEMP: data_in.get(MAX_TEMP),
+                ATTR_FORECAST_PRECIPITATION: data_in.get(RAIN),
+                ATTR_FORECAST_WIND_BEARING: data_in.get(WINDAZIMUTH),
+                ATTR_FORECAST_WIND_SPEED: data_in.get(WINDSPEED)
+            }
 
             fcdata_out.append(data_out)
 

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -131,13 +131,17 @@ class BrWeather(WeatherEntity):
 
     @property
     def visibility(self):
-        """Return the current visibility."""
-        return self._data.visibility
+        """Return the current visibility in km."""
+        if self._data.visibility is None:
+            return None
+        return round(self._data.visibility / 1000, 1)
 
     @property
     def wind_speed(self):
-        """Return the current windspeed."""
-        return self._data.wind_speed
+        """Return the current windspeed in km/h."""
+        if self._data.wind_speed is None:
+            return None
+        return round(self._data.wind_speed * 3.6, 1)
 
     @property
     def wind_bearing(self):
@@ -176,9 +180,10 @@ class BrWeather(WeatherEntity):
                 ATTR_FORECAST_TEMP: data_in.get(MAX_TEMP),
                 ATTR_FORECAST_PRECIPITATION: data_in.get(RAIN),
                 ATTR_FORECAST_WIND_BEARING: data_in.get(WINDAZIMUTH),
-                ATTR_FORECAST_WIND_SPEED: data_in.get(WINDSPEED)
+                ATTR_FORECAST_WIND_SPEED: round(data_in.get(WINDSPEED) * 3.6, 1)
             }
 
             fcdata_out.append(data_out)
 
         return fcdata_out
+

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -180,7 +180,7 @@ class BrWeather(WeatherEntity):
                 ATTR_FORECAST_TEMP: data_in.get(MAX_TEMP),
                 ATTR_FORECAST_PRECIPITATION: data_in.get(RAIN),
                 ATTR_FORECAST_WIND_BEARING: data_in.get(WINDAZIMUTH),
-                ATTR_FORECAST_WIND_SPEED: 
+                ATTR_FORECAST_WIND_SPEED:
                     round(data_in.get(WINDSPEED) * 3.6, 1)
             }
 

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -180,10 +180,10 @@ class BrWeather(WeatherEntity):
                 ATTR_FORECAST_TEMP: data_in.get(MAX_TEMP),
                 ATTR_FORECAST_PRECIPITATION: data_in.get(RAIN),
                 ATTR_FORECAST_WIND_BEARING: data_in.get(WINDAZIMUTH),
-                ATTR_FORECAST_WIND_SPEED: round(data_in.get(WINDSPEED) * 3.6, 1)
+                ATTR_FORECAST_WIND_SPEED: 
+                    round(data_in.get(WINDSPEED) * 3.6, 1)
             }
 
             fcdata_out.append(data_out)
 
         return fcdata_out
-

--- a/homeassistant/components/buienradar/weather.py
+++ b/homeassistant/components/buienradar/weather.py
@@ -6,7 +6,8 @@ import voluptuous as vol
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION, ATTR_FORECAST_TEMP, ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity,
-    ATTR_FORECAST_PRECIPITATION)
+    ATTR_FORECAST_PRECIPITATION, ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_SPEED)
 from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, TEMP_CELSIUS)
 from homeassistant.helpers import config_validation as cv
@@ -104,7 +105,8 @@ class BrWeather(WeatherEntity):
     @property
     def condition(self):
         """Return the current condition."""
-        from buienradar.buienradar import (CONDCODE)
+        from buienradar.constants import (CONDCODE)
+
         if self._data and self._data.condition:
             ccode = self._data.condition.get(CONDCODE)
             if ccode:
@@ -150,25 +152,33 @@ class BrWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        from buienradar.buienradar import (CONDITION, CONDCODE, RAIN, DATETIME,
-                                           MIN_TEMP, MAX_TEMP)
+        from buienradar.constants import (CONDITION, CONDCODE, RAIN, DATETIME,
+                                          MIN_TEMP, MAX_TEMP, WINDAZIMUTH,
+                                          WINDSPEED)
 
-        if self._forecast:
-            fcdata_out = []
-            cond = self.hass.data[DATA_CONDITION]
-            if self._data.forecast:
-                for data_in in self._data.forecast:
-                    # remap keys from external library to
-                    # keys understood by the weather component:
-                    data_out = {}
-                    condcode = data_in.get(CONDITION, []).get(CONDCODE)
+        if not self._forecast:
+            return
 
-                    data_out[ATTR_FORECAST_TIME] = data_in.get(DATETIME)
-                    data_out[ATTR_FORECAST_CONDITION] = cond[condcode]
-                    data_out[ATTR_FORECAST_TEMP_LOW] = data_in.get(MIN_TEMP)
-                    data_out[ATTR_FORECAST_TEMP] = data_in.get(MAX_TEMP)
-                    data_out[ATTR_FORECAST_PRECIPITATION] = data_in.get(RAIN)
+        fcdata_out = []
+        cond = self.hass.data[DATA_CONDITION]
 
-                    fcdata_out.append(data_out)
+        if not self._data.forecast:
+            return
 
-            return fcdata_out
+        for data_in in self._data.forecast:
+            # remap keys from external library to
+            # keys understood by the weather component:
+            data_out = {}
+            condcode = data_in.get(CONDITION, []).get(CONDCODE)
+
+            data_out[ATTR_FORECAST_TIME] = data_in.get(DATETIME)
+            data_out[ATTR_FORECAST_CONDITION] = cond[condcode]
+            data_out[ATTR_FORECAST_TEMP_LOW] = data_in.get(MIN_TEMP)
+            data_out[ATTR_FORECAST_TEMP] = data_in.get(MAX_TEMP)
+            data_out[ATTR_FORECAST_PRECIPITATION] = data_in.get(RAIN)
+            data_out[ATTR_FORECAST_WIND_BEARING] = data_in.get(WINDAZIMUTH)
+            data_out[ATTR_FORECAST_WIND_SPEED] = data_in.get(WINDSPEED)
+
+            fcdata_out.append(data_out)
+
+        return fcdata_out

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -314,7 +314,7 @@ bthomehub5-devicelist==0.1.1
 btsmarthub_devicelist==0.1.3
 
 # homeassistant.components.buienradar
-buienradar==0.91
+buienradar==1.0.1
 
 # homeassistant.components.caldav
 caldav==0.6.1


### PR DESCRIPTION
## Breaking Change:
The following sensor types (monitored_conditions) are no longer supported, since they are no longer provided by the json api of buienradar:

- snow_1d .. snow_5d

The following monitored conditions will change unit:

- windgust (now km/h, was m/s)
- windspeed  (now km/h, was m/s)
- windspeed_?d  (now km/h, was m/s)
- visibility (now km, was m)

## Description:
Switching over to new version of python-buienrader (1.0.1); this version now leverages the new json buienradar-api. This API provides new sensor data to home-assistant:

- barometerfc
- barometerfcname
- barometerfcnamenl
- feeltemperature
- rainlast24hour
- rainlasthour
- minrain_1d .. minrain_5d
- maxrain_1d .. maxrain_5d

Forecast data (Weather component) will now also contain:
- windbearing
- windspeed

**Related issue (if applicable):** 
Pyhton-buienradar 1.0.1 now also includes the buienradar radar url functionality, requested here: https://github.com/home-assistant/home-assistant/pull/23358

unit conversion from m and m/s to km and km/h, as mentioned here:
https://github.com/home-assistant/home-assistant/issues/20142
https://github.com/home-assistant/home-assistant/issues/18558

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9605


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
