### PR TITLE
[climate] Add missing evohome requirement

### DIFF
--- a/homeassistant/components/evohome/manifest.json
+++ b/homeassistant/components/evohome/manifest.json
@@ -3,7 +3,8 @@
   "name": "Evohome",
   "documentation": "https://www.home-assistant.io/components/evohome",
   "requirements": [
-    "evohomeclient==0.3.3"
+    "evohomeclient==0.3.3",
+    "python-dateutil==2.8.0"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1410,6 +1410,9 @@ python-blockchain-api==0.0.2
 # homeassistant.components.clementine
 python-clementine-remote==1.0.1
 
+# homeassistant.components.evohome
+python-dateutil==2.8.0
+
 # homeassistant.components.digital_ocean
 python-digitalocean==1.13.2
 


### PR DESCRIPTION
## Breaking Change:

climate-1.0

## Description:
Replaces #25010, whihc I managed to accidentally close

 - add **python-dateutil** as a `requirement` (used to convert naive local `datetime` to UTC)

As far as I can tell, `util.dt` (and `pytz`) is unable to do the job that `dateutil` can: determine the local TZ/offset.

In addition, `dateutil.tz` is now [recommended](https://docs.python.org/3/library/datetime.html#timezone-objects) by python - "_`dateutil.tz` library brings the IANA timezone database (also known as the Olson database) to Python and its usage is recommended._"

**Related issue (if applicable):** fixes N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
