### PR TITLE
Add homekit_controller support for Door sensor by Aqara

### DIFF
--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -1,7 +1,9 @@
 """Support for Homekit motion sensors."""
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, DEVICE_CLASS_DOOR, DEVICE_CLASS_MOTION
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, DEVICE_CLASS_DOOR, DEVICE_CLASS_MOTION
+)
 
 from . import KNOWN_DEVICES, HomeKitEntity
 

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -19,6 +19,7 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     'window': 'cover',
     'window-covering': 'cover',
     'lock-mechanism': 'lock',
+    'contact': 'binary_sensor',
     'motion': 'binary_sensor',
     'humidity': 'sensor',
     'light': 'sensor',


### PR DESCRIPTION
## Breaking Change:

No breaking changes.

## Description:

Added support of an Aqara Window Door Sensor for the homekit controller integration.
By default this sensor is 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]