### PR TITLE
Toon fixes for Climate 1.0

### DIFF
--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
@@ -78,9 +78,11 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
         return TEMP_CELSIUS
 
     @property
-    def preset_mode(self) -> str:
+    def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
-        return self._state.lower()
+        if self._state is not None:
+            return self._state.lower()
+        return None
 
     @property
     def preset_modes(self) -> List[str]:
@@ -88,12 +90,12 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
         return SUPPORT_PRESET
 
     @property
-    def current_temperature(self) -> float:
+    def current_temperature(self) -> Optional[float]:
         """Return the current temperature."""
         return self._current_temperature
 
     @property
-    def target_temperature(self) -> float:
+    def target_temperature(self) -> Optional[float]:
         """Return the temperature we try to reach."""
         return self._target_temperature
 
@@ -121,7 +123,8 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        self.toon.thermostat_state = preset_mode
+        if preset_mode is not None:
+            self.toon.thermostat_state = preset_mode
 
     def set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""


### PR DESCRIPTION
## Description:

Climate 1.0 fixes for Toon.

- Fixes type hints on some occasions.
- Ignore `None` preset, since Toon does not support turning off a preset
- Handle no presets active on Toon

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
toon:
  client_id: fxiyXLtFfhimADJlmFjTjXdHoxZ8AFg7
  client_secret: kPUCx88CTCSMAaBA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
