### PR TITLE
'pushed' value of button press was always 0 + added state_changed event

### DIFF
--- a/homeassistant/components/enocean/binary_sensor.py
+++ b/homeassistant/components/enocean/binary_sensor.py
@@ -71,9 +71,9 @@ class EnOceanBinarySensor(enocean.EnOceanDevice, BinarySensorDevice):
         # Energy Bow
         pushed = None
 
-        if packet.data[6] == 0x30:
+        if packet.data[1] == 0x10:
             pushed = 1
-        elif packet.data[6] == 0x20:
+        elif packet.data[1] == 0x00:
             pushed = 0
 
         self.schedule_update_ha_state()


### PR DESCRIPTION
## Description:
When using home assistant with an IQfy pressure sensor ([link](https://www.iqfy.de/en/products/product/Drucksensor.html)) I noticed that regardless of whether I "push" or "release" the switch, the events were always the same, 'pushed' value is always 0

This example is commented in the existing codebase:
`        Example packet data:
        - 2nd button pressed
            ['0xf6', '0x10', '0x00', '0x2d', '0xcf', '0x45', '0x30']
        - button released
            ['0xf6', '0x00', '0x00', '0x2d', '0xcf', '0x45', '0x20']`

The code checked on the last byte to detect the "pushed"  (resp. 0x30 and 0x20).
However I notice the IQfy sensor always gives 0x20 as last byte. The 2nd byte seems like a more consistent approach, the value is either 0x10 or 0x00 in the example, and also on the IQfy sensor.

**EDIT**
Added another commit. Currently the enocean binary sensor setup only generated its own "button_pushed" events. As I need a more generic way to access state changes, I added support for state_changed events. The old button_pushed event is still created so this change is fully backwards compatible.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]