### PR TITLE
Fix Netatmo rain gauge precision

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -256,7 +256,7 @@ class NetatmoSensor(Entity):
             elif self.type == 'rain':
                 self._state = data['Rain']
             elif self.type == 'sum_rain_1':
-                self._state = data['sum_rain_1']
+                self._state = round(data['sum_rain_1'], 1)
             elif self.type == 'sum_rain_24':
                 self._state = data['sum_rain_24']
             elif self.type == 'noise':


### PR DESCRIPTION
## Description:
The Netatmo rain gauge only provides a precision of 0.1 mm but the API returns up to three digits.
So we can safely round the values to only one decimal places.

**Related issue (if applicable):** fixes #23400

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
