### PR TITLE
Improve autodiscovered yeelights model detection

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -124,12 +124,10 @@ def setup(hass, config):
 
         name = "yeelight_%s_%s" % (info['device_type'],
                                    info['properties']['mac'])
-        ipaddr = info[CONF_HOST]
-        device_config = DEVICE_SCHEMA({
-            CONF_NAME: name,
-        })
 
-        _setup_device(hass, config, ipaddr, device_config)
+        device_config = DEVICE_SCHEMA({CONF_NAME: name})
+
+        _setup_device(hass, config, info[CONF_HOST], device_config)
 
     discovery.listen(hass, SERVICE_YEELIGHT, device_discovered)
 

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -122,14 +122,11 @@ def setup(hass, config):
     def device_discovered(_, info):
         _LOGGER.debug("Adding autodetected %s", info['hostname'])
 
-        device_type = info['device_type']
-
-        name = "yeelight_%s_%s" % (device_type,
+        name = "yeelight_%s_%s" % (info['device_type'],
                                    info['properties']['mac'])
         ipaddr = info[CONF_HOST]
         device_config = DEVICE_SCHEMA({
             CONF_NAME: name,
-            CONF_MODEL: device_type
         })
 
         _setup_device(hass, config, ipaddr, device_config)

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -179,8 +179,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _lights_setup_helper(YeelightAmbientLight)
     else:
         _lights_setup_helper(YeelightGenericLight)
-        _LOGGER.warn("Cannot determine device type for %s, %s."
-                     "Falling back to white only", device.ipaddr, device.name)
+        _LOGGER.warning("Cannot determine device type for %s, %s. "
+                        "Falling back to white only", device.ipaddr,
+                        device.name)
 
     hass.data[data_key] += lights
     add_entities(lights, True)

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -178,7 +178,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _lights_setup_helper(YeelightWithAmbientLight)
         _lights_setup_helper(YeelightAmbientLight)
     else:
-        _LOGGER.error("Cannot determine device type for %s, %s",
+        _lights_setup_helper(YeelightGenericLight)
+        _LOGGER.warn("Cannot determine device type for %s, %s\n"
+                     "Falling back to white only",
                       device.ipaddr, device.name)
 
     hass.data[data_key] += lights

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -179,9 +179,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _lights_setup_helper(YeelightAmbientLight)
     else:
         _lights_setup_helper(YeelightGenericLight)
-        _LOGGER.warn("Cannot determine device type for %s, %s\n"
-                     "Falling back to white only",
-                      device.ipaddr, device.name)
+        _LOGGER.warn("Cannot determine device type for %s, %s."
+                     "Falling back to white only", device.ipaddr, device.name)
 
     hass.data[data_key] += lights
     add_entities(lights, True)


### PR DESCRIPTION
## Description:
Autodiscovery shouln't set device model. There are many different models and we would end up adding each one in the mapping dict https://github.com/home-assistant/home-assistant/blob/e790fb1af1c20d75bcb5252c66825c1e86b32175/homeassistant/components/yeelight/light.py#L91 . Instead lets allow light type to be discovered same way as manually configured light, by doing https://yeelight.readthedocs.io/en/latest/yeelight.html#yeelight.Bulb.bulb_type method call. If light is discovered, that means its online so we can fetch its properties for device type recognition.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/24643

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]