### PR TITLE
 Upgrade luftdaten to 0.6.1

### DIFF
--- a/homeassistant/components/luftdaten/manifest.json
+++ b/homeassistant/components/luftdaten/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/luftdaten",
   "requirements": [
-    "luftdaten==0.6.0"
+    "luftdaten==0.6.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/luftdaten/manifest.json
+++ b/homeassistant/components/luftdaten/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/luftdaten",
   "requirements": [
-    "luftdaten==0.3.4"
+    "luftdaten==0.6.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -725,7 +725,7 @@ logi_circle==0.2.2
 london-tube-status==0.2
 
 # homeassistant.components.luftdaten
-luftdaten==0.3.4
+luftdaten==0.6.0
 
 # homeassistant.components.lupusec
 lupupy==0.0.17

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -725,7 +725,7 @@ logi_circle==0.2.2
 london-tube-status==0.2
 
 # homeassistant.components.luftdaten
-luftdaten==0.6.0
+luftdaten==0.6.1
 
 # homeassistant.components.lupusec
 lupupy==0.0.17

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -185,7 +185,7 @@ libpurecool==0.5.0
 libsoundtouch==0.7.2
 
 # homeassistant.components.luftdaten
-luftdaten==0.3.4
+luftdaten==0.6.0
 
 # homeassistant.components.mythicbeastsdns
 mbddns==0.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -185,7 +185,7 @@ libpurecool==0.5.0
 libsoundtouch==0.7.2
 
 # homeassistant.components.luftdaten
-luftdaten==0.6.0
+luftdaten==0.6.1
 
 # homeassistant.components.mythicbeastsdns
 mbddns==0.1.2


### PR DESCRIPTION
## Breaking Change:

The under-laying Python module is now limited to the P1 (particles 10 microns and below) and P2  (particles 2.5 microns and below). This means that you have to recreate your sensors.

## Description:
Changelog: https://github.com/fabaff/python-luftdaten/blob/master/CHANGES.rst#20190625---061

Especially, better handling of empty API responses which was fixed by @jvanderneutstulen

**Related issue (if applicable):**

- fixes #19981
- fixes #23645
- fixes #21680

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ x I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
