### PR TITLE
Correctly store removed entities for restore state

### DIFF
--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -1,6 +1,5 @@
 """Support for restoring entity states on startup."""
 import asyncio
-import json
 import logging
 from datetime import timedelta, datetime
 from typing import Any, Dict, List, Set, Optional  # noqa  pylint_disable=unused-import

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -203,7 +203,7 @@ def _encode_complex(value):
             _encode(key): _encode_complex(value)
             for key, value in value.items()
         }
-    elif isinstance(value, (list, set)):
+    elif isinstance(value, list):
         return [_encode_complex(val) for val in value]
 
     new_value = _encode(value)

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -1,5 +1,6 @@
 """Support for restoring entity states on startup."""
 import asyncio
+import json
 import logging
 from datetime import timedelta, datetime
 from typing import Any, Dict, List, Set, Optional  # noqa  pylint_disable=unused-import
@@ -177,10 +178,41 @@ class RestoreStateData():
         # When an entity is being removed from hass, store its last state. This
         # allows us to support state restoration if the entity is removed, then
         # re-added while hass is still running.
-        self.last_states[entity_id] = StoredState(
-            self.hass.states.get(entity_id), dt_util.utcnow())
+        state = self.hass.states.get(entity_id)
+        # To fully mimic all the attribute data types when loaded from storage,
+        # we're going to serialize it to JSON and then re-load it.
+        if state is not None:
+            state = State.from_dict(_encode_complex(state.as_dict()))
+
+        self.last_states[entity_id] = StoredState(state, dt_util.utcnow())
 
         self.entity_ids.remove(entity_id)
+
+
+def _encode(value):
+    """Little helper to JSON encode a value."""
+    try:
+        return JSONEncoder.default(None, value)
+    except TypeError:
+        return value
+
+
+def _encode_complex(value):
+    """Recursively encode all values with the JSONEncoder."""
+    if isinstance(value, dict):
+        return {
+            _encode(key): _encode_complex(value)
+            for key, value in value.items()
+        }
+    elif isinstance(value, (list, set)):
+        return [_encode_complex(val) for val in value]
+
+    new_value = _encode(value)
+
+    if isinstance(new_value, type(value)):
+        return new_value
+
+    return _encode_complex(new_value)
 
 
 class RestoreEntity(Entity):


### PR DESCRIPTION
## Description:
State restoration would return attributes with different types if an entity was restored whose state was stored during the same run.

**Related issue (if applicable):** #24951

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
