### PR TITLE
Fix 'for' option in numeric_state trigger

### DIFF
--- a/homeassistant/components/automation/numeric_state.py
+++ b/homeassistant/components/automation/numeric_state.py
@@ -79,7 +79,7 @@ async def async_trigger(hass, config, action, automation_info):
 
             if time_delta:
                 unsub_track_same[entity] = async_track_same_state(
-                    hass, time_delta, call_action, entity_ids=entity_id,
+                    hass, time_delta, call_action, entity_ids=entity,
                     async_check_same_func=check_numeric_state)
             else:
                 call_action()


### PR DESCRIPTION
## Description:
Under certain scenarios the `numeric_state` trigger does not properly implement the `for` option. E.g., if two or more entities are listed, and one changes to a value that meets the `above` and/or `below` options, and maintains a value that meets that criteria long enough to satisfy the `for` period, but during that time another entity changes to a value that does _not_ meet the `above`/`below` criteria, the "same state period monitoring" for the first entity will be effectively canceled because it sees the new state of the _second_ entity as being a new state for the _first_ entity, and hence concludes it is no longer meeting the criteria.

**Related issue (if applicable):** None

**Related PR:** #24904 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  trigger:
    platform: numeric_state
    entity_id: [ENTITY1, ENTITY2]
    above: VALUE
    for: PERIOD
```
Consider this sequence:
1. ENTITY1 changes to a value that is above VALUE
2. Before PERIOD expires ENTITY2 changes to a value that is _not_ above VALUE.
3. PERIOD expires.

What _should_ happen is the trigger should fire with:
```
trigger.entity_id = ENTITY1
```
However this was not happening. ENTITY1 would have to change to a value that is _not_ above VALUE and then back to a value that _is_ above VALUE for the for period to start again.

This fixes it so that it _will_ trigger under these conditions.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
