### PR TITLE
Add bypass for rest sensor if the timeout is exceeded

### DIFF
--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -180,6 +180,8 @@ class RestData:
             method, resource, headers=headers, auth=auth, data=data).prepare()
         self._verify_ssl = verify_ssl
         self._timeout = timeout
+        self._resource = resource
+        self._headers = headers
         self.data = None
 
     def update(self):
@@ -193,6 +195,11 @@ class RestData:
 
             self.data = response.text
         except requests.exceptions.RequestException as ex:
-            _LOGGER.error("Error fetching data: %s from %s failed with %s",
-                          self._request, self._request.url, ex)
-            self.data = None
+            try:
+                response = requests.get(self._resource, headers=self._headers,
+                                        timeout=self._timeout)
+                self.data = response.text
+            except:
+                _LOGGER.error("Error fetching data: %s from %s failed with %s",
+                              self._request, self._request.url, ex)
+                self.data = None


### PR DESCRIPTION
## Description:
I had the problem that the Scrape sensor could not be configured for a specific URL. It failed with `HTTPSConnectionPool(host='www.accuweather.com', port=443): Read timed out. (read timeout=10)`. The URL I want to scrape is `https://www.accuweather.com/en/de/hamburg/20095/biking-daily-forecast/178556?day=1`
My config looks like this:
```
sensor:
  - platform: scrape
    name: "Todays Biking Weather"
    resource: https://www.accuweather.com/en/de/hamburg/20095/biking-daily-forecast/178556
    select: 'li[class="title pos"]'
    headers:
      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36
```

I try to fix this issue by adding a request.get() command if the timeout exceeded.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
