### PR TITLE
Update pysonos to 0.0.16

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.15"
+    "pysonos==0.0.16"
   ],
   "dependencies": [],
   "ssdp": {

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -34,8 +34,7 @@ from . import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PARALLEL_UPDATES = 0
-
+SCAN_INTERVAL = 10
 DISCOVERY_INTERVAL = 60
 
 # Quiet down pysonos logging to just actual problems.
@@ -241,7 +240,7 @@ class SonosEntity(MediaPlayerDevice):
         """Initialize the Sonos entity."""
         self._seen = None
         self._subscriptions = []
-        self._receives_events = False
+        self._poll_timer = None
         self._volume_increment = 2
         self._unique_id = player.uid
         self._player = player
@@ -347,6 +346,10 @@ class SonosEntity(MediaPlayerDevice):
         if self._seen < time.monotonic() - 2*DISCOVERY_INTERVAL:
             self._available = False
 
+            if self._poll_timer:
+                self._poll_timer()
+                self._poll_timer = None
+
             def _unsub(subscriptions):
                 for subscription in subscriptions:
                     subscription.unsubscribe()
@@ -393,7 +396,8 @@ class SonosEntity(MediaPlayerDevice):
 
     def _subscribe_to_player_events(self):
         """Add event subscriptions."""
-        self._receives_events = False
+        self._poll_timer = self.hass.helpers.event.track_time_interval(
+            self.update, datetime.timedelta(seconds=SCAN_INTERVAL))
 
         # New player available, build the current group topology
         for entity in self.hass.data[DATA_SONOS].entities:
@@ -412,16 +416,20 @@ class SonosEntity(MediaPlayerDevice):
         subscribe(player.zoneGroupTopology, self.update_groups)
         subscribe(player.contentDirectory, self.update_content)
 
-    def update(self):
+    @property
+    def should_poll(self):
+        """Return that we should not be polled (we handle that internally)."""
+        return False
+
+    def update(self, now=None):
         """Retrieve latest state."""
-        if self._available and not self._receives_events:
-            try:
-                self.update_groups()
-                self.update_volume()
-                if self.is_coordinator:
-                    self.update_media()
-            except SoCoException:
-                pass
+        try:
+            self.update_groups()
+            self.update_volume()
+            if self.is_coordinator:
+                self.update_media()
+        except SoCoException:
+            pass
 
     def update_media(self, event=None):
         """Update information about currently playing media."""
@@ -653,7 +661,10 @@ class SonosEntity(MediaPlayerDevice):
                     self.hass.data[DATA_SONOS].topology_condition.notify_all()
 
         if event:
-            self._receives_events = True
+            # Cancel poll timer since we do receive events
+            if self._poll_timer:
+                self._poll_timer()
+                self._poll_timer = None
 
             if not hasattr(event, 'zone_player_uui_ds_in_group'):
                 return

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1351,7 +1351,7 @@ pysmarty==0.8
 pysnmp==4.4.9
 
 # homeassistant.components.sonos
-pysonos==0.0.15
+pysonos==0.0.16
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -286,7 +286,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.8
 
 # homeassistant.components.sonos
-pysonos==0.0.15
+pysonos==0.0.16
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

The [pysonos update](https://github.com/amelchio/pysonos/releases/tag/v0.0.16) increases the timeout on API calls in order to fix #24532. To avoid warnings when we hit such a long timeout in `update()`, this PR moves Sonos to custom polling.

Custom polling also improves the normal situation where we are able to run in push mode because we will no longer run a no-op update every 10 seconds.

**Related issue (if applicable):** fixes #24532

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html