### PR TITLE
Added multi-server support for CUPS

### DIFF
--- a/homeassistant/components/cups/sensor.py
+++ b/homeassistant/components/cups/sensor.py
@@ -62,7 +62,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             data = CupsData(host, port)
             data.update()
         except RuntimeError:
-            _LOGGER.error("Unable to connect to CUPS server: %s:%s", host, port)
+            _LOGGER.error("Unable to connect to CUPS server: %s:%s",
+                          host, port)
             raise PlatformNotReady()
 
         dev = []


### PR DESCRIPTION
## Description:
Added multi server support for the CUPS integration

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9667

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: cups      
  - servers:
      - printers:
          - C410
          - C430
      - host: 192.168.1.50
        port: 631
        printers:
          - C450
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
