### PR TITLE
Batch of Component(s) -> Integration(s)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 - Make sure you are running the latest version of Home Assistant before reporting an issue: https://github.com/home-assistant/home-assistant/releases
 - Frontend issues should be submitted to the home-assistant-polymer repository: https://github.com/home-assistant/home-assistant-polymer/issues
 - iOS issues should be submitted to the home-assistant-iOS repository: https://github.com/home-assistant/home-assistant-iOS/issues
-- Do not report issues for components if you are using custom components: files in <config-dir>/custom_components
+- Do not report issues for integrations if you are using custom integration: files in <config-dir>/custom_components
 - This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
 - Provide as many details as possible. Paste logs, configuration sample and code into the backticks. Do not delete any text from this template!
 -->

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -9,7 +9,7 @@ about: Create a report to help us improve
 - Make sure you are running the latest version of Home Assistant before reporting an issue: https://github.com/home-assistant/home-assistant/releases
 - Frontend issues should be submitted to the home-assistant-polymer repository: https://github.com/home-assistant/home-assistant-polymer/issues
 - iOS issues should be submitted to the home-assistant-iOS repository: https://github.com/home-assistant/home-assistant-iOS/issues
-- Do not report issues for components if you are using custom components: files in <config-dir>/custom_components
+- Do not report issues for integrations if you are using a custom integration: files in <config-dir>/custom_components
 - This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
 - Provide as many details as possible. Paste logs, configuration sample and code into the backticks. Do not delete any text from this template!
 -->

--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -36,7 +36,7 @@ def is_on(hass, entity_id=None):
             continue
 
         if not hasattr(component, 'is_on'):
-            _LOGGER.warning("Component %s has no is_on method.", domain)
+            _LOGGER.warning("Integration %s has no is_on method.", domain)
             continue
 
         if component.is_on(ent_id):

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -186,7 +186,7 @@ def _get_camera_from_entity_id(hass, entity_id):
     component = hass.data.get(DOMAIN)
 
     if component is None:
