### PR TITLE
Add support for sensor state STATE_UNAVAILABLE

### DIFF
--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.components import group
 from homeassistant.components.recorder.util import execute, session_scope
 from homeassistant.const import (
     ATTR_TEMPERATURE, ATTR_UNIT_OF_MEASUREMENT, CONF_SENSORS, STATE_OK,
-    STATE_PROBLEM, STATE_UNKNOWN, TEMP_CELSIUS)
+    STATE_PROBLEM, STATE_UNAVAILABLE, STATE_UNKNOWN, TEMP_CELSIUS)
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
@@ -185,7 +185,7 @@ class Plant(Entity):
         value = new_state.state
         _LOGGER.debug("Received callback from %s with value %s",
                       entity_id, value)
-        if value == STATE_UNKNOWN:
+        if value == STATE_UNAVAILABLE or value == STATE_UNKNOWN:
             return
 
         reading = self._sensormap[entity_id]

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -185,20 +185,30 @@ class Plant(Entity):
         value = new_state.state
         _LOGGER.debug("Received callback from %s with value %s",
                       entity_id, value)
-        if value == STATE_UNAVAILABLE or value == STATE_UNKNOWN:
+        if value == STATE_UNKNOWN:
             return
 
         reading = self._sensormap[entity_id]
         if reading == READING_MOISTURE:
-            self._moisture = int(float(value))
+            if value != STATE_UNAVAILABLE:
+                value = int(float(value))
+            self._moisture = value
         elif reading == READING_BATTERY:
-            self._battery = int(float(value))
+            if value != STATE_UNAVAILABLE:
+                value = int(float(value))
+            self._battery = value
         elif reading == READING_TEMPERATURE:
-            self._temperature = float(value)
+            if value != STATE_UNAVAILABLE:
+                value = float(value)
+            self._temperature = value
         elif reading == READING_CONDUCTIVITY:
-            self._conductivity = int(float(value))
+            if value != STATE_UNAVAILABLE:
+                value = int(float(value))
+            self._conductivity = value
         elif reading == READING_BRIGHTNESS:
-            self._brightness = int(float(value))
+            if value != STATE_UNAVAILABLE:
+                value = int(float(value))
+            self._brightness = value
             self._brightness_history.add_measurement(
                 self._brightness, new_state.last_updated)
         else:
@@ -216,12 +226,15 @@ class Plant(Entity):
             params = self.READINGS[sensor_name]
             value = getattr(self, '_{}'.format(sensor_name))
             if value is not None:
-                if sensor_name == READING_BRIGHTNESS:
-                    result.append(self._check_min(
-                        sensor_name, self._brightness_history.max, params))
+                if value == STATE_UNAVAILABLE:
+                    result.append('{} unavailable'.format(sensor_name))
                 else:
-                    result.append(self._check_min(sensor_name, value, params))
-                result.append(self._check_max(sensor_name, value, params))
+                    if sensor_name == READING_BRIGHTNESS:
+                        result.append(self._check_min(
+                            sensor_name, self._brightness_history.max, params))
+                    else:
+                        result.append(self._check_min(sensor_name, value, params))
+                    result.append(self._check_max(sensor_name, value, params))
 
         result = [r for r in result if r is not None]
 

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -233,7 +233,8 @@ class Plant(Entity):
                         result.append(self._check_min(
                             sensor_name, self._brightness_history.max, params))
                     else:
-                        result.append(self._check_min(sensor_name, value, params))
+                        result.append(self._check_min(sensor_name, value,
+                                                      params))
                     result.append(self._check_max(sensor_name, value, params))
 
         result = [r for r in result if r is not None]

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -4,8 +4,8 @@ import unittest
 import pytest
 from datetime import datetime, timedelta
 
-from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, STATE_UNAVAILABLE, STATE_UNKNOWN,
-                                 STATE_PROBLEM, STATE_OK)
+from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, STATE_UNAVAILABLE,
+                                 STATE_UNKNOWN, STATE_PROBLEM, STATE_OK)
 from homeassistant.components import recorder
 import homeassistant.components.plant as plant
 from homeassistant.setup import setup_component

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -133,10 +133,10 @@ class TestPlant(unittest.TestCase):
                              {ATTR_UNIT_OF_MEASUREMENT: 'us/cm'})
         self.hass.block_till_done()
         state = self.hass.states.get('plant.'+plant_name)
-        assert state.state == STATE_UNKNOWN
-        assert state.attributes[plant.READING_MOISTURE] is None
+        assert state.state == STATE_PROBLEM
+        assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
 
-    def test_keep_old_state_if_unavailable(self):
+    def test_state_problem_if_unavailable(self):
         """Test updating the state with unavailable after setting it to valid value.
 
         Make sure that plant processes this correctly.
@@ -147,17 +147,18 @@ class TestPlant(unittest.TestCase):
                 plant_name: GOOD_CONFIG
             }
         })
-        self.hass.states.set(MOISTURE_ENTITY, 5,
+        self.hass.states.set(MOISTURE_ENTITY, 42,
                              {ATTR_UNIT_OF_MEASUREMENT: 'us/cm'})
         self.hass.block_till_done()
         state = self.hass.states.get('plant.' + plant_name)
-        assert state.attributes[plant.READING_MOISTURE] == 5
+        assert state.state == STATE_OK
+        assert state.attributes[plant.READING_MOISTURE] == 42
         self.hass.states.set(MOISTURE_ENTITY, STATE_UNAVAILABLE,
                              {ATTR_UNIT_OF_MEASUREMENT: 'us/cm'})
         self.hass.block_till_done()
         state = self.hass.states.get('plant.'+plant_name)
         assert state.state == STATE_PROBLEM
-        assert state.attributes[plant.READING_MOISTURE] == 5
+        assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
 
     @pytest.mark.skipif(plant.ENABLE_LOAD_HISTORY is False,
                         reason="tests for loading from DB are unstable, thus"


### PR DESCRIPTION
Fixed integration with ESPhome, which caused an error if ESPhome did not update fast enough on startup

## Description:
There is a race condition on the state of the sensor when starting home assistant, in case of ESPHome this results in an error along the lines of: `ValueError: could not convert string to [insert casted value]: 'unavailable'`.

This fix updates the plant sensor state to `STATE_PROBLEM` and sets the attribute of the `STATE_UNAVAILABLE` sensor to `STATE_UNAVAILABLE`.

We should not ignore `STATE_UNAVAILABLE` for a sensor related to a plant, as this may cause the user to think that everything is fine, while the plant is dying, which is why I chose to set the plant state to `STATE_PROBLEM` in this case.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
