### PR TITLE
Update REST Sensors to allow json_attributes_template for state attributes (MQTT style)

### DIFF
--- a/homeassistant/components/rest/binary_sensor.py
+++ b/homeassistant/components/rest/binary_sensor.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv, template
 
-from .sensor import (CONF_JSON_ATTRS, DEFAULT_FORCE_UPDATE, RestData)
+from .sensor import CONF_JSON_ATTRS, DEFAULT_FORCE_UPDATE, RestData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -98,16 +98,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # No need to update the sensor now because it will determine its state
     # based in the rest resource that has just been retrieved.
-    add_entities([RestBinarySensor(
-        hass, rest, name, device_class,
-        value_template, json_attrs, force_update)])
+    add_entities(
+        [
+            RestBinarySensor(
+                hass, rest, name, device_class, value_template, json_attrs, force_update
+            )
+        ]
+    )
 
 
 class RestBinarySensor(BinarySensorDevice):
     """Representation of a REST binary sensor."""
 
-    def __init__(self, hass, rest, name, device_class, value_template,
-                 json_attrs, force_update):
+    def __init__(
+        self, hass, rest, name, device_class, value_template, json_attrs, force_update
+    ):
         """Initialize a REST binary sensor."""
         self._hass = hass
         self.rest = rest
@@ -171,28 +176,26 @@ class RestBinarySensor(BinarySensorDevice):
         if self._json_attrs and value:
             try:
                 if isinstance(self._json_attrs, template.Template):
-                    attr = self._json_attrs. \
-                        render_with_possible_json_value(value)
+                    attr = self._json_attrs.render_with_possible_json_value(value)
                 elif isinstance(self._json_attrs, dict):
                     json_dict = {}
                     try:
                         json_dict = json.loads(value)
                     except (ValueError, TypeError):
-                        _LOGGER.warning("REST result could not be parsed "
-                                        "as JSON")
+                        _LOGGER.warning("REST result could not be parsed " "as JSON")
                         _LOGGER.debug("Erroneous JSON: %s", value)
                     else:
                         attr.update(
-                            template.render_complex(self._json_attrs,
-                                                    {'value': value,
-                                                     'value_json': json_dict}))
+                            template.render_complex(
+                                self._json_attrs,
+                                {"value": value, "value_json": json_dict},
+                            )
+                        )
                 self._attributes = attr
             except (exceptions.TemplateError, vol.Invalid) as ex:
-                _LOGGER.error("Error rendering '%s' for template: %s",
-                              self.name, ex)
+                _LOGGER.error("Error rendering '%s' for template: %s", self.name, ex)
         if value is not None and self._value_template is not None:
-            value = self._value_template.render_with_possible_json_value(
-                value, None)
+            value = self._value_template.render_with_possible_json_value(value, None)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/rest/binary_sensor.py
+++ b/homeassistant/components/rest/binary_sensor.py
@@ -1,9 +1,11 @@
 """Support for RESTful binary sensors."""
+import json
 import logging
 
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 import voluptuous as vol
 
+from homeassistant import exceptions
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,
     PLATFORM_SCHEMA,
@@ -12,6 +14,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_DEVICE_CLASS,
+    CONF_FORCE_UPDATE,
     CONF_HEADERS,
     CONF_METHOD,
     CONF_NAME,
@@ -26,9 +29,9 @@ from homeassistant.const import (
     HTTP_DIGEST_AUTHENTICATION,
 )
 from homeassistant.exceptions import PlatformNotReady
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, template
 
-from .sensor import RestData
+from .sensor import (CONF_JSON_ATTRS, DEFAULT_FORCE_UPDATE, RestData)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,6 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             [HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]
         ),
         vol.Optional(CONF_HEADERS): {cv.string: cv.string},
+        vol.Optional(CONF_JSON_ATTRS): vol.Any(cv.template_complex, cv.template),
         vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(["POST", "GET"]),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
@@ -52,6 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+        vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     }
 )
