### PR TITLE
Add ESPHome event generation and user-defined service array support

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -6,14 +6,14 @@ from typing import Any, Callable, Dict, List, Optional
 
 from aioesphomeapi import (
     APIClient, APIConnectionError, DeviceInfo, EntityInfo, EntityState,
-    ServiceCall, UserService, UserServiceArgType)
+    HomeassistantServiceCall, UserService, UserServiceArgType)
 import voluptuous as vol
 
 from homeassistant import const
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PORT, EVENT_HOMEASSISTANT_STOP)
-from homeassistant.core import Event, State, callback
+from homeassistant.core import Event, State, callback, EventOrigin
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
@@ -98,7 +98,7 @@ async def async_setup_entry(hass: HomeAssistantType,
         entry_data.async_update_state(hass, state)
 
     @callback
-    def async_on_service_call(service: ServiceCall) -> None:
+    def async_on_service_call(service: HomeassistantServiceCall) -> None:
         """Call service when user automation in ESPHome config is triggered."""
         domain, service_name = service.service.split('.', 1)
         service_data = service.data
@@ -114,8 +114,17 @@ async def async_setup_entry(hass: HomeAssistantType,
                 _LOGGER.error('Error rendering data template: %s', ex)
                 return
 
-        hass.async_create_task(hass.services.async_call(
-            domain, service_name, service_data, blocking=True))
+        if service.is_event:
+            # ESPHome uses servicecall packet for both events and service calls
+            # Ensure the user can only send events of form 'esphome.xyz'
+            if domain != 'esphome':
+                raise ValueError("Can only generate events under esphome "
+                                 "domain!")
+            hass.bus.async_fire(service.service, service_data,
+                                EventOrigin.remote)
+        else:
+            hass.async_create_task(hass.services.async_call(
+                domain, service_name, service_data, blocking=True))
 
     async def send_home_assistant_state(entity_id: str, _,
                                         new_state: Optional[State]) -> None:
@@ -239,7 +248,7 @@ async def _async_setup_device_registry(hass: HomeAssistantType,
                                        entry: ConfigEntry,
                                        device_info: DeviceInfo):
     """Set up device registry feature for a particular config entry."""
-    sw_version = device_info.esphome_core_version
+    sw_version = device_info.esphome_version
     if device_info.compilation_time:
         sw_version += ' ({})'.format(device_info.compilation_time)
     device_registry = await dr.async_get_registry(hass)
@@ -266,6 +275,10 @@ async def _register_service(hass: HomeAssistantType,
             UserServiceArgType.INT: vol.Coerce(int),
             UserServiceArgType.FLOAT: vol.Coerce(float),
             UserServiceArgType.STRING: cv.string,
+            UserServiceArgType.BOOL_ARRAY: [cv.boolean],
+            UserServiceArgType.INT_ARRAY: [vol.Coerce(int)],
+            UserServiceArgType.FLOAT_ARRAY: [vol.Coerce(float)],
+            UserServiceArgType.STRING_ARRAY: [cv.string],
         }[arg.type_]
 
     async def execute_service(call):

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -13,7 +13,7 @@ from homeassistant import const
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PORT, EVENT_HOMEASSISTANT_STOP)
-from homeassistant.core import Event, State, callback, EventOrigin
+from homeassistant.core import Event, State, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -118,10 +118,10 @@ async def async_setup_entry(hass: HomeAssistantType,
             # ESPHome uses servicecall packet for both events and service calls
             # Ensure the user can only send events of form 'esphome.xyz'
             if domain != 'esphome':
-                raise ValueError("Can only generate events under esphome "
-                                 "domain!")
-            hass.bus.async_fire(service.service, service_data,
-                                EventOrigin.remote)
+                _LOGGER.error("Can only generate events under esphome "
+                              "domain!")
+                return
+            hass.bus.async_fire(service.service, service_data)
         else:
             hass.async_create_task(hass.services.async_call(
                 domain, service_name, service_data, blocking=True))

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/esphome",
   "requirements": [
-    "aioesphomeapi==2.1.0"
+    "aioesphomeapi==2.2.0"
   ],
   "dependencies": [],
   "zeroconf": ["_esphomelib._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -129,7 +129,7 @@ aiobotocore==0.10.2
 aiodns==2.0.0
 
 # homeassistant.components.esphome
-aioesphomeapi==2.1.0
+aioesphomeapi==2.2.0
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -48,7 +48,7 @@ aioautomatic==0.6.5
 aiobotocore==0.10.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.1.0
+aioesphomeapi==2.2.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

Part of https://github.com/esphome/esphome/pull/633/files

Adds two new features to ESPHome:

 - Users can send events from ESPHome to HA (closes https://github.com/esphome/feature-requests/issues/89). This uses the existing HA service packet type and just adds an option boolean field. Only events beginning with `esphome.` can be generated (for security reasons).

 - Native API User-defined services can now also accept arrays as parameters.

aioesphomeapi changelog: https://github.com/esphome/aioesphomeapi/compare/v2.1.0...v2.2.0

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
