### PR TITLE
Upgrade to async_upnp_client==0.14.10 and increase search timeout

### DIFF
--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Dlna dmr",
   "documentation": "https://www.home-assistant.io/components/dlna_dmr",
   "requirements": [
-    "async-upnp-client==0.14.7"
+    "async-upnp-client==0.14.10"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -32,7 +32,8 @@ class Device:
 
         # discover devices
         from async_upnp_client.profiles.igd import IgdDevice
-        discovery_infos = await IgdDevice.async_search(source_ip=local_ip)
+        discovery_infos = await IgdDevice.async_search(source_ip=local_ip,
+                                                       timeout=10)
 
         # add extra info and store devices
         devices = []

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/upnp",
   "requirements": [
-    "async-upnp-client==0.14.7"
+    "async-upnp-client==0.14.10"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.upnp
-async-upnp-client==0.14.7
+async-upnp-client==0.14.10
 
 # homeassistant.components.stream
 av==6.1.2


### PR DESCRIPTION
## Breaking Change:

## Description:

Upgrade to `async_upnp_client==0.14.10` , and set custom timeout when searching for UPnP/IGD devices.

**Related issue (if applicable):** fixes #23728

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
