### PR TITLE
Add missing support for jewish_calendar.omer_count sensor

### DIFF
--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -185,6 +185,8 @@ class JewishCalSensor(Entity):
             self._state = times.havdalah
         elif self.type == 'issur_melacha_in_effect':
             self._state = make_zmanim(now).issur_melacha_in_effect
+        elif self.type == 'omer_count':
+            self._state = date.omer_day
         else:
             times = make_zmanim(today).zmanim
             self._state = times[self.type].time()

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -479,8 +479,8 @@ class TestJewishCalenderSensor():
                               "tzname", "latitude", "longitude", "result"],
                              omer_params, ids=omer_test_ids)
     def test_omer_sensor(self, now, candle_lighting, havdalah,
-                                  diaspora, tzname, latitude, longitude,
-                                  result):
+                         diaspora, tzname, latitude, longitude,
+                         result):
         """Test Omer Count sensor output."""
         time_zone = get_time_zone(tzname)
         set_default_time_zone(time_zone)
@@ -498,4 +498,3 @@ class TestJewishCalenderSensor():
                 sensor.async_update(),
                 self.hass.loop).result()
             assert sensor.state == result
-

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -445,3 +445,53 @@ class TestJewishCalenderSensor():
                 sensor.async_update(),
                 self.hass.loop).result()
             assert sensor.state == result
+
+    omer_params = [
+        make_nyc_test_params(dt(2019, 4, 21, 0, 0), 1),
+        make_jerusalem_test_params(dt(2019, 4, 21, 0, 0), 1),
+        make_nyc_test_params(dt(2019, 5, 23, 0, 0), 33),
+        make_jerusalem_test_params(dt(2019, 5, 23, 0, 0), 33),
+        make_nyc_test_params(dt(2019, 6, 8, 0, 0), 49),
+        make_jerusalem_test_params(dt(2019, 6, 8, 0, 0), 49),
+        make_nyc_test_params(dt(2019, 6, 9, 0, 0), 0),
+        make_jerusalem_test_params(dt(2019, 6, 9, 0, 0), 0),
+        make_nyc_test_params(dt(2019, 1, 1, 0, 0), 0),
+        make_jerusalem_test_params(dt(2019, 1, 1, 0, 0), 0),
+    ]
+    omer_test_ids = [
+        "nyc_first_day_of_omer",
+        "israel_first_day_of_omer",
+        "nyc_lag_baomer",
+        "israel_lag_baomer",
+        "nyc_last_day_of_omer",
+        "israel_last_day_of_omer",
+        "nyc_shavuot_no_omer",
+        "israel_shavuot_no_omer",
+        "nyc_jan_1st_no_omer",
+        "israel_jan_1st_no_omer",
+    ]
+
+    @pytest.mark.parametrize(["now", "candle_lighting", "havdalah", "diaspora",
+                              "tzname", "latitude", "longitude", "result"],
+                             omer_params, ids=omer_test_ids)
+    def test_omer_sensor(self, now, candle_lighting, havdalah,
+                                  diaspora, tzname, latitude, longitude,
+                                  result):
+        """Test Omer Count sensor output."""
+        time_zone = get_time_zone(tzname)
+        set_default_time_zone(time_zone)
+        test_time = time_zone.localize(now)
+        self.hass.config.latitude = latitude
+        self.hass.config.longitude = longitude
+        sensor = JewishCalSensor(
+            name='test', language='english',
+            sensor_type='omer_count',
+            latitude=latitude, longitude=longitude,
+            timezone=time_zone, diaspora=diaspora)
+        sensor.hass = self.hass
+        with patch('homeassistant.util.dt.now', return_value=test_time):
+            run_coroutine_threadsafe(
+                sensor.async_update(),
+                self.hass.loop).result()
+            assert sensor.state == result
+

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -449,6 +449,8 @@ class TestJewishCalenderSensor():
     omer_params = [
         make_nyc_test_params(dt(2019, 4, 21, 0, 0), 1),
         make_jerusalem_test_params(dt(2019, 4, 21, 0, 0), 1),
+        make_nyc_test_params(dt(2019, 4, 21, 23, 0), 2),
+        make_jerusalem_test_params(dt(2019, 4, 21, 23, 0), 2),
         make_nyc_test_params(dt(2019, 5, 23, 0, 0), 33),
         make_jerusalem_test_params(dt(2019, 5, 23, 0, 0), 33),
         make_nyc_test_params(dt(2019, 6, 8, 0, 0), 49),
@@ -461,6 +463,8 @@ class TestJewishCalenderSensor():
     omer_test_ids = [
         "nyc_first_day_of_omer",
         "israel_first_day_of_omer",
+        "nyc_first_day_of_omer_after_tzeit",
+        "israel_first_day_of_omer_after_tzeit",
         "nyc_lag_baomer",
         "israel_lag_baomer",
         "nyc_last_day_of_omer",


### PR DESCRIPTION
## Description:
One sensor that's documented and should be supported is missing from the actual implementation. This PR fixes that.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
