### PR TITLE
Make sure volume level is valid when incrementing/decrementing

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -226,14 +226,16 @@ class VizioDevice(MediaPlayerDevice):
         self._device.vol_up(num=self._volume_step)
         if self._volume_level is not None:
             self._volume_level = min(1.,
-                self._volume_level + self._volume_step / self._max_volume)
+                                     self._volume_level +
+                                     self._volume_step / self._max_volume)
 
     def volume_down(self):
         """Decreasing volume of the device."""
         self._device.vol_down(num=self._volume_step)
         if self._volume_level is not None:
             self._volume_level = max(0.,
-                self._volume_level - self._volume_step / self._max_volume)
+                                     self._volume_level -
+                                     self._volume_step / self._max_volume)
 
     def validate_setup(self):
         """Validate if host is available and auth token is correct."""

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -223,13 +223,17 @@ class VizioDevice(MediaPlayerDevice):
 
     def volume_up(self):
         """Increasing volume of the device."""
-        self._volume_level += self._volume_step / self._max_volume
         self._device.vol_up(num=self._volume_step)
+        if self._volume_level is not None:
+            self._volume_level = min(1.,
+                self._volume_level + self._volume_step / self._max_volume)
 
     def volume_down(self):
         """Decreasing volume of the device."""
-        self._volume_level -= self._volume_step / self._max_volume
         self._device.vol_down(num=self._volume_step)
+        if self._volume_level is not None:
+            self._volume_level = max(0.,
+                self._volume_level - self._volume_step / self._max_volume)
 
     def validate_setup(self):
         """Validate if host is available and auth token is correct."""


### PR DESCRIPTION
## Description:

Make sure `self._volume_level is not None` before incrementing/decrementing it. Also, make sure the volume level stays between 0 and 1. 

**Related issue (if applicable):** fixes *that time when the Vizio component wasn't getting the volume level for my TV and the volume up/down commands encountered errors trying to add to/subtract from `None`*

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
