### PR TITLE
Fix homekit_controller on climate-1.0

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -35,7 +35,7 @@ from .reproduce_state import async_reproduce_states  # noqa
 
 DEFAULT_MIN_TEMP = 7
 DEFAULT_MAX_TEMP = 35
-DEFAULT_MIN_HUMITIDY = 30
+DEFAULT_MIN_HUMIDITY = 30
 DEFAULT_MAX_HUMIDITY = 99
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
@@ -443,7 +443,7 @@ class ClimateDevice(Entity):
     @property
     def min_humidity(self) -> int:
         """Return the minimum humidity."""
-        return DEFAULT_MIN_HUMITIDY
+        return DEFAULT_MIN_HUMIDITY
 
     @property
     def max_humidity(self) -> int:

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -164,14 +164,6 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
     @property
     def state(self):
         """Return the current state."""
-        # If the device reports its operating mode as off, it sometimes doesn't
-        # report a new state.
-        if self._current_mode == HVAC_MODE_OFF:
-            return HVAC_MODE_OFF
-
-        if self._state == HVAC_MODE_OFF and \
-                self._current_mode != HVAC_MODE_OFF:
-            return HVAC_MODE_OFF
         return self._state
 
     @property

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -1,12 +1,12 @@
 """Support for Homekit climate devices."""
 import logging
 
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import (
+    ClimateDevice, DEFAULT_MIN_HUMIDITY, DEFAULT_MAX_HUMIDITY,
+)
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF,
-
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
-    SUPPORT_TARGET_HUMIDITY_HIGH, SUPPORT_TARGET_HUMIDITY_LOW)
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY)
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 
 from . import KNOWN_DEVICES, HomeKitEntity
@@ -62,8 +62,8 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         self._target_humidity = None
         self._min_target_temp = None
         self._max_target_temp = None
-        self._min_target_humidity = None
-        self._max_target_humidity = None
+        self._min_target_humidity = DEFAULT_MIN_HUMIDITY
+        self._max_target_humidity = DEFAULT_MAX_HUMIDITY
         super().__init__(*args)
 
     def get_characteristic_types(self):
@@ -116,11 +116,9 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
 
         if 'minValue' in characteristic:
             self._min_target_humidity = characteristic['minValue']
-            self._features |= SUPPORT_TARGET_HUMIDITY_LOW
 
         if 'maxValue' in characteristic:
             self._max_target_humidity = characteristic['maxValue']
-            self._features |= SUPPORT_TARGET_HUMIDITY_HIGH
 
     def _update_heating_cooling_current(self, value):
         self._state = MODE_HOMEKIT_TO_HASS.get(value)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -11,9 +11,7 @@ import pytest
 
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
-    SUPPORT_TARGET_HUMIDITY_HIGH, SUPPORT_TARGET_HUMIDITY_LOW,
-    SUPPORT_OPERATION_MODE)
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY)
 
 
 from tests.components.homekit_controller.common import (
@@ -36,12 +34,10 @@ async def test_ecobee3_setup(hass):
     climate_state = await climate_helper.poll_and_get_state()
     assert climate_state.attributes['friendly_name'] == 'HomeW'
     assert climate_state.attributes['supported_features'] == (
-        SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_HUMIDITY |
-        SUPPORT_TARGET_HUMIDITY_HIGH | SUPPORT_TARGET_HUMIDITY_LOW |
-        SUPPORT_OPERATION_MODE
+        SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_HUMIDITY
     )
 
-    assert climate_state.attributes['operation_list'] == [
+    assert climate_state.attributes['hvac_modes'] == [
         'off',
         'heat',
         'cool',

--- a/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
+++ b/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
@@ -5,7 +5,7 @@ https://github.com/home-assistant/home-assistant/issues/20885
 """
 
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
+    SUPPORT_TARGET_TEMPERATURE)
 from tests.components.homekit_controller.common import (
     setup_accessories_from_file, setup_test_accessories, Helper
 )
@@ -25,7 +25,7 @@ async def test_lennox_e30_setup(hass):
     climate_state = await climate_helper.poll_and_get_state()
     assert climate_state.attributes['friendly_name'] == 'Lennox'
     assert climate_state.attributes['supported_features'] == (
-        SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
+        SUPPORT_TARGET_TEMPERATURE
     )
 
     device_registry = await hass.helpers.device_registry.async_get_registry()

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -1,6 +1,6 @@
 """Basic checks for HomeKitclimate."""
 from homeassistant.components.climate.const import (
-    DOMAIN, SERVICE_SET_OPERATION_MODE, SERVICE_SET_TEMPERATURE,
+    DOMAIN, SERVICE_SET_HVAC_MODE, SERVICE_SET_TEMPERATURE,
     SERVICE_SET_HUMIDITY)
 from tests.components.homekit_controller.common import (
     FakeService, setup_test_component)
@@ -50,7 +50,7 @@ async def test_climate_respect_supported_op_modes_1(hass, utcnow):
     helper = await setup_test_component(hass, [service])
 
     state = await helper.poll_and_get_state()
-    assert state.attributes['operation_list'] == ['off', 'heat']
+    assert state.attributes['hvac_modes'] == ['off', 'heat']
 
 
 async def test_climate_respect_supported_op_modes_2(hass, utcnow):
@@ -63,7 +63,7 @@ async def test_climate_respect_supported_op_modes_2(hass, utcnow):
     helper = await setup_test_component(hass, [service])
 
     state = await helper.poll_and_get_state()
-    assert state.attributes['operation_list'] == ['off', 'heat', 'cool']
+    assert state.attributes['hvac_modes'] == ['off', 'heat', 'cool']
 
 
 async def test_climate_change_thermostat_state(hass, utcnow):
@@ -72,16 +72,16 @@ async def test_climate_change_thermostat_state(hass, utcnow):
 
     helper = await setup_test_component(hass, [ThermostatService()])
 
-    await hass.services.async_call(DOMAIN, SERVICE_SET_OPERATION_MODE, {
+    await hass.services.async_call(DOMAIN, SERVICE_SET_HVAC_MODE, {
         'entity_id': 'climate.testdevice',
-        'operation_mode': 'heat',
+        'hvac_mode': 'heat',
     }, blocking=True)
 
     assert helper.characteristics[HEATING_COOLING_TARGET].value == 1
 
-    await hass.services.async_call(DOMAIN, SERVICE_SET_OPERATION_MODE, {
+    await hass.services.async_call(DOMAIN, SERVICE_SET_HVAC_MODE, {
         'entity_id': 'climate.testdevice',
-        'operation_mode': 'cool',
+        'hvac_mode': 'cool',
     }, blocking=True)
     assert helper.characteristics[HEATING_COOLING_TARGET].value == 2
 


### PR DESCRIPTION
## Description:

This fixes the tests for homekit_controller climate on the climate-1.0 branch. It also fixes a typo in climate (humitidy vs humidity)

**Related issue (if applicable):**  #23899

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
