### PR TITLE
Fix zeroconf migration messing up ESPHome discovery

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -56,6 +56,7 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
         self.context['title_placeholders'] = {
             'name': self._name
         }
+        self.context['name'] = self._name
 
         # Only show authentication step if device uses password
         if device_info.uses_password:
@@ -98,9 +99,11 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
                     already_configured = data.device_info.name == node_name
 
             if already_configured:
-                return self.async_abort(
-                    reason='already_configured'
-                )
+                return self.async_abort(reason='already_configured')
+
+        for flow in self._async_in_progress():
+            if flow['context']['name'] == node_name:
+                return self.async_abort(reason='already_configured')
 
         return await self._async_authenticate_or_add(user_input={
             'host': address,


### PR DESCRIPTION
## Description:

See https://github.com/esphome/issues/issues/451

The discovery -> zeroconf migration introduced a slight semantic difference.

Before, when discovery would notice two payloads with exact same data, it would not forward the duplicate payload.

zeroconf does not do this de-duplication - any payload is directly forwarded to the integration.

The result is that config flows show up multiple times. For each time the payload is received.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/451

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
