### PR TITLE
Add initial Noonlight component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -178,6 +178,7 @@ homeassistant/components/nextbus/* @vividboarder
 homeassistant/components/nissan_leaf/* @filcole
 homeassistant/components/nmbs/* @thibmaek
 homeassistant/components/no_ip/* @fabaff
+homeassistant/components/noonlight/* @heythisisnate @snicker
 homeassistant/components/notify/* @home-assistant/core
 homeassistant/components/nsw_fuel_station/* @nickw444
 homeassistant/components/nuki/* @pschmitt

--- a/homeassistant/components/noonlight/__init__.py
+++ b/homeassistant/components/noonlight/__init__.py
@@ -21,7 +21,7 @@ TOKEN_CHECK_INTERVAL = timedelta(minutes=15)
 CONF_SECRET = 'secret'
 CONF_API_ENDPOINT = 'api_endpoint'
 CONF_TOKEN_ENDPOINT = 'token_endpoint'
-    
+
 REQUIREMENTS = ['noonlight>=0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,21 +39,21 @@ CONFIG_SCHEMA = vol.Schema({
 async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
-        
+
     conf = config[DOMAIN]
-        
-    
+
+
     if DOMAIN not in hass.data:
         noonlight_platform = NoonlightPlatform(hass, conf)
         hass.data[DOMAIN] = noonlight_platform
 
     async def check_api_token(now):
         """Check if the current API token has expired and renew if so"""
-        
+
         next_check_interval = TOKEN_CHECK_INTERVAL
-        
+
         result = await noonlight_platform.check_api_token()
-        
+
         if not result:
             _LOGGER.error("api token failed renewal, retrying in 3 min...")
             next_check_interval = timedelta(minutes=3)
@@ -66,60 +66,60 @@ async def async_setup(hass, config):
         """Schedule the first token renewal when Home Assistant starts up."""
         async_track_point_in_utc_time(hass, check_api_token, dt_util.utcnow())
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, 
-        schedule_first_token_check)
-    
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START,
+                               schedule_first_token_check)
+
     load_platform(hass, 'switch', DOMAIN, None, config)
-    
+
     return True
-    
-class NoonlightPlatform(object):
+
+class NoonlightPlatform():
     """Platform for interacting with Noonlight from HomeAssistant"""
     def __init__(self, hass, conf):
         self.hass = hass
         self.config = conf
         self._client = None
         self._time_to_renew = timedelta(hours=2)
-        
+
     @property
     def latitude(self):
         return self.config \
             .get(CONF_LATITUDE, self.hass.config.latitude)
-        
+
     @property
     def longitude(self):
         return self.config \
             .get(CONF_LONGITUDE, self.hass.config.longitude)
-        
+
     @property
     def access_token(self):
         return self.config \
-            .get(CONF_ACCESS_TOKEN,{}) \
+            .get(CONF_ACCESS_TOKEN, {}) \
             .get('token')
-        
+
     @property
     def access_token_expiry(self):
         return self.config \
-            .get(CONF_ACCESS_TOKEN,{}) \
-            .get('expires',dt_util.utc_from_timestamp(0))
-        
+            .get(CONF_ACCESS_TOKEN, {}) \
+            .get('expires', dt_util.utc_from_timestamp(0))
+
     @property
     def access_token_expires_in(self):
         return self.access_token_expiry - dt_util.utcnow()
-        
+
     @property
     def should_token_be_renewed(self):
         return self.access_token is None \
             or self.access_token_expires_in <= self._time_to_renew
-        
+
     @property
     def client(self):
         if self._client is None:
             import noonlight as nl
-            self._client = nl.NoonlightClient(token = self.access_token)
+            self._client = nl.NoonlightClient(token=self.access_token)
         return self._client
-        
-    async def check_api_token(self, force_renew = False):
+
+    async def check_api_token(self, force_renew=False):
         _LOGGER.debug("checking if token needs renewal, expires: {0:.1f}h" \
             .format(self.access_token_expires_in.total_seconds() / 3600.0))
         if self.should_token_be_renewed or force_renew:
@@ -127,32 +127,28 @@ class NoonlightPlatform(object):
                 _LOGGER.debug("Renewing Noonlight access token...")
                 path = self.config.get(CONF_TOKEN_ENDPOINT)
                 data = {
-                    'id': self.config.get(CONF_ID), 
+                    'id': self.config.get(CONF_ID),
                     'secret': self.config.get(CONF_SECRET)
                 }
                 token_response = await self.client._post(path=path, data=data)
                 if 'token' in token_response and 'expires' in token_response:
                     self._set_token_response(token_response)
                     _LOGGER.debug("token renewed, expires at {0} ({1:.1f}h)" \
-                        .format(
-                            self.access_token_expiry,
-                            self.access_token_expires_in.total_seconds()/3600.0
-                        )
-                    )
+                        .format(self.access_token_expiry,
+                                self.access_token_expires_in.total_seconds()/3600.0))
                     return True
-                else:
-                    raise Exception("unexpected token_response: {}" \
-                        .format(token_response))
-            except:
+                raise Exception("unexpected token_response: {}" \
+                    .format(token_response))
+            except Exception:
                 _LOGGER.exception("Failed to renew Noonlight token!")
                 return False
         return True
-                
+
     def _set_token_response(self, token_response):
         expires = dt_util.parse_datetime(token_response['expires'])
         if expires is not None:
             token_response['expires'] = expires
         else:
             token_response['expires'] = dt_util.utc_from_timestamp(0)
-        self.client.set_token(token = token_response.get('token'))
+        self.client.set_token(token=token_response.get('token'))
         self.config[CONF_ACCESS_TOKEN] = token_response

--- a/homeassistant/components/noonlight/__init__.py
+++ b/homeassistant/components/noonlight/__init__.py
@@ -22,8 +22,6 @@ CONF_SECRET = 'secret'
 CONF_API_ENDPOINT = 'api_endpoint'
 CONF_TOKEN_ENDPOINT = 'token_endpoint'
 
-REQUIREMENTS = ['noonlight>=0.1.0']
-
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/noonlight/__init__.py
+++ b/homeassistant/components/noonlight/__init__.py
@@ -16,6 +16,8 @@ import homeassistant.util.dt as dt_util
 
 DOMAIN = 'noonlight'
 
+EVENT_NOONLIGHT_TOKEN_REFRESHED = 'noonlight_token_refreshed'
+
 TOKEN_CHECK_INTERVAL = timedelta(minutes=15)
 
 CONF_SECRET = 'secret'
@@ -134,6 +136,9 @@ class NoonlightPlatform():
                     _LOGGER.debug("token renewed, expires at {0} ({1:.1f}h)" \
                         .format(self.access_token_expiry,
                                 self.access_token_expires_in.total_seconds()/3600.0))
+                    self.hass.bus.fire(EVENT_NOONLIGHT_TOKEN_REFRESHED, {
+                            'token': self.client._token
+                        })
                     return True
                 raise Exception("unexpected token_response: {}" \
                     .format(token_response))

--- a/homeassistant/components/noonlight/__init__.py
+++ b/homeassistant/components/noonlight/__init__.py
@@ -175,9 +175,8 @@ class NoonlightIntegration():
                                   .format(self.access_token_expiry,
                                           self.access_token_expires_in
                                               .total_seconds()/3600.0))
-                    self.hass.bus.fire(EVENT_NOONLIGHT_TOKEN_REFRESHED, {
-                            'token': self.client._token
-                        })
+                    self.hass.helpers.dispatcher.async_dispatcher_send(
+                        EVENT_NOONLIGHT_TOKEN_REFRESHED)
                     return True
                 raise NoonlightException("unexpected token_response: {}"
                                 .format(token_response))

--- a/homeassistant/components/noonlight/__init__.py
+++ b/homeassistant/components/noonlight/__init__.py
@@ -1,0 +1,141 @@
+"""Noonlight platform for HomeAssistant"""
+from datetime import datetime, timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_ID, CONF_ACCESS_TOKEN, CONF_LATITUDE, CONF_LONGITUDE, 
+    CONF_BINARY_SENSORS, CONF_FILENAME, CONF_MONITORED_CONDITIONS,
+    CONF_SENSORS, CONF_STRUCTURE, EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP)
+from homeassistant.core import callback
+from homeassistant.helpers.discovery import load_platform
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_point_in_utc_time
+import homeassistant.util.dt as dt_util
+    
+DOMAIN = 'noonlight'
+
+TOKEN_CHECK_INTERVAL = timedelta(minutes=15)
+
+CONF_SECRET = 'secret'
+CONF_API_ENDPOINT = 'api_endpoint'
+CONF_TOKEN_ENDPOINT = 'token_endpoint'
+    
+REQUIREMENTS = ['noonlight>=0.1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ID): cv.string,
+        vol.Required(CONF_SECRET): cv.string,
+        vol.Required(CONF_API_ENDPOINT): cv.string,
+        vol.Required(CONF_TOKEN_ENDPOINT): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    if DOMAIN not in config:
+        return True
+        
+    conf = config[DOMAIN]
+        
+    
+    if DOMAIN not in hass.data:
+        noonlight_platform = NoonlightPlatform(hass, conf)
+        hass.data[DOMAIN] = noonlight_platform
+
+    async def check_api_token(now):
+        """Check if the current API token has expired and renew if so"""
+        
+        next_check_interval = TOKEN_CHECK_INTERVAL
+        
+        result = await noonlight_platform.check_api_token()
+        
+        if not result:
+            _LOGGER.error('Noonlight token failed to renew, trying again in 3 minutes...')
+            next_check_interval = timedelta(minutes=3)
+
+        async_track_point_in_utc_time(
+            hass, check_api_token, dt_util.utcnow() + next_check_interval)
+
+    @callback
+    def schedule_first_token_check(event):
+        """Schedule the first token renewal when Home Assistant starts up."""
+        async_track_point_in_utc_time(hass, check_api_token, dt_util.utcnow())
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, schedule_first_token_check)
+    
+    load_platform(hass, 'switch', DOMAIN, None, config)
+    
+    return True
+    
+class NoonlightPlatform(object):
+    """Platform for interacting with Noonlight from HomeAssistant"""
+    def __init__(self, hass, conf):
+        self.hass = hass
+        self.config = conf
+        self._client = None
+        self._time_to_renew = timedelta(hours=2)
+        
+    @property
+    def latitude(self):
+        return self.config.get(CONF_LATITUDE, self.hass.config.latitude)
+        
+    @property
+    def longitude(self):
+        return self.config.get(CONF_LONGITUDE, self.hass.config.longitude)
+        
+    @property
+    def access_token(self):
+        return self.config.get(CONF_ACCESS_TOKEN,{}).get('token')
+        
+    @property
+    def access_token_expiry(self):
+        return self.config.get(CONF_ACCESS_TOKEN,{}).get('expires',dt_util.utc_from_timestamp(0))
+        
+    @property
+    def access_token_expires_in(self):
+        return self.access_token_expiry - dt_util.utcnow()
+        
+    @property
+    def should_token_be_renewed(self):
+        return self.access_token is None or self.access_token_expires_in <= self._time_to_renew
+        
+    @property
+    def client(self):
+        if self._client is None:
+            import noonlight
+            self._client = noonlight.NoonlightClient(token = self.access_token)
+        return self._client
+        
+    async def check_api_token(self, force_renew = False):
+        _LOGGER.debug('Checking to see if Noonlight access token needs renewal, expires in {0:.1f}h'.format(self.access_token_expires_in.total_seconds() / 3600.0))
+        if self.should_token_be_renewed or force_renew:
+            try:
+                _LOGGER.debug('Renewing Noonlight access token...')
+                token_response = await self.client._post(path = self.config.get(CONF_TOKEN_ENDPOINT), data = {'id': self.config.get(CONF_ID), 'secret': self.config.get(CONF_SECRET)})
+                if 'token' in token_response and 'expires' in token_response:
+                    self._set_token_response(token_response)
+                    _LOGGER.info('Noonlight access token successfully renewed, expires at {0} ({1:.1f}h)'.format(self.access_token_expiry,self.access_token_expires_in.total_seconds() / 3600.0))
+                    return True
+                else:
+                    raise Exception('unexpected token_response: {}'.format(token_response))
+            except:
+                _LOGGER.exception('Failed to renew Noonlight token!')
+                return False
+        return True
+                
+    def _set_token_response(self, token_response):
+        expires = dt_util.parse_datetime(token_response['expires'])
+        if expires is not None:
+            token_response['expires'] = expires
+        else:
+            token_response['expires'] = dt_util.utc_from_timestamp(0)
+        self.client.set_token(token = token_response.get('token'))
+        self.config[CONF_ACCESS_TOKEN] = token_response
+        
+    

--- a/homeassistant/components/noonlight/__init__.py
+++ b/homeassistant/components/noonlight/__init__.py
@@ -64,7 +64,7 @@ async def async_setup(hass, config):
             persistent_notification.create(
                     hass,
                     "Noonlight API token failed to renew {} time{}!\n"
-                    "HomeAssistant will automatically attempt to renew the "
+                    "Home Assistant will automatically attempt to renew the "
                     "API token in 3 minutes.".format(
                             check_api_token.fail_count,
                             's' if check_api_token.fail_count > 1 else ''
@@ -100,7 +100,7 @@ async def async_setup(hass, config):
     return True
 
 class NoonlightPlatform():
-    """Platform for interacting with Noonlight from HomeAssistant"""
+    """Platform for interacting with Noonlight from Home Assistant"""
     def __init__(self, hass, conf):
         self.hass = hass
         self.config = conf
@@ -143,6 +143,8 @@ class NoonlightPlatform():
         if self._client is None:
             import noonlight as nl
             self._client = nl.NoonlightClient(token=self.access_token)
+            api_url = self.config.get(CONF_API_ENDPOINT)
+            self._client._base_url = api_url
         return self._client
 
     async def check_api_token(self, force_renew=False):

--- a/homeassistant/components/noonlight/manifest.json
+++ b/homeassistant/components/noonlight/manifest.json
@@ -1,0 +1,15 @@
+{
+  "domain": "noonlight",
+  "name": "Noonlight",
+  "documentation": "https://www.home-assistant.io/components/noonlight",
+  "requirements": [
+    "noonlight>=0.1.0"
+  ],
+  "dependencies": [
+    "http"
+  ],
+  "codeowners": [
+    "@heythisisnate",
+	"@snicker"
+  ]
+}

--- a/homeassistant/components/noonlight/manifest.json
+++ b/homeassistant/components/noonlight/manifest.json
@@ -3,7 +3,7 @@
   "name": "Noonlight",
   "documentation": "https://www.home-assistant.io/components/noonlight",
   "requirements": [
-    "noonlight>=0.1.0"
+    "noonlight==0.1.0"
   ],
   "dependencies": [
     "http"

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -7,6 +7,8 @@ from homeassistant.components import persistent_notification
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.helpers.event import async_track_time_interval
 
+from noonlight import NoonlightClient
+
 from . import (DOMAIN, EVENT_NOONLIGHT_TOKEN_REFRESHED,
                NOTIFICATION_ALARM_CREATE_FAILURE)
 
@@ -76,7 +78,7 @@ class NoonlightSwitch(SwitchDevice):
                         }
                     }
                 )
-            except Exception as e:
+            except NoonlightClient.ClientError as e:
                 persistent_notification.create(
                         self.hass,
                         "Failed to send an alarm to Noonlight!\n\n"
@@ -110,7 +112,7 @@ class NoonlightSwitch(SwitchDevice):
                     )
 
     async def async_turn_off(self, **kwargs):
-        """Turn off the switch if the active alarm is canceled"""
+        """Turn off the switch if the active alarm is canceled."""
         if self._alarm is not None:
             if self._alarm.status == CONST_ALARM_STATUS_CANCELED:
                 self._alarm = None

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -1,0 +1,63 @@
+"""Create a switch to trigger an alarm in Noonlight"""
+import logging
+
+from . import DOMAIN
+DEFAULT_NAME = 'noonlight_switch'
+
+from homeassistant.components.switch import SwitchDevice
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# DEPENDENCIES = ['noonlight']
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Create a switch to create an alarm with the Noonlight service"""
+    noonlight_platform = hass.data[DOMAIN]
+    noonlight_switch = NoonlightSwitch(noonlight_platform)
+    async_add_entities([noonlight_switch])
+
+
+class NoonlightSwitch(SwitchDevice):
+    """Representation of a Noonlight alarm switch."""
+
+    def __init__(self, noonlight_platform):
+        """Initialize the Noonlight switch."""
+        self.noonlight = noonlight_platform
+        self._name = DEFAULT_NAME
+        self._alarm = None
+        self._state = False
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+        
+    @property
+    def available(self):
+        """ensure that the Noonlight access token is valid"""
+        return self.noonlight.access_token_expires_in.total_seconds() > 0
+
+    @property
+    def is_on(self):
+        """Return the status of the switch."""
+        return self._state
+
+    async def async_turn_on(self, **kwargs):
+        """Activate an alarm"""
+        #[TODO] read list of monitored sensors, use sensor type to determine 
+        #   whether medical, fire, or police should be notified
+        if self._alarm is None:
+            self._alarm = await self.noonlight.client.create_alarm(body = {'location.coordinates': {'lat':self.noonlight.latitude, 'lng':self.noonlight.latitude, 'accuracy': 5} })
+            if self._alarm and self._alarm.status == 'ACTIVE': #[todo] change to constant from noonlight library
+                self._state = True        
+
+    async def async_turn_off(self, **kwargs):
+        """Send a command to cancel the active alarm"""
+        if self._alarm is not None:
+            response = await self._alarm.cancel()
+            if response:
+                self._alarm = None
+                self._state = False

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from . import (DOMAIN, EVENT_NOONLIGHT_TOKEN_REFRESHED,
         NOTIFICATION_ALARM_CREATE_FAILURE)
 
-DEFAULT_NAME = 'noonlight_switch'
+DEFAULT_NAME = 'Noonlight Switch'
 
 CONST_ALARM_STATUS_ACTIVE = 'ACTIVE'
 CONST_ALARM_STATUS_CANCELED = 'CANCELED'

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -8,7 +8,7 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.helpers.event import async_track_time_interval
 
 from . import (DOMAIN, EVENT_NOONLIGHT_TOKEN_REFRESHED,
-        NOTIFICATION_ALARM_CREATE_FAILURE)
+               NOTIFICATION_ALARM_CREATE_FAILURE)
 
 DEFAULT_NAME = 'Noonlight Switch'
 
@@ -17,17 +17,19 @@ CONST_ALARM_STATUS_CANCELED = 'CANCELED'
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create a switch to create an alarm with the Noonlight service"""
     noonlight_platform = hass.data[DOMAIN]
     noonlight_switch = NoonlightSwitch(noonlight_platform)
     async_add_entities([noonlight_switch])
-    
+
     def noonlight_token_refreshed(event):
         noonlight_switch.schedule_update_ha_state()
-    
-    hass.bus.async_listen(EVENT_NOONLIGHT_TOKEN_REFRESHED, noonlight_token_refreshed)
+
+    hass.bus.async_listen(EVENT_NOONLIGHT_TOKEN_REFRESHED,
+                          noonlight_token_refreshed)
 
 
 class NoonlightSwitch(SwitchDevice):
@@ -54,22 +56,22 @@ class NoonlightSwitch(SwitchDevice):
     def is_on(self):
         """Return the status of the switch."""
         return self._state
-        
+
     async def update_alarm_status(self):
         if self._alarm is not None:
             return await self._alarm.get_status()
 
     async def async_turn_on(self, **kwargs):
         """Activate an alarm"""
-        #[TODO] read list of monitored sensors, use sensor type to determine
+        # [TODO] read list of monitored sensors, use sensor type to determine
         #   whether medical, fire, or police should be notified
         if self._alarm is None:
             try:
                 self._alarm = await self.noonlight.client.create_alarm(
                     body={
                         'location.coordinates': {
-                            'lat':self.noonlight.latitude,
-                            'lng':self.noonlight.longitude,
+                            'lat': self.noonlight.latitude,
+                            'lng': self.noonlight.longitude,
                             'accuracy': 5
                         }
                     }
@@ -78,20 +80,22 @@ class NoonlightSwitch(SwitchDevice):
                 persistent_notification.create(
                         self.hass,
                         "Failed to send an alarm to Noonlight!\n\n"
-                        "({}: {})".format(type(e).__name__,str(e)),
+                        "({}: {})".format(type(e).__name__, str(e)),
                         "Noonlight Alarm Failure",
                         NOTIFICATION_ALARM_CREATE_FAILURE)
             if self._alarm and self._alarm.status == CONST_ALARM_STATUS_ACTIVE:
                 _LOGGER.debug(
                         'noonlight alarm has been initiated. '
                         'id: {id} status: {status}'.format(
-                            id=self._alarm.id, 
+                            id=self._alarm.id,
                             status=self._alarm.status))
                 self._state = True
                 cancel_interval = None
+
                 async def check_alarm_status_interval(now):
                     _LOGGER.debug('checking alarm status...')
-                    if await self.update_alarm_status() == CONST_ALARM_STATUS_CANCELED:
+                    if await self.update_alarm_status() == \
+                            CONST_ALARM_STATUS_CANCELED:
                         _LOGGER.debug(
                                 'alarm {id} has been canceled!'.format(
                                     id=self._alarm.id))
@@ -100,9 +104,9 @@ class NoonlightSwitch(SwitchDevice):
                         await self.async_turn_off()
                         self.schedule_update_ha_state()
                 cancel_interval = async_track_time_interval(
-                        self.hass, 
-                        check_alarm_status_interval, 
-                        timedelta(seconds = 15)
+                        self.hass,
+                        check_alarm_status_interval,
+                        timedelta(seconds=15)
                     )
 
     async def async_turn_off(self, **kwargs):

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -33,7 +33,7 @@ class NoonlightSwitch(SwitchDevice):
     def name(self):
         """Return the name of the switch."""
         return self._name
-        
+
     @property
     def available(self):
         """ensure that the Noonlight access token is valid"""
@@ -46,20 +46,20 @@ class NoonlightSwitch(SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Activate an alarm"""
-        #[TODO] read list of monitored sensors, use sensor type to determine 
+        #[TODO] read list of monitored sensors, use sensor type to determine
         #   whether medical, fire, or police should be notified
         if self._alarm is None:
             self._alarm = await self.noonlight.client.create_alarm(
-                body = {
+                body={
                     'location.coordinates': {
-                        'lat':self.noonlight.latitude, 
-                        'lng':self.noonlight.latitude, 
+                        'lat':self.noonlight.latitude,
+                        'lng':self.noonlight.latitude,
                         'accuracy': 5
-                    } 
+                    }
                 }
             )
             if self._alarm and self._alarm.status == 'ACTIVE':
-                self._state = True        
+                self._state = True
 
     async def async_turn_off(self, **kwargs):
         """Send a command to cancel the active alarm"""

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -23,8 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create a switch to create an alarm with the Noonlight service"""
-    noonlight_platform = hass.data[DOMAIN]
-    noonlight_switch = NoonlightSwitch(noonlight_platform)
+    noonlight_integration = hass.data[DOMAIN]
+    noonlight_switch = NoonlightSwitch(noonlight_integration)
     async_add_entities([noonlight_switch])
 
     def noonlight_token_refreshed(event):
@@ -37,9 +37,9 @@ async def async_setup_platform(
 class NoonlightSwitch(SwitchDevice):
     """Representation of a Noonlight alarm switch."""
 
-    def __init__(self, noonlight_platform):
+    def __init__(self, noonlight_integration):
         """Initialize the Noonlight switch."""
-        self.noonlight = noonlight_platform
+        self.noonlight = noonlight_integration
         self._name = DEFAULT_NAME
         self._alarm = None
         self._state = False

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -1,16 +1,15 @@
 """Create a switch to trigger an alarm in Noonlight"""
 import logging
 
+from homeassistant.components.switch import SwitchDevice
+
 from . import DOMAIN
+
 DEFAULT_NAME = 'noonlight_switch'
 
-from homeassistant.components.switch import SwitchDevice
 
 
 _LOGGER = logging.getLogger(__name__)
-
-# DEPENDENCIES = ['noonlight']
-
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -50,8 +49,16 @@ class NoonlightSwitch(SwitchDevice):
         #[TODO] read list of monitored sensors, use sensor type to determine 
         #   whether medical, fire, or police should be notified
         if self._alarm is None:
-            self._alarm = await self.noonlight.client.create_alarm(body = {'location.coordinates': {'lat':self.noonlight.latitude, 'lng':self.noonlight.latitude, 'accuracy': 5} })
-            if self._alarm and self._alarm.status == 'ACTIVE': #[todo] change to constant from noonlight library
+            self._alarm = await self.noonlight.client.create_alarm(
+                body = {
+                    'location.coordinates': {
+                        'lat':self.noonlight.latitude, 
+                        'lng':self.noonlight.latitude, 
+                        'accuracy': 5
+                    } 
+                }
+            )
+            if self._alarm and self._alarm.status == 'ACTIVE':
                 self._state = True        
 
     async def async_turn_off(self, **kwargs):

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -66,7 +66,7 @@ class NoonlightSwitch(SwitchDevice):
                 body={
                     'location.coordinates': {
                         'lat':self.noonlight.latitude,
-                        'lng':self.noonlight.latitude,
+                        'lng':self.noonlight.longitude,
                         'accuracy': 5
                     }
                 }

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -27,11 +27,11 @@ async def async_setup_platform(
     noonlight_switch = NoonlightSwitch(noonlight_integration)
     async_add_entities([noonlight_switch])
 
-    def noonlight_token_refreshed(event):
+    def noonlight_token_refreshed():
         noonlight_switch.schedule_update_ha_state()
 
-    hass.bus.async_listen(EVENT_NOONLIGHT_TOKEN_REFRESHED,
-                          noonlight_token_refreshed)
+    hass.helpers.dispatcher.async_dispatcher_connect(
+        EVENT_NOONLIGHT_TOKEN_REFRESHED, noonlight_token_refreshed)
 
 
 class NoonlightSwitch(SwitchDevice):

--- a/homeassistant/components/noonlight/switch.py
+++ b/homeassistant/components/noonlight/switch.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.helpers.event import async_track_time_interval
 
-from . import DOMAIN
+from . import DOMAIN, EVENT_NOONLIGHT_TOKEN_REFRESHED
 
 DEFAULT_NAME = 'noonlight_switch'
 
@@ -21,6 +21,11 @@ async def async_setup_platform(
     noonlight_platform = hass.data[DOMAIN]
     noonlight_switch = NoonlightSwitch(noonlight_platform)
     async_add_entities([noonlight_switch])
+    
+    def noonlight_token_refreshed(event):
+        noonlight_switch.schedule_update_ha_state()
+    
+    hass.bus.async_listen(EVENT_NOONLIGHT_TOKEN_REFRESHED, noonlight_token_refreshed)
 
 
 class NoonlightSwitch(SwitchDevice):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -805,6 +805,9 @@ niko-home-control==0.2.1
 # homeassistant.components.nilu
 niluclient==0.1.2
 
+# homeassistant.components.noonlight
+noonlight==0.1.0
+
 # homeassistant.components.nederlandse_spoorwegen
 nsapi==2.7.4
 


### PR DESCRIPTION
## Description:

This adds a new Noonlight component and switch for sending alarms to the Noonlight platform (https://noonlight.com/)

documentation PR here : https://github.com/home-assistant/home-assistant.io/pull/9663

## Example entry for `configuration.yaml` (if applicable):
```
# Example configuration.yaml entry
noonlight:
  id: NOONLIGHT_ID
  secret: NOONLIGHT_SECRET
  api_endpoint: https://api.noonlight.com/platform/v1
  token_endpoint: https://noonlight.konnected.io/ha/token
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
