### PR TITLE
Improve toon climate

### DIFF
--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -63,18 +63,12 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
 
     @property
     def hvac_mode(self) -> str:
-        """Return hvac operation ie. heat, cool mode.
-
-        Need to be one of HVAC_MODE_*.
-        """
+        """Return hvac operation ie. heat, cool mode."""
         return HVAC_MODE_HEAT
 
     @property
     def hvac_modes(self) -> List[str]:
-        """Return the list of available hvac operation modes.
-
-        Need to be a subset of HVAC_MODES.
-        """
+        """Return the list of available hvac operation modes."""
         return [HVAC_MODE_HEAT]
 
     @property

--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Optional
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT, PRESET_AWAY, PRESET_COMFORT, PRESET_HOME, PRESET_SLEEP,
-    SUPPORT_PRESET_MODE, SUPPORT_TARGET_TEMPERATURE)
+    SUPPORT_PRESET_MODE, SUPPORT_TARGET_TEMPERATURE, CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.helpers.typing import HomeAssistantType
@@ -44,6 +45,7 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
 
         self._current_temperature = None
         self._target_temperature = None
+        self._heating = False
         self._next_target_temperature = None
         self._preset = None
 
@@ -70,6 +72,13 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
     def hvac_modes(self) -> List[str]:
         """Return the list of available hvac operation modes."""
         return [HVAC_MODE_HEAT]
+
+    @property
+    def hvac_action(self) -> Optional[str]:
+        """Return the current running hvac operation."""
+        if self._heating:
+            return CURRENT_HVAC_HEAT
+        return CURRENT_HVAC_IDLE
 
     @property
     def temperature_unit(self) -> str:
@@ -139,3 +148,4 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
         self._current_temperature = self.toon.temperature
         self._target_temperature = self.toon.thermostat
         self._heating_type = self.toon.agreement.heating_type
+        self._heating = self.toon.thermostat_info.burner_info == 1

--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -116,13 +116,13 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
     def set_temperature(self, **kwargs) -> None:
         """Change the setpoint of the thermostat."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
-        self._client.thermostat = temperature
+        self._client.thermostat = self._target_temperature = temperature
         self.schedule_update_ha_state()
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode is not None:
-            self._client.thermostat_state = preset_mode
+            self._client.thermostat_state = self._preset = preset_mode
             self.schedule_update_ha_state()
 
     def set_hvac_mode(self, hvac_mode: str) -> None:

--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -42,10 +42,10 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
         """Initialize the Toon climate device."""
         self._client = toon_client
 
-        self._state = None
         self._current_temperature = None
         self._target_temperature = None
         self._next_target_temperature = None
+        self._preset = None
 
         self._heating_type = None
 
@@ -85,8 +85,8 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
     @property
     def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
-        if self._state is not None:
-            return self._state.lower()
+        if self._preset is not None:
+            return self._preset.lower()
         return None
 
     @property
@@ -138,9 +138,9 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateDevice):
     def update(self) -> None:
         """Update local state."""
         if self.toon.thermostat_state is None:
-            self._state = None
+            self._preset = None
         else:
-            self._state = self.toon.thermostat_state.name
+            self._preset = self.toon.thermostat_state.name
 
         self._current_temperature = self.toon.temperature
         self._target_temperature = self.toon.thermostat


### PR DESCRIPTION
## Description:

- Renames internal climate state variable to preset
   > Since that is what they are now, so adjusted used variable naming.
- Updates local variables on preset and temp changes
   > Because updating is now asynced via dispatchers, the fronted UI sometimes would behave "jumpy", by setting it locally as well, this issue has gone away.
- Shorten function comments
-  Adds support for hvac_action

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
toon:
  client_id: fxiyXLtFfhimADJlmFjTjXdHoxZ8AFg7
  client_secret: kPUCx88CTCSMAaBA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
