### PR TITLE
Bump pyvera to 0.3.2, null/missing value protection

### DIFF
--- a/homeassistant/components/vera/manifest.json
+++ b/homeassistant/components/vera/manifest.json
@@ -3,7 +3,7 @@
   "name": "Vera",
   "documentation": "https://www.home-assistant.io/components/vera",
   "requirements": [
-    "pyvera==0.3.1"
+    "pyvera==0.3.2"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1544,7 +1544,7 @@ pyuptimerobot==0.0.5
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.3.1
+pyvera==0.3.2
 
 # homeassistant.components.vesync
 pyvesync_v2==0.9.7


### PR DESCRIPTION
## Description:

Bump `pyvera` to 0.3.2, protects against missing/null values returned by the Vera.

(https://github.com/pavoni/pyvera/commit/031abc0ab91169a525012df2c9ddf7ebbfa90501)
