### PR TITLE
Remove conversation from default config

### DIFF
--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -7,7 +7,6 @@
     "automation",
     "cloud",
     "config",
-    "conversation",
     "frontend",
     "history",
     "logbook",


### PR DESCRIPTION
## Breaking Change:

The conversation integration is no longer loaded as part of the default config. If you wish to continue using it, add `conversation:` to your configuration.yaml.

## Description:
The conversation integration allows users to give voice commands via the frontend (the microphone button in Lovelace). It also allows people to configure their own custom sentences. However, this is barely used and the default settings are making it not a very useful feature.

I suggest that we retire it from the default config, and we can always add it back if it becomes more useful.

