### PR TITLE
Use signal dispatcher to invoke plaato state update

### DIFF
--- a/homeassistant/components/plaato/sensor.py
+++ b/homeassistant/components/plaato/sensor.py
@@ -3,6 +3,7 @@
 import logging
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
 
 from . import (
@@ -45,7 +46,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             async_add_entities(entities, True)
         else:
             for entity in devices[device_id]:
-                entity.async_schedule_update_ha_state()
+                async_dispatcher_send(hass, "{}_{}".format(PLAATO_DOMAIN,
+                                                           entity.unique_id))
 
     hass.data[SENSOR_DATA_KEY] = async_dispatcher_connect(
         hass, SENSOR_UPDATE, _update_sensor
@@ -137,3 +139,9 @@ class PlaatoSensor(Entity):
     def should_poll(self):
         """Return the polling state."""
         return False
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            "{}_{}".format(PLAATO_DOMAIN, self.unique_id),
+            self.async_schedule_update_ha_state)


### PR DESCRIPTION
## Description:

Uses signal dispatcher to invoke entity update since calling `entity.async_schedule_update_ha_state` directly on a non pulling entity is unsafe

**Related comment:** https://github.com/home-assistant/home-assistant/pull/23727#discussion_r295059679

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html