### PR TITLE
Allow updating of via_device in device registry

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -138,12 +138,12 @@ class DeviceRegistry:
     def async_update_device(
             self, device_id, *, area_id=_UNDEF,
             name=_UNDEF, name_by_user=_UNDEF,
-            new_identifiers=_UNDEF):
+            new_identifiers=_UNDEF, via_device_id=_UNDEF):
         """Update properties of a device."""
         return self._async_update_device(
             device_id, area_id=area_id,
             name=name, name_by_user=name_by_user,
-            new_identifiers=new_identifiers)
+            new_identifiers=new_identifiers, via_device_id=via_device_id)
 
     @callback
     def _async_update_device(self, device_id, *, add_config_entry_id=_UNDEF,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -395,7 +395,7 @@ async def test_format_mac(registry):
 
 
 async def test_update(registry):
-    """Verify that we can update area_id of a device."""
+    """Verify that we can update some attributes of a device."""
     entry = registry.async_get_or_create(
         config_entry_id='1234',
         connections={
@@ -412,13 +412,14 @@ async def test_update(registry):
     with patch.object(registry, 'async_schedule_save') as mock_save:
         updated_entry = registry.async_update_device(
             entry.id, area_id='12345A', name_by_user='Test Friendly Name',
-            new_identifiers=new_identifiers)
+            new_identifiers=new_identifiers, via_device_id='98765B')
 
     assert mock_save.call_count == 1
     assert updated_entry != entry
     assert updated_entry.area_id == '12345A'
     assert updated_entry.name_by_user == 'Test Friendly Name'
     assert updated_entry.identifiers == new_identifiers
+    assert updated_entry.via_device_id == '98765B'
 
 
 async def test_loading_race_condition(hass):


### PR DESCRIPTION
# Description:

This PR allows `via_device_id` to be changed in the device registry. This is useful when devices may switch between hubs.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
