### PR TITLE
Fix monitoring of trays in syncthru component

### DIFF
--- a/homeassistant/components/syncthru/sensor.py
+++ b/homeassistant/components/syncthru/sensor.py
@@ -31,10 +31,10 @@ DEFAULT_MONITORED_CONDITIONS.extend(
     ['drum_{}'.format(key) for key in DRUM_COLORS]
 )
 DEFAULT_MONITORED_CONDITIONS.extend(
-    ['trays_{}'.format(key) for key in TRAYS]
+    ['tray_{}'.format(key) for key in TRAYS]
 )
 DEFAULT_MONITORED_CONDITIONS.extend(
-    ['output_trays_{}'.format(key) for key in OUTPUT_TRAYS]
+    ['output_tray_{}'.format(key) for key in OUTPUT_TRAYS]
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:

Fixes that trays can be monitored by the Samsung syncthru component again. This broke in a recent patch of the component.

**Related issue (if applicable):** fixes #24933 

## Example entry for `configuration.yaml` : stays the same

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
