### PR TITLE
Migrate Homematic IP Cloud to climate-1.0

### DIFF
--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -51,6 +51,9 @@ PRESET_HOME = 'home'
 # Device is prepared for sleep
 PRESET_SLEEP = 'sleep'
 
+# Device is in manual mode
+PRESET_MANUAL = 'manual'
+
 
 # Possible fan state
 FAN_ON = "on"

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -119,7 +119,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         if self._device.controlMode == HMIP_ECO_CM:
             return PRESET_ECO
         if self._home.get_functionalHome(IndoorClimateHome).absenceType \
-                in [AbsenceType.PERIOD, AbsenceType.PERMANENT, 
+                in [AbsenceType.PERIOD, AbsenceType.PERMANENT,
                     AbsenceType.VACATION]:
             return PRESET_AWAY
 

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -90,6 +90,8 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         Need to be one of HVAC_MODE_*.
         """
         if self._device.boostMode:
+            return HVAC_MODE_AUTO
+        if self._device.controlMode == HMIP_MANUAL_CM:
             return HVAC_MODE_HEAT
 
         return HVAC_MODE_AUTO
@@ -117,7 +119,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         if self._device.controlMode == HMIP_ECO_CM:
             return PRESET_ECO
         if self._home.get_functionalHome(IndoorClimateHome).absenceType \
-                != AbsenceType.NOT_ABSENT:
+                in [AbsenceType.PERIOD, AbsenceType.PERMANENT , AbsenceType.VACATION]:
             return PRESET_AWAY
 
         return None

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -1,14 +1,18 @@
 """Support for HomematicIP Cloud climate devices."""
 import logging
+from typing import Awaitable
 
 from homematicip.aio.device import (
     AsyncHeatingThermostat, AsyncHeatingThermostatCompact)
 from homematicip.aio.group import AsyncHeatingGroup
 from homematicip.aio.home import AsyncHome
+from homematicip.base.enums import AbsenceType
+from homematicip.functionalHomes import IndoorClimateHome
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO, STATE_MANUAL, SUPPORT_TARGET_TEMPERATURE)
+    HVAC_MODE_AUTO, HVAC_MODE_HEAT, PRESET_AWAY, PRESET_BOOST, PRESET_COMFORT,
+    PRESET_ECO, PRESET_MANUAL, SUPPORT_PRESET_MODE, SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
@@ -17,12 +21,9 @@ from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-HA_STATE_TO_HMIP = {
-    HVAC_MODE_AUTO: 'AUTOMATIC',
-    STATE_MANUAL: 'MANUAL',
-}
-
-HMIP_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_HMIP.items()}
+HMIP_AUTOMATIC_CM = 'AUTOMATIC'
+HMIP_MANUAL_CM = 'MANUAL'
+HMIP_ECO_CM = 'ECO'
 
 
 async def async_setup_platform(
@@ -63,7 +64,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
     @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
-        return SUPPORT_TARGET_TEMPERATURE
+        return SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE
 
     @property
     def target_temperature(self) -> float:
@@ -84,8 +85,50 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     @property
     def hvac_mode(self) -> str:
-        """Return current operation ie. automatic or manual."""
-        return HMIP_STATE_TO_HA.get(self._device.controlMode)
+        """Return hvac operation ie. heat, cool mode.
+
+        Need to be one of HVAC_MODE_*.
+        """
+        if self._device.boostMode:
+            return HVAC_MODE_HEAT
+
+        return HVAC_MODE_AUTO
+
+    @property
+    def hvac_modes(self):
+        """Return the list of available hvac operation modes.
+
+        Need to be a subset of HVAC_MODES.
+        """
+        return [HVAC_MODE_AUTO, HVAC_MODE_HEAT]
+
+    @property
+    def preset_mode(self):
+        """Return the current preset mode, e.g., home, away, temp.
+
+        Requires SUPPORT_PRESET_MODE.
+        """
+        if self._device.boostMode:
+            return PRESET_BOOST
+        if self._device.controlMode == HMIP_AUTOMATIC_CM:
+            return PRESET_COMFORT
+        if self._device.controlMode == HMIP_MANUAL_CM:
+            return PRESET_MANUAL
+        if self._device.controlMode == HMIP_ECO_CM:
+            return PRESET_ECO
+        if self._home.get_functionalHome(IndoorClimateHome).absenceType \
+                != AbsenceType.NOT_ABSENT:
+            return PRESET_AWAY
+
+        return None
+
+    @property
+    def preset_modes(self):
+        """Return a list of available preset modes.
+
+        Requires SUPPORT_PRESET_MODE.
+        """
+        return [PRESET_BOOST, PRESET_COMFORT, PRESET_MANUAL]
 
     @property
     def min_temp(self) -> float:
@@ -103,6 +146,22 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         if temperature is None:
             return
         await self._device.set_point_temperature(temperature)
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> Awaitable[None]:
+        """Set new target hvac mode."""
+        if hvac_mode == HVAC_MODE_AUTO:
+            await self._device.set_control_mode(HMIP_AUTOMATIC_CM)
+        else:
+            await self._device.set_control_mode(HMIP_MANUAL_CM)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> Awaitable[None]:
+        """Set new preset mode."""
+        if preset_mode == PRESET_BOOST:
+            await self._device.set_boost()
+        elif preset_mode == PRESET_COMFORT:
+            await self._device.set_control_mode(HMIP_AUTOMATIC_CM)
+        elif preset_mode == PRESET_MANUAL:
+            await self._device.set_control_mode(HMIP_MANUAL_CM)
 
 
 def _get_first_heating_thermostat(heating_group: AsyncHeatingGroup):

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -119,7 +119,8 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         if self._device.controlMode == HMIP_ECO_CM:
             return PRESET_ECO
         if self._home.get_functionalHome(IndoorClimateHome).absenceType \
-                in [AbsenceType.PERIOD, AbsenceType.PERMANENT , AbsenceType.VACATION]:
+                in [AbsenceType.PERIOD, AbsenceType.PERMANENT, 
+                    AbsenceType.VACATION]:
             return PRESET_AWAY
 
         return None


### PR DESCRIPTION
## Description:
This is the initial PR to migrate HmIP climate to 1.0.

PRESET_AWAY and PRESET_ECO should be displayed per device, but these modes cannot be set on a device level. A service to control PRESET_AWAY and PRESET_ECO might be added in a follow up PR.

The HmIP Climate device has a PRESET manual mode. In this mode the set temperature will be used and no temperature profile will be active.
Thats why i added an additional constant.

As far as i could see there is no corresponding ui implementations for hvac_mode and preset_mode, so it is harder to test.

I hope this PR helps.



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
