### PR TITLE
Cloud: Make sure on_connect forwards platform only once

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -191,8 +191,16 @@ async def async_setup(hass, config):
     hass.helpers.service.async_register_admin_service(
         DOMAIN, SERVICE_REMOTE_DISCONNECT, _service_handler)
 
+    loaded_binary_sensor = False
+
     async def _on_connect():
         """Discover RemoteUI binary sensor."""
+        nonlocal loaded_binary_sensor
+
+        if loaded_binary_sensor:
+            return
+
+        loaded_binary_sensor = True
         hass.async_create_task(hass.helpers.discovery.async_load_platform(
             'binary_sensor', DOMAIN, {}, config))
 

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -164,6 +164,7 @@ async def test_on_connect(hass, mock_cloud_fixture):
 
     assert len(hass.states.async_entity_ids('binary_sensor')) == 0
 
+    assert 'async_setup' in str(cl.iot._on_connect[-1])
     await cl.iot._on_connect[-1]()
     await hass.async_block_till_done()
 

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -154,3 +154,24 @@ async def test_setup_setup_cloud_user(hass, hass_storage):
 
     assert cloud_user
     assert cloud_user.groups[0].id == GROUP_ID_ADMIN
+
+
+async def test_on_connect(hass, mock_cloud_fixture):
+    """Test cloud on connect triggers."""
+    cl = hass.data['cloud']
+
+    assert len(cl.iot._on_connect) == 4
+
+    assert len(hass.states.async_entity_ids('binary_sensor')) == 0
+
+    await cl.iot._on_connect[-1]()
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids('binary_sensor')) == 1
+
+    with patch('homeassistant.helpers.discovery.async_load_platform',
+               side_effect=mock_coro) as mock_load:
+        await cl.iot._on_connect[-1]()
+        await hass.async_block_till_done()
+
+    assert len(mock_load.mock_calls) == 0


### PR DESCRIPTION
## Description:
Only forward the cloud entry once.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
