### PR TITLE
Add spotify service to allow to play music from playlist

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -101,7 +101,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities([player], True)
 
     def play_playlist_service(service):
-        media_content_id = service.data.get(ATTR_MEDIA_CONTENT_ID)
+        media_content_id = service.data[ATTR_MEDIA_CONTENT_ID]
         random_song = service.data.get(ATTR_RANDOM_SONG)
         player.play_playlist(media_content_id, random_song)
 

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -11,7 +11,8 @@ from homeassistant.components.media_player import (
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC, MEDIA_TYPE_PLAYLIST, SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SELECT_SOURCE, SUPPORT_SHUFFLE_SET, SUPPORT_VOLUME_SET, ATTR_MEDIA_CONTENT_ID)
+    SUPPORT_SELECT_SOURCE, SUPPORT_SHUFFLE_SET, SUPPORT_VOLUME_SET,
+    ATTR_MEDIA_CONTENT_ID)
 from homeassistant.const import (
     CONF_NAME, STATE_IDLE, STATE_PAUSED, STATE_PLAYING)
 from homeassistant.core import callback
@@ -102,7 +103,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         player.play_playlist_random_music(media_content_id)
 
     hass.services.register(
-        DOMAIN, SERVICE_PLAY_PLAYLIST_RANDOM_MUSIC, play_playlist_random_music_service,
+        DOMAIN, SERVICE_PLAY_PLAYLIST_RANDOM_MUSIC,
+        play_playlist_random_music_service,
         schema=PLAY_PLAYLIST_RANDOM_MUSIC_SCHEMA)
 
 
@@ -269,7 +271,7 @@ class SpotifyMediaPlayer(MediaPlayerDevice):
         self._player.start_playback(**kwargs)
 
     def play_playlist_random_music(self, media_id, **kwargs):
-        """Play random music in a playlist"""
+        """Play random music in a playlist."""
         if not media_id.startswith('spotify:playlist:'):
             _LOGGER.error("media id must be spotify playlist uri")
             return

--- a/homeassistant/components/spotify/services.yaml
+++ b/homeassistant/components/spotify/services.yaml
@@ -1,6 +1,9 @@
-play_playlist_random_music:
-  description: Play a random music from a Spotify playlist.
+play_playlist:
+  description: Play a Spotify playlist.
   fields:
     media_content_id:
       description: Spotify URI of the playlist.
       example: 'spotify:playlist:0IpRnqCHSjun48oQRX1Dy7'
+    random_song:
+      description: True to select random song at start, False to start from beginning.
+      example: true

--- a/homeassistant/components/spotify/services.yaml
+++ b/homeassistant/components/spotify/services.yaml
@@ -1,0 +1,6 @@
+play_playlist_random_music:
+  description: Play a random music from a Spotify playlist.
+  fields:
+    media_content_id:
+      description: Spotify URI of the playlist.
+      example: 'spotify:playlist:0IpRnqCHSjun48oQRX1Dy7'


### PR DESCRIPTION
## Description:
Adding new custom service `play_playlist` to start playing a Spotify playlist.

This custom service allows an extra parameter `random_song`, from default `media_player.media_play` to allow select a random music at start.

Example of usage:
```yaml
- service: spotify.play_playlist
  data_template:
    media_content_id: 'spotify:playlist:2ixmMpm2kRTv40a5vtb'
    random_song: true
``` 
Suggestions for better naming accepted !

[Architecture discussion](https://github.com/home-assistant/architecture/issues/251)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#9798

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
