### PR TITLE
Fix life360 exception when no location provided

### DIFF
--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -177,8 +177,11 @@ class Life360Scanner:
         return prev_seen
 
     def _update_member(self, member, dev_id):
-        loc = member.get('location', {})
-        last_seen = _utc_from_ts(loc.get('timestamp'))
+        loc = member.get('location')
+        try:
+            last_seen = _utc_from_ts(loc.get('timestamp'))
+        except AttributeError:
+            last_seen = None
         prev_seen = self._prev_seen(dev_id, last_seen)
 
         if not loc:


### PR DESCRIPTION
## Description:
A bug was introduced when the original custom integration was submitted to become a standard integration. This fixes the bug by changing the code that gets a member's location record back to the way it was before.

**Related issue (if applicable):** fixes #24775 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
life360:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
