### PR TITLE
Update "state" only if value comes from device

### DIFF
--- a/homeassistant/components/zwave/sensor.py
+++ b/homeassistant/components/zwave/sensor.py
@@ -51,8 +51,9 @@ class ZWaveSensor(ZWaveDeviceEntity):
 
     def update_properties(self):
         """Handle the data changes for node values."""
-        self._state = self.values.primary.data
-        self._units = self.values.primary.units
+        value = self.values.primary
+        self._state = value.data if value.is_set else None
+        self._units = value.units
 
     @property
     def force_update(self):


### PR DESCRIPTION
## Description:

**Related issue:** fixes #23351

After a power outage I verified the energy value of a `zwave` device (Qubino Smart Meter) to jump from 30.7 to 23.1 and back to 30.7 causing the `utility_meter` to jump accordingly.

This is due to the fact that when zwave starts it read the first value from the configuration xml file and not from the network. The configuration xml file is saved only when `hass.io` graceful restart (or stop) appens. So in case of a power outage the values stored in the configuration file can be very old (3 days in my case). This cause a "jump" in the `utility_meter `value. The result were an energy counter that counted the last 3 days twice.

My solution is to ignore the initial value. I can recognize this by using the `is_set` property.

> `is_set` returns `True `if the value has actually been set by a status message from the device, rather than simply being the default.

Ref:
https://github.com/OpenZWave/python-openzwave/blob/master/src-api/openzwave/value.py#L417 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]