### PR TITLE
Add fan support to lutron_caseta

### DIFF
--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -17,7 +17,6 @@ DOMAIN = 'lutron_caseta'
 CONF_KEYFILE = 'keyfile'
 CONF_CERTFILE = 'certfile'
 CONF_CA_CERTS = 'ca_certs'
-CONF_CERT_REQUIRED = 'cert_required'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -25,7 +24,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_KEYFILE): cv.string,
         vol.Required(CONF_CERTFILE): cv.string,
         vol.Required(CONF_CA_CERTS): cv.string,
-        vol.Optional(CONF_CERT_REQUIRED, default=False): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -42,11 +40,10 @@ async def async_setup(hass, base_config):
     keyfile = hass.config.path(config[CONF_KEYFILE])
     certfile = hass.config.path(config[CONF_CERTFILE])
     ca_certs = hass.config.path(config[CONF_CA_CERTS])
-    cert_required = config[CONF_CERT_REQUIRED]
 
     bridge = Smartbridge.create_tls(
         hostname=config[CONF_HOST], keyfile=keyfile, certfile=certfile,
-        ca_certs=ca_certs, cert_required=cert_required)
+        ca_certs=ca_certs)
     hass.data[LUTRON_CASETA_SMARTBRIDGE] = bridge
     await bridge.connect()
     if not hass.data[LUTRON_CASETA_SMARTBRIDGE].is_connected():

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -46,7 +46,7 @@ async def async_setup(hass, base_config):
 
     bridge = Smartbridge.create_tls(
         hostname=config[CONF_HOST], keyfile=keyfile, certfile=certfile,
-        ca_certs=ca_certs, cert_required)
+        ca_certs=ca_certs, cert_required=cert_required)
     hass.data[LUTRON_CASETA_SMARTBRIDGE] = bridge
     await bridge.connect()
     if not hass.data[LUTRON_CASETA_SMARTBRIDGE].is_connected():

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -46,7 +46,7 @@ async def async_setup(hass, base_config):
 
     bridge = Smartbridge.create_tls(
         hostname=config[CONF_HOST], keyfile=keyfile, certfile=certfile,
-        ca_certs=ca_certs, cert_required=cert_required)
+        ca_certs=ca_certs, cert_required)
     hass.data[LUTRON_CASETA_SMARTBRIDGE] = bridge
     await bridge.connect()
     if not hass.data[LUTRON_CASETA_SMARTBRIDGE].is_connected():

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 LUTRON_CASETA_COMPONENTS = [
-    'light', 'switch', 'cover', 'scene'
+    'light', 'switch', 'cover', 'scene', 'fan'
 ]
 
 

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -17,6 +17,7 @@ DOMAIN = 'lutron_caseta'
 CONF_KEYFILE = 'keyfile'
 CONF_CERTFILE = 'certfile'
 CONF_CA_CERTS = 'ca_certs'
+CONF_CERT_REQUIRED = 'cert_required'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -24,13 +25,13 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_KEYFILE): cv.string,
         vol.Required(CONF_CERTFILE): cv.string,
         vol.Required(CONF_CA_CERTS): cv.string,
+        vol.Optional(CONF_CERT_REQUIRED, default=False): cv.boolean,
     })
 }, extra=vol.ALLOW_EXTRA)
 
 LUTRON_CASETA_COMPONENTS = [
     'light', 'switch', 'cover', 'scene', 'fan'
 ]
-
 
 async def async_setup(hass, base_config):
     """Set up the Lutron component."""
@@ -40,9 +41,11 @@ async def async_setup(hass, base_config):
     keyfile = hass.config.path(config[CONF_KEYFILE])
     certfile = hass.config.path(config[CONF_CERTFILE])
     ca_certs = hass.config.path(config[CONF_CA_CERTS])
+    cert_required = config[CONF_CERT_REQUIRED]
+
     bridge = Smartbridge.create_tls(
         hostname=config[CONF_HOST], keyfile=keyfile, certfile=certfile,
-        ca_certs=ca_certs)
+        ca_certs=ca_certs, cert_required=cert_required)
     hass.data[LUTRON_CASETA_SMARTBRIDGE] = bridge
     await bridge.connect()
     if not hass.data[LUTRON_CASETA_SMARTBRIDGE].is_connected():

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -33,6 +33,7 @@ LUTRON_CASETA_COMPONENTS = [
     'light', 'switch', 'cover', 'scene', 'fan'
 ]
 
