### PR TITLE
Support mqtt discovery topic prefix with slashes

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -15,8 +15,8 @@ from .const import ATTR_DISCOVERY_HASH, CONF_STATE_TOPIC
 _LOGGER = logging.getLogger(__name__)
 
 TOPIC_MATCHER = re.compile(
-    r'(?P<prefix_topic>\w+)/(?P<component>\w+)/'
-    r'(?:(?P<node_id>[a-zA-Z0-9_-]+)/)?(?P<object_id>[a-zA-Z0-9_-]+)/config')
+    r'(?P<component>\w+)/(?:(?P<node_id>[a-zA-Z0-9_-]+)/)'
+    r'?(?P<object_id>[a-zA-Z0-9_-]+)/config')
 
 SUPPORTED_COMPONENTS = [
     'alarm_control_panel',
@@ -233,12 +233,13 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         """Process the received message."""
         payload = msg.payload
         topic = msg.topic
-        match = TOPIC_MATCHER.match(topic)
+        topic_trimmed = topic.replace('{}/'.format(discovery_topic), '', 1)
+        match = TOPIC_MATCHER.match(topic_trimmed)
 
         if not match:
             return
 
-        _prefix_topic, component, node_id, object_id = match.groups()
+        component, node_id, object_id = match.groups()
 
         if component not in SUPPORTED_COMPONENTS:
             _LOGGER.warning("Component %s is not supported", component)


### PR DESCRIPTION
## Description:

The [mqtt discovery](https://www.home-assistant.io/docs/mqtt/discovery/) component allows a `discovery_prefix` to be set. However: Using a prefix with slashes like `my_home/homeassistant/register` breaks [parsing](https://github.com/home-assistant/home-assistant/blob/b70f907d256fd17be7a58037291f0ab4c74f3f8b/homeassistant/components/mqtt/discovery.py#L17-L19) of the topic. The regex doesn't support any slashes within the `discovery_prefix`.

This PR changes this by removing the discovery prefix before parsing the topic. I decided against extending the regex, as this would have been overly complex.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
