### PR TITLE
Update Watson_TTS to support new neural voices.

### DIFF
--- a/homeassistant/components/watson_tts/tts.py
+++ b/homeassistant/components/watson_tts/tts.py
@@ -22,24 +22,37 @@ CONF_TEXT_TYPE = 'text'
 SUPPORTED_VOICES = [
     "de-DE_BirgitVoice",
     "de-DE_BirgitV2Voice",
+    "de-DE_BirgitV3Voice",
     "de-DE_DieterVoice",
     "de-DE_DieterV2Voice",
+    "de-DE_DieterV3Voice",
     "en-GB_KateVoice",
+    "en-GB_KateV3Voice",
     "en-US_AllisonVoice",
     "en-US_AllisonV2Voice",
+    "en-US_AllisonV3Voice",
     "en-US_LisaVoice",
     "en-US_LisaV2Voice",
+    "en-US_LisaV3Voice",
     "en-US_MichaelVoice",
     "en-US_MichaelV2Voice",
+    "en-US_MichaelV3Voice",
     "es-ES_EnriqueVoice",
+    "es-ES_EnriqueV3Voice",
     "es-ES_LauraVoice",
+    "es-ES_LauraV3Voice",
     "es-LA_SofiaVoice",
+    "es-LA_SofiaV3Voice",
     "es-US_SofiaVoice",
+    "es-US_SofiaV3Voice",
     "fr-FR_ReneeVoice",
+    "fr-FR_ReneeV3Voice",
     "it-IT_FrancescaVoice",
     "it-IT_FrancescaV2Voice",
+    "it-IT_FrancescaV3Voice",
     "ja-JP_EmiVoice",
-    "pt-BR_IsabelaVoice"
+    "pt-BR_IsabelaVoice",
+    "pt-BR_IsabelaV3Voice"
 ]
 
 SUPPORTED_OUTPUT_FORMATS = [


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
