### PR TITLE
Add climate related services to Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -20,6 +20,17 @@ from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_DURATION = 'duration'
+ATTR_ENDTIME = 'endtime'
+ATTR_TEMPERATURE = 'temperature'
+ATTR_ACCESSPOINT_ID = 'accesspoint_id'
+
+SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION = 'activate_eco_mode_with_duration'
+SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD = 'activate_eco_mode_with_period'
+SERVICE_ACTIVATE_VACATION = 'activate_vacation'
+SERVICE_DEACTIVATE_ECO_MODE = 'deactivate_eco_mode'
+SERVICE_DEACTIVATE_VACATION = 'deactivate_vacation'
+
 CONFIG_SCHEMA = vol.Schema({
     vol.Optional(DOMAIN, default=[]): vol.All(cv.ensure_list, [vol.Schema({
         vol.Optional(CONF_NAME, default=''): vol.Any(cv.string),
@@ -27,6 +38,36 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_AUTHTOKEN): cv.string,
     })]),
 }, extra=vol.ALLOW_EXTRA)
+
+SCHEMA_ACTIVATE_ECO_MODE_WITH_DURATION = vol.Schema({
+    vol.Required(ATTR_DURATION): cv.positive_int,
+    vol.Optional(ATTR_ACCESSPOINT_ID):
+        vol.All(str, vol.Length(min=24, max=24)),
+})
+
+SCHEMA_ACTIVATE_ECO_MODE_WITH_PERIOD = vol.Schema({
+    vol.Required(ATTR_ENDTIME): cv.datetime,
+    vol.Optional(ATTR_ACCESSPOINT_ID):
+        vol.All(str, vol.Length(min=24, max=24)),
+})
+
+SCHEMA_ACTIVATE_VACATION = vol.Schema({
+    vol.Required(ATTR_ENDTIME): cv.datetime,
+    vol.Required(ATTR_TEMPERATURE, default=18.0):
+        vol.All(vol.Coerce(float), vol.Range(min=0, max=55)),
+    vol.Optional(ATTR_ACCESSPOINT_ID):
+        vol.All(str, vol.Length(min=24, max=24)),
+})
+
+SCHEMA_DEACTIVATE_ECO_MODE = vol.Schema({
+    vol.Optional(ATTR_ACCESSPOINT_ID):
+        vol.All(str, vol.Length(min=24, max=24)),
+})
+
+SCHEMA_DEACTIVATE_VACATION = vol.Schema({
+    vol.Optional(ATTR_ACCESSPOINT_ID):
+        vol.All(str, vol.Length(min=24, max=24)),
+})
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -45,6 +86,104 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     HMIPC_NAME: conf[CONF_NAME],
                 }
             ))
