### PR TITLE
Added percent to the disk,memory and swap percent labels

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -26,13 +26,13 @@ DEFAULT_VERSION = 2
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 SENSOR_TYPES = {
-    'disk_use_percent': ['Disk used', '%', 'mdi:harddisk'],
+    'disk_use_percent': ['Disk used percent', '%', 'mdi:harddisk'],
     'disk_use': ['Disk used', 'GiB', 'mdi:harddisk'],
     'disk_free': ['Disk free', 'GiB', 'mdi:harddisk'],
-    'memory_use_percent': ['RAM used', '%', 'mdi:memory'],
+    'memory_use_percent': ['RAM used percent', '%', 'mdi:memory'],
     'memory_use': ['RAM used', 'MiB', 'mdi:memory'],
     'memory_free': ['RAM free', 'MiB', 'mdi:memory'],
-    'swap_use_percent': ['Swap used', '%', 'mdi:memory'],
+    'swap_use_percent': ['Swap used percent', '%', 'mdi:memory'],
     'swap_use': ['Swap used', 'GiB', 'mdi:memory'],
     'swap_free': ['Swap free', 'GiB', 'mdi:memory'],
     'processor_load': ['CPU load', '15 min', 'mdi:memory'],


### PR DESCRIPTION
## Breaking Change:
The disk_use, memory_use and swap_use percentage items will now have percentage in the name.

## Description:
Currently the disk_use, memory_use and swap_use entities are duplicated in random order

**Related issue (if applicable):** fixes #24574

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: glances
    host: 10.18.1.1
    name: Medusa
    version: 2
    resources:
      - disk_use_percent
      - disk_use
      - memory_use_percent
      - memory_use
      - swap_use_percent
      - swap_use
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
