### PR TITLE
Add a rpi_pfio2 component to have multiboard support for PiFace Digital2 boards

### DIFF
--- a/homeassistant/components/rpi_pfio2/__init__.py
+++ b/homeassistant/components/rpi_pfio2/__init__.py
@@ -1,0 +1,65 @@
+"""Support for controlling the PiFace Digital I/O module on a RPi."""
+import logging
+
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+
+REQUIREMENTS = ['pifacecommon==4.2.2', 'pifacedigitalio==3.0.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'rpi_pfio2'
+
+DATA_PFIO_LISTENER = 'pfio_listener'
+
+BOARD_ADDRESSES = [0,1,2,3]
+
+def setup(hass, config):
+    """Set up the Raspberry PI PFIO component."""
+    import pifacedigitalio as PFIO
+    pifacedigital={}
+    hass.data[DATA_PFIO_LISTENER]={}
+    for address in BOARD_ADDRESSES:
+        try:
+            pifacedigital[address] = PFIO.PiFaceDigital(address)
+            hass.data[DATA_PFIO_LISTENER][address] = PFIO.InputEventListener(chip=pifacedigital[address])
+        except:
+            pass
+
+    def cleanup_pfio(event):
+        """Stuff to do before stopping."""
+        PFIO.deinit()
+
+    def prepare_pfio(event):
+        """Stuff to do when home assistant starts."""
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_pfio)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_pfio)
+    PFIO.init()
+
+    return True
+
+
+def write_output(port, value, hardware_addr=0):
+    """Write a value to a PFIO."""
+    import pifacedigitalio as PFIO
+    PFIO.digital_write(port, value, hardware_addr)
+
+
+def read_input(port, hardware_addr=0):
+    """Read a value from a PFIO."""
+    import pifacedigitalio as PFIO
+    return PFIO.digital_read(port, hardware_addr)
+
+
+def edge_detect(hass, port, event_callback, settle, hardware_addr=0):
+    """Add detection for RISING and FALLING events."""
+    import pifacedigitalio as PFIO
+    hass.data[DATA_PFIO_LISTENER][hardware_addr].register(
+        port, PFIO.IODIR_BOTH, event_callback, settle_time=settle)
+
+
+def activate_listener(hass):
+    """Activate the registered listener events."""
+    for address in hass.data[DATA_PFIO_LISTENER]:
+        hass.data[DATA_PFIO_LISTENER][address].activate()