@@ -70,8 +75,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     headers = config.get(CONF_HEADERS)
     device_class = config.get(CONF_DEVICE_CLASS)
     value_template = config.get(CONF_VALUE_TEMPLATE)
+    json_attrs = config.get(CONF_JSON_ATTRS)
+    force_update = config.get(CONF_FORCE_UPDATE)
+
     if value_template is not None:
         value_template.hass = hass
+
+    template.attach(hass, json_attrs)
 
     if username and password:
         if config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
@@ -88,13 +98,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # No need to update the sensor now because it will determine its state
     # based in the rest resource that has just been retrieved.
-    add_entities([RestBinarySensor(hass, rest, name, device_class, value_template)])
+    add_entities([RestBinarySensor(
+        hass, rest, name, device_class,
+        value_template, json_attrs, force_update)])
 
 
 class RestBinarySensor(BinarySensorDevice):
     """Representation of a REST binary sensor."""
 
-    def __init__(self, hass, rest, name, device_class, value_template):
+    def __init__(self, hass, rest, name, device_class, value_template,
+                 json_attrs, force_update):
         """Initialize a REST binary sensor."""
         self._hass = hass
         self.rest = rest
@@ -103,6 +116,9 @@ class RestBinarySensor(BinarySensorDevice):
         self._state = False
         self._previous_data = None
         self._value_template = value_template
+        self._json_attrs = json_attrs
+        self._attributes = None
+        self._force_update = force_update
 
     @property
     def name(self):
@@ -118,6 +134,11 @@ class RestBinarySensor(BinarySensorDevice):
     def available(self):
         """Return the availability of this sensor."""
         return self.rest.data is not None
+
+    @property
+    def force_update(self):
+        """Force update."""
+        return self._force_update
 
     @property
     def is_on(self):
@@ -142,3 +163,38 @@ class RestBinarySensor(BinarySensorDevice):
     def update(self):
         """Get the latest data from REST API and updates the state."""
         self.rest.update()
+        value = self.rest.data
+
+        self._attributes = {}
+        attr = {}
+
+        if self._json_attrs and value:
+            try:
+                if isinstance(self._json_attrs, template.Template):
+                    attr = self._json_attrs. \
+                        render_with_possible_json_value(value)
+                elif isinstance(self._json_attrs, dict):
+                    json_dict = {}
+                    try:
+                        json_dict = json.loads(value)
+                    except (ValueError, TypeError):
+                        _LOGGER.warning("REST result could not be parsed "
+                                        "as JSON")
+                        _LOGGER.debug("Erroneous JSON: %s", value)
+                    else:
+                        attr.update(
+                            template.render_complex(self._json_attrs,
+                                                    {'value': value,
+                                                     'value_json': json_dict}))
+                self._attributes = attr
+            except (exceptions.TemplateError, vol.Invalid) as ex:
+                _LOGGER.error("Error rendering '%s' for template: %s",
+                              self.name, ex)
+        if value is not None and self._value_template is not None:
+            value = self._value_template.render_with_possible_json_value(
+                value, None)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -48,8 +48,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             [HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]
         ),
         vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.string}),
-        vol.Optional(CONF_JSON_ATTRS): vol.Any(cv.template_complex, cv.template),
-        vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
         vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(METHODS),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
@@ -58,6 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_JSON_ATTRS): vol.Any(cv.template_complex, cv.template),
         vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
@@ -179,30 +178,36 @@ class RestSensor(Entity):
         self.rest.update()
         value = self.rest.data
 
