### PR TITLE
Add radiotherm CT80 current humidity support

### DIFF
--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -102,6 +102,7 @@ class RadioThermostat(ClimateDevice):
         self.device = device
         self._target_temperature = None
         self._current_temperature = None
+        self._current_humidity = None
         self._current_operation = HVAC_MODE_OFF
         self._name = None
         self._fmode = None
@@ -216,6 +217,16 @@ class RadioThermostat(ClimateDevice):
 
         current_temp = data['temp']
 
+        if self._is_model_ct80:
+            try:
+                humiditydata = self.device.tstat.humidity['raw']
+            except radiotherm.validate.RadiothermTestatError:
+                _LOGGER.warning('%s (%s) was busy (invalid value returned)',
+                                self._name, self.device.host)
+                return
+            current_humidity = humiditydata['humidity']
+            self._current_humidity = current_humidity
+            
         # Map thermostat values into various STATE_ flags.
         self._current_temperature = current_temp
         self._fmode = CODE_TO_FAN_MODE[data['fmode']]

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -226,7 +226,7 @@ class RadioThermostat(ClimateDevice):
                 return
             current_humidity = humiditydata['humidity']
             self._current_humidity = current_humidity
-            
+
         # Map thermostat values into various STATE_ flags.
         self._current_temperature = current_temp
         self._fmode = CODE_TO_FAN_MODE[data['fmode']]

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -225,7 +225,7 @@ class RadioThermostat(ClimateDevice):
         if self._is_model_ct80:
             try:
                 humiditydata = self.device.tstat.humidity['raw']
-            except radiotherm.validate.RadiothermTestatError:
+            except radiotherm.validate.RadiothermTstatError:
                 _LOGGER.warning('%s (%s) was busy (invalid value returned)',
                                 self._name, self.device.host)
                 return

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -181,7 +181,7 @@ class RadioThermostat(ClimateDevice):
     def current_humidity(self):
         """Return the current temperature."""
         return self._current_humidity
-    
+
     @property
     def hvac_mode(self):
         """Return the current operation. head, cool idle."""

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -178,6 +178,11 @@ class RadioThermostat(ClimateDevice):
         return self._current_temperature
 
     @property
+    def current_humidity(self):
+        """Return the current temperature."""
+        return self._current_humidity
+    
+    @property
     def hvac_mode(self):
         """Return the current operation. head, cool idle."""
         return self._current_operation


### PR DESCRIPTION
## Description:

Added a check for if device is a CT80, and if so, queries the humidity object to get the current measured humidity reading.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
