### PR TITLE
Better pairing for Xiaomi devices in ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -14,7 +14,7 @@ from random import uniform
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from ..helpers import (
-    bind_configure_reporting, construct_unique_id,
+    configure_reporting, construct_unique_id,
     safe_read, get_attr_id_by_name, bind_cluster)
 from ..const import (
     REPORT_CONFIG_DEFAULT, SIGNAL_ATTR_UPDATED, ATTRIBUTE_CHANNEL,
@@ -137,24 +137,21 @@ class ZigbeeChannel:
         if self._zha_device.manufacturer != 'LUMI':
             if self.cluster.cluster_id >= 0xfc00 and manufacturer_code:
                 manufacturer = manufacturer_code
-            if self.cluster.bind_only:
-                await bind_cluster(self._unique_id, self.cluster)
-            else:
-                skip_bind = False  # bind cluster only for the 1st attr
+            await bind_cluster(self._unique_id, self.cluster)
+            if not self.cluster.bind_only:
                 for report_config in self._report_config:
                     attr = report_config.get('attr')
                     min_report_interval, max_report_interval, change = \
                         report_config.get('config')
-                    await bind_configure_reporting(
+                    await configure_reporting(
                         self._unique_id, self.cluster, attr,
                         min_report=min_report_interval,
                         max_report=max_report_interval,
                         reportable_change=change,
-                        skip_bind=skip_bind,
                         manufacturer=manufacturer
                     )
-                    skip_bind = True
                     await asyncio.sleep(uniform(0.1, 0.5))
+
         _LOGGER.debug(
             "%s: finished channel configuration",
             self._unique_id

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -133,26 +133,28 @@ class ZigbeeChannel:
         """Set cluster binding and attribute reporting."""
         manufacturer = None
         manufacturer_code = self._zha_device.manufacturer_code
-        if self.cluster.cluster_id >= 0xfc00 and manufacturer_code:
-            manufacturer = manufacturer_code
-        if self.cluster.bind_only:
-            await bind_cluster(self._unique_id, self.cluster)
-        else:
-            skip_bind = False  # bind cluster only for the 1st configured attr
-            for report_config in self._report_config:
-                attr = report_config.get('attr')
-                min_report_interval, max_report_interval, change = \
-                    report_config.get('config')
-                await bind_configure_reporting(
-                    self._unique_id, self.cluster, attr,
-                    min_report=min_report_interval,
-                    max_report=max_report_interval,
-                    reportable_change=change,
-                    skip_bind=skip_bind,
-                    manufacturer=manufacturer
-                )
-                skip_bind = True
-                await asyncio.sleep(uniform(0.1, 0.5))
+        # Xiaomi devices don't need this and it disrupts pairing
+        if self._zha_device.manufacturer != 'LUMI':
+            if self.cluster.cluster_id >= 0xfc00 and manufacturer_code:
+                manufacturer = manufacturer_code
+            if self.cluster.bind_only:
+                await bind_cluster(self._unique_id, self.cluster)
+            else:
+                skip_bind = False  # bind cluster only for the 1st attr
+                for report_config in self._report_config:
+                    attr = report_config.get('attr')
+                    min_report_interval, max_report_interval, change = \
+                        report_config.get('config')
+                    await bind_configure_reporting(
+                        self._unique_id, self.cluster, attr,
+                        min_report=min_report_interval,
+                        max_report=max_report_interval,
+                        reportable_change=change,
+                        skip_bind=skip_bind,
+                        manufacturer=manufacturer
+                    )
+                    skip_bind = True
+                    await asyncio.sleep(uniform(0.1, 0.5))
         _LOGGER.debug(
             "%s: finished channel configuration",
             self._unique_id

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -35,6 +35,9 @@ class IASZoneChannel(ZigbeeChannel):
 
     async def async_configure(self):
         """Configure IAS device."""
+        # Xiaomi devices don't need this and it disrupts pairing
+        if self._zha_device.manufacturer == 'LUMI':
+            return
         from zigpy.exceptions import DeliveryError
         _LOGGER.debug("%s: started IASZoneChannel configuration",
                       self._unique_id)


### PR DESCRIPTION
## Description:
This PR adds checks to skip bind and configure reporting calls for all clusters on Xiaomi devices. I am not a fan of the manufacturer check in generic code but the usability improvement for users warrants the change. This should significantly reduce the failed pairing attempts for Xiaomi devices. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]