-        raise HomeAssistantError('Camera component not set up')
+        raise HomeAssistantError('Camera integration not set up')
 
     camera = component.get_entity(entity_id)
 

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -286,7 +286,7 @@ async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
     """
     _LOGGER.warning(
         'Setting configuration for Cast via platform is deprecated. '
-        'Configure via Cast component instead.')
+        'Configure via Cast integration instead.')
     await _async_setup_platform(
         hass, config, async_add_entities, discovery_info)
 

--- a/homeassistant/components/ebusd/__init__.py
+++ b/homeassistant/components/ebusd/__init__.py
@@ -59,7 +59,7 @@ def setup(hass, config):
         conf.get(CONF_HOST), conf.get(CONF_PORT))
 
     try:
-        _LOGGER.debug("Ebusd component setup started")
+        _LOGGER.debug("Ebusd integration setup started")
         import ebusdpy
         ebusdpy.init(server_address)
         hass.data[DOMAIN] = EbusdData(server_address, circuit)
@@ -74,7 +74,7 @@ def setup(hass, config):
         hass.services.register(
             DOMAIN, SERVICE_EBUSD_WRITE, hass.data[DOMAIN].write)
 
-        _LOGGER.debug("Ebusd component setup completed")
+        _LOGGER.debug("Ebusd integration setup completed")
         return True
     except (socket.timeout, socket.error):
         return False

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -162,7 +162,7 @@ def async_register_built_in_panel(hass, component_name,
     panels = hass.data.setdefault(DATA_PANELS, {})
 
     if panel.frontend_url_path in panels:
-        _LOGGER.warning("Overwriting component %s", panel.frontend_url_path)
+        _LOGGER.warning("Overwriting integration %s", panel.frontend_url_path)
 
     panels[panel.frontend_url_path] = panel
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -62,7 +62,7 @@ def trusted_networks_deprecated(value):
         return value
 
     _LOGGER.warning(
-        "Configuring trusted_networks via the http component has been"
+        "Configuring trusted_networks via the http integration has been"
         " deprecated. Use the trusted networks auth provider instead."
         " For instructions, see https://www.home-assistant.io/docs/"
         "authentication/providers/#trusted-networks")
@@ -75,7 +75,7 @@ def api_password_deprecated(value):
         return value
 
     _LOGGER.warning(
-        "Configuring api_password via the http component has been"
+        "Configuring api_password via the http integration has been"
         " deprecated. Use the legacy api password auth provider instead."
         " For instructions, see https://www.home-assistant.io/docs/"
         "authentication/providers/#legacy-api-password")

--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -154,7 +154,7 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
         data = {ATTR_EVENT: event}
 
         self.hass.services.call(IFTTT_DOMAIN, SERVICE_TRIGGER, data)
-        _LOGGER.debug("Called IFTTT component to trigger event %s", event)
+        _LOGGER.debug("Called IFTTT integration to trigger event %s", event)
         if self._optimistic:
             self._state = state
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -242,7 +242,7 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         component, node_id, object_id = match.groups()
 
         if component not in SUPPORTED_COMPONENTS:
-            _LOGGER.warning("Component %s is not supported", component)
+            _LOGGER.warning("Integration %s is not supported", component)
             return
 
         if payload:

--- a/homeassistant/components/nest/sensor.py
+++ b/homeassistant/components/nest/sensor.py
@@ -77,7 +77,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             if variable in DEPRECATED_WEATHER_VARS:
                 wstr = ("Nest no longer provides weather data like %s. See "
                         "https://home-assistant.io/components/#weather "
-                        "for a list of other weather components to use." %
+                        "for a list of other weather integrations to use." %
                         variable)
             else:
                 wstr = (variable + " is no a longer supported "

--- a/homeassistant/components/nissan_leaf/__init__.py
+++ b/homeassistant/components/nissan_leaf/__init__.py
@@ -471,7 +471,7 @@ class LeafEntity(Entity):
     def log_registration(self):
         """Log registration."""
         _LOGGER.debug(
-            "Registered %s component for VIN %s",
+            "Registered %s integration for VIN %s",
             self.__class__.__name__, self.car.leaf.vin)
 
     @property

--- a/homeassistant/components/nissan_leaf/sensor.py
+++ b/homeassistant/components/nissan_leaf/sensor.py
@@ -81,7 +81,7 @@ class LeafRangeSensor(LeafEntity):
     def log_registration(self):
         """Log registration."""
         _LOGGER.debug(
-            "Registered LeafRangeSensor component with HASS for VIN %s",
+            "Registered LeafRangeSensor integration with HASS for VIN %s",
             self.car.leaf.vin)
 
     @property

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -32,7 +32,7 @@ class LeafClimateSwitch(LeafEntity, ToggleEntity):
     def log_registration(self):
         """Log registration."""
         _LOGGER.debug(
-            "Registered LeafClimateSwitch component with HASS for VIN %s",
+            "Registered LeafClimateSwitch integration with HASS for VIN %s",
             self.car.leaf.vin)
 
     @property

--- a/homeassistant/components/pandora/media_player.py
+++ b/homeassistant/components/pandora/media_player.py
@@ -353,7 +353,7 @@ def _pianobar_exists():
         return True
 
     _LOGGER.warning(
-        "The Pandora component depends on the Pianobar client, which "
+        "The Pandora integration depends on the Pianobar client, which "
         "cannot be found. Please install using instructions at "
         "https://home-assistant.io/components/media_player.pandora/")
     return False

--- a/homeassistant/components/sigfox/sensor.py
+++ b/homeassistant/components/sigfox/sensor.py
@@ -72,7 +72,7 @@ class SigfoxAPI:
                 _LOGGER.error(
                     "Unable to login to Sigfox API, error code %s", str(
                         response.status_code))
-            raise ValueError('Sigfox component not set up')
+            raise ValueError('Sigfox integration not set up')
         return True
 
     def get_device_types(self):

--- a/homeassistant/components/smappee/__init__.py
+++ b/homeassistant/components/smappee/__init__.py
@@ -55,7 +55,7 @@ def setup(hass, config):
                       password, host, host_password)
 
     if not smappee.is_local_active and not smappee.is_remote_active:
-        _LOGGER.error("Neither Smappee server or local component enabled.")
+        _LOGGER.error("Neither Smappee server or local integration enabled.")
         return False
 
     hass.data[DATA_SMAPPEE] = smappee
@@ -85,7 +85,7 @@ class Smappee:
                     "Smappee server authentication failed (%s)",
                     error)
         else:
-            _LOGGER.warning("Smappee server component init skipped.")
+            _LOGGER.warning("Smappee server integration init skipped.")
 
         if host is not None:
             try:
@@ -98,7 +98,7 @@ class Smappee:
                     "Local Smappee device authentication failed (%s)",
                     error)
         else:
-            _LOGGER.warning("Smappee local component init skipped.")
+            _LOGGER.warning("Smappee local integration init skipped.")
 
         self.locations = {}
         self.info = {}

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -63,7 +63,7 @@ async def async_migrate_entry(hass: HomeAssistantType, entry: ConfigEntry):
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Initialize config entry which represents an installed SmartApp."""
     if not validate_webhook_requirements(hass):
