### PR TITLE
Fix mimetypes on borked Windows machines

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -1,6 +1,7 @@
 """Handle the frontend for Home Assistant."""
 import json
 import logging
+import mimetypes
 import os
 import pathlib
 
@@ -19,6 +20,13 @@ from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
 from .storage import async_setup_frontend_storage
+
+
+# Fix mimetypes for borked Windows machines
+# https://github.com/home-assistant/home-assistant-polymer/issues/3336
+mimetypes.add_type("text/css", ".css")
+mimetypes.add_type("application/javascript", ".js")
+
 
 DOMAIN = 'frontend'
 CONF_THEMES = 'themes'


### PR DESCRIPTION
## Description:
Some Windows users have messed up mimetypes in their Windows registry, probably due to some application doing that incorrectly. This messes with the mimetypes that we return when serving the frontend. Browsers are very particularly when it comes to mimetypes, refuse to execute any JavaScript without the correct type.

So this PR will hardcode the mimetypes for CSS and JS.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant-polymer/issues/3336

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

