### PR TITLE
New google_cloud TTS languages that looks like supported by Google but not documented

### DIFF
--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -22,15 +22,16 @@ CONF_GAIN = 'gain'
 CONF_PROFILES = 'profiles'
 
 SUPPORTED_LANGUAGES = [
-    'da-DK', 'de-DE', 'en-AU', 'en-GB', 'en-US', 'es-ES', 'fr-CA', 'fr-FR',
-    'hu-HU', 'it-IT', 'ja-JP', 'ko-KR', 'nb-NO', 'nl-NL', 'pl-PL', 'pt-BR',
-    'pt-PT', 'ru-RU', 'sk-SK', 'sv-SE', 'tr-TR', 'uk-UA',
+    'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en-AU', 'en-GB', 'en-IN', 'en-US',
+    'es-ES', 'fi-FI', 'fil-PH', 'fr-CA', 'fr-FR', 'hi-IN', 'hu-HU', 'id-ID',
+    'it-IT', 'ja-JP', 'ko-KR', 'nb-NO', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT',
+    'ru-RU', 'sk-SK', 'sv-SE', 'tr-TR', 'uk-UA', 'vi-VN',
 ]
 DEFAULT_LANG = 'en-US'
 
 DEFAULT_GENDER = 'NEUTRAL'
 
-VOICE_REGEX = r'[a-z]{2}-[A-Z]{2}-(Standard|Wavenet)-[A-Z]|'
+VOICE_REGEX = r'[a-z]{2,3}-[A-Z]{2}-(Standard|Wavenet)-[A-Z]|'
 DEFAULT_VOICE = ''
 
 DEFAULT_ENCODING = 'MP3'


### PR DESCRIPTION
## Breaking Change:

Added new google_cloud TTS languages that looks like supported by Google but not documented

## Description:

* Added new languages:
  * **cs-CZ** – Czech, Czech Republic
  * **el-GR** – Modern Greek (1453-), Greece
  * **en-IN** – English, India
  * **fi-FI** – Finnish, Finland
  * **fil-PH** – Filipino, Philippines
  * **hi-IN** – Hindi, India
  * **id-ID** – Indonesian, Indonesia
  * **vi-VN** – Vietnamese, Viet Nam
* Fixed regex expression to match language codes like **fil-PH**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#9753

**Related issue (if applicable):** fixes #24858 (simular)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
