### PR TITLE
Fix powercontrol media player on alexa

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -339,15 +339,11 @@ class MediaPlayerCapabilities(AlexaEntity):
     def interfaces(self):
         """Yield the supported interfaces."""
         yield AlexaEndpointHealth(self.hass, self.entity)
+        yield AlexaPowerController(self.entity)
 
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & media_player.const.SUPPORT_VOLUME_SET:
             yield AlexaSpeaker(self.entity)
-
-        power_features = (media_player.SUPPORT_TURN_ON |
-                          media_player.SUPPORT_TURN_OFF)
-        if supported & power_features:
-            yield AlexaPowerController(self.entity)
 
         step_volume_features = (media_player.const.SUPPORT_VOLUME_MUTE |
                                 media_player.const.SUPPORT_VOLUME_STEP)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -558,11 +558,22 @@ async def test_media_player_power(hass):
     assert_endpoint_capabilities(
         appliance,
         'Alexa.InputController',
+        'Alexa.PowerController',
         'Alexa.Speaker',
         'Alexa.StepSpeaker',
         'Alexa.PlaybackController',
         'Alexa.EndpointHealth',
     )
+
+    await assert_request_calls_service(
+        'Alexa.PowerController', 'TurnOn', 'media_player#test',
+        'media_player.media_play',
+        hass)
+
+    await assert_request_calls_service(
+        'Alexa.PowerController', 'TurnOff', 'media_player#test',
+        'media_player.media_stop',
+        hass)
 
 
 async def test_alert(hass):


### PR DESCRIPTION
## Description:

This reverts my previous solution to handle the power states with Media Player. It was the wrong fix. After that, the media player did not anymore control able by Alexa (in german). I did the right thing but wrong for Alexa.

This is the bugfix that someone had on discord before.