### PR TITLE
Add support for recording history to Apache Kafka

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -34,6 +34,7 @@ omit =
     homeassistant/components/androidtv/*
     homeassistant/components/anel_pwrctrl/switch.py
     homeassistant/components/anthemav/media_player.py
+    homeassistant/components/apache_kafka/*
     homeassistant/components/apcupsd/*
     homeassistant/components/apple_tv/*
     homeassistant/components/aqualogic/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,7 @@ homeassistant/components/alpha_vantage/* @fabaff
 homeassistant/components/amazon_polly/* @robbiet480
 homeassistant/components/ambiclimate/* @danielhiversen
 homeassistant/components/ambient_station/* @bachya
+homeassistant/components/apache_kafka/* @bachya
 homeassistant/components/api/* @home-assistant/core
 homeassistant/components/aprs/* @PhilRW
 homeassistant/components/arcam_fmj/* @elupus

--- a/homeassistant/components/apache_kafka/__init__.py
+++ b/homeassistant/components/apache_kafka/__init__.py
@@ -1,0 +1,85 @@
+"""Support for Apache Kafka."""
+from datetime import datetime
+import json
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_IP_ADDRESS, CONF_PORT, EVENT_HOMEASSISTANT_STOP, EVENT_STATE_CHANGED,
+    STATE_UNAVAILABLE, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entityfilter import FILTER_SCHEMA
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'apache_kafka'
+
+CONF_FILTER = 'filter'
+CONF_TOPIC = 'topic'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_IP_ADDRESS): cv.string,
+        vol.Required(CONF_PORT): cv.port,
+        vol.Required(CONF_TOPIC): cv.string,
+        vol.Optional(CONF_FILTER, default={}): FILTER_SCHEMA,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Activate the Apache Kafka integration."""
+    from aiokafka import AIOKafkaProducer
+
+    conf = config[DOMAIN]
+    topic_name = conf[CONF_TOPIC]
+    entities_filter = conf[CONF_FILTER]
+
+    producer = AIOKafkaProducer(
+        loop=hass.loop,
+        bootstrap_servers="{0}:{1}".format(
+            conf[CONF_IP_ADDRESS], conf[CONF_PORT]),
+        compression_type="gzip",
+    )
+
+    encoder = DateTimeJSONEncoder()
+
+    async def send_to_pubsub(event):
+        """Send states to Pub/Sub."""
+        await producer.start()
+
+        state = event.data.get('new_state')
+        if (state is None
+                or state.state in (STATE_UNKNOWN, '', STATE_UNAVAILABLE)
+                or not entities_filter(state.entity_id)):
+            return
+
+        as_dict = state.as_dict()
+        data = json.dumps(
+            obj=as_dict,
+            default=encoder.encode
+        ).encode('utf-8')
+
+        try:
+            await producer.send_and_wait(topic_name, data)
+        finally:
+            producer.stop()
+
+    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, producer.stop())
+    hass.bus.listen(EVENT_STATE_CHANGED, send_to_pubsub)
+
+    return True
+
+
+class DateTimeJSONEncoder(json.JSONEncoder):
+    """Encode python objects.
+
+    Additionally add encoding for datetime objects as isoformat.
+    """
+
+    def default(self, o):  # pylint: disable=E0202
+        """Implement encoding logic."""
+        if isinstance(o, datetime):
+            return o.isoformat()
+        return super().default(o)

--- a/homeassistant/components/apache_kafka/__init__.py
+++ b/homeassistant/components/apache_kafka/__init__.py
@@ -1,11 +1,8 @@
 """Support for Apache Kafka."""
-import asyncio
 from datetime import datetime
 import json
 import logging
 
-from aiokafka import AIOKafkaProducer
-from aiokafka.errors import KafkaError
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -31,24 +28,46 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-async def async_setup(hass, config):
+def setup(hass, config):
     """Activate the Apache Kafka integration."""
+    from aiokafka import AIOKafkaProducer
+
     conf = config[DOMAIN]
+    topic_name = conf[CONF_TOPIC]
+    entities_filter = conf[CONF_FILTER]
 
-    kafka = hass.data[DOMAIN] = KafkaManager(
-        hass,
-        conf[CONF_IP_ADDRESS],
-        conf[CONF_PORT],
-        conf[CONF_TOPIC],
-        conf[CONF_FILTER])
+    producer = AIOKafkaProducer(
+        loop=hass.loop,
+        bootstrap_servers="{0}:{1}".format(
+            conf[CONF_IP_ADDRESS], conf[CONF_PORT]),
+        compression_type="gzip",
+    )
 
-    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, kafka.shutdown())
+    encoder = DateTimeJSONEncoder()
 
-    try:
-        await kafka.start()
-    except asyncio.TimeoutError:
-        _LOGGER.error('Timed out while connecting to Kafka')
-        return False
+    async def send_to_pubsub(event):
+        """Send states to Pub/Sub."""
+        await producer.start()
+
+        state = event.data.get('new_state')
+        if (state is None
+                or state.state in (STATE_UNKNOWN, '', STATE_UNAVAILABLE)
+                or not entities_filter(state.entity_id)):
+            return
+
+        as_dict = state.as_dict()
+        data = json.dumps(
+            obj=as_dict,
+            default=encoder.encode
+        ).encode('utf-8')
+
+        try:
+            await producer.send_and_wait(topic_name, data)
+        finally:
+            producer.stop()
+
+    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, producer.stop())
+    hass.bus.listen(EVENT_STATE_CHANGED, send_to_pubsub)
 
     return True
 
@@ -64,51 +83,3 @@ class DateTimeJSONEncoder(json.JSONEncoder):
         if isinstance(o, datetime):
             return o.isoformat()
         return super().default(o)
-
-
-class KafkaManager:
-    """Define a manager to buffer events to Kafka."""
-
-    def __init__(
-            self,
-            hass,
-            ip_address,
-            port,
-            topic,
-            entities_filter):
-        """Initialize."""
-        self._encoder = DateTimeJSONEncoder()
-        self._entities_filter = entities_filter
-        self._producer = AIOKafkaProducer(
-            loop=hass.loop,
-            bootstrap_servers="{0}:{1}".format(ip_address, port),
-            compression_type="gzip",
-        )
-        self._topic = topic
-
-        hass.bus.listen(EVENT_STATE_CHANGED, self._write_to_kafka)
-
-    def _encode_event(self, event):
-        """Translate events into a binary JSON payload."""
-        state = event.data.get('new_state')
-        if (state is None
-                or state.state in (STATE_UNKNOWN, '', STATE_UNAVAILABLE)
-                or not self._entities_filter(state.entity_id)):
-            return
-
-        return json.dumps(
-            obj=state.as_dict(),
-            default=self._encoder.encode
-        ).encode('utf-8')
-
-    async def _write_to_kafka(self, event):
-        """Write a binary payload to Kafka."""
-        await self._producer.send_and_wait(self._topic, event)
-
-    async def start(self):
-        """Start the Kafka manager."""
-        asyncio.wait_for(self._producer.start(), timeout=5)
-
-    async def shutdown(self):
-        """Shut the manager down."""
-        await self._producer.stop()

--- a/homeassistant/components/apache_kafka/__init__.py
+++ b/homeassistant/components/apache_kafka/__init__.py
@@ -4,7 +4,6 @@ import json
 import logging
 
 from aiokafka import AIOKafkaProducer
-from aiokafka.errors import KafkaError
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/apache_kafka/manifest.json
+++ b/homeassistant/components/apache_kafka/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "apache_kafka",
+  "name": "Apache Kafka",
+  "documentation": "https://www.home-assistant.io/components/apache_kafka",
+  "requirements": [
+    "aiokafka==0.5.1"
+  ],
+  "dependencies": [],
+  "codeowners": []
+}

--- a/homeassistant/components/apache_kafka/manifest.json
+++ b/homeassistant/components/apache_kafka/manifest.json
@@ -6,5 +6,7 @@
     "aiokafka==0.5.1"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@bachya"
+  ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -150,6 +150,9 @@ aiohue==1.9.1
 # homeassistant.components.imap
 aioimaplib==0.7.15
 
+# homeassistant.components.apache_kafka
+aiokafka==0.5.1
+
 # homeassistant.components.lifx
 aiolifx==0.6.7
 


### PR DESCRIPTION
## Description:

This PR adds support for recording `history` to an [Apache Kafka](https://kafka.apache.org/) topic.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9836

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
apache_kafka:
  ip_address: localhost
  port: 9092
  topic: home_assistant_1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
