### PR TITLE
Fix device tracker see for entity registry entities

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -140,7 +140,7 @@ class DeviceTracker:
                 await device.async_update_ha_state()
             return
 
-        # Guard from calling see on config entry entities.
+        # Guard from calling see on entity registry entities.
         entity_id = ENTITY_ID_FORMAT.format(dev_id)
         if registry.async_is_registered(entity_id):
             LOGGER.error(

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -84,7 +84,6 @@ class DeviceTracker:
         self.defaults = defaults
         self.group = None
         self._is_updating = asyncio.Lock()
-        self._registry_task = None
 
         for dev in devices:
             if self.devices[dev.dev_id] is not dev:
@@ -117,10 +116,7 @@ class DeviceTracker:
 
         This method is a coroutine.
         """
-        if not self._registry_task:
-            self._registry_task = self.hass.async_create_task(
-                async_get_registry(self.hass))
-        registry = await self._registry_task
+        registry = await async_get_registry(self.hass)
         if mac is None and dev_id is None:
             raise HomeAssistantError('Neither mac or device id passed in')
         if mac is not None:

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -134,6 +134,16 @@ class DeviceTracker:
                 await device.async_update_ha_state()
             return
 
+        # Guard from calling see on config entry entities.
+        registry = await self.hass.helpers.entity_registry.async_get_registry()
+        # generate entity_id
+        entity_id = ENTITY_ID_FORMAT.format(dev_id)
+        if registry.async_is_registered(entity_id):
+            LOGGER.error(
+                "The see service is not supported for this entity %s",
+                entity_id)
+            return
+
         # If no device can be found, create it
         dev_id = util.ensure_unique_string(dev_id, self.devices.keys())
         device = Device(

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -322,7 +322,7 @@ async def test_see_service(mock_see, hass):
 
 
 async def test_see_service_guard_config_entry(hass, mock_device_tracker_conf):
-    """Test the gaurd if the device is registered in the entity registry."""
+    """Test the guard if the device is registered in the entity registry."""
     mock_entry = Mock()
     dev_id = 'test'
     entity_id = const.ENTITY_ID_FORMAT.format(dev_id)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -338,7 +338,7 @@ async def test_see_service_gaurd_config_entry(hass, mock_device_tracker_conf):
     common.async_see(hass, **params)
     await hass.async_block_till_done()
 
-    assert len(devices) == 0
+    assert not devices
 
 
 async def test_new_device_event_fired(hass, mock_device_tracker_conf):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import json
 import logging
 import os
-from unittest.mock import call
+from unittest.mock import Mock, call
 
 from asynctest import patch
 import pytest
@@ -12,9 +12,9 @@ from homeassistant.components import zone
 import homeassistant.components.device_tracker as device_tracker
 from homeassistant.components.device_tracker import const, legacy
 from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN,
-    ATTR_ICON, CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME,
-    ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_GPS_ACCURACY)
+    ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, ATTR_GPS_ACCURACY,
+    ATTR_HIDDEN, ATTR_ICON, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_PLATFORM,
+    STATE_HOME, STATE_NOT_HOME)
 from homeassistant.core import State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import discovery
@@ -23,8 +23,8 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    assert_setup_component, async_fire_time_changed, mock_restore_cache,
-    patch_yaml_files)
+    assert_setup_component, async_fire_time_changed, mock_registry,
+    mock_restore_cache, patch_yaml_files)
 from tests.components.device_tracker import common
 
 TEST_PLATFORM = {device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}}
@@ -319,6 +319,26 @@ async def test_see_service(mock_see, hass):
     assert mock_see.call_count == 1
     assert mock_see.call_count == 1
     assert mock_see.call_args == call(**params)
+
+
+async def test_see_service_gaurd_config_entry(hass, mock_device_tracker_conf):
+    """Test the gaurd if the device is registered in the entity registry."""
+    mock_entry = Mock()
+    dev_id = 'test'
+    entity_id = const.ENTITY_ID_FORMAT.format(dev_id)
+    mock_registry(hass, {entity_id: mock_entry})
+    devices = mock_device_tracker_conf
+    assert await async_setup_component(
+        hass, device_tracker.DOMAIN, TEST_PLATFORM)
+    params = {
+        'dev_id': dev_id,
+        'gps': [.3, .8],
+    }
+
+    common.async_see(hass, **params)
+    await hass.async_block_till_done()
+
+    assert len(devices) == 0
 
 
 async def test_new_device_event_fired(hass, mock_device_tracker_conf):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -321,7 +321,7 @@ async def test_see_service(mock_see, hass):
     assert mock_see.call_args == call(**params)
 
 
-async def test_see_service_gaurd_config_entry(hass, mock_device_tracker_conf):
+async def test_see_service_guard_config_entry(hass, mock_device_tracker_conf):
     """Test the gaurd if the device is registered in the entity registry."""
     mock_entry = Mock()
     dev_id = 'test'


### PR DESCRIPTION
## Breaking Change:
N/A: Note that the see service was broken for entity registry (config entry) entities already in https://github.com/home-assistant/home-assistant/pull/24040.
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- Add a test that checks if we guard for see service adding entity registry registered entities.
- Guard from seeing devices part of entity registry.

**Related issue (if applicable):**
fixes #24626 


## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
