### PR TITLE
Change Ambient solar radiation units to lx

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -183,7 +183,7 @@ SENSOR_TYPES = {
     TYPE_SOILTEMP7F: ('Soil Temp 7', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP8F: ('Soil Temp 8', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP9F: ('Soil Temp 9', '°F', TYPE_SENSOR, 'temperature'),
-    TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, None),
+    TYPE_SOLARRADIATION: ('Solar Rad', 'lx', TYPE_SENSOR, 'illuminance'),
     TYPE_TEMP10F: ('Temp 10', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_TEMP1F: ('Temp 1', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_TEMP2F: ('Temp 2', '°F', TYPE_SENSOR, 'temperature'),

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.const import ATTR_NAME
 
-from . import SENSOR_TYPES, AmbientWeatherEntity
+from . import SENSOR_TYPES, TYPE_SOLARRADIATION, AmbientWeatherEntity
 from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TYPE_SENSOR
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,5 +61,13 @@ class AmbientWeatherSensor(AmbientWeatherEntity):
 
     async def async_update(self):
         """Fetch new state data for the sensor."""
-        self._state = self._ambient.stations[
+        new_state = self._ambient.stations[
             self._mac_address][ATTR_LAST_DATA].get(self._sensor_type)
+
+        if self._sensor_type == TYPE_SOLARRADIATION:
+            # Ambient's units for solar radiation (illuminance) are
+            # W/m^2; since those aren't commonly used in the HASS
+            # world, transform them to lx:
+            self._state = round(float(new_state)/0.0079)
+        else:
+            self._state = new_state


### PR DESCRIPTION
## Breaking Change:

The Ambient solar radiation sensor now measures its values in `lx` instead of `W/m²`. Any automations that use this sensor should be updated accordingly.

## Description:

By default, the Ambient solar radiation (i.e., brightness) sensor is measured in `W/m²`. Since this unit of measurement is not used anywhere else, this PR updates the sensor to use the more prevalent `lx` unit.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
