### PR TITLE
Small changes to bluetooth RSSI tracking

### DIFF
--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -108,7 +108,9 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 result = bluetooth.lookup_name(mac, timeout=5)
                 rssi = None
                 if request_rssi:
-                    rssi = BluetoothRSSI(mac).request_rssi()
+                    client = BluetoothRSSI(mac)
+                    rssi = client.request_rssi()
+                    client.close()
                 if result is None:
                     # Could not lookup device name
                     continue

--- a/homeassistant/components/bluetooth_tracker/manifest.json
+++ b/homeassistant/components/bluetooth_tracker/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bluetooth tracker",
   "documentation": "https://www.home-assistant.io/components/bluetooth_tracker",
   "requirements": [
-    "bt_proximity==0.1.2",
+    "bt_proximity==0.2",
     "pybluez==0.22"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -302,7 +302,7 @@ brottsplatskartan==0.0.1
 brunt==0.1.3
 
 # homeassistant.components.bluetooth_tracker
-bt_proximity==0.1.2
+bt_proximity==0.2
 
 # homeassistant.components.bt_home_hub_5
 bthomehub5-devicelist==0.1.1


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Updated bluetooth RSSI tracking library and made sure to always close bluetooth sockets.

**Related issue (if applicable):** #16448 (might not fix)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
    - platform: bluetooth_tracker
      interval_seconds: 2
      request_rssi: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

<!-- If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)-->

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
<!--  - [ ] Untested files have been added to `.coveragerc`. -->

<!--
If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
