### PR TITLE
Add datetime option to input_datetime.set_datetime service

### DIFF
--- a/homeassistant/components/input_datetime/services.yaml
+++ b/homeassistant/components/input_datetime/services.yaml
@@ -3,7 +3,9 @@ set_datetime:
   fields:
     entity_id: {description: Entity id of the input datetime to set the new value.,
       example: input_datetime.test_date_time}
-    date: {description: The target date the entity should be set to.,
+    date: {description: The target date the entity should be set to. Do not use with datetime.,
       example: '"date": "2019-04-22"'}
-    time: {description: The target time the entity should be set to.,
+    time: {description: The target time the entity should be set to. Do not use with datetime.,
       example: '"time": "05:30:00"'}
+    datetime: {description: The target date & time the entity should be set to. Do not use with date or time.,
+      example: '"datetime": "2019-04-22 05:30:00"'}


### PR DESCRIPTION
## Description:
Setting the date & time of an `input_datetime` with fixed values using the `date` and `time` options of the `input_datetime.set_datetime` service works just fine. When using templating, however, it's not as easy. Often it requires repeating much of the template for both options. Worse, if using `now()` or `utcnow()` in the templates, it's possible for the two templates to grab the date/time right before and right after midnight, leading to unexpected, and probably undesirable, results. And although that may be unlikely, it's possible, and if it's possible, it _will_ happen eventually.

This adds a new option -- `datetime` -- that allows both date & time to be set with just one template, avoiding the issues described above.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9791

## Example entry for `configuration.yaml` (if applicable):
```yaml
- service: input_datetime.set_datetime
  entity_id: input_datetime.x
  data_template:
    datetime: "{{ now().strftime('%Y-%d-%m %H:%M:%S') }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