-        self._attributes = {}
-        attr = {}
-
-        if self._json_attrs and value:
-            try:
-                if isinstance(self._json_attrs, template.Template):
-                    attr = self._json_attrs.render_with_possible_json_value(value)
-                elif isinstance(self._json_attrs, dict):
-                    json_dict = {}
-                    try:
-                        json_dict = json.loads(value)
-                    except (ValueError, TypeError):
-                        _LOGGER.warning("REST result could not be parsed " "as JSON")
-                        _LOGGER.debug("Erroneous JSON: %s", value)
-                    else:
-                        attr.update(
-                            template.render_complex(
-                                self._json_attrs,
-                                {"value": value, "value_json": json_dict},
+        if self._json_attrs:
+            self._attributes = {}
+            attr = {}
+            if value:
+                try:
+                    if isinstance(self._json_attrs, template.Template):
+                        attr = self._json_attrs.render_with_possible_json_value(value)
+                    elif isinstance(self._json_attrs, dict):
+                        json_dict = {}
+                        try:
+                            json_dict = json.loads(value)
+                        except (ValueError, TypeError):
+                            _LOGGER.warning(
+                                "REST result could not be parsed " "as JSON"
                             )
-                        )
-                self._attributes = attr
-            except (exceptions.TemplateError, vol.Invalid) as ex:
-                _LOGGER.error("Error rendering '%s' for template: %s", self.name, ex)
+                            _LOGGER.debug("Erroneous JSON: %s", value)
+                        else:
+                            attr.update(
+                                template.render_complex(
+                                    self._json_attrs,
+                                    {"value": value, "value_json": json_dict},
+                                )
+                            )
+                    self._attributes = attr
+                except (exceptions.TemplateError, vol.Invalid) as ex:
+                    _LOGGER.error(
+                        "Error rendering '%s' for template: %s", self.name, ex
+                    )
+            else:
+                _LOGGER.warning("Empty reply found when expecting JSON data")
         if value is not None and self._value_template is not None:
             value = self._value_template.render_with_possible_json_value(value, None)
 

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -7,8 +7,7 @@ import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
 from homeassistant import exceptions
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA)
+from homeassistant.components.sensor import PLATFORM_SCHEMA, DEVICE_CLASSES_SCHEMA
 from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_FORCE_UPDATE,
@@ -186,25 +185,24 @@ class RestSensor(Entity):
         if self._json_attrs and value:
             try:
                 if isinstance(self._json_attrs, template.Template):
-                    attr = self._json_attrs. \
-                        render_with_possible_json_value(value)
+                    attr = self._json_attrs.render_with_possible_json_value(value)
                 elif isinstance(self._json_attrs, dict):
                     json_dict = {}
                     try:
                         json_dict = json.loads(value)
                     except (ValueError, TypeError):
-                        _LOGGER.warning("REST result could not be parsed "
-                                        "as JSON")
+                        _LOGGER.warning("REST result could not be parsed " "as JSON")
                         _LOGGER.debug("Erroneous JSON: %s", value)
                     else:
                         attr.update(
-                            template.render_complex(self._json_attrs,
-                                                    {'value': value,
-                                                     'value_json': json_dict}))
+                            template.render_complex(
+                                self._json_attrs,
+                                {"value": value, "value_json": json_dict},
+                            )
+                        )
                 self._attributes = attr
             except (exceptions.TemplateError, vol.Invalid) as ex:
