### PR TITLE
Tahoma: Do not reverse open/close calls

### DIFF
--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -19,9 +19,11 @@ ATTR_LOCK_END_TS = 'lock_end_ts'
 ATTR_LOCK_LEVEL = 'lock_level'
 ATTR_LOCK_ORIG = 'lock_originator'
 
+HORIZONTAL_AWNING = 'io:HorizontalAwningIOComponent'
+
 TAHOMA_DEVICE_CLASSES = {
     'io:ExteriorVenetianBlindIOComponent': DEVICE_CLASS_BLIND,
-    'io:HorizontalAwningIOComponent': DEVICE_CLASS_AWNING,
+    HORIZONTAL_AWNING: DEVICE_CLASS_AWNING,
     'io:RollerShutterGenericIOComponent': DEVICE_CLASS_SHUTTER,
     'io:RollerShutterUnoIOComponent': DEVICE_CLASS_SHUTTER,
     'io:RollerShutterVeluxIOComponent': DEVICE_CLASS_SHUTTER,
@@ -130,18 +132,16 @@ class TahomaCover(TahomaDevice, CoverDevice):
         #   _position: 0 is closed, 100 is fully open.
         #   'core:ClosureState': 100 is closed, 0 is fully open.
         if self._closure is not None:
-            if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            if self.tahoma_device.type == HORIZONTAL_AWNING:
                 self._position = self._closure
+                self._closed = self._position == 0
             else:
                 self._position = 100 - self._closure
+                self._closed = self._position == 100
             if self._position <= 5:
                 self._position = 0
             if self._position >= 95:
                 self._position = 100
-            if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-                self._closed = self._position == 0
-            else:
-                self._closed = self._position == 100
         else:
             self._position = None
             if 'core:OpenClosedState' in self.tahoma_device.active_states:
@@ -160,7 +160,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+        if self.tahoma_device.type == HORIZONTAL_AWNING:
             self.apply_action('setPosition', kwargs.get(ATTR_POSITION, 0))
         else:
             self.apply_action('setPosition',
@@ -206,17 +206,11 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-            self.apply_action('close')
-        else:
-            self.apply_action('open')
+        self.apply_action('open')
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-            self.apply_action('open')
-        else:
-            self.apply_action('close')
+        self.apply_action('close')
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -232,7 +226,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
                  'rts:BlindRTSComponent'):
             self.apply_action('my')
         elif self.tahoma_device.type in \
-                ('io:HorizontalAwningIOComponent',
+                (HORIZONTAL_AWNING,
                  'io:RollerShutterGenericIOComponent',
                  'io:VerticalExteriorAwningIOComponent'):
             self.apply_action('stop')


### PR DESCRIPTION
## Breaking Change:

Tahoma: the open/close service functionality works again like in 0.94.

Please test this and let me know if this works. 

## Description:
In 0.95 (via #23257) the issue of horizontal awning having reverse open/close position was addressed. It also included the switching open/close services, which was incorrect, a reported in #24813.

**Related issue (if applicable):** fixes #24813

