### PR TITLE
Fix xiaomi_miio fan speed_list missing off

### DIFF
--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -7,9 +7,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.fan import (FanEntity, PLATFORM_SCHEMA,
-                                          SUPPORT_SET_SPEED, DOMAIN, )
+                                          SUPPORT_SET_SPEED, SPEED_OFF, DOMAIN, )
 from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_TOKEN,
-                                 ATTR_ENTITY_ID, STATE_OFF, )
+                                 ATTR_ENTITY_ID, )
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
@@ -248,13 +248,13 @@ AVAILABLE_ATTRIBUTES_AIRFRESH = {
     ATTR_EXTRA_FEATURES: 'extra_features',
 }
 
-OPERATION_MODES_AIRPURIFIER = [STATE_OFF, 'Auto', 'Silent', 'Favorite', 'Idle']
-OPERATION_MODES_AIRPURIFIER_PRO = [STATE_OFF, 'Auto', 'Silent', 'Favorite']
+OPERATION_MODES_AIRPURIFIER = [SPEED_OFF, 'Auto', 'Silent', 'Favorite', 'Idle']
+OPERATION_MODES_AIRPURIFIER_PRO = [SPEED_OFF, 'Auto', 'Silent', 'Favorite']
 OPERATION_MODES_AIRPURIFIER_PRO_V7 = OPERATION_MODES_AIRPURIFIER_PRO
-OPERATION_MODES_AIRPURIFIER_2S = [STATE_OFF, 'Auto', 'Silent', 'Favorite']
-OPERATION_MODES_AIRPURIFIER_V3 = [STATE_OFF, 'Auto', 'Silent', 'Favorite', 'Idle',
+OPERATION_MODES_AIRPURIFIER_2S = [SPEED_OFF, 'Auto', 'Silent', 'Favorite']
+OPERATION_MODES_AIRPURIFIER_V3 = [SPEED_OFF, 'Auto', 'Silent', 'Favorite', 'Idle',
                                   'Medium', 'High', 'Strong']
-OPERATION_MODES_AIRFRESH = [STATE_OFF, 'Auto', 'Silent', 'Interval', 'Low',
+OPERATION_MODES_AIRFRESH = [SPEED_OFF, 'Auto', 'Silent', 'Interval', 'Low',
                             'Middle', 'Strong']
 
 SUCCESS = ['ok']
@@ -688,7 +688,7 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
         if self.supported_features & SUPPORT_SET_SPEED == 0:
             return
 
-        if speed == STATE_OFF:
+        if speed == SPEED_OFF:
             await self.async_turn_off()
             return
 
@@ -972,7 +972,7 @@ class XiaomiAirFresh(XiaomiGenericDevice):
         if self.supported_features & SUPPORT_SET_SPEED == 0:
             return
 
-        if speed == STATE_OFF:
+        if speed == SPEED_OFF:
             await self.async_turn_off()
             return
 

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.components.fan import (FanEntity, PLATFORM_SCHEMA,
                                           SUPPORT_SET_SPEED, DOMAIN, )
 from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_TOKEN,
-                                 ATTR_ENTITY_ID, )
+                                 ATTR_ENTITY_ID, STATE_OFF, )
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
@@ -248,13 +248,13 @@ AVAILABLE_ATTRIBUTES_AIRFRESH = {
     ATTR_EXTRA_FEATURES: 'extra_features',
 }
 
-OPERATION_MODES_AIRPURIFIER = ['Auto', 'Silent', 'Favorite', 'Idle']
-OPERATION_MODES_AIRPURIFIER_PRO = ['Auto', 'Silent', 'Favorite']
+OPERATION_MODES_AIRPURIFIER = [STATE_OFF, 'Auto', 'Silent', 'Favorite', 'Idle']
+OPERATION_MODES_AIRPURIFIER_PRO = [STATE_OFF, 'Auto', 'Silent', 'Favorite']
 OPERATION_MODES_AIRPURIFIER_PRO_V7 = OPERATION_MODES_AIRPURIFIER_PRO
-OPERATION_MODES_AIRPURIFIER_2S = ['Auto', 'Silent', 'Favorite']
-OPERATION_MODES_AIRPURIFIER_V3 = ['Auto', 'Silent', 'Favorite', 'Idle',
+OPERATION_MODES_AIRPURIFIER_2S = [STATE_OFF, 'Auto', 'Silent', 'Favorite']
+OPERATION_MODES_AIRPURIFIER_V3 = [STATE_OFF, 'Auto', 'Silent', 'Favorite', 'Idle',
                                   'Medium', 'High', 'Strong']
-OPERATION_MODES_AIRFRESH = ['Auto', 'Silent', 'Interval', 'Low',
+OPERATION_MODES_AIRFRESH = [STATE_OFF, 'Auto', 'Silent', 'Interval', 'Low',
                             'Middle', 'Strong']
 
 SUCCESS = ['ok']
@@ -688,6 +688,10 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
         if self.supported_features & SUPPORT_SET_SPEED == 0:
             return
 
+        if speed == STATE_OFF:
+            await self.async_turn_off()
+            return
+
         from miio.airpurifier import OperationMode
 
         _LOGGER.debug("Setting the operation mode to: %s", speed)
@@ -966,6 +970,10 @@ class XiaomiAirFresh(XiaomiGenericDevice):
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         if self.supported_features & SUPPORT_SET_SPEED == 0:
+            return
+
+        if speed == STATE_OFF:
+            await self.async_turn_off()
             return
 
         from miio.airfresh import OperationMode


### PR DESCRIPTION
### Breaking Change:

No breaking changes.

## Description:

The `fan` platform of `xiaomi_miio` component doesn't support fan speed `SPEED_OFF`. This is incompatible with `homekit` which requires first `fan.attributes.speed_list` element to be `off`.

This results in:
```
['Auto', 'Silent', 'Favorite'] does not contain the speed setting 'off' as its first element. Assuming that 'Auto' is equivalent to 'off'.
```

And wrong speed/power controls in HomeKit.

My PR fixes this issue by adding `SPEED_OFF` for supported speeds and handling it as making fan turn off after selecting this speed.

**Related issues:**

#22760 #24712 #23211

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
