### PR TITLE
Fix PS4 entities with shared host not updating and latency with multiple connections

### DIFF
--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.8.4"
+    "pyps4-homeassistant==0.8.5"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.8.3"
+    "pyps4-homeassistant==0.8.4"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -154,20 +154,20 @@ class PS4Device(MediaPlayerDevice):
         if self._ps4.ddp_protocol is not None:
             # Request Status with asyncio transport.
             self._ps4.get_status()
-            if not self._ps4.connected and not self._ps4.is_standby:
+            if not self._ps4.connected and not self._ps4.is_standby\
+                    and self._state is not None:
                 await self._ps4.async_connect()
 
         # Try to ensure correct status is set on startup for device info.
         if self._ps4.ddp_protocol is None:
             # Use socket.socket.
             await self.hass.async_add_executor_job(self._ps4.get_status)
+            if self._info is None:
+                # Add entity to registry.
+                await self.async_get_device_info(self._ps4.status)
             self._ps4.ddp_protocol = self.hass.data[PS4_DATA].protocol
             self.subscribe_to_protocol()
 
-            if self._ps4.status is not None:
-                if self._info is None:
-                    # Add entity to registry.
-                    await self.async_get_device_info(self._ps4.status)
         self._parse_status()
 
     def _parse_status(self):

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -154,8 +154,7 @@ class PS4Device(MediaPlayerDevice):
         if self._ps4.ddp_protocol is not None:
             # Request Status with asyncio transport.
             self._ps4.get_status()
-            if not self._ps4.connected and not self._ps4.is_standby\
-                    and self._state is not None:
+            if not self._ps4.connected and not self._ps4.is_standby:
                 await self._ps4.async_connect()
 
         # Try to ensure correct status is set on startup for device info.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1303,7 +1303,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.3
+pyps4-homeassistant==0.8.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1303,7 +1303,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.4
+pyps4-homeassistant==0.8.5
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.3
+pyps4-homeassistant==0.8.4
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.4
+pyps4-homeassistant==0.8.5
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93


### PR DESCRIPTION
## Description:
Fixes entities sharing same PS4 (different account), not getting updated via callback.
Also fixes device info call.
Fixes bug in library where more than 1 connection adds latency to connections.

I would recommend that PR #24101 not be merged to master without this PR because of the connection bugs.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
