### PR TITLE
Use climate device's target temp step value

### DIFF
--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -6,7 +6,8 @@ from pyhap.const import CATEGORY_THERMOSTAT
 from homeassistant.components.climate.const import (
     ATTR_CURRENT_TEMPERATURE, ATTR_MAX_TEMP, ATTR_MIN_TEMP,
     ATTR_OPERATION_LIST, ATTR_OPERATION_MODE, ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW, DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP,
+    ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_STEP,
+    DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP,
     DOMAIN as DOMAIN_CLIMATE,
     SERVICE_SET_OPERATION_MODE as SERVICE_SET_OPERATION_MODE_THERMOSTAT,
     SERVICE_SET_TEMPERATURE as SERVICE_SET_TEMPERATURE_THERMOSTAT, STATE_AUTO,
@@ -57,6 +58,8 @@ class Thermostat(HomeAccessory):
         self._flag_heatingthresh = False
         self.support_power_state = False
         min_temp, max_temp = self.get_temperature_range()
+        temp_step = self.hass.states.get(self.entity_id) \
+            .attributes.get(ATTR_TARGET_TEMP_STEP, 0.5)
 
         # Add additional characteristics if auto mode is supported
         self.chars = []
@@ -84,7 +87,7 @@ class Thermostat(HomeAccessory):
             CHAR_TARGET_TEMPERATURE, value=21.0,
             properties={PROP_MIN_VALUE: min_temp,
                         PROP_MAX_VALUE: max_temp,
-                        PROP_MIN_STEP: 0.5},
+                        PROP_MIN_STEP: temp_step},
             setter_callback=self.set_target_temperature)
 
         # Display units characteristic
@@ -99,14 +102,14 @@ class Thermostat(HomeAccessory):
                 CHAR_COOLING_THRESHOLD_TEMPERATURE, value=23.0,
                 properties={PROP_MIN_VALUE: min_temp,
                             PROP_MAX_VALUE: max_temp,
-                            PROP_MIN_STEP: 0.5},
+                            PROP_MIN_STEP: temp_step},
                 setter_callback=self.set_cooling_threshold)
         if CHAR_HEATING_THRESHOLD_TEMPERATURE in self.chars:
             self.char_heating_thresh_temp = serv_thermostat.configure_char(
                 CHAR_HEATING_THRESHOLD_TEMPERATURE, value=19.0,
                 properties={PROP_MIN_VALUE: min_temp,
                             PROP_MAX_VALUE: max_temp,
-                            PROP_MIN_STEP: 0.5},
+                            PROP_MIN_STEP: temp_step},
                 setter_callback=self.set_heating_threshold)
 
     def get_temperature_range(self):

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -6,9 +6,10 @@ import pytest
 
 from homeassistant.components.climate.const import (
     ATTR_CURRENT_TEMPERATURE, ATTR_MAX_TEMP, ATTR_MIN_TEMP,
-    ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH, ATTR_OPERATION_MODE,
-    ATTR_OPERATION_LIST, DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP,
-    DOMAIN as DOMAIN_CLIMATE, STATE_AUTO, STATE_COOL, STATE_HEAT)
+    ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_STEP,
+    ATTR_OPERATION_MODE, ATTR_OPERATION_LIST, DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP, DOMAIN as DOMAIN_CLIMATE, STATE_AUTO, STATE_COOL,
+    STATE_HEAT)
 from homeassistant.components.homekit.const import (
     ATTR_VALUE, DEFAULT_MAX_TEMP_WATER_HEATER, DEFAULT_MIN_TEMP_WATER_HEATER,
     PROP_MAX_VALUE, PROP_MIN_STEP, PROP_MIN_VALUE)
@@ -405,6 +406,19 @@ async def test_thermostat_get_temperature_range(hass, hk_driver, cls):
                           {ATTR_MIN_TEMP: 60, ATTR_MAX_TEMP: 70})
     await hass.async_block_till_done()
     assert acc.get_temperature_range() == (15.5, 21.0)
+
+
+async def test_thermostat_temperature_step_whole(hass, hk_driver, cls):
+    """Test climate device with single digit precision."""
+    entity_id = 'climate.test'
+
+    hass.states.async_set(entity_id, STATE_OFF, {ATTR_TARGET_TEMP_STEP: 1})
+    await hass.async_block_till_done()
+    acc = cls.thermostat(hass, hk_driver, 'Climate', entity_id, 2, None)
+    await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
+
+    assert acc.char_target_temp.properties[PROP_MIN_STEP] == 1.0
 
 
 async def test_water_heater(hass, hk_driver, cls, events):


### PR DESCRIPTION
## Description:
HomeKit climate devices currently assume a 0.5 degree step for the target temperature and do not use the climate entity's specific step value (which may be half degree, one degree...)
This change uses the climate entity's specific step value to pass along to HomeKit, so the target temperature slider will only stop on values with that interval.
If the climate device does not define a step value, the previous value of 0.5 is used instead.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: generic_thermostat
    name: Study
    heater: switch.study_heater
    target_sensor: sensor.study_temperature
    precision: 1.0

homekit:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
