### PR TITLE
Rewrite calendar component

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -1,35 +1,29 @@
 """Support for Google Calendar event device sensors."""
-import logging
 from datetime import timedelta
+import logging
 import re
 
 from aiohttp import web
 
-from homeassistant.components.google import (
-    CONF_OFFSET, CONF_DEVICE_ID, CONF_NAME)
+from homeassistant.components import http
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.config_validation import (  # noqa
-    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
-from homeassistant.helpers.config_validation import time_period_str
-from homeassistant.helpers.entity import Entity, generate_entity_id
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE, time_period_str)
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util import dt
-from homeassistant.components import http
-
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'calendar'
-
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
-
 SCAN_INTERVAL = timedelta(seconds=60)
 
 
 async def async_setup(hass, config):
     """Track states and offer events for calendars."""
-    component = EntityComponent(
+    component = hass.data[DOMAIN] = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, DOMAIN)
 
     hass.http.register_view(CalendarListView(component))
@@ -43,10 +37,6 @@ async def async_setup(hass, config):
     return True
 
 
-DEFAULT_CONF_TRACK_NEW = True
-DEFAULT_CONF_OFFSET = '!!'
-
-
 def get_date(date):
     """Get the dateTime from date or dateTime as a local."""
     if 'date' in date:
@@ -55,70 +45,106 @@ def get_date(date):
     return dt.as_local(dt.parse_datetime(date['dateTime']))
 
 
+def normalize_event(event):
+    """Normalize a calendar event."""
+    normalized_event = {}
+
+    start = event.get('start')
+    end = event.get('end')
+    start = get_date(start) if start is not None else None
+    end = get_date(end) if end is not None else None
+    normalized_event['dt_start'] = start
+    normalized_event['dt_end'] = end
+
+    start = start.strftime(DATE_STR_FORMAT) if start is not None else None
+    end = end.strftime(DATE_STR_FORMAT) if end is not None else None
+    normalized_event['start'] = start
+    normalized_event['end'] = end
+
+    # cleanup the string so we don't have a bunch of double+ spaces
+    summary = event.get('summary', '')
+    normalized_event['message'] = re.sub('  +', '', summary).strip()
+    normalized_event['location'] = event.get('location', '')
+    normalized_event['description'] = event.get('description', '')
+    normalized_event['all_day'] = 'date' in event['start']
+
+    return normalized_event
+
+
+def calculate_offset(event, offset):
+    """Calculate event offset.
+
+    Return the updated event with the offset_time included.
+    """
+    summary = event.get('summary', '')
+    # check if we have an offset tag in the message
+    # time is HH:MM or MM
+    reg = '{}([+-]?[0-9]{{0,2}}(:[0-9]{{0,2}})?)'.format(offset)
+    search = re.search(reg, summary)
+    if search and search.group(1):
+        time = search.group(1)
+        if ':' not in time:
+            if time[0] == '+' or time[0] == '-':
+                time = '{}0:{}'.format(time[0], time[1:])
+            else:
+                time = '0:{}'.format(time)
+
+        offset_time = time_period_str(time)
+        summary = (
+            summary[:search.start()] + summary[search.end():]).strip()
+        event['summary'] = summary
+    else:
+        offset_time = dt.dt.timedelta()  # default it
+
+    event['offset_time'] = offset_time
+    return event
+
+
+def is_offset_reached(event):
+    """Have we reached the offset time specified in the event title."""
+    start = get_date(event['start'])
+    if start is None or event['offset_time'] == dt.dt.timedelta():
+        return False
+
+    return start + event['offset_time'] <= dt.now(start.tzinfo)
+
+
 class CalendarEventDevice(Entity):
     """A calendar event device."""
 
-    # Classes overloading this must set data to an object
-    # with an update() method
-    data = None
-
-    def __init__(self, hass, data):
-        """Create the Calendar Event Device."""
-        self._name = data.get(CONF_NAME)
-        self.dev_id = data.get(CONF_DEVICE_ID)
-        self._offset = data.get(CONF_OFFSET, DEFAULT_CONF_OFFSET)
-        self.entity_id = generate_entity_id(
-            ENTITY_ID_FORMAT, self.dev_id, hass=hass)
-
-        self._cal_data = {
-            'all_day': False,
-            'offset_time': dt.dt.timedelta(),
-            'message': '',
-            'start': None,
-            'end': None,
-            'location': '',
-            'description': '',
-        }
-
-        self.update()
-
-    def offset_reached(self):
-        """Have we reached the offset time specified in the event title."""
-        if self._cal_data['start'] is None or \
-           self._cal_data['offset_time'] == dt.dt.timedelta():
-            return False
-
-        return self._cal_data['start'] + self._cal_data['offset_time'] <= \
-            dt.now(self._cal_data['start'].tzinfo)
+    @property
+    def event(self):
+        """Return the next upcoming event."""
+        raise NotImplementedError()
 
     @property
