### PR TITLE
Fix HmIP climate 1.0 boost mode

### DIFF
--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -112,14 +112,14 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         """
         if self._device.boostMode:
             return PRESET_BOOST
-        if self._device.controlMode == HMIP_AUTOMATIC_CM:
-            return PRESET_COMFORT
-        if self._device.controlMode == HMIP_ECO_CM:
-            return PRESET_ECO
         if (self._home.get_functionalHome(IndoorClimateHome).absenceType
                 in [AbsenceType.PERIOD, AbsenceType.PERMANENT,
                     AbsenceType.VACATION]):
             return PRESET_AWAY
+        if self._device.controlMode == HMIP_AUTOMATIC_CM:
+            return PRESET_COMFORT
+        if self._device.controlMode == HMIP_ECO_CM:
+            return PRESET_ECO
 
         return None
 
@@ -157,6 +157,8 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     async def async_set_preset_mode(self, preset_mode: str) -> Awaitable[None]:
         """Set new preset mode."""
+        if self._device.boostMode and preset_mode != PRESET_BOOST:
+            await self._device.set_boost(False)
         if preset_mode == PRESET_BOOST:
             await self._device.set_boost()
         elif preset_mode == PRESET_COMFORT:


### PR DESCRIPTION
## Description:
After some ui testing:
This fixes the usage of the boost mode.


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
