### PR TITLE
Update homekit_controller to use HVAC_MODE_HEAT_COOL instead of HVAC_MODE_AUTO

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -5,7 +5,7 @@ from homeassistant.components.climate import (
     ClimateDevice, DEFAULT_MIN_HUMIDITY, DEFAULT_MAX_HUMIDITY,
 )
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF,
+    HVAC_MODE_HEAT_COOL, HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF,
     CURRENT_HVAC_OFF, CURRENT_HVAC_HEAT, CURRENT_HVAC_COOL,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY)
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
@@ -19,7 +19,7 @@ MODE_HOMEKIT_TO_HASS = {
     0: HVAC_MODE_OFF,
     1: HVAC_MODE_HEAT,
     2: HVAC_MODE_COOL,
-    3: HVAC_MODE_AUTO,
+    3: HVAC_MODE_HEAT_COOL,
 }
 
 # Map of hass operation modes to homekit modes

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -41,7 +41,7 @@ async def test_ecobee3_setup(hass):
         'off',
         'heat',
         'cool',
-        'auto',
+        'heat_cool',
     ]
 
     assert climate_state.attributes['min_temp'] == 7.2


### PR DESCRIPTION
## Description:

I incorrectly mapped 'auto' mode in the HomeKit spec to auto mode in HomeAssistant. They are different things, and actually it should be mapped to `HVAC_MODE_HEAT_COOL`.

**Related issue (if applicable):** #23899

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
