### PR TITLE
Fix geniushub issue #24530 (via a client bump) & handle edge cases

### DIFF
--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -18,8 +18,9 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the Genius Hub sensor entities."""
     client = hass.data[DOMAIN]['client']
 
+    devices = [d for d in client.hub.device_objs if d.type is not None]
     switches = [GeniusBinarySensor(client, d)
-                for d in client.hub.device_objs if d.type[:21] in GH_IS_SWITCH]
+                for d in devices if d.type[:21] in GH_IS_SWITCH]
 
     async_add_entities(switches)
 

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.4.11"
+    "geniushub-client==0.4.12"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/water_heater.py
+++ b/homeassistant/components/geniushub/water_heater.py
@@ -95,10 +95,9 @@ class GeniusWaterHeater(WaterHeaterDevice):
     def current_temperature(self):
         """Return the current temperature."""
         try:
-            temp = self._boiler.temperature
+            return self._boiler.temperature
         except AttributeError:
-            temp = None
-        return temp
+            return None
 
     @property
     def target_temperature(self):

--- a/homeassistant/components/geniushub/water_heater.py
+++ b/homeassistant/components/geniushub/water_heater.py
@@ -94,7 +94,11 @@ class GeniusWaterHeater(WaterHeaterDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._boiler.temperature
+        try:
+            temp = self._boiler.temperature
+        except AttributeError:
+            temp = None
+        return temp
 
     @property
     def target_temperature(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -494,7 +494,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.4.11
+geniushub-client==0.4.12
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
## Breaking Change:

NO breaking changes.

## Description:
Bump the **geniushub-client** to swap a `_LOGGER.exception()` for a `_LOGGER.error()` that is causing climate platform to fail to load if only one zone's schedule is invalid.

Handle two edge cases revealed during testing: Null devices, and DHW zones without a temperature probe.

**Related issue (if applicable):** fixes #24530

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** No changes

## Example entry for `configuration.yaml` (if applicable):
Unchanged

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works. N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
