### PR TITLE
Fix home coach discovery

### DIFF
--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/components/netatmo",
   "requirements": [
-    "pyatmo==2.1.0"
+    "pyatmo==2.1.1"
   ],
   "dependencies": [
     "webhook"

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -149,7 +149,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             # Test if manually configured
             if CONF_MODULES in config:
                 module_items = config[CONF_MODULES].items()
+                module_names = data.get_module_names()
                 for module_name, monitored_conditions in module_items:
+                    if module_name not in module_names:
+                        continue
                     for condition in monitored_conditions:
                         dev.append(NetatmoSensor(
                             data, module_name, condition.lower(),
@@ -527,6 +530,8 @@ class NetatmoData:
 
     def get_module_names(self):
         """Return all module available on the API as a list."""
+        if self.station is not None:
+            return self.station_data.modulesNamesList(station=self.station)
         return self.station_data.modulesNamesList()
 
     def update(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ pyalarmdotcom==0.3.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==2.1.0
+pyatmo==2.1.1
 
 # homeassistant.components.apple_tv
 pyatv==0.3.12


### PR DESCRIPTION
## Description:
Fix configuration of multiple home coach devices and discovery of those.
Fix issue with manual configuration of home coach or weather station devices.

**Related issue (if applicable):** fixes #22066 and fixes #23340 and fixes #24793 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html