### PR TITLE
Update LIFX brightness during long transitions

### DIFF
--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -484,7 +484,8 @@ class LIFXLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return convert_16_to_8(self.bulb.color[2])
+        fade = self.bulb.power_level / 65535
+        return convert_16_to_8(int(fade * self.bulb.color[2]))
 
     @property
     def color_temp(self):


### PR DESCRIPTION
## Description:

Scale the brightness by the current power level (which is between 0 and 65535 during a transition).

**Related issue (if applicable):** fixes #24631

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the development checklist
