### PR TITLE
Update Waze route dependency to 0.10 

### DIFF
--- a/homeassistant/components/waze_travel_time/manifest.json
+++ b/homeassistant/components/waze_travel_time/manifest.json
@@ -3,7 +3,7 @@
   "name": "Waze travel time",
   "documentation": "https://www.home-assistant.io/components/waze_travel_time",
   "requirements": [
-    "WazeRouteCalculator==0.9"
+    "WazeRouteCalculator==0.10"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -93,7 +93,7 @@ TwitterAPI==2.5.9
 # VL53L1X2==0.1.5
 
 # homeassistant.components.waze_travel_time
-WazeRouteCalculator==0.9
+WazeRouteCalculator==0.10
 
 # homeassistant.components.yessssms
 YesssSMS==0.2.3


### PR DESCRIPTION
Update waze calculator to 0.10, this was supposed to have been done in #22428 but was missed. See discussion [here](https://community.home-assistant.io/t/waze-travel-time-update/50955/201)

## Breaking Change:

## Description:
Author of PR #22428 intended to have the dependency for wazeRouteCalc bumped to 0.10 with his PR but mistakenly didnt add that to the index when he pushed.  This is intended to finish that fix.

**Related issue (if applicable):** fixes #22428

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
