### PR TITLE
Update pysonos to 0.0.15

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.14"
+    "pysonos==0.0.15"
   ],
   "dependencies": [],
   "ssdp": {

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -227,10 +227,10 @@ def _timespan_secs(timespan):
 
 
 def _is_radio_uri(uri):
-    """Return whether the URI is a radio stream."""
+    """Return whether the URI is a stream (not a playlist)."""
     radio_schemes = (
         'x-rincon-mp3radio:', 'x-sonosapi-stream:', 'x-sonosapi-radio:',
-        'x-sonosapi-hls:', 'hls-radio:')
+        'x-sonosapi-hls:', 'hls-radio:', 'x-rincon-stream:')
     return uri.startswith(radio_schemes)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1351,7 +1351,7 @@ pysmarty==0.8
 pysnmp==4.4.9
 
 # homeassistant.components.sonos
-pysonos==0.0.14
+pysonos==0.0.15
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -286,7 +286,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.8
 
 # homeassistant.components.sonos
-pysonos==0.0.14
+pysonos==0.0.15
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

Adds support for selecting favorites that are Line-in sources. Sonos presents these as a special kind of radio stream.

**Related issue (if applicable):** [discussed in the forum](https://community.home-assistant.io/t/simple-automation-giving-me-issues/121730/8)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html