### PR TITLE
Support podcast episodes as Sonos favorites

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.19"
+    "pysonos==0.0.20"
   ],
   "dependencies": [],
   "ssdp": {

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -371,9 +371,15 @@ class SonosEntity(MediaPlayerDevice):
 
     def _set_favorites(self):
         """Set available favorites."""
-        favorites = self.soco.music_library.get_sonos_favorites()
-        # Exclude favorites that are non-playable due to no linked resources
-        self._favorites = [f for f in favorites if f.reference.resources]
+        self._favorites = []
+        for fav in self.soco.music_library.get_sonos_favorites():
+            try:
+                # Exclude non-playable favorites with no linked resources
+                if fav.reference.resources:
+                    self._favorites.append(fav)
+            except SoCoException as ex:
+                # Skip unknown types
+                _LOGGER.error("Unhandled favorite '%s': %s", fav.title, ex)
 
     def _radio_artwork(self, url):
         """Return the private URL with artwork for a radio stream."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1378,7 +1378,7 @@ pysmarty==0.8
 pysnmp==4.4.9
 
 # homeassistant.components.sonos
-pysonos==0.0.19
+pysonos==0.0.20
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -298,7 +298,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.9
 
 # homeassistant.components.sonos
-pysonos==0.0.19
+pysonos==0.0.20
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

Updates to [pysonos 0.0.20](https://github.com/amelchio/pysonos/releases/tag/v0.0.20) which has an object type for podcast episodes. This adds support for playing such favorites. More importantly, though, it avoids crashing the Sonos integration during startup when such a favorite is present.

This bug was hard to find because the exception that was supposed to be unhandled and thus noisy in `_set_favorites()` was actually caught elsewhere. So I changed the error handling.

**Related issue (if applicable):** fixes #24853

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
