### PR TITLE
Remove myself as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -115,7 +115,6 @@ homeassistant/components/history/* @home-assistant/core
 homeassistant/components/history_graph/* @andrey-git
 homeassistant/components/hive/* @Rendili @KJonline
 homeassistant/components/homeassistant/* @home-assistant/core
-homeassistant/components/homekit/* @cdce8p
 homeassistant/components/homekit_controller/* @Jc2k
 homeassistant/components/homematic/* @pvizeli @danielperna84
 homeassistant/components/honeywell/* @zxdavb
@@ -306,5 +305,4 @@ homeassistant/components/zoneminder/* @rohankapoorcom
 homeassistant/components/zwave/* @home-assistant/z-wave
 
 # Individual files
-homeassistant/components/group/cover @cdce8p
 homeassistant/components/demo/weather @fabaff

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -6,7 +6,5 @@
     "HAP-python==2.5.0"
   ],
   "dependencies": [],
-  "codeowners": [
-    "@cdce8p"
-  ]
+  "codeowners": []
 }

--- a/script/hassfest/codeowners.py
+++ b/script/hassfest/codeowners.py
@@ -27,7 +27,6 @@ homeassistant/scripts/check_config.py @kellerza
 
 INDIVIDUAL_FILES = """
 # Individual files
-homeassistant/components/group/cover @cdce8p
 homeassistant/components/demo/weather @fabaff
 """
 


### PR DESCRIPTION
## Description:
Remove myself as codeowner for the `HomeKit` component.

During the last months, I haven't been able to contribute to Home Assistant and the `HomeKit` component as much as I would have liked. To the extend that PRs from other contributors couldn't get merged because they depended on code that wasn't written yet. I don't see this situations changing in the future.

Therefore I believe that it would be best to hand over code ownership for the `HomeKit` component and let others continue the work.

CC: @balloob