### PR TITLE
Fix a bug with Ambient PWS reconnection

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -327,7 +327,7 @@ class AmbientStation:
             """Define a handler to fire when the websocket is connected."""
             _LOGGER.info('Connected to websocket')
             _LOGGER.debug('Watchdog starting')
-            if self._watchdog_listener:
+            if self._watchdog_listener is not None:
                 self._watchdog_listener()
             self._watchdog_listener = async_call_later(
                 self._hass, DEFAULT_WATCHDOG_SECONDS, _ws_reconnect)

--- a/homeassistant/components/ambient_station/manifest.json
+++ b/homeassistant/components/ambient_station/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ambient_station",
   "requirements": [
-    "aioambient==0.3.0"
+    "aioambient==0.3.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -114,7 +114,7 @@ adguardhome==0.2.1
 afsapi==0.0.4
 
 # homeassistant.components.ambient_station
-aioambient==0.3.0
+aioambient==0.3.1
 
 # homeassistant.components.asuswrt
 aioasuswrt==1.1.21

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -39,7 +39,7 @@ YesssSMS==0.2.3
 adguardhome==0.2.1
 
 # homeassistant.components.ambient_station
-aioambient==0.3.0
+aioambient==0.3.1
 
 # homeassistant.components.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:

This PR bumps `aioambient` to 0.3.1. Changelog: https://github.com/bachya/aioambient/releases/tag/0.3.1

Additionally, it makes a small change to remove a spurious warning that could occur if the integration attempted to cancel a timer handle that didn't exit.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/24509

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
