### PR TITLE
Upgrade hdate==0.8.8

### DIFF
--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jewish calendar",
   "documentation": "https://www.home-assistant.io/components/jewish_calendar",
   "requirements": [
-    "hdate==0.8.7"
+    "hdate==0.8.8"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -578,7 +578,7 @@ hass-nabucasa==0.15
 hbmqtt==0.9.4
 
 # homeassistant.components.jewish_calendar
-hdate==0.8.7
+hdate==0.8.8
 
 # homeassistant.components.heatmiser
 heatmiserV3==0.9.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -154,7 +154,7 @@ hass-nabucasa==0.15
 hbmqtt==0.9.4
 
 # homeassistant.components.jewish_calendar
-hdate==0.8.7
+hdate==0.8.8
 
 # homeassistant.components.workday
 holidays==0.9.10


### PR DESCRIPTION
## Breaking Change:
None
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This should fix inconsistencies between issur_melacha_in_effect sensor and candle_lighting time.

**Related issue (if applicable):**
Probably fixes #24479 and fixes #23852

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
N/A

## Example entry for `configuration.yaml` (if applicable): N/A
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
