### PR TITLE
Ps4 move send_command service to init

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -1,15 +1,26 @@
 """Support for PlayStation 4 consoles."""
 import logging
 
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_COMMAND, ATTR_ENTITY_ID, CONF_REGION, CONF_TOKEN)
 from homeassistant.core import split_entity_id
-from homeassistant.const import CONF_REGION, CONF_TOKEN
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry, config_validation as cv
+from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import location
 
 from .config_flow import PlayStation4FlowHandler  # noqa: pylint: disable=unused-import
-from .const import DOMAIN, PS4_DATA  # noqa: pylint: disable=unused-import
+from .const import COMMANDS, DOMAIN, PS4_DATA
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_COMMAND = 'send_command'
+
+PS4_COMMAND_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_COMMAND): vol.In(list(COMMANDS))
+})
 
 
 class PS4Data():
@@ -30,6 +41,7 @@ async def async_setup(hass, config):
     transport, protocol = await async_create_ddp_endpoint()
     hass.data[PS4_DATA].protocol = protocol
     _LOGGER.debug("PS4 DDP endpoint created: %s, %s", transport, protocol)
+    await async_service_handle(hass)
     return True
 
 
@@ -124,3 +136,18 @@ def format_unique_id(creds, mac_address):
     """Use last 4 Chars of credential as suffix. Unique ID per PSN user."""
     suffix = creds[-4:]
     return "{}_{}".format(mac_address, suffix)
+
+
+async def async_service_handle(hass: HomeAssistantType):
+    """Handle for services."""
+    async def async_service_command(call):
+        """Service for sending commands."""
+        entity_ids = call.data[ATTR_ENTITY_ID]
+        command = call.data[ATTR_COMMAND]
+        for device in hass.data[PS4_DATA].devices:
+            if device.entity_id in entity_ids:
+                await device.async_send_command(command)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_COMMAND, async_service_command,
+        schema=PS4_COMMAND_SCHEMA)

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -41,7 +41,7 @@ async def async_setup(hass, config):
     transport, protocol = await async_create_ddp_endpoint()
     hass.data[PS4_DATA].protocol = protocol
     _LOGGER.debug("PS4 DDP endpoint created: %s, %s", transport, protocol)
-    await async_service_handle(hass)
+    service_handle(hass)
     return True
 
 
@@ -138,7 +138,7 @@ def format_unique_id(creds, mac_address):
     return "{}_{}".format(mac_address, suffix)
 
 
-async def async_service_handle(hass: HomeAssistantType):
+def service_handle(hass: HomeAssistantType):
     """Handle for services."""
     async def async_service_command(call):
         """Service for sending commands."""

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -5,5 +5,8 @@ DEFAULT_ALIAS = 'Home-Assistant'
 DOMAIN = 'ps4'
 PS4_DATA = 'ps4_data'
 
+COMMANDS = (
+    'up', 'down', 'right', 'left', 'enter', 'back', 'option', 'ps')
+
 # Deprecated used for logger/backwards compatibility from 0.89
 REGIONS = ['R1', 'R2', 'R3', 'R4', 'R5']

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -2,8 +2,6 @@
 import logging
 import asyncio
 
-import voluptuous as vol
-
 from homeassistant.core import callback
 from homeassistant.components.media_player import (
     ENTITY_IMAGE_URL, MediaPlayerDevice)
@@ -12,9 +10,8 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PAUSE, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
 from homeassistant.components.ps4 import format_unique_id
 from homeassistant.const import (
-    ATTR_COMMAND, ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_REGION,
+    CONF_HOST, CONF_NAME, CONF_REGION,
     CONF_TOKEN, STATE_IDLE, STATE_OFF, STATE_PLAYING)
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.util.json import load_json, save_json
 
@@ -30,45 +27,12 @@ ICON = 'mdi:playstation'
 GAMES_FILE = '.ps4-games.json'
 MEDIA_IMAGE_DEFAULT = None
 
-COMMANDS = (
-    'up',
-    'down',
-    'right',
-    'left',
-    'enter',
-    'back',
-    'option',
-    'ps',
-)
-
-SERVICE_COMMAND = 'send_command'
-
-PS4_COMMAND_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_COMMAND): vol.In(list(COMMANDS))
-})
-
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up PS4 from a config entry."""
     config = config_entry
     await async_setup_platform(
         hass, config, async_add_entities, discovery_info=None)
-
-    async def async_service_handle(hass):
-        """Handle for services."""
-        async def async_service_command(call):
-            entity_ids = call.data[ATTR_ENTITY_ID]
-            command = call.data[ATTR_COMMAND]
-            for device in hass.data[PS4_DATA].devices:
-                if device.entity_id in entity_ids:
-                    await device.async_send_command(command)
-
-        hass.services.async_register(
-            PS4_DOMAIN, SERVICE_COMMAND, async_service_command,
-            schema=PS4_COMMAND_SCHEMA)
-
-    await async_service_handle(hass)
 
 
 async def async_setup_platform(


### PR DESCRIPTION
## Description:
Move send_command service to init instead of in media_player.py

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
