### PR TITLE
Sun listener to adapt to core config updates

### DIFF
--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -24,6 +24,9 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
     async_track_utc_time_change,
 )
+from homeassistant.helpers.sun import (
+    get_astral_event_next, SUN_EVENT_SUNRISE
+)
 from homeassistant.helpers.template import Template
 from homeassistant.components import sun
 import homeassistant.util.dt as dt_util
@@ -434,6 +437,68 @@ async def test_track_sunrise(hass):
     await hass.async_block_till_done()
     assert len(runs) == 1
     assert len(offset_runs) == 1
+
+
+async def test_track_sunrise_update_location(hass):
+    """Test track the sunrise."""
+    # Setup sun component
+    hass.config.latitude = 32.87336
+    hass.config.longitude = 117.22743
+    assert await async_setup_component(hass, sun.DOMAIN, {
+        sun.DOMAIN: {sun.CONF_ELEVATION: 0}})
+
+    # Get next sunrise
+    astral = Astral()
+    utc_now = datetime(2014, 5, 24, 12, 0, 0, tzinfo=dt_util.UTC)
+    utc_today = utc_now.date()
+
+    mod = -1
+    while True:
+        next_rising = (astral.sunrise_utc(
+            utc_today + timedelta(days=mod),
+            hass.config.latitude, hass.config.longitude))
+        if next_rising > utc_now:
+            break
+        mod += 1
+
+    # Track sunrise
+    runs = []
+    with patch('homeassistant.util.dt.utcnow', return_value=utc_now):
+        async_track_sunrise(hass, lambda: runs.append(1))
+
+    # Mimick sunrise
+    _send_time_changed(hass, next_rising)
+    await hass.async_block_till_done()
+    assert len(runs) == 1
+
+    # Move!
+    with patch('homeassistant.util.dt.utcnow', return_value=utc_now):
+        await hass.config.async_update(
+            latitude=40.755931,
+            longitude=-73.984606,
+        )
+        await hass.async_block_till_done()
+
+    # Mimick sunrise
+    _send_time_changed(hass, next_rising)
+    await hass.async_block_till_done()
+    # Did not increase
+    assert len(runs) == 1
+
+    # Get next sunrise
+    mod = -1
+    while True:
+        next_rising = (astral.sunrise_utc(
+            utc_today + timedelta(days=mod),
+            hass.config.latitude, hass.config.longitude))
+        if next_rising > utc_now:
+            break
+        mod += 1
+
+    # Mimick sunrise at new location
+    _send_time_changed(hass, next_rising)
+    await hass.async_block_till_done()
+    assert len(runs) == 2
 
 
 async def test_track_sunset(hass):

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -24,9 +24,6 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
     async_track_utc_time_change,
 )
-from homeassistant.helpers.sun import (
-    get_astral_event_next, SUN_EVENT_SUNRISE
-)
 from homeassistant.helpers.template import Template
 from homeassistant.components import sun
 import homeassistant.util.dt as dt_util


### PR DESCRIPTION
## Description:
This makes the sun listener adapt to core config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
