### PR TITLE
Splunk component filter support

### DIFF
--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -11,10 +11,12 @@ from homeassistant.const import (
     CONF_PORT, CONF_TOKEN, EVENT_STATE_CHANGED)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.helpers.json import JSONEncoder
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_FILTER = 'filter'
 DOMAIN = 'splunk'
 
 DEFAULT_HOST = 'localhost'
@@ -30,6 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SSL, default=False): cv.boolean,
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_FILTER, default={}): FILTER_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -43,6 +46,7 @@ def setup(hass, config):
     use_ssl = conf.get(CONF_SSL)
     verify_ssl = conf.get(CONF_VERIFY_SSL)
     name = conf.get(CONF_NAME)
+    entity_filter = conf[CONF_FILTER]
 
     if use_ssl:
         uri_scheme = 'https://'
@@ -57,7 +61,7 @@ def setup(hass, config):
         """Listen for new messages on the bus and sends them to Splunk."""
         state = event.data.get('new_state')
 
-        if state is None:
+        if state is None or not entity_filter(state.entity_id):
             return
 
         try:

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -38,14 +38,15 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 def post_request(event_collector, body, headers, verify_ssl):
+    """Post request to Splunk."""
     try:
         payload = {
             "host": event_collector,
             "event": body,
         }
         requests.post(event_collector,
-                    data=json.dumps(payload, cls=JSONEncoder),
-                    headers=headers, timeout=10, verify=verify_ssl)
+                      data=json.dumps(payload, cls=JSONEncoder),
+                      headers=headers, timeout=10, verify=verify_ssl)
 
     except requests.exceptions.RequestException as error:
         _LOGGER.exception("Error saving event to Splunk: %s", error)
@@ -95,7 +96,6 @@ def setup(hass, config):
         ]
 
         post_request(event_collector, json_body, headers, verify_ssl)
-
 
     hass.bus.listen(EVENT_STATE_CHANGED, splunk_event_listener)
 

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -15,8 +15,6 @@ from tests.common import (
     mock_state_change_event
 )
 
-
-
 class TestSplunk(unittest.TestCase):
     """Test the Splunk component."""
 
@@ -159,7 +157,6 @@ class TestSplunk(unittest.TestCase):
         """Test event listener."""
         self._setup_with_filter(mock_requests)
 
-        now = dt_util.now()
         testdata = [
             {
                 'entity_id': 'other_domain.other_entity',
@@ -180,11 +177,8 @@ class TestSplunk(unittest.TestCase):
             self.hass.block_till_done()
 
             if test['filter_expected']:
-                """Verify that the request post did not occur for a filtered events"""
                 assert not splunk.post_request.called
             else:
-                """Verify that the request post did occur for a non-filtered events"""
                 assert splunk.post_request.called
 
             splunk.post_request.reset_mock()
-

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -133,7 +133,7 @@ class TestSplunk(unittest.TestCase):
                     timeout=10, verify=True)
             self.mock_post.reset_mock()
 
-    def _setup_with_filter(self, mock_requests):
+    def _setup_with_filter(self):
         """Test the setup."""
         config = {
             'splunk': {
@@ -156,7 +156,7 @@ class TestSplunk(unittest.TestCase):
     @mock.patch.object(splunk, 'post_request')
     def test_splunk_entityfilter(self, mock_requests):
         """Test event listener."""
-        self._setup_with_filter(mock_requests)
+        self._setup_with_filter()
 
         testdata = [
             {

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -15,6 +15,7 @@ from tests.common import (
     mock_state_change_event
 )
 
+
 class TestSplunk(unittest.TestCase):
     """Test the Splunk component."""
 

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -8,8 +8,13 @@ import homeassistant.components.splunk as splunk
 from homeassistant.const import STATE_ON, STATE_OFF, EVENT_STATE_CHANGED
 from homeassistant.helpers import state as state_helper
 import homeassistant.util.dt as dt_util
+from homeassistant.core import State
 
-from tests.common import get_test_home_assistant
+from tests.common import (
+    get_test_home_assistant,
+    mock_state_change_event
+)
+
 
 
 class TestSplunk(unittest.TestCase):
@@ -33,6 +38,14 @@ class TestSplunk(unittest.TestCase):
                 'ssl': 'False',
                 'verify_ssl': 'True',
                 'name': 'hostname',
+                'filter': {
+                    'exclude_domains': [
+                          'fake'
+                    ],
+                    'exclude_entities': [
+                        'fake.entity'
+                    ],
+                }
             }
         }
 
@@ -120,3 +133,58 @@ class TestSplunk(unittest.TestCase):
                     headers={'Authorization': 'Splunk secret'},
                     timeout=10, verify=True)
             self.mock_post.reset_mock()
+
+    def _setup_with_filter(self, mock_requests):
+        """Test the setup."""
+        config = {
+            'splunk': {
+                'host': 'host',
+                'token': 'secret',
+                'port': 8088,
+                'filter': {
+                    'exclude_domains': [
+                        'excluded_domain'
+                    ],
+                    'exclude_entities': [
+                        'other_domain.excluded_entity'
+                    ]
+                }
+            }
+        }
+
+        setup_component(self.hass, splunk.DOMAIN, config)
+
+    @mock.patch.object(splunk, 'post_request')
+    def test_splunk_entityfilter(self, mock_requests):
+        """Test event listener."""
+        self._setup_with_filter(mock_requests)
+
+        now = dt_util.now()
+        testdata = [
+            {
+                'entity_id': 'other_domain.other_entity',
+                'filter_expected': False
+            },
+            {
+                'entity_id': 'other_domain.excluded_entity',
+                'filter_expected': True
+            },
+            {
+                'entity_id': 'excluded_domain.other_entity',
+                'filter_expected': True
+            }
+        ]
+
+        for test in testdata:
+            mock_state_change_event(self.hass, State(test['entity_id'], 'on'))
+            self.hass.block_till_done()
+
+            if test['filter_expected']:
+                """Verify that the request post did not occur for a filtered events"""
+                assert not splunk.post_request.called
+            else:
+                """Verify that the request post did occur for a non-filtered events"""
+                assert splunk.post_request.called
+
+            splunk.post_request.reset_mock()
+


### PR DESCRIPTION
## Description:
Adding "filter" support for the Splunk component.  Filter implementation is modeled after the current HomeKit component filter support.  This is the THIRD PR for this.  First attempt was screwy in terms of commit information, and couldn't figure out how to resolve with prior PR, so started over. Second had a long pause while I found the time to figure out how to write the test cases.  This time, everything should be ready to go with little delay (hopefully).

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** TBD; need to create; will update

## Example entry for `configuration.yaml` (if applicable):
```yaml
splunk:
  token: XXXXXXXXXXX
  host: splunk.example.com
  port: 8088
  ssl: true
  verify_ssl: false
  name: homeassistant
  filter:
    exclude_domains:
      - automation
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) : https://github.com/home-assistant/home-assistant.io/pull/9831

If the code communicates with devices, web services, or third-party tools:
  - [X] No changes to communication code.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
