### PR TITLE
AdGuard to update entry on updated hass.io discovery

### DIFF
--- a/homeassistant/components/adguard/strings.json
+++ b/homeassistant/components/adguard/strings.json
@@ -23,7 +23,8 @@
             "connection_error": "Failed to connect."
         },
         "abort": {
-            "single_instance_allowed": "Only a single configuration of AdGuard Home is allowed."
+            "single_instance_allowed": "Only a single configuration of AdGuard Home is allowed.",
+            "existing_instance_updated": "Updated existing configuration."
         }
     }
 }


### PR DESCRIPTION
## Description:
When hass.io sends a discovery, check if there is new info, and if so, update the running config entry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
