### PR TITLE
Use met.no instead of yr.no in default config

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -60,10 +60,9 @@ default_config:
 # http:
 #   base_url: example.duckdns.org:8123
 
-# Sensors
-sensor:
-  # Weather prediction
-  - platform: yr
+# Weather prediction
+weather:
+  - platform: met
 
 # Text to speech
 tts:


### PR DESCRIPTION
## Description:
Yr.no has long been used as a configuration example of a sensor.
It is however not optimal for lovelace, so I propose replacing it with the met.no weather component.

This *does* mean that there is no *sensor* in the default configuration anymore, though...

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
