### PR TITLE
Remove monitored conditions from syncthru configuration

### DIFF
--- a/homeassistant/components/syncthru/sensor.py
+++ b/homeassistant/components/syncthru/sensor.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_RESOURCE, CONF_HOST, CONF_NAME, CONF_MONITORED_CONDITIONS)
+    CONF_RESOURCE, CONF_HOST, CONF_NAME)
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
@@ -40,10 +40,6 @@ DEFAULT_MONITORED_CONDITIONS.extend(
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(
-        CONF_MONITORED_CONDITIONS,
-        default=DEFAULT_MONITORED_CONDITIONS
-    ): vol.All(cv.ensure_list, [vol.In(DEFAULT_MONITORED_CONDITIONS)])
 })
 
 
@@ -60,11 +56,11 @@ async def async_setup_platform(hass,
         host = discovery_info.get(CONF_HOST)
         name = discovery_info.get(CONF_NAME, DEFAULT_NAME)
         # Main device, always added
-        monitored = DEFAULT_MONITORED_CONDITIONS
     else:
         host = config.get(CONF_RESOURCE)
         name = config.get(CONF_NAME)
-        monitored = config.get(CONF_MONITORED_CONDITIONS)
+    # always pass through all of the obtained information
+    monitored = DEFAULT_MONITORED_CONDITIONS
 
     session = aiohttp_client.async_get_clientsession(hass)
 


### PR DESCRIPTION
## Breaking Change:
The monitored_conditions configuration option [has been removed](https://github.com/home-assistant/architecture/blob/master/adr/0003-monitor-condition-and-data-selectors.md). All available monitored conditions will be used by default. Users that have been using the monitored_conditions option need to remove it from the syncthru section in configuration.yaml.


## Description:
As noted in [this comment on my last PR](https://github.com/home-assistant/home-assistant/pull/24961#pullrequestreview-258305105) monitored conditions are to be successively removed from home-assistant. Thus, now it is forbidden to use them anymore.
Removes the option of specifying monitored conditions in the syncthru component.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9825

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: syncthru
    resource: http://my-printer.address
    name: My Awesome Printer
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
