### PR TITLE
Add template support to template trigger's for option

### DIFF
--- a/homeassistant/components/automation/template.py
+++ b/homeassistant/components/automation/template.py
@@ -5,17 +5,20 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import CONF_VALUE_TEMPLATE, CONF_PLATFORM, CONF_FOR
+from homeassistant import exceptions
 from homeassistant.helpers import condition
 from homeassistant.helpers.event import (
     async_track_same_state, async_track_template)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, template
 
 _LOGGER = logging.getLogger(__name__)
 
 TRIGGER_SCHEMA = IF_ACTION_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'template',
     vol.Required(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_FOR): vol.Any(
+        vol.All(cv.time_period, cv.positive_timedelta),
+        cv.template, cv.template_complex),
 })
 
 
@@ -24,6 +27,7 @@ async def async_trigger(hass, config, action, automation_info):
     value_template = config.get(CONF_VALUE_TEMPLATE)
     value_template.hass = hass
     time_delta = config.get(CONF_FOR)
+    template.attach(hass, time_delta)
     unsub_track_same = None
 
     @callback
@@ -31,24 +35,48 @@ async def async_trigger(hass, config, action, automation_info):
         """Listen for state changes and calls action."""
         nonlocal unsub_track_same
 
+        variables = {
+            'trigger': {
+                'platform': 'template',
+                'entity_id': entity_id,
+                'from_state': from_s,
+                'to_state': to_s,
+            },
+        }
+
         @callback
         def call_action():
             """Call action with right context."""
-            hass.async_run_job(action({
-                'trigger': {
-                    'platform': 'template',
-                    'entity_id': entity_id,
-                    'from_state': from_s,
-                    'to_state': to_s,
-                },
-            }, context=(to_s.context if to_s else None)))
+            hass.async_run_job(action(
+                variables, context=(to_s.context if to_s else None)))
 
         if not time_delta:
             call_action()
             return
 
+        try:
+            if isinstance(time_delta, template.Template):
+                period = vol.All(
+                    cv.time_period,
+                    cv.positive_timedelta)(
+                        time_delta.async_render(variables))
+            elif isinstance(time_delta, dict):
+                time_delta_data = {}
+                time_delta_data.update(
+                    template.render_complex(time_delta, variables))
+                period = vol.All(
+                    cv.time_period,
+                    cv.positive_timedelta)(
+                        time_delta_data)
+            else:
+                period = time_delta
+        except (exceptions.TemplateError, vol.Invalid) as ex:
+            _LOGGER.error("Error rendering '%s' for template: %s",
+                          automation_info['name'], ex)
+            return
+
         unsub_track_same = async_track_same_state(
-            hass, time_delta, call_action,
+            hass, period, call_action,
             lambda _, _2, _3: condition.async_template(hass, value_template),
             value_template.extract_entities())
 


### PR DESCRIPTION
## Description:
Allow the use of templates with the template trigger's `for` option.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9714

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  - alias: Use template in trigger's for option
    trigger:
      platform: template
      value_template: >
        {{ is_state('binary_sensor.a', 'on') and
           states('sensor.b')|float > 10 }}
      for:
        minutes: "{{ states('input_number.minutes')|int }}"
        seconds: "{{ states('input_number.seconds')|int }}"
      action:
        ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
