### PR TITLE
Add show_as_state options to Life360

### DIFF
--- a/homeassistant/components/life360/__init__.py
+++ b/homeassistant/components/life360/__init__.py
@@ -16,7 +16,8 @@ import homeassistant.helpers.config_validation as cv
 from .const import (
     CONF_AUTHORIZATION, CONF_CIRCLES, CONF_DRIVING_SPEED, CONF_ERROR_THRESHOLD,
     CONF_MAX_GPS_ACCURACY, CONF_MAX_UPDATE_WAIT, CONF_MEMBERS,
-    CONF_WARNING_THRESHOLD, DOMAIN)
+    CONF_SHOW_AS_STATE, CONF_WARNING_THRESHOLD, DOMAIN, SHOW_DRIVING,
+    SHOW_MOVING)
 from .helpers import get_api
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,6 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_PREFIX = DOMAIN
 
 CONF_ACCOUNTS = 'accounts'
+
+SHOW_AS_STATE_OPTS = [SHOW_DRIVING, SHOW_MOVING]
 
 
 def _excl_incl_list_to_filter_dict(value):
@@ -108,6 +111,8 @@ LIFE360_SCHEMA = vol.All(
             vol.All(vol.Any(None, cv.string), _prefix),
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
             cv.time_period,
+        vol.Optional(CONF_SHOW_AS_STATE, default=[]): vol.All(
+            cv.ensure_list, [vol.In(SHOW_AS_STATE_OPTS)]),
         vol.Optional(CONF_WARNING_THRESHOLD): _THRESHOLD,
     }),
     _thresholds

--- a/homeassistant/components/life360/const.py
+++ b/homeassistant/components/life360/const.py
@@ -8,4 +8,8 @@ CONF_ERROR_THRESHOLD = 'error_threshold'
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 CONF_MAX_UPDATE_WAIT = 'max_update_wait'
 CONF_MEMBERS = 'members'
+CONF_SHOW_AS_STATE = 'show_as_state'
 CONF_WARNING_THRESHOLD = 'warning_threshold'
+
+SHOW_DRIVING = 'driving'
+SHOW_MOVING = 'moving'


### PR DESCRIPTION
## Description:
The original Life360 custom integration had a feature whereby the entity's state could be set to driving or moving if the device was not in a HA zone and the Life360 server indicated the device was driving or moving, respectively. This feature was removed when submitted to become a standard integration.

Users have requested this feature be added to the standard integration.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9684

## Example entry for `configuration.yaml` (if applicable):
```yaml
life360:
  show_as_state:
    - driving
    - moving
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