-                _LOGGER.error("Error rendering '%s' for template: %s",
-                              self.name, ex)
+                _LOGGER.error("Error rendering '%s' for template: %s", self.name, ex)
         if value is not None and self._value_template is not None:
             value = self._value_template.render_with_possible_json_value(value, None)
 

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -148,22 +148,26 @@ class TestRestBinarySensor(unittest.TestCase):
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.rest = Mock('RestData')
-        self.rest.update = Mock('RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '{ "key": false }'))
-        self.name = 'foo'
-        self.device_class = 'light'
-        self.value_template = \
-            template.Template('{{ value_json.key }}', self.hass)
-        self.json_attrs_tpl = template.Template('{{ value_json.key }}')
+        self.rest = Mock("RestData")
+        self.rest.update = Mock(
+            "RestData.update", side_effect=self.update_side_effect('{ "key": false }')
+        )
+        self.name = "foo"
+        self.device_class = "light"
+        self.value_template = template.Template("{{ value_json.key }}", self.hass)
+        self.json_attrs_tpl = template.Template("{{ value_json.key }}")
         self.json_attrs_tpl.hass = self.hass
         self.force_update = False
 
         self.binary_sensor = rest.RestBinarySensor(
-            self.hass, self.rest, self.name, self.device_class,
-            self.value_template, self.json_attrs_tpl,
-            self.force_update)
+            self.hass,
+            self.rest,
+            self.name,
+            self.device_class,
+            self.value_template,
+            self.json_attrs_tpl,
+            self.force_update,
+        )
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -222,69 +226,95 @@ class TestRestBinarySensor(unittest.TestCase):
             "rest.RestData.update", side_effect=self.update_side_effect("true")
         )
         self.binary_sensor = rest.RestBinarySensor(
-            self.hass, self.rest, self.name, self.device_class, None, ['key'],
-            self.force_update)
+            self.hass,
+            self.rest,
+            self.name,
+            self.device_class,
+            None,
+            ["key"],
+            self.force_update,
+        )
         self.binary_sensor.update()
         assert STATE_ON == self.binary_sensor.state
         assert self.binary_sensor.available
 
     def test_update_with_json_attrs(self):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '{ "key": true }'))
-        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
-                                                   self.name,
-                                                   self.device_class, None,
-                                                   ['key'],
-                                                   self.json_attrs_tpl,
-                                                   self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect('{ "key": true }'),
+        )
+        self.binary_sensor = rest.RestBinarySensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.binary_sensor.update()
-        assert self.binary_sensor.device_state_attributes['key']
+        assert self.binary_sensor.device_state_attributes["key"]
 
