### PR TITLE
Reset location elevation back to civil after updating sun

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -170,6 +170,7 @@ class Sun(Entity):
             utc_point_in_time, 'dusk', PHASE_ASTRONOMICAL_TWILIGHT)
         self.next_midnight = self._check_event(
             utc_point_in_time, 'solar_midnight', None)
+        self.location.solar_depression = 'civil'
 
         # if the event was solar midday or midnight, phase will now
         # be None. Solar noon doesn't always happen when the sun is


### PR DESCRIPTION
## Description:

Depression of twilight was being set to astronomical twilight, this was leaking out and affecting the flux component.

The flux component still won't handle places where the sun doesn't set or reach twilight.

**Related issue (if applicable):** fixes #24335

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
