### PR TITLE
Fix yeelight color temp getter

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -99,9 +99,7 @@ MODEL_TO_DEVICE_TYPE = {
     'ceiling1': BulbType.WhiteTemp,
     'ceiling2': BulbType.WhiteTemp,
     'ceiling3': BulbType.WhiteTemp,
-    'ceiling4': BulbType.WhiteTempMood,
-    'white_temp': BulbType.WhiteTemp,
-    'white_temp_ambilight': BulbType.WhiteTempMood}
+    'ceiling4': BulbType.WhiteTempMood}
 
 
 def _transitions_config_parser(transitions):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -99,7 +99,9 @@ MODEL_TO_DEVICE_TYPE = {
     'ceiling1': BulbType.WhiteTemp,
     'ceiling2': BulbType.WhiteTemp,
     'ceiling3': BulbType.WhiteTemp,
-    'ceiling4': BulbType.WhiteTempMood}
+    'ceiling4': BulbType.WhiteTempMood,
+    'white_temp': BulbType.WhiteTemp,
+    'white_temp_ambilight': BulbType.WhiteTempMood}
 
 
 def _transitions_config_parser(transitions):
@@ -277,10 +279,10 @@ class YeelightGenericLight(Light):
     @property
     def color_temp(self) -> int:
         """Return the color temperature."""
-        temp = self._get_property('ct')
-        if temp:
-            self._color_temp = temp
-        return kelvin_to_mired(int(self._color_temp))
+        temp_in_k = self._get_property('ct')
+        if temp_in_k:
+            self._color_temp = kelvin_to_mired(int(temp_in_k))
+        return self._color_temp
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Description:
Fix after refactor, part of logic was missing. https://github.com/home-assistant/home-assistant/commit/6d3c3ce449e3aa97604ffce6557dfb450161c418#diff-6b4ac627753ee21cde162f000848ba3bL380

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/24816

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
