### PR TITLE
Add ability to send attachments in pushover notifications

### DIFF
--- a/homeassistant/components/pushover/manifest.json
+++ b/homeassistant/components/pushover/manifest.json
@@ -3,7 +3,7 @@
   "name": "Pushover",
   "documentation": "https://www.home-assistant.io/components/pushover",
   "requirements": [
-    "python-pushover==0.3"
+    "python-pushover==0.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -84,8 +84,7 @@ class PushoverNotificationService(BaseNotificationService):
                         # Remove attachment key to send without attachment.
                         del data[ATTR_ATTACHMENT]
                 else:
-                    _LOGGER.error(
-                        'Path is not whitelisted: %s' % data[ATTR_ATTACHMENT])
+                    _LOGGER.error('Path is not whitelisted')
                     # Remove attachment key to send without attachment.
                     del data[ATTR_ATTACHMENT]
 

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -62,9 +62,9 @@ class PushoverNotificationService(BaseNotificationService):
                 try:
                     import requests
                     response = requests.get(
-                            data[ATTR_ATTACHMENT],
-                            stream=True,
-                            timeout=5)
+                        data[ATTR_ATTACHMENT],
+                        stream=True,
+                        timeout=5)
                     if response.status_code == 200:
                         # Replace the attachment identifier with file object.
                         data[ATTR_ATTACHMENT] = response.content

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -68,7 +68,7 @@ class PushoverNotificationService(BaseNotificationService):
                     if response.status_code == 200:
                         # Replace the attachment identifier with file object.
                         data[ATTR_ATTACHMENT] = response.content
-                except RequestException as ex_val:
+                except requests.exceptions.RequestException as ex_val:
                     _LOGGER.error(str(ex_val))
                     # Remove attachment key to try sending without attachment
                     del data[ATTR_ATTACHMENT]

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -67,8 +67,12 @@ class PushoverNotificationService(BaseNotificationService):
                     if response.status_code == 200:
                         # Replace the attachment identifier with file object.
                         data[ATTR_ATTACHMENT] = response.content
+                    else:
+                        _LOGGER.error('Image not found')
+                        # Remove attachment key to send without attachment.
+                        del data[ATTR_ATTACHMENT]
                 except requests.exceptions.RequestException as ex_val:
-                    _LOGGER.error(str(ex_val))
+                    _LOGGER.error(ex_val)
                     # Remove attachment key to try sending without attachment
                     del data[ATTR_ATTACHMENT]
             else:
@@ -79,8 +83,8 @@ class PushoverNotificationService(BaseNotificationService):
                         file_handle = open(data[ATTR_ATTACHMENT], 'rb')
                         # Replace the attachment identifier with file object.
                         data[ATTR_ATTACHMENT] = file_handle
-                    except IOError as ex_val:
-                        _LOGGER.error(str(ex_val))
+                    except OSError as ex_val:
+                        _LOGGER.error(ex_val)
                         # Remove attachment key to send without attachment.
                         del data[ATTR_ATTACHMENT]
                 else:
@@ -100,6 +104,6 @@ class PushoverNotificationService(BaseNotificationService):
             try:
                 self.pushover.send_message(message, **data)
             except ValueError as val_err:
-                _LOGGER.error(str(val_err))
+                _LOGGER.error(val_err)
             except RequestError:
                 _LOGGER.exception("Could not send pushover notification")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1451,7 +1451,7 @@ python-nest==4.1.0
 python-nmap==0.6.1
 
 # homeassistant.components.pushover
-python-pushover==0.3
+python-pushover==0.4
 
 # homeassistant.components.qbittorrent
 python-qbittorrent==0.3.1


### PR DESCRIPTION

## Description:
Added new feature, ability to send attachments in pushover notifications. This requires an upgrade of the python-pushover package from v0.3 to v0.4. Existing functionality preserved.


## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
