### PR TITLE
Fix netatmo weatherstation setup error 

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -170,15 +170,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 def find_devices(data):
     """Find all devices."""
     dev = []
-    not_handled = []
     module_names = data.get_module_names()
     for module_name in module_names:
         for condition in data.station_data.monitoredConditions(module_name):
             dev.append(NetatmoSensor(
                 data, module_name, condition.lower(), data.station))
-
-    for module_name in not_handled:
-        _LOGGER.error('Module name: "%s" not found', module_name)
     return dev
 
 

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -99,6 +99,12 @@ MODULE_TYPE_RAIN = 'NAModule3'
 MODULE_TYPE_INDOOR = 'NAModule4'
 
 
+NETATMO_DEVICE_TYPES = {
+    'WeatherStationData': 'weather station',
+    'HomeCoachData': 'home coach'
+}
+
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available Netatmo weather sensors."""
     dev = []
@@ -135,6 +141,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             try:
                 data = NetatmoData(auth, data_class, config.get(CONF_STATION))
             except pyatmo.NoDevice:
+                _LOGGER.warning(
+                    "No %s devices found",
+                    NETATMO_DEVICE_TYPES[data_class.__name__]
+                )
                 continue
             # Test if manually configured
             if CONF_MODULES in config:

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -138,9 +138,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 module_items = config[CONF_MODULES].items()
                 for module_name, monitored_conditions in module_items:
                     for condition in monitored_conditions:
-                        dev.append(NetatmoSensor(
-                            data, module_name, condition.lower(),
-                            config.get(CONF_STATION)))
+                        if data.station_data:
+                            dev.append(NetatmoSensor(
+                                data, module_name, condition.lower(),
+                                config.get(CONF_STATION)))
                 continue
 
             # otherwise add all modules and conditions
@@ -187,12 +188,11 @@ class NetatmoSensor(Entity):
         self._device_class = SENSOR_TYPES[self.type][3]
         self._icon = SENSOR_TYPES[self.type][2]
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
-        self._module_type = self.netatmo_data. \
-            station_data.moduleByName(module=module_name)['type']
-        module_id = self.netatmo_data. \
-            station_data.moduleByName(station=self.station_name,
-                                      module=module_name)['_id']
-        self._unique_id = '{}-{}'.format(module_id, self.type)
+        module = self.netatmo_data.station_data.moduleByName(
+            station=self.station_name, module=module_name
+        )
+        self._module_type = module['type']
+        self._unique_id = '{}-{}'.format(module['_id'], self.type)
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
Check if station data is received before adding the sensor.
Reduce method calls.

**Related issue (if applicable):** fixes #24727 and possibly #22066

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html