### PR TITLE
[bug fix] Handle stacktrace when rtorrent host is unreachable

### DIFF
--- a/homeassistant/components/rtorrent/sensor.py
+++ b/homeassistant/components/rtorrent/sensor.py
@@ -99,8 +99,9 @@ class RTorrentSensor(Entity):
         try:
             self.data = multicall()
             self._available = True
-        except (xmlrpc.client.ProtocolError, ConnectionRefusedError):
-            _LOGGER.error("Connection to rtorrent lost")
+        except (xmlrpc.client.ProtocolError,
+                ConnectionRefusedError, OSError) as ex:
+            _LOGGER.error("Connection to rtorrent failed (%s)", ex)
             self._available = False
             return
 


### PR DESCRIPTION
## Description:

Bug fix a stacktrace from the `rtorrent` sensor.

My log is full of these when my NAS (which runs rtorrent) is down:

```
2019-06-15 00:03:17 ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.rtorrent_up_speed fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/rtorrent/sensor.py", line 100, in update
    self.data = multicall()
  File "/usr/local/lib/python3.7/xmlrpc/client.py", line 882, in __call__
    return MultiCallIterator(self.__server.system.multicall(marshalled_list))
  File "/usr/local/lib/python3.7/xmlrpc/client.py", line 1112, in __call__
    return self.__send(self.__name, args)
  File "/usr/local/lib/python3.7/xmlrpc/client.py", line 1452, in __request
    verbose=self.__verbose
  File "/usr/local/lib/python3.7/xmlrpc/client.py", line 1154, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/local/lib/python3.7/xmlrpc/client.py", line 1166, in single_request
    http_conn = self.send_request(host, handler, request_body, verbose)
  File "/usr/local/lib/python3.7/xmlrpc/client.py", line 1279, in send_request
    self.send_content(connection, request_body)
  File "/usr/local/lib/python3.7/xmlrpc/client.py", line 1309, in send_content
    connection.endheaders(request_body)
  File "/usr/local/lib/python3.7/http/client.py", line 1224, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.7/http/client.py", line 1016, in _send_output
    self.send(msg)
  File "/usr/local/lib/python3.7/http/client.py", line 956, in send
    self.connect()
  File "/usr/local/lib/python3.7/http/client.py", line 928, in connect
    (self.host,self.port), self.timeout, self.source_address)
  File "/usr/local/lib/python3.7/socket.py", line 727, in create_connection
    raise err
  File "/usr/local/lib/python3.7/socket.py", line 716, in create_connection
    sock.connect(sa)
OSError: [Errno 113] Host is unreachable
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]