### PR TITLE
Fix downloader_download_failed event not firing for HTTP response errors

### DIFF
--- a/homeassistant/components/downloader/__init__.py
+++ b/homeassistant/components/downloader/__init__.py
@@ -79,6 +79,11 @@ def setup(hass, config):
                         "downloading '%s' failed, status_code=%d",
                         url,
                         req.status_code)
+                    hass.bus.fire(
+                        "{}_{}".format(DOMAIN, DOWNLOAD_FAILED_EVENT), {
+                            'url': url,
+                            'filename': filename
+                            })
 
                 else:
                     if filename is None and \


### PR DESCRIPTION
## Description:

Fix downloader_download_failed event not firing for HTTP response errors

The Downloader component documentation at https://www.home-assistant.io/components/downloader/ says:
> In case download failed another event ‘downloader_download_failed’ is emitted to indicate that the download did not complete successfully.

However currently the event is only fired if there's a ConnectionError exception, and not if the download fails due to a non-200 HTTP response code. Only a warning is logged. According to the docs, this case should also fire a downloader_download_failed event. This PR adds that event.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