-    def name(self):
-        """Return the name of the entity."""
-        return self._name
+    def state_attributes(self):
+        """Return the entity state attributes."""
+        event = self.event
+        if event is None:
+            return None
 
-    @property
-    def device_state_attributes(self):
-        """Return the device state attributes."""
-        start = self._cal_data.get('start', None)
-        end = self._cal_data.get('end', None)
-        start = start.strftime(DATE_STR_FORMAT) if start is not None else None
-        end = end.strftime(DATE_STR_FORMAT) if end is not None else None
-
+        event = normalize_event(event)
         return {
-            'message': self._cal_data.get('message', ''),
-            'all_day': self._cal_data.get('all_day', False),
-            'offset_reached': self.offset_reached(),
-            'start_time': start,
-            'end_time': end,
-            'location': self._cal_data.get('location', None),
-            'description': self._cal_data.get('description', None),
+            'message': event['message'],
+            'all_day': event['all_day'],
+            'start_time': event['start'],
+            'end_time': event['end'],
+            'location': event['location'],
+            'description': event['description'],
         }
 
     @property
     def state(self):
         """Return the state of the calendar event."""
-        start = self._cal_data.get('start', None)
-        end = self._cal_data.get('end', None)
+        event = self.event
+        if event is None:
+            return STATE_OFF
+
+        event = normalize_event(event)
+        start = event['dt_start']
+        end = event['dt_end']
+
         if start is None or end is None:
             return STATE_OFF
 
@@ -127,65 +153,11 @@ class CalendarEventDevice(Entity):
         if start <= now < end:
             return STATE_ON
 
-        if now >= end:
-            self.cleanup()
-
         return STATE_OFF
 
-    def cleanup(self):
-        """Cleanup any start/end listeners that were setup."""
-        self._cal_data = {
-            'all_day': False,
-            'offset_time': 0,
-            'message': '',
-            'start': None,
-            'end': None,
-            'location': None,
-            'description': None
-        }
-
-    def update(self):
-        """Search for the next event."""
-        if not self.data or not self.data.update():
-            # update cached, don't do anything
-            return
-
-        if not self.data.event:
-            # we have no event to work on, make sure we're clean
-            self.cleanup()
-            return
-
-        start = get_date(self.data.event['start'])
-        end = get_date(self.data.event['end'])
-
-        summary = self.data.event.get('summary', '')
-
-        # check if we have an offset tag in the message
-        # time is HH:MM or MM
-        reg = '{}([+-]?[0-9]{{0,2}}(:[0-9]{{0,2}})?)'.format(self._offset)
-        search = re.search(reg, summary)
-        if search and search.group(1):
-            time = search.group(1)
-            if ':' not in time:
-                if time[0] == '+' or time[0] == '-':
-                    time = '{}0:{}'.format(time[0], time[1:])
-                else:
-                    time = '0:{}'.format(time)
-
-            offset_time = time_period_str(time)
-            summary = (summary[:search.start()] + summary[search.end():]) \
-                .strip()
-        else:
-            offset_time = dt.dt.timedelta()  # default it
-
-        # cleanup the string so we don't have a bunch of double+ spaces
-        self._cal_data['message'] = re.sub('  +', '', summary).strip()
-        self._cal_data['offset_time'] = offset_time
-        self._cal_data['location'] = self.data.event.get('location', '')
-        self._cal_data['description'] = self.data.event.get('description', '')
-        self._cal_data['start'] = start
-        self._cal_data['end'] = end
-        self._cal_data['all_day'] = 'date' in self.data.event['start']
+    async def async_get_events(self, hass, start_date, end_date):
+        """Return calendar events within a datetime range."""
+        raise NotImplementedError()
 
 
 class CalendarEventView(http.HomeAssistantView):
@@ -227,11 +199,11 @@ class CalendarListView(http.HomeAssistantView):
 
     async def get(self, request):
         """Retrieve calendar list."""
-        get_state = request.app['hass'].states.get
+        hass = request.app['hass']
         calendar_list = []
 
         for entity in self.component.entities:
