### PR TITLE
Switched from unmaintained tuyapy to tuyaha

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -46,7 +46,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up Tuya Component."""
-    from tuyapy import TuyaApi
+    from tuyaha import TuyaApi
 
     tuya = TuyaApi()
     username = config[DOMAIN][CONF_USERNAME]

--- a/homeassistant/components/tuya/manifest.json
+++ b/homeassistant/components/tuya/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tuya",
   "documentation": "https://www.home-assistant.io/components/tuya",
   "requirements": [
-    "tuyapy==0.1.3"
+    "tuyaha==0.0.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1811,7 +1811,7 @@ tplink==0.2.1
 transmissionrpc==0.11
 
 # homeassistant.components.tuya
-tuyapy==0.1.3
+tuyaha==0.0.1
 
 # homeassistant.components.twilio
 twilio==6.19.1


### PR DESCRIPTION
## Description:

After 10 days, access token to Tuya API expires and `tuyapy` library tries to acquire a new one, but that function calls a broken url. This leads to an error like this:
```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='px1.tuyaeu.comhomeassistant', port=443): Max retries exceeded with url: /access.do?grant_type=refresh_token&refresh_token=... (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fade0473748>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```
I don't know whether Tuya API allows to use expired token, but still this bug should be fixed. As `tuyapy` maintainer [has left the company](https://github.com/home-assistant/home-assistant/issues/19074#issuecomment-471370475) and there was no reply from `tuyasmart@tuya.com` for a week, I forked `tuyapy`. The name of the new library is [tuyaha](https://github.com/PaulAnnekov/tuyaha). Version 0.0.1 is already [published](https://pypi.org/project/tuyaha/) to pypi and contains fixed code. This PR uses new library.

**Related issue:** possible fix for #20413

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
