### PR TITLE
Fix APRS imports

### DIFF
--- a/homeassistant/components/aprs/device_tracker.py
+++ b/homeassistant/components/aprs/device_tracker.py
@@ -5,9 +5,9 @@ import threading
 
 import voluptuous as vol
 
-from homeassistant.components.device_tracker import (
-    ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE, PLATFORM_SCHEMA)
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.const import (
+    ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
     CONF_HOST, CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv


### PR DESCRIPTION
## Description:

This should fix the current build failure:
```
ImportError while importing test module '/Users/am/home-assistant/tests/components/aprs/test_device_tracker.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/components/aprs/test_device_tracker.py:6: in <module>
    import homeassistant.components.aprs.device_tracker as device_tracker
homeassistant/components/aprs/device_tracker.py:8: in <module>
    from homeassistant.components.device_tracker import (
E   ImportError: cannot import name 'ATTR_LATITUDE'
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
