### PR TITLE
Add template capability to blink.save_video service

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -61,7 +61,7 @@ SERVICE_TRIGGER_SCHEMA = vol.Schema({
 
 SERVICE_SAVE_VIDEO_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    vol.Required(CONF_FILENAME): cv.string,
+    vol.Required(CONF_FILENAME): cv.template,
 })
 
 CONFIG_SCHEMA = vol.Schema(
@@ -139,7 +139,11 @@ def setup(hass, config):
 async def async_handle_save_video_service(hass, call):
     """Handle save video service calls."""
     camera_name = call.data[CONF_NAME]
-    video_path = call.data[CONF_FILENAME]
+    filename = call.data[CONF_FILENAME]
+    filename.hass = hass
+
+    video_path = filename.async_render()
+    _LOGGER.debug("Video path: %s", video_path)
     if not hass.config.is_allowed_path(video_path):
         _LOGGER.error(
             "Can't write %s, no access to path!", video_path)

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -143,7 +143,6 @@ async def async_handle_save_video_service(hass, call):
     filename.hass = hass
 
     video_path = filename.async_render()
-    _LOGGER.debug("Video path: %s", video_path)
     if not hass.config.is_allowed_path(video_path):
         _LOGGER.error(
             "Can't write %s, no access to path!", video_path)


### PR DESCRIPTION
## Description:
Updates the `blink.save_video` service to allow templating, rather than just a string.  This was the original intent for the service, I just screwed it up the first time 😄  (and the docs already assume templates are allowed, so they do not need updating)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