-            state = get_state(entity.entity_id)
+            state = hass.states.get(entity.entity_id)
             calendar_list.append({
                 "name": state.name,
                 "entity_id": entity.entity_id,

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -1,7 +1,6 @@
 """Demo platform that has two fake binary sensors."""
 import copy
 
-from homeassistant.components.google import CONF_DEVICE_ID, CONF_NAME
 import homeassistant.util.dt as dt_util
 
 from homeassistant.components.calendar import CalendarEventDevice, get_date
@@ -12,27 +11,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     calendar_data_future = DemoGoogleCalendarDataFuture()
     calendar_data_current = DemoGoogleCalendarDataCurrent()
     add_entities([
-        DemoGoogleCalendar(hass, calendar_data_future, {
-            CONF_NAME: 'Calendar 1',
-            CONF_DEVICE_ID: 'calendar_1',
-        }),
-
-        DemoGoogleCalendar(hass, calendar_data_current, {
-            CONF_NAME: 'Calendar 2',
-            CONF_DEVICE_ID: 'calendar_2',
-        }),
+        DemoGoogleCalendar(hass, calendar_data_future, 'Calendar 1'),
+        DemoGoogleCalendar(hass, calendar_data_current, 'Calendar 2'),
     ])
 
 
 class DemoGoogleCalendarData:
     """Representation of a Demo Calendar element."""
 
-    event = {}
-
-    # pylint: disable=no-self-use
-    def update(self):
-        """Return true so entity knows we have new data."""
-        return True
+    event = None
 
     async def async_get_events(self, hass, start_date, end_date):
         """Get all events in a specific time frame."""
@@ -84,11 +71,21 @@ class DemoGoogleCalendarDataCurrent(DemoGoogleCalendarData):
 class DemoGoogleCalendar(CalendarEventDevice):
     """Representation of a Demo Calendar element."""
 
-    def __init__(self, hass, calendar_data, data):
-        """Initialize Google Calendar but without the API calls."""
+    def __init__(self, hass, calendar_data, name):
+        """Initialize demo calendar."""
         self.data = calendar_data
-        super().__init__(hass, data)
+        self._name = name
+
+    @property
+    def event(self):
+        """Return the next upcoming event."""
+        return self.data.event
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
 
     async def async_get_events(self, hass, start_date, end_date):
-        """Get all events in a specific time frame."""
+        """Return calendar events within a datetime range."""
         return await self.data.async_get_events(hass, start_date, end_date)

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 from voluptuous.error import Error as VoluptuousError
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.setup import setup_component
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.event import track_time_change
@@ -311,9 +310,6 @@ def do_setup(hass, hass_config, config):
                                         bool, DEFAULT_CONF_TRACK_NEW)
     setup_services(hass, hass_config, track_new_found_calendars,
                    calendar_service)
-
-    # Ensure component is loaded
-    setup_component(hass, 'calendar', config)
 
     for calendar in hass.data[DATA_INDEX].values():
         discovery.load_platform(hass, 'calendar', DOMAIN, calendar,

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -1,13 +1,17 @@
 """Support for Google Calendar Search binary sensors."""
+import copy
 from datetime import timedelta
 import logging
 
-from homeassistant.components.calendar import CalendarEventDevice
+from homeassistant.components.calendar import (
+    ENTITY_ID_FORMAT, CalendarEventDevice, calculate_offset, is_offset_reached)
+from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.util import Throttle, dt
 
 from . import (
-    CONF_CAL_ID, CONF_ENTITIES, CONF_IGNORE_AVAILABILITY, CONF_SEARCH,
-    CONF_TRACK, TOKEN_FILE, CONF_MAX_RESULTS, GoogleCalendarService)
+    CONF_CAL_ID, CONF_DEVICE_ID, CONF_ENTITIES, CONF_IGNORE_AVAILABILITY,
+    CONF_MAX_RESULTS, CONF_NAME, CONF_OFFSET, CONF_SEARCH, CONF_TRACK,
+    DEFAULT_CONF_OFFSET, TOKEN_FILE, GoogleCalendarService)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,26 +33,65 @@ def setup_platform(hass, config, add_entities, disc_info=None):
         return
 
     calendar_service = GoogleCalendarService(hass.config.path(TOKEN_FILE))
-    add_entities([GoogleCalendarEventDevice(hass, calendar_service,
-                                            disc_info[CONF_CAL_ID], data)
-                  for data in disc_info[CONF_ENTITIES] if data[CONF_TRACK]])
+    entities = []
+    for data in disc_info[CONF_ENTITIES]:
+        if not data[CONF_TRACK]:
+            continue
+        entity_id = generate_entity_id(
+            ENTITY_ID_FORMAT, data[CONF_DEVICE_ID], hass=hass)
+        entity = GoogleCalendarEventDevice(
+            calendar_service, disc_info[CONF_CAL_ID], data, entity_id)
+        entities.append(entity)
+
+    add_entities(entities, True)
 
 
 class GoogleCalendarEventDevice(CalendarEventDevice):
     """A calendar event device."""
 
-    def __init__(self, hass, calendar_service, calendar, data):
+    def __init__(self, calendar_service, calendar, data, entity_id):
         """Create the Calendar event device."""
-        self.data = GoogleCalendarData(calendar_service, calendar,
-                                       data.get(CONF_SEARCH),
-                                       data.get(CONF_IGNORE_AVAILABILITY),
-                                       data.get(CONF_MAX_RESULTS))
+        self.data = GoogleCalendarData(
+            calendar_service, calendar,
+            data.get(CONF_SEARCH), data.get(CONF_IGNORE_AVAILABILITY),
+            data.get(CONF_MAX_RESULTS))
+        self._event = None
+        self._name = data[CONF_NAME]
+        self._offset = data.get(CONF_OFFSET, DEFAULT_CONF_OFFSET)
+        self._offset_reached = False
+        self.entity_id = entity_id
 
-        super().__init__(hass, data)
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {
+            'offset_reached': self._offset_reached,
+        }
+
+    @property
+    def event(self):
+        """Return the next upcoming event."""
+        return self._event
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return self._name
 
     async def async_get_events(self, hass, start_date, end_date):
         """Get all events in a specific time frame."""
         return await self.data.async_get_events(hass, start_date, end_date)
+
+    def update(self):
+        """Update event data."""
+        self.data.update()
+        event = copy.deepcopy(self.data.event)
+        if event is None:
+            self._event = event
+            return
+        event = calculate_offset(event, self._offset)
+        self._offset_reached = is_offset_reached(event)
+        self._event = event
 
 
 class GoogleCalendarData:
@@ -71,7 +114,7 @@ class GoogleCalendarData:
         try:
             service = self.calendar_service.get()
         except ServerNotFoundError:
-            _LOGGER.warning("Unable to connect to Google, using cached data")
+            _LOGGER.error("Unable to connect to Google")
             return None, None
         params = dict(DEFAULT_GOOGLE_SEARCH_PARAMS)
         params['calendarId'] = self.calendar_id
@@ -87,7 +130,7 @@ class GoogleCalendarData:
         service, params = await hass.async_add_executor_job(
             self._prepare_query)
         if service is None:
-            return
+            return []
         params['timeMin'] = start_date.isoformat('T')
         params['timeMax'] = end_date.isoformat('T')
 
@@ -111,7 +154,7 @@ class GoogleCalendarData:
         """Get the latest data."""
         service, params = self._prepare_query()
         if service is None:
-            return False
+            return
         params['timeMin'] = dt.now().isoformat('T')
 
         events = service.events()
@@ -131,4 +174,3 @@ class GoogleCalendarData:
                 break
 
         self.event = new_event
-        return True

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -17,6 +17,7 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import async_mock_service
 
+
 GOOGLE_CONFIG = {
     CONF_CLIENT_ID: 'client_id',
     CONF_CLIENT_SECRET: 'client_secret',
@@ -304,7 +305,7 @@ async def test_all_day_offset_event(hass, mock_next_event):
     }
 
 
-async def test_update_false(hass, google_service):
+async def test_update_error(hass, google_service):
     """Test that the calendar handles a server error."""
     google_service.return_value.get = Mock(
         side_effect=httplib2.ServerNotFoundError("unit test"))


### PR DESCRIPTION
## Breaking Change:
The entity state attributes are not reset when the calendar event has passed. The last event attributes will remain until new calendar event info is generated by the integration. Automations that rely on state attributes getting reset will need to be updated.

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
* The calendar integration has been rewritten to follow our current standards. This is the first step in solving https://github.com/home-assistant/architecture/issues/38.
* The change is mostly non breaking. The reset (clean up) of state attributes upon an event time passing has been removed though. It seemed weird to reset the attributes to some arbitrary default values instead of keeping the attributes representing the last event.
* All platforms have been converted.

### Changes:
* Save entity component in hass.data.
* Rename device_state_attributes to state_attributes in base calendar entity.
* Remove offset attribute from base state_attributes.
* Extract offset helpers to calendar component.
* Clean imports.
* Remove stale constants.
* Remove name and add async_get_events.
* Add normalize_event helper function. Copied from #21495.
* Add event property to base entity.
* Use event property for calendar state.
* Ensure event start and end.
* Remove base entity init.
* Temporary keep old start and end datetime format.
* Convert demo calendar.
* Convert google calendar.
* Convert caldav calendar.
* Convert todoist calendar.


**Related issue (if applicable):**
https://github.com/home-assistant/architecture/issues/38

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
