### PR TITLE
Upgrade vallox to async client API

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -96,7 +96,7 @@ async def async_setup(hass, config):
 
     client = Vallox(host)
     state_proxy = ValloxStateProxy(hass, client)
-    service_handler = ValloxServiceHandler(hass, client, state_proxy)
+    service_handler = ValloxServiceHandler(client, state_proxy)
 
     hass.data[DOMAIN] = {
         'client': client,
@@ -160,10 +160,8 @@ class ValloxStateProxy:
         _LOGGER.debug("Updating Vallox state cache")
 
         try:
-            self._metric_cache = await self._hass.async_add_executor_job(
-                self._client.fetch_metrics)
-            self._profile = await self._hass.async_add_executor_job(
-                self._client.get_profile)
+            self._metric_cache = await self._client.fetch_metrics()
+            self._profile = await self._client.get_profile()
             self._valid = True
 
         except OSError as err:
@@ -176,9 +174,8 @@ class ValloxStateProxy:
 class ValloxServiceHandler:
     """Services implementation."""
 
-    def __init__(self, hass, client, state_proxy):
+    def __init__(self, client, state_proxy):
         """Initialize the proxy."""
-        self._hass = hass
         self._client = client
         self._state_proxy = state_proxy
 
@@ -187,8 +184,7 @@ class ValloxServiceHandler:
         _LOGGER.debug("Setting ventilation profile to: %s", profile)
 
         try:
-            await self._hass.async_add_executor_job(
-                self._client.set_profile, STR_TO_PROFILE[profile])
+            await self._client.set_profile(STR_TO_PROFILE[profile])
             return True
 
         except OSError as err:
@@ -201,8 +197,7 @@ class ValloxServiceHandler:
         _LOGGER.debug("Setting Home fan speed to: %d%%", fan_speed)
 
         try:
-            await self._hass.async_add_executor_job(
-                self._client.set_values,
+            await self._client.set_values(
                 {METRIC_KEY_PROFILE_FAN_SPEED_HOME: fan_speed})
             return True
 
@@ -216,8 +211,7 @@ class ValloxServiceHandler:
         _LOGGER.debug("Setting Away fan speed to: %d%%", fan_speed)
 
         try:
-            await self._hass.async_add_executor_job(
-                self._client.set_values,
+            await self._client.set_values(
                 {METRIC_KEY_PROFILE_FAN_SPEED_AWAY: fan_speed})
             return True
 
@@ -231,8 +225,7 @@ class ValloxServiceHandler:
         _LOGGER.debug("Setting Boost fan speed to: %d%%", fan_speed)
 
         try:
-            await self._hass.async_add_executor_job(
-                self._client.set_values,
+            await self._client.set_values(
                 {METRIC_KEY_PROFILE_FAN_SPEED_BOOST: fan_speed})
             return True
 

--- a/homeassistant/components/vallox/fan.py
+++ b/homeassistant/components/vallox/fan.py
@@ -36,8 +36,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     client = hass.data[DOMAIN]['client']
 
-    await hass.async_add_executor_job(
-        client.set_settable_address, METRIC_KEY_MODE, int)
+    client.set_settable_address(METRIC_KEY_MODE, int)
 
     device = ValloxFan(hass.data[DOMAIN]['name'],
                        client,
@@ -134,8 +133,7 @@ class ValloxFan(FanEntity):
 
         if self._state is False:
             try:
-                await self.hass.async_add_executor_job(
-                    self._client.set_values, {METRIC_KEY_MODE: 0})
+                await self._client.set_values({METRIC_KEY_MODE: 0})
 
                 # This state change affects other entities like sensors. Force
                 # an immediate update that can be observed by all parties
@@ -152,8 +150,7 @@ class ValloxFan(FanEntity):
         """Turn the device off."""
         if self._state is True:
             try:
-                await self.hass.async_add_executor_job(
-                    self._client.set_values, {METRIC_KEY_MODE: 5})
+                await self._client.set_values({METRIC_KEY_MODE: 5})
 
                 # Same as for turn_on method.
                 await self._state_proxy.async_update(None)

--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -3,7 +3,7 @@
   "name": "Vallox",
   "documentation": "https://www.home-assistant.io/components/vallox",
   "requirements": [
-    "vallox-websocket-api==1.5.2"
+    "vallox-websocket-api==2.0.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1829,7 +1829,7 @@ uscisstatus==0.1.1
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==1.5.2
+vallox-websocket-api==2.0.0
 
 # homeassistant.components.venstar
 venstarcolortouch==0.7


### PR DESCRIPTION
CC @MartinHjelmare @yozik04

Thanks for your quick support @yozik04 :+1: 

## Breaking Change:

N/A

## Description:

Upgrade to async version of `vallox_websocket_api`.

## Example entry for `configuration.yaml` (if applicable):
```yaml
vallox:
  host: IP_ADDRESS
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
