### PR TITLE
Guard module being None

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -549,7 +549,13 @@ def deprecated(key: str,
         - Once the invalidation_version is crossed, raises vol.Invalid if key
         is detected
     """
-    module_name = inspect.getmodule(inspect.stack()[1][0]).__name__
+    module = inspect.getmodule(inspect.stack()[1][0])
+    if module is not None:
+        module_name = module.__name__
+    else:
+        # Unclear when it is None, but it happens, so let's guard.
+        # https://github.com/home-assistant/home-assistant/issues/24982
+        module_name = __name__
 
     if replacement_key and invalidation_version:
         warning = ("The '{key}' option (with value '{value}') is"

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -833,6 +833,16 @@ def test_deprecated_with_replacement_key_invalidation_version_default(
             "invalid in version 0.1.0") == str(exc_info.value)
 
 
+def test_deprecated_cant_find_module():
+    """Test if the current module cannot be inspected."""
+    with patch('inspect.getmodule', return_value=None):
+        # This used to raise.
+        cv.deprecated(
+            'mars', replacement_key='jupiter', invalidation_version='1.0.0',
+            default=False
+        )
+
+
 def test_key_dependency():
     """Test key_dependency validator."""
     schema = vol.Schema(cv.key_dependency('beer', 'soda'))


### PR DESCRIPTION
## Description:
Unclear when this happens, but will add a guard so it cannot happen anymore.

**Related issue (if applicable):** fixes #24982

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