+
+    async def _async_activate_eco_mode_with_duration(service):
+        """Service to activate eco mode with duration."""
+        duration = service.data[ATTR_DURATION]
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+
+        if hapid:
+            home = _get_home(hapid)
+            if home:
+                await home.activate_absence_with_duration(duration)
+        else:
+            for hapid in hass.data[DOMAIN]:
+                home = hass.data[DOMAIN][hapid].home
+                await home.activate_absence_with_duration(duration)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION,
+        _async_activate_eco_mode_with_duration,
+        schema=SCHEMA_ACTIVATE_ECO_MODE_WITH_DURATION)
+
+    async def _async_activate_eco_mode_with_period(service):
+        """Service to activate eco mode with period."""
+        endtime = service.data[ATTR_ENDTIME]
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+
+        if hapid:
+            home = _get_home(hapid)
+            if home:
+                await home.activate_absence_with_period(endtime)
+        else:
+            for hapid in hass.data[DOMAIN]:
+                home = hass.data[DOMAIN][hapid].home
+                await home.activate_absence_with_period(endtime)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD,
+        _async_activate_eco_mode_with_period,
+        schema=SCHEMA_ACTIVATE_ECO_MODE_WITH_PERIOD)
+
+    async def _async_activate_vacation(service):
+        """Service to activate vacation."""
+        endtime = service.data[ATTR_ENDTIME]
+        temperature = service.data[ATTR_TEMPERATURE]
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+
+        if hapid:
+            home = _get_home(hapid)
+            if home:
+                await home.activate_vacation(endtime, temperature)
+        else:
+            for hapid in hass.data[DOMAIN]:
+                home = hass.data[DOMAIN][hapid].home
+                await home.activate_vacation(endtime, temperature)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ACTIVATE_VACATION, _async_activate_vacation,
+        schema=SCHEMA_ACTIVATE_VACATION)
+
+    async def _async_deactivate_eco_mode(service):
+        """Service to deactivate eco mode."""
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+
+        if hapid:
+            home = _get_home(hapid)
+            if home:
+                await home.deactivate_absence()
+        else:
+            for hapid in hass.data[DOMAIN]:
+                home = hass.data[DOMAIN][hapid].home
+                await home.deactivate_absence()
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_DEACTIVATE_ECO_MODE, _async_deactivate_eco_mode,
+        schema=SCHEMA_DEACTIVATE_ECO_MODE)
+
+    async def _async_deactivate_vacation(service):
+        """Service to deactivate vacation."""
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+
+        if hapid:
+            home = _get_home(hapid)
+            if home:
+                await home.deactivate_vacation()
+        else:
+            for hapid in hass.data[DOMAIN]:
+                home = hass.data[DOMAIN][hapid].home
+                await home.deactivate_vacation()
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_DEACTIVATE_VACATION, _async_deactivate_vacation,
+        schema=SCHEMA_DEACTIVATE_VACATION)
+
+    def _get_home(hapid: str):
+        """Return a HmIP home."""
+        hap = hass.data[DOMAIN][hapid]
+        if hap:
+            return hap.home
+        return None
 
     return True
 

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_DURATION = 'duration'
 ATTR_ENDTIME = 'endtime'
 ATTR_TEMPERATURE = 'temperature'
-ATTR_HAPID = 'hapid'
+ATTR_ACCESSPOINT_ID = 'accesspoint_id'
 
 SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION = 'activate_eco_mode_with_duration'
 SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD = 'activate_eco_mode_with_period'
