### PR TITLE
Fail when user tries run custom config flow

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -553,6 +553,14 @@ class ConfigEntries:
             _LOGGER.error('Cannot find integration %s', handler_key)
             raise data_entry_flow.UnknownHandler
 
+        # Our config flow list is based on built-in integrations. If overriden,
+        # we should not load it's config flow.
+        if not integration.is_built_in:
+            _LOGGER.error(
+                'Config flow is not supported for custom integration %s',
+                handler_key)
+            raise data_entry_flow.UnknownHandler
+
         # Make sure requirements and dependencies of component are resolved
         await async_process_deps_reqs(
             self.hass, self._hass_config, integration)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -123,6 +123,11 @@ class Integration:
         self.requirements = manifest['requirements']  # type: List[str]
         _LOGGER.info("Loaded %s from %s", self.domain, pkg_path)
 
+    @property
+    def is_built_in(self) -> bool:
+        """Test if package is a built-in integration."""
+        return self.pkg_path.startswith(PACKAGE_BUILTIN)
+
     def get_component(self) -> ModuleType:
         """Return the component."""
         cache = self.hass.data.setdefault(DATA_COMPONENTS, {})

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
@@ -934,3 +934,17 @@ async def test_entry_reload_error(hass, manager, state):
     assert len(async_setup_entry.mock_calls) == 0
 
     assert entry.state == state
+
+
+async def test_init_custom_integration(hass):
+    """Test initializing flow for custom integration."""
+    integration = loader.Integration(hass, 'custom_components.hue', None, {
+        'name': 'Hue',
+        'dependencies': [],
+        'requirements': [],
+        'domain': 'hue',
+    })
+    with pytest.raises(data_entry_flow.UnknownHandler):
+        with patch('homeassistant.loader.async_get_integration',
+                   return_value=mock_coro(integration)):
+            await hass.config_entries.flow.async_init('bla')

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -152,6 +152,16 @@ def test_integration_properties(hass):
     assert integration.domain == 'hue'
     assert integration.dependencies == ['test-dep']
     assert integration.requirements == ['test-req==1.0.0']
+    assert integration.is_built_in is True
+
+    integration = loader.Integration(
+        hass, 'custom_components.hue', None, {
+            'name': 'Philips Hue',
+            'domain': 'hue',
+            'dependencies': ['test-dep'],
+            'requirements': ['test-req==1.0.0'],
+        })
+    assert integration.is_built_in is False
 
 
 async def test_integrations_only_once(hass):


### PR DESCRIPTION
## Description:
Fail with a useful message when a user tries to start a config flow from a custom integration. This will help Life360 users understand why the new config flow is not working.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
