### PR TITLE
Add protocol choice for Stream Component.

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -564,13 +564,14 @@ async def ws_camera_stream(hass, connection, msg):
 
         async with async_timeout.timeout(10):
             source = await camera.stream_source()
+            protocol = await camera.stream_protocol()
 
         if not source:
             raise HomeAssistantError("{} does not support play stream service"
                                      .format(camera.entity_id))
 
         fmt = msg['format']
-        url = request_stream(hass, source, fmt=fmt,
+        url = request_stream(hass, source, protocol, fmt=fmt,
                              keepalive=camera_prefs.preload_stream)
         connection.send_result(msg['id'], {'url': url})
     except HomeAssistantError as ex:
@@ -646,6 +647,7 @@ async def async_handle_play_stream_service(camera, service_call):
     """Handle play stream services calls."""
     async with async_timeout.timeout(10):
         source = await camera.stream_source()
+        protocol = await camera.stream_protocol()
 
     if not source:
         raise HomeAssistantError("{} does not support play stream service"
@@ -656,7 +658,7 @@ async def async_handle_play_stream_service(camera, service_call):
     fmt = service_call.data[ATTR_FORMAT]
     entity_ids = service_call.data[ATTR_MEDIA_PLAYER]
 
-    url = request_stream(hass, source, fmt=fmt,
+    url = request_stream(hass, source, protocol, fmt=fmt,
                          keepalive=camera_prefs.preload_stream)
     data = {
         ATTR_ENTITY_ID: entity_ids,
@@ -673,6 +675,7 @@ async def async_handle_record_service(camera, call):
     """Handle stream recording service calls."""
     async with async_timeout.timeout(10):
         source = await camera.stream_source()
+        protocol = await camera.stream_protocol()
 
     if not source:
         raise HomeAssistantError("{} does not support record service"

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -2,6 +2,7 @@
 DOMAIN = 'stream'
 
 CONF_STREAM_SOURCE = 'stream_source'
+CONF_PROTOCOL = 'protocol'
 CONF_LOOKBACK = 'lookback'
 CONF_DURATION = 'duration'
 


### PR DESCRIPTION
## Breaking Change:

A way to choice the protocol of the camera for streaming.

## Description:

Default configuration still tcp, but you can change to udp

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
Camera stream not working in udp only camera.

## Example entry for `configuration.yaml`:
```yaml
- platform: generic
  name: Piscine
  still_image_url: http://192.168.1.8:8765/picture/4/currentx
  stream_source: rtsp://xxxx:xxx@192.168.1.74:554/onvif1
  protocol: udp
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

I haven't time to make beautifull pull request, re-use my code if it help to improve Hass.