### PR TITLE
Prepare Netatmo for climate 1.0

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -1,6 +1,7 @@
 """Support for Netatmo Smart thermostats."""
-import logging
 from datetime import timedelta
+import logging
+from typing import Optional, List
 
 import requests
 import voluptuous as vol
@@ -8,21 +9,55 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT, SUPPORT_ON_OFF, SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_AWAY_MODE, STATE_MANUAL, HVAC_MODE_AUTO,
-    STATE_ECO, HVAC_MODE_COOL, HVAC_MODE_OFF)
+    HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF,
+    PRESET_AWAY,
+    CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE,
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE
+)
 from homeassistant.const import (
-    TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_NAME)
+    TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_NAME, PRECISION_HALVES)
 from homeassistant.util import Throttle
 
 from .const import DATA_NETATMO_AUTH
 
 _LOGGER = logging.getLogger(__name__)
 
+PRESET_FROST_GUARD = 'frost_guard'
+PRESET_MAX = 'max'
+PRESET_OFF = HVAC_MODE_OFF
+PRESET_SCHEDULE = 'schedule'
+
+SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE)
+SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF]
+SUPPORT_PRESET = [
+    PRESET_AWAY, PRESET_FROST_GUARD, PRESET_SCHEDULE, PRESET_MAX, PRESET_OFF
+]
+
+STATE_NETATMO_SCHEDULE = 'schedule'
+STATE_NETATMO_HG = 'hg'
+STATE_NETATMO_MAX = PRESET_MAX
+STATE_NETATMO_AWAY = PRESET_AWAY
+STATE_NETATMO_OFF = PRESET_OFF
+STATE_NETATMO_MANUAL = 'manual'
+
+HVAC_MAP_NETATMO = {
+    STATE_NETATMO_SCHEDULE: HVAC_MODE_AUTO,
+    STATE_NETATMO_HG: HVAC_MODE_AUTO,
+    STATE_NETATMO_MAX: HVAC_MODE_HEAT,
+    STATE_NETATMO_OFF: HVAC_MODE_OFF,
+    STATE_NETATMO_MANUAL: HVAC_MODE_AUTO,
+    STATE_NETATMO_AWAY: HVAC_MODE_AUTO
+}
+
+CURRENT_HVAC_MAP_NETATMO = {
+    True: CURRENT_HVAC_HEAT,
+    False: CURRENT_HVAC_IDLE,
+}
+
 CONF_HOMES = 'homes'
 CONF_ROOMS = 'rooms'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
 
 HOME_CONFIG_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
@@ -32,34 +67,6 @@ HOME_CONFIG_SCHEMA = vol.Schema({
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOMES): vol.All(cv.ensure_list, [HOME_CONFIG_SCHEMA])
 })
-
-STATE_NETATMO_SCHEDULE = 'schedule'
-STATE_NETATMO_HG = 'hg'
-STATE_NETATMO_MAX = 'max'
-STATE_NETATMO_AWAY = 'away'
-STATE_NETATMO_OFF = HVAC_MODE_OFF
-STATE_NETATMO_MANUAL = STATE_MANUAL
-
-DICT_NETATMO_TO_HA = {
-    STATE_NETATMO_SCHEDULE: HVAC_MODE_AUTO,
-    STATE_NETATMO_HG: HVAC_MODE_COOL,
-    STATE_NETATMO_MAX: HVAC_MODE_HEAT,
-    STATE_NETATMO_AWAY: STATE_ECO,
-    STATE_NETATMO_OFF: HVAC_MODE_OFF,
-    STATE_NETATMO_MANUAL: STATE_MANUAL
-}
-
-DICT_HA_TO_NETATMO = {
-    HVAC_MODE_AUTO: STATE_NETATMO_SCHEDULE,
-    HVAC_MODE_COOL: STATE_NETATMO_HG,
-    HVAC_MODE_HEAT: STATE_NETATMO_MAX,
-    STATE_ECO: STATE_NETATMO_AWAY,
-    HVAC_MODE_OFF: STATE_NETATMO_OFF,
-    STATE_MANUAL: STATE_NETATMO_MANUAL
-}
-
-SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE |
-                 SUPPORT_AWAY_MODE)
 
 NA_THERM = 'NATherm1'
 NA_VALVE = 'NRV'
