### PR TITLE
PS4 handle no connection/ fix spamming of logs when device is off

### DIFF
--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.8.5"
+    "pyps4-homeassistant==0.8.7"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -30,7 +30,7 @@ ICON = 'mdi:playstation'
 GAMES_FILE = '.ps4-games.json'
 MEDIA_IMAGE_DEFAULT = None
 
-DEFAULT_ENTRIES = 2
+DEFAULT_RETRIES = 2
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up PS4 from a config entry."""
@@ -172,7 +172,7 @@ class PS4Device(MediaPlayerDevice):
                 if self._state != STATE_OFF:
                     self.state_off()
 
-        elif self._retry > DEFAULT_ENTRIES:
+        elif self._retry > DEFAULT_RETRIES:
             self.state_unknown()
         else:
             self._retry += 1

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -2,6 +2,9 @@
 import logging
 import asyncio
 
+import pyps4_homeassistant.ps4 as pyps4
+from pyps4_homeassistant.errors import NotReady
+
 from homeassistant.core import callback
 from homeassistant.components.media_player import (
     ENTITY_IMAGE_URL, MediaPlayerDevice)
@@ -27,6 +30,7 @@ ICON = 'mdi:playstation'
 GAMES_FILE = '.ps4-games.json'
 MEDIA_IMAGE_DEFAULT = None
 
+DEFAULT_ENTRIES = 2
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up PS4 from a config entry."""
@@ -38,7 +42,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up PS4 Platform."""
-    import pyps4_homeassistant.ps4 as pyps4
     games_file = hass.config.path(GAMES_FILE)
     creds = config.data[CONF_TOKEN]
     device_list = []
@@ -118,8 +121,15 @@ class PS4Device(MediaPlayerDevice):
         if self._ps4.ddp_protocol is not None:
             # Request Status with asyncio transport.
             self._ps4.get_status()
-            if not self._ps4.connected and not self._ps4.is_standby:
-                await self._ps4.async_connect()
+
+            # Don't attempt to connect if entity is connected or if,
+            # PS4 is in standby or disconnected from LAN or powered off.
+            if not self._ps4.connected and not self._ps4.is_standby and\
+                    self._ps4.is_available:
+                try:
+                    await self._ps4.async_connect()
+                except NotReady:
+                    pass
 
         # Try to ensure correct status is set on startup for device info.
         if self._ps4.ddp_protocol is None:
@@ -162,7 +172,7 @@ class PS4Device(MediaPlayerDevice):
                 if self._state != STATE_OFF:
                     self.state_off()
 
-        elif self._retry > 5:
+        elif self._retry > DEFAULT_ENTRIES:
             self.state_unknown()
         else:
             self._retry += 1

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -32,6 +32,7 @@ MEDIA_IMAGE_DEFAULT = None
 
 DEFAULT_RETRIES = 2
 
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up PS4 from a config entry."""
     config = config_entry

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1324,7 +1324,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.5
+pyps4-homeassistant==0.8.7
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -286,7 +286,7 @@ pyopenuv==1.0.9
 pyotp==2.2.7
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.5
+pyps4-homeassistant==0.8.7
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Better handling of exception/ prevent trying to connect when no connection. (PS4 powered off/ disconnected).

**Related issue (if applicable):** fixes #24925
## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
