### PR TITLE
Add websocket API command for Z-Wave network status

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.dispatcher import (
 
 from . import const
 from . import config_flow  # noqa pylint: disable=unused-import
+from . import websocket_api as wsapi
 from .const import (
     CONF_AUTOHEAL, CONF_DEBUG, CONF_POLLING_INTERVAL,
     CONF_USB_STICK_PATH, CONF_CONFIG_PATH, CONF_NETWORK_KEY,
@@ -300,6 +301,8 @@ async def async_setup_entry(hass, config_entry):
     hass.data[DATA_ENTITY_VALUES] = []
 
     registry = await async_get_registry(hass)
+
+    wsapi.async_load_websocket_api(hass)
 
     if use_debug:  # pragma: no cover
         def log_all(signal, value=None):

--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -13,6 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 TYPE = 'type'
 ID = 'id'
 
+
 @websocket_api.require_admin
 @websocket_api.websocket_command({
     vol.Required(TYPE): 'zwave/network_status'
@@ -21,8 +22,8 @@ def websocket_network_status(hass, connection, msg):
     """Get Z-Wave network status."""
     network = hass.data[DATA_NETWORK]
     connection.send_result(msg[ID], {
-        'state' : network.state,
-        'state_str' : network.state_str
+        'state': network.state,
+        'state_str': network.state_str
     })
 
 

--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -1,0 +1,31 @@
+"""Web socket API for Z-Wave."""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+
+from .const import DATA_NETWORK
+
+_LOGGER = logging.getLogger(__name__)
+
+TYPE = 'type'
+ID = 'id'
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required(TYPE): 'zwave/network_status'
+})
+def websocket_network_status(hass, connection, msg):
+    """Get Z-Wave network status."""
+    network = hass.data[DATA_NETWORK]
+    connection.send_result(msg[ID], {
+        'state' : network.state,
+        'state_str' : network.state_str
+    })
+
+
+def async_load_websocket_api(hass):
+    """Set up the web socket API."""
+    websocket_api.async_register_command(hass, websocket_network_status)

--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -5,6 +5,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
+from homeassistant.core import callback
 
 from .const import DATA_NETWORK
 
@@ -26,7 +27,7 @@ def websocket_network_status(hass, connection, msg):
         'state_str': network.state_str
     })
 
-
+@callback
 def async_load_websocket_api(hass):
     """Set up the web socket API."""
     websocket_api.async_register_command(hass, websocket_network_status)

--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -24,8 +24,8 @@ def websocket_network_status(hass, connection, msg):
     network = hass.data[DATA_NETWORK]
     connection.send_result(msg[ID], {
         'state': network.state,
-        'state_str': network.state_str
     })
+
 
 @callback
 def async_load_websocket_api(hass):


### PR DESCRIPTION
## Description:
Adds a websocket API command for Z-Wave network status. Will be used by the frontend in the future.

Split into a separate websocket_api.py file as I'd like to add additional commands in the future to improve feedback for things like adding nodes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]