### PR TITLE
Add time delta option when searching for deutsche_bahn connections

### DIFF
--- a/homeassistant/components/deutsche_bahn/sensor.py
+++ b/homeassistant/components/deutsche_bahn/sensor.py
@@ -13,8 +13,8 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_DESTINATION = 'to'
 CONF_START = 'from'
-CONF_TIME_DELTA = 'offset'
-DEFAULT_TIME_DELTA = timedelta(minutes=0)
+CONF_OFFSET = 'offset'
+DEFAULT_OFFSET = timedelta(minutes=0)
 CONF_ONLY_DIRECT = 'only_direct'
 DEFAULT_ONLY_DIRECT = False
 
@@ -25,7 +25,7 @@ SCAN_INTERVAL = timedelta(minutes=2)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,
     vol.Required(CONF_START): cv.string,
-    vol.Optional(CONF_TIME_DELTA, default=DEFAULT_TIME_DELTA): cv.time_period,
+    vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): cv.time_period,
     vol.Optional(CONF_ONLY_DIRECT, default=DEFAULT_ONLY_DIRECT): cv.boolean,
 })
 
@@ -34,20 +34,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Deutsche Bahn Sensor."""
     start = config.get(CONF_START)
     destination = config.get(CONF_DESTINATION)
-    time_delta = config.get(CONF_TIME_DELTA)
+    offset = config.get(CONF_OFFSET)
     only_direct = config.get(CONF_ONLY_DIRECT)
 
     add_entities([DeutscheBahnSensor(start, destination,
-                                     time_delta, only_direct)], True)
+                                     offset, only_direct)], True)
 
 
 class DeutscheBahnSensor(Entity):
     """Implementation of a Deutsche Bahn sensor."""
 
-    def __init__(self, start, goal, time_delta, only_direct):
+    def __init__(self, start, goal, offset, only_direct):
         """Initialize the sensor."""
         self._name = '{} to {}'.format(start, goal)
-        self.data = SchieneData(start, goal, time_delta, only_direct)
+        self.data = SchieneData(start, goal, offset, only_direct)
         self._state = None
 
     @property
@@ -86,13 +86,13 @@ class DeutscheBahnSensor(Entity):
 class SchieneData:
     """Pull data from the bahn.de web page."""
 
-    def __init__(self, start, goal, time_delta, only_direct):
+    def __init__(self, start, goal, offset, only_direct):
         """Initialize the sensor."""
         import schiene
 
         self.start = start
         self.goal = goal
-        self.time_delta = time_delta
+        self.offset = offset
         self.only_direct = only_direct
         self.schiene = schiene.Schiene()
         self.connections = [{}]
@@ -101,7 +101,7 @@ class SchieneData:
         """Update the connection data."""
         self.connections = self.schiene.connections(
             self.start, self.goal,
-            dt_util.as_local(dt_util.utcnow())+self.time_delta,
+            dt_util.as_local(dt_util.utcnow())+self.offset,
             self.only_direct)
 
         if not self.connections:

--- a/homeassistant/components/deutsche_bahn/sensor.py
+++ b/homeassistant/components/deutsche_bahn/sensor.py
@@ -37,7 +37,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     time_delta = config.get(CONF_TIME_DELTA)
     only_direct = config.get(CONF_ONLY_DIRECT)
 
-    add_entities([DeutscheBahnSensor(start, destination, time_delta, only_direct)], True)
+    add_entities([DeutscheBahnSensor(start, destination,
+                                     time_delta, only_direct)], True)
 
 
 class DeutscheBahnSensor(Entity):
@@ -99,7 +100,8 @@ class SchieneData:
     def update(self):
         """Update the connection data."""
         self.connections = self.schiene.connections(
-            self.start, self.goal, dt_util.as_local(dt_util.utcnow())+self.time_delta,
+            self.start, self.goal,
+            dt_util.as_local(dt_util.utcnow())+self.time_delta,
             self.only_direct)
 
         if not self.connections:

--- a/homeassistant/components/deutsche_bahn/sensor.py
+++ b/homeassistant/components/deutsche_bahn/sensor.py
@@ -101,7 +101,7 @@ class SchieneData:
         """Update the connection data."""
         self.connections = self.schiene.connections(
             self.start, self.goal,
-            dt_util.as_local(dt_util.utcnow())+self.offset,
+            dt_util.as_local(dt_util.utcnow()+self.offset),
             self.only_direct)
 
         if not self.connections:

--- a/homeassistant/components/deutsche_bahn/sensor.py
+++ b/homeassistant/components/deutsche_bahn/sensor.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_DESTINATION = 'to'
 CONF_START = 'from'
-CONF_TIME_DELTA = 'in'
+CONF_TIME_DELTA = 'offset'
 DEFAULT_TIME_DELTA = timedelta(minutes=0)
 CONF_ONLY_DIRECT = 'only_direct'
 DEFAULT_ONLY_DIRECT = False

--- a/homeassistant/components/deutsche_bahn/sensor.py
+++ b/homeassistant/components/deutsche_bahn/sensor.py
@@ -13,6 +13,8 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_DESTINATION = 'to'
 CONF_START = 'from'
+CONF_TIME_DELTA = 'in'
+DEFAULT_TIME_DELTA = timedelta(minutes=0)
 CONF_ONLY_DIRECT = 'only_direct'
 DEFAULT_ONLY_DIRECT = False
 
@@ -23,6 +25,7 @@ SCAN_INTERVAL = timedelta(minutes=2)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,
     vol.Required(CONF_START): cv.string,
+    vol.Optional(CONF_TIME_DELTA, default=DEFAULT_TIME_DELTA): cv.time_period,
     vol.Optional(CONF_ONLY_DIRECT, default=DEFAULT_ONLY_DIRECT): cv.boolean,
 })
 
@@ -31,18 +34,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Deutsche Bahn Sensor."""
     start = config.get(CONF_START)
     destination = config.get(CONF_DESTINATION)
