### PR TITLE
Migrate incomfort to new climate schema

### DIFF
--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -1,13 +1,14 @@
 """Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
+from typing import Awaitable, Dict, Optional, List
+
 from homeassistant.components.climate import ClimateDevice
-from homeassistant.components.climate.const import SUPPORT_TARGET_TEMPERATURE
-from homeassistant.const import (ATTR_TEMPERATURE, TEMP_CELSIUS)
+from homeassistant.components.climate.const import (
+    HVAC_MODE_HEAT, SUPPORT_TARGET_TEMPERATURE)
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import DOMAIN
-
-INTOUCH_SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
 INTOUCH_MAX_TEMP = 30.0
 INTOUCH_MIN_TEMP = 5.0
@@ -40,51 +41,67 @@ class InComfortClimate(ClimateDevice):
         self.async_schedule_update_ha_state(force_refresh=True)
 
     @property
-    def name(self):
+    def should_poll(self) -> bool:
+        """Return False as this device should never be polled."""
+        return False
+
+    @property
+    def name(self) -> str:
         """Return the name of the climate device."""
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def device_state_attributes(self) -> Dict:
         """Return the device state attributes."""
         return {'status': self._room.status}
 
     @property
-    def current_temperature(self):
-        """Return the current temperature."""
-        return self._room.room_temp
-
-    @property
-    def target_temperature(self):
-        """Return the temperature we try to reach."""
-        return self._room.override
-
-    @property
-    def min_temp(self):
-        """Return max valid temperature that can be set."""
-        return INTOUCH_MIN_TEMP
-
-    @property
-    def max_temp(self):
-        """Return max valid temperature that can be set."""
-        return INTOUCH_MAX_TEMP
-
-    @property
-    def temperature_unit(self):
+    def temperature_unit(self) -> str:
         """Return the unit of measurement."""
         return TEMP_CELSIUS
 
     @property
-    def supported_features(self):
-        """Return the list of supported features."""
-        return INTOUCH_SUPPORT_FLAGS
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode.
 
-    async def async_set_temperature(self, **kwargs):
+        Need to be one of HVAC_MODE_*.
+        """
+        return HVAC_MODE_HEAT
+
+    @property
+    def hvac_modes(self) -> List[str]:
+        """Return the list of available hvac operation modes.
+
+        Need to be a subset of HVAC_MODES.
+        """
+        return [HVAC_MODE_HEAT]
+
+    @property
+    def current_temperature(self) -> Optional[float]:
+        """Return the current temperature."""
+        return self._room.room_temp
+
+    @property
+    def target_temperature(self) -> Optional[float]:
+        """Return the temperature we try to reach."""
+        return self._room.override
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+        return SUPPORT_TARGET_TEMPERATURE
+
+    @property
+    def min_temp(self) -> float:
+        """Return max valid temperature that can be set."""
+        return INTOUCH_MIN_TEMP
+
+    @property
+    def max_temp(self) -> float:
+        """Return max valid temperature that can be set."""
+        return INTOUCH_MAX_TEMP
+
+    async def async_set_temperature(self, **kwargs) -> Awaitable[None]:
         """Set a new target temperature for this zone."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
-
-    @property
-    def should_poll(self) -> bool:
-        """Return False as this device should never be polled."""
-        return False

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -101,7 +101,11 @@ class InComfortClimate(ClimateDevice):
         """Return max valid temperature that can be set."""
         return INTOUCH_MAX_TEMP
 
-    async def async_set_temperature(self, **kwargs) -> Awaitable[None]:
+    async def async_set_temperature(self, **kwargs) -> None:
         """Set a new target temperature for this zone."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
+
+     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        pass


### PR DESCRIPTION
## Breaking Change:

None known

## Description:
Migrates **incomfort** to `climate-1.0`

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
