### PR TITLE
Add custom broadcast support for WOL in samsungtv component

### DIFF
--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -62,7 +62,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         port = config.get(CONF_PORT)
         name = config.get(CONF_NAME)
         mac = config.get(CONF_MAC)
-        broadcast = config.GET(CONF_BROADCAST)
+        broadcast = config.get(CONF_BROADCAST)
         timeout = config.get(CONF_TIMEOUT)
     elif discovery_info is not None:
         tv_name = discovery_info.get('name')

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -85,7 +85,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     ip_addr = socket.gethostbyname(host)
     if ip_addr not in known_devices:
         known_devices.add(ip_addr)
-        add_entities([SamsungTVDevice(host, port, name, timeout, mac, uuid, broadcast)])
+        add_entities([SamsungTVDevice(host, port, name, timeout, mac, uuid, 
+            broadcast)])
         _LOGGER.info("Samsung TV %s:%d added as '%s'", host, port, name)
     else:
         _LOGGER.info("Ignoring duplicate Samsung TV %s:%d", host, port)
@@ -285,7 +286,8 @@ class SamsungTVDevice(MediaPlayerDevice):
         """Turn the media player on."""
         if self._mac:
             if self._broadcast:
-                self._wol.send_magic_packet(self._mac, ip_address=self._broadcast)
+                self._wol.send_magic_packet(self._mac,
+                    ip_address=self._broadcast)
             else:
                 self._wol.send_magic_packet(self._mac)
         else:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -85,8 +85,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     ip_addr = socket.gethostbyname(host)
     if ip_addr not in known_devices:
         known_devices.add(ip_addr)
-        add_entities([SamsungTVDevice(host, port, name, timeout, mac, uuid, 
-            broadcast)])
+        add_entities([SamsungTVDevice(host, port, name, timeout, mac, uuid,
+                                      broadcast)])
         _LOGGER.info("Samsung TV %s:%d added as '%s'", host, port, name)
     else:
         _LOGGER.info("Ignoring duplicate Samsung TV %s:%d", host, port)
@@ -286,8 +286,8 @@ class SamsungTVDevice(MediaPlayerDevice):
         """Turn the media player on."""
         if self._mac:
             if self._broadcast:
-                self._wol.send_magic_packet(self._mac,
-                    ip_address=self._broadcast)
+                self._wol.send_magic_packet(
+                    self._mac, ip_address=self._broadcast)
             else:
                 self._wol.send_magic_packet(self._mac)
         else:

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -11,7 +11,7 @@ import tests.common
 from homeassistant.components.media_player.const import SUPPORT_TURN_ON, \
     MEDIA_TYPE_CHANNEL, MEDIA_TYPE_URL
 from homeassistant.components.samsungtv.media_player import setup_platform, \
-    CONF_TIMEOUT, SamsungTVDevice, SUPPORT_SAMSUNGTV
+    CONF_TIMEOUT, CONF_BROADCAST, SamsungTVDevice, SUPPORT_SAMSUNGTV
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_ON, \
     CONF_MAC, STATE_OFF
 from tests.common import MockDependency

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -24,6 +24,7 @@ WORKING_CONFIG = {
     CONF_PORT: 8001,
     CONF_TIMEOUT: 10,
     CONF_MAC: 'fake',
+    CONF_BROADCAST: 'fake',
     'uuid': None,
 }
 


### PR DESCRIPTION
## Description:
If TV address belongs to a different subnet, WOL magic packet may not reach it. This patch brings `samsungtv` on par with `wake_on_lan` component by supporting `broadcast` property and underlying functionality.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: samsungtv
    host: 192.168.10.100
    mac: 00:11:22:33:44:55:66
    broadcast: 192.168.10.255
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
