### PR TITLE
Caldav fix

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -156,9 +156,12 @@ class WebDavCalendarData:
                 "description": self.get_attr_value(vevent, "description"),
             }
 
-            # CO Same here google integration returns a dict. Need to cleanup if accepted.
-            data['start'] = self.get_hass_date(get_date(data['start']).isoformat())
-            data['end'] = self.get_hass_date(get_date(data['end']).isoformat())
+            data['start'] = get_date(data['start']).isoformat()
+            data['end'] = get_date(data['end']).isoformat()
+            # CO: Here google integration returns a dict. And below in update method a dict is also returned.
+            # (Need to cleanup if accepted.)
+            data['start'] = self.get_hass_date(data['start'])
+            data['end'] = self.get_hass_date(data['end'])
 
             event_list.append(data)
 

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -142,16 +142,23 @@ class WebDavCalendarData:
             if hasattr(vevent, 'uid'):
                 uid = vevent.uid.value
             data = {
+                # Some custom cards access 'id' and 'summary' of event object because google calendar integration / google calendar event API has it.
+                # CO: Here a "uid" is given (from caldav spec), but it is "id" in google calendar integration / google calendar event API.
                 "uid": uid,
+                "id": uid,
+                # CO: Here it is called title and not summary?! See update method below and the google calendar integration / google calendar event API.
                 "title": vevent.summary.value,
+                "summary": vevent.summary.value,
+
                 "start": self.get_hass_date(vevent.dtstart.value),
                 "end": self.get_hass_date(self.get_end_date(vevent)),
                 "location": self.get_attr_value(vevent, "location"),
                 "description": self.get_attr_value(vevent, "description"),
             }
 
-            data['start'] = get_date(data['start']).isoformat()
-            data['end'] = get_date(data['end']).isoformat()
+            # CO Same here google integration returns a dict. Need to cleanup if accepted.
+            data['start'] = self.get_hass_date(get_date(data['start']).isoformat())
+            data['end'] = self.get_hass_date(get_date(data['end']).isoformat())
 
             event_list.append(data)
 
@@ -190,6 +197,7 @@ class WebDavCalendarData:
 
         # Populate the entity attributes with the event values
         self.event = {
+            # CO: Here it is called summary but above it is title?!
             "summary": vevent.summary.value,
             "start": self.get_hass_date(vevent.dtstart.value),
             "end": self.get_hass_date(self.get_end_date(vevent)),

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -142,11 +142,19 @@ class WebDavCalendarData:
             if hasattr(vevent, 'uid'):
                 uid = vevent.uid.value
             data = {
-                # Some custom cards access 'id' and 'summary' of event object because google calendar integration / google calendar event API has it.
-                # CO: Here a "uid" is given (from caldav spec), but it is "id" in google calendar integration / google calendar event API.
+                # CO:
+                # Some custom cards access 'id' and 'summary' of event object
+                # because google calendar integration / google calendar event
+                # API has it.
+                #
+                # CO: Here a "uid" is given (from caldav spec),
+                # but it is "id" in google calendar integration
+                #                                / google calendar event API.
                 "uid": uid,
                 "id": uid,
-                # CO: Here it is called title and not summary?! See update method below and the google calendar integration / google calendar event API.
+                # CO: Here it is called title and not summary?!
+                # See update method below and the google calendar integration
+                #                                 / google calendar event API.
                 "title": vevent.summary.value,
                 "summary": vevent.summary.value,
 
@@ -158,7 +166,8 @@ class WebDavCalendarData:
 
             data['start'] = get_date(data['start']).isoformat()
             data['end'] = get_date(data['end']).isoformat()
-            # CO: Here google integration returns a dict. And below in update method a dict is also returned.
+            # CO: Here google integration returns a dict.
+            # And below in update method a dict is also returned.
             # (Need to cleanup if accepted.)
             data['start'] = self.get_hass_date(data['start'])
             data['end'] = self.get_hass_date(data['end'])


### PR DESCRIPTION
## Breaking Change:

The current output of WebDavCalendarData::async_get_events does not match the output from google calendar component.
Partly you could just add the missing/renamed fields but for start and end there will be a breaking change (before a date/datetime, then a dict like {'datetime': <datetime>}.

## Description:

The current output of WebDavCalendarData::async_get_events does not match the output from google calendar component. That leads to problem by custom cards like atomic_calendar and calendar_card. Both do not work correctly with caldav:
* atomic_calendar cannot read title/summary, nor start and end date correctly
* calendar_card only shows one event

**This fix/workaround (see below) makes it possible to use those custom cards with caldav.**

Overall this fix should be a start of discussion. 
I would argue the main problem is that the calendar event data is not clearly defined:
* An 'id' is missing (at least those custom cards need one)
* Is it title, summary or message?
* How does 'start', 'end' data look like (I guess this is clear in the code, see calendar::get_date).

## Example entry for `configuration.yaml` (if applicable):
NA

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
