### PR TITLE
Use step from tado rather than assuming 0.1

### DIFF
--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -85,12 +85,14 @@ def create_climate_device(tado, hass, zone, name, zone_id):
 
     min_temp = float(temperatures['celsius']['min'])
     max_temp = float(temperatures['celsius']['max'])
+    step = temperatures['celsius'].get('step', PRECISION_TENTHS)
 
     data_id = 'zone {} {}'.format(name, zone_id)
     device = TadoClimate(tado,
                          name, zone_id, data_id,
                          hass.config.units.temperature(min_temp, unit),
                          hass.config.units.temperature(max_temp, unit),
+                         step,
                          ac_mode)
 
     tado.add_sensor(data_id, {
@@ -107,7 +109,7 @@ class TadoClimate(ClimateDevice):
     """Representation of a tado climate device."""
 
     def __init__(self, store, zone_name, zone_id, data_id,
-                 min_temp, max_temp, ac_mode,
+                 min_temp, max_temp, step, ac_mode,
                  tolerance=0.3):
         """Initialize of Tado climate device."""
         self._store = store
@@ -127,6 +129,7 @@ class TadoClimate(ClimateDevice):
         self._is_away = False
         self._min_temp = min_temp
         self._max_temp = max_temp
+        self._step = step
         self._target_temp = None
         self._tolerance = tolerance
         self._cooling = False
@@ -194,7 +197,7 @@ class TadoClimate(ClimateDevice):
     @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
-        return PRECISION_TENTHS
+        return self._step
 
     @property
     def target_temperature(self):


### PR DESCRIPTION
## Description:
Use the device specific step value from tado when present rather than assuming it will be 0.1.
Smart thermostats use 0.1, radiator thermostats 1.0

## Example entry for `configuration.yaml` (if applicable):
```yaml
tado:
  username:
  password:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
