### PR TITLE
Fix broken test in Python 3.7

### DIFF
--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -21,7 +21,7 @@ def test_sensitive_data_filter():
 
 @asyncio.coroutine
 def test_async_handler_loop_log(loop):
-    """Test the logging sensitive data filter."""
+    """Test logging data inside from inside the event loop."""
     loop._thread_ident = threading.get_ident()
 
     queue = asyncio.Queue(loop=loop)
@@ -40,13 +40,13 @@ def test_async_handler_loop_log(loop):
     log_record = logging.makeLogRecord({'msg': "Test Log Record"})
     handler.emit(log_record)
     yield from handler.async_close(True)
-    assert queue.get_nowait() == log_record
+    assert queue.get_nowait().msg == "Test Log Record"
     assert queue.empty()
 
 
 @asyncio.coroutine
 def test_async_handler_thread_log(loop):
-    """Test the logging sensitive data filter."""
+    """Test logging data from a thread."""
     loop._thread_ident = threading.get_ident()
 
     queue = asyncio.Queue(loop=loop)
@@ -63,7 +63,7 @@ def test_async_handler_thread_log(loop):
     yield from loop.run_in_executor(None, add_log)
     yield from handler.async_close(True)
 
-    assert queue.get_nowait() == log_record
+    assert queue.get_nowait().msg == "Test Log Record"
     assert queue.empty()
 
 


### PR DESCRIPTION
## Description:
Python 3.7.4 introduced a slight change in how the logging module works, causing our test to fail. Our test expected that the emitted log record would be the same as that we got in the end, this is no longer the case.

