### PR TITLE
Fix an error in the dyson service description

### DIFF
--- a/homeassistant/components/dyson/services.yaml
+++ b/homeassistant/components/dyson/services.yaml
@@ -59,6 +59,6 @@ set_speed:
     entity_id:
       description: Name(s) of the entities to set the speed for
       example: 'fan.living_room'
-    timer:
+    dyson_speed:
       description: Speed
       example: 1


### PR DESCRIPTION
## Breaking Change:

The description of the dyson component to set the speed was telling something not possible.
As I only touched the description and not the service itself, i'll not fill the entire template :)
