### PR TITLE
Update dublin bus transport url

### DIFF
--- a/homeassistant/components/dublin_bus_transport/sensor.py
+++ b/homeassistant/components/dublin_bus_transport/sensor.py
@@ -117,7 +117,9 @@ class DublinPublicTransportSensor(Entity):
         return ICON
 
     def update(self):
-        """Get the latest data from opendata.ch and update the states."""
+        """
+        Get the latest data from data.smartdublin.ie and update the states.
+        """
         self.data.update()
         self._times = self.data.info
         try:
@@ -138,7 +140,7 @@ class PublicTransportData:
                       ATTR_DUE_IN: 'n/a'}]
 
     def update(self):
-        """Get the latest data from opendata.ch."""
+        """Get the latest data from data.smartdublin.ie."""
         params = {}
         params['stopid'] = self.stop
 

--- a/homeassistant/components/dublin_bus_transport/sensor.py
+++ b/homeassistant/components/dublin_bus_transport/sensor.py
@@ -1,5 +1,5 @@
 """
-Support for Dublin RTPI information from data.dublinked.ie.
+Support for Dublin RTPI information from data.smartdublin.ie.
 
 For more info on the API see :
 https://data.gov.ie/dataset/real-time-passenger-information-rtpi-for-dublin-bus-bus-eireann-luas-and-irish-rail/resource/4b9f2c4f-6bf5-4958-a43a-f12dab04cf61
@@ -20,7 +20,7 @@ from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
-_RESOURCE = 'https://data.dublinked.ie/cgi-bin/rtpi/realtimebusinformation'
+_RESOURCE = 'https://data.smartdublin.ie/cgi-bin/rtpi/realtimebusinformation'
 
 ATTR_STOP_ID = 'Stop ID'
 ATTR_ROUTE = 'Route'
@@ -28,7 +28,7 @@ ATTR_DUE_IN = 'Due in'
 ATTR_DUE_AT = 'Due at'
 ATTR_NEXT_UP = 'Later Bus'
 
-ATTRIBUTION = "Data provided by data.dublinked.ie"
+ATTRIBUTION = "Data provided by data.smartdublin.ie"
 
 CONF_STOP_ID = 'stopid'
 CONF_ROUTE = 'route'


### PR DESCRIPTION
fixes #23911

## Description:
- Url changed, dublinked.ie now redirects to data.smartdublin.ie.
- Fix a docsting

**Related issue (if applicable):** fixes #23911

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9763

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
