### PR TITLE
Allow csv string for rgb_color, hs_color & xy_color in light.turn_on service

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -84,6 +84,13 @@ VALID_TRANSITION = vol.All(vol.Coerce(float), vol.Clamp(min=0, max=6553))
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
 VALID_BRIGHTNESS_PCT = vol.All(vol.Coerce(float), vol.Range(min=0, max=100))
 
+
+def _csv(value):
+    if isinstance(value, str):
+        return tuple(member.strip() for member in value.split(','))
+    return value
+
+
 LIGHT_TURN_ON_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
     vol.Exclusive(ATTR_PROFILE, COLOR_GROUP): cv.string,
     ATTR_TRANSITION: VALID_TRANSITION,
@@ -91,15 +98,18 @@ LIGHT_TURN_ON_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
     ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
     vol.Exclusive(ATTR_COLOR_NAME, COLOR_GROUP): cv.string,
     vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP):
-        vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
+        vol.All(_csv,
+                vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
                 vol.Coerce(tuple)),
     vol.Exclusive(ATTR_XY_COLOR, COLOR_GROUP):
-        vol.All(vol.ExactSequence((cv.small_float, cv.small_float)),
+        vol.All(_csv,
+                vol.ExactSequence((cv.small_float, cv.small_float)),
                 vol.Coerce(tuple)),
     vol.Exclusive(ATTR_HS_COLOR, COLOR_GROUP):
-        vol.All(vol.ExactSequence(
-            (vol.All(vol.Coerce(float), vol.Range(min=0, max=360)),
-             vol.All(vol.Coerce(float), vol.Range(min=0, max=100)))),
+        vol.All(_csv,
+                vol.ExactSequence(
+                    (vol.All(vol.Coerce(float), vol.Range(min=0, max=360)),
+                     vol.All(vol.Coerce(float), vol.Range(min=0, max=100)))),
                 vol.Coerce(tuple)),
     vol.Exclusive(ATTR_COLOR_TEMP, COLOR_GROUP):
         vol.All(vol.Coerce(int), vol.Range(min=1)),

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -220,6 +220,28 @@ class TestLight(unittest.TestCase):
             light.ATTR_HS_COLOR: (71.059, 100),
         } == data
 
+        # Ensure all attributes process correctly when using csv string
+        common.turn_on(self.hass, dev1.entity_id, rgb_color='255, 255, 255')
+        common.turn_on(self.hass, dev2.entity_id, xy_color='.4, .6')
+        common.turn_on(self.hass, dev3.entity_id, hs_color='180.5, 50.5')
+
+        self.hass.block_till_done()
+
+        method, data = dev1.last_call('turn_on')
+        assert {
+            light.ATTR_HS_COLOR: (0, 0),
+        } == data
+
+        method, data = dev2.last_call('turn_on')
+        assert {
+            light.ATTR_HS_COLOR: (71.059, 100),
+        } == data
+
+        method, data = dev3.last_call('turn_on')
+        assert {
+            light.ATTR_HS_COLOR: (180.5, 50.5),
+        } == data
+
         # Ensure attributes are filtered when light is turned off
         common.turn_on(self.hass, dev1.entity_id,
                        transition=10, brightness=0, color_name='blue')


### PR DESCRIPTION
## Description:
Oftentimes users are stumped how to use templates with the `light.turn_on` service's `rgb_color`, `hs_color` & `xy_color` attributes. Given the current implementation, the only way to do so is to provide a separate template for each numeric component, e.g.:
```text
service: light.turn_on
data_template:
  rgb_color:
    - "{{ ... }}"
    - "{{ ... }}"
    - "{{ ... }}"
```
or
```text
service: light.turn_on
data_template:
  rgb_color: ["{{ ... }}", "{{ ... }}", "{{ ... }}"]
```
However, I've often see people try to do this:
```text
service: light.turn_on
data_template:
  rgb_color: >
    - {{ ... }}
    - {{ ... }}
    - {{ ... }}
```
or this:
```text
service: light.turn_on
data_template:
  rgb_color: "[{{ ... }}, {{ ... }}, {{ ... }}]"
```
and especially this:
```text
service: light.turn_on
data_template:
  rgb_color: >
    {% if ... %}
      [0,0,255]
    {% elif ... %}
      [0,255,0]
    {% else %}
      [255,0,0]
    {% endif %}
```
none of which, of course, will work.

To make it easier, and allow the entire value to be provided in _one_ template, enhance the service's schema to accept a string containing comma separated values and split them into a tuple of individual values (to be further processed by the remainder of the schema.) This allows a template similar to the following:
```text
service: light.turn_on
data_template:
  rgb_color: >
    {% set ... %}
    {{ ... }}, {{ ... }}, {{ ... }}
```
or this:
```text
service: light.turn_on
data_template:
  rgb_color: >
    {% set r,g,b = state_attr(entity_id, 'rgb_color') %}
    {% if r == 255 %}
      0, 255, 0
    {% elif g == 255 %}
      0, 0, 255
    {% else %}
      255, 0, 0
    {% endif %}
```
which both show the use of a single template that can share common calculations, etc.

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9828

## Example entry for `configuration.yaml` (if applicable):
See description above.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
