### PR TITLE
Add missing yeelight models mapping

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -96,6 +96,8 @@ MODEL_TO_DEVICE_TYPE = {
     'color2': BulbType.Color,
     'strip1': BulbType.Color,
     'bslamp1': BulbType.Color,
+    'RGBW': BulbType.Color,
+    'lamp1': BulbType.WhiteTemp,
     'ceiling1': BulbType.WhiteTemp,
     'ceiling2': BulbType.WhiteTemp,
     'ceiling3': BulbType.WhiteTemp,


### PR DESCRIPTION
### Breaking Change:

No breaking changes.

## Description:

Adds support for missing `yeelight` models.

**Related issue (if applicable):**

Fixes #24962

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
