### PR TITLE
Add 'unique_id' Property to Inverter Sensors

### DIFF
--- a/homeassistant/components/solax/manifest.json
+++ b/homeassistant/components/solax/manifest.json
@@ -3,7 +3,7 @@
     "name": "Solax Inverter",
     "documentation": "https://www.home-assistant.io/components/solax",
     "requirements": [
-      "solax==0.1.0"
+      "solax==0.1.1"
     ],
     "dependencies": [],
     "codeowners": ["@squishykid"]

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.event import async_track_time_interval
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_IP_ADDRESS): cv.string
+    vol.Required(CONF_IP_ADDRESS): cv.string,
 })
 
 SCAN_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -41,7 +41,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         unit = solax.INVERTER_SENSORS[sensor][1]
         if unit == 'C':
             unit = TEMP_CELSIUS
-        sensor_name = f'{config[CONF_NAME]} {sensor}'
+        sensor_name = '{} {}'.format(config[CONF_NAME], sensor)
         devices.append(Inverter(sensor_name, unit))
     endpoint.sensors = devices
     async_add_entities(devices)

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -8,8 +8,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
         TEMP_CELSIUS,
-        CONF_IP_ADDRESS,
-        CONF_NAME,
+        CONF_IP_ADDRESS
 )
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
@@ -20,8 +19,7 @@ from homeassistant.helpers.event import async_track_time_interval
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_IP_ADDRESS): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
+    vol.Required(CONF_IP_ADDRESS): cv.string
 })
 
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -34,11 +32,8 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     api = solax.RealTimeAPI(config[CONF_IP_ADDRESS])
     endpoint = RealTimeDataEndpoint(hass, api)
-    serial = config.get(CONF_NAME, None)
-    if serial is None:
-        resp = await api.get_data()
-        serial = resp.serial_number
-
+    resp = await api.get_data()
+    serial = resp.serial_number
     hass.async_add_job(endpoint.async_refresh)
     async_track_time_interval(hass, endpoint.async_refresh, SCAN_INTERVAL)
     devices = []

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -41,8 +41,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         unit = solax.INVERTER_SENSORS[sensor][1]
         if unit == 'C':
             unit = TEMP_CELSIUS
-        sensor_name = '{} {}'.format(config[CONF_NAME], sensor)
-        devices.append(Inverter(sensor_name, unit))
+        devices.append(Inverter(config[CONF_NAME], sensor, unit))
     endpoint.sensors = devices
     async_add_entities(devices)
 
@@ -82,8 +81,9 @@ class RealTimeDataEndpoint:
 class Inverter(Entity):
     """Class for a sensor."""
 
-    def __init__(self, key, unit):
+    def __init__(self, inverter_name, key, unit):
         """Initialize an inverter sensor."""
+        self.inverter_name = inverter_name
         self.key = key
         self.value = None
         self.unit = unit
@@ -96,7 +96,7 @@ class Inverter(Entity):
     @property
     def name(self):
         """Name of this inverter attribute."""
-        return self.key
+        return '{} {}'.format(self.inverter_name, self.key)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -38,10 +38,11 @@ async def async_setup_platform(hass, config, async_add_entities,
     async_track_time_interval(hass, endpoint.async_refresh, SCAN_INTERVAL)
     devices = []
     for sensor in solax.INVERTER_SENSORS:
-        unit = solax.INVERTER_SENSORS[sensor][1]
+        idx, unit = solax.INVERTER_SENSORS[sensor]
         if unit == 'C':
             unit = TEMP_CELSIUS
-        devices.append(Inverter(serial, sensor, unit))
+        uid = '{}-{}'.format(serial, idx)
+        devices.append(Inverter(uid, serial, sensor, unit))
     endpoint.sensors = devices
     async_add_entities(devices)
 
@@ -81,9 +82,10 @@ class RealTimeDataEndpoint:
 class Inverter(Entity):
     """Class for a sensor."""
 
-    def __init__(self, inverter_name, key, unit):
+    def __init__(self, uid, serial, key, unit):
         """Initialize an inverter sensor."""
-        self.inverter_name = inverter_name
+        self.uid = uid
+        self.serial = serial
         self.key = key
         self.value = None
         self.unit = unit
@@ -92,11 +94,16 @@ class Inverter(Entity):
     def state(self):
         """State of this inverter attribute."""
         return self.value
+    
+    @property
+    def unique_id(self):
+        """Unique Id"""
+        return self.uid
 
     @property
     def name(self):
         """Name of this inverter attribute."""
-        return 'Solax {} {}'.format(self.inverter_name, self.key)
+        return 'Solax {} {}'.format(self.serial, self.key)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -8,7 +8,8 @@ import voluptuous as vol
 
 from homeassistant.const import (
         TEMP_CELSIUS,
-        CONF_IP_ADDRESS
+        CONF_IP_ADDRESS,
+        CONF_NAME,
 )
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
@@ -20,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_IP_ADDRESS): cv.string,
+    vol.Optional(CONF_NAME, default='Solax'): cv.string,
 })
 
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -39,7 +41,8 @@ async def async_setup_platform(hass, config, async_add_entities,
         unit = solax.INVERTER_SENSORS[sensor][1]
         if unit == 'C':
             unit = TEMP_CELSIUS
-        devices.append(Inverter(sensor, unit))
+        sensor_name = f'{config[CONF_NAME]} {sensor}'
+        devices.append(Inverter(sensor_name, unit))
     endpoint.sensors = devices
     async_add_entities(devices)
 

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -94,10 +94,10 @@ class Inverter(Entity):
     def state(self):
         """State of this inverter attribute."""
         return self.value
-    
+
     @property
     def unique_id(self):
-        """Unique Id"""
+        """Return unique id."""
         return self.uid
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1702,7 +1702,7 @@ solaredge-local==0.1.4
 solaredge==0.0.2
 
 # homeassistant.components.solax
-solax==0.1.0
+solax==0.1.1
 
 # homeassistant.components.honeywell
 somecomfort==0.5.2


### PR DESCRIPTION
## Description:

Give your inverters a custom name, distinguish between multiple inverters.

**Related issue (if applicable):** fixes #24591

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
