### PR TITLE
Update DelugeClient to 1.7.1

### DIFF
--- a/homeassistant/components/deluge/manifest.json
+++ b/homeassistant/components/deluge/manifest.json
@@ -3,7 +3,7 @@
   "name": "Deluge",
   "documentation": "https://www.home-assistant.io/components/deluge",
   "requirements": [
-    "deluge-client==1.4.0"
+    "deluge-client==1.7.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -355,7 +355,7 @@ datapoint==0.4.3
 defusedxml==0.6.0
 
 # homeassistant.components.deluge
-deluge-client==1.4.0
+deluge-client==1.7.1
 
 # homeassistant.components.denonavr
 denonavr==0.7.9


### PR DESCRIPTION
## Breaking Change:
Updating deluge-client to version 1.7.1 to solve connectivity issues to Deluge daemon 2.0

## Description:
As described in  #24517 - I'm failing to connect to deluge 2.0.3 daemon. I suspect that to be due to changes in the client (daemon 2.0.x is not backward compatible as written in the release notes).
This is an attempt to update the deluge-client package in order to solve this problem

**Related issue (if applicable):** fixes #24517

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: deluge
    name: localDeluge
    host: !secret deluge_ip
    port: !secret deluge_port
    username: !secret deluge_username
    password: !secret deluge_password
    monitored_variables:
      - 'current_status'
      - 'download_speed'
      - 'upload_speed'

switch:
  - platform: deluge
    name: localDeluge
    host: !secret deluge_ip
    port: !secret deluge_port
    username: !secret deluge_username
    password: !secret deluge_password
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