@@ -115,27 +122,26 @@ class NetatmoThermostat(ClimateDevice):
         self._data = data
         self._state = None
         self._room_id = room_id
-        room_name = self._data.homedata.rooms[self._data.home][room_id]['name']
-        self._name = 'netatmo_{}'.format(room_name)
+        self._room_name = self._data.homedata.rooms[
+            self._data.home][room_id]['name']
+        self._name = 'netatmo_{}'.format(self._room_name)
+        self._current_temperature = None
         self._target_temperature = None
+        self._preset = None
         self._away = None
-        self._module_type = self._data.room_status[room_id]['module_type']
-        if self._module_type == NA_VALVE:
-            self._operation_list = [DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG]]
-            self._support_flags = SUPPORT_FLAGS
-        elif self._module_type == NA_THERM:
-            self._operation_list = [DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_MANUAL],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
-                                    DICT_NETATMO_TO_HA[STATE_NETATMO_OFF]]
-            self._support_flags = SUPPORT_FLAGS | SUPPORT_ON_OFF
-        self._operation_mode = None
+        self._operation_list = [HVAC_MODE_AUTO, HVAC_MODE_HEAT]
+        self._support_flags = SUPPORT_FLAGS
+        self._hvac_mode = None
         self.update_without_throttle = False
+
+        try:
+            self._module_type = self._data.room_status[room_id]['module_type']
+        except KeyError:
+            _LOGGER.error("Thermostat in %s not available", room_id)
+        
+        if self._module_type == NA_THERM:
+            self._operation_list.append(HVAC_MODE_OFF)
+
 
     @property
     def supported_features(self):
@@ -155,113 +161,82 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._data.room_status[self._room_id]['current_temperature']
+        return self._current_temperature
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._data.room_status[self._room_id]['target_temperature']
+        return self._target_temperature
+
+    @property
+    def target_temperature_step(self) -> Optional[float]:
+        """Return the supported step of target temperature."""
+        return PRECISION_HALVES
 
     @property
     def hvac_mode(self):
-        """Return the current state of the thermostat."""
-        return self._operation_mode
+        """Return hvac operation ie. heat, cool mode."""
+        return self._hvac_mode
 
     @property
     def hvac_modes(self):
-        """Return the operation modes list."""
-        return self._operation_list
+        """Return the list of available hvac operation modes."""
+        return SUPPORT_HVAC
 
     @property
-    def device_state_attributes(self):
-        """Return device specific state attributes."""
-        module_type = self._data.room_status[self._room_id]['module_type']
-        if module_type not in (NA_THERM, NA_VALVE):
-            return {}
-        state_attributes = {
-            "home_id": self._data.homedata.gethomeId(self._data.home),
-            "room_id": self._room_id,
-            "setpoint_default_duration": self._data.setpoint_duration,
-            "away_temperature": self._data.away_temperature,
-            "hg_temperature": self._data.hg_temperature,
-            "operation_mode": self._operation_mode,
-            "module_type": module_type,
-            "module_id": self._data.room_status[self._room_id]['module_id']
-        }
-        if module_type == NA_THERM:
-            state_attributes["boiler_status"] = self._data.boilerstatus
-        elif module_type == NA_VALVE:
-            state_attributes["heating_power_request"] = \
-                self._data.room_status[self._room_id]['heating_power_request']
-        return state_attributes
+    def hvac_action(self) -> Optional[str]:
+        """Return the current running hvac operation if supported."""
+        if self._module_type == NA_THERM:
+            return CURRENT_HVAC_MAP_NETATMO[self._data.boilerstatus]
+        # Maybe it is a valve
+        if self._data.room_status[self._room_id]['heating_power_request'] > 0:
+            return CURRENT_HVAC_HEAT
+        return CURRENT_HVAC_IDLE
 
