### PR TITLE
Fix calling empty script turn off

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -79,9 +79,14 @@ async def async_setup(hass, config):
     async def turn_off_service(service):
         """Cancel a script."""
         # Stopping a script is ok to be done in parallel
+        scripts = await component.async_extract_from_service(service)
+
+        if not scripts:
+            return
+
         await asyncio.wait([
             script.async_turn_off() for script
-            in await component.async_extract_from_service(service)
+            in scripts
         ])
 
     async def toggle_service(service):

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -322,3 +322,13 @@ async def test_logging_script_error(hass, caplog):
     assert err.value.domain == 'non'
     assert err.value.service == 'existing'
     assert 'Error executing script' in caplog.text
+
+
+async def test_turning_no_scripts_off(hass):
+    """Test it is possible to turn two scripts off."""
+    assert await async_setup_component(hass, 'script', {})
+
+    # Testing it doesn't raise
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, {'entity_id': []}, blocking=True
+    )


### PR DESCRIPTION
## Description:
Script turn_off service would crash if we end up calling it while selecting 0 scripts.

**Related issue (if applicable):** fixes #24662

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
