### PR TITLE
Template support for alarm_control_panel

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -1,0 +1,322 @@
+"""Support for Template alarm control panels."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.components.alarm_control_panel import (
+    ENTITY_ID_FORMAT, FORMAT_NUMBER, AlarmControlPanel)
+from homeassistant.const import (
+    CONF_VALUE_TEMPLATE, CONF_ICON_TEMPLATE, CONF_ENTITY_PICTURE_TEMPLATE,
+    CONF_ENTITY_ID, CONF_FRIENDLY_NAME, STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED,
+    STATE_ALARM_ARMED_NIGHT, EVENT_HOMEASSISTANT_START, MATCH_ALL, ATTR_CODE
+)
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.script import Script
+
+_LOGGER = logging.getLogger(__name__)
+_VALID_STATES = [STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
+                 STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED,
+                 STATE_ALARM_ARMED_NIGHT]
+
+CONF_ARM_AWAY_ACTION = 'arm_away'
+CONF_ARM_HOME_ACTION = 'arm_home'
+CONF_ARM_NIGHT_ACTION = 'arm_night'
+CONF_DISARM_ACTION = 'disarm'
+CONF_ALARM_CONTROL_PANELS = 'panels'
+CONF_CODE_ARM_REQUIRED = 'code_arm_required'
+
+ALARM_CONTROL_PANEL_SCHEMA = vol.Schema({
+    vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_DISARM_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Optional(CONF_ARM_AWAY_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Optional(CONF_ARM_HOME_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Optional(CONF_ARM_NIGHT_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Optional(CONF_ICON_TEMPLATE): cv.template,
+    vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
+    vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+    vol.Optional(CONF_ENTITY_ID): cv.entity_ids
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ALARM_CONTROL_PANELS):
+        cv.schema_with_slug_keys(ALARM_CONTROL_PANEL_SCHEMA),
+})
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the Template Alarm Control Panels."""
+    alarm_control_panels = []
+
+    for device, device_config in config[CONF_ALARM_CONTROL_PANELS].items():
+        friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
+        state_template = device_config.get(CONF_VALUE_TEMPLATE)
+        icon_template = device_config.get(CONF_ICON_TEMPLATE)
+        entity_picture_template = device_config.get(
+            CONF_ENTITY_PICTURE_TEMPLATE)
+        disarm_action = device_config.get(CONF_DISARM_ACTION)
+        arm_away_action = device_config.get(CONF_ARM_AWAY_ACTION)
+        arm_home_action = device_config.get(CONF_ARM_HOME_ACTION)
+        arm_night_action = device_config.get(CONF_ARM_NIGHT_ACTION)
+        code_arm_required = device_config.get(CONF_CODE_ARM_REQUIRED)
+
+        template_entity_ids = set()
+
+        if state_template is not None:
+            temp_ids = state_template.extract_entities()
+            if str(temp_ids) != MATCH_ALL:
+                template_entity_ids |= set(temp_ids)
+        else:
+            _LOGGER.warning("No value template - will use optimistic state")
+
+        if icon_template is not None:
+            temp_ids = icon_template.extract_entities()
+            if str(temp_ids) != MATCH_ALL:
+                template_entity_ids |= set(temp_ids)
+
+        if entity_picture_template is not None:
+            temp_ids = entity_picture_template.extract_entities()
+            if str(temp_ids) != MATCH_ALL:
+                template_entity_ids |= set(temp_ids)
+
+        if not template_entity_ids:
+            template_entity_ids = MATCH_ALL
+
+        entity_ids = device_config.get(CONF_ENTITY_ID, template_entity_ids)
+
+        alarm_control_panels.append(
+            AlarmControlPanelTemplate(
+                hass, device, friendly_name, state_template,
+                icon_template, entity_picture_template, disarm_action,
+                arm_away_action, arm_home_action, arm_night_action,
+                code_arm_required, entity_ids)
+        )
+
+    if not alarm_control_panels:
+        _LOGGER.error("No alarm control panels added")
+        return False
+
+    async_add_entities(alarm_control_panels)
+    return True
+
+
+class AlarmControlPanelTemplate(AlarmControlPanel):
+    """Representation of a templated Alarm Control Panel."""
+
+    def __init__(self, hass, device_id, friendly_name, state_template,
+                 icon_template, entity_picture_template, disarm_action,
+                 arm_away_action, arm_home_action, arm_night_action,
+                 code_arm_required, entity_ids):
+        """Initialize the panel."""
+        self.hass = hass
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, device_id, hass=hass)
+        self._name = friendly_name
+        self._template = state_template
+        self._icon_template = icon_template
+        self._entity_picture_template = entity_picture_template
+        self._disarm_script = None
+        self._code_arm_required = code_arm_required
+        if disarm_action is not None:
+            self._disarm_script = Script(hass, disarm_action)
+        self._arm_away_script = None
+        if arm_away_action is not None:
+            self._arm_away_script = Script(hass, arm_away_action)
+        self._arm_home_script = None
+        if arm_home_action is not None:
+            self._arm_home_script = Script(hass, arm_home_action)
+        self._arm_night_script = None
+        if arm_night_action is not None:
+            self._arm_night_script = Script(hass, arm_night_action)
+
+        self._state = False
+        self._icon = None
+        self._entity_picture = None
+        self._brightness = None
+        self._entities = entity_ids
+
+        if self._template is not None:
+            self._template.hass = self.hass
+        if self._icon_template is not None:
+            self._icon_template.hass = self.hass
+        if self._entity_picture_template is not None:
+            self._entity_picture_template.hass = self.hass
+
+    @property
+    def name(self):
+        """Return the display name of this alarm control panel."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def entity_picture(self):
+        """Return the entity picture to use in the frontend, if any."""
+        return self._entity_picture
+
+    @property
+    def code_format(self):
+        """Return one or more digits/characters."""
+        return FORMAT_NUMBER
+
+    @property
+    def code_arm_required(self):
+        """Whether the code is required for arm actions."""
+        return self._code_arm_required
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        @callback
+        def template_alarm_state_listener(entity, old_state, new_state):
+            """Handle target device state changes."""
+            self.async_schedule_update_ha_state(True)
+
+        @callback
+        def template_alarm_control_panel_startup(event):
+            """Update template on startup."""
+            if self._template is not None:
+                async_track_state_change(
+                    self.hass, self._entities, template_alarm_state_listener)
+
+            self.async_schedule_update_ha_state(True)
+
+        self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START, template_alarm_control_panel_startup)
+
+    async def async_alarm_arm_away(self, code=None):
+        """Arm the panel to Away."""
+        optimistic_set = False
+
+        if self._template is None:
+            _LOGGER.info("Optimistically setting arm state to Away")
+            self._state = STATE_ALARM_ARMED_AWAY
+            optimistic_set = True
+
+        if self._arm_away_script is not None:
+            await self._arm_away_script.async_run({
+                ATTR_CODE: code
+            }, context=self._context)
+        else:
+            _LOGGER.warning("No script action defined for Arm Away.")
+
+        if optimistic_set:
+            self.async_schedule_update_ha_state()
+
+    async def async_alarm_arm_home(self, code=None):
+        """Arm the panel to Home."""
+        optimistic_set = False
+
+        if self._template is None:
+            _LOGGER.info("Optimistically setting arm state to Home")
+            self._state = STATE_ALARM_ARMED_HOME
+            optimistic_set = True
+
+        if self._arm_home_script is not None:
+            await self._arm_home_script.async_run({
+                ATTR_CODE: code
+            }, context=self._context)
+        else:
+            _LOGGER.warning("No script action defined for Arm Home.")
+
+        if optimistic_set:
+            self.async_schedule_update_ha_state()
+
+    async def async_alarm_arm_night(self, code=None):
+        """Arm the panel to Night."""
+        optimistic_set = False
+
+        if self._template is None:
+            _LOGGER.info("Optimistically setting arm state to Night")
+            self._state = STATE_ALARM_ARMED_NIGHT
+            optimistic_set = True
+
+        if self._arm_night_script is not None:
+            await self._arm_night_script.async_run({
+                ATTR_CODE: code
+            }, context=self._context)
+        else:
+            _LOGGER.warning("No script action defined for Arm Night.")
+
+        if optimistic_set:
+            self.async_schedule_update_ha_state()
+
+    async def async_alarm_disarm(self, code=None):
+        """Disarm the panel."""
+        optimistic_set = False
+
+        if self._template is None:
+            _LOGGER.info("Optimistically setting arm state to Disarmed")
+            self._state = STATE_ALARM_DISARMED
+            optimistic_set = True
+
+        if self._disarm_script is not None:
+            await self._disarm_script.async_run({
+                ATTR_CODE: code
+            }, context=self._context)
+        else:
+            _LOGGER.warning("No script action defined for Disarm.")
+
+        if optimistic_set:
+            self.async_schedule_update_ha_state()
+
+    async def async_update(self):
+        """Update the state from the template."""
+        if self._template is not None:
+            try:
+                state = self._template.async_render().lower()
+            except TemplateError as ex:
+                _LOGGER.error(ex)
+                self._state = None
+
+            if state in _VALID_STATES:
+                self._state = state
+            else:
+                _LOGGER.error(
+                    'Received invalid alarm panel state: %s. Expected: %s',
+                    state, ', '.join(_VALID_STATES))
+                self._state = None
+
+        for property_name, template in (
+                ('_icon', self._icon_template),
+                ('_entity_picture', self._entity_picture_template)):
+            if template is None:
+                continue
+
+            try:
+                setattr(self, property_name, template.async_render())
+            except TemplateError as ex:
+                friendly_property_name = property_name[1:].replace('_', ' ')
+                if ex.args and ex.args[0].startswith(
+                        "UndefinedError: 'None' has no attribute"):
+                    # Common during HA startup - so just a warning
+                    _LOGGER.warning('Could not render %s template %s,'
+                                    ' the state is unknown.',
+                                    friendly_property_name, self._name)
+                    return
+
+                try:
+                    setattr(self, property_name,
+                            getattr(super(), property_name))
+                except AttributeError:
+                    _LOGGER.error('Could not render %s template %s: %s',
+                                  friendly_property_name, self._name, ex)

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -136,7 +136,7 @@ class AlarmControlPanelTemplate(AlarmControlPanel):
         if arm_night_action is not None:
             self._arm_night_script = Script(hass, arm_night_action)
 
-        self._state = False
+        self._state = None
         self._icon = None
         self._entity_picture = None
         self._brightness = None

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -40,7 +40,7 @@ ALARM_CONTROL_PANEL_SCHEMA = vol.Schema({
     vol.Optional(CONF_ICON_TEMPLATE): cv.template,
     vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
     vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
-    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+    vol.Optional(CONF_FRIENDLY_NAME, default="Template Alarm"): cv.string,
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -1,0 +1,518 @@
+"""The tests for the Template alarm control panel platform."""
+import logging
+
+from homeassistant.core import callback
+from homeassistant import setup
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN, SERVICE_ALARM_ARM_AWAY,
+    SERVICE_ALARM_ARM_HOME, SERVICE_ALARM_ARM_NIGHT,
+    SERVICE_ALARM_DISARM)
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT, STATE_ALARM_DISARMED)
+
+from tests.common import (get_test_home_assistant,
+                          assert_setup_component)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestTemplateAlarmControlPanel:
+    """Test the Template alarm control panel."""
+
+    hass = None
+    calls = None
+    # pylint: disable=invalid-name
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.calls = []
+
+        @callback
+        def record_call(service):
+            """Track function calls.."""
+            self.calls.append(service)
+
+        self.hass.services.register('test', 'automation', record_call)
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_template_state_text(self):
+        """Test the state text of a template."""
+        with assert_setup_component(1, 'alarm_control_panel'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{{ states('alarm_control_panel.test') }}",
+                            'arm_away': {
+                                'service': 'alarm_control_panel.alarm_arm_away',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.set('alarm_control_panel.test',
+                                     STATE_ALARM_ARMED_HOME)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_ARMED_HOME
+
+        state = self.hass.states.set('alarm_control_panel.test',
+                                     STATE_ALARM_ARMED_AWAY)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_ARMED_AWAY
+
+        state = self.hass.states.set('alarm_control_panel.test',
+                                     STATE_ALARM_ARMED_NIGHT)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_ARMED_NIGHT
+
+        state = self.hass.states.set('alarm_control_panel.test',
+                                     STATE_ALARM_DISARMED)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_DISARMED
+
+    def test_template_syntax_error(self):
+        """Test templating syntax error."""
+        with assert_setup_component(0, 'alarm_control_panel'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{% if blah %}",
+                            'arm_away': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_away',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    def test_invalid_name_does_not_create(self):
+        """Test invalid name."""
+        with assert_setup_component(0, 'alarm_control_panel'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'bad name here': {
+                            'value_template':
+                                "{{ disarmed }}",
+                            'arm_away': {
+                                'service': 'alarm_control_panel.alarm_arm_away',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    def test_invalid_panel_does_not_create(self):
+        """Test invalid alarm control panel."""
+        with assert_setup_component(0, 'light'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template',
+                    'wibble': {
+                        'test_panel': 'Invalid'
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    def test_no_panels_does_not_create(self):
+        """Test if there are no panels -> no creation."""
+        with assert_setup_component(0, 'light'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template'
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    def test_disarm_action(self):
+        """Test disarm action."""
+        assert setup.setup_component(self.hass, 'alarm_control_panel', {
+            'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{{ states('alarm_control_panel.test') }}",
+                            'arm_away': {
+                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service': 'test.automation'
+                            }
+                        }
+                    }
+                }
+        })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self.hass.states.set('alarm_control_panel.test_template_panel',
+                             STATE_ALARM_ARMED_AWAY)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_ARMED_AWAY
+
+        self.hass.services.call(DOMAIN, SERVICE_ALARM_DISARM, {
+            'entity_id': 'alarm_control_panel.test_template_panel'
+        })
+        self.hass.block_till_done()
+
+        assert len(self.calls) == 1
+
+    def test_arm_away_action(self):
+        """Test disarm action."""
+        assert setup.setup_component(self.hass, 'alarm_control_panel', {
+            'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{{ states('alarm_control_panel.test') }}",
+                            'arm_away': {
+                                'service': 'test.automation'
+                            },
+                            'arm_home': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            }
+                        }
+                    }
+                }
+        })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self.hass.states.set('alarm_control_panel.test_template_panel',
+                             STATE_ALARM_DISARMED)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_DISARMED
+
+        self.hass.services.call(DOMAIN, SERVICE_ALARM_ARM_AWAY, {
+            'entity_id': 'alarm_control_panel.test_template_panel'
+        })
+        self.hass.block_till_done()
+
+        assert len(self.calls) == 1
+
+    def test_arm_night_action(self):
+        """Test disarm action."""
+        assert setup.setup_component(self.hass, 'alarm_control_panel', {
+            'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{{ states('alarm_control_panel.test') }}",
+                            'arm_away': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service': 'test.automation'
+                            },
+                            'disarm': {
+                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            }
+                        }
+                    }
+                }
+        })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self.hass.states.set('alarm_control_panel.test_template_panel',
+                             STATE_ALARM_DISARMED)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_DISARMED
+
+        self.hass.services.call(DOMAIN, SERVICE_ALARM_ARM_NIGHT, {
+            'entity_id': 'alarm_control_panel.test_template_panel'
+        })
+        self.hass.block_till_done()
+
+        assert len(self.calls) == 1
+
+    def test_arm_home_action(self):
+        """Test disarm action."""
+        assert setup.setup_component(self.hass, 'alarm_control_panel', {
+            'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{{ states('alarm_control_panel.test') }}",
+                            'arm_away': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service': 'test.automation'
+                            },
+                            'arm_night': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            }
+                        }
+                    }
+                }
+        })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self.hass.states.set('alarm_control_panel.test_template_panel',
+                             STATE_ALARM_DISARMED)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.state == STATE_ALARM_DISARMED
+
+        self.hass.services.call(DOMAIN, SERVICE_ALARM_ARM_HOME, {
+            'entity_id': 'alarm_control_panel.test_template_panel'
+        })
+        self.hass.block_till_done()
+
+        assert len(self.calls) == 1
+
+    def test_friendly_name(self):
+        """Test the accessibility of the friendly_name attribute."""
+        with assert_setup_component(1, 'alarm_control_panel'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'friendly_name': 'Template Alarm Panel',
+                            'value_template':
+                                "{{ disarmed }}",
+                            'arm_away': {
+                                'service': 'alarm_control_panel.alarm_arm_away',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state is not None
+
+        assert state.attributes.get('friendly_name') == 'Template Alarm Panel'

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -540,3 +540,135 @@ class TestTemplateAlarmControlPanel:
         assert state is not None
 
         assert state.attributes.get('friendly_name') == 'Template Alarm Panel'
+
+    def test_icon_template(self):
+        """Test icon template."""
+        with assert_setup_component(1, 'alarm_control_panel'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{{ states('alarm_control_panel.test') }}",
+                            'arm_away': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_away',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'icon_template':
+                                "{% if states.alarm_control_panel."
+                                "test_template_panel.state == 'armed_away' %}"
+                                "mdi:check"
+                                "{% endif %}"
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.attributes.get('icon') == ''
+
+        state = self.hass.states.set('alarm_control_panel.test',
+                                     STATE_ALARM_ARMED_AWAY)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+
+        assert state.attributes['icon'] == 'mdi:check'
+
+    def test_entity_picture_template(self):
+        """Test entity_picture template."""
+        with assert_setup_component(1, 'alarm_control_panel'):
+            assert setup.setup_component(self.hass, 'alarm_control_panel', {
+                'alarm_control_panel': {
+                    'platform': 'template',
+                    'panels': {
+                        'test_template_panel': {
+                            'value_template':
+                                "{{ states('alarm_control_panel.test') }}",
+                            'arm_away': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_away',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_home': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'arm_night': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'disarm': {
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
+                                'entity_id': 'alarm_control_panel.test',
+                                'data': {
+                                    'code': '1234'
+                                }
+                            },
+                            'entity_picture_template':
+                                "{% if states.alarm_control_panel."
+                                "test_template_panel.state == 'armed_away' %}"
+                                "/local/light.png"
+                                "{% endif %}"
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+        assert state.attributes.get('entity_picture') == ''
+
+        state = self.hass.states.set('alarm_control_panel.test',
+                                     STATE_ALARM_ARMED_AWAY)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('alarm_control_panel.test_template_panel')
+
+        assert state.attributes['entity_picture'] == '/local/light.png'

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -51,28 +51,32 @@ class TestTemplateAlarmControlPanel:
                             'value_template':
                                 "{{ states('alarm_control_panel.test') }}",
                             'arm_away': {
-                                'service': 'alarm_control_panel.alarm_arm_away',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_away',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_home': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_night': {
-                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'disarm': {
-                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -177,28 +181,32 @@ class TestTemplateAlarmControlPanel:
                             'value_template':
                                 "{{ disarmed }}",
                             'arm_away': {
-                                'service': 'alarm_control_panel.alarm_arm_away',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_away',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_home': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_night': {
-                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'disarm': {
-                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -255,21 +263,24 @@ class TestTemplateAlarmControlPanel:
                             'value_template':
                                 "{{ states('alarm_control_panel.test') }}",
                             'arm_away': {
-                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_home': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_night': {
-                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -313,21 +324,24 @@ class TestTemplateAlarmControlPanel:
                                 'service': 'test.automation'
                             },
                             'arm_home': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_night': {
-                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'disarm': {
-                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -365,14 +379,16 @@ class TestTemplateAlarmControlPanel:
                             'value_template':
                                 "{{ states('alarm_control_panel.test') }}",
                             'arm_away': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_home': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -382,7 +398,8 @@ class TestTemplateAlarmControlPanel:
                                 'service': 'test.automation'
                             },
                             'disarm': {
-                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -420,7 +437,8 @@ class TestTemplateAlarmControlPanel:
                             'value_template':
                                 "{{ states('alarm_control_panel.test') }}",
                             'arm_away': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -430,14 +448,16 @@ class TestTemplateAlarmControlPanel:
                                 'service': 'test.automation'
                             },
                             'arm_night': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'disarm': {
-                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
@@ -477,28 +497,32 @@ class TestTemplateAlarmControlPanel:
                             'value_template':
                                 "{{ disarmed }}",
                             'arm_away': {
-                                'service': 'alarm_control_panel.alarm_arm_away',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_away',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_home': {
-                                'service': 'alarm_control_panel.alarm_arm_home',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_home',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'arm_night': {
-                                'service': 'alarm_control_panel.alarm_arm_night',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_night',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'
                                 }
                             },
                             'disarm': {
-                                'service': 'alarm_control_panel.alarm_arm_disarm',
+                                'service':
+                                    'alarm_control_panel.alarm_arm_disarm',
                                 'entity_id': 'alarm_control_panel.test',
                                 'data': {
                                     'code': '1234'


### PR DESCRIPTION
## Description:

Template support for alarm control panel - templated state, icon, entity picture. Scripted actions for arm away, home, stay and disarm.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9801

TBD

## Example entry for `configuration.yaml` (if applicable):
```yaml

alarm_control_panel:
  - platform: template
    panels:
      alarmdecoder:
        friendly_name: "Virtual Alarm Panel"
        code_arm_required: false
        value_template: "{{ states('alarm_control_panel.alarm_panel') }}"
        disarm:
          service: alarm_control_panel.alarm_disarm
          data:
            entity_id: alarm_control_panel.alarm_panel
            code: !secret alarm_code
        arm_away:
          service: alarm_control_panel.alarm_arm_away
          data:
            entity_id: alarm_control_panel.alarm_panel
            code: !secret alarm_code
        arm_home:
          service: alarm_control_panel.alarm_arm_home
          data:
            entity_id: alarm_control_panel.alarm_panel
            code: !secret alarm_code
        arm_night:
          service: alarm_control_panel.alarm_arm_night
          data:
            entity_id: alarm_control_panel.alarm_panel
            code: !secret alarm_code

```

## Checklist:
  - [ X] The code change is tested and works locally.
  - [X ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ X] There is no commented out code in this PR.
  - [ X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [NA ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [NA] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html