### PR TITLE
Add modbus sensor for SunSpec standard

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -373,6 +373,7 @@ omit =
     homeassistant/components/mobile_app/*
     homeassistant/components/mochad/*
     homeassistant/components/modbus/*
+    homeassistant/components/modbus_sunspec/*
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/mopar/*
     homeassistant/components/mpchc/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -168,6 +168,7 @@ homeassistant/components/miflora/* @danielhiversen @ChristianKuehnel
 homeassistant/components/mill/* @danielhiversen
 homeassistant/components/min_max/* @fabaff
 homeassistant/components/mobile_app/* @robbiet480
+homeassistant/components/modbus_sunspec/* @jkells
 homeassistant/components/monoprice/* @etsinko
 homeassistant/components/moon/* @fabaff
 homeassistant/components/mpd/* @fabaff

--- a/homeassistant/components/modbus_sunspec/__init__.py
+++ b/homeassistant/components/modbus_sunspec/__init__.py
@@ -1,0 +1,1 @@
+"""The modbus_sunspec component."""

--- a/homeassistant/components/modbus_sunspec/manifest.json
+++ b/homeassistant/components/modbus_sunspec/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "modbus_sunspec",
+  "name": "Modbus SunSpec",
+  "documentation": "https://www.home-assistant.io/components/modbus_sunspec",
+  "requirements": [
+    "pymodbus==1.5.2"
+  ],
+  "dependencies": [],
+  "codeowners": []
+}

--- a/homeassistant/components/modbus_sunspec/manifest.json
+++ b/homeassistant/components/modbus_sunspec/manifest.json
@@ -5,6 +5,6 @@
   "requirements": [
     "pymodbus==1.5.2"
   ],
-  "dependencies": [],
-  "codeowners": []
+  "dependencies": ["modbus"],
+  "codeowners": ["@jkells"]
 }

--- a/homeassistant/components/modbus_sunspec/sensor.py
+++ b/homeassistant/components/modbus_sunspec/sensor.py
@@ -1,0 +1,210 @@
+"""Support for Modbus sensors that follow the SunSpec specification."""
+import logging
+
+import voluptuous as vol
+from pymodbus.payload import BinaryPayloadDecoder
+from pymodbus.constants import Endian
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_SLAVE)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.restore_state import RestoreEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+MODBUS_DOMAIN = "modbus"
+DEFAULT_HUB = 'default'
+CONF_BASE_REGISTER = 'base_register'
+CONF_MODEL = "model"
+CONF_HUB = "hub"
+
+# SunSpec model identifiers
+SINGLE_PHASE_INVERTER_MODEL = 101
+SPLIT_PHASE_INVERTER_MODEL = 102
+THREE_PHASE_INVERTER_MODEL = 103
+SINGLE_PHASE_METER_MODEL = 201
+SPLIT_PHASE_METER_MODEL = 202
+WYE_CONNECT_THREE_PHASE_METER_MODEL = 203
+DELTA_CONNECT_THREE_PHASE_METER_MODEL = 204
+
+# SunSpec block offsets
+METER_AC_POWER_OFFSET = 18
+METER_AC_POWER_SCALE_FACTOR_OFFSET = 4
+INVERTER_AC_POWER_OFFSET = 14
+INVERTER_AC_POWER_SCALE_FACTOR_OFFSET = 1
+
+
+SUPPORTED_INVERTERS = [
+    SINGLE_PHASE_INVERTER_MODEL,
+    SPLIT_PHASE_INVERTER_MODEL,
+    THREE_PHASE_INVERTER_MODEL
+]
+
+SUPPORTER_METERS = [
+    SINGLE_PHASE_METER_MODEL,
+    SPLIT_PHASE_METER_MODEL,
+    WYE_CONNECT_THREE_PHASE_METER_MODEL,
+    DELTA_CONNECT_THREE_PHASE_METER_MODEL
+]
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MODEL): [{
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_BASE_REGISTER): cv.positive_int,
+        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
+        vol.Optional(CONF_SLAVE): cv.positive_int,
+    }]
+})
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Setup the platform"""
+    sensors = []
+
+    for model in config.get(CONF_MODEL):
+        hub_name = model.get(CONF_HUB)
+        base_register = model.get(CONF_BASE_REGISTER)
+        slave = model.get(CONF_SLAVE)
+
+        hub = hass.data[MODBUS_DOMAIN][hub_name]
+        try:
+            model_id = get_sunspec_model_id(hub, base_register, slave)
+        except AttributeError:
+            _LOGGER.error("No response from hub %s, slave %s", hub_name, slave)
+            return False
+
+        if model_id in SUPPORTED_INVERTERS:
+            sensors.append(SunSpecModbusInverter(
+                hub,
+                model.get(CONF_NAME),
+                model.get(CONF_BASE_REGISTER),
+                model.get(CONF_SLAVE)))
+
+        if model_id in SUPPORTER_METERS:
+            sensors.append(SunSpecModbusMeter(
+                hub,
+                model.get(CONF_NAME),
+                model.get(CONF_BASE_REGISTER),
+                model.get(CONF_SLAVE)))
+
+    if not sensors:
+        return False
+
+    add_entities(sensors)
+    return True
+
+def get_sunspec_model_id(hub, base_register, slave):
+    """Determine the id of a SunSpec model located at base_register"""
+    result = hub.read_holding_registers(slave, base_register, 2)
+    decoder = BinaryPayloadDecoder.fromRegisters(result.registers,
+                                                 byteorder=Endian.Big,
+                                                 wordorder=Endian.Big)
+    return decoder.decode_16bit_uint()
+
+def get_sunspec_scaled_register(hub, register, slave, value_offset, scale_factor_offset):
+    """Implement an atomic read of a scaled value"""
+    value_register = register + value_offset
+    count = scale_factor_offset + 1
+    result = hub.read_holding_registers(slave, value_register, count)
+
+    decoder = BinaryPayloadDecoder.fromRegisters(result.registers,
+                                                 byteorder=Endian.Big,
+                                                 wordorder=Endian.Big)
+    value = decoder.decode_16bit_int()
+    decoder.skip_bytes(scale_factor_offset - 1)
+    scale_factor = decoder.decode_16bit_int()
+
+    return round(value * 10 ** scale_factor, 0)
+
+
+class SunSpecModbusInverter(RestoreEntity):
+    """Sunspec register sensor."""
+
+    def __init__(self, hub, name, base_register, slave):
+        """Initialize the SunSpec register sensor."""
+        self._hub = hub
+        self._name = name
+        self._slave = int(slave) if slave else None
+        self._base_register = int(base_register)
+        self._value = None
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = await self.async_get_last_state()
+        if not state:
+            return
+        self._value = state.state
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._value
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return "W"
+
+    def update(self):
+        """Update the state of the sensor."""
+        try:
+            self._value = get_sunspec_scaled_register(
+                self._hub,
+                self._base_register,
+                self._slave,
+                INVERTER_AC_POWER_OFFSET,
+                INVERTER_AC_POWER_SCALE_FACTOR_OFFSET)
+        except AttributeError:
+            _LOGGER.error("No response from hub %s, slave %s", self._hub.name, self._slave)
+            return
+
+class SunSpecModbusMeter(RestoreEntity):
+    """Sunspec register sensor."""
+
+    def __init__(self, hub, name, base_register, slave):
+        """Initialize the SunSpec register sensor."""
+        self._hub = hub
+        self._name = name
+        self._slave = int(slave) if slave else None
+        self._base_register = int(base_register)
+        self._value = None
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = await self.async_get_last_state()
+        if not state:
+            return
+        self._value = state.state
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._value
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return "W"
+
+    def update(self):
+        """Update the state of the sensor."""
+        try:
+            self._value = get_sunspec_scaled_register(self._hub,
+                                                      self._base_register,
+                                                      self._slave,
+                                                      METER_AC_POWER_OFFSET,
+                                                      METER_AC_POWER_SCALE_FACTOR_OFFSET)
+        except AttributeError:
+            _LOGGER.error("No response from hub %s, slave %s", self._hub.name, self._slave)
+            return

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1242,6 +1242,7 @@ pymitv==1.4.3
 pymochad==0.2.0
 
 # homeassistant.components.modbus
+# homeassistant.components.modbus_sunspec
 pymodbus==1.5.2
 
 # homeassistant.components.monoprice


### PR DESCRIPTION
Hi Team,

I understand I've got a bit of work to do on this before it would be ready to merge, I was just hoping to get some very early feedback on this before I put any time into polishing it up.

Data from my inverter comes in pairs of registers, a value and a scale factor. The value is multiplied by 10^scale factor to get the real value.

Using the sensor from the Modbus component it's impossible to atomically read a range of registers which means the value and scale factor can be read out of sync. A dozen times a day this leads to random sensor readings that are an order of magnitude wrong, playing havoc with integrations!

It turns out my inverter and power meter both implement a standard called SunSpec which gives a standard layout to the register map.

This component understands some of that standard so it can create sensors for SunSpec compliant Modbus devices without manually looking up register addresses. It also atomically reads values with scale factors and applies them.

The config looks like:
```
sensor:
  - platform: modbus-sunspec
     name: device1
     base_register: 40000
     slave: 1
  - name: device2
     base_register: 50000
     slave: 1
```

The component determines what type of device it's talking to according to the spec and creates the relevant sensors.

My questions are:

 * Would something like this be suitable to include in Home Assistant?
 * Architecturally is this how I should implement it? I'm using the hub from the modbus component to read the registers.
 * How much of this belongs in HA and how much should be in a module? It's pretty simple at the moment but it does only read the AC Power, when it can generate a dozen or so sensors per SunSpec device it might get a bit bigger. One of the challenges I have is I'm using the HA modbus hub to talk to the device so the code is going to be very HA specific.
