### PR TITLE
Update tuyaha to 0.0.2 to catch API exceptions

### DIFF
--- a/homeassistant/components/tuya/manifest.json
+++ b/homeassistant/components/tuya/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tuya",
   "documentation": "https://www.home-assistant.io/components/tuya",
   "requirements": [
-    "tuyaha==0.0.1"
+    "tuyaha==0.0.2"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1817,7 +1817,7 @@ tplink==0.2.1
 transmissionrpc==0.11
 
 # homeassistant.components.tuya
-tuyaha==0.0.1
+tuyaha==0.0.2
 
 # homeassistant.components.twilio
 twilio==6.19.1


### PR DESCRIPTION
## Description:

Tuya API endpoint returns 504 Timeout several times a month. The fix in tuyaha [0.0.2](https://github.com/PaulAnnekov/tuyaha/releases/tag/0.0.2) correctly handles HTTP errors and logs them as warning instead of triggering incomprehensible `JSONDecodeError` exception.

**Related issue (if applicable):** fixes #19074

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
