### PR TITLE
Add support for multiple N26 accounts

### DIFF
--- a/homeassistant/components/n26/__init__.py
+++ b/homeassistant/components/n26/__init__.py
@@ -4,6 +4,8 @@ import logging
 
 import voluptuous as vol
 
+from n26 import api as n26_api, config as n26_config
+
 from homeassistant.const import (
     CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
@@ -18,12 +20,12 @@ DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
 
 # define configuration parameters
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [{
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_SCAN_INTERVAL,
                      default=DEFAULT_SCAN_INTERVAL): cv.time_period,
-    }),
+    }])
 }, extra=vol.ALLOW_EXTRA)
 
 N26_COMPONENTS = [
@@ -34,24 +36,30 @@ N26_COMPONENTS = [
 
 def setup(hass, config):
     """Set up N26 Component."""
-    user = config[DOMAIN][CONF_USERNAME]
-    password = config[DOMAIN][CONF_PASSWORD]
+    acc_list = config[DOMAIN]
 
-    from n26 import api, config as api_config
-    api = api.Api(api_config.Config(user, password))
+    api_data_list = []
 
-    from requests import HTTPError
-    try:
-        api.get_token()
-    except HTTPError as err:
-        _LOGGER.error(str(err))
-        return False
+    for acc in acc_list:
+        user = acc[CONF_USERNAME]
+        password = acc[CONF_PASSWORD]
 
-    api_data = N26Data(api)
-    api_data.update()
+        api = n26_api.Api(n26_config.Config(user, password))
+
+        from requests import HTTPError
+        try:
+            api.get_token()
+        except HTTPError as err:
+            _LOGGER.error(str(err))
+            return False
+
+        api_data = N26Data(api)
+        api_data.update()
+
+        api_data_list.append(api_data)
 
     hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][DATA] = api_data
+    hass.data[DOMAIN][DATA] = api_data_list
 
     # Load components for supported devices
     for component in N26_COMPONENTS:

--- a/homeassistant/components/n26/sensor.py
+++ b/homeassistant/components/n26/sensor.py
@@ -30,15 +30,20 @@ ICON_SPACE = 'mdi:crop-square'
 def setup_platform(
         hass, config, add_entities, discovery_info=None):
     """Set up the N26 sensor platform."""
-    api_data = hass.data[DOMAIN][DATA]
+    api_list = hass.data[DOMAIN][DATA]
 
-    sensor_entities = [N26Account(api_data)]
+    if api_list is None:
+        return
 
-    for card in api_data.cards:
-        sensor_entities.append(N26Card(api_data, card))
+    sensor_entities = []
+    for api_data in api_list:
+        sensor_entities.append(N26Account(api_data))
 
-    for space in api_data.spaces["spaces"]:
-        sensor_entities.append(N26Space(api_data, space))
+        for card in api_data.cards:
+            sensor_entities.append(N26Card(api_data, card))
+
+        for space in api_data.spaces["spaces"]:
+            sensor_entities.append(N26Space(api_data, space))
 
     add_entities(sensor_entities)
 
@@ -204,7 +209,8 @@ class N26Space(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        return "space_{}".format(self._space["name"].lower())
+        return "space_{}_{}".format(self._data.balance["iban"][-4:],
+                                    self._space["name"].lower())
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/n26/sensor.py
+++ b/homeassistant/components/n26/sensor.py
@@ -30,6 +30,10 @@ ICON_SPACE = 'mdi:crop-square'
 def setup_platform(
         hass, config, add_entities, discovery_info=None):
     """Set up the N26 sensor platform."""
+
+    if discovery_info is None:
+        return
+
     api_list = hass.data[DOMAIN][DATA]
 
     sensor_entities = []

--- a/homeassistant/components/n26/sensor.py
+++ b/homeassistant/components/n26/sensor.py
@@ -30,7 +30,6 @@ ICON_SPACE = 'mdi:crop-square'
 def setup_platform(
         hass, config, add_entities, discovery_info=None):
     """Set up the N26 sensor platform."""
-
     if discovery_info is None:
         return
 

--- a/homeassistant/components/n26/sensor.py
+++ b/homeassistant/components/n26/sensor.py
@@ -32,9 +32,6 @@ def setup_platform(
     """Set up the N26 sensor platform."""
     api_list = hass.data[DOMAIN][DATA]
 
-    if api_list is None:
-        return
-
     sensor_entities = []
     for api_data in api_list:
         sensor_entities.append(N26Account(api_data))

--- a/homeassistant/components/n26/switch.py
+++ b/homeassistant/components/n26/switch.py
@@ -16,9 +16,6 @@ def setup_platform(
     """Set up the N26 switch platform."""
     api_list = hass.data[DOMAIN][DATA]
 
-    if api_list is None:
-        return
-
     switch_entities = []
     for api_data in api_list:
         for card in api_data.cards:

--- a/homeassistant/components/n26/switch.py
+++ b/homeassistant/components/n26/switch.py
@@ -14,10 +14,10 @@ SCAN_INTERVAL = DEFAULT_SCAN_INTERVAL
 def setup_platform(
         hass, config, add_entities, discovery_info=None):
     """Set up the N26 switch platform."""
-    api_list = hass.data[DOMAIN][DATA]
-
     if discovery_info is None:
         return
+
+    api_list = hass.data[DOMAIN][DATA]
 
     switch_entities = []
     for api_data in api_list:

--- a/homeassistant/components/n26/switch.py
+++ b/homeassistant/components/n26/switch.py
@@ -14,11 +14,15 @@ SCAN_INTERVAL = DEFAULT_SCAN_INTERVAL
 def setup_platform(
         hass, config, add_entities, discovery_info=None):
     """Set up the N26 switch platform."""
-    api_data = hass.data[DOMAIN][DATA]
+    api_list = hass.data[DOMAIN][DATA]
+
+    if api_list is None:
+        return
 
     switch_entities = []
-    for card in api_data.cards:
-        switch_entities.append(N26CardSwitch(api_data, card))
+    for api_data in api_list:
+        for card in api_data.cards:
+            switch_entities.append(N26CardSwitch(api_data, card))
 
     add_entities(switch_entities)
 

--- a/homeassistant/components/n26/switch.py
+++ b/homeassistant/components/n26/switch.py
@@ -16,6 +16,9 @@ def setup_platform(
     """Set up the N26 switch platform."""
     api_list = hass.data[DOMAIN][DATA]
 
+    if discovery_info is None:
+        return
+
     switch_entities = []
     for api_data in api_list:
         for card in api_data.cards:


### PR DESCRIPTION
## Breaking Change:

The generation of unique ids for spaces has been changed. Previous format was `space_<name>`, new format is `space_<iban[-4:]_<name>`. Otherwise we cannot guarantee uniqueness of ids in case of two accounts have spaces with the same name, e.g. the "main" spaces have always the same name by default. Users may need to remove the stale old id entities, representing spaces, from the entity registry.

## Description:

Added support for multiple N26 accounts.

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/9577

## Example entry for `configuration.yaml` (if applicable):
```yaml
n26:                                                                                                                                                   
    - username: email1@example.com                                                                                                                    
      password: !secret n26_password1                                                                                                                     
    - username: email2@example.com 
      password: !secret n26_password2    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