+
 async def async_setup(hass, base_config):
     """Set up the Lutron component."""
     from pylutron_caseta.smartbridge import Smartbridge

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -2,18 +2,28 @@
 import logging
 
 from homeassistant.components.fan import (
-    SUPPORT_SET_SPEED, FanEntity, DOMAIN)
+    SUPPORT_SET_SPEED, FanEntity, DOMAIN,
+    SPEED_HIGH, SPEED_LOW, SPEED_MEDIUM, SPEED_OFF)
 
 from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-LUTRON_SPEED_OFF = 'Off'
-LUTRON_SPEED_LOW = 'Low'
-LUTRON_SPEED_MEDIUM = 'Medium'
-LUTRON_SPEED_MEDIUMHIGH = "MediumHigh"
-LUTRON_SPEED_HIGH = 'High'
+VALUE_TO_SPEED = {
+    'Off': SPEED_OFF,
+    'Low': SPEED_LOW,
+    'Medium': SPEED_MEDIUM,
+    'High': SPEED_HIGH,
+    'MediumHigh': 'mediumhigh'
+}
 
+SPEED_TO_VALUE = {
+    SPEED_OFF: 'Off',
+    SPEED_LOW: 'Low',
+    SPEED_MEDIUM: 'Medium',
+    SPEED_HIGH: 'High',
+    'mediumhigh': 'MediumHigh'
+}
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -36,18 +46,12 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     @property
     def speed(self) -> str:
         """Return the current speed."""
-        return self._state["fan_speed"]
+        return VALUE_TO_SPEED[self._state["fan_speed"]]
 
     @property
     def speed_list(self) -> list:
-        """Get the list of available speeds.
-
-        Note: The default Hass Speeds were all lower case
-        and missing MediumHigh. Lutron Case and fan
-        speeds specified instead.
-        """
-        return [LUTRON_SPEED_OFF, LUTRON_SPEED_LOW, LUTRON_SPEED_MEDIUM,
-                LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
+        """Get the list of available speeds."""
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, 'mediumhigh', SPEED_HIGH]
 
     @property
     def supported_features(self) -> int:
@@ -57,24 +61,24 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     async def async_turn_on(self, speed: str = None, **kwargs):
         """Turn the fan on."""
         if speed is None:
-            speed = LUTRON_SPEED_MEDIUMHIGH
+            speed = 'mediumhigh'
         await self.async_set_speed(speed)
 
     async def async_turn_off(self, **kwargs):
         """Turn the fan off."""
-        await self.async_set_speed(LUTRON_SPEED_OFF)
+        await self.async_set_speed(SPEED_OFF)
 
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
-        self._smartbridge.set_fan(self._device_id, speed)
+        self._smartbridge.set_fan(self._device_id, SPEED_TO_VALUE[speed])
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state["fan_speed"] in [LUTRON_SPEED_LOW,
-                                            LUTRON_SPEED_MEDIUM,
-                                            LUTRON_SPEED_MEDIUMHIGH,
-                                            LUTRON_SPEED_HIGH]
+        return VALUE_TO_SPEED[self._state["fan_speed"]] in [SPEED_LOW,
+                                            SPEED_MEDIUM,
+                                            'mediumhigh',
+                                            SPEED_HIGH]
 
     async def async_update(self):
         """Update when forcing a refresh of the device."""

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -1,8 +1,8 @@
 """Support for Lutron Caseta fans."""
 import logging
 
-from homeassistant.components.fan import (SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SPEED_OFF,
-                                            SUPPORT_SET_SPEED, FanEntity, DOMAIN)
+from homeassistant.components.fan import (
+    SUPPORT_SET_SPEED, FanEntity, DOMAIN)
 
 from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
 
@@ -13,6 +13,7 @@ LUTRON_SPEED_LOW = 'Low'
 LUTRON_SPEED_MEDIUM = 'Medium'
 LUTRON_SPEED_MEDIUMHIGH = "MediumHigh"
 LUTRON_SPEED_HIGH = 'High'
