### PR TITLE
Tweak geniushub battery icons according to device state

### DIFF
--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -115,8 +115,8 @@ class GeniusDevice(Entity):
         attrs['assigned_zone'] = self._device.assignedZones[0]['name']
 
         last_comms = self._device._info_raw['childValues']['lastComms']['val']  # noqa; pylint: disable=protected-access
-        attrs['last_comms'] = datetime.utcfromtimestamp(
-            last_comms).isoformat()
+        attrs['last_comms'] = datetime.fromtimestamp(
+            last_comms, tz=UTC).isoformat()
 
         return {**attrs}
 

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -69,8 +69,6 @@ class GeniusDevice(Entity):
         last_comms = utc_from_timestamp(values['lastComms']['val'])
         interval = timedelta(seconds=values['WakeUp_Interval']['val'] * 3)
 
-        _LOGGER.warn("lc = %s, utcnow = %s", last_comms, utcnow())
-
         if last_comms < utcnow() - interval:
             return "mdi:battery-unknown"
 

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -59,22 +59,17 @@ class GeniusDevice(Entity):
         return self._name
 
     @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
+    def icon(self):
+        """Return the icon of the sensor."""
         child_values = self._device._info_raw['childValues']  # noqa; pylint: disable=protected-access
 
         last_comms = datetime.fromtimestamp(child_values['lastComms']['val'])
         interval = child_values['WakeUp_Interval']['val']
 
-        return last_comms > datetime.now() - timedelta(seconds=interval * 3)
-
-    @property
-    def icon(self):
-        """Return the icon of the sensor."""
-        level = self.state
-
-        if self.state == 0 or not self.available:
+        if last_comms < datetime.now() - timedelta(seconds=interval * 3):
             return "mdi:battery-unknown"
+
+        level = self.state
 
         if level > 95:
             return "mdi:battery"
@@ -84,7 +79,7 @@ class GeniusDevice(Entity):
             return "mdi:battery-60"
         if level > 55:
             return "mdi:battery-40"
-        if level > 40:
+        if level > 45:
             return "mdi:battery-20"
 
         return "mdi:battery-alert"

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -1,12 +1,12 @@
 """Support for Genius Hub sensor devices."""
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 import logging
 
 from homeassistant.const import DEVICE_CLASS_BATTERY
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
-from homeassistant.util.dt import utcnow, UTC
+from homeassistant.util.dt import utc_from_timestamp, utcnow
 
 from . import DOMAIN
 
@@ -66,8 +66,10 @@ class GeniusDevice(Entity):
         """Return the icon of the sensor."""
         values = self._device._info_raw['childValues']  # noqa; pylint: disable=protected-access
 
-        last_comms = datetime.fromtimestamp(values['lastComms']['val'], tz=UTC)
+        last_comms = utc_from_timestamp(values['lastComms']['val'])
         interval = timedelta(seconds=values['WakeUp_Interval']['val'] * 3)
+
+        _LOGGER.warn("lc = %s, utcnow = %s", last_comms, utcnow())
 
         if last_comms < utcnow() - interval:
             return "mdi:battery-unknown"
@@ -115,8 +117,7 @@ class GeniusDevice(Entity):
         attrs['assigned_zone'] = self._device.assignedZones[0]['name']
 
         last_comms = self._device._info_raw['childValues']['lastComms']['val']  # noqa; pylint: disable=protected-access
-        attrs['last_comms'] = datetime.fromtimestamp(
-            last_comms, tz=UTC).isoformat()
+        attrs['last_comms'] = utc_from_timestamp(last_comms).isoformat()
 
         return {**attrs}
 


### PR DESCRIPTION
## Breaking Change:

No breaking change.

## Description:

Set the icon of the battery to `mdi:battery-unknown` if the device has not been heard from for more than 3 **Wakeup_Interval**s.

Set the icon of the battery`mdi:battery-alert` if level <45% (similar to the vendor)

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** None required.

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
