### PR TITLE
Restore automation last_triggered as datetime & fix test

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.loader import bind_hass
-from homeassistant.util.dt import utcnow
+from homeassistant.util.dt import parse_datetime, utcnow
 
 DOMAIN = 'automation'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
@@ -228,6 +228,8 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         if state:
             enable_automation = state.state == STATE_ON
             self._last_triggered = state.attributes.get('last_triggered')
+            if isinstance(self._last_triggered, str):
+                self._last_triggered = parse_datetime(self._last_triggered)
             _LOGGER.debug("Loaded automation %s with state %s from state "
                           " storage last state %s", self.entity_id,
                           enable_automation, state)

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -227,9 +227,9 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         state = await self.async_get_last_state()
         if state:
             enable_automation = state.state == STATE_ON
-            self._last_triggered = state.attributes.get('last_triggered')
-            if isinstance(self._last_triggered, str):
-                self._last_triggered = parse_datetime(self._last_triggered)
+            last_triggered = state.attributes.get('last_triggered')
+            if last_triggered is not None:
+                self._last_triggered = parse_datetime(last_triggered)
             _LOGGER.debug("Loaded automation %s with state %s from state "
                           " storage last state %s", self.entity_id,
                           enable_automation, state)

--- a/tests/common.py
+++ b/tests/common.py
@@ -29,9 +29,11 @@ from homeassistant.const import (
     ATTR_DISCOVERED, ATTR_SERVICE, DEVICE_DEFAULT_NAME,
     EVENT_HOMEASSISTANT_CLOSE, EVENT_PLATFORM_DISCOVERED, EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED, SERVER_PORT, STATE_ON, STATE_OFF)
+from homeassistant.core import State
 from homeassistant.helpers import (
     area_registry, device_registry, entity, entity_platform, entity_registry,
     intent, restore_state, storage)
+from homeassistant.helpers.json import JSONEncoder
 from homeassistant.setup import async_setup_component, setup_component
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.util.async_ import (
@@ -763,9 +765,14 @@ def mock_restore_cache(hass, states):
     data = restore_state.RestoreStateData(hass)
     now = date_util.utcnow()
 
-    data.last_states = {
-        state.entity_id: restore_state.StoredState(state, now)
-        for state in states}
+    last_states = {}
+    for state in states:
+        restored_state = state.as_dict()
+        restored_state['attributes'] = json.loads(json.dumps(
+            restored_state['attributes'], cls=JSONEncoder))
+        last_states[state.entity_id] = restore_state.StoredState(
+            State.from_dict(restored_state), now)
+    data.last_states = last_states
     _LOGGER.debug('Restore cache: %s', data.last_states)
     assert len(data.last_states) == len(states), \
         "Duplicate entity_id? {}".format(states)


### PR DESCRIPTION
## Description:
An automation entity's `last_triggered` attribute is either `None` (when it hasn't triggered), or a `datetime` when it has. However, if the entity is restored after a restart, its `last_triggered` attribute was not being properly restored to a `datetime` (if it was a `datetime`.) Rather, it was being restored in its JSON serialized format, which is an ISO formatted string. This is because `AutomationEntity`'s `async_added_to_hass` method was not parsing it back to a `datetime` (like other code does. E.g., see the `State` class's handling of its `last_updated` and `last_changed` fields.)

Furthermore, the common test function, `mock_restore_cache`, was not properly accounting for what happens to certain data types (such as `datetime`) when they are saved & restored. Hence the bug in `AutomationEntity.async_added_to_hass` was missed.

This PR not only fixes the restoring of the `last_triggered` attribute, but also fixes the common test.

**Related issue (if applicable):**
Although there are no known issues logged due to this problem, there has been plenty of discussion on the community forum about this issue and how to work around it. I have been personally involved in several of them over the last number of months. E.g., templates that should be able to do things like this:
```text
now() - state_attr('automation.xyz', 'last_triggered')
```
have to workaround the possibility that sometimes `last_triggered` is a `datetime`, and sometimes it's an ISO formatted string, and as such, have to first convert everything to a Unix timestamp like this:
```text
as_timestamp(now()) - as_timestamp(state_attr('automation.xyz', 'last_triggered'))
```

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
