### PR TITLE
SMA sensor: Add optional path

### DIFF
--- a/homeassistant/components/sma/sensor.py
+++ b/homeassistant/components/sma/sensor.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_SSL, CONF_VERIFY_SSL,
-    EVENT_HOMEASSISTANT_STOP)
+    EVENT_HOMEASSISTANT_STOP, CONF_PATH)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -52,6 +52,7 @@ CUSTOM_SCHEMA = vol.Any({
         vol.All(cv.string, vol.Length(min=13, max=15)),
     vol.Required(CONF_UNIT): cv.string,
     vol.Optional(CONF_FACTOR, default=1): vol.Coerce(float),
+    vol.Optional(CONF_PATH): vol.All(cv.ensure_list, [str]),
 })
 
 PLATFORM_SCHEMA = vol.All(PLATFORM_SCHEMA.extend({
@@ -79,7 +80,8 @@ async def async_setup_platform(
     sensor_def = pysma.Sensors()
 
     # Sensor from the custom config
-    sensor_def.add([pysma.Sensor(o[CONF_KEY], n, o[CONF_UNIT], o[CONF_FACTOR])
+    sensor_def.add([pysma.Sensor(o[CONF_KEY], n, o[CONF_UNIT], o[CONF_FACTOR],
+                                 o.get(CONF_PATH))
                     for n, o in config[CONF_CUSTOM].items()])
 
     # Use all sensors by default


### PR DESCRIPTION
## Description:
Add an optional `path:` option to custom sensors to pass through to the `pysma` library

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: sma
    host: IP_ADDRESS_OF_DEVICE
    password: YOUR_SMA_PASSWORD
    sensors:
      custom1:
    custom:
      custom1:
         key: 6400_00543A01
         unit: kWh
         path: "63".[]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
