### PR TITLE
Fix fan speeds to match roborock.vacuum.s5 v3.3.9_001768 firmware

### DIFF
--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -33,11 +33,13 @@ SERVICE_START_REMOTE_CONTROL = 'xiaomi_remote_control_start'
 SERVICE_STOP_REMOTE_CONTROL = 'xiaomi_remote_control_stop'
 SERVICE_CLEAN_ZONE = 'xiaomi_clean_zone'
 
+# roborock.vacuum.s5 v3.3.9_001768 firmware (CRoboController::SetFanPower2Nav())
 FAN_SPEEDS = {
     'Quiet': 38,
     'Balanced': 60,
-    'Turbo': 77,
-    'Max': 90}
+    'Turbo': 75,
+    'Max': 100,
+    'Mop': 105}
 
 ATTR_CLEAN_START = 'clean_start'
 ATTR_CLEAN_STOP = 'clean_stop'


### PR DESCRIPTION
## Description:
Adds "Mop Mode" and adjusts fan speeds levels to latest firmware.

As you can see from code below there are fixed mode values that could be used but as the home-assistant code works now those are not usable. I guess the proper way would be to set each mode value on device and read back the value that has been set. 

```
int __fastcall CRoboController::SetFanPower2Nav(CRoboController *this, int fanpower)
{
  char v4; // r9
  signed int v5; // r0
  void **v7; // [sp+8h] [bp-38h]
  int v8; // [sp+Ch] [bp-34h]
  int v9; // [sp+10h] [bp-30h]
  int v10; // [sp+14h] [bp-2Ch]
  int v11; // [sp+18h] [bp-28h]

  LogPrint(4820, "SetFanPower2Nav", dword_5B4D8 & 0x2000, 269296, fanpower);
  if ( fanpower < 0 )
  {
    fanpower = g_fanpower;
    if ( g_fanpower <= 0 )
      fanpower = dword_5DD28;
    if ( fanpower != 105 )
      goto LABEL_3;
LABEL_13:
    v4 = 30;
    v5 = 1;
    fanpower = 30;
    goto LABEL_9;
  }
  if ( fanpower == 105 )                        // MOPPING_MODE
    goto LABEL_13;
LABEL_3:
  switch ( fanpower )
  {
    case 101:                                   // QUIET_MODE
      v4 = 38;
      v5 = 0;
      fanpower = 38;
      break;
    case 103:                                   // TURBO_MODE
      v4 = 75;
      v5 = 0;
      fanpower = 75;
      break;
    case 104:                                   // MAX_MODE
      v4 = 100;
      v5 = 0;
      fanpower = 100;
      break;
    default:
      if ( (unsigned int)fanpower > 100 )       // BALANCED_MODE
      {
        v4 = 60;
        v5 = 0;
        fanpower = 60;
      }
      else
      {
        v4 = fanpower;
        v5 = 0;
      }
      break;
  }
LABEL_9:
  v11 = v5;
  v7 = &off_40518;
  v9 = 0;
  v10 = fanpower;
  v8 = 14;
  CRoboController::SendEvent(this, 2, &v7, 0);
  *((_BYTE *)this + 513) = v4;
  return LogPrint(4849, "SetFanPower2Nav", dword_5B4D8 & 0x2000, 269332, fanpower);
}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
