### PR TITLE
Bump adguardhome to 0.2.1

### DIFF
--- a/homeassistant/components/adguard/manifest.json
+++ b/homeassistant/components/adguard/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/adguard",
     "requirements": [
-        "adguardhome==0.2.0"
+        "adguardhome==0.2.1"
     ],
     "dependencies": [],
     "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,7 +108,7 @@ adafruit-blinka==1.2.1
 adafruit-circuitpython-mcp230xx==1.1.2
 
 # homeassistant.components.adguard
-adguardhome==0.2.0
+adguardhome==0.2.1
 
 # homeassistant.components.frontier_silicon
 afsapi==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyTransportNSW==0.1.1
 YesssSMS==0.2.3
 
 # homeassistant.components.adguard
-adguardhome==0.2.0
+adguardhome==0.2.1
 
 # homeassistant.components.ambient_station
 aioambient==0.3.0


### PR DESCRIPTION
## Description:

Bump `adguardhome` to 0.2.1, fixing an issue with the add filter subscription call in AdGuard Home 0.96

Release notes: <https://github.com/frenck/python-adguardhome/releases/tag/v0.2.1>

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html

Signed-off-by: Franck Nijhof <frenck@addons.community>