--- a/homeassistant/components/rpi_pfio2/binary_sensor.py
+++ b/homeassistant/components/rpi_pfio2/binary_sensor.py
@@ -1,0 +1,102 @@
+"""Support for binary sensor using the PiFace Digital I/O module on a RPi."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import (
+    PLATFORM_SCHEMA, BinarySensorDevice)
+from homeassistant.components import rpi_pfio2
+from homeassistant.const import CONF_NAME, DEVICE_DEFAULT_NAME
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_INVERT_LOGIC = 'invert_logic'
+CONF_PORTS = 'ports'
+CONF_SETTLE_TIME = 'settle_time'
+
+CONF_BOARDS = 'boards'
+
+DEFAULT_INVERT_LOGIC = False
+DEFAULT_SETTLE_TIME = 20
+
+DEPENDENCIES = ['rpi_pfio2']
+
+PORT_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_SETTLE_TIME, default=DEFAULT_SETTLE_TIME):
+        cv.positive_int,
+    vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+})
+
+BOARD_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PORTS, default={}): vol.Schema({
+        cv.positive_int: PORT_SCHEMA,
+    })
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_BOARDS, default={}): vol.Schema({
+        cv.positive_int: BOARD_SCHEMA,
+    })
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the PiFace Digital Input devices."""
+    binary_sensors = []
+    boards = config.get(CONF_BOARDS)
+    for board, board_entity in boards.items():
+        ports = board_entity.get(CONF_PORTS)
+        for port, port_entity in ports.items():
+            name = port_entity.get(CONF_NAME)
+            settle_time = port_entity[CONF_SETTLE_TIME] / 1000
+            invert_logic = port_entity[CONF_INVERT_LOGIC]
+
+            binary_sensors.append(RPiPFIOBinarySensor(
+                hass, port, name, settle_time, invert_logic, board))
+    add_entities(binary_sensors, True)
+
+    rpi_pfio.activate_listener(hass)
+
+
+class RPiPFIOBinarySensor(BinarySensorDevice):
+    """Represent a binary sensor that a PiFace Digital Input."""
+
+    def __init__(self, hass, port, name, settle_time, invert_logic, hardware_addr=0):
+        """Initialize the RPi binary sensor."""
+        self._port = port
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._invert_logic = invert_logic
+        self._hardware_addr = hardware_addr
+        self._state = None
+
+        def read_pfio(port, hardware_addr=0):
+            """Read state from PFIO."""
+            self._state = rpi_pfio.read_input(self._port, self._hardware_addr)
+            self.schedule_update_ha_state()
+        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time, self._hardware_addr)
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the state of the entity."""
+        return self._state != self._invert_logic
+
+    @property
+    def hardware_addr(self):
+        """Return the hardware address."""
+        return self._hardware_addr
+
+    def update(self):
+        """Update the PFIO state."""
+        self._state = rpi_pfio.read_input(self._port, self._hardware_addr)

--- a/homeassistant/components/rpi_pfio2/binary_sensor.py
+++ b/homeassistant/components/rpi_pfio2/binary_sensor.py
@@ -57,7 +57,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 hass, port, name, settle_time, invert_logic, board))
     add_entities(binary_sensors, True)
 
-    rpi_pfio.activate_listener(hass)
+    rpi_pfio2.activate_listener(hass)
 
 
 class RPiPFIOBinarySensor(BinarySensorDevice):
@@ -73,9 +73,9 @@ class RPiPFIOBinarySensor(BinarySensorDevice):
 
         def read_pfio(port, hardware_addr=0):
             """Read state from PFIO."""
-            self._state = rpi_pfio.read_input(self._port, self._hardware_addr)
+            self._state = rpi_pfio2.read_input(self._port, self._hardware_addr)
             self.schedule_update_ha_state()
-        rpi_pfio.edge_detect(hass, self._port, read_pfio, settle_time, self._hardware_addr)
+        rpi_pfio2.edge_detect(hass, self._port, read_pfio, settle_time, self._hardware_addr)
 
     @property
     def should_poll(self):
@@ -99,4 +99,4 @@ class RPiPFIOBinarySensor(BinarySensorDevice):
 
     def update(self):
         """Update the PFIO state."""
-        self._state = rpi_pfio.read_input(self._port, self._hardware_addr)
+        self._state = rpi_pfio2.read_input(self._port, self._hardware_addr)

--- a/homeassistant/components/rpi_pfio2/manifest.json
+++ b/homeassistant/components/rpi_pfio2/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "rpi_pfio2",
+  "name": "Rpi pfio2",
+  "documentation": "https://www.home-assistant.io/components/rpi_pfio2",
+  "requirements": [
+    "pifacecommon==4.2.2",
+    "pifacedigitalio==3.0.5"
+  ],
+  "dependencies": [],
+  "codeowners": []
+}

--- a/homeassistant/components/rpi_pfio2/switch.py
+++ b/homeassistant/components/rpi_pfio2/switch.py
@@ -71,7 +71,7 @@ class RPiPFIOSwitch(ToggleEntity):
             state_to_set = 0
         else:
             state_to_set = 1
-        rpi_pfio.write_output(self._port, state_to_set , self._hardware_addr)
+        rpi_pfio2.write_output(self._port, state_to_set , self._hardware_addr)
 
     @property
     def name(self):
@@ -95,12 +95,12 @@ class RPiPFIOSwitch(ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1, self._hardware_addr)
+        rpi_pfio2.write_output(self._port, 0 if self._invert_logic else 1, self._hardware_addr)
         self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0, self._hardware_addr)
+        rpi_pfio2.write_output(self._port, 1 if self._invert_logic else 0, self._hardware_addr)
         self._state = False
         self.schedule_update_ha_state()

--- a/homeassistant/components/rpi_pfio2/switch.py
+++ b/homeassistant/components/rpi_pfio2/switch.py
@@ -1,0 +1,106 @@
+"""Support for switches using the PiFace Digital I/O module on a RPi."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import rpi_pfio2
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.const import ATTR_NAME, DEVICE_DEFAULT_NAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import ToggleEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['rpi_pfio2']
+
+ATTR_INVERT_LOGIC = 'invert_logic'
+ATTR_INITIAL_STATE = "initial_state"
+
+CONF_PORTS = 'ports'
+
+CONF_BOARDS = 'boards'
+
+DEFAULT_INVERT_LOGIC = False
+DEFAULT_INITIAL_STATE = False
+
+PORT_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_NAME): cv.string,
+    vol.Optional(ATTR_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+    vol.Optional(ATTR_INITIAL_STATE, default=DEFAULT_INITIAL_STATE): cv.boolean,
+})
+
+BOARD_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PORTS, default={}): vol.Schema({
+        cv.positive_int: PORT_SCHEMA,
+    })
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_BOARDS, default={}): vol.Schema({
+        cv.positive_int: BOARD_SCHEMA,
+    })
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the PiFace Digital Output devices."""
+    switches = []
+    boards = config.get(CONF_BOARDS)
+    for board, board_entity in boards.items():
+        ports = board_entity.get(CONF_PORTS)
+        for port, port_entity in ports.items():
+            name = port_entity.get(ATTR_NAME)
+            invert_logic = port_entity[ATTR_INVERT_LOGIC]
+            initial_state = port_entity[ATTR_INITIAL_STATE]
+            switches.append(RPiPFIOSwitch(port, name, invert_logic, initial_state, board))
+    add_entities(switches)
+
+
+class RPiPFIOSwitch(ToggleEntity):
+    """Representation of a PiFace Digital Output."""
+
+    def __init__(self, port, name, invert_logic, initial_state, hardware_addr=0):
+        """Initialize the pin."""
+        self._port = port
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._invert_logic = invert_logic
+        self._initial_state = initial_state
+        self._hardware_addr = hardware_addr
+        self._state = initial_state
+        if self._invert_logic == self._initial_state:
+            state_to_set = 0
+        else:
+            state_to_set = 1
+        rpi_pfio.write_output(self._port, state_to_set , self._hardware_addr)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def hardware_addr(self):
+        """Return the hardware address."""
+        return self._hardware_addr
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        rpi_pfio.write_output(self._port, 0 if self._invert_logic else 1, self._hardware_addr)
+        self._state = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        rpi_pfio.write_output(self._port, 1 if self._invert_logic else 0, self._hardware_addr)
+        self._state = False
+        self.schedule_update_ha_state()


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#9160

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
 - platform: rpi_pfio2
    boards:
      0:
        ports:
          0:
            name: Garage door
            invert_logic: true
            initial_state: off

binary_sensor:
  - platform: rpi_pfio2
    boards:
      0:
        ports:
          7:
            name: Garage door
            settle_time: 63
            invert_logic: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
