### PR TITLE
Save cached logi_circle tokens in config folder

### DIFF
--- a/homeassistant/components/logi_circle/__init__.py
+++ b/homeassistant/components/logi_circle/__init__.py
@@ -105,7 +105,7 @@ async def async_setup_entry(hass, entry):
         client_secret=entry.data[CONF_CLIENT_SECRET],
         api_key=entry.data[CONF_API_KEY],
         redirect_uri=entry.data[CONF_REDIRECT_URI],
-        cache_file=DEFAULT_CACHEDB
+        cache_file=hass.config.path(DEFAULT_CACHEDB)
     )
 
     if not logi_circle.authorized:

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -157,7 +157,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow):
             client_secret=client_secret,
             api_key=api_key,
             redirect_uri=redirect_uri,
-            cache_file=DEFAULT_CACHEDB)
+            cache_file=self.hass.config.path(DEFAULT_CACHEDB))
 
         try:
             with async_timeout.timeout(_TIMEOUT):


### PR DESCRIPTION
## Breaking change:

The default path for cached Logi Circle tokens has been changed from the working directory to the config folder.

Users who run Home Assistant from a working directory other than their config folder will need to either:
* Move the `.logi_cache.pickle` file from their working directory to their config folder, or
* Add the Logi Circle integration through the integrations menu after updating to recreate the access tokens.

## Description:

Resolves an issue where cached tokens for the `logi_circle` integration were saved in the current working directory, instead of the config folder. This is particularly problematic on Docker-backed HA instances, as the tokens are blown away whenever the container is recreated.

**Related issue (if applicable):** fixes #24533 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
logi_circle:
  client_id: YOUR_CLIENT_ID
  client_secret: YOUR_CLIENT_SECRET
  api_key: YOUR_API_KEY
  redirect_uri: YOUR_REDIRECT_URI
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
