### PR TITLE
Improve SmartThings test mocking

### DIFF
--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -1,12 +1,12 @@
 """Test configuration and mocks for the SmartThings component."""
 from collections import defaultdict
-from unittest.mock import Mock, patch
 from uuid import uuid4
 
+from asynctest import Mock, patch
 from pysmartthings import (
     CLASSIFICATION_AUTOMATION, AppEntity, AppOAuthClient, AppSettings,
-    DeviceEntity, InstalledApp, Location, SceneEntity, SmartThings,
-    Subscription)
+    DeviceEntity, DeviceStatus, InstalledApp, Location, SceneEntity,
+    SmartThings, Subscription)
 from pysmartthings.api import Api
 import pytest
 
@@ -21,8 +21,6 @@ from homeassistant.config_entries import (
     CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_WEBHOOK_ID
 from homeassistant.setup import async_setup_component
-
-from tests.common import mock_coro
 
 COMPONENT_PREFIX = "homeassistant.components.smartthings."
 
@@ -81,29 +79,22 @@ def locations_fixture(location):
 @pytest.fixture(name="app")
 def app_fixture(hass, config_file):
     """Fixture for a single app."""
-    app = AppEntity(Mock())
-    app.apply_data({
-        'appName': APP_NAME_PREFIX + str(uuid4()),
-        'appId': str(uuid4()),
-        'appType': 'WEBHOOK_SMART_APP',
-        'classifications': [CLASSIFICATION_AUTOMATION],
-        'displayName': 'Home Assistant',
-        'description':
-            hass.config.location_name + " at " + hass.config.api.base_url,
-        'singleInstance': True,
-        'webhookSmartApp': {
-            'targetUrl': webhook.async_generate_url(
-                hass, hass.data[DOMAIN][CONF_WEBHOOK_ID]),
-            'publicKey': ''}
-    })
-    app.refresh = Mock()
-    app.refresh.return_value = mock_coro()
-    app.save = Mock()
-    app.save.return_value = mock_coro()
-    settings = AppSettings(app.app_id)
-    settings.settings[SETTINGS_INSTANCE_ID] = config_file[CONF_INSTANCE_ID]
-    app.settings = Mock()
-    app.settings.return_value = mock_coro(return_value=settings)
+    app = Mock(AppEntity)
+    app.app_name = APP_NAME_PREFIX + str(uuid4())
+    app.app_id = str(uuid4())
+    app.app_type = 'WEBHOOK_SMART_APP'
+    app.classifications = [CLASSIFICATION_AUTOMATION]
+    app.display_name = 'Home Assistant'
+    app.description = hass.config.location_name + " at " + \
+        hass.config.api.base_url
+    app.single_instance = True
+    app.webhook_target_url = webhook.async_generate_url(
+        hass, hass.data[DOMAIN][CONF_WEBHOOK_ID])
+
+    settings = Mock(AppSettings)
+    settings.app_id = app.app_id
+    settings.settings = {SETTINGS_INSTANCE_ID: config_file[CONF_INSTANCE_ID]}
+    app.settings.return_value = settings
     return app
 
 
@@ -161,10 +152,9 @@ def config_file_fixture():
 @pytest.fixture(name='smartthings_mock')
 def smartthings_mock_fixture(locations):
     """Fixture to mock smartthings API calls."""
-    def _location(location_id):
-        return mock_coro(
-            return_value=next(location for location in locations
-                              if location.location_id == location_id))
+    async def _location(location_id):
+        return next(location for location in locations
+                    if location.location_id == location_id)
 
     smartthings_mock = Mock(SmartThings)
     smartthings_mock.location.side_effect = _location
@@ -178,65 +168,17 @@ def smartthings_mock_fixture(locations):
 @pytest.fixture(name='device')
 def device_fixture(location):
     """Fixture representing devices loaded."""
-    item = DeviceEntity(None)
-    item.status.refresh = Mock()
-    item.status.refresh.return_value = mock_coro()
-    item.apply_data({
-        "deviceId": "743de49f-036f-4e9c-839a-2f89d57607db",
-        "name": "GE In-Wall Smart Dimmer",
-        "label": "Front Porch Lights",
-        "deviceManufacturerCode": "0063-4944-3038",
-        "locationId": location.location_id,
-        "deviceTypeId": "8a9d4b1e3b9b1fe3013b9b206a7f000d",
-        "deviceTypeName": "Dimmer Switch",
-        "deviceNetworkType": "ZWAVE",
-        "components": [
-            {
-                "id": "main",
-                "capabilities": [
-                    {
-                        "id": "switch",
-                        "version": 1
-                    },
-                    {
-                        "id": "switchLevel",
-                        "version": 1
-                    },
-                    {
-                        "id": "refresh",
-                        "version": 1
-                    },
-                    {
-                        "id": "indicator",
-                        "version": 1
-                    },
-                    {
-                        "id": "sensor",
-                        "version": 1
-                    },
-                    {
-                        "id": "actuator",
-                        "version": 1
-                    },
-                    {
-                        "id": "healthCheck",
-                        "version": 1
-                    },
-                    {
-                        "id": "light",
-                        "version": 1
-                    }
-                ]
-            }
-        ],
-        "dth": {
-            "deviceTypeId": "8a9d4b1e3b9b1fe3013b9b206a7f000d",
-            "deviceTypeName": "Dimmer Switch",
-            "deviceNetworkType": "ZWAVE",
-            "completedSetup": False
-        },
-        "type": "DTH"
-    })
+    item = Mock(DeviceEntity)
+    item.device_id = "743de49f-036f-4e9c-839a-2f89d57607db"
+    item.name = "GE In-Wall Smart Dimmer"
+    item.label = "Front Porch Lights"
+    item.location_id = location.location_id
+    item.capabilities = [
+        "switch", "switchLevel", "refresh", "indicator", "sensor", "actuator",
+        "healthCheck", "light"
+    ]
+    item.components = {"main": item.capabilities}
+    item.status = Mock(DeviceStatus)
     return item
 
 
@@ -270,8 +212,7 @@ def subscription_factory_fixture():
 def device_factory_fixture():
     """Fixture for creating mock devices."""
     api = Mock(spec=Api)
-    api.post_device_command.side_effect = \
-        lambda *args, **kwargs: mock_coro(return_value={})
+    api.post_device_command.return_value = {}
 
     def _factory(label, capabilities, status: dict = None):
         device_data = {
@@ -309,8 +250,7 @@ def device_factory_fixture():
 def scene_factory_fixture(location):
     """Fixture for creating mock devices."""
     api = Mock(spec=Api)
-    api.execute_scene.side_effect = \
-        lambda *args, **kwargs: mock_coro(return_value={})
+    api.execute_scene.return_value = {}
 
     def _factory(name):
         scene_data = {

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -162,7 +162,7 @@ def smartthings_mock_fixture(locations):
     with patch(COMPONENT_PREFIX + "SmartThings", new=mock), \
             patch(COMPONENT_PREFIX + "config_flow.SmartThings", new=mock), \
             patch(COMPONENT_PREFIX + "smartapp.SmartThings", new=mock):
-        yield mock
+        yield smartthings_mock
 
 
 @pytest.fixture(name='device')

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -1,8 +1,8 @@
 """Tests for the SmartThings config flow module."""
-from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from aiohttp import ClientResponseError
+from asynctest import Mock, patch
 from pysmartthings import APIResponseError
 
 from homeassistant import data_entry_flow
@@ -14,8 +14,6 @@ from homeassistant.components.smartthings.const import (
     CONF_INSTALLED_APP_ID, CONF_INSTALLED_APPS, CONF_LOCATION_ID,
     CONF_REFRESH_TOKEN, DOMAIN)
 from homeassistant.config_entries import ConfigEntry
-
-from tests.common import mock_coro
 
 
 async def test_step_user(hass):
@@ -84,8 +82,8 @@ async def test_token_unauthorized(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.return_value = mock_coro(
-        exception=ClientResponseError(None, None, status=401))
+    smartthings_mock.return_value.apps.side_effect = \
+        ClientResponseError(None, None, status=401)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -99,8 +97,8 @@ async def test_token_forbidden(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.return_value = mock_coro(
-        exception=ClientResponseError(None, None, status=403))
+    smartthings_mock.return_value.apps.side_effect = \
+        ClientResponseError(None, None, status=403)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -118,8 +116,7 @@ async def test_webhook_error(hass, smartthings_mock):
     error = APIResponseError(None, None, data=data, status=422)
     error.is_target_error = Mock(return_value=True)
 
-    smartthings_mock.return_value.apps.return_value = mock_coro(
-        exception=error)
+    smartthings_mock.return_value.apps.side_effect = error
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -136,8 +133,7 @@ async def test_api_error(hass, smartthings_mock):
     data = {'error': {}}
     error = APIResponseError(None, None, data=data, status=400)
 
-    smartthings_mock.return_value.apps.return_value = mock_coro(
-        exception=error)
+    smartthings_mock.return_value.apps.side_effect = error
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -151,8 +147,8 @@ async def test_unknown_api_error(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.return_value = mock_coro(
-        exception=ClientResponseError(None, None, status=404))
+    smartthings_mock.return_value.apps.side_effect = \
+        ClientResponseError(None, None, status=404)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -166,8 +162,7 @@ async def test_unknown_error(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.return_value = mock_coro(
-        exception=Exception('Unknown error'))
+    smartthings_mock.return_value.apps.side_effect = Exception('Unknown error')
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -183,11 +178,8 @@ async def test_app_created_then_show_wait_form(
     flow.hass = hass
 
     smartthings = smartthings_mock.return_value
-    smartthings.apps.return_value = mock_coro(return_value=[])
-    smartthings.create_app.return_value = \
-        mock_coro(return_value=(app, app_oauth_client))
-    smartthings.update_app_settings.return_value = mock_coro()
-    smartthings.update_app_oauth.return_value = mock_coro()
+    smartthings.apps.return_value = []
+    smartthings.create_app.return_value = (app, app_oauth_client)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -201,24 +193,18 @@ async def test_cloudhook_app_created_then_show_wait_form(
     # Unload the endpoint so we can reload it under the cloud.
     await smartapp.unload_smartapp_endpoint(hass)
 
-    mock_async_active_subscription = Mock(return_value=True)
-    mock_create_cloudhook = Mock(return_value=mock_coro(
-        return_value="http://cloud.test"))
-    with patch.object(cloud, 'async_active_subscription',
-                      new=mock_async_active_subscription), \
-        patch.object(cloud, 'async_create_cloudhook',
-                     new=mock_create_cloudhook):
+    with patch.object(cloud, 'async_active_subscription', return_value=True), \
+        patch.object(
+                cloud, 'async_create_cloudhook',
+                return_value='http://cloud.test') as mock_create_cloudhook:
 
         await smartapp.setup_smartapp_endpoint(hass)
 
         flow = SmartThingsFlowHandler()
         flow.hass = hass
         smartthings = smartthings_mock.return_value
-        smartthings.apps.return_value = mock_coro(return_value=[])
-        smartthings.create_app.return_value = \
-            mock_coro(return_value=(app, app_oauth_client))
-        smartthings.update_app_settings.return_value = mock_coro()
-        smartthings.update_app_oauth.return_value = mock_coro()
+        smartthings.apps.return_value = []
+        smartthings.create_app.return_value = (app, app_oauth_client)
 
         result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -234,9 +220,8 @@ async def test_app_updated_then_show_wait_form(
     flow.hass = hass
 
     api = smartthings_mock.return_value
-    api.apps.return_value = mock_coro(return_value=[app])
-    api.generate_app_oauth.return_value = \
-        mock_coro(return_value=app_oauth_client)
+    api.apps.return_value = [app]
+    api.generate_app_oauth.return_value = app_oauth_client
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -82,7 +82,7 @@ async def test_token_unauthorized(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.side_effect = \
+    smartthings_mock.apps.side_effect = \
         ClientResponseError(None, None, status=401)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
@@ -97,7 +97,7 @@ async def test_token_forbidden(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.side_effect = \
+    smartthings_mock.apps.side_effect = \
         ClientResponseError(None, None, status=403)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
@@ -116,7 +116,7 @@ async def test_webhook_error(hass, smartthings_mock):
     error = APIResponseError(None, None, data=data, status=422)
     error.is_target_error = Mock(return_value=True)
 
-    smartthings_mock.return_value.apps.side_effect = error
+    smartthings_mock.apps.side_effect = error
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -133,7 +133,7 @@ async def test_api_error(hass, smartthings_mock):
     data = {'error': {}}
     error = APIResponseError(None, None, data=data, status=400)
 
-    smartthings_mock.return_value.apps.side_effect = error
+    smartthings_mock.apps.side_effect = error
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -147,7 +147,7 @@ async def test_unknown_api_error(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.side_effect = \
+    smartthings_mock.apps.side_effect = \
         ClientResponseError(None, None, status=404)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
@@ -162,7 +162,7 @@ async def test_unknown_error(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.return_value.apps.side_effect = Exception('Unknown error')
+    smartthings_mock.apps.side_effect = Exception('Unknown error')
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -177,9 +177,8 @@ async def test_app_created_then_show_wait_form(
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings = smartthings_mock.return_value
-    smartthings.apps.return_value = []
-    smartthings.create_app.return_value = (app, app_oauth_client)
+    smartthings_mock.apps.return_value = []
+    smartthings_mock.create_app.return_value = (app, app_oauth_client)
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -202,9 +201,8 @@ async def test_cloudhook_app_created_then_show_wait_form(
 
         flow = SmartThingsFlowHandler()
         flow.hass = hass
-        smartthings = smartthings_mock.return_value
-        smartthings.apps.return_value = []
-        smartthings.create_app.return_value = (app, app_oauth_client)
+        smartthings_mock.apps.return_value = []
+        smartthings_mock.create_app.return_value = (app, app_oauth_client)
 
         result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -219,9 +217,8 @@ async def test_app_updated_then_show_wait_form(
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    api = smartthings_mock.return_value
-    api.apps.return_value = [app]
-    api.generate_app_oauth.return_value = app_oauth_client
+    smartthings_mock.apps.return_value = [app]
+    smartthings_mock.generate_app_oauth.return_value = app_oauth_client
 
     result = await flow.async_step_user({'access_token': str(uuid4())})
 
@@ -260,7 +257,7 @@ async def test_config_entry_created_when_installed(
     flow.hass = hass
     flow.access_token = str(uuid4())
     flow.app_id = installed_app.app_id
-    flow.api = smartthings_mock.return_value
+    flow.api = smartthings_mock
     flow.oauth_client_id = str(uuid4())
     flow.oauth_client_secret = str(uuid4())
     data = {
@@ -292,7 +289,7 @@ async def test_multiple_config_entry_created_when_installed(
     flow.hass = hass
     flow.access_token = str(uuid4())
     flow.app_id = app.app_id
-    flow.api = smartthings_mock.return_value
+    flow.api = smartthings_mock
     flow.oauth_client_id = str(uuid4())
     flow.oauth_client_secret = str(uuid4())
     for installed_app in installed_apps:

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -112,8 +112,7 @@ async def test_unauthorized_installed_app_raises_not_ready(
         smartthings_mock):
     """Test config entry not ready raised when the app isn't authorized."""
     setattr(hass.config_entries, '_entries', [config_entry])
-    setattr(installed_app, '_installed_app_status',
-            InstalledAppStatus.PENDING)
+    installed_app.installed_app_status = InstalledAppStatus.PENDING
 
     smartthings_mock.app.return_value = app
     smartthings_mock.installed_app.return_value = installed_app

--- a/tests/components/smartthings/test_scene.py
+++ b/tests/components/smartthings/test_scene.py
@@ -40,7 +40,7 @@ async def test_scene_activate(hass, scene):
     assert state.attributes['color'] == scene.color
     assert state.attributes['location_id'] == scene.location_id
     # pylint: disable=protected-access
-    assert scene._api.execute_scene.call_count == 1  # type: ignore
+    assert scene.execute.call_count == 1  # type: ignore
 
 
 async def test_unload_config_entry(hass, scene):

--- a/tests/components/smartthings/test_smartapp.py
+++ b/tests/components/smartthings/test_smartapp.py
@@ -60,7 +60,6 @@ async def test_smartapp_install_creates_flow(
     """Test installation creates flow."""
     # Arrange
     setattr(hass.config_entries, '_entries', [config_entry])
-    api = smartthings_mock.return_value
     app = Mock()
     app.app_id = config_entry.data['app_id']
     request = Mock()
@@ -73,7 +72,7 @@ async def test_smartapp_install_creates_flow(
         device_factory('', [Capability.switch, Capability.switch_level]),
         device_factory('', [Capability.switch])
     ]
-    api.devices.return_value = devices
+    smartthings_mock.devices.return_value = devices
     # Act
     await smartapp.smartapp_install(hass, request, None, app)
     # Assert
@@ -147,13 +146,11 @@ async def test_smartapp_webhook(hass):
 async def test_smartapp_sync_subscriptions(
         hass, smartthings_mock, device_factory, subscription_factory):
     """Test synchronization adds and removes."""
-    api = smartthings_mock.return_value
-    subscriptions = [
+    smartthings_mock.subscriptions.return_value = [
         subscription_factory(Capability.thermostat),
         subscription_factory(Capability.switch),
         subscription_factory(Capability.switch_level)
     ]
-    api.subscriptions.return_value = subscriptions
     devices = [
         device_factory('', [Capability.battery, 'ping']),
         device_factory('', [Capability.switch, Capability.switch_level]),
@@ -163,21 +160,19 @@ async def test_smartapp_sync_subscriptions(
     await smartapp.smartapp_sync_subscriptions(
         hass, str(uuid4()), str(uuid4()), str(uuid4()), devices)
 
-    assert api.subscriptions.call_count == 1
-    assert api.delete_subscription.call_count == 1
-    assert api.create_subscription.call_count == 1
+    assert smartthings_mock.subscriptions.call_count == 1
+    assert smartthings_mock.delete_subscription.call_count == 1
+    assert smartthings_mock.create_subscription.call_count == 1
 
 
 async def test_smartapp_sync_subscriptions_up_to_date(
         hass, smartthings_mock, device_factory, subscription_factory):
     """Test synchronization does nothing when current."""
-    api = smartthings_mock.return_value
-    subscriptions = [
+    smartthings_mock.subscriptions.return_value = [
         subscription_factory(Capability.battery),
         subscription_factory(Capability.switch),
         subscription_factory(Capability.switch_level)
     ]
-    api.subscriptions.return_value = subscriptions
     devices = [
         device_factory('', [Capability.battery, 'ping']),
         device_factory('', [Capability.switch, Capability.switch_level]),
@@ -187,23 +182,21 @@ async def test_smartapp_sync_subscriptions_up_to_date(
     await smartapp.smartapp_sync_subscriptions(
         hass, str(uuid4()), str(uuid4()), str(uuid4()), devices)
 
-    assert api.subscriptions.call_count == 1
-    assert api.delete_subscription.call_count == 0
-    assert api.create_subscription.call_count == 0
+    assert smartthings_mock.subscriptions.call_count == 1
+    assert smartthings_mock.delete_subscription.call_count == 0
+    assert smartthings_mock.create_subscription.call_count == 0
 
 
 async def test_smartapp_sync_subscriptions_handles_exceptions(
         hass, smartthings_mock, device_factory, subscription_factory):
     """Test synchronization does nothing when current."""
-    api = smartthings_mock.return_value
-    api.delete_subscription.side_effect = Exception
-    api.create_subscription.side_effect = Exception
-    subscriptions = [
+    smartthings_mock.delete_subscription.side_effect = Exception
+    smartthings_mock.create_subscription.side_effect = Exception
+    smartthings_mock.subscriptions.return_value = [
         subscription_factory(Capability.battery),
         subscription_factory(Capability.switch),
         subscription_factory(Capability.switch_level)
     ]
-    api.subscriptions.return_value = subscriptions
     devices = [
         device_factory('', [Capability.thermostat, 'ping']),
         device_factory('', [Capability.switch, Capability.switch_level]),
@@ -213,6 +206,6 @@ async def test_smartapp_sync_subscriptions_handles_exceptions(
     await smartapp.smartapp_sync_subscriptions(
         hass, str(uuid4()), str(uuid4()), str(uuid4()), devices)
 
-    assert api.subscriptions.call_count == 1
-    assert api.delete_subscription.call_count == 1
-    assert api.create_subscription.call_count == 1
+    assert smartthings_mock.subscriptions.call_count == 1
+    assert smartthings_mock.delete_subscription.call_count == 1
+    assert smartthings_mock.create_subscription.call_count == 1


### PR DESCRIPTION
## Description:
Switches over to using `asynctest` and mocks to eliminate some nasty async mocking and internal implementation patching.  Only test changes.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]