### PR TITLE
Fix another Life360 bug

### DIFF
--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -294,7 +294,6 @@ class Life360Scanner:
             member_id = member['id']
             if member_id in members_updated:
                 continue
-            members_updated.append(member_id)
             err_key = 'Member data'
             try:
                 first = member.get('firstName')
@@ -318,6 +317,7 @@ class Life360Scanner:
             self._ok(err_key)
 
             if include_member and sharing:
+                members_updated.append(member_id)
                 self._update_member(member, dev_id)
 
     def _update_life360(self, now=None):


### PR DESCRIPTION
## Description:
Another bug was introduced when reorganizing the code as part of making it a standard component. This time it prevents proper updating of a Life360 Member who is in more than one Life360 Circle, but does not share their location in some of the Circles.

**Related issue (if applicable):** fixes #24803 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
