### PR TITLE
Make sure entity config is never none

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -37,7 +37,7 @@ class GoogleConfig(AbstractConfig):
     @property
     def entity_config(self):
         """Return entity config."""
-        return self._config.get(CONF_ENTITY_CONFIG, {})
+        return self._config.get(CONF_ENTITY_CONFIG) or {}
 
     @property
     def secure_devices_pin(self):


### PR DESCRIPTION
## Description:
Entity config is not a mandatory field and it's not initialized when it's omitted. 

When no user entity config provided, a sync would fail.  

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/0-95-adguard-life360-plaato-airlock/123665/63?u=balloob
