### PR TITLE
Bump ZHA dependencies.

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,9 +4,9 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/zha",
   "requirements": [
-    "bellows-homeassistant==0.8.0",
+    "bellows-homeassistant==0.8.1",
     "zha-quirks==0.0.14",
-    "zigpy-deconz==0.1.4",
+    "zigpy-deconz==0.1.6",
     "zigpy-homeassistant==0.5.0",
     "zigpy-xbee-homeassistant==0.3.0"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -241,7 +241,7 @@ batinfo==0.4.2
 beautifulsoup4==4.7.1
 
 # homeassistant.components.zha
-bellows-homeassistant==0.8.0
+bellows-homeassistant==0.8.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.5.3
@@ -1923,7 +1923,7 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.1.4
+zigpy-deconz==0.1.6
 
 # homeassistant.components.zha
 zigpy-homeassistant==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -79,7 +79,7 @@ av==6.1.2
 axis==25
 
 # homeassistant.components.zha
-bellows-homeassistant==0.8.0
+bellows-homeassistant==0.8.1
 
 # homeassistant.components.caldav
 caldav==0.6.1


### PR DESCRIPTION
## Description:
Bump ZHA dependencies:
- zigpy-deconz==0.1.6
- bellows-homeassistant==0.8.1

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
