### PR TITLE
Upgrade jinja2 to >=2.10.1

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -12,7 +12,7 @@ distro==1.4.0
 hass-nabucasa==0.15
 home-assistant-frontend==20190627.0
 importlib-metadata==0.15
-jinja2>=2.10
+jinja2>=2.10.1
 netdisco==2.6.0
 pip>=8.0.3
 python-slugify==3.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ attrs==19.1.0
 bcrypt==3.1.6
 certifi>=2018.04.16
 importlib-metadata==0.15
-jinja2>=2.10
+jinja2>=2.10.1
 PyJWT==1.7.1
 cryptography==2.6.1
 pip>=8.0.3

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIRES = [
     'bcrypt==3.1.6',
     'certifi>=2018.04.16',
     'importlib-metadata==0.15',
-    'jinja2>=2.10',
+    'jinja2>=2.10.1',
     'PyJWT==1.7.1',
     # PyJWT has loose dependency. We want the latest one.
     'cryptography==2.6.1',


### PR DESCRIPTION
## Description:
Changelog: https://github.com/pallets/jinja/blob/master/CHANGES.rst#version-2101

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