-    @property
-    def is_away_mode_on(self):
-        """Return true if away mode is on."""
-        return self._away
+    def set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        mode = None
 
-    @property
-    def is_on(self):
-        """Return true if on."""
-        return self.target_temperature > 0
+        if hvac_mode == HVAC_MODE_OFF:
+            mode = STATE_NETATMO_OFF
+        elif hvac_mode == HVAC_MODE_AUTO:
+            mode = STATE_NETATMO_SCHEDULE
+        elif hvac_mode == HVAC_MODE_HEAT:
+            mode = STATE_NETATMO_MAX
 
-    def turn_away_mode_on(self):
-        """Turn away on."""
-        self.set_operation_mode(DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY])
+        self.set_preset_mode(mode)
 
-    def turn_away_mode_off(self):
-        """Turn away off."""
-        self.set_operation_mode(DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE])
-
-    def turn_off(self):
-        """Turn Netatmo off."""
-        _LOGGER.debug("Switching off ...")
-        self.set_operation_mode(DICT_NETATMO_TO_HA[STATE_NETATMO_OFF])
-        self.update_without_throttle = True
-        self.schedule_update_ha_state()
-
-    def turn_on(self):
-        """Turn Netatmo on."""
-        _LOGGER.debug("Switching on ...")
-        _LOGGER.debug("Setting temperature first to %d ...",
-                      self._data.hg_temperature)
-        self._data.homestatus.setroomThermpoint(
-            self._data.homedata.gethomeId(self._data.home),
-            self._room_id, STATE_NETATMO_MANUAL, self._data.hg_temperature)
-        _LOGGER.debug("Setting operation mode to schedule ...")
-        self._data.homestatus.setThermmode(
-            self._data.homedata.gethomeId(self._data.home),
-            STATE_NETATMO_SCHEDULE)
-        self.update_without_throttle = True
-        self.schedule_update_ha_state()
-
-    def set_hvac_mode(self, hvac_mode):
-        """Set HVAC mode (auto, auxHeatOnly, cool, heat, off)."""
-        if not self.is_on:
-            self.turn_on()
-        if hvac_mode in [DICT_NETATMO_TO_HA[STATE_NETATMO_MAX],
-                         DICT_NETATMO_TO_HA[STATE_NETATMO_OFF]]:
+    def set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if preset_mode in [STATE_NETATMO_MAX, STATE_NETATMO_OFF]:
             self._data.homestatus.setroomThermpoint(
-                self._data.homedata.gethomeId(self._data.home),
-                self._room_id, DICT_HA_TO_NETATMO[hvac_mode])
-        elif hvac_mode in [DICT_NETATMO_TO_HA[STATE_NETATMO_HG],
-                           DICT_NETATMO_TO_HA[STATE_NETATMO_SCHEDULE],
-                           DICT_NETATMO_TO_HA[STATE_NETATMO_AWAY]]:
+                self._data.home_id, self._room_id, preset_mode
+            )
+        elif preset_mode in [
+            STATE_NETATMO_SCHEDULE, STATE_NETATMO_HG, STATE_NETATMO_AWAY
+        ]:
             self._data.homestatus.setThermmode(
-                self._data.homedata.gethomeId(self._data.home),
-                DICT_HA_TO_NETATMO[hvac_mode])
-        self.update_without_throttle = True
-        self.schedule_update_ha_state()
+                self._data.home_id, preset_mode
+            )
+
+    @property
+    def preset_mode(self) -> Optional[str]:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return self._preset
+
+    @property
+    def preset_modes(self) -> Optional[List[str]]:
+        """Return a list of available preset modes."""
+        return SUPPORT_PRESET
 
     def set_temperature(self, **kwargs):
         """Set new target temperature for 2 hours."""
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is None:
             return
