### PR TITLE
Watson-TTS - Missing comma preventing other voices being used.

### DIFF
--- a/homeassistant/components/watson_tts/tts.py
+++ b/homeassistant/components/watson_tts/tts.py
@@ -23,7 +23,7 @@ SUPPORTED_VOICES = [
     "de-DE_BirgitVoice",
     "de-DE_BirgitV2Voice",
     "de-DE_DieterVoice",
-    "de-DE_DieterV2Voice"
+    "de-DE_DieterV2Voice",
     "en-GB_KateVoice",
     "en-US_AllisonVoice",
     "en-US_AllisonV2Voice",


### PR DESCRIPTION

The comma was missing for one of the listed voices in the new watson_tts component. This was preventing it and the next one from being a valid voice in configuration.

Invalid config for [tts.watson_tts]: value is not allowed for dictionary value @ data['voice']. Got 'en-GB_KateVoice'. (See /config/configuration.yaml, line 96). Please check the docs at https://home-assistant.io/components/tts.watson_tts/
Connection lost. Reconnecting…


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here> 
Not required

## Example entry for `configuration.yaml` (if applicable):
```yaml
NA

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
