### PR TITLE
Add status update for NIGHT to AlarmDecoder

### DIFF
--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -6,7 +6,8 @@ import voluptuous as vol
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.const import (
     ATTR_CODE, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED)
+    STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED,
+    STATE_ALARM_ARMED_NIGHT)
 import homeassistant.helpers.config_validation as cv
 
 from . import DATA_AD, SIGNAL_PANEL_MESSAGE
@@ -63,6 +64,8 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
             self._state = STATE_ALARM_TRIGGERED
         elif message.armed_away:
             self._state = STATE_ALARM_ARMED_AWAY
+        elif message.armed_home and "***NIGHT-STAY***" in message.text:
+            self._state = STATE_ALARM_ARMED_NIGHT
         elif message.armed_home:
             self._state = STATE_ALARM_ARMED_HOME
         else:


### PR DESCRIPTION
## Description:

Report an "Armed Night" (vs Armed Home) status when the panel is armed to Night mode, either at the keypad or using the appropriate HASS service.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

Not applicable

## Example entry for `configuration.yaml` (if applicable):

Not applicable

## Checklist:
  - [ X] The code change is tested and works locally.
  - [X ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X ] There is no commented out code in this PR.
  - [ X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [NA ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ NA] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ NA] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [NA ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ NA] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