-        mode = STATE_NETATMO_MANUAL
         self._data.homestatus.setroomThermpoint(
             self._data.homedata.gethomeId(self._data.home),
-            self._room_id, DICT_HA_TO_NETATMO[mode], temp)
+            self._room_id, STATE_NETATMO_MANUAL, temp)
         self.update_without_throttle = True
         self.schedule_update_ha_state()
 
@@ -277,12 +252,20 @@ class NetatmoThermostat(ClimateDevice):
             _LOGGER.error("NetatmoThermostat::update() "
                           "got exception.")
             return
-        self._target_temperature = \
-            self._data.room_status[self._room_id]['target_temperature']
-        self._operation_mode = DICT_NETATMO_TO_HA[
-            self._data.room_status[self._room_id]['setpoint_mode']]
-        self._away = self._operation_mode == DICT_NETATMO_TO_HA[
-            STATE_NETATMO_AWAY]
+        try:
+            self._current_temperature = \
+                self._data.room_status[self._room_id]['current_temperature']
+            self._target_temperature = \
+                self._data.room_status[self._room_id]['target_temperature']
+            self._preset = \
+                self._data.room_status[self._room_id]["setpoint_mode"]
+        except KeyError:
+            _LOGGER.error(
+                "The thermostat in room %s seems to be out of reach.",
+                self._room_id
+            )
+        self._hvac_mode = HVAC_MAP_NETATMO[self._preset]
+        self._away = self._hvac_mode == HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
 
 
 class HomeData:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -24,20 +24,19 @@ _LOGGER = logging.getLogger(__name__)
 
 PRESET_FROST_GUARD = 'frost_guard'
 PRESET_MAX = 'max'
-PRESET_OFF = None
 PRESET_SCHEDULE = 'schedule'
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE)
 SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF]
 SUPPORT_PRESET = [
-    PRESET_AWAY, PRESET_FROST_GUARD, PRESET_SCHEDULE, PRESET_MAX, PRESET_OFF
+    PRESET_AWAY, PRESET_FROST_GUARD, PRESET_SCHEDULE, PRESET_MAX,
 ]
 
 STATE_NETATMO_SCHEDULE = 'schedule'
 STATE_NETATMO_HG = 'hg'
 STATE_NETATMO_MAX = PRESET_MAX
 STATE_NETATMO_AWAY = PRESET_AWAY
-STATE_NETATMO_OFF = PRESET_OFF
+STATE_NETATMO_OFF = "off"
 STATE_NETATMO_MANUAL = 'manual'
 
 HVAC_MAP_NETATMO = {
@@ -207,7 +206,11 @@ class NetatmoThermostat(ClimateDevice):
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        if preset_mode in [STATE_NETATMO_MAX, STATE_NETATMO_OFF]:
+        if preset_mode is None:
+            self._data.homestatus.setroomThermpoint(
+                self._data.home_id, self._room_id, "off"
+            )
+        if preset_mode == STATE_NETATMO_MAX:
             self._data.homestatus.setroomThermpoint(
                 self._data.home_id, self._room_id, preset_mode
             )

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PRESET_FROST_GUARD = 'frost_guard'
 PRESET_MAX = 'max'
-PRESET_OFF = HVAC_MODE_OFF
+PRESET_OFF = None
 PRESET_SCHEDULE = 'schedule'
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE)
@@ -138,10 +138,9 @@ class NetatmoThermostat(ClimateDevice):
             self._module_type = self._data.room_status[room_id]['module_type']
         except KeyError:
             _LOGGER.error("Thermostat in %s not available", room_id)
-        
+
         if self._module_type == NA_THERM:
             self._operation_list.append(HVAC_MODE_OFF)
-
 
     @property
     def supported_features(self):
@@ -181,7 +180,7 @@ class NetatmoThermostat(ClimateDevice):
     @property
     def hvac_modes(self):
         """Return the list of available hvac operation modes."""
-        return SUPPORT_HVAC
+        return self._operation_list
 
     @property
     def hvac_action(self) -> Optional[str]:


### PR DESCRIPTION
## Description:
Prepare the Netatmo climate component for the big Climate-1.0 change in #23899.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
