### PR TITLE
Upgrade insteonplm to 0.16.0 and add INSTEON scene triggering

### DIFF
--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -1,4 +1,5 @@
 """Support for INSTEON Modems (PLM and Hub)."""
+# Dummy comment to trigger CLA
 import collections
 import logging
 from typing import Dict

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -601,7 +601,7 @@ class InsteonEntity(Entity):
     @callback
     def _aldb_loaded(self):
         """All-Link Database loaded for the device."""
-        self.print_aldb()
+        self._print_aldb()
 
     def _get_label(self):
         """Get the device label for grouped devices."""

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_ADDRESS, CONF_ENTITY_ID, CONF_HOST, CONF_PLATFORM, CONF_PORT,
-    EVENT_HOMEASSISTANT_STOP)
+    ENTITY_MATCH_ALL, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
 from homeassistant.helpers.dispatcher import (
@@ -49,7 +49,6 @@ SRV_X10_ALL_LIGHTS_ON = 'x10_all_lights_on'
 SRV_ALL_LINK_GROUP = 'group'
 SRV_ALL_LINK_MODE = 'mode'
 SRV_LOAD_DB_RELOAD = 'reload'
-SRV_LOAD_ALL_DATABASES = 'all'
 SRV_CONTROLLER = 'controller'
 SRV_RESPONDER = 'responder'
 SRV_HOUSECODE = 'housecode'
@@ -139,7 +138,7 @@ DEL_ALL_LINK_SCHEMA = vol.Schema({
 
 
 LOAD_ALDB_SCHEMA = vol.Schema({
-    vol.Required(CONF_ENTITY_ID): vol.Any(cv.entity_id, SRV_LOAD_ALL_DATABASES),
+    vol.Required(CONF_ENTITY_ID): vol.Any(cv.entity_id, ENTITY_MATCH_ALL),
     vol.Optional(SRV_LOAD_DB_RELOAD, default=False): cv.boolean,
     })
 
@@ -259,7 +258,7 @@ async def async_setup(hass, config):
         """Load the device All-Link database."""
         entity_id = service.data[CONF_ENTITY_ID]
         reload = service.data[SRV_LOAD_DB_RELOAD]
-        if entity_id.lower() == SRV_LOAD_ALL_DATABASES:
+        if entity_id.lower() == ENTITY_MATCH_ALL:
             for entity_id in hass.data[DOMAIN].get(INSTEON_ENTITIES):
                 _send_load_aldb_signal(entity_id, reload)
         else:
@@ -277,7 +276,6 @@ async def async_setup(hass, config):
         entity_id = service.data[CONF_ENTITY_ID]
         signal = '{}_{}'.format(entity_id, SIGNAL_PRINT_ALDB)
         dispatcher_send(hass, signal)
-
 
     def print_im_aldb(service):
         """Print the All-Link Database for a device."""
@@ -586,9 +584,9 @@ class InsteonEntity(Entity):
             self.async_entity_update)
         self.hass.data[DOMAIN][INSTEON_ENTITIES][self.entity_id] = self
         load_signal = '{}_{}'.format(self.entity_id, SIGNAL_LOAD_ALDB)
-        async_dispatcher_connect(self.hass, load_signal, self._load_aldb) 
+        async_dispatcher_connect(self.hass, load_signal, self._load_aldb)
         print_signal = '{}_{}'.format(self.entity_id, SIGNAL_PRINT_ALDB)
-        async_dispatcher_connect(self.hass, print_signal, self._print_aldb) 
+        async_dispatcher_connect(self.hass, print_signal, self._print_aldb)
 
     def _load_aldb(self, reload=False):
         """Load the device All-Link Database."""

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -76,6 +76,7 @@ def set_default_port(schema: Dict) -> Dict:
             schema[CONF_IP_PORT] = 25105
     return schema
 
+
 CONF_DEVICE_OVERRIDE_SCHEMA = vol.All(
     cv.deprecated(CONF_PLATFORM), vol.Schema({
         vol.Required(CONF_ADDRESS): cv.string,
@@ -86,6 +87,7 @@ CONF_DEVICE_OVERRIDE_SCHEMA = vol.All(
         vol.Optional(CONF_PLATFORM): cv.string,
     }))
 
+
 CONF_X10_SCHEMA = vol.All(
     vol.Schema({
         vol.Required(CONF_HOUSECODE): cv.string,
@@ -93,6 +95,7 @@ CONF_X10_SCHEMA = vol.All(
         vol.Required(CONF_PLATFORM): cv.string,
         vol.Optional(CONF_DIM_STEPS): vol.Range(min=2, max=255)
         }))
+
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All(
@@ -117,34 +120,42 @@ CONFIG_SCHEMA = vol.Schema({
         set_default_port)
     }, extra=vol.ALLOW_EXTRA)
 
+
 ADD_ALL_LINK_SCHEMA = vol.Schema({
     vol.Required(SRV_ALL_LINK_GROUP): vol.Range(min=0, max=255),
     vol.Required(SRV_ALL_LINK_MODE): vol.In([SRV_CONTROLLER, SRV_RESPONDER]),
     })
 
+
 DEL_ALL_LINK_SCHEMA = vol.Schema({
     vol.Required(SRV_ALL_LINK_GROUP): vol.Range(min=0, max=255),
     })
+
 
 LOAD_ALDB_SCHEMA = vol.Schema({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Optional(SRV_LOAD_DB_RELOAD, default='false'): cv.boolean,
     })
 
+
 PRINT_ALDB_SCHEMA = vol.Schema({
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     })
+
 
 X10_HOUSECODE_SCHEMA = vol.Schema({
     vol.Required(SRV_HOUSECODE): vol.In(HOUSECODES),
     })
 
+
 TRIGGER_SCENE_SCHEMA = vol.Schema({
     vol.Required(SRV_ALL_LINK_GROUP): vol.Range(min=0, max=255)})
+
 
 LOAD_ALL_ALDB_SCHEMA = vol.Schema({
     vol.Optional(SRV_LOAD_DB_RELOAD, default='false'): cv.boolean,
     })
+
 
 STATE_NAME_LABEL_MAP = {
     'keypadButtonA': 'Button A',

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -1,5 +1,4 @@
 """Support for INSTEON Modems (PLM and Hub)."""
-# Dummy comment to trigger CLA
 import collections
 import logging
 from typing import Dict

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -3,7 +3,7 @@
   "name": "Insteon",
   "documentation": "https://www.home-assistant.io/components/insteon",
   "requirements": [
-    "insteonplm==0.15.4"
+    "insteonplm==0.16.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/insteon/services.yaml
+++ b/homeassistant/components/insteon/services.yaml
@@ -48,3 +48,21 @@ x10_all_lights_off:
     housecode:
       description: X10 house code
       example: c
+scene_on:
+  description: Trigger an INSTEON scene to turn ON.
+  fields:
+    group:
+      description: INSTEON group or scene number
+      example: 26
+scene_off:
+  description: Trigger an INSTEON scene to turn OFF.
+  fields:
+    group:
+      description: INSTEON group or scene number
+      example: 26
+load_all_databases:
+  description: Load the All-Link database for all INSTEON devices.
+  fields:
+    reload:
+      description: Reload all records. If true the current records are cleared from memory (does not effect the device) and the records are reloaded. If false the existing records are left in place and only missing records are added. Default is false.
+      example: 'true'

--- a/homeassistant/components/insteon/services.yaml
+++ b/homeassistant/components/insteon/services.yaml
@@ -17,7 +17,7 @@ load_all_link_database:
   description: Load the All-Link Database for a device. WARNING - Loading a device All-LInk database is very time consuming and inconsistent. This may take a LONG time and may need to be repeated to obtain all records.
   fields:
     entity_id:
-      description: Name of the device to print
+      description: Name of the device to load. Use "all" to load the database of all devices.
       example: 'light.1a2b3c'
     reload:
       description: Reload all records. If true the current records are cleared from memory (does not effect the device) and the records are reloaded. If false the existing records are left in place and only missing records are added. Default is false.
@@ -60,9 +60,3 @@ scene_off:
     group:
       description: INSTEON group or scene number
       example: 26
-load_all_databases:
-  description: Load the All-Link database for all INSTEON devices.
-  fields:
-    reload:
-      description: Reload all records. If true the current records are cleared from memory (does not effect the device) and the records are reloaded. If false the existing records are left in place and only missing records are added. Default is false.
-      example: 'true'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -647,7 +647,7 @@ incomfort-client==0.3.0
 influxdb==5.2.0
 
 # homeassistant.components.insteon
-insteonplm==0.15.4
+insteonplm==0.16.0
 
 # homeassistant.components.iperf3
 iperf3==0.1.10


### PR DESCRIPTION
## Description:
This PR adds a feature to turn on and off an INSTEON scene. These are different than HA scenes as they are hardware based. The underlying library is upgraded to 0.16.0 to enable INSTEON scenes and also fixes the issue with dimmers showing as on level 1 regardless of dimming level.

**Related issue (if applicable):** fixes #21997

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9692

## Example entry for `configuration.yaml` (if applicable):


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
