### PR TITLE
Remove temperature attribute from SimpliSafe alarm control panel

### DIFF
--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -14,7 +14,6 @@ from .const import DATA_CLIENT, DOMAIN, TOPIC_UPDATE
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ALARM_ACTIVE = 'alarm_active'
-ATTR_TEMPERATURE = 'temperature'
 
 
 async def async_setup_platform(
@@ -120,8 +119,6 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
         from simplipy.system import SystemStates
 
         self._attrs[ATTR_ALARM_ACTIVE] = self._system.alarm_going_off
-        if self._system.temperature:
-            self._attrs[ATTR_TEMPERATURE] = self._system.temperature
 
         if self._system.state == SystemStates.error:
             return


### PR DESCRIPTION
## Breaking Change:

The SimpliSafe alarm control panel no longer shows a temperature attribute.

## Description:

For a while, I've noticed the `temperature` attribute of my SimpliSafe alarm control panel wasn't updating. Today, I realized this is because I'm not actively hitting the endpoint to update sensor values (due to (a) SimpliSafe being a private API and (b) it being murky whether that API could handle regular API requests for updating sensors). Therefore, for now, removing this attribute.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
