### PR TITLE
Handle netatmo climate timeouts gracefully

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -2,6 +2,7 @@
 import logging
 from datetime import timedelta
 
+import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -370,6 +371,9 @@ class ThermostatData:
             self.homestatus = pyatmo.HomeStatus(self.auth, home=self.home)
         except TypeError:
             _LOGGER.error("Error when getting homestatus.")
+            return
+        except requests.exceptions.Timeout:
+            _LOGGER.warning("Timed out when connecting to Netatmo server.")
             return
         _LOGGER.debug("Following is the debugging output for homestatus:")
         _LOGGER.debug(self.homestatus.rawData)


### PR DESCRIPTION
## Description:
Handle timeouts gracefully. 

**Related issue (if applicable):** fixes #24751

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
