### PR TITLE
Fix time expression parsing

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -221,7 +221,7 @@ def parse_time_expression(parameter: Any, min_value: int, max_value: int) \
     if parameter is None or parameter == MATCH_ALL:
         res = [x for x in range(min_value, max_value + 1)]
     elif isinstance(parameter, str) and parameter.startswith('/'):
-        parameter = float(parameter[1:])
+        parameter = int(parameter[1:])
         res = [x for x in range(min_value, max_value + 1)
                if x % parameter == 0]
     elif not hasattr(parameter, '__iter__'):
@@ -302,7 +302,7 @@ def find_next_time_expression_time(now: dt.datetime,
     next_hour = _lower_bound(hours, result.hour)
     if next_hour != result.hour:
         # We're in the next hour. Seconds+minutes needs to be reset.
-        result.replace(second=seconds[0], minute=minutes[0])
+        result = result.replace(second=seconds[0], minute=minutes[0])
 
     if next_hour is None:
         # No minute to match in this day. Roll-over to next day.

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -213,7 +213,7 @@ def test_find_next_time_expression_time_basic():
     assert datetime(2018, 10, 7, 10, 30, 0) == \
         find(datetime(2018, 10, 7, 10, 30, 0), '*', '/30', 0)
 
-    assert datetime(2018, 10, 7, 12, 30, 30) == \
+    assert datetime(2018, 10, 7, 12, 0, 30) == \
         find(datetime(2018, 10, 7, 10, 30, 0), '/3', '/30', [30, 45])
 
     assert datetime(2018, 10, 8, 5, 0, 0) == \


### PR DESCRIPTION
## Description:

The resetting of minutes/seconds was not stored. This caused time_pattern triggers to miss the initial matches when started before a matching hour. We even had a test proving this bug :-)

(I also changed an odd cast that I found while investigating this.)

**Related issue (if applicable):** fixes #21547, fixes #24691

## Example entry for `configuration.yaml` (if applicable):
```yaml
    trigger:
      - platform: time_pattern
        hours: '23'
        minutes: '/5'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