+
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -28,6 +29,7 @@ async def async_setup_platform(
     async_add_entities(devs, True)
     return True
 
+
 class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     """Representation of a Lutron Caseta fan. Including Fan Speed."""
 
@@ -39,13 +41,17 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds.
-        Note: The default Hass Speeds were all lower case and missing MediumHigh
-        Lutron Case and fan speeds specified instead."""
-        return [LUTRON_SPEED_OFF, LUTRON_SPEED_LOW, LUTRON_SPEED_MEDIUM , LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
+
+        Note: The default Hass Speeds were all lower case
+        and missing MediumHigh. Lutron Case and fan
+        speeds specified instead.
+        """
+        return [LUTRON_SPEED_OFF, LUTRON_SPEED_LOW, LUTRON_SPEED_MEDIUM,
+            LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
 
     @property
     def supported_features(self) -> int:
-        """Flag supported features. Speed Only"""
+        """Flag supported features. Speed Only."""
         return SUPPORT_SET_SPEED
 
     async def async_turn_on(self, speed: str = None, **kwargs):
@@ -66,7 +72,9 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self._state["fan_speed"] in [LUTRON_SPEED_LOW, LUTRON_SPEED_MEDIUM, LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
+        return self._state["fan_speed"] in [LUTRON_SPEED_LOW,
+            LUTRON_SPEED_MEDIUM, LUTRON_SPEED_MEDIUMHIGH,
+            LUTRON_SPEED_HIGH]
 
     async def async_update(self):
         """Update when forcing a refresh of the device."""

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -36,7 +36,7 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     @property
     def speed(self) -> str:
         """Return the current speed."""
-        return self._speed
+        return self._state["fan_speed"]
 
     @property
     def speed_list(self) -> list:
@@ -66,8 +66,7 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
 
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
-        self._speed = speed
-        self._smartbridge.set_fan(self._device_id, self._speed)
+        self._smartbridge.set_fan(self._device_id, speed)
 
     @property
     def is_on(self):
@@ -80,5 +79,4 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     async def async_update(self):
         """Update when forcing a refresh of the device."""
         self._state = self._smartbridge.get_device_by_id(self._device_id)
-        self._speed = self._state["fan_speed"]
         _LOGGER.debug("State of this lutron fan device is %s", self._state)

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -47,7 +47,7 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
         speeds specified instead.
         """
         return [LUTRON_SPEED_OFF, LUTRON_SPEED_LOW, LUTRON_SPEED_MEDIUM,
-            LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
+                LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
 
     @property
     def supported_features(self) -> int:
@@ -73,8 +73,9 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     def is_on(self):
         """Return true if device is on."""
         return self._state["fan_speed"] in [LUTRON_SPEED_LOW,
-            LUTRON_SPEED_MEDIUM, LUTRON_SPEED_MEDIUMHIGH,
-            LUTRON_SPEED_HIGH]
+                                            LUTRON_SPEED_MEDIUM,
+                                            LUTRON_SPEED_MEDIUMHIGH,
+                                            LUTRON_SPEED_HIGH]
 
     async def async_update(self):
         """Update when forcing a refresh of the device."""

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -1,0 +1,75 @@
+"""Support for Lutron Caseta fans."""
+import logging
+
+from homeassistant.components.fan import (SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SPEED_OFF,
+                                            SUPPORT_SET_SPEED, FanEntity, DOMAIN)
+
+from . import LUTRON_CASETA_SMARTBRIDGE, LutronCasetaDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+LUTRON_SPEED_OFF = 'Off'
+LUTRON_SPEED_LOW = 'Low'
+LUTRON_SPEED_MEDIUM = 'Medium'
+LUTRON_SPEED_MEDIUMHIGH = "MediumHigh"
+LUTRON_SPEED_HIGH = 'High'
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up Lutron fan."""
+    devs = []
+    bridge = hass.data[LUTRON_CASETA_SMARTBRIDGE]
+    fan_devices = bridge.get_devices_by_domain(DOMAIN)
+
+    for fan_device in fan_devices:
+        dev = LutronCasetaFan(fan_device, bridge)
+        devs.append(dev)
+
+    async_add_entities(devs, True)
+    return True
+
+class LutronCasetaFan(LutronCasetaDevice, FanEntity):
+    """Representation of a Lutron Caseta fan. Including Fan Speed."""
+
+    @property
+    def speed(self) -> str:
+        """Return the current speed."""
+        return self._speed
+
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds.
+        Note: The default Hass Speeds were all lower case and missing MediumHigh
+        Lutron Case and fan speeds specified instead."""
+        return [LUTRON_SPEED_OFF, LUTRON_SPEED_LOW, LUTRON_SPEED_MEDIUM , LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features. Speed Only"""
+        return SUPPORT_SET_SPEED
+
+    async def async_turn_on(self, speed: str = None, **kwargs):
+        """Turn the fan on."""
+        if speed is None:
+            speed = LUTRON_SPEED_MEDIUMHIGH
+        await self.async_set_speed(speed)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the fan off."""
+        await self.async_set_speed(LUTRON_SPEED_OFF)
+
+    async def async_set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        self._speed = speed
+        self._smartbridge.set_fan(self._device_id, self._speed)
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state["fan_speed"] in [LUTRON_SPEED_LOW, LUTRON_SPEED_MEDIUM, LUTRON_SPEED_MEDIUMHIGH, LUTRON_SPEED_HIGH]
+
+    async def async_update(self):
+        """Update when forcing a refresh of the device."""
+        self._state = self._smartbridge.get_device_by_id(self._device_id)
+        self._speed = self._state["fan_speed"]
+        _LOGGER.debug("State of this lutron fan device is %s", self._state)

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -13,16 +13,14 @@ VALUE_TO_SPEED = {
     'Off': SPEED_OFF,
     'Low': SPEED_LOW,
     'Medium': SPEED_MEDIUM,
-    'High': SPEED_HIGH,
-    'MediumHigh': 'mediumhigh'
+    'High': SPEED_HIGH
 }
 
 SPEED_TO_VALUE = {
     SPEED_OFF: 'Off',
     SPEED_LOW: 'Low',
     SPEED_MEDIUM: 'Medium',
-    SPEED_HIGH: 'High',
-    'mediumhigh': 'MediumHigh'
+    SPEED_HIGH: 'High'
 }
 
 
@@ -52,7 +50,7 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, 'mediumhigh', SPEED_HIGH]
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
     @property
     def supported_features(self) -> int:
@@ -62,7 +60,7 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     async def async_turn_on(self, speed: str = None, **kwargs):
         """Turn the fan on."""
         if speed is None:
-            speed = 'mediumhigh'
+            speed = SPEED_MEDIUM
         await self.async_set_speed(speed)
 
     async def async_turn_off(self, **kwargs):
@@ -78,7 +76,6 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
         """Return true if device is on."""
         return VALUE_TO_SPEED[self._state["fan_speed"]] in [SPEED_LOW,
                                                             SPEED_MEDIUM,
-                                                            'mediumhigh',
                                                             SPEED_HIGH]
 
     async def async_update(self):

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -25,6 +25,7 @@ SPEED_TO_VALUE = {
     'mediumhigh': 'MediumHigh'
 }
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up Lutron fan."""
@@ -76,9 +77,9 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     def is_on(self):
         """Return true if device is on."""
         return VALUE_TO_SPEED[self._state["fan_speed"]] in [SPEED_LOW,
-                                            SPEED_MEDIUM,
-                                            'mediumhigh',
-                                            SPEED_HIGH]
+                                                            SPEED_MEDIUM,
+                                                            'mediumhigh',
+                                                            SPEED_HIGH]
 
     async def async_update(self):
         """Update when forcing a refresh of the device."""

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -23,6 +23,7 @@ SPEED_TO_VALUE = {
     SPEED_HIGH: 'High'
 }
 
+FAN_SPEEDS = [STATE_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -36,7 +37,6 @@ async def async_setup_platform(
         devs.append(dev)
 
     async_add_entities(devs, True)
-    return True
 
 
 class LutronCasetaFan(LutronCasetaDevice, FanEntity):
@@ -50,7 +50,7 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+        return FAN_SPEEDS
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -25,6 +25,7 @@ SPEED_TO_VALUE = {
 
 FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up Lutron fan."""

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -23,7 +23,7 @@ SPEED_TO_VALUE = {
     SPEED_HIGH: 'High'
 }
 
-FAN_SPEEDS = [STATE_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Adding the lutron caseta fan controller to a smartbridge will break the lutron_caset component. That is really a pylutron_caseta issue and not home assistant issue. This pull request simply adds support for the fan controls based on changes made in a separate commit to the pylutron_caseta repository.
https://github.com/gurumitts/pylutron-caseta/pull/34 

Additional work is likely needed to up the version of pylutron_caseta and etc in  pypi.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
lutron_caseta:
  host: 192.168.1.1
  keyfile: ./config/lutron/caseta.key
  certfile: ./config/lutron/caseta.crt
  ca_certs: ./config/lutron/caseta-bridge.crt

```

## Checklist:
  - [ X] The code change is tested and works locally.
  - [X ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ X] There is no commented out code in this PR.
  - [ X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
