### PR TITLE
Change unique_id formula for Notion entities

### DIFF
--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, async_dispatcher_send)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import slugify
 
 from .config_flow import configured_instances
 from .const import (
@@ -267,7 +268,7 @@ class NotionEntity(Entity):
     @property
     def unique_id(self):
         """Return a unique, unchanging string that represents this sensor."""
-        return self._task_id
+        return '{0}_{1}'.format(self._sensor_id, slugify(self._name))
 
     async def _update_bridge_id(self):
         """Update the entity's bridge ID if it has changed.

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, async_dispatcher_send)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util import slugify
 
 from .config_flow import configured_instances
 from .const import (
@@ -268,7 +267,8 @@ class NotionEntity(Entity):
     @property
     def unique_id(self):
         """Return a unique, unchanging string that represents this sensor."""
-        return '{0}_{1}'.format(self._sensor_id, slugify(self._name))
+        task = self._notion.tasks[self._task_id]
+        return '{0}_{1}'.format(self._sensor_id, task['task_type'])
 
     async def _update_bridge_id(self):
         """Update the entity's bridge ID if it has changed.


### PR DESCRIPTION
## Description:

The yet-to-be-released Notion component had entities who could change unique IDs, meaning that duplicates would be created. This PR alters the formula to be more stable: instead of using the task ID, (which, due to a possible API bug, can change), use the sensor ID (which has not been observed to change).

Because Notion hasn't been released yet, this isn't a user-facing breaking change. This should go out at the same time (CC: @balloob).

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/25075

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
notion:
  username: !secret notion_username
  password: !secret notion_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
