### PR TITLE
WIP Allow editing of saved sources/media data with services for PS4 integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -464,7 +464,6 @@ omit =
     homeassistant/components/prometheus/*
     homeassistant/components/prowl/notify.py
     homeassistant/components/proxy/camera.py
-    homeassistant/components/ps4/__init__.py
     homeassistant/components/ps4/media_player.py
     homeassistant/components/ptvsd/*
     homeassistant/components/pulseaudio_loopback/switch.py

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -468,7 +468,7 @@ def load_games(hass: HomeAssistantType) -> dict:
     # Convert str format to dict format if not already.
     if games is not None:
         for game, data in games.items():
-            if type(data) is not dict:
+            if not isinstance(data, dict):
                 games[game] = {ATTR_MEDIA_TITLE: data,
                                ATTR_MEDIA_IMAGE_URL: None,
                                ATTR_LOCKED: False,
@@ -486,7 +486,7 @@ def save_games(hass: HomeAssistantType, games: dict):
 
     # Retry loading file
     if games is None:
-        load_games()
+        load_games(hass)
 
 
 def _set_media(hass: HomeAssistantType, games: dict, media_content_id,

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -1,15 +1,87 @@
 """Support for PlayStation 4 consoles."""
 import logging
 
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_COMMAND, ATTR_ENTITY_ID, ATTR_LOCKED, CONF_REGION, CONF_TOKEN)
 from homeassistant.core import split_entity_id
-from homeassistant.const import CONF_REGION, CONF_TOKEN
-from homeassistant.helpers import entity_registry
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry, config_validation as cv
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.components.media_player.const import (
+    ATTR_MEDIA_CONTENT_ID, ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_TITLE,
+    MEDIA_TYPE_APP, MEDIA_TYPE_GAME)
 from homeassistant.util import location
+from homeassistant.util.json import load_json, save_json
+
 
 from .config_flow import PlayStation4FlowHandler  # noqa: pylint: disable=unused-import
-from .const import DOMAIN, PS4_DATA  # noqa: pylint: disable=unused-import
+from .const import (
+    ATTR_MEDIA_IMAGE_URL, COMMANDS, DEFAULT_URL, DOMAIN, GAMES_FILE, PS4_DATA)
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_COMMAND = 'send_command'
+SERVICE_LOCK_MEDIA = 'lock_media'
+SERVICE_LOCK_CURRENT_MEDIA = 'lock_current_media'
+SERVICE_UNLOCK_MEDIA = 'unlock_media'
+SERVICE_UNLOCK_CURRENT_MEDIA = 'unlock_current_media'
+SERVICE_EDIT_MEDIA = 'edit_media'
+SERVICE_EDIT_CURRENT_MEDIA = 'edit_current_media'
+SERVICE_ADD_MEDIA = 'add_media'
+SERVICE_REMOVE_MEDIA = 'remove_media'
+
+
+PS4_COMMAND_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_COMMAND): vol.All(cv.ensure_list, [COMMANDS])
+})
+
+PS4_LOCK_CURRENT_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_id
+})
+
+PS4_UNLOCK_CURRENT_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_id
+})
+
+PS4_LOCK_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+})
+
+PS4_UNLOCK_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+})
+
+PS4_EDIT_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+    vol.Optional(ATTR_MEDIA_TITLE, default=''): str,
+    vol.Optional(ATTR_MEDIA_IMAGE_URL, default=DEFAULT_URL): cv.url,
+    vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
+        [MEDIA_TYPE_GAME, MEDIA_TYPE_APP])
+})
+
+PS4_EDIT_CURRENT_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_MEDIA_TITLE, default=''): str,
+    vol.Optional(ATTR_MEDIA_IMAGE_URL, default=DEFAULT_URL): cv.url,
+    vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
+        [MEDIA_TYPE_GAME, MEDIA_TYPE_APP])
+})
+
+PS4_ADD_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+    vol.Required(ATTR_MEDIA_TITLE): str,
+    vol.Optional(ATTR_MEDIA_IMAGE_URL, default=''): vol.Any(
+        cv.url, str),
+    vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
+        [MEDIA_TYPE_GAME, MEDIA_TYPE_APP])
+})
+
+PS4_REMOVE_MEDIA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+})
 
 
 class PS4Data():
@@ -21,33 +93,35 @@ class PS4Data():
         self.protocol = None
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     """Set up the PS4 Component."""
     from pyps4_homeassistant.ddp import async_create_ddp_endpoint
 
     hass.data[PS4_DATA] = PS4Data()
 
+    # Create async transport/protocol to poll for status updates.
     transport, protocol = await async_create_ddp_endpoint()
     hass.data[PS4_DATA].protocol = protocol
     _LOGGER.debug("PS4 DDP endpoint created: %s, %s", transport, protocol)
+    await async_service_handle(hass)
     return True
 
 
-async def async_setup_entry(hass, config_entry):
+async def async_setup_entry(hass: HomeAssistantType, config_entry) -> bool:
     """Set up PS4 from a config entry."""
     hass.async_create_task(hass.config_entries.async_forward_entry_setup(
         config_entry, 'media_player'))
     return True
 
 
-async def async_unload_entry(hass, entry):
+async def async_unload_entry(hass: HomeAssistantType, entry) -> bool:
     """Unload a PS4 config entry."""
     await hass.config_entries.async_forward_entry_unload(
         entry, 'media_player')
     return True
 
 
-async def async_migrate_entry(hass, entry):
+async def async_migrate_entry(hass: HomeAssistantType, entry) -> bool:
     """Migrate old entry."""
     from pyps4_homeassistant.media_art import COUNTRIES
 
@@ -124,3 +198,300 @@ def format_unique_id(creds, mac_address):
     """Use last 4 Chars of credential as suffix. Unique ID per PSN user."""
     suffix = creds[-4:]
     return "{}_{}".format(mac_address, suffix)
+
+
+async def async_service_handle(hass: HomeAssistantType):
+    """Handle for services."""
+    async def async_service_command(call):
+        """Service for sending commands."""
+        entity_ids = call.data[ATTR_ENTITY_ID]
+        command = call.data[ATTR_COMMAND]
+        for device in hass.data[PS4_DATA].devices:
+            if device.entity_id in entity_ids:
+                await device.async_send_command(command)
+
+    async def async_service_lock_media(call):
+        """Service to lock media data that entity is playing."""
+        games = load_games(hass)
+        media_content_id = call.data[ATTR_MEDIA_CONTENT_ID]
+        data = games.get(media_content_id)
+        if data is not None:
+            data[ATTR_LOCKED] = True
+            games[media_content_id] = data
+            save_games(hass, games)
+            _LOGGER.debug("Setting Lock to %s", data[ATTR_LOCKED])
+        else:
+            raise HomeAssistantError(
+                "Media ID: {} is not in source list".format(
+                    media_content_id))
+
+    async def async_service_unlock_media(call):
+        """Service to lock media data that entity is playing."""
+        games = load_games(hass)
+        media_content_id = call.data[ATTR_MEDIA_CONTENT_ID]
+        data = games.get(media_content_id)
+        if data is not None:
+            data[ATTR_LOCKED] = False
+            games[media_content_id] = data
+            save_games(hass, games)
+            _LOGGER.debug("Setting Lock to %s", data[ATTR_LOCKED])
+
+            _refresh_entity_media(hass, media_content_id)
+        else:
+            raise HomeAssistantError(
+                "Media ID: {} is not in source list".format(
+                    media_content_id))
+
+    async def async_service_lock_current_media(call):
+        """Service to lock media data that entity is playing."""
+        games = load_games(hass)
+        media_content_id = None
+        entity_id = call.data[ATTR_ENTITY_ID]
+        for device in hass.data[PS4_DATA].devices:
+            if device.entity_id == entity_id:
+                entity = device
+                media_id = entity.media_content_id
+                if media_id is not None:
+                    media_content_id = media_id
+
+        if media_content_id is not None:
+            data = games.get(media_content_id)
+            if data is not None:
+                data[ATTR_LOCKED] = True
+                games[media_content_id] = data
+                save_games(hass, games)
+                _LOGGER.debug("Setting Lock to %s", data[ATTR_LOCKED])
+        else:
+            raise HomeAssistantError(
+                "Entity: {} has no current media data".format(entity_id))
+
+    async def async_service_unlock_current_media(call):
+        """Service to unlock media data that entity is playing."""
+        games = load_games(hass)
+        media_content_id = None
+        entity_id = call.data[ATTR_ENTITY_ID]
+        for device in hass.data[PS4_DATA].devices:
+            if device.entity_id == entity_id:
+                entity = device
+                media_id = entity.media_content_id
+                if media_id is not None:
+                    media_content_id = media_id
+
+        if media_content_id is not None:
+            data = games.get(media_content_id)
+            if data is not None:
+                data[ATTR_LOCKED] = False
+                games[media_content_id] = data
+                save_games(hass, games)
+                _LOGGER.debug("Setting Lock to %s", data[ATTR_LOCKED])
+
+                _refresh_entity_media(hass, media_content_id)
+        else:
+            raise HomeAssistantError(
+                "Entity: {} has no current media data".format(entity_id))
+
+    async def async_service_add_media(call):
+        """Add media data manually."""
+        games = load_games(hass)
+
+        media_content_id = call.data[ATTR_MEDIA_CONTENT_ID]
+        media_title = call.data[ATTR_MEDIA_TITLE]
+
+        media_url = None if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL\
+            else call.data[ATTR_MEDIA_IMAGE_URL]
+
+        media_type = MEDIA_TYPE_GAME\
+            if call.data[ATTR_MEDIA_CONTENT_TYPE] == ''\
+            else call.data[ATTR_MEDIA_CONTENT_TYPE]
+
+        _set_media(hass, games, media_content_id, media_title,
+                   media_url, media_type)
+
+    async def async_service_remove_media(call):
+        """Remove media data manually."""
+        games = load_games(hass)
+        media_content_id = call.data[ATTR_MEDIA_CONTENT_ID]
+
+        if media_content_id in games:
+            games.pop(media_content_id)
+            save_games(hass, games)
+
+    async def async_service_edit_media(call):
+        """Service call for editing existing media data."""
+        games = load_games(hass)
+        media_content_id = call.data[ATTR_MEDIA_CONTENT_ID]
+        data = games.get(media_content_id)
+
+        if data is not None:
+            media_title = None if call.data[ATTR_MEDIA_TITLE] == ''\
+                else call.data[ATTR_MEDIA_TITLE]
+
+            media_url = None\
+                if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL\
+                else call.data[ATTR_MEDIA_IMAGE_URL]
+
+            media_type = MEDIA_TYPE_GAME\
+                if call.data[ATTR_MEDIA_CONTENT_TYPE] == ''\
+                else call.data[ATTR_MEDIA_CONTENT_TYPE]
+
+            if media_title is None:
+                stored_title = data.get(ATTR_MEDIA_TITLE)
+                if stored_title is not None:
+                    media_title = stored_title
+
+            if media_url is None:
+                stored_url = data.get(ATTR_MEDIA_IMAGE_URL)
+                if stored_url is not None:
+                    media_url = stored_url
+
+            if media_type is None:
+                stored_type = data.get(ATTR_MEDIA_CONTENT_TYPE)
+                if stored_type is not None:
+                    media_type = stored_type
+
+            _set_media(hass, games, media_content_id, media_title,
+                       media_url, media_type)
+            _refresh_entity_media(hass, media_content_id)
+        else:
+            raise HomeAssistantError(
+                "Media ID: {} is not in source list".format(
+                    media_content_id))
+
+    async def async_service_edit_current_media(call):
+        """Service call for editing existing media data."""
+        games = load_games(hass)
+        media_content_id = None
+        entity_id = call.data[ATTR_ENTITY_ID]
+        for device in hass.data[PS4_DATA].devices:
+            if device.entity_id == entity_id:
+                entity = device
+
+        media_content_id = entity.media_content_id
+        data = games.get(media_content_id)
+
+        if data is not None:
+            media_title = None if call.data[ATTR_MEDIA_TITLE] == ''\
+                else call.data[ATTR_MEDIA_TITLE]
+
+            media_url = None\
+                if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL\
+                else call.data[ATTR_MEDIA_IMAGE_URL]
+
+            media_type = MEDIA_TYPE_GAME\
+                if call.data[ATTR_MEDIA_CONTENT_TYPE] == ''\
+                else call.data[ATTR_MEDIA_CONTENT_TYPE]
+
+            if media_title is None:
+                stored_title = data.get(ATTR_MEDIA_TITLE)
+                if stored_title is not None:
+                    media_title = stored_title
+
+            if media_url is None:
+                stored_url = data.get(ATTR_MEDIA_IMAGE_URL)
+                if stored_url is not None:
+                    media_url = stored_url
+
+            if media_type is None:
+                stored_type = data.get(ATTR_MEDIA_CONTENT_TYPE)
+                if stored_type is not None:
+                    media_type = stored_type
+
+            _set_media(hass, games, media_content_id, media_title,
+                       media_url, media_type)
+            _refresh_entity_media(hass, media_content_id)
+        else:
+            raise HomeAssistantError(
+                "Media ID: {} is not in source list".format(
+                    media_content_id))
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_COMMAND, async_service_command,
+        schema=PS4_COMMAND_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_LOCK_MEDIA, async_service_lock_media,
+        schema=PS4_LOCK_MEDIA_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_UNLOCK_MEDIA,
+        async_service_unlock_media,
+        schema=PS4_UNLOCK_MEDIA_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_LOCK_CURRENT_MEDIA,
+        async_service_lock_current_media,
+        schema=PS4_LOCK_CURRENT_MEDIA_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_UNLOCK_CURRENT_MEDIA,
+        async_service_unlock_current_media,
+        schema=PS4_UNLOCK_CURRENT_MEDIA_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_ADD_MEDIA, async_service_add_media,
+        schema=PS4_ADD_MEDIA_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_REMOVE_MEDIA,
+        async_service_remove_media,
+        schema=PS4_REMOVE_MEDIA_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_EDIT_MEDIA, async_service_edit_media,
+        schema=PS4_EDIT_MEDIA_SCHEMA)
+
+
+def load_games(hass):
+    """Load games for sources."""
+    g_file = hass.config.path(GAMES_FILE)
+    try:
+        games = load_json(g_file)
+
+    # If file does not exist, create empty file.
+    except FileNotFoundError:
+        games = {}
+        save_games(hass, games)
+
+    # Convert str format to dict format if not already.
+    if games is not None:
+        for game, data in games.items():
+            if type(data) is not dict:
+                games[game] = {ATTR_MEDIA_TITLE: data,
+                               ATTR_MEDIA_IMAGE_URL: None,
+                               ATTR_LOCKED: False,
+                               ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME}
+
+    return games
+
+
+def save_games(hass, games):
+    """Save games to file."""
+    g_file = hass.config.path(GAMES_FILE)
+    try:
+        save_json(g_file, games)
+    except OSError as error:
+        _LOGGER.error("Could not save game list, %s", error)
+
+    # Retry loading file
+    if games is None:
+        load_games()
+
+
+def _set_media(hass, games, media_content_id, media_title,
+               media_url, media_type):
+    """Set media data."""
+    if games.get(media_content_id) is not None:
+        data = games[media_content_id]
+    else:
+        data = {}
+        data[ATTR_MEDIA_CONTENT_ID] = media_content_id
+
+    data[ATTR_LOCKED] = True
+    data[ATTR_MEDIA_TITLE] = media_title
+    data[ATTR_MEDIA_IMAGE_URL] = media_url
+    data[ATTR_MEDIA_CONTENT_TYPE] = media_type
+    games[media_content_id] = data
+    save_games(hass, games)
+
+
+def _refresh_entity_media(hass, media_content_id):
+    """Refresh media properties if device is playing the same media."""
+    for device in hass.data[PS4_DATA].devices:
+        if device.media_content_id == media_content_id:
+            device.reset_title()
+            device.schedule_update()
+            _LOGGER.debug(
+                "Refreshing media data for: %s", device.entity_id)

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -35,7 +35,7 @@ SERVICE_REMOVE_MEDIA = 'remove_media'
 
 PS4_COMMAND_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_COMMAND): vol.All(cv.ensure_list, [COMMANDS])
+    vol.Required(ATTR_COMMAND): vol.In(list(COMMANDS))
 })
 
 PS4_LOCK_CURRENT_MEDIA_SCHEMA = vol.Schema({
@@ -233,9 +233,10 @@ async def async_service_handle(hass: HomeAssistantType):
         if data is not None:
             data[ATTR_LOCKED] = False
             games[media_content_id] = data
+            _LOGGER.debug("Setting Lock to %s", data[ATTR_LOCKED])
+            _LOGGER.debug("Edited data %s", games[media_content_id])
             save_games(hass, games)
             _LOGGER.debug("Setting Lock to %s", data[ATTR_LOCKED])
-
             _refresh_entity_media(hass, media_content_id)
         else:
             raise HomeAssistantError(
@@ -506,11 +507,13 @@ def _set_media(hass: HomeAssistantType, games: dict, media_content_id,
     _LOGGER.debug("Setting media data, %s: %s", media_content_id, data)
 
 
-def _refresh_entity_media(hass: HomeAssistantType, media_content_id):
+def _refresh_entity_media(
+        hass: HomeAssistantType, media_content_id, update_entity=True):
     """Refresh media properties if data is changed.."""
     for device in hass.data[PS4_DATA].devices:
         if device.media_content_id == media_content_id:
             device.reset_title()
-            device.schedule_update()
+            if update_entity:
+                device.schedule_update()
             _LOGGER.debug(
                 "Refreshing media data for: %s", device.entity_id)

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -1,5 +1,6 @@
 """Constants for PlayStation 4."""
 ATTR_MEDIA_IMAGE_URL = 'media_image_url'
+CONFIG_ENTRY_VERSION = 3
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
 DEFAULT_ALIAS = 'Home-Assistant'

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -1,9 +1,15 @@
 """Constants for PlayStation 4."""
+ATTR_MEDIA_IMAGE_URL = 'media_image_url'
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
 DEFAULT_ALIAS = 'Home-Assistant'
+DEFAULT_URL = 'http://localhost'
 DOMAIN = 'ps4'
+GAMES_FILE = '.ps4-games.json'
 PS4_DATA = 'ps4_data'
+
+COMMANDS = (
+    'up', 'down', 'right', 'left', 'enter', 'back', 'option', 'ps',)
 
 # Deprecated used for logger/backwards compatibility from 0.89
 REGIONS = ['R1', 'R2', 'R3', 'R4', 'R5']

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -10,7 +10,7 @@ GAMES_FILE = '.ps4-games.json'
 PS4_DATA = 'ps4_data'
 
 COMMANDS = (
-    'up', 'down', 'right', 'left', 'enter', 'back', 'option', 'ps',)
+    'up', 'down', 'right', 'left', 'enter', 'back', 'option', 'ps')
 
 # Deprecated used for logger/backwards compatibility from 0.89
 REGIONS = ['R1', 'R2', 'R3', 'R4', 'R5']

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.8.5"
+    "pyps4-homeassistant==0.8.6"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.8.6"
+    "pyps4-homeassistant==0.8.7"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -224,7 +224,7 @@ class PS4Device(MediaPlayerDevice):
         self._media_type = None
         self._source = None
 
-    async def async_get_title_data(self, title_id, name, search_all=True):
+    async def async_get_title_data(self, title_id, name):
         """Get PS Store Data."""
         from pyps4_homeassistant.errors import PSDataIncomplete
         _LOGGER.debug("Starting PS Store Search, %s: %s", title_id, name)

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -224,9 +224,9 @@ class PS4Device(MediaPlayerDevice):
         self._media_type = None
         self._source = None
 
-    async def async_get_title_data(self, title_id, name):
+    async def async_get_title_data(self, title_id, name, search_all=True):
         """Get PS Store Data."""
-        from pyps4_homeassistant.errors import PSDataIncomplete, PSSearchError
+        from pyps4_homeassistant.errors import PSDataIncomplete
         _LOGGER.debug("Starting PS Store Search, %s: %s", title_id, name)
         app_name = None
         art = None
@@ -234,7 +234,7 @@ class PS4Device(MediaPlayerDevice):
         try:
             title = await self._ps4.async_get_ps_store_data(
                 name, title_id, self._region)
-        except (PSDataIncomplete, PSSearchError):
+        except PSDataIncomplete:
             title = None
         except asyncio.TimeoutError:
             title = None
@@ -333,7 +333,7 @@ class PS4Device(MediaPlayerDevice):
         """Remove Entity from Hass."""
         # Close TCP Transport.
         if self._ps4.connected:
-            await self._ps4.close()
+            self._ps4.close()
         self.hass.data[PS4_DATA].devices.remove(self)
 
     @property

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -28,6 +28,8 @@ SUPPORT_PS4 = SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
 ICON = 'mdi:playstation'
 MEDIA_IMAGE_DEFAULT = None
 
+DEFAULT_RETRIES = 2
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up PS4 from a config entry."""
@@ -189,7 +191,7 @@ class PS4Device(MediaPlayerDevice):
                 if self._state != STATE_OFF:
                     self.state_off()
 
-        elif self._retry > 5:
+        elif self._retry > DEFAULT_RETRIES:
             self.state_unknown()
         else:
             self._retry += 1
@@ -224,7 +226,7 @@ class PS4Device(MediaPlayerDevice):
 
     async def async_get_title_data(self, title_id, name):
         """Get PS Store Data."""
-        from pyps4_homeassistant.errors import PSDataIncomplete
+        from pyps4_homeassistant.errors import PSDataIncomplete, PSSearchError
         _LOGGER.debug("Starting PS Store Search, %s: %s", title_id, name)
         app_name = None
         art = None
@@ -232,8 +234,7 @@ class PS4Device(MediaPlayerDevice):
         try:
             title = await self._ps4.async_get_ps_store_data(
                 name, title_id, self._region)
-
-        except PSDataIncomplete:
+        except (PSDataIncomplete, PSSearchError):
             title = None
         except asyncio.TimeoutError:
             title = None

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -123,7 +123,8 @@ class PS4Device(MediaPlayerDevice):
             self._ps4.get_status()
 
             """Don't attempt to connect if entity is connected or if
-            PS4 is in standby or disconnected from LAN or powered off."""
+            PS4 is in standby or disconnected from LAN or powered off.
+            """
             if not self._ps4.connected and not self._ps4.is_standby and\
                     self._ps4.is_available:
                 try:

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -333,7 +333,7 @@ class PS4Device(MediaPlayerDevice):
         """Remove Entity from Hass."""
         # Close TCP Transport.
         if self._ps4.connected:
-            self._ps4.close()
+            await self._ps4.close()
         self.hass.data[PS4_DATA].devices.remove(self)
 
     @property

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -115,8 +115,9 @@ class PS4Device(MediaPlayerDevice):
         self.check_region()
 
     async def async_update(self):
-        from pyps4_homeassistant.errors import NotReady
         """Retrieve the latest data."""
+        from pyps4_homeassistant.errors import NotReady
+
         if self._ps4.ddp_protocol is not None:
             # Request Status with asyncio transport.
             self._ps4.get_status()

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -168,7 +168,7 @@ class PS4Device(MediaPlayerDevice):
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
 
-                        use_data = self._get_media_attrs(title_id, name)
+                        use_data = self._get_media_attrs()
 
                         if not use_data:
                             # Get data from PS Store.
@@ -187,7 +187,7 @@ class PS4Device(MediaPlayerDevice):
         else:
             self._retry += 1
 
-    def _get_media_attrs(self, title_id, name):
+    def _get_media_attrs(self):
         """Get media attributes."""
         if self._media_content_id in self._games:
             store = self._games[self._media_content_id]

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -168,23 +168,12 @@ class PS4Device(MediaPlayerDevice):
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
 
-                        if self._media_content_id in self._games:
-                            store = self._games[self._media_content_id]
+                        use_data = self._get_media_attrs(title_id, name)
 
-                            # If locked get attributes from file.
-                            locked = store.get(ATTR_LOCKED)
-                            if locked:
-                                self._media_title = store.get(ATTR_MEDIA_TITLE)
-                                self._source = self._media_title
-                                self._media_image = store.get(
-                                    ATTR_MEDIA_IMAGE_URL)
-                                self._media_type = store.get(
-                                    ATTR_MEDIA_CONTENT_TYPE)
-                                return
-
-                        # Get data from PS Store.
-                        asyncio.ensure_future(
-                            self.async_get_title_data(title_id, name))
+                        if not use_data:
+                            # Get data from PS Store.
+                            asyncio.ensure_future(
+                                self.async_get_title_data(title_id, name))
 
                 else:
                     if self._state != STATE_IDLE:
@@ -197,6 +186,23 @@ class PS4Device(MediaPlayerDevice):
             self.state_unknown()
         else:
             self._retry += 1
+
+    def _get_media_attrs(self, title_id, name):
+        """Get media attributes."""
+        if self._media_content_id in self._games:
+            store = self._games[self._media_content_id]
+
+            # If locked get attributes from file.
+            locked = store.get(ATTR_LOCKED)
+            if locked:
+                self._media_title = store.get(ATTR_MEDIA_TITLE)
+                self._source = self._media_title
+                self._media_image = store.get(
+                    ATTR_MEDIA_IMAGE_URL)
+                self._media_type = store.get(
+                    ATTR_MEDIA_CONTENT_TYPE)
+                return True
+        return False
 
     def idle(self):
         """Set states for state idle."""

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -8,23 +8,69 @@ send_command:
       description: Button to press.
       example: 'ps'
 
-edit_media_data:
-  description: Edit or correct media data attributes and prevent automatic updates to media data.
+lock_media:
+  description: Lock media data attributes to prevent automatic updates to media data.
   fields:
-    locked:
-      description: Set to 'True' to lock and prevent media data from automatically updating. Set to 'False' to have Home Assistant automatically retrieve the current data from the PlayStation Store. Defaults to 'True'.
-      example: 'False'
-    entity_id: 
-      description: Entity ID to get current media attributes from. To simply lock the current media data, you may also just specify the entity.
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title. Defaults to the ID of the currently playing title if 'entity_id' is specified.
+      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
+      example: 'CUSA00123'
+
+unlock_media:
+  description: Unlock media data attributes to allow automatic updates to media data.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
+      example: 'CUSA00123'
+
+lock_current_media:
+  description: Lock the attributes of the media which is currently playing.
+  fields:
+    entity_id: 
+      description: The entity that is playing media.
+      example: 'media_player.playstation_4'
+
+unlock_current_media:
+  description: Unlock the attributes of the media which is currently playing.
+  fields:
+    entity_id: 
+      description: The entity that is playing media.
+      example: 'media_player.playstation_4'
+
+add_media:
+  description: Manually add media data to source list.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title.
       example: 'CUSA00123'
     media_content_title:
-      description: The name for the media title. Defaults to the current title. The 'locked' field must be set to 'True' if specified.
+      description: The name for the media title. Defaults to the current title.
       example: 'A Title: 5'
     media_image_url:
-      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder. Defaults to the current image url if any. The 'locked' field must be set to 'True' if specified.
+      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
       example: 'http://localhost:8123/local/image.jpg'
     media_content_type:
-      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'. The 'locked' field must be set to 'True' if specified.
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
+      example: 'game'
+
+remove_media:
+  description: Remove media data from source list.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title.
+      example: 'CUSA00123'
+
+edit_media:
+  description: Edit or correct media data attributes and prevent automatic updates to media data.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.
+      example: 'CUSA00123'
+    media_title:
+      description: The name for the media title.
+      example: 'A Title: The Name'
+    media_image_url:
+      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      example: 'http://localhost:8123/local/image.jpg'
+    media_content_type:
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
       example: 'game'

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -42,7 +42,7 @@ add_media:
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title.
       example: 'CUSA00123'
-    media_content_title:
+    media_title:
       description: The name for the media title. Defaults to the current title.
       example: 'A Title: 5'
     media_image_url:

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -7,3 +7,24 @@ send_command:
     command:
       description: Button to press.
       example: 'ps'
+
+edit_title_data:
+  description: Edit/correct title data and prevent automatic changes to title data.
+  fields:
+    locked:
+      description: Set to 'True' to lock title data / prevent title data from automatically updating. Set to 'False' to have Home Assistant automatically get the current data from the PlayStation Store. Defaults to 'True'.
+      example: 'False'
+    entity_id: 
+      description: Entity ID to get current title attributes from. To only lock the current title data, you may also just specify the entity.
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title. Defaults to the ID of the currently playing title if 'entity_id' is specified.
+      example: 'CUSA00123'
+    media_content_title:
+      description: The name for the title. Defaults to the current title. The 'locked' field must be set to 'True' if specified.
+      example: 'A Title'
+    media_image_url:
+      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder. Defaults to the current url if any. The 'locked' field must be set to 'True' if specified.
+      example: 'http://localhost:8123/local/image.jpg'
+    media_content_type:
+      description: The type of a title. Must be 'game' or 'app'. Defaults to 'game'. The 'locked' field must be set to 'True' if specified.
+      example: 'game'

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -9,7 +9,7 @@ send_command:
       example: 'ps'
 
 lock_media:
-  description: Lock media data attributes to prevent automatic updates to media data. Media data will no longer be updated automatically.
+  description: Lock media data attributes to prevent automatic updates to media data. Media data will be locked and not be updated automatically.
   fields:
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
@@ -23,7 +23,7 @@ unlock_media:
       example: 'CUSA00123'
 
 edit_media:
-  description: Edit or correct media data attributes. Media data will be locked.
+  description: Edit or correct media data attributes. Media data will no longer be updated automatically.
   fields:
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
@@ -39,7 +39,7 @@ edit_media:
       example: 'game'
 
 lock_current_media:
-  description: Lock the attributes of the media which is currently playing. Media data will no longer be updated automatically.
+  description: Lock the attributes of the media which is currently playing. Media data will be locked and not be updated automatically.
   fields:
     entity_id: 
       description: The entity that is playing media.
@@ -53,7 +53,7 @@ unlock_current_media:
       example: 'media_player.playstation_4'
 
 edit_current_media:
-  description: Edit or correct media data attributes of the media which is currently playing. Media data will be locked.
+  description: Edit or correct media data attributes of the media which is currently playing. Media data will be locked and not be updated automatically.
   fields:
     entity_id:
       description: The entity that is playing media.

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -8,23 +8,23 @@ send_command:
       description: Button to press.
       example: 'ps'
 
-edit_title_data:
-  description: Edit/correct title data and prevent automatic changes to title data.
+edit_media_data:
+  description: Edit or correct media data attributes and prevent automatic updates to media data.
   fields:
     locked:
-      description: Set to 'True' to lock title data / prevent title data from automatically updating. Set to 'False' to have Home Assistant automatically get the current data from the PlayStation Store. Defaults to 'True'.
+      description: Set to 'True' to lock and prevent media data from automatically updating. Set to 'False' to have Home Assistant automatically retrieve the current data from the PlayStation Store. Defaults to 'True'.
       example: 'False'
     entity_id: 
-      description: Entity ID to get current title attributes from. To only lock the current title data, you may also just specify the entity.
+      description: Entity ID to get current media attributes from. To simply lock the current media data, you may also just specify the entity.
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title. Defaults to the ID of the currently playing title if 'entity_id' is specified.
       example: 'CUSA00123'
     media_content_title:
-      description: The name for the title. Defaults to the current title. The 'locked' field must be set to 'True' if specified.
-      example: 'A Title'
+      description: The name for the media title. Defaults to the current title. The 'locked' field must be set to 'True' if specified.
+      example: 'A Title: 5'
     media_image_url:
-      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder. Defaults to the current url if any. The 'locked' field must be set to 'True' if specified.
+      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder. Defaults to the current image url if any. The 'locked' field must be set to 'True' if specified.
       example: 'http://localhost:8123/local/image.jpg'
     media_content_type:
-      description: The type of a title. Must be 'game' or 'app'. Defaults to 'game'. The 'locked' field must be set to 'True' if specified.
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'. The 'locked' field must be set to 'True' if specified.
       example: 'game'

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -9,44 +9,76 @@ send_command:
       example: 'ps'
 
 lock_media:
-  description: Lock media data attributes to prevent automatic updates to media data.
+  description: Lock media data attributes to prevent automatic updates to media data. Media data will no longer be updated automatically.
   fields:
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
       example: 'CUSA00123'
 
 unlock_media:
-  description: Unlock media data attributes to allow automatic updates to media data.
+  description: Unlock media data attributes to allow automatic updates to media data. Media data will be updated automatically.
   fields:
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
+      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list. Media data will be updated automatically.
       example: 'CUSA00123'
 
+edit_media:
+  description: Edit or correct media data attributes. Media data will be locked.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.
+      example: 'CUSA00123'
+    media_title:
+      description: The name for the media title.
+      example: 'A Title: The Name'
+    media_image_url:
+      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      example: 'http://localhost:8123/local/image.jpg'
+    media_content_type:
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
+      example: 'game'
+
 lock_current_media:
-  description: Lock the attributes of the media which is currently playing.
+  description: Lock the attributes of the media which is currently playing. Media data will no longer be updated automatically.
   fields:
     entity_id: 
       description: The entity that is playing media.
       example: 'media_player.playstation_4'
 
 unlock_current_media:
-  description: Unlock the attributes of the media which is currently playing.
+  description: Unlock the attributes of the media which is currently playing. Media data will be updated automatically.
   fields:
     entity_id: 
       description: The entity that is playing media.
       example: 'media_player.playstation_4'
 
+edit_current_media:
+  description: Edit or correct media data attributes of the media which is currently playing. Media data will be locked.
+  fields:
+    entity_id:
+      description: The entity that is playing media.
+      example: 'CUSA00123'
+    media_title:
+      description: The name for the media title.
+      example: 'A Title: The Name'
+    media_image_url:
+      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      example: 'http://localhost:8123/local/image.jpg'
+    media_content_type:
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
+      example: 'game'
+
 add_media:
-  description: Manually add media data to source list.
+  description: Manually add media data to source list. Media data will not be updated automatically.
   fields:
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title.
       example: 'CUSA00123'
     media_title:
       description: The name for the media title. Defaults to the current title.
-      example: 'A Title: 5'
+      example: 'A Title: The Name'
     media_image_url:
-      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
       example: 'http://localhost:8123/local/image.jpg'
     media_content_type:
       description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
@@ -58,19 +90,3 @@ remove_media:
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title.
       example: 'CUSA00123'
-
-edit_media:
-  description: Edit or correct media data attributes and prevent automatic updates to media data.
-  fields:
-    media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.
-      example: 'CUSA00123'
-    media_title:
-      description: The name for the media title.
-      example: 'A Title: The Name'
-    media_image_url:
-      description: A URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
-      example: 'http://localhost:8123/local/image.jpg'
-    media_content_type:
-      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
-      example: 'game'

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -19,14 +19,14 @@ unlock_media:
   description: Unlock media data attributes to allow automatic updates to media data. Media data will be updated automatically.
   fields:
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list. Media data will be updated automatically.
+      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
       example: 'CUSA00123'
 
 edit_media:
   description: Edit or correct media data attributes. Media data will be locked.
   fields:
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title. Must be specified if 'entity_id' is not specified.
+      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
       example: 'CUSA00123'
     media_title:
       description: The name for the media title.
@@ -57,7 +57,7 @@ edit_current_media:
   fields:
     entity_id:
       description: The entity that is playing media.
-      example: 'CUSA00123'
+      example: 'media_player.playstation_4'
     media_title:
       description: The name for the media title.
       example: 'A Title: The Name'
@@ -69,7 +69,7 @@ edit_current_media:
       example: 'game'
 
 add_media:
-  description: Manually add media data to source list. Media data will not be updated automatically.
+  description: Manually add media data to source list. Media data will be locked and not be updated automatically.
   fields:
     media_content_id:
       description: The ID or the PlayStation Store SKU ID of the title.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1307,7 +1307,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.6
+pyps4-homeassistant==0.8.7
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1307,7 +1307,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.5
+pyps4-homeassistant==0.8.6
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.5
+pyps4-homeassistant==0.8.6
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -281,7 +281,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.6
+pyps4-homeassistant==0.8.7
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -127,7 +127,7 @@ class TestPS4MediaServices(unittest.TestCase):
         self.hass.stop()
         self.cleanup()
 
-    def setup_mock_media_player(self):
+    def setup_mock_component(self):
         """Setup Mock Media Player."""
         entry = MockConfigEntry(
             domain=ps4.DOMAIN, data=MOCK_DATA, version=VERSION)

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -325,66 +325,86 @@ class TestPS4MediaServices(unittest.TestCase):
 
     def test_lock_current_media(self):
         """Test lock_current_media service."""
+        mock_id1 = 'Mock_ID1'
+        mock_id2 = 'Mock_ID2'
+        mock_data = {mock_id1: MOCK_GAMES_DATA, mock_id2: MOCK_GAMES_DATA}
+
         self.setup_mock_component()
-        self.set_games_data(MOCK_GAMES)
+        self.set_games_data(mock_data)
         mock_games = ps4.load_games(self.hass)
+        assert len(mock_games) == 2
 
         mock_devices = self.hass.data[PS4_DATA].devices
         assert len(mock_devices) == 1
         mock_entity = mock_devices[0]
 
         # Set media_id attr
-        mock_entity._media_content_id = MOCK_ID
+        mock_entity._media_content_id = mock_id1
         assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
-        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+        assert mock_games[mock_id1][ATTR_LOCKED] is False
 
         self.hass.services.call(
             DOMAIN, 'lock_current_media',
             {ATTR_ENTITY_ID: mock_entity.entity_id})
 
         mock_games = ps4.load_games(self.hass)
-        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[mock_id1][ATTR_LOCKED] is True
+        # Ensure other data entry is unaffected.
+        assert mock_games[mock_id2][ATTR_LOCKED] is False
 
     def test_unlock_current_media(self):
         """Test unlock_current_media service."""
+        mock_id1 = 'Mock_ID1'
+        mock_id2 = 'Mock_ID2'
+        mock_data = {mock_id1: MOCK_GAMES_DATA_LOCKED,
+                     mock_id2: MOCK_GAMES_DATA_LOCKED}
+
         self.setup_mock_component()
-        self.set_games_data(MOCK_GAMES_LOCKED)
+        self.set_games_data(mock_data)
         mock_games = ps4.load_games(self.hass)
+        assert len(mock_games) == 2
 
         mock_devices = self.hass.data[PS4_DATA].devices
         assert len(mock_devices) == 1
         mock_entity = mock_devices[0]
 
-        mock_entity._media_content_id = MOCK_ID
+        mock_entity._media_content_id = mock_id1
         assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
-        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[mock_id1][ATTR_LOCKED] is True
 
         self.hass.services.call(
             DOMAIN, 'unlock_current_media',
             {ATTR_ENTITY_ID: mock_entity.entity_id})
 
         mock_games = ps4.load_games(self.hass)
-        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+        assert mock_games[mock_id1][ATTR_LOCKED] is False
+        # Ensure other data entry is unaffected.
+        assert mock_games[mock_id2][ATTR_LOCKED] is True
 
     def test_edit_current_media(self):
         """Test edit_current_media service."""
+        mock_id1 = 'Mock_ID1'
+        mock_id2 = 'Mock_ID2'
+        mock_data = {mock_id1: MOCK_GAMES_DATA, mock_id2: MOCK_GAMES_DATA}
+
         self.setup_mock_component()
-        self.set_games_data(MOCK_GAMES)
+        self.set_games_data(mock_data)
         mock_games = ps4.load_games(self.hass)
+        assert len(mock_games) == 2
 
         mock_devices = self.hass.data[PS4_DATA].devices
         assert len(mock_devices) == 1
         mock_entity = mock_devices[0]
 
         # Set media_id attr
-        mock_entity._media_content_id = MOCK_ID
+        mock_entity._media_content_id = mock_id1
 
         assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
-        assert MOCK_ID in mock_games
-        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
-        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == MOCK_TITLE
-        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
-        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE
+        assert mock_id1 in mock_games
+        assert mock_games[mock_id1][ATTR_LOCKED] is False
+        assert mock_games[mock_id1][ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_games[mock_id1][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_games[mock_id1][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE
 
         # Change the playing title only.
         mock_title = 'Some New Title'
@@ -394,11 +414,17 @@ class TestPS4MediaServices(unittest.TestCase):
              ATTR_MEDIA_TITLE: mock_title})
 
         mock_games = ps4.load_games(self.hass)
-        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
-        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == mock_title
+        assert mock_games[mock_id1][ATTR_LOCKED] is True
+        assert mock_games[mock_id1][ATTR_MEDIA_TITLE] == mock_title
         # Test that not specified attributes remain the same.
-        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
-        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE
+        assert mock_games[mock_id1][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_games[mock_id1][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE
+
+        # Ensure other data entry is unaffected.
+        assert mock_games[mock_id2][ATTR_LOCKED] is False
+        assert mock_games[mock_id2][ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_games[mock_id2][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_games[mock_id2][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE
 
     def test_send_command(self):
         """Test send_command service."""

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -11,7 +11,6 @@ from homeassistant.components import ps4
 from homeassistant.components.ps4.const import (
     ATTR_MEDIA_IMAGE_URL, COMMANDS, CONFIG_ENTRY_VERSION as VERSION,
     DOMAIN, GAMES_FILE, PS4_DATA)
-
 from homeassistant.const import (
     ATTR_COMMAND, ATTR_LOCKED, ATTR_ENTITY_ID, CONF_HOST,
     CONF_NAME, CONF_REGION, CONF_TOKEN)

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -146,7 +146,7 @@ class TestPS4MediaServices(unittest.TestCase):
         mock_empty = ps4.load_games(self.hass)
 
         assert isinstance(mock_empty, dict)
-        assert mock_empty is None
+        assert not mock_empty
         assert self.mock_file == '{}/{}'.format(
             self.hass.config.path(), GAMES_FILE)
 
@@ -301,7 +301,7 @@ class TestPS4MediaServices(unittest.TestCase):
         self.hass.services.call(
             DOMAIN, 'remove_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID})
         mock_games = ps4.load_games(self.hass)
-        assert mock_games is None
+        assert not mock_games
 
     def test_add_media(self):
         """Test media entry is added."""
@@ -309,7 +309,7 @@ class TestPS4MediaServices(unittest.TestCase):
         self.set_games_data({})
         mock_games = ps4.load_games(self.hass)
 
-        assert mock_games is None
+        assert not mock_games
         self.hass.services.call(
             DOMAIN, 'add_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID,
                                   ATTR_MEDIA_TITLE: MOCK_TITLE,

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -11,7 +11,6 @@ from homeassistant.components import ps4
 from homeassistant.components.ps4.const import (
     ATTR_MEDIA_IMAGE_URL, CONFIG_ENTRY_VERSION as VERSION,
     DOMAIN, GAMES_FILE, PS4_DATA)
-
 from homeassistant.const import (
     ATTR_LOCKED, ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_REGION, CONF_TOKEN)
 from homeassistant.util.json import save_json

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -1,0 +1,401 @@
+"""Tests for the PS4 Integration."""
+import os
+import unittest
+from unittest.mock import patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.media_player.const import (
+    ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_CONTENT_ID, ATTR_MEDIA_TITLE,
+    MEDIA_TYPE_APP, MEDIA_TYPE_GAME)
+from homeassistant.components import ps4
+from homeassistant.components.ps4.const import (
+    ATTR_MEDIA_IMAGE_URL, CONFIG_ENTRY_VERSION as VERSION,
+    DOMAIN, GAMES_FILE, PS4_DATA)
+
+from homeassistant.const import (
+    ATTR_LOCKED, ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_REGION, CONF_TOKEN)
+from homeassistant.util.json import save_json
+from homeassistant.setup import setup_component
+from tests.common import (
+    get_test_config_dir, get_test_home_assistant, MockConfigEntry, mock_coro)
+
+MOCK_ID = 'CUSA00123'
+MOCK_URL = 'http://someurl.jpeg'
+MOCK_TITLE = 'Some Title'
+MOCK_TYPE = MEDIA_TYPE_GAME
+
+MOCK_GAMES_DATA_OLD_STR_FORMAT = {'mock_id': 'mock_title',
+                                  'mock_id2': 'mock_title2'}
+
+MOCK_GAMES_DATA = {
+    ATTR_LOCKED: False,
+    ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME,
+    ATTR_MEDIA_IMAGE_URL: MOCK_URL,
+    ATTR_MEDIA_TITLE: MOCK_TITLE}
+
+MOCK_GAMES_DATA_LOCKED = {
+    ATTR_LOCKED: True,
+    ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME,
+    ATTR_MEDIA_IMAGE_URL: MOCK_URL,
+    ATTR_MEDIA_TITLE: MOCK_TITLE}
+
+MOCK_GAMES = {MOCK_ID: MOCK_GAMES_DATA}
+MOCK_GAMES_LOCKED = {MOCK_ID: MOCK_GAMES_DATA_LOCKED}
+
+MOCK_HOST = '192.168.0.1'
+MOCK_NAME = 'test_ps4'
+MOCK_REGION = 'Some Region'
+MOCK_CREDS = '1234567890A'
+MOCK_PS4 = None
+
+MOCK_DEVICE = {
+    CONF_HOST: MOCK_HOST,
+    CONF_NAME: MOCK_NAME,
+    CONF_REGION: MOCK_REGION
+}
+
+MOCK_DATA = {
+    CONF_TOKEN: MOCK_CREDS,
+    'devices': [MOCK_DEVICE]
+}
+
+MOCK_FLOW_RESULT = {
+    'version': VERSION, 'handler': DOMAIN,
+    'type': data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
+    'title': 'test_ps4', 'data': MOCK_DATA
+}
+
+MOCK_ENTRY_ID = 'SomeID'
+
+MOCK_CONFIG = MockConfigEntry(
+    domain=DOMAIN, data=MOCK_DATA, entry_id=MOCK_ENTRY_ID)
+
+MOCK_STATUS = {'running-app-titleid': 'CUSA00000',
+               'host-type': 'PS4', 'host-ip': MOCK_HOST,
+               'host-request-port': '997', 'host-id': 'MACADDRESS',
+               'status_code': 200, 'host-name': 'FakePs4',
+               'device-discovery-protocol-version': '00020020',
+               'status': 'Ok', 'running-app-name': 'Random Game',
+               'system-version': '06508011'}
+
+
+async def test_ps4_integration_setup(hass):
+    """Test PS4 integration is setup."""
+    await ps4.async_setup(hass, {})
+    await hass.async_block_till_done()
+    assert hass.data[PS4_DATA].protocol is not None
+
+
+async def test_creating_entry_sets_up_media_player(hass):
+    """Test setting up PS4 loads the media player."""
+    mock_flow =\
+        'homeassistant.components.ps4.PlayStation4FlowHandler.async_step_user'
+    with patch('homeassistant.components.ps4.media_player.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup,\
+            patch(mock_flow, return_value=mock_coro(MOCK_FLOW_RESULT)):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={'source': config_entries.SOURCE_USER})
+        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 1
+
+
+class TestPS4MediaServices(unittest.TestCase):
+    """Test services for PS4."""
+
+    def cleanup(self):
+        """Cleanup any data created from the tests."""
+        if os.path.isfile(self.mock_file):
+            os.remove(self.mock_file)
+
+    def set_games_data(self, mock_data):
+        """Set data in games file for tests."""
+        save_json(self.mock_file, mock_data)
+        self.hass.block_till_done()
+
+    def setUp(self):
+        """Setup test environment."""
+        self.hass = get_test_home_assistant()
+        self.hass.start()
+        self.hass.block_till_done()
+        self.mock_file = get_test_config_dir(GAMES_FILE)
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+        self.cleanup()
+
+    def setup_mock_component(self):
+        """Setup Mock Component."""
+        entry = MockConfigEntry(
+            domain=ps4.DOMAIN, data=MOCK_DATA, version=VERSION)
+        entry.add_to_manager(self.hass.config_entries)
+        setup_component(self.hass, DOMAIN, {DOMAIN: {}})
+        self.hass.block_till_done()
+
+    def test_media_player_is_setup(self):
+        """Test media_player is setup correctly."""
+        self.setup_mock_component()
+        assert len(self.hass.data[PS4_DATA].devices) == 1
+
+    def test_file_created_if_none(self):
+        """Test that games file is created if it does not exist."""
+        self.cleanup()
+        mock_empty = ps4.load_games(self.hass)
+
+        assert type(mock_empty) == dict
+        assert len(mock_empty) == 0
+        assert self.mock_file == '{}/{}'.format(
+            self.hass.config.path(), GAMES_FILE)
+
+    def test_games_reformat_to_dict(self):
+        """Test old data format is converted to new format."""
+        self.set_games_data(MOCK_GAMES_DATA_OLD_STR_FORMAT)
+        mock_games = ps4.load_games(self.hass)
+
+        # New format is a nested dict.
+        assert type(mock_games) == dict
+        assert mock_games['mock_id'][ATTR_MEDIA_TITLE] == 'mock_title'
+        assert mock_games['mock_id2'][ATTR_MEDIA_TITLE] == 'mock_title2'
+        for mock_game, mock_title in mock_games.items():
+            mock_data = mock_games[mock_game]
+            assert type(mock_data) == dict
+            assert mock_data[ATTR_MEDIA_IMAGE_URL] is None
+            assert mock_data[ATTR_LOCKED] is False
+            assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_GAME
+
+    def test_load_games(self):
+        """Test that games are loaded correctly."""
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+
+        assert type(mock_games) == dict
+        mock_data = mock_games[MOCK_ID]
+        assert type(mock_data) == dict
+        assert mock_data[ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_data[ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_data[ATTR_LOCKED] is False
+        assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_GAME
+
+    def test_unlock_media(self):
+        """Test that data is unlocked with unlock_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES_LOCKED)
+        mock_games = ps4.load_games(self.hass)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        self.hass.services.call(
+            DOMAIN, 'unlock_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID})
+
+        # Reload data again.
+        mock_games = ps4.load_games(self.hass)
+
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+
+    def test_lock_media(self):
+        """Test that data is locked with lock_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+        self.hass.services.call(
+            DOMAIN, 'lock_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID})
+        mock_games = ps4.load_games(self.hass)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+
+    def test_edit_media_title(self):
+        """Test that title is edited with edit_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+
+        # Test edit title.
+        mock_title = 'some_new_title'
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == MOCK_TITLE
+        self.hass.services.call(
+            DOMAIN, 'edit_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID,
+                                   ATTR_MEDIA_TITLE: mock_title})
+        mock_games = ps4.load_games(self.hass)
+        # Locked attribute should be True now (data is locked).
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == mock_title
+        # Test that not specified attributes remain the same.
+        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] ==\
+            MEDIA_TYPE_GAME
+
+    def test_edit_media_url(self):
+        """Test that url is edited with edit_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+
+        # Test edit url.
+        mock_url = 'http://somenewurl'
+        self.hass.services.call(
+            DOMAIN, 'edit_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID,
+                                   ATTR_MEDIA_IMAGE_URL: mock_url})
+
+        mock_games = ps4.load_games(self.hass)
+        # Locked attribute should be True now (data is locked).
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == mock_url
+        # Test that not specified attributes remain the same.
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] ==\
+            MOCK_TYPE
+
+    def test_edit_media_type(self):
+        """Test that media_type is edited with edit_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+
+        # Test edit type.
+        mock_type = MEDIA_TYPE_APP
+        self.hass.services.call(
+            DOMAIN, 'edit_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID,
+                                   ATTR_MEDIA_CONTENT_TYPE: mock_type})
+        mock_games = ps4.load_games(self.hass)
+
+        # Locked attribute should be True now (data is locked).
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] ==\
+            MEDIA_TYPE_APP
+        # Test that not specified attributes remain the same.
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+
+    def test_edit_media_all(self):
+        """Test that all data is edited with edit_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+        mock_title = 'some_new_title'
+        mock_url = 'http://somenewurl'
+        mock_type = MEDIA_TYPE_APP
+
+        # Edit all attributes.
+        self.hass.services.call(
+            DOMAIN, 'edit_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID,
+                                   ATTR_MEDIA_TITLE: mock_title,
+                                   ATTR_MEDIA_IMAGE_URL: mock_url,
+                                   ATTR_MEDIA_CONTENT_TYPE: mock_type})
+        mock_games = ps4.load_games(self.hass)
+
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] == mock_type
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == mock_title
+        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == mock_url
+
+    def test_remove_media(self):
+        """Test media entry is removed."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+
+        assert len(mock_games) == 1
+        self.hass.services.call(
+            DOMAIN, 'remove_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID})
+        mock_games = ps4.load_games(self.hass)
+        assert len(mock_games) == 0
+
+    def test_add_media(self):
+        """Test media entry is added."""
+        self.setup_mock_component()
+        self.set_games_data({})
+        mock_games = ps4.load_games(self.hass)
+
+        assert len(mock_games) == 0
+        self.hass.services.call(
+            DOMAIN, 'add_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID,
+                                  ATTR_MEDIA_TITLE: MOCK_TITLE,
+                                  ATTR_MEDIA_IMAGE_URL: MOCK_URL})
+
+        mock_games = ps4.load_games(self.hass)
+        assert len(mock_games) == 1
+        assert MOCK_ID in mock_games
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        # Defaults to MEDIA_TYPE_GAME if not specified.
+        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE
+
+    def test_lock_current_media(self):
+        """Test lock_current_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+
+        mock_devices = self.hass.data[PS4_DATA].devices
+        assert len(mock_devices) == 1
+        mock_entity = mock_devices[0]
+
+        # Set media_id attr
+        mock_entity._media_content_id = MOCK_ID
+        assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+
+        self.hass.services.call(
+            DOMAIN, 'lock_current_media',
+            {ATTR_ENTITY_ID: mock_entity.entity_id})
+
+        mock_games = ps4.load_games(self.hass)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+
+    def test_unlock_current_media(self):
+        """Test unlock_current_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES_LOCKED)
+        mock_games = ps4.load_games(self.hass)
+
+        mock_devices = self.hass.data[PS4_DATA].devices
+        assert len(mock_devices) == 1
+        mock_entity = mock_devices[0]
+
+        mock_entity._media_content_id = MOCK_ID
+        assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+
+        self.hass.services.call(
+            DOMAIN, 'unlock_current_media',
+            {ATTR_ENTITY_ID: mock_entity.entity_id})
+
+        mock_games = ps4.load_games(self.hass)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+
+    def test_edit_current_media(self):
+        """Test edit_current_media service."""
+        self.setup_mock_component()
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+
+        mock_devices = self.hass.data[PS4_DATA].devices
+        assert len(mock_devices) == 1
+        mock_entity = mock_devices[0]
+
+        # Set media_id attr
+        mock_entity._media_content_id = MOCK_ID
+
+        assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
+        assert MOCK_ID in mock_games
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is False
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE
+
+        # Change the playing title only.
+        mock_title = 'Some New Title'
+        self.hass.services.call(
+            DOMAIN, 'edit_current_media',
+            {ATTR_ENTITY_ID: mock_entity.entity_id,
+             ATTR_MEDIA_TITLE: mock_title})
+
+        mock_games = ps4.load_games(self.hass)
+        assert mock_games[MOCK_ID][ATTR_LOCKED] is True
+        assert mock_games[MOCK_ID][ATTR_MEDIA_TITLE] == mock_title
+        # Test that not specified attributes remain the same.
+        assert mock_games[MOCK_ID][ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_games[MOCK_ID][ATTR_MEDIA_CONTENT_TYPE] == MOCK_TYPE

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -137,7 +137,7 @@ class TestPS4MediaServices(unittest.TestCase):
 
     def test_media_player_is_setup(self):
         """Test media_player is setup correctly."""
-        self.setup_mock_media_player()
+        self.setup_mock_component()
         assert len(self.hass.data[PS4_DATA].devices) == 1
 
     def test_file_created_if_none(self):
@@ -145,8 +145,8 @@ class TestPS4MediaServices(unittest.TestCase):
         self.cleanup()
         mock_empty = ps4.load_games(self.hass)
 
-        assert type(mock_empty) == dict
-        assert len(mock_empty) == 0
+        assert isinstance(mock_empty, dict)
+        assert mock_empty is None
         assert self.mock_file == '{}/{}'.format(
             self.hass.config.path(), GAMES_FILE)
 
@@ -156,12 +156,13 @@ class TestPS4MediaServices(unittest.TestCase):
         mock_games = ps4.load_games(self.hass)
 
         # New format is a nested dict.
-        assert type(mock_games) == dict
+        assert isinstance(mock_games, dict)
         assert mock_games['mock_id'][ATTR_MEDIA_TITLE] == 'mock_title'
         assert mock_games['mock_id2'][ATTR_MEDIA_TITLE] == 'mock_title2'
-        for mock_game, mock_title in mock_games.items():
+        for mock_game in mock_games:
             mock_data = mock_games[mock_game]
-            assert type(mock_data) == dict
+            assert isinstance(mock_data, dict)
+            assert mock_data
             assert mock_data[ATTR_MEDIA_IMAGE_URL] is None
             assert mock_data[ATTR_LOCKED] is False
             assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_GAME
@@ -170,10 +171,10 @@ class TestPS4MediaServices(unittest.TestCase):
         """Test that games are loaded correctly."""
         self.set_games_data(MOCK_GAMES)
         mock_games = ps4.load_games(self.hass)
+        assert isinstance(mock_games, dict)
 
-        assert type(mock_games) == dict
         mock_data = mock_games[MOCK_ID]
-        assert type(mock_data) == dict
+        assert isinstance(mock_data, dict)
         assert mock_data[ATTR_MEDIA_TITLE] == MOCK_TITLE
         assert mock_data[ATTR_MEDIA_IMAGE_URL] == MOCK_URL
         assert mock_data[ATTR_LOCKED] is False
@@ -300,7 +301,7 @@ class TestPS4MediaServices(unittest.TestCase):
         self.hass.services.call(
             DOMAIN, 'remove_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID})
         mock_games = ps4.load_games(self.hass)
-        assert len(mock_games) == 0
+        assert mock_games is None
 
     def test_add_media(self):
         """Test media entry is added."""
@@ -308,7 +309,7 @@ class TestPS4MediaServices(unittest.TestCase):
         self.set_games_data({})
         mock_games = ps4.load_games(self.hass)
 
-        assert len(mock_games) == 0
+        assert mock_games is None
         self.hass.services.call(
             DOMAIN, 'add_media', {ATTR_MEDIA_CONTENT_ID: MOCK_ID,
                                   ATTR_MEDIA_TITLE: MOCK_TITLE,
@@ -339,7 +340,7 @@ class TestPS4MediaServices(unittest.TestCase):
         mock_entity = mock_devices[0]
 
         # Set media_id attr
-        mock_entity._media_content_id = mock_id1
+        mock_entity._media_content_id = mock_id1  # noqa: pylint: disable=protected-access
         assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
         assert mock_games[mock_id1][ATTR_LOCKED] is False
 
@@ -368,7 +369,7 @@ class TestPS4MediaServices(unittest.TestCase):
         assert len(mock_devices) == 1
         mock_entity = mock_devices[0]
 
-        mock_entity._media_content_id = mock_id1
+        mock_entity._media_content_id = mock_id1  # noqa: pylint: disable=protected-access
         assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
         assert mock_games[mock_id1][ATTR_LOCKED] is True
 
@@ -397,7 +398,7 @@ class TestPS4MediaServices(unittest.TestCase):
         mock_entity = mock_devices[0]
 
         # Set media_id attr
-        mock_entity._media_content_id = mock_id1
+        mock_entity._media_content_id = mock_id1  # noqa: pylint: disable=protected-access
 
         assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
         assert mock_id1 in mock_games

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -127,8 +127,8 @@ class TestPS4MediaServices(unittest.TestCase):
         self.hass.stop()
         self.cleanup()
 
-    def setup_mock_component(self):
-        """Setup Mock Component."""
+    def setup_mock_media_player(self):
+        """Setup Mock Media Player."""
         entry = MockConfigEntry(
             domain=ps4.DOMAIN, data=MOCK_DATA, version=VERSION)
         entry.add_to_manager(self.hass.config_entries)

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -137,7 +137,7 @@ class TestPS4MediaServices(unittest.TestCase):
 
     def test_media_player_is_setup(self):
         """Test media_player is setup correctly."""
-        self.setup_mock_component()
+        self.setup_mock_media_player()
         assert len(self.hass.data[PS4_DATA].devices) == 1
 
     def test_file_created_if_none(self):

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -116,7 +116,7 @@ class TestPS4MediaServices(unittest.TestCase):
         self.hass.block_till_done()
 
     def setUp(self):
-        """Setup test environment."""
+        """Set up test environment."""
         self.hass = get_test_home_assistant()
         self.hass.start()
         self.hass.block_till_done()
@@ -128,7 +128,7 @@ class TestPS4MediaServices(unittest.TestCase):
         self.cleanup()
 
     def setup_mock_component(self):
-        """Setup Mock Media Player."""
+        """Set up Mock Media Player."""
         entry = MockConfigEntry(
             domain=ps4.DOMAIN, data=MOCK_DATA, version=VERSION)
         entry.add_to_manager(self.hass.config_entries)


### PR DESCRIPTION
## Description:
- Reformat stored data for sources. Reformat from dict with values=string/Source Title to values=dict of media attributes
- Placed all services within __init__.py
- Add services to edit source data attributes. Allow manual correction of incorrect media attributes from frontend and text editor.
- Allows locking of data (Use stored data instead of fetching)
- Allow cover art to be specified; allow loading of cover art from local config/www/ dir
- Add tests to __init__.py


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9840

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
