### PR TITLE
Correct socket use in cert_expiry platform

### DIFF
--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -103,7 +103,8 @@ class SSLCertificate(Entity):
             self._available = False
             return
         except OSError:
-            _LOGGER.error("Cannot fetch certificate from %s", self.server_name, exc_info=1)
+            _LOGGER.error("Cannot fetch certificate from %s",
+                          self.server_name, exc_info=1)
             self._available = False
             return
 

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -77,6 +77,11 @@ class SSLCertificate(Entity):
         """Icon to use in the frontend, if any."""
         return 'mdi:certificate'
 
+    @property
+    def available(self):
+        """Icon to use in the frontend, if any."""
+        return self._available
+
     def update(self):
         """Fetch the certificate information."""
         ctx = ssl.create_default_context()
@@ -90,16 +95,20 @@ class SSLCertificate(Entity):
 
         except socket.gaierror:
             _LOGGER.error("Cannot resolve hostname: %s", self.server_name)
+            self._available = False
             return
         except socket.timeout:
             _LOGGER.error(
                 "Connection timeout with server: %s", self.server_name)
+            self._available = False
             return
         except OSError:
             _LOGGER.error("Cannot fetch certificate from %s", self.server_name, exc_info=1)
+            self._available = False
             return
 
         ts_seconds = ssl.cert_time_to_seconds(cert['notAfter'])
         timestamp = datetime.fromtimestamp(ts_seconds)
         expiry = timestamp - datetime.today()
+        self._available = True
         self._state = expiry.days


### PR DESCRIPTION
## Description:
Make sure we use same family for ssl socket and connection

getaddrinfo result could be different from what connection
was made with. It also blocks potential use of
happy eye balls algorithm

This also fixes lingering sockets until python garbage
collection as well as add support to display availability of sensor.

This may fix related issues, but i've not really reproduced them.

**Related issue (if applicable):** #10550  #12607

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: cert_expiry
    host: google.com
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - ~[ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~

If the code communicates with devices, web services, or third-party tools:
  - ~[ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.~
  - ~[ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.~
  - ~[ ] Untested files have been added to `.coveragerc`.~

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
