### PR TITLE
Allow more universal media_player attributes to be overridden by the user

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -214,22 +214,22 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     @property
     def media_content_id(self):
         """Return the content ID of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_ID)
+        return self._override_or_child_attr(ATTR_MEDIA_CONTENT_ID)
 
     @property
     def media_content_type(self):
         """Return the content type of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_TYPE)
+        return self._override_or_child_attr(ATTR_MEDIA_CONTENT_TYPE)
 
     @property
     def media_duration(self):
         """Return the duration of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_DURATION)
+        return self._override_or_child_attr(ATTR_MEDIA_DURATION)
 
     @property
     def media_image_url(self):
         """Image url of current playing media."""
-        return self._child_attr(ATTR_ENTITY_PICTURE)
+        return self._override_or_child_attr(ATTR_ENTITY_PICTURE)
 
     @property
     def entity_picture(self):
@@ -245,62 +245,62 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     @property
     def media_title(self):
         """Title of current playing media."""
-        return self._child_attr(ATTR_MEDIA_TITLE)
+        return self._override_or_child_attr(ATTR_MEDIA_TITLE)
 
     @property
     def media_artist(self):
         """Artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ARTIST)
+        return self._override_or_child_attr(ATTR_MEDIA_ARTIST)
 
     @property
     def media_album_name(self):
         """Album name of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_NAME)
+        return self._override_or_child_attr(ATTR_MEDIA_ALBUM_NAME)
 
     @property
     def media_album_artist(self):
         """Album artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_ARTIST)
+        return self._override_or_child_attr(ATTR_MEDIA_ALBUM_ARTIST)
 
     @property
     def media_track(self):
         """Track number of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_TRACK)
+        return self._override_or_child_attr(ATTR_MEDIA_TRACK)
 
     @property
     def media_series_title(self):
         """Return the title of the series of current playing media (TV)."""
-        return self._child_attr(ATTR_MEDIA_SERIES_TITLE)
+        return self._override_or_child_attr(ATTR_MEDIA_SERIES_TITLE)
 
     @property
     def media_season(self):
         """Season of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_SEASON)
+        return self._override_or_child_attr(ATTR_MEDIA_SEASON)
 
     @property
     def media_episode(self):
         """Episode of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_EPISODE)
+        return self._override_or_child_attr(ATTR_MEDIA_EPISODE)
 
     @property
     def media_channel(self):
         """Channel currently playing."""
-        return self._child_attr(ATTR_MEDIA_CHANNEL)
+        return self._override_or_child_attr(ATTR_MEDIA_CHANNEL)
 
     @property
     def media_playlist(self):
         """Title of Playlist currently playing."""
-        return self._child_attr(ATTR_MEDIA_PLAYLIST)
+        return self._override_or_child_attr(ATTR_MEDIA_PLAYLIST)
 
     @property
     def app_id(self):
         """ID of the current running app."""
-        return self._child_attr(ATTR_APP_ID)
+        return self._override_or_child_attr(ATTR_APP_ID)
 
     @property
     def app_name(self):
         """Name of the current running app."""
-        return self._child_attr(ATTR_APP_NAME)
+        return self._override_or_child_attr(ATTR_APP_NAME)
 
     @property
     def source(self):
@@ -359,12 +359,12 @@ class UniversalMediaPlayer(MediaPlayerDevice):
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_POSITION)
+        return self._override_or_child_attr(ATTR_MEDIA_POSITION)
 
     @property
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        return self._child_attr(ATTR_MEDIA_POSITION_UPDATED_AT)
+        return self._override_or_child_attr(ATTR_MEDIA_POSITION_UPDATED_AT)
 
     def async_turn_on(self):
         """Turn the media player on.


### PR DESCRIPTION
## Description:
Currently, the [`universal` `media_player`](https://www.home-assistant.io/components/universal/) only allows for the `is_volume_muted`, `state`, `source`, `source_list` and `volume_level` attributes to be overridden in the `attributes:` section of the config. 

This PR allows `media_content_id`, `media_content_type`, `media_duration`, `media_image_url` (and thereby `entity_picture`), `media_title`, `media_artist`, `media_album_name`, `media_album_artist`, `media_track`, `media_series_title`, `media_season`, `media_episode`, `media_channel`, `media_playlist`, `app_id`, `app_name`, `media_position`, and `media_position_updated_at` to be overridden in the same way.

Rationale: I needed to override `app_name` so that the custom Lovelace card [`mini-media-player`](https://github.com/kalkih/mini-media-player) would show my chosen source instead of passing through to the Assistant speaker's `app_name` that reports "Default Media Receiver". Because the other attributes listed above are just as easy to allow to be overridden as `app_name`, I included them in this PR instead of leaving them alone with the arbitrary restriction that they must take their value from the active child. That is to say, I don't have a known use case for these but someone else might.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9871

## Example entry for `configuration.yaml` (if applicable):
This is the same as the current documentation's example configuration until the last 4 `attributes`.
```yaml
# Example configuration.yaml entry
media_player:
  - platform: universal
    name: MEDIA_PLAYER_NAME
    children:
      - media_player.CHILD_1_ID
      - media_player.CHILD_2_ID
    commands:
      turn_on:
        service: SERVICE
        data: SERVICE_DATA
      turn_off:
        service: SERVICE
        data: SERVICE_DATA
      volume_up:
        service: SERVICE
        data: SERVICE_DATA
      volume_down:
        service: SERVICE
        data: SERVICE_DATA
      volume_mute:
        service: SERVICE
        data: SERVICE_DATA
    attributes:
      is_volume_muted: ENTITY_ID|ATTRIBUTE
      state: ENTITY_ID|ATTRIBUTE
      app_name: ENTITY_ID|ATTRIBUTE
      media_duration: ENTITY_ID|ATTRIBUTE
      media_position: ENTITY_ID|ATTRIBUTE
      media_position_updated_at: ENTITY_ID|ATTRIBUTE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
