### PR TITLE
0.94.2

### DIFF
--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -14,6 +14,8 @@ from .const import CONF_MODEL, DOMAIN
 from .device import get_device
 from .errors import AlreadyConfigured, AuthenticationRequired, CannotConnect
 
+AXIS_OUI = {'00408C', 'ACCC8E', 'B8A44F'}
+
 CONFIG_FILE = 'axis.conf'
 
 EVENT_TYPES = ['motion', 'vmd3', 'pir', 'sound',
@@ -151,10 +153,14 @@ class AxisFlowHandler(config_entries.ConfigFlow):
 
         This flow is triggered by the discovery component.
         """
+        serialnumber = discovery_info['properties']['macaddress']
+
+        if serialnumber[:6] not in AXIS_OUI:
+            return self.async_abort(reason='not_axis_device')
+
         if discovery_info[CONF_HOST].startswith('169.254'):
             return self.async_abort(reason='link_local_address')
 
-        serialnumber = discovery_info['properties']['macaddress']
         # pylint: disable=unsupported-assignment-operation
         self.context['macaddress'] = serialnumber
 

--- a/homeassistant/components/axis/strings.json
+++ b/homeassistant/components/axis/strings.json
@@ -21,7 +21,8 @@
         "abort": {
             "already_configured": "Device is already configured",
             "bad_config_file": "Bad data from config file",
-            "link_local_address": "Link local addresses are not supported"
+            "link_local_address": "Link local addresses are not supported",
+            "not_axis_device": "Discovered device not an Axis device"
         }
     }
 }

--- a/homeassistant/components/config/core.py
+++ b/homeassistant/components/config/core.py
@@ -56,7 +56,7 @@ async def websocket_update_config(hass, connection, msg):
     data.pop('type')
 
     try:
-        await hass.config.update(**data)
+        await hass.config.async_update(**data)
         connection.send_result(msg['id'])
     except ValueError as err:
         connection.send_error(

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -9,7 +9,6 @@ from pydeconz.utils import (
     async_discovery, async_get_api_key, async_get_bridgeid)
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
@@ -154,6 +153,9 @@ class DeconzFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered deCONZ bridge."""
+        from homeassistant.components.ssdp import (
+            ATTR_MANUFACTURERURL, ATTR_SERIAL)
+
         if discovery_info[ATTR_MANUFACTURERURL] != DECONZ_MANUFACTURERURL:
             return self.async_abort(reason='not_deconz_bridge')
 

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/deconz",
   "requirements": [
-    "pydeconz==59"
+    "pydeconz==60"
   ],
   "ssdp": {
     "manufacturer": [

--- a/homeassistant/components/gpslogger/__init__.py
+++ b/homeassistant/components/gpslogger/__init__.py
@@ -11,19 +11,21 @@ from homeassistant.const import HTTP_UNPROCESSABLE_ENTITY, \
 from homeassistant.helpers import config_entry_flow
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    ATTR_ALTITUDE,
+    ATTR_ACCURACY,
+    ATTR_ACTIVITY,
+    ATTR_DEVICE,
+    ATTR_DIRECTION,
+    ATTR_PROVIDER,
+    ATTR_SPEED,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 TRACKER_UPDATE = '{}_tracker_update'.format(DOMAIN)
 
-ATTR_ALTITUDE = 'altitude'
-ATTR_ACCURACY = 'accuracy'
-ATTR_ACTIVITY = 'activity'
-ATTR_DEVICE = 'device'
-ATTR_DIRECTION = 'direction'
-ATTR_PROVIDER = 'provider'
-ATTR_SPEED = 'speed'
 
 DEFAULT_ACCURACY = 200
 DEFAULT_BATTERY = -1

--- a/homeassistant/components/gpslogger/const.py
+++ b/homeassistant/components/gpslogger/const.py
@@ -1,3 +1,11 @@
 """Const for GPSLogger."""
 
 DOMAIN = 'gpslogger'
+
+ATTR_ALTITUDE = 'altitude'
+ATTR_ACCURACY = 'accuracy'
+ATTR_ACTIVITY = 'activity'
+ATTR_DEVICE = 'device'
+ATTR_DIRECTION = 'direction'
+ATTR_PROVIDER = 'provider'
+ATTR_SPEED = 'speed'

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -9,7 +9,8 @@ from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components.homeassistant import SERVICE_CHECK_CONFIG
 import homeassistant.config as conf_util
 from homeassistant.const import (
-    ATTR_NAME, SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP)
+    ATTR_NAME, SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP,
+    EVENT_CORE_CONFIG_UPDATE)
 from homeassistant.core import DOMAIN as HASS_DOMAIN, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
@@ -194,8 +195,13 @@ async def async_setup(hass, config):
 
     await hassio.update_hass_api(config.get('http', {}), refresh_token.token)
 
-    if 'homeassistant' in config:
-        await hassio.update_hass_timezone(config['homeassistant'])
+    async def push_config(_):
+        """Push core config to Hass.io."""
+        await hassio.update_hass_timezone(str(hass.config.time_zone))
+
+    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, push_config)
+
+    await push_config(None)
 
     async def async_service_handler(service):
         """Handle service calls for Hass.io."""

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -11,7 +11,7 @@ from homeassistant.components.http import (
     CONF_SERVER_PORT,
     CONF_SSL_CERTIFICATE,
 )
-from homeassistant.const import CONF_TIME_ZONE, SERVER_PORT
+from homeassistant.const import SERVER_PORT
 
 from .const import X_HASSIO
 
@@ -140,13 +140,13 @@ class HassIO:
                                        payload=options)
 
     @_api_bool
-    def update_hass_timezone(self, core_config):
+    def update_hass_timezone(self, timezone):
         """Update Home-Assistant timezone data on Hass.io.
 
         This method return a coroutine.
         """
         return self.send_command("/supervisor/options", payload={
-            'timezone': core_config.get(CONF_TIME_ZONE)
+            'timezone': timezone
         })
 
     async def send_command(self, command, method="post", payload=None,

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -8,7 +8,6 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.ssdp import ATTR_MANUFACTURERURL
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
@@ -146,6 +145,8 @@ class HueFlowHandler(config_entries.ConfigFlow):
         This flow is triggered by the SSDP component. It will check if the
         host is already configured and delegate to the import step if not.
         """
+        from homeassistant.components.ssdp import ATTR_MANUFACTURERURL
+
         if discovery_info[ATTR_MANUFACTURERURL] != HUE_MANUFACTURERURL:
             return self.async_abort(reason='not_hue_bridge')
 

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -3,10 +3,12 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.loader import bind_hass
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, CONF_ICON, CONF_RADIUS)
+    CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, CONF_ICON, CONF_RADIUS,
+    EVENT_CORE_CONFIG_UPDATE)
 from homeassistant.helpers import config_per_platform
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.util import slugify
@@ -90,12 +92,24 @@ async def async_setup(hass, config):
             hass.async_create_task(zone.async_update_ha_state())
             entities.add(zone.entity_id)
 
-    if ENTITY_ID_HOME not in entities and HOME_ZONE not in zone_entries:
-        zone = Zone(hass, hass.config.location_name,
-                    hass.config.latitude, hass.config.longitude,
-                    DEFAULT_RADIUS, ICON_HOME, False)
-        zone.entity_id = ENTITY_ID_HOME
-        hass.async_create_task(zone.async_update_ha_state())
+    if ENTITY_ID_HOME in entities or HOME_ZONE in zone_entries:
+        return True
+
+    zone = Zone(hass, hass.config.location_name,
+                hass.config.latitude, hass.config.longitude,
+                DEFAULT_RADIUS, ICON_HOME, False)
+    zone.entity_id = ENTITY_ID_HOME
+    hass.async_create_task(zone.async_update_ha_state())
+
+    @callback
+    def core_config_updated(_):
+        """Handle core config updated."""
+        zone.name = hass.config.location_name
+        zone.latitude = hass.config.latitude
+        zone.longitude = hass.config.longitude
+        zone.async_write_ha_state()
+
+    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, core_config_updated)
 
     return True
 

--- a/homeassistant/components/zone/zone.py
+++ b/homeassistant/components/zone/zone.py
@@ -23,20 +23,17 @@ def in_zone(zone, latitude, longitude, radius=0) -> bool:
 class Zone(Entity):
     """Representation of a Zone."""
 
+    name = None
+
     def __init__(self, hass, name, latitude, longitude, radius, icon, passive):
         """Initialize the zone."""
         self.hass = hass
-        self._name = name
-        self._latitude = latitude
-        self._longitude = longitude
+        self.name = name
+        self.latitude = latitude
+        self.longitude = longitude
         self._radius = radius
         self._icon = icon
         self._passive = passive
-
-    @property
-    def name(self):
-        """Return the name of the zone."""
-        return self._name
 
     @property
     def state(self):
@@ -53,8 +50,8 @@ class Zone(Entity):
         """Return the state attributes of the zone."""
         data = {
             ATTR_HIDDEN: True,
-            ATTR_LATITUDE: self._latitude,
-            ATTR_LONGITUDE: self._longitude,
+            ATTR_LATITUDE: self.latitude,
+            ATTR_LONGITUDE: self.longitude,
             ATTR_RADIUS: self._radius,
         }
         if self._passive:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 94
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1288,10 +1288,7 @@ class Config:
                 unit_system: Optional[str] = None,
                 location_name: Optional[str] = None,
                 time_zone: Optional[str] = None) -> None:
-        """Update the configuration from a dictionary.
-
-        Async friendly.
-        """
+        """Update the configuration from a dictionary."""
         self.config_source = source
         if latitude is not None:
             self.latitude = latitude
@@ -1309,11 +1306,8 @@ class Config:
         if time_zone is not None:
             self.set_time_zone(time_zone)
 
-    async def update(self, **kwargs: Any) -> None:
-        """Update the configuration from a dictionary.
-
-        Async friendly.
-        """
+    async def async_update(self, **kwargs: Any) -> None:
+        """Update the configuration from a dictionary."""
         self._update(source=SOURCE_STORAGE, **kwargs)
         await self.async_store()
         self.hass.bus.async_fire(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1045,7 +1045,7 @@ pydaikin==1.4.6
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==59
+pydeconz==60
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -230,7 +230,7 @@ pyHS100==0.3.5
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==59
+pydeconz==60
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -169,7 +169,7 @@ async def test_zeroconf_flow(hass):
             data={
                 config_flow.CONF_HOST: '1.2.3.4',
                 config_flow.CONF_PORT: 80,
-                'properties': {'macaddress': '1234'}
+                'properties': {'macaddress': '00408C12345'}
             },
             context={'source': 'zeroconf'}
         )
@@ -184,7 +184,7 @@ async def test_zeroconf_flow_known_device(hass):
     This is legacy support from devices registered with configurator.
     """
     with patch('homeassistant.components.axis.config_flow.load_json',
-               return_value={'1234ABCD': {
+               return_value={'00408C12345': {
                    config_flow.CONF_HOST: '2.3.4.5',
                    config_flow.CONF_USERNAME: 'user',
                    config_flow.CONF_PASSWORD: 'pass',
@@ -208,7 +208,7 @@ async def test_zeroconf_flow_known_device(hass):
                 config_flow.CONF_HOST: '1.2.3.4',
                 config_flow.CONF_PORT: 80,
                 'hostname': 'name',
-                'properties': {'macaddress': '1234ABCD'}
+                'properties': {'macaddress': '00408C12345'}
             },
             context={'source': 'zeroconf'}
         )
@@ -221,7 +221,7 @@ async def test_zeroconf_flow_already_configured(hass):
     entry = MockConfigEntry(
         domain=axis.DOMAIN,
         data={axis.CONF_DEVICE: {axis.config_flow.CONF_HOST: '1.2.3.4'},
-              axis.config_flow.CONF_MAC: '1234ABCD'}
+              axis.config_flow.CONF_MAC: '00408C12345'}
     )
     entry.add_to_hass(hass)
 
@@ -233,7 +233,7 @@ async def test_zeroconf_flow_already_configured(hass):
             config_flow.CONF_PASSWORD: 'pass',
             config_flow.CONF_PORT: 80,
             'hostname': 'name',
-            'properties': {'macaddress': '1234ABCD'}
+            'properties': {'macaddress': '00408C12345'}
         },
         context={'source': 'zeroconf'}
     )
@@ -242,11 +242,29 @@ async def test_zeroconf_flow_already_configured(hass):
     assert result['reason'] == 'already_configured'
 
 
+async def test_zeroconf_flow_ignore_non_axis_device(hass):
+    """Test that zeroconf doesn't setup devices with link local addresses."""
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        data={
+            config_flow.CONF_HOST: '169.254.3.4',
+            'properties': {'macaddress': '01234567890'}
+        },
+        context={'source': 'zeroconf'}
+    )
+
+    assert result['type'] == 'abort'
+    assert result['reason'] == 'not_axis_device'
+
+
 async def test_zeroconf_flow_ignore_link_local_address(hass):
     """Test that zeroconf doesn't setup devices with link local addresses."""
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
-        data={config_flow.CONF_HOST: '169.254.3.4'},
+        data={
+            config_flow.CONF_HOST: '169.254.3.4',
+            'properties': {'macaddress': '00408C12345'}
+        },
         context={'source': 'zeroconf'}
     )
 
