### PR TITLE
Fix locative device update

### DIFF
--- a/homeassistant/components/locative/device_tracker.py
+++ b/homeassistant/components/locative/device_tracker.py
@@ -85,6 +85,8 @@ class LocativeEntity(DeviceTrackerEntity):
     @callback
     def _async_receive_data(self, device, location, location_name):
         """Update device data."""
+        if device != self._name:
+            return
         self._location_name = location_name
         self._location = location
         self.async_write_ha_state()


### PR DESCRIPTION
## Breaking Change:
N/A
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
- Add a locative test where two devices are updated after one another.
- Fix locative updating all devices to the same state, when one device is updated.

**Related issue (if applicable):**
fixes #24674 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
