### PR TITLE
Update pyHik library to 0.2.3

### DIFF
--- a/homeassistant/components/hikvision/manifest.json
+++ b/homeassistant/components/hikvision/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hikvision",
   "documentation": "https://www.home-assistant.io/components/hikvision",
   "requirements": [
-    "pyhik==0.2.2"
+    "pyhik==0.2.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1152,7 +1152,7 @@ pyhaversion==2.2.1
 pyheos==0.5.2
 
 # homeassistant.components.hikvision
-pyhik==0.2.2
+pyhik==0.2.3
 
 # homeassistant.components.hive
 pyhiveapi==0.2.17


### PR DESCRIPTION
## Description:
Update pyHik library to 0.2.3.  The new version catches an XML parsing error in the camera alert stream fixing a long standing problem with connections going stale.


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
