### PR TITLE
Fix owntracks source_type for location messages with default trigger

### DIFF
--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
 )
 from homeassistant.components.device_tracker.const import (
-    ENTITY_ID_FORMAT, ATTR_SOURCE_TYPE)
+    ENTITY_ID_FORMAT, ATTR_SOURCE_TYPE, SOURCE_TYPE_GPS)
 from homeassistant.components.device_tracker.config_entry import (
     DeviceTrackerEntity
 )
@@ -127,7 +127,7 @@ class OwnTracksEntity(DeviceTrackerEntity, RestoreEntity):
     @property
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
-        return self._data.get('source_type')
+        return self._data.get('source_type', SOURCE_TYPE_GPS)
 
     @property
     def device_info(self):

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -411,6 +411,19 @@ async def test_location_update(hass, context):
     """Test the update of a location."""
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
 
+    assert_location_source_type(hass, 'gps')
+    assert_location_latitude(hass, LOCATION_MESSAGE['lat'])
+    assert_location_accuracy(hass, LOCATION_MESSAGE['acc'])
+    assert_location_state(hass, 'outer')
+
+
+async def test_location_update_no_t_key(hass, context):
+    """Test the update of a location when message does not contain 't'."""
+    message = LOCATION_MESSAGE.copy()
+    message.pop('t')
+    await send_message(hass, LOCATION_TOPIC, message)
+
+    assert_location_source_type(hass, 'gps')
     assert_location_latitude(hass, LOCATION_MESSAGE['lat'])
     assert_location_accuracy(hass, LOCATION_MESSAGE['acc'])
     assert_location_state(hass, 'outer')


### PR DESCRIPTION
## Description:

Some location update messages do not contain the 't' (trigger) key. Before the change in 0.94 to
entity based trackers, these would default to source_type of 'gps' (due to default parameter
value in async_see method.) To mirror this behavior in the new entity based tracker, the
source_type property should default to SOURCE_TYPE_GPS under the same conditions.

**Related issue (if applicable):** fixes #24496 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
