### PR TITLE
Bump up ZHA dependencies.

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -6,9 +6,9 @@
   "requirements": [
     "bellows-homeassistant==0.8.2",
     "zha-quirks==0.0.17",
-    "zigpy-deconz==0.1.6",
-    "zigpy-homeassistant==0.6.1",
-    "zigpy-xbee-homeassistant==0.3.0"
+    "zigpy-deconz==0.2.0",
+    "zigpy-homeassistant==0.7.0",
+    "zigpy-xbee-homeassistant==0.4.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1945,13 +1945,13 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.1.6
+zigpy-deconz==0.2.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.6.1
+zigpy-homeassistant==0.7.0
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.3.0
+zigpy-xbee-homeassistant==0.4.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -373,4 +373,4 @@ wakeonlan==1.1.6
 zeroconf==0.23.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.6.1
+zigpy-homeassistant==0.7.0


### PR DESCRIPTION
## Description:
- Bump zigpy-homeassistant to 0.7.0
- Bump zigpy-deconz to 0.2.1
- Bump zigpy-xbee-homeassistant to 0.4.0



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
