### PR TITLE
Update pysonos to 0.0.17

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.16"
+    "pysonos==0.0.17"
   ],
   "dependencies": [],
   "ssdp": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1364,7 +1364,7 @@ pysmarty==0.8
 pysnmp==4.4.9
 
 # homeassistant.components.sonos
-pysonos==0.0.16
+pysonos==0.0.17
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -293,7 +293,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.9
 
 # homeassistant.components.sonos
-pysonos==0.0.16
+pysonos==0.0.17
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

Changelog: [v0.0.17](https://github.com/amelchio/pysonos/releases/tag/v0.0.17)

This mutes a harmless warning that was reported in #beta:
```
2019-06-23 10:23:52 WARNING (Thread-10) [pysonos.events] Event contains illegal metadatafor 'current_track_meta_data'.
Error message: 'Could not create Resource from Element: protocolInfo not found (required).'
The result will be a SoCoFault.
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
