### PR TITLE
Add RainMachine device classes where appropriate

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -69,14 +69,15 @@ BINARY_SENSORS = {
 
 SENSORS = {
     TYPE_FLOW_SENSOR_CLICK_M3: (
-        'Flow Sensor Clicks', 'mdi:water-pump', 'clicks/m^3'),
+        'Flow Sensor Clicks', 'mdi:water-pump', 'clicks/m^3', None),
     TYPE_FLOW_SENSOR_CONSUMED_LITERS: (
-        'Flow Sensor Consumed Liters', 'mdi:water-pump', 'liter'),
+        'Flow Sensor Consumed Liters', 'mdi:water-pump', 'liter', None),
     TYPE_FLOW_SENSOR_START_INDEX: (
         'Flow Sensor Start Index', 'mdi:water-pump', None),
     TYPE_FLOW_SENSOR_WATERING_CLICKS: (
-        'Flow Sensor Clicks', 'mdi:water-pump', 'clicks'),
-    TYPE_FREEZE_TEMP: ('Freeze Protect Temperature', 'mdi:thermometer', '°C'),
+        'Flow Sensor Clicks', 'mdi:water-pump', 'clicks', None),
+    TYPE_FREEZE_TEMP: (
+        'Freeze Protect Temperature', 'mdi:thermometer', '°C', 'temperature'),
 }
 
 BINARY_SENSOR_SCHEMA = vol.Schema({
@@ -371,9 +372,15 @@ class RainMachineEntity(Entity):
     def __init__(self, rainmachine):
         """Initialize."""
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._device_class = None
         self._dispatcher_handlers = []
         self._name = None
         self.rainmachine = rainmachine
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
 
     @property
     def device_info(self):

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -26,9 +26,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     sensors = []
     for sensor_type in rainmachine.sensor_conditions:
-        name, icon, unit = SENSORS[sensor_type]
+        name, icon, unit, device_class = SENSORS[sensor_type]
         sensors.append(
-            RainMachineSensor(rainmachine, sensor_type, name, icon, unit))
+            RainMachineSensor(
+                rainmachine, sensor_type, name, icon, unit, device_class))
 
     async_add_entities(sensors, True)
 
@@ -36,10 +37,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class RainMachineSensor(RainMachineEntity):
     """A sensor implementation for raincloud device."""
 
-    def __init__(self, rainmachine, sensor_type, name, icon, unit):
+    def __init__(
+            self, rainmachine, sensor_type, name, icon, unit, device_class):
         """Initialize."""
         super().__init__(rainmachine)
 
+        self._device_class = device_class
         self._icon = icon
         self._name = name
         self._sensor_type = sensor_type


### PR DESCRIPTION
## Description:

This PR adds device class support for the one RainMachine sensor that needs it (and lays a foundation for future sensors to have the same).

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
