### PR TITLE
Install requirements for integrations in packages before importing them.

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -30,6 +30,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import (
     Integration, async_get_integration, IntegrationNotFound
 )
+from homeassistant.requirements import async_process_requirements
 from homeassistant.util.yaml import load_yaml, SECRET_YAML
 from homeassistant.util.package import is_docker_env
 import homeassistant.helpers.config_validation as cv
@@ -591,6 +592,13 @@ async def merge_packages_config(hass: HomeAssistant, config: Dict,
                 integration = await async_get_integration(hass, domain)
             except IntegrationNotFound:
                 _log_pkg_error(pack_name, comp_name, config, "does not exist")
+                continue
+
+            if (not hass.config.skip_pip and integration.requirements and
+                    not await async_process_requirements(
+                        hass, integration.domain, integration.requirements)):
+                _log_pkg_error(pack_name, comp_name, config,
+                               "unable to install all requirements")
                 continue
 
             try:


### PR DESCRIPTION
<!--  ## Breaking Change:

What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

This change will install the requirements of integrations (if any) before trying to import it.

If the integration import has imports from external packages in the top (not in a function/method) you will get this error on config_check and startup if the configuration for that integration is in a package instead of directly in configuration,yaml:

```text
Package package_name setup failed. Component integration_name does not exist
```


**Related issue (if applicable):** fixes #24954 fixes #24720

There is also an issue with Yellight could not find a related issue for it but it was reported in [#devs_general](https://discordapp.com/channels/330944238910963714/554842238073700352/596854093549666305)

After the move to manifest.json for requirements, more and more integrations will start to get this issue as well.

<!-- 
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Example entry for `configuration.yaml` (if applicable):
```yaml

```
-->
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** 
    _[Travis](https://travis-ci.com/ludeeus/home-assistant/builds/118187198) and [CircleCI](https://circleci.com/gh/ludeeus/home-assistant) passed in my fork._
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
<!-- 
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
