### PR TITLE
Fix 'for' option in state trigger

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -58,7 +58,7 @@ async def async_trigger(hass, config, action, automation_info):
         unsub_track_same[entity] = async_track_same_state(
             hass, time_delta, call_action,
             lambda _, _2, to_state: to_state.state == to_s.state,
-            entity_ids=entity_id)
+            entity_ids=entity)
 
     unsub = async_track_state_change(
         hass, entity_id, state_automation_listener, from_state, to_state)

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -648,3 +648,104 @@ async def test_wait_template_with_trigger(hass, calls):
     assert 1 == len(calls)
     assert 'state - test.entity - hello - world' == \
         calls[0].data['some']
+
+
+async def test_if_fires_on_entities_change_no_overlap(hass, calls):
+    """Test for firing on entities change with no overlap."""
+    assert await async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'trigger': {
+                'platform': 'state',
+                'entity_id': [
+                    'test.entity_1',
+                    'test.entity_2',
+                ],
+                'to': 'world',
+                'for': {
+                    'seconds': 5
+                },
+            },
+            'action': {
+                'service': 'test.automation',
+                'data_template': {
+                    'some': '{{ trigger.entity_id }}',
+                },
+            }
+        }
+    })
+    await hass.async_block_till_done()
+
+    utcnow = dt_util.utcnow()
+    with patch('homeassistant.core.dt_util.utcnow') as mock_utcnow:
+        mock_utcnow.return_value = utcnow
+        hass.states.async_set('test.entity_1', 'world')
+        await hass.async_block_till_done()
+        mock_utcnow.return_value += timedelta(seconds=10)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        await hass.async_block_till_done()
+        assert 1 == len(calls)
+        assert 'test.entity_1' == calls[0].data['some']
+
+        hass.states.async_set('test.entity_2', 'world')
+        await hass.async_block_till_done()
+        mock_utcnow.return_value += timedelta(seconds=10)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        await hass.async_block_till_done()
+        assert 2 == len(calls)
+        assert 'test.entity_2' == calls[1].data['some']
+
+
+async def test_if_fires_on_entities_change_overlap(hass, calls):
+    """Test for firing on entities change with overlap."""
+    assert await async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'trigger': {
+                'platform': 'state',
+                'entity_id': [
+                    'test.entity_1',
+                    'test.entity_2',
+                ],
+                'to': 'world',
+                'for': {
+                    'seconds': 5
+                },
+            },
+            'action': {
+                'service': 'test.automation',
+                'data_template': {
+                    'some': '{{ trigger.entity_id }}',
+                },
+            }
+        }
+    })
+    await hass.async_block_till_done()
+
+    utcnow = dt_util.utcnow()
+    with patch('homeassistant.core.dt_util.utcnow') as mock_utcnow:
+        mock_utcnow.return_value = utcnow
+        hass.states.async_set('test.entity_1', 'world')
+        await hass.async_block_till_done()
+        mock_utcnow.return_value += timedelta(seconds=1)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        hass.states.async_set('test.entity_2', 'world')
+        await hass.async_block_till_done()
+        mock_utcnow.return_value += timedelta(seconds=1)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        hass.states.async_set('test.entity_2', 'hello')
+        await hass.async_block_till_done()
+        mock_utcnow.return_value += timedelta(seconds=1)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        hass.states.async_set('test.entity_2', 'world')
+        await hass.async_block_till_done()
+        assert 0 == len(calls)
+        mock_utcnow.return_value += timedelta(seconds=3)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        await hass.async_block_till_done()
+        assert 1 == len(calls)
+        assert 'test.entity_1' == calls[0].data['some']
+
+        mock_utcnow.return_value += timedelta(seconds=3)
+        async_fire_time_changed(hass, mock_utcnow.return_value)
+        await hass.async_block_till_done()
+        assert 2 == len(calls)
+        assert 'test.entity_2' == calls[1].data['some']


### PR DESCRIPTION
## Description:
Under certain scenarios the `state` trigger does not properly implement the `for` option. E.g., if two or more entities are listed, and one changes to the `to` state, and stays in that state long enough to satisfy the `for` period, but during that time another entity changes to a different state, the "same state period monitoring" for the first entity will be effectively canceled because it sees the new state of the _second_ entity as being a new state for the _first_ entity, and hence concludes it is no longer the "same state."

**Related issue (if applicable):** None

**Related PR:** #24910 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  trigger:
    platform: state
    entity_id: [ENTITY1, ENTITY2]
    to: STATE
    for: PERIOD
```
Consider this sequence:
1. ENTITY1 changes to STATE
2. Before PERIOD expires ENTITY2 changes to a state other than STATE.
3. PERIOD expires.

What _should_ happen is the trigger should fire with:
```
trigger.entity_id = ENTITY1
trigger.to_state.state = STATE
trigger.for = PERIOD
```
However this was not happening. ENTITY1 would have to change to some other state and then back to STATE for the for period to start again.

This fixes it so that it _will_ trigger under these conditions.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
