### PR TITLE
Test dependency updates

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,4 +15,4 @@ pytest-cov==2.7.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
 pytest==5.0.1
-requests_mock==1.5.2
+requests_mock==1.6.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,5 +14,5 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.7.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
-pytest==5.0.0
+pytest==5.0.1
 requests_mock==1.5.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 # linters such as flake8 and pylint should be pinned, as new releases
 # make new things fail. Manually update these pins when pulling in a
 # new version
-asynctest==0.12.3
+asynctest==0.13.0
 codecov==2.0.15
 coveralls==1.2.0
 flake8-docstrings==1.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -15,7 +15,7 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.7.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
-pytest==5.0.0
+pytest==5.0.1
 requests_mock==1.5.2
 
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2,7 +2,7 @@
 # linters such as flake8 and pylint should be pinned, as new releases
 # make new things fail. Manually update these pins when pulling in a
 # new version
-asynctest==0.12.3
+asynctest==0.13.0
 codecov==2.0.15
 coveralls==1.2.0
 flake8-docstrings==1.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -16,7 +16,7 @@ pytest-cov==2.7.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
 pytest==5.0.1
-requests_mock==1.5.2
+requests_mock==1.6.0
 
 
 # homeassistant.components.homekit


### PR DESCRIPTION
## Description:

Upgrade pytest to 5.0.1, asynctest to 0.13.0, and requests_mock to 1.6.0.

https://docs.pytest.org/en/latest/changelog.html#pytest-5-0-1-2019-07-04
(no change log available in asynctest or requests_mock)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
