### PR TITLE
Ignore duplicate tradfri discovery

### DIFF
--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -78,13 +78,22 @@ class FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_zeroconf(self, user_input):
         """Handle zeroconf discovery."""
+        host = user_input['host']
+
+        # pylint: disable=unsupported-assignment-operation
+        self.context['host'] = host
+
+        if any(host == flow['context']['host']
+               for flow in self._async_in_progress()):
+            return self.async_abort(reason='already_in_progress')
+
         for entry in self._async_current_entries():
-            if entry.data[CONF_HOST] == user_input['host']:
+            if entry.data[CONF_HOST] == host:
                 return self.async_abort(
                     reason='already_configured'
                 )
 
-        self._host = user_input['host']
+        self._host = host
         return await self.async_step_auth()
 
     async_step_homekit = async_step_zeroconf

--- a/homeassistant/components/tradfri/strings.json
+++ b/homeassistant/components/tradfri/strings.json
@@ -17,7 +17,8 @@
       "timeout": "Timeout validating the code."
     },
     "abort": {
-      "already_configured": "Bridge is already configured"
+      "already_configured": "Bridge is already configured.",
+      "already_in_progress": "Bridge configuration is already in progress."
     }
   }
 }

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -273,7 +273,7 @@ async def test_import_duplicate_aborted(hass):
     assert flow['reason'] == 'already_configured'
 
 
-async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
+async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
     """Test a duplicate discovery in progress is ignored."""
     result = await hass.config_entries.flow.async_init(
         'tradfri', context={'source': 'zeroconf'}, data={

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -258,7 +258,7 @@ async def test_discovery_duplicate_aborted(hass):
 
 
 async def test_import_duplicate_aborted(hass):
-    """Test a duplicate discovery host is ignored."""
+    """Test a duplicate import host is ignored."""
     MockConfigEntry(
         domain='tradfri',
         data={'host': 'some-host'}
@@ -271,3 +271,20 @@ async def test_import_duplicate_aborted(hass):
 
     assert flow['type'] == data_entry_flow.RESULT_TYPE_ABORT
     assert flow['reason'] == 'already_configured'
+
+
+async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
+    """Test a duplicate discovery in progress is ignored."""
+    result = await hass.config_entries.flow.async_init(
+        'tradfri', context={'source': 'zeroconf'}, data={
+            'host': '123.123.123.123'
+        })
+
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+
+    result2 = await hass.config_entries.flow.async_init(
+        'tradfri', context={'source': 'zeroconf'}, data={
+            'host': '123.123.123.123'
+        })
+
+    assert result2['type'] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
## Description:
Filter out duplicate tradfri discoveries.

**Related issue (if applicable):** fixes issue reported by @cgtobi in #beta

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