+    time_delta = config.get(CONF_TIME_DELTA)
     only_direct = config.get(CONF_ONLY_DIRECT)
 
-    add_entities([DeutscheBahnSensor(start, destination, only_direct)], True)
+    add_entities([DeutscheBahnSensor(start, destination, time_delta, only_direct)], True)
 
 
 class DeutscheBahnSensor(Entity):
     """Implementation of a Deutsche Bahn sensor."""
 
-    def __init__(self, start, goal, only_direct):
+    def __init__(self, start, goal, time_delta, only_direct):
         """Initialize the sensor."""
         self._name = '{} to {}'.format(start, goal)
-        self.data = SchieneData(start, goal, only_direct)
+        self.data = SchieneData(start, goal, time_delta, only_direct)
         self._state = None
 
     @property
@@ -81,12 +85,13 @@ class DeutscheBahnSensor(Entity):
 class SchieneData:
     """Pull data from the bahn.de web page."""
 
-    def __init__(self, start, goal, only_direct):
+    def __init__(self, start, goal, time_delta, only_direct):
         """Initialize the sensor."""
         import schiene
 
         self.start = start
         self.goal = goal
+        self.time_delta = time_delta
         self.only_direct = only_direct
         self.schiene = schiene.Schiene()
         self.connections = [{}]
@@ -94,7 +99,7 @@ class SchieneData:
     def update(self):
         """Update the connection data."""
         self.connections = self.schiene.connections(
-            self.start, self.goal, dt_util.as_local(dt_util.utcnow()),
+            self.start, self.goal, dt_util.as_local(dt_util.utcnow())+self.time_delta,
             self.only_direct)
 
         if not self.connections:


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Add another option 'offset' to search for upcoming connections in the future.
Handy if you need a few minutes to get to the train station and need to add that to the queried departure time.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9647

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: deutsche_bahn
    from: Essen HBf
    to: Düsseldorf HBf
    offset: '00:10:00'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