-        _LOGGER.warning("The 'base_url' of the 'http' component must be "
+        _LOGGER.warning("The 'base_url' of the 'http' integration must be "
                         "configured and start with 'https://'")
         return False
 

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -44,7 +44,7 @@ def request_stream(hass, stream_source, *, fmt='hls',
                    keepalive=False, options=None):
     """Set up stream with token."""
     if DOMAIN not in hass.config.components:
-        raise HomeAssistantError("Stream component is not set up.")
+        raise HomeAssistantError("Stream integration is not set up.")
 
     if options is None:
         options = {}

--- a/homeassistant/components/zabbix/sensor.py
+++ b/homeassistant/components/zabbix/sensor.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     zapi = hass.data[zabbix.DOMAIN]
     if not zapi:
-        _LOGGER.error("zapi is None. Zabbix component hasn't been loaded?")
+        _LOGGER.error("zapi is None. Zabbix integration hasn't been loaded?")
         return False
 
     _LOGGER.info("Connected to Zabbix API Version %s", zapi.api_version())

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -522,7 +522,7 @@ async def async_process_ha_core_config(
 def _log_pkg_error(
         package: str, component: str, config: Dict, message: str) -> None:
     """Log an error while merging packages."""
-    message = "Package {} setup failed. Component {} {}".format(
+    message = "Package {} setup failed. Integration {} {}".format(
         package, component, message)
 
     pack_config = config[CONF_CORE][CONF_PACKAGES].get(package, config)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -227,7 +227,7 @@ class IntegrationNotFound(LoaderError):
 
     def __init__(self, domain: str) -> None:
         """Initialize a component not found error."""
-        super().__init__("Component {} not found.".format(domain))
+        super().__init__("Integration {} not found.".format(domain))
         self.domain = domain
 
 
@@ -429,7 +429,7 @@ def _async_mount_config_dir(hass,  # type: HomeAssistant
     Async friendly but not a coroutine.
     """
     if hass.config.config_dir is None:
-        _LOGGER.error("Can't load components - config dir is not set")
+        _LOGGER.error("Can't load integrations - config dir is not set")
         return False
     if hass.config.config_dir not in sys.path:
         sys.path.insert(0, hass.config.config_dir)

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -293,7 +293,7 @@ async def check_ha_config_file(hass):
 
     def _pack_error(package, component, config, message):
         """Handle errors from packages: _log_pkg_error."""
-        message = "Package {} setup failed. Component {} {}".format(
+        message = "Package {} setup failed. Integration {} {}".format(
             package, component, message)
         domain = 'homeassistant.packages.{}.{}'.format(package, component)
         pack_config = core_config[CONF_PACKAGES].get(package, config)
@@ -355,7 +355,7 @@ async def check_ha_config_file(hass):
         try:
             component = integration.get_component()
         except ImportError:
-            result.add_error("Component not found: {}".format(domain))
+            result.add_error("Integration not found: {}".format(domain))
             continue
 
         if hasattr(component, 'CONFIG_SCHEMA'):

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -168,10 +168,10 @@ async def _async_setup_component(hass: core.HomeAssistant,
     _LOGGER.info("Setup of domain %s took %.1f seconds.", domain, end - start)
 
     if result is False:
-        log_error("Component failed to initialize.")
+        log_error("Integration failed to initialize.")
         return False
     if result is not True:
-        log_error("Component {!r} did not return boolean if setup was "
+        log_error("Integration {!r} did not return boolean if setup was "
                   "successful. Disabling component.".format(domain))
         return False
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -263,7 +263,7 @@ def gather_requirements_from_manifests(errors, reqs):
 
         if not integration.manifest:
             errors.append(
-                'The manifest for component {} is invalid.'.format(domain)
+                'The manifest for integration {} is invalid.'.format(domain)
             )
             continue
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -329,7 +329,7 @@ mock_mqtt_component = threadsafe_coroutine_factory(async_mock_mqtt_component)
 def mock_component(hass, component):
     """Mock a component is setup."""
     if component in hass.config.components:
-        AssertionError("Component {} is already setup".format(component))
+        AssertionError("Integration {} is already setup".format(component))
 
     hass.config.components.add(component)
 

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -77,7 +77,7 @@ async def test_only_valid_components(hass, mqtt_mock, caplog):
 
     await hass.async_block_till_done()
 
-    assert 'Component {} is not supported'.format(
+    assert 'Integration {} is not supported'.format(
         invalid_component
     ) in caplog.text
 


### PR DESCRIPTION
## Description:

This correct a batch of log occurrences where "component(s)" was used and replaced them by "integration(s)".

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
