### PR TITLE
Update geojson_client library to version 0.4

### DIFF
--- a/homeassistant/components/geo_json_events/manifest.json
+++ b/homeassistant/components/geo_json_events/manifest.json
@@ -3,7 +3,7 @@
   "name": "Geo json events",
   "documentation": "https://www.home-assistant.io/components/geo_json_events",
   "requirements": [
-    "geojson_client==0.3"
+    "geojson_client==0.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
+++ b/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nsw rural fire service feed",
   "documentation": "https://www.home-assistant.io/components/nsw_rural_fire_service_feed",
   "requirements": [
-    "geojson_client==0.3"
+    "geojson_client==0.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/usgs_earthquakes_feed/manifest.json
+++ b/homeassistant/components/usgs_earthquakes_feed/manifest.json
@@ -3,7 +3,7 @@
   "name": "Usgs earthquakes feed",
   "documentation": "https://www.home-assistant.io/components/usgs_earthquakes_feed",
   "requirements": [
-    "geojson_client==0.3"
+    "geojson_client==0.4"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -502,7 +502,7 @@ geniushub-client==0.4.12
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed
 # homeassistant.components.usgs_earthquakes_feed
-geojson_client==0.3
+geojson_client==0.4
 
 # homeassistant.components.aprs
 geopy==1.19.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -124,7 +124,7 @@ gTTS-token==1.1.3
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed
 # homeassistant.components.usgs_earthquakes_feed
-geojson_client==0.3
+geojson_client==0.4
 
 # homeassistant.components.aprs
 geopy==1.19.0


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
By changing the `nsw_rural_fire_service_feed` platform's GeoJSON feed from HTTP to HTTPS, the external IDs supplied by the feed are changing from "http://incidents.rfs.nsw.gov.au/api/v1/incidents/..." to "https://incidents.rfs.nsw.gov.au/api/v1/incidents/...".
This should normally not make any difference to anyone consuming this feed. Only if for example you have set up a template sensor or automation that reads the `external_id` attribute of a `geo_location` entity and compare it against a pattern, you would need to change this.

## Description:
Update geojson_client library to version 0.4.
This changes the access to the external feed from HTTP to HTTPS for the `nsw_rural_fire_service_feed` platform.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
