### PR TITLE
Fix sending update when not logged in

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -116,7 +116,7 @@ class AlexaConfig(alexa_config.AbstractConfig):
             if body['reason'] in ('RefreshTokenNotFound', 'UnknownRegion'):
                 raise RequireRelink
 
-            return alexa_errors.NoTokenAvailable
+            raise alexa_errors.NoTokenAvailable
 
         self._token = body['access_token']
         self._endpoint = body['event_endpoint']
@@ -239,7 +239,7 @@ class AlexaConfig(alexa_config.AbstractConfig):
 
     async def _handle_entity_registry_updated(self, event):
         """Handle when entity registry updated."""
-        if not self.enabled:
+        if not self.enabled or not self._cloud.is_logged_in:
             return
 
         action = event.data['action']

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -352,9 +352,9 @@ async def test_alexa_update_expose_trigger_sync(hass, cloud_prefs):
     assert to_remove == ['light.kitchen']
 
 
-async def test_alexa_entity_registry_sync(hass, cloud_prefs):
+async def test_alexa_entity_registry_sync(hass, mock_cloud_login, cloud_prefs):
     """Test Alexa config responds to entity registry."""
-    client.AlexaConfig(hass, ALEXA_SCHEMA({}), cloud_prefs, None)
+    client.AlexaConfig(hass, ALEXA_SCHEMA({}), cloud_prefs, hass.data['cloud'])
 
     with patch_sync_helper() as (to_update, to_remove):
         hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, {


### PR DESCRIPTION
## Description:
Alexa Cloud entity registry listener now checks that we're logged in before updating registered entities.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
