### PR TITLE
Allow extra js modules to be included in frontend

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -25,7 +25,7 @@ CONF_THEMES = 'themes'
 CONF_EXTRA_HTML_URL = 'extra_html_url'
 CONF_EXTRA_HTML_URL_ES5 = 'extra_html_url_es5'
 CONF_EXTRA_MODULE_URL = 'extra_module_url'
-CONF_EXTRA_MODULE_URL_ES5 = 'extra_module_url_es5'
+CONF_EXTRA_JS_URL_ES5 = 'extra_js_url_es5'
 CONF_FRONTEND_REPO = 'development_repo'
 CONF_JS_VERSION = 'javascript_version'
 EVENT_PANELS_UPDATED = 'panels_updated'
@@ -58,7 +58,7 @@ DATA_JS_VERSION = 'frontend_js_version'
 DATA_EXTRA_HTML_URL = 'frontend_extra_html_url'
 DATA_EXTRA_HTML_URL_ES5 = 'frontend_extra_html_url_es5'
 DATA_EXTRA_MODULE_URL = 'frontend_extra_module_url'
-DATA_EXTRA_MODULE_URL_ES5 = 'frontend_extra_module_url_es5'
+DATA_EXTRA_JS_URL_ES5 = 'frontend_extra_js_url_es5'
 DATA_THEMES = 'frontend_themes'
 DATA_DEFAULT_THEME = 'frontend_default_theme'
 DEFAULT_THEME = 'default'
@@ -77,7 +77,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_EXTRA_MODULE_URL):
             vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_EXTRA_MODULE_URL_ES5):
+        vol.Optional(CONF_EXTRA_JS_URL_ES5):
             vol.All(cv.ensure_list, [cv.string]),
         # We no longer use these options.
         vol.Optional(CONF_EXTRA_HTML_URL_ES5): cv.match_all,
@@ -192,9 +192,9 @@ def add_extra_html_url(hass, url, es5=False):
     url_set.add(url)
 
 
-def add_extra_module_url(hass, url, es5=False):
-    """Register extra module url to load."""
-    key = DATA_EXTRA_MODULE_URL_ES5 if es5 else DATA_EXTRA_MODULE_URL
+def add_extra_js_url(hass, url, es5=False):
+    """Register extra js or module url to load."""
+    key = DATA_EXTRA_JS_URL_ES5 if es5 else DATA_EXTRA_MODULE_URL
     url_set = hass.data.get(key)
     if url_set is None:
         url_set = hass.data[key] = set()
@@ -270,13 +270,13 @@ async def async_setup(hass, config):
         hass.data[DATA_EXTRA_MODULE_URL] = set()
 
     for url in conf.get(CONF_EXTRA_MODULE_URL, []):
-        add_extra_module_url(hass, url)
+        add_extra_js_url(hass, url)
 
-    if DATA_EXTRA_MODULE_URL_ES5 not in hass.data:
-        hass.data[DATA_EXTRA_MODULE_URL_ES5] = set()
+    if DATA_EXTRA_JS_URL_ES5 not in hass.data:
+        hass.data[DATA_EXTRA_JS_URL_ES5] = set()
 
-    for url in conf.get(CONF_EXTRA_MODULE_URL_ES5, []):
-        add_extra_module_url(hass, url, True)
+    for url in conf.get(CONF_EXTRA_JS_URL_ES5, []):
+        add_extra_js_url(hass, url, True)
 
     _async_setup_themes(hass, conf.get(CONF_THEMES))
 
@@ -426,7 +426,7 @@ class IndexView(web_urldispatcher.AbstractResource):
                 theme_color=MANIFEST_JSON['theme_color'],
                 extra_urls=hass.data[DATA_EXTRA_HTML_URL],
                 extra_modules=hass.data[DATA_EXTRA_MODULE_URL],
-                extra_modules_es5=hass.data[DATA_EXTRA_MODULE_URL_ES5],
+                extra_js_es5=hass.data[DATA_EXTRA_JS_URL_ES5],
             ),
             content_type='text/html'
         )

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -24,6 +24,8 @@ DOMAIN = 'frontend'
 CONF_THEMES = 'themes'
 CONF_EXTRA_HTML_URL = 'extra_html_url'
 CONF_EXTRA_HTML_URL_ES5 = 'extra_html_url_es5'
