### PR TITLE
Fixes for incomfort migration to climate-1.0

### DIFF
--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -29,7 +29,7 @@ class InComfortClimate(ClimateDevice):
         self._room = room
         self._name = 'Room {}'.format(room.room_no)
 
-    def async_added_to_hass(self) -> None:
+    async def async_added_to_hass(self) -> Awaitable[None]:
         """Set up a listener when this entity is added to HA."""
         async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
 
@@ -97,6 +97,6 @@ class InComfortClimate(ClimateDevice):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
 
-    def async_set_hvac_mode(self, hvac_mode: str) -> None:
+    async def async_set_hvac_mode(self, hvac_mode: str) -> Awaitable[None]:
         """Set new target hvac mode."""
         pass

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -1,5 +1,5 @@
 """Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
-from typing import Dict, Optional, List
+from typing import Any, Awaitable, Dict, Optional, List
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
@@ -9,9 +9,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import DOMAIN
-
-INTOUCH_MAX_TEMP = 30.0
-INTOUCH_MIN_TEMP = 5.0
 
 
 async def async_setup_platform(hass, hass_config, async_add_entities,
@@ -32,7 +29,7 @@ class InComfortClimate(ClimateDevice):
         self._room = room
         self._name = 'Room {}'.format(room.room_no)
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> Awaitable[None]:
         """Set up a listener when this entity is added to HA."""
         async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
 
@@ -51,7 +48,7 @@ class InComfortClimate(ClimateDevice):
         return self._name
 
     @property
-    def device_state_attributes(self) -> Dict:
+    def device_state_attributes(self) -> Dict[str, Any]:
         """Return the device state attributes."""
         return {'status': self._room.status}
 
@@ -62,18 +59,12 @@ class InComfortClimate(ClimateDevice):
 
     @property
     def hvac_mode(self) -> str:
-        """Return hvac operation ie. heat, cool mode.
-
-        Need to be one of HVAC_MODE_*.
-        """
+        """Return hvac operation ie. heat, cool mode."""
         return HVAC_MODE_HEAT
 
     @property
     def hvac_modes(self) -> List[str]:
-        """Return the list of available hvac operation modes.
-
-        Need to be a subset of HVAC_MODES.
-        """
+        """Return the list of available hvac operation modes."""
         return [HVAC_MODE_HEAT]
 
     @property
@@ -94,18 +85,18 @@ class InComfortClimate(ClimateDevice):
     @property
     def min_temp(self) -> float:
         """Return max valid temperature that can be set."""
-        return INTOUCH_MIN_TEMP
+        return 5.0
 
     @property
     def max_temp(self) -> float:
         """Return max valid temperature that can be set."""
-        return INTOUCH_MAX_TEMP
+        return 30.0
 
-    async def async_set_temperature(self, **kwargs) -> None:
+    async def async_set_temperature(self, **kwargs) -> Awaitable[None]:
         """Set a new target temperature for this zone."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
 
-    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+    async def async_set_hvac_mode(self, hvac_mode: str) -> Awaitable[None]:
         """Set new target hvac mode."""
         pass

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -1,5 +1,5 @@
 """Support for an Intergas boiler via an InComfort/InTouch Lan2RF gateway."""
-from typing import Any, Awaitable, Dict, Optional, List
+from typing import Any, Dict, Optional, List
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -97,6 +97,6 @@ class InComfortClimate(ClimateDevice):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
 
-    async def async_set_hvac_mode(self, hvac_mode: str) -> None]
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
         pass

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -29,7 +29,7 @@ class InComfortClimate(ClimateDevice):
         self._room = room
         self._name = 'Room {}'.format(room.room_no)
 
-    async def async_added_to_hass(self) -> Awaitable[None]:
+    async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
         async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
 
@@ -92,11 +92,11 @@ class InComfortClimate(ClimateDevice):
         """Return max valid temperature that can be set."""
         return 30.0
 
-    async def async_set_temperature(self, **kwargs) -> Awaitable[None]:
+    async def async_set_temperature(self, **kwargs) -> None:
         """Set a new target temperature for this zone."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
 
-    async def async_set_hvac_mode(self, hvac_mode: str) -> Awaitable[None]:
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None]
         """Set new target hvac mode."""
         pass

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -29,7 +29,7 @@ class InComfortClimate(ClimateDevice):
         self._room = room
         self._name = 'Room {}'.format(room.room_no)
 
-    async def async_added_to_hass(self) -> Awaitable[None]:
+    def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
         async_dispatcher_connect(self.hass, DOMAIN, self._refresh)
 
@@ -97,6 +97,6 @@ class InComfortClimate(ClimateDevice):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
 
-    async def async_set_hvac_mode(self, hvac_mode: str) -> Awaitable[None]:
+    def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
         pass


### PR DESCRIPTION
## Breaking Change:

None, but note: WIP

## Description:

Minor fixes for the migration of  climate component of this integration.
 - corrected type hints
 - minor refactors

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
