### PR TITLE
braviatv, nmap_tracker: use getmac for getting MAC addresses

### DIFF
--- a/homeassistant/components/braviatv/manifest.json
+++ b/homeassistant/components/braviatv/manifest.json
@@ -3,7 +3,8 @@
   "name": "Braviatv",
   "documentation": "https://www.home-assistant.io/components/braviatv",
   "requirements": [
-    "braviarc-homeassistant==0.3.7.dev0"
+    "braviarc-homeassistant==0.3.7.dev0",
+    "getmac==0.8.1"
   ],
   "dependencies": [
     "configurator"

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -2,6 +2,7 @@
 import ipaddress
 import logging
 
+from getmac import get_mac_address
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -71,7 +72,6 @@ def setup_bravia(config, pin, hass, add_entities):
         request_configuration(config, hass, add_entities)
         return
 
-    from getmac import get_mac_address
     try:
         if ipaddress.ip_address(host).version == 6:
             mode = 'ip6'

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -1,6 +1,6 @@
 """Support for interface with a Sony Bravia TV."""
+import ipaddress
 import logging
-import re
 
 import voluptuous as vol
 
@@ -40,19 +40,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def _get_mac_address(ip_address):
-    """Get the MAC address of the device."""
-    from subprocess import Popen, PIPE
-
-    pid = Popen(["arp", "-n", ip_address], stdout=PIPE)
-    pid_component = pid.communicate()[0]
-    match = re.search(r"(([a-f\d]{1,2}\:){5}[a-f\d]{1,2})".encode('UTF-8'),
-                      pid_component)
-    if match is not None:
-        return match.groups()[0]
-    return None
-
-
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Sony Bravia TV platform."""
     host = config.get(CONF_HOST)
@@ -84,9 +71,16 @@ def setup_bravia(config, pin, hass, add_entities):
         request_configuration(config, hass, add_entities)
         return
 
-    mac = _get_mac_address(host)
-    if mac is not None:
-        mac = mac.decode('utf8')
+    from getmac import get_mac_address
+    try:
+        if ipaddress.ip_address(host).version == 6:
+            mode = 'ip6'
+        else:
+            mode = 'ip'
+    except ValueError:
+        mode = 'hostname'
+    mac = get_mac_address(**{mode: host})
+
     # If we came here and configuring this host, mark as done
     if host in _CONFIGURING:
         request_id = _CONFIGURING.pop(host)

--- a/homeassistant/components/nmap_tracker/device_tracker.py
+++ b/homeassistant/components/nmap_tracker/device_tracker.py
@@ -3,6 +3,7 @@ import logging
 from collections import namedtuple
 from datetime import timedelta
 
+from getmac import get_mac_address
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -111,8 +112,6 @@ class NmapDeviceScanner(DeviceScanner):
                                   arguments=options)
         except PortScannerError:
             return False
-
-        from getmac import get_mac_address
 
         now = dt_util.now()
         for ipv4, info in result['scan'].items():

--- a/homeassistant/components/nmap_tracker/manifest.json
+++ b/homeassistant/components/nmap_tracker/manifest.json
@@ -3,7 +3,8 @@
   "name": "Nmap tracker",
   "documentation": "https://www.home-assistant.io/components/nmap_tracker",
   "requirements": [
-    "python-nmap==0.6.1"
+    "python-nmap==0.6.1",
+    "getmac==0.8.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -513,6 +513,10 @@ georss_ign_sismologia_client==0.2
 # homeassistant.components.qld_bushfire
 georss_qld_bushfire_alert_client==0.3
 
+# homeassistant.components.braviatv
+# homeassistant.components.nmap_tracker
+getmac==0.8.1
+
 # homeassistant.components.gitter
 gitterpy==0.1.7
 


### PR DESCRIPTION
## Description:

See discussion in https://github.com/home-assistant/home-assistant/pull/24601

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/pull/24601

## Checklist:
  - [x] The code change is tested and works locally.  **nmap tracker only**
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
