### PR TITLE
Added covers to the velbus component with autodicovery, bumped python…

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -38,6 +38,7 @@ async def async_setup(hass, config):
     def callback():
         modules = controller.get_modules()
         discovery_info = {
+            'cover': [],
             'switch': [],
             'binary_sensor': [],
             'climate': [],
@@ -59,6 +60,8 @@ async def async_setup(hass, config):
                       discovery_info['binary_sensor'], config)
         load_platform(hass, 'sensor', DOMAIN,
                       discovery_info['sensor'], config)
+        load_platform(hass, 'cover', DOMAIN,
+                      discovery_info['cover'], config)
 
     def syn_clock(self, service=None):
         controller.sync_clock()

--- a/homeassistant/components/velbus/cover.py
+++ b/homeassistant/components/velbus/cover.py
@@ -1,86 +1,29 @@
 """Support for Velbus covers."""
 import logging
-import time
-
-import voluptuous as vol
 
 from homeassistant.components.cover import (
-    PLATFORM_SCHEMA, SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_STOP, CoverDevice)
-from homeassistant.const import CONF_COVERS, CONF_NAME
-import homeassistant.helpers.config_validation as cv
+    CoverDevice, PLATFORM_SCHEMA, SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_STOP)
 
-from . import DOMAIN
+from . import DOMAIN as VELBUS_DOMAIN, VelbusEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-COVER_SCHEMA = vol.Schema({
-    vol.Required('module'): cv.positive_int,
-    vol.Required('open_channel'): cv.positive_int,
-    vol.Required('close_channel'): cv.positive_int,
-    vol.Required(CONF_NAME): cv.string
-})
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_COVERS): cv.schema_with_slug_keys(COVER_SCHEMA),
-})
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up cover controlled by Velbus."""
-    devices = config.get(CONF_COVERS, {})
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up the Velbus xover platform."""
+    if discovery_info is None:
+        return
     covers = []
-
-    velbus = hass.data[DOMAIN]
-    for device_name, device_config in devices.items():
-        covers.append(
-            VelbusCover(
-                velbus,
-                device_config.get(CONF_NAME, device_name),
-                device_config.get('module'),
-                device_config.get('open_channel'),
-                device_config.get('close_channel')
-            )
-        )
-
-    if not covers:
-        _LOGGER.error("No covers added")
-        return False
-
-    add_entities(covers)
+    for cover in discovery_info:
+        module = hass.data[VELBUS_DOMAIN].get_module(cover[0]) 
+        channel = cover[1]
+        covers.append(VelbusCover(module, channel))
+    async_add_entities(covers)
 
 
-class VelbusCover(CoverDevice):
+class VelbusCover(VelbusEntity, CoverDevice):
     """Representation a Velbus cover."""
-
-    def __init__(self, velbus, name, module, open_channel, close_channel):
-        """Initialize the cover."""
-        self._velbus = velbus
-        self._name = name
-        self._close_channel_state = None
-        self._open_channel_state = None
-        self._module = module
-        self._open_channel = open_channel
-        self._close_channel = close_channel
-
-    async def async_added_to_hass(self):
-        """Add listener for Velbus messages on bus."""
-        def _init_velbus():
-            """Initialize Velbus on startup."""
-            self._velbus.subscribe(self._on_message)
-            self.get_status()
-
-        await self.hass.async_add_job(_init_velbus)
-
-    def _on_message(self, message):
-        import velbus
-        if isinstance(message, velbus.RelayStatusMessage):
-            if message.address == self._module:
-                if message.channel == self._close_channel:
-                    self._close_channel_state = message.is_on()
-                    self.schedule_update_ha_state()
-                if message.channel == self._open_channel:
-                    self._open_channel_state = message.is_on()
-                    self.schedule_update_ha_state()
 
     @property
     def supported_features(self):
@@ -88,64 +31,30 @@ class VelbusCover(CoverDevice):
         return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
 
     @property
-    def should_poll(self):
-        """Disable polling."""
-        return False
-
-    @property
-    def name(self):
-        """Return the name of the cover."""
-        return self._name
-
-    @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self._close_channel_state
+        return self._module.is_closed(self._channel)
 
     @property
     def current_cover_position(self):
         """Return current position of cover.
 
-        None is unknown.
+        None is unknown, 0 is closed, 100 is fully open
         """
+        if self._module.is_closed(self._channel):
+            return 0
+        if self._module.is_open(self._channel):
+            return 100
         return None
-
-    def _relay_off(self, channel):
-        import velbus
-        message = velbus.SwitchRelayOffMessage()
-        message.set_defaults(self._module)
-        message.relay_channels = [channel]
-        self._velbus.send(message)
-
-    def _relay_on(self, channel):
-        import velbus
-        message = velbus.SwitchRelayOnMessage()
-        message.set_defaults(self._module)
-        message.relay_channels = [channel]
-        self._velbus.send(message)
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        self._relay_off(self._close_channel)
-        time.sleep(0.3)
-        self._relay_on(self._open_channel)
+        self._module.open(self._channel)
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        self._relay_off(self._open_channel)
-        time.sleep(0.3)
-        self._relay_on(self._close_channel)
+        self._module.close(self._channel)
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self._relay_off(self._open_channel)
-        time.sleep(0.3)
-        self._relay_off(self._close_channel)
-
-    def get_status(self):
-        """Retrieve current status."""
-        import velbus
-        message = velbus.ModuleStatusRequestMessage()
-        message.set_defaults(self._module)
-        message.channels = [self._open_channel, self._close_channel]
-        self._velbus.send(message)
+        self._module.stop(self._channel)

--- a/homeassistant/components/velbus/cover.py
+++ b/homeassistant/components/velbus/cover.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.cover import (
-    CoverDevice, PLATFORM_SCHEMA, SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_STOP)
+    CoverDevice, SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_STOP)
 
 from . import DOMAIN as VELBUS_DOMAIN, VelbusEntity
 
@@ -16,7 +16,7 @@ async def async_setup_platform(
         return
     covers = []
     for cover in discovery_info:
-        module = hass.data[VELBUS_DOMAIN].get_module(cover[0]) 
+        module = hass.data[VELBUS_DOMAIN].get_module(cover[0])
         channel = cover[1]
         covers.append(VelbusCover(module, channel))
     async_add_entities(covers)

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -3,7 +3,7 @@
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/components/velbus",
   "requirements": [
-    "python-velbus==2.0.26"
+    "python-velbus==2.0.27"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1487,7 +1487,7 @@ python-telnet-vlc==1.0.4
 python-twitch-client==0.6.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.26
+python-velbus==2.0.27
 
 # homeassistant.components.vlc
 python-vlc==1.1.2


### PR DESCRIPTION
Added autodicovery for covers in velbus
Bumped the python velbus version

## Breaking Change:
The velbus covers are now autodicoverd

## Description:
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9742

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
