### PR TITLE
OwnTracks cloudhook made optional

### DIFF
--- a/homeassistant/components/owntracks/.translations/en.json
+++ b/homeassistant/components/owntracks/.translations/en.json
@@ -9,6 +9,9 @@
         "step": {
             "user": {
                 "description": "Are you sure you want to set up OwnTracks?",
+                "data": {
+                    "cloudhook": "Prepare a publicly accessible URL using Home Assistant Cloud"
+                },
                 "title": "Set up OwnTracks"
             }
         },

--- a/homeassistant/components/owntracks/strings.json
+++ b/homeassistant/components/owntracks/strings.json
@@ -4,6 +4,9 @@
     "step": {
       "user": {
         "title": "Set up OwnTracks",
+        "data": {
+            "cloudhook": "Prepare a publicly accessible URL using Home Assistant Cloud"
+        },
         "description": "Are you sure you want to set up OwnTracks?"
       }
     },

--- a/tests/components/owntracks/test_config_flow.py
+++ b/tests/components/owntracks/test_config_flow.py
@@ -52,10 +52,27 @@ async def test_with_cloud_sub(hass):
                   return_value=mock_coro('https://hooks.nabu.casa/ABCD')):
         result = await hass.config_entries.flow.async_init(
             'owntracks', context={'source': 'user'},
-            data={}
+            data={
+                'cloudhook': True
+            }
         )
 
     entry = result['result']
     assert entry.data['cloudhook']
     assert result['description_placeholders']['webhook_url'] == \
         'https://hooks.nabu.casa/ABCD'
+
+
+async def test_with_cloud_sub_no_cloudhook(hass):
+    """Test creating a config flow while subscribed."""
+    with patch('homeassistant.components.cloud.async_active_subscription',
+               return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            'owntracks', context={'source': 'user'},
+            data={
+                'cloudhook': False
+            }
+        )
+
+    entry = result['result']
+    assert not entry.data['cloudhook']


### PR DESCRIPTION
## Description:

Currently, if you create OwnTracks integration it implicitly creates *managed* cloud hook. 

This PR adds a checkbox for the user to decide whether they need the webhook to be forwarded thru Nabu Casa.

Context for the UC: the user has a fully functional server available from the internet and uses Nabu Casa only for Assistant/Alexa integration.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
