### PR TITLE
Upgrade mypy to 0.711, drop no longer needed workarounds

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -257,8 +257,7 @@ class ConfigEntry:
                           self.title, self.domain)
             return False
         # Handler may be a partial
-        # type ignore: https://github.com/python/typeshed/pull/3077
-        while isinstance(handler, functools.partial):  # type: ignore
+        while isinstance(handler, functools.partial):
             handler = handler.func
 
         if self.version == handler.VERSION:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -270,9 +270,8 @@ class HomeAssistant:
 
         # Check for partials to properly determine if coroutine function
         check_target = target
-        # type ignores: https://github.com/python/typeshed/pull/3077
-        while isinstance(check_target, functools.partial):  # type: ignore
-            check_target = check_target.func  # type: ignore
+        while isinstance(check_target, functools.partial):
+            check_target = check_target.func
 
         if asyncio.iscoroutine(check_target):
             task = self.loop.create_task(target)  # type: ignore
@@ -947,9 +946,8 @@ class Service:
         self.func = func
         self.schema = schema
         # Properly detect wrapped functions
-        # type ignores: https://github.com/python/typeshed/pull/3077
-        while isinstance(func, functools.partial):  # type: ignore
-            func = func.func  # type: ignore
+        while isinstance(func, functools.partial):
+            func = func.func
         self.is_callback = is_callback(func)
         self.is_coroutinefunction = asyncio.iscoroutinefunction(func)
 

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -141,9 +141,8 @@ def catch_log_exception(
 
     # Check for partials to properly determine if coroutine function
     check_func = func
-    # type ignores: https://github.com/python/typeshed/pull/3077
-    while isinstance(check_func, partial):  # type: ignore
-        check_func = check_func.func  # type: ignore
+    while isinstance(check_func, partial):
+        check_func = check_func.func
 
     wrapper_func = None
     if asyncio.iscoroutinefunction(check_func):

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ coveralls==1.2.0
 flake8-docstrings==1.3.0
 flake8==3.7.7
 mock-open==1.3.1
-mypy==0.710
+mypy==0.711
 pydocstyle==3.0.0
 pylint==2.3.1
 pytest-aiohttp==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -8,7 +8,7 @@ coveralls==1.2.0
 flake8-docstrings==1.3.0
 flake8==3.7.7
 mock-open==1.3.1
-mypy==0.710
+mypy==0.711
 pydocstyle==3.0.0
 pylint==2.3.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Description:

https://mypy-lang.blogspot.com/2019/06/mypy-0711-released.html

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