-    @patch('homeassistant.components.rest.binary_sensor._LOGGER')
+    @patch("homeassistant.components.rest.binary_sensor._LOGGER")
     def test_update_with_json_attrs_no_data(self, mock_logger):
         """Test attributes when no JSON result fetched."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(None))
-        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
-                                                   self.name,
-                                                   self.device_class, None,
-                                                   ['key'],
-                                                   self.json_attrs_tpl,
-                                                   self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update", side_effect=self.update_side_effect(None)
+        )
+        self.binary_sensor = rest.RestBinarySensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.binary_sensor.update()
         assert {} == self.binary_sensor.device_state_attributes
         assert mock_logger.warning.called
 
-    @patch('homeassistant.components.rest.binary_sensor._LOGGER')
+    @patch("homeassistant.components.rest.binary_sensor._LOGGER")
     def test_update_with_json_attrs_not_dict(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '["list", "of", "things"]'))
-        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
-                                                   self.name,
-                                                   self.device_class, None,
-                                                   ['key'],
-                                                   self.json_attrs_tpl,
-                                                   self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect('["list", "of", "things"]'),
+        )
+        self.binary_sensor = rest.RestBinarySensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.binary_sensor.update()
         assert {} == self.binary_sensor.device_state_attributes
         assert mock_logger.warning.called
 
-    @patch('homeassistant.components.rest.binary_sensor._LOGGER')
+    @patch("homeassistant.components.rest.binary_sensor._LOGGER")
     def test_update_with_json_attrs_bad_json(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    'This is text rather than JSON data.'))
-        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
-                                                   self.name,
-                                                   self.device_class, None,
-                                                   ['key'],
-                                                   self.json_attrs_tpl,
-                                                   self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect("This is text rather than JSON data."),
+        )
+        self.binary_sensor = rest.RestBinarySensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.binary_sensor.update()
         assert {} == self.binary_sensor.device_state_attributes
         assert mock_logger.warning.called
@@ -292,18 +322,21 @@ class TestRestBinarySensor(unittest.TestCase):
 
     def test_update_with_json_attrs_and_template(self):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '{ "key": false }'))
-        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
-                                                   self.name,
-                                                   self.device_class,
-                                                   self.value_template,
-                                                   ['key'],
-                                                   self.json_attrs_tpl,
-                                                   self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect('{ "key": false }'),
+        )
+        self.binary_sensor = rest.RestBinarySensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.device_class,
+            self.value_template,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.binary_sensor.update()
 
         assert STATE_OFF == self.binary_sensor.state
-        assert not self.binary_sensor.device_state_attributes['key'], \
-            self.force_update
+        assert not self.binary_sensor.device_state_attributes["key"], self.force_update

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -250,7 +250,6 @@ class TestRestBinarySensor(unittest.TestCase):
             self.name,
             self.device_class,
             None,
-            ["key"],
             self.json_attrs_tpl,
             self.force_update,
         )
@@ -269,7 +268,6 @@ class TestRestBinarySensor(unittest.TestCase):
             self.name,
             self.device_class,
             None,
-            ["key"],
             self.json_attrs_tpl,
             self.force_update,
         )
@@ -290,7 +288,6 @@ class TestRestBinarySensor(unittest.TestCase):
             self.name,
             self.device_class,
             None,
-            ["key"],
             self.json_attrs_tpl,
             self.force_update,
         )
@@ -311,7 +308,6 @@ class TestRestBinarySensor(unittest.TestCase):
             self.name,
             self.device_class,
             None,
-            ["key"],
             self.json_attrs_tpl,
             self.force_update,
         )
@@ -332,7 +328,6 @@ class TestRestBinarySensor(unittest.TestCase):
             self.name,
             self.device_class,
             self.value_template,
-            ["key"],
             self.json_attrs_tpl,
             self.force_update,
         )

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -148,17 +148,22 @@ class TestRestBinarySensor(unittest.TestCase):
     def setUp(self):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
-        self.rest = Mock("RestData")
-        self.rest.update = Mock(
-            "RestData.update", side_effect=self.update_side_effect('{ "key": false }')
-        )
-        self.name = "foo"
-        self.device_class = "light"
-        self.value_template = template.Template("{{ value_json.key }}", self.hass)
+        self.rest = Mock('RestData')
+        self.rest.update = Mock('RestData.update',
+                                side_effect=self.update_side_effect(
+                                    '{ "key": false }'))
+        self.name = 'foo'
+        self.device_class = 'light'
+        self.value_template = \
+            template.Template('{{ value_json.key }}', self.hass)
+        self.json_attrs_tpl = template.Template('{{ value_json.key }}')
+        self.json_attrs_tpl.hass = self.hass
+        self.force_update = False
 
         self.binary_sensor = rest.RestBinarySensor(
-            self.hass, self.rest, self.name, self.device_class, self.value_template
-        )
+            self.hass, self.rest, self.name, self.device_class,
+            self.value_template, self.json_attrs_tpl,
+            self.force_update)
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -180,6 +185,10 @@ class TestRestBinarySensor(unittest.TestCase):
         """Test the initial state."""
         self.binary_sensor.update()
         assert STATE_OFF == self.binary_sensor.state
+
+    def test_force_update(self):
+        """Test the unit of measurement."""
+        assert self.force_update == self.binary_sensor.force_update
 
     def test_update_when_value_is_none(self):
         """Test state gets updated to unknown when sensor returns no data."""
@@ -213,8 +222,88 @@ class TestRestBinarySensor(unittest.TestCase):
             "rest.RestData.update", side_effect=self.update_side_effect("true")
         )
         self.binary_sensor = rest.RestBinarySensor(
-            self.hass, self.rest, self.name, self.device_class, None
-        )
+            self.hass, self.rest, self.name, self.device_class, None, ['key'],
+            self.force_update)
         self.binary_sensor.update()
         assert STATE_ON == self.binary_sensor.state
         assert self.binary_sensor.available
+
+    def test_update_with_json_attrs(self):
+        """Test attributes get extracted from a JSON result."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(
+                                    '{ "key": true }'))
+        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
+                                                   self.name,
+                                                   self.device_class, None,
+                                                   ['key'],
+                                                   self.json_attrs_tpl,
+                                                   self.force_update)
+        self.binary_sensor.update()
+        assert self.binary_sensor.device_state_attributes['key']
+
+    @patch('homeassistant.components.rest.binary_sensor._LOGGER')
+    def test_update_with_json_attrs_no_data(self, mock_logger):
+        """Test attributes when no JSON result fetched."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(None))
+        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
+                                                   self.name,
+                                                   self.device_class, None,
+                                                   ['key'],
+                                                   self.json_attrs_tpl,
+                                                   self.force_update)
+        self.binary_sensor.update()
+        assert {} == self.binary_sensor.device_state_attributes
+        assert mock_logger.warning.called
+
+    @patch('homeassistant.components.rest.binary_sensor._LOGGER')
+    def test_update_with_json_attrs_not_dict(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(
+                                    '["list", "of", "things"]'))
+        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
+                                                   self.name,
+                                                   self.device_class, None,
+                                                   ['key'],
+                                                   self.json_attrs_tpl,
+                                                   self.force_update)
+        self.binary_sensor.update()
+        assert {} == self.binary_sensor.device_state_attributes
+        assert mock_logger.warning.called
+
+    @patch('homeassistant.components.rest.binary_sensor._LOGGER')
+    def test_update_with_json_attrs_bad_json(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(
+                                    'This is text rather than JSON data.'))
+        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
+                                                   self.name,
+                                                   self.device_class, None,
+                                                   ['key'],
+                                                   self.json_attrs_tpl,
+                                                   self.force_update)
+        self.binary_sensor.update()
+        assert {} == self.binary_sensor.device_state_attributes
+        assert mock_logger.warning.called
+        assert mock_logger.debug.called
+
+    def test_update_with_json_attrs_and_template(self):
+        """Test attributes get extracted from a JSON result."""
+        self.rest.update = Mock('rest.RestData.update',
+                                side_effect=self.update_side_effect(
+                                    '{ "key": false }'))
+        self.binary_sensor = rest.RestBinarySensor(self.hass, self.rest,
+                                                   self.name,
+                                                   self.device_class,
+                                                   self.value_template,
+                                                   ['key'],
+                                                   self.json_attrs_tpl,
+                                                   self.force_update)
+        self.binary_sensor.update()
+
+        assert STATE_OFF == self.binary_sensor.state
+        assert not self.binary_sensor.device_state_attributes['key'], \
+            self.force_update

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -151,14 +151,20 @@ class TestRestSensor(unittest.TestCase):
         self.device_class = None
         self.value_template = template("{{ value_json.key }}")
         self.value_template.hass = self.hass
-        self.json_attrs_tpl = template('{{ value_json | tojson }}')
+        self.json_attrs_tpl = template("{{ value_json | tojson }}")
         self.json_attrs_tpl.hass = self.hass
         self.force_update = False
 
         self.sensor = rest.RestSensor(
-            self.hass, self.rest, self.name, self.unit_of_measurement,
-            self.device_class, self.value_template, [], self.json_attrs_tpl,
-            self.force_update
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            self.value_template,
+            [],
+            self.json_attrs_tpl,
+            self.force_update,
         )
 
     def tearDown(self):
@@ -207,41 +213,61 @@ class TestRestSensor(unittest.TestCase):
 
     def test_update_with_no_template(self):
         """Test update when there is no value template."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    'plain_state'))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.device_class, None, [],