@@ -41,13 +41,13 @@ CONFIG_SCHEMA = vol.Schema({
 
 SCHEMA_ACTIVATE_ECO_MODE_WITH_DURATION = vol.Schema({
     vol.Required(ATTR_DURATION): cv.positive_int,
-    vol.Optional(ATTR_HAPID):
+    vol.Optional(ATTR_ACCESSPOINT_ID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
 SCHEMA_ACTIVATE_ECO_MODE_WITH_PERIOD = vol.Schema({
     vol.Required(ATTR_ENDTIME): cv.datetime,
-    vol.Optional(ATTR_HAPID):
+    vol.Optional(ATTR_ACCESSPOINT_ID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
@@ -55,17 +55,17 @@ SCHEMA_ACTIVATE_VACATION = vol.Schema({
     vol.Required(ATTR_ENDTIME): cv.datetime,
     vol.Required(ATTR_TEMPERATURE, default=18.0):
         vol.All(vol.Coerce(float), vol.Range(min=0, max=55)),
-    vol.Optional(ATTR_HAPID):
+    vol.Optional(ATTR_ACCESSPOINT_ID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
 SCHEMA_DEACTIVATE_ECO_MODE = vol.Schema({
-    vol.Optional(ATTR_HAPID):
+    vol.Optional(ATTR_ACCESSPOINT_ID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
 SCHEMA_DEACTIVATE_VACATION = vol.Schema({
-    vol.Optional(ATTR_HAPID):
+    vol.Optional(ATTR_ACCESSPOINT_ID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
@@ -90,7 +90,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def _async_activate_eco_mode_with_duration(service):
         """Service to activate eco mode with duration."""
         duration = service.data[ATTR_DURATION]
-        hapid = service.data.get(ATTR_HAPID)
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
 
         if hapid:
             home = _get_home(hapid)
@@ -109,7 +109,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def _async_activate_eco_mode_with_period(service):
         """Service to activate eco mode with period."""
         endtime = service.data[ATTR_ENDTIME]
-        hapid = service.data.get(ATTR_HAPID)
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
 
         if hapid:
             home = _get_home(hapid)
@@ -129,7 +129,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Service to activate vacation."""
         endtime = service.data[ATTR_ENDTIME]
         temperature = service.data[ATTR_TEMPERATURE]
-        hapid = service.data.get(ATTR_HAPID)
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
 
         if hapid:
             home = _get_home(hapid)
@@ -146,7 +146,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def _async_deactivate_eco_mode(service):
         """Service to deactivate eco mode."""
-        hapid = service.data.get(ATTR_HAPID)
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
 
         if hapid:
             home = _get_home(hapid)
@@ -163,7 +163,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def _async_deactivate_vacation(service):
         """Service to deactivate vacation."""
-        hapid = service.data.get(ATTR_HAPID)
+        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
 
         if hapid:
             home = _get_home(hapid)

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_DURATION = 'duration'
 ATTR_ENDTIME = 'endtime'
 ATTR_TEMPERATURE = 'temperature'
-ATTR_ACCESSPOINT_ID = 'accesspoint_id'
+ATTR_HAPID = 'hapid'
 
 SERVICE_ACTIVATE_ECO_MODE_WITH_DURATION = 'activate_eco_mode_with_duration'
 SERVICE_ACTIVATE_ECO_MODE_WITH_PERIOD = 'activate_eco_mode_with_period'
@@ -41,13 +41,13 @@ CONFIG_SCHEMA = vol.Schema({
 
 SCHEMA_ACTIVATE_ECO_MODE_WITH_DURATION = vol.Schema({
     vol.Required(ATTR_DURATION): cv.positive_int,
-    vol.Optional(ATTR_ACCESSPOINT_ID):
+    vol.Optional(ATTR_HAPID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
 SCHEMA_ACTIVATE_ECO_MODE_WITH_PERIOD = vol.Schema({
     vol.Required(ATTR_ENDTIME): cv.datetime,
-    vol.Optional(ATTR_ACCESSPOINT_ID):
+    vol.Optional(ATTR_HAPID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
@@ -55,17 +55,17 @@ SCHEMA_ACTIVATE_VACATION = vol.Schema({
     vol.Required(ATTR_ENDTIME): cv.datetime,
     vol.Required(ATTR_TEMPERATURE, default=18.0):
         vol.All(vol.Coerce(float), vol.Range(min=0, max=55)),
-    vol.Optional(ATTR_ACCESSPOINT_ID):
+    vol.Optional(ATTR_HAPID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
 SCHEMA_DEACTIVATE_ECO_MODE = vol.Schema({
-    vol.Optional(ATTR_ACCESSPOINT_ID):
+    vol.Optional(ATTR_HAPID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
 SCHEMA_DEACTIVATE_VACATION = vol.Schema({
-    vol.Optional(ATTR_ACCESSPOINT_ID):
+    vol.Optional(ATTR_HAPID):
         vol.All(str, vol.Length(min=24, max=24)),
 })
 
@@ -90,7 +90,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def _async_activate_eco_mode_with_duration(service):
         """Service to activate eco mode with duration."""
         duration = service.data[ATTR_DURATION]
-        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+        hapid = service.data.get(ATTR_HAPID)
 
         if hapid:
             home = _get_home(hapid)
@@ -109,7 +109,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def _async_activate_eco_mode_with_period(service):
         """Service to activate eco mode with period."""
         endtime = service.data[ATTR_ENDTIME]
-        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+        hapid = service.data.get(ATTR_HAPID)
 
         if hapid:
             home = _get_home(hapid)
@@ -129,7 +129,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Service to activate vacation."""
         endtime = service.data[ATTR_ENDTIME]
         temperature = service.data[ATTR_TEMPERATURE]
-        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+        hapid = service.data.get(ATTR_HAPID)
 
         if hapid:
             home = _get_home(hapid)
@@ -146,7 +146,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def _async_deactivate_eco_mode(service):
         """Service to deactivate eco mode."""
-        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+        hapid = service.data.get(ATTR_HAPID)
 
         if hapid:
             home = _get_home(hapid)
@@ -163,7 +163,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def _async_deactivate_vacation(service):
         """Service to deactivate vacation."""
-        hapid = service.data.get(ATTR_ACCESSPOINT_ID)
+        hapid = service.data.get(ATTR_HAPID)
 
         if hapid:
             home = _get_home(hapid)

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -1,0 +1,49 @@
+# Describes the format for available component services
+
+activate_eco_mode_with_duration:
+  description: Activate eco mode with period.
+  fields:
+    duration:
+      description: The duration of eco mode in minutes.
+      example: 60
+    accesspoint_id:
+      description: The ID of the Homematic IP Access Point
+      example: 3014xxxxxxxxxxxxxxxxxxxx
+
+activate_eco_mode_with_period:
+  description: Activate eco mode with period.
+  fields:
+    endtime:
+      description: The time when the eco mode should automatically be disabled.
+      example: 2019-02-17 14:00
+    accesspoint_id:
+      description: The ID of the Homematic IP Access Point
+      example: 3014xxxxxxxxxxxxxxxxxxxx
+
+activate_vacation:
+  description: Activates the vacation mode until the given time.
+  fields:
+    endtime:
+      description: The time when the vacation mode should automatically be disabled.
+      example: 2019-09-17 14:00
+    temperature:
+      description: the set temperature during the vacation mode.
+      example: 18.5
+    accesspoint_id:
+      description: The ID of the Homematic IP Access Point
+      example: 3014xxxxxxxxxxxxxxxxxxxx
+
+deactivate_eco_mode:
+  description: Deactivates the eco mode immediately.
+  fields:
+    accesspoint_id:
+      description: The ID of the Homematic IP Access Point
+      example: 3014xxxxxxxxxxxxxxxxxxxx
+
+deactivate_vacation:
+  description: Deactivates the vacation mode immediately.
+  fields:
+    accesspoint_id:
+      description: The ID of the Homematic IP Access Point
+      example: 3014xxxxxxxxxxxxxxxxxxxx
+

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -6,7 +6,7 @@ activate_eco_mode_with_duration:
     duration:
       description: The duration of eco mode in minutes.
       example: 60
-    accesspoint_id:
+    hapid:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
@@ -16,7 +16,7 @@ activate_eco_mode_with_period:
     endtime:
       description: The time when the eco mode should automatically be disabled.
       example: 2019-02-17 14:00
-    accesspoint_id:
+    hapid:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
@@ -29,21 +29,21 @@ activate_vacation:
     temperature:
       description: the set temperature during the vacation mode.
       example: 18.5
-    accesspoint_id:
+    hapid:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 deactivate_eco_mode:
   description: Deactivates the eco mode immediately.
   fields:
-    accesspoint_id:
+    hapid:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 deactivate_vacation:
   description: Deactivates the vacation mode immediately.
   fields:
-    accesspoint_id:
+    hapid:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 

--- a/homeassistant/components/homematicip_cloud/services.yaml
+++ b/homeassistant/components/homematicip_cloud/services.yaml
@@ -6,7 +6,7 @@ activate_eco_mode_with_duration:
     duration:
       description: The duration of eco mode in minutes.
       example: 60
-    hapid:
+    accesspoint_id:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
@@ -16,7 +16,7 @@ activate_eco_mode_with_period:
     endtime:
       description: The time when the eco mode should automatically be disabled.
       example: 2019-02-17 14:00
-    hapid:
+    accesspoint_id:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
@@ -29,21 +29,21 @@ activate_vacation:
     temperature:
       description: the set temperature during the vacation mode.
       example: 18.5
-    hapid:
+    accesspoint_id:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 deactivate_eco_mode:
   description: Deactivates the eco mode immediately.
   fields:
-    hapid:
+    accesspoint_id:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 
 deactivate_vacation:
   description: Deactivates the vacation mode immediately.
   fields:
-    hapid:
+    accesspoint_id:
       description: The ID of the Homematic IP Access Point
       example: 3014xxxxxxxxxxxxxxxxxxxx
 


### PR DESCRIPTION
Description:
This PR add required services for Homematic IP Cloud to control eco and vacation modes.
These modes are not controlable on an entity level.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#9832

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