@@ -257,7 +275,7 @@ async def test_zeroconf_flow_ignore_link_local_address(hass):
 async def test_zeroconf_flow_bad_config_file(hass):
     """Test that zeroconf discovery with bad config files abort."""
     with patch('homeassistant.components.axis.config_flow.load_json',
-               return_value={'1234ABCD': {
+               return_value={'00408C12345': {
                    config_flow.CONF_HOST: '2.3.4.5',
                    config_flow.CONF_USERNAME: 'user',
                    config_flow.CONF_PASSWORD: 'pass',
@@ -268,7 +286,7 @@ async def test_zeroconf_flow_bad_config_file(hass):
             config_flow.DOMAIN,
             data={
                 config_flow.CONF_HOST: '1.2.3.4',
-                'properties': {'macaddress': '1234ABCD'}
+                'properties': {'macaddress': '00408C12345'}
             },
             context={'source': 'zeroconf'}
         )

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import asyncio
 
 from homeassistant.components.deconz import config_flow
+from homeassistant.components.ssdp import ATTR_MANUFACTURERURL, ATTR_SERIAL
 from tests.common import MockConfigEntry
 
 import pydeconz
@@ -175,8 +176,8 @@ async def test_bridge_ssdp_discovery(hass):
         data={
             config_flow.CONF_HOST: '1.2.3.4',
             config_flow.CONF_PORT: 80,
-            config_flow.ATTR_SERIAL: 'id',
-            config_flow.ATTR_MANUFACTURERURL:
+            ATTR_SERIAL: 'id',
+            ATTR_MANUFACTURERURL:
                 config_flow.DECONZ_MANUFACTURERURL,
             config_flow.ATTR_UUID: 'uuid:1234'
         },
@@ -192,7 +193,7 @@ async def test_bridge_ssdp_discovery_not_deconz_bridge(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         data={
-            config_flow.ATTR_MANUFACTURERURL: 'not deconz bridge'
+            ATTR_MANUFACTURERURL: 'not deconz bridge'
         },
         context={'source': 'ssdp'}
     )
@@ -217,8 +218,8 @@ async def test_bridge_discovery_update_existing_entry(hass):
         config_flow.DOMAIN,
         data={
             config_flow.CONF_HOST: 'mock-deconz',
-            config_flow.ATTR_SERIAL: 'id',
-            config_flow.ATTR_MANUFACTURERURL:
+            ATTR_SERIAL: 'id',
+            ATTR_MANUFACTURERURL:
                 config_flow.DECONZ_MANUFACTURERURL,
             config_flow.ATTR_UUID: 'uuid:1234'
         },

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -29,11 +29,16 @@ def hassio_env():
 @pytest.fixture
 def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
     """Create mock hassio http client."""
-    with patch('homeassistant.components.hassio.HassIO.update_hass_api',
-               Mock(return_value=mock_coro({"result": "ok"}))), \
-            patch('homeassistant.components.hassio.HassIO.'
-                  'get_homeassistant_info',
-                  Mock(side_effect=HassioAPIError())):
+    with patch(
+            'homeassistant.components.hassio.HassIO.update_hass_api',
+            return_value=mock_coro({"result": "ok"})
+    ), patch(
+        'homeassistant.components.hassio.HassIO.update_hass_timezone',
+        return_value=mock_coro({"result": "ok"})
+    ), patch(
+        'homeassistant.components.hassio.HassIO.get_homeassistant_info',
+        side_effect=HassioAPIError()
+    ):
         hass.state = CoreState.starting
         hass.loop.run_until_complete(async_setup_component(hass, 'hassio', {
             'http': {

--- a/tests/components/hassio/test_addon_panel.py
+++ b/tests/components/hassio/test_addon_panel.py
@@ -56,7 +56,7 @@ async def test_hassio_addon_panel_startup(hass, aioclient_mock, hassio_env):
         })
         await hass.async_block_till_done()
 
-        assert aioclient_mock.call_count == 2
+        assert aioclient_mock.call_count == 3
         assert mock_panel.called
         mock_panel.assert_called_with(
             hass, 'test1', {
@@ -98,7 +98,7 @@ async def test_hassio_addon_panel_api(hass, aioclient_mock, hassio_env,
         })
         await hass.async_block_till_done()
 
-        assert aioclient_mock.call_count == 2
+        assert aioclient_mock.call_count == 3
         assert mock_panel.called
         mock_panel.assert_called_with(
             hass, 'test1', {

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -43,7 +43,7 @@ def test_setup_api_ping(hass, aioclient_mock):
         result = yield from async_setup_component(hass, 'hassio', {})
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert hass.components.hassio.get_homeassistant_version() == "10.0"
     assert hass.components.hassio.is_hassio()
 
@@ -82,7 +82,7 @@ def test_setup_api_push_api_data(hass, aioclient_mock):
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 9999
     assert aioclient_mock.mock_calls[1][2]['watchdog']
@@ -101,7 +101,7 @@ def test_setup_api_push_api_data_server_host(hass, aioclient_mock):
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 9999
     assert not aioclient_mock.mock_calls[1][2]['watchdog']
@@ -117,7 +117,7 @@ async def test_setup_api_push_api_data_default(hass, aioclient_mock,
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 8123
     refresh_token = aioclient_mock.mock_calls[1][2]['refresh_token']
@@ -177,26 +177,28 @@ async def test_setup_api_existing_hassio_user(hass, aioclient_mock,
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert not aioclient_mock.mock_calls[1][2]['ssl']
     assert aioclient_mock.mock_calls[1][2]['port'] == 8123
     assert aioclient_mock.mock_calls[1][2]['refresh_token'] == token.token
 
 
-@asyncio.coroutine
-def test_setup_core_push_timezone(hass, aioclient_mock):
+async def test_setup_core_push_timezone(hass, aioclient_mock):
     """Test setup with API push default data."""
+    hass.config.time_zone = 'testzone'
+
     with patch.dict(os.environ, MOCK_ENVIRON):
-        result = yield from async_setup_component(hass, 'hassio', {
+        result = await async_setup_component(hass, 'hassio', {
             'hassio': {},
-            'homeassistant': {
-                'time_zone': 'testzone',
-            },
         })
         assert result
 
     assert aioclient_mock.call_count == 5
     assert aioclient_mock.mock_calls[2][2]['timezone'] == "testzone"
+
+    await hass.config.async_update(time_zone='America/New_York')
+    await hass.async_block_till_done()
+    assert aioclient_mock.mock_calls[-1][2]['timezone'] == "America/New_York"
 
 
 @asyncio.coroutine
@@ -209,7 +211,7 @@ def test_setup_hassio_no_additional_data(hass, aioclient_mock):
         })
         assert result
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5
     assert aioclient_mock.mock_calls[-1][3]['X-Hassio-Key'] == "123456"
 
 
@@ -288,14 +290,14 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
         'hassio', 'addon_stdin', {'addon': 'test', 'input': 'test'})
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 6
+    assert aioclient_mock.call_count == 7
     assert aioclient_mock.mock_calls[-1][2] == 'test'
 
     yield from hass.services.async_call('hassio', 'host_shutdown', {})
     yield from hass.services.async_call('hassio', 'host_reboot', {})
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 8
+    assert aioclient_mock.call_count == 9
 
     yield from hass.services.async_call('hassio', 'snapshot_full', {})
     yield from hass.services.async_call('hassio', 'snapshot_partial', {
@@ -305,7 +307,7 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
     })
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 11
     assert aioclient_mock.mock_calls[-1][2] == {
         'addons': ['test'], 'folders': ['ssl'], 'password': "123456"}
 
@@ -321,7 +323,7 @@ def test_service_calls(hassio_env, hass, aioclient_mock):
     })
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 12
+    assert aioclient_mock.call_count == 13
     assert aioclient_mock.mock_calls[-1][2] == {
         'addons': ['test'], 'folders': ['ssl'], 'homeassistant': False,
         'password': "123456"
@@ -341,12 +343,12 @@ def test_service_calls_core(hassio_env, hass, aioclient_mock):
     yield from hass.services.async_call('homeassistant', 'stop')
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 3
+    assert aioclient_mock.call_count == 4
 
     yield from hass.services.async_call('homeassistant', 'check_config')
     yield from hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 3
+    assert aioclient_mock.call_count == 4
 
     with patch(
         'homeassistant.config.async_check_ha_config_file',
@@ -356,4 +358,4 @@ def test_service_calls_core(hassio_env, hass, aioclient_mock):
         yield from hass.async_block_till_done()
         assert mock_check_config.called
 
-    assert aioclient_mock.call_count == 4
+    assert aioclient_mock.call_count == 5

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -221,3 +221,24 @@ class TestComponentZone(unittest.TestCase):
 
         assert zone.zone.in_zone(self.hass.states.get('zone.passive_zone'),
                                  latitude, longitude)
+
+
+async def test_core_config_update(hass):
+    """Test updating core config will update home zone."""
+    assert await setup.async_setup_component(hass, 'zone', {})
+
+    home = hass.states.get('zone.home')
+
+    await hass.config.async_update(
+        location_name='Updated Name',
+        latitude=10,
+        longitude=20,
+    )
+    await hass.async_block_till_done()
+
+    home_updated = hass.states.get('zone.home')
+
+    assert home is not home_updated
+    assert home_updated.name == 'Updated Name'
+    assert home_updated.attributes['latitude'] == 10
+    assert home_updated.attributes['longitude'] == 20

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -444,7 +444,7 @@ async def test_updating_configuration(hass, hass_storage):
     hass_storage["core.config"] = dict(core_data)
     await config_util.async_process_ha_core_config(
         hass, {'whitelist_external_dirs': '/tmp'})
-    await hass.config.update(latitude=50)
+    await hass.config.async_update(latitude=50)
 
     new_core_data = copy.deepcopy(core_data)
     new_core_data['data']['latitude'] = 50

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -955,7 +955,7 @@ async def test_event_on_update(hass, hass_storage):
 
     assert hass.config.latitude != 12
 
-    await hass.config.update(latitude=12)
+    await hass.config.async_update(latitude=12)
     await hass.async_block_till_done()
 
     assert hass.config.latitude == 12
@@ -963,10 +963,10 @@ async def test_event_on_update(hass, hass_storage):
     assert events[0].data == {'latitude': 12}
 
 
-def test_bad_timezone_raises_value_error(hass):
+async def test_bad_timezone_raises_value_error(hass):
     """Test bad timezone raises ValueError."""
     with pytest.raises(ValueError):
-        hass.config.set_time_zone('not_a_timezone')
+        await hass.config.async_update(time_zone='not_a_timezone')
 
 
 @patch('homeassistant.core.monotonic')


### PR DESCRIPTION
- Load the SSDP component only when it's needed ([@aerialls] - [#24420]) ([deconz docs]) ([hue docs])
- Axis discovery MAC filter ([@Kane610] - [#24442]) ([axis docs])
- Remember gpslogger entities across restarts (fixes #24432) ([@andkit] - [#24444]) ([gpslogger docs])
- Update Hass.io when core config is updated ([@balloob] - [#24461]) ([hassio docs])
- Sun listener to adapt to core config updates ([@balloob] - [#24464])
- Update home zone when core config updated ([@balloob] - [#24237]) ([config docs]) ([zone docs])

[#24237]: https://github.com/home-assistant/home-assistant/pull/24237
[#24420]: https://github.com/home-assistant/home-assistant/pull/24420
[#24442]: https://github.com/home-assistant/home-assistant/pull/24442
[#24444]: https://github.com/home-assistant/home-assistant/pull/24444
[#24461]: https://github.com/home-assistant/home-assistant/pull/24461
[#24464]: https://github.com/home-assistant/home-assistant/pull/24464
[@Kane610]: https://github.com/Kane610
[@aerialls]: https://github.com/aerialls
[@andkit]: https://github.com/andkit
[@balloob]: https://github.com/balloob
[axis docs]: https://www.home-assistant.io/components/axis/
[config docs]: https://www.home-assistant.io/components/config/
[deconz docs]: https://www.home-assistant.io/components/deconz/
[gpslogger docs]: https://www.home-assistant.io/components/gpslogger/
[hassio docs]: https://www.home-assistant.io/components/hassio/
[hue docs]: https://www.home-assistant.io/components/hue/
[zone docs]: https://www.home-assistant.io/components/zone/