-                                      None,
-                                      self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update", side_effect=self.update_side_effect("plain_state")
+        )
+        self.sensor = rest.RestSensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            None,
+            [],
+            None,
+            self.force_update,
+        )
         self.sensor.update()
         assert "plain_state" == self.sensor.state
         assert self.sensor.available
 
     def test_update_with_json_attrs(self):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '{ "key": "some_json_value" }'))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.device_class, None, ['key'],
-                                      self.json_attrs_tpl,
-                                      self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect('{ "key": "some_json_value" }'),
+        )
+        self.sensor = rest.RestSensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.sensor.update()
         assert "some_json_value" == self.sensor.device_state_attributes["key"]
 
     @patch("homeassistant.components.rest.sensor._LOGGER")
     def test_update_with_json_attrs_no_data(self, mock_logger):
         """Test attributes when no JSON result fetched."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(None))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.device_class, None, ['key'],
-                                      self.json_attrs_tpl,
-                                      self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update", side_effect=self.update_side_effect(None)
+        )
+        self.sensor = rest.RestSensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.sensor.update()
         assert {} == self.sensor.device_state_attributes
         assert mock_logger.warning.called
@@ -249,29 +275,43 @@ class TestRestSensor(unittest.TestCase):
     @patch("homeassistant.components.rest.sensor._LOGGER")
     def test_update_with_json_attrs_not_dict(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '["list", "of", "things"]'))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.device_class, None, ['key'],
-                                      self.json_attrs_tpl,
-                                      self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect('["list", "of", "things"]'),
+        )
+        self.sensor = rest.RestSensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.sensor.update()
         assert {} == self.sensor.device_state_attributes
         assert mock_logger.warning.called
 
-    @patch('homeassistant.components.rest.sensor._LOGGER')
+    @patch("homeassistant.components.rest.sensor._LOGGER")
     def test_update_with_json_attrs_bad_json(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    'This is text rather than JSON data.'))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.device_class, None, ['key'],
-                                      self.json_attrs_tpl,
-                                      self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect("This is text rather than JSON data."),
+        )
+        self.sensor = rest.RestSensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            None,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.sensor.update()
         assert {} == self.sensor.device_state_attributes
         assert mock_logger.warning.called
@@ -279,15 +319,23 @@ class TestRestSensor(unittest.TestCase):
 
     def test_update_with_json_attrs_and_template(self):
         """Test attributes get extracted from a JSON result."""
-        self.rest.update = Mock('rest.RestData.update',
-                                side_effect=self.update_side_effect(
-                                    '{ "key": "json_state_updated_value" }'))
-        self.sensor = rest.RestSensor(self.hass, self.rest, self.name,
-                                      self.unit_of_measurement,
-                                      self.device_class,
-                                      self.value_template, ['key'],
-                                      self.json_attrs_tpl,
-                                      self.force_update)
+        self.rest.update = Mock(
+            "rest.RestData.update",
+            side_effect=self.update_side_effect(
+                '{ "key": "json_state_updated_value" }'
+            ),
+        )
+        self.sensor = rest.RestSensor(
+            self.hass,
+            self.rest,
+            self.name,
+            self.unit_of_measurement,
+            self.device_class,
+            self.value_template,
+            ["key"],
+            self.json_attrs_tpl,
+            self.force_update,
+        )
         self.sensor.update()
 
         assert "json_state_updated_value" == self.sensor.state


### PR DESCRIPTION
## Description:

1) Add `json_attributes` and  `force_update` options to the `rest` platform's `binary_sensor` platform (already exist in `sensor`)
2) Update the `rest` `sensor` and `binary_sensor` devices to allow MQTT-style `json_attribute_template` options to break out the JSON response into state attributes.  Currently only first-level JSON dict values can be handled as device state attributes, this allows you to add a nested JSON response object as state values and then (coupled with `json_attributes`) filter *that* object further. [MQTT Documentation](https://www.home-assistant.io/components/sensor.mqtt/#json-attributes-template-configuration) for reference. 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9722

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: rest
    scan_interval: 600
    resource: !secret resource_url
    name: VPN
    device_class: connectivity
    value_template: "{{ value_json['user']['connected'] }}"
    headers:
      User-Agent: Home Assistant
      Content-Type: application/json
    json_attributes:
      bytes_read: "{{ value_json.connection.bytes_read }}"
      bytes_write: "{{ value_json.connection.bytes_write }}"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [N/A] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [N/A] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