+CONF_EXTRA_MODULE_URL = 'extra_module_url'
+CONF_EXTRA_MODULE_URL_ES5 = 'extra_module_url_es5'
 CONF_FRONTEND_REPO = 'development_repo'
 CONF_JS_VERSION = 'javascript_version'
 EVENT_PANELS_UPDATED = 'panels_updated'
@@ -55,6 +57,8 @@ DATA_PANELS = 'frontend_panels'
 DATA_JS_VERSION = 'frontend_js_version'
 DATA_EXTRA_HTML_URL = 'frontend_extra_html_url'
 DATA_EXTRA_HTML_URL_ES5 = 'frontend_extra_html_url_es5'
+DATA_EXTRA_MODULE_URL = 'frontend_extra_module_url'
+DATA_EXTRA_MODULE_URL_ES5 = 'frontend_extra_module_url_es5'
 DATA_THEMES = 'frontend_themes'
 DATA_DEFAULT_THEME = 'frontend_default_theme'
 DEFAULT_THEME = 'default'
@@ -70,6 +74,10 @@ CONFIG_SCHEMA = vol.Schema({
             cv.string: {cv.string: cv.string}
         }),
         vol.Optional(CONF_EXTRA_HTML_URL):
+            vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXTRA_MODULE_URL):
+            vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXTRA_MODULE_URL_ES5):
             vol.All(cv.ensure_list, [cv.string]),
         # We no longer use these options.
         vol.Optional(CONF_EXTRA_HTML_URL_ES5): cv.match_all,
@@ -184,6 +192,15 @@ def add_extra_html_url(hass, url, es5=False):
     url_set.add(url)
 
 
+def add_extra_module_url(hass, url, es5=False):
+    """Register extra module url to load."""
+    key = DATA_EXTRA_MODULE_URL_ES5 if es5 else DATA_EXTRA_MODULE_URL
+    url_set = hass.data.get(key)
+    if url_set is None:
+        url_set = hass.data[key] = set()
+    url_set.add(url)
+
+
 def add_manifest_json_key(key, val):
     """Add a keyval to the manifest.json."""
     MANIFEST_JSON[key] = val
@@ -248,6 +265,18 @@ async def async_setup(hass, config):
 
     for url in conf.get(CONF_EXTRA_HTML_URL, []):
         add_extra_html_url(hass, url, False)
+
+    if DATA_EXTRA_MODULE_URL not in hass.data:
+        hass.data[DATA_EXTRA_MODULE_URL] = set()
+
+    for url in conf.get(CONF_EXTRA_MODULE_URL, []):
+        add_extra_module_url(hass, url)
+
+    if DATA_EXTRA_MODULE_URL_ES5 not in hass.data:
+        hass.data[DATA_EXTRA_MODULE_URL_ES5] = set()
+
+    for url in conf.get(CONF_EXTRA_MODULE_URL_ES5, []):
+        add_extra_module_url(hass, url, True)
 
     _async_setup_themes(hass, conf.get(CONF_THEMES))
 
@@ -396,6 +425,8 @@ class IndexView(web_urldispatcher.AbstractResource):
             text=template.render(
                 theme_color=MANIFEST_JSON['theme_color'],
                 extra_urls=hass.data[DATA_EXTRA_HTML_URL],
+                extra_modules=hass.data[DATA_EXTRA_MODULE_URL],
+                extra_modules_es5=hass.data[DATA_EXTRA_MODULE_URL_ES5],
             ),
             content_type='text/html'
         )


### PR DESCRIPTION
## Description:
HTML imports are being deprecated, and the recommended way forward is to use js module imports instead. This allows specifying modules that will be imported in the frontend.

A use case may be adding aditional icon sets. This *could* be done using lovelace modules, but then the new icons would work only after loading the lovelace panel. I.e. in a browser opened directly to e.g.`/states` or `/config/entity_registry` the new icons wouldn't show up.

Corresponding frontend PR: home-assistant/home-assistant-polymer#3288


(Quick and dirty WIP/POC)

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9674

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
  extra_module_url:
    - /local/mything.js
  extra_module_url_es5:
    - /local/mything_for_older_browsers.js

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
