### PR TITLE
Add template support to state trigger's for option

### DIFF
--- a/homeassistant/components/automation/state.py
+++ b/homeassistant/components/automation/state.py
@@ -1,11 +1,16 @@
 """Offer state listening automation rules."""
+import logging
+
 import voluptuous as vol
 
+from homeassistant import exceptions
 from homeassistant.core import callback
 from homeassistant.const import MATCH_ALL, CONF_PLATFORM, CONF_FOR
+from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.event import (
     async_track_state_change, async_track_same_state)
-import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_ENTITY_ID = 'entity_id'
 CONF_FROM = 'from'
@@ -17,7 +22,9 @@ TRIGGER_SCHEMA = vol.All(vol.Schema({
     # These are str on purpose. Want to catch YAML conversions
     vol.Optional(CONF_FROM): str,
     vol.Optional(CONF_TO): str,
-    vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_FOR): vol.Any(
+        vol.All(cv.time_period, cv.positive_timedelta),
+        cv.template, cv.template_complex),
 }), cv.key_dependency(CONF_FOR, CONF_TO))
 
 
@@ -27,8 +34,10 @@ async def async_trigger(hass, config, action, automation_info):
     from_state = config.get(CONF_FROM, MATCH_ALL)
     to_state = config.get(CONF_TO, MATCH_ALL)
     time_delta = config.get(CONF_FOR)
+    template.attach(hass, time_delta)
     match_all = (from_state == MATCH_ALL and to_state == MATCH_ALL)
     unsub_track_same = {}
+    period = {}
 
     @callback
     def state_automation_listener(entity, from_s, to_s):
@@ -42,7 +51,7 @@ async def async_trigger(hass, config, action, automation_info):
                     'entity_id': entity,
                     'from_state': from_s,
                     'to_state': to_s,
-                    'for': time_delta,
+                    'for': time_delta if not time_delta else period[entity]
                 }
             }, context=to_s.context))
 
@@ -55,8 +64,38 @@ async def async_trigger(hass, config, action, automation_info):
             call_action()
             return
 
+        variables = {
+            'trigger': {
+                'platform': 'state',
+                'entity_id': entity,
+                'from_state': from_s,
+                'to_state': to_s,
+            }
+        }
+
+        try:
+            if isinstance(time_delta, template.Template):
+                period[entity] = vol.All(
+                    cv.time_period,
+                    cv.positive_timedelta)(
+                        time_delta.async_render(variables))
+            elif isinstance(time_delta, dict):
+                time_delta_data = {}
+                time_delta_data.update(
+                    template.render_complex(time_delta, variables))
+                period[entity] = vol.All(
+                    cv.time_period,
+                    cv.positive_timedelta)(
+                        time_delta_data)
+            else:
+                period[entity] = time_delta
+        except (exceptions.TemplateError, vol.Invalid) as ex:
+            _LOGGER.error("Error rendering '%s' for template: %s",
+                          automation_info['name'], ex)
+            return
+
         unsub_track_same[entity] = async_track_same_state(
-            hass, time_delta, call_action,
+            hass, period[entity], call_action,
             lambda _, _2, to_state: to_state.state == to_s.state,
             entity_ids=entity)
 


### PR DESCRIPTION
## Description:
Allow the use of templates with the state trigger's `for` option.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9762

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  - alias: Use template in trigger's for option
    trigger:
      platform: state
      entity_id: sensor.a
      to: some_state
      for:
        minutes: "{{ states('input_number.minutes')|int }}"
        seconds: "{{ states('input_number.seconds')|int }}"
      action:
        ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
