### PR TITLE
Add support for Sonos Playlists as Sources

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -368,7 +368,7 @@ class SonosEntity(MediaPlayerDevice):
         self._favorites = [f for f in favorites if f.reference.resources]
         playlists = self.soco.get_sonos_playlists()
         self._favorites.extend(playlists)
-        
+
     def _radio_artwork(self, url):
         """Return the private URL with artwork for a radio stream."""
         if url not in ('', 'NOT_IMPLEMENTED', None):
@@ -529,7 +529,8 @@ class SonosEntity(MediaPlayerDevice):
         # Check if currently playing radio station is in favorites
         self._source_name = None
         for fav in self._favorites:
-            if hasattr(fav, 'reference') and fav.reference.get_uri() == media_info['CurrentURI']:
+            if hasattr(fav, 'reference') and \
+               fav.reference.get_uri() == media_info['CurrentURI']:
                 self._source_name = fav.title
 
     def update_media_music(self, update_media_position, track_info):
@@ -796,7 +797,7 @@ class SonosEntity(MediaPlayerDevice):
                     self.soco.clear_queue()
                     self.soco.add_to_queue(src)
                     self.soco.play_from_queue(0)
-                    
+
     @property
     @soco_coordinator
     def source_list(self):

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -529,8 +529,8 @@ class SonosEntity(MediaPlayerDevice):
         # Check if currently playing radio station is in favorites
         self._source_name = None
         for fav in self._favorites:
-            if hasattr(fav, 'reference') and \
-               fav.reference.get_uri() == media_info['CurrentURI']:
+            if (hasattr(fav, 'reference') and
+                    fav.reference.get_uri() == media_info['CurrentURI']):
                 self._source_name = fav.title
 
     def update_media_music(self, update_media_position, track_info):


### PR DESCRIPTION
## Description:
Adds support for HA to treat a Sonos Playlist (defined in My Sonos in the Sonos App) as a "source" to be played with `media_player.select_source`, the same way that Sonos Favorites are currently handled.  This makes it easy to play a playlist as part of an automation, and lets them appear in the source dropdown in the UI for easy selection.

Generally it was just a matter of grabbing the playlists with the existing call from pysonos, and adding them to the favorites list.  The only issue is playlist objects do not have a `reference` attribute.  I thought it was cleaner to check and make sure that attribute exists in the few places it's used than to maintain two separate lists with almost identical functionality.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
