### PR TITLE
Migrate Sonos discovery to manifest

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -49,7 +49,6 @@ CONFIG_ENTRY_HANDLERS = {
     SERVICE_DAIKIN: 'daikin',
     SERVICE_HEOS: 'heos',
     SERVICE_TELLDUSLIVE: 'tellduslive',
-    'sonos': 'sonos',
     SERVICE_IGD: 'upnp',
 }
 
@@ -100,6 +99,7 @@ MIGRATED_SERVICE_HANDLERS = [
     'homekit',
     'ikea_tradfri',
     'philips_hue',
+    'sonos',
     SERVICE_WEMO,
 ]
 

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -7,6 +7,11 @@
     "pysonos==0.0.14"
   ],
   "dependencies": [],
+  "ssdp": {
+    "st": [
+      "urn:schemas-upnp-org:device:ZonePlayer:1"
+    ]
+  },
   "codeowners": [
     "@amelchio"
   ]

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -15,5 +15,9 @@ SSDP = {
             "hue"
         ]
     },
-    "st": {}
+    "st": {
+        "urn:schemas-upnp-org:device:ZonePlayer:1": [
+            "sonos"
+        ]
+    }
 }


### PR DESCRIPTION
## Description:
Move Sonos discovery to the manifest, making it discoverable via `ssdp`.

