### PR TITLE
Make sure alert is set up after notify

### DIFF
--- a/homeassistant/components/alert/manifest.json
+++ b/homeassistant/components/alert/manifest.json
@@ -4,5 +4,8 @@
   "documentation": "https://www.home-assistant.io/components/alert",
   "requirements": [],
   "dependencies": [],
+  "after_dependencies": [
+    "notify"
+  ],
   "codeowners": []
 }


### PR DESCRIPTION
## Description:
Make sure the alert integration is set up after the notify integration so that all services are available.

**Related issue (if applicable):** fixes #24823

