### PR TITLE
Fix window exception in WWLLN

### DIFF
--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -60,11 +60,14 @@ class WWLLNFlowHandler(config_entries.ConfigFlow):
         else:
             user_input[CONF_UNIT_SYSTEM] = CONF_UNIT_SYSTEM_METRIC
 
-        # To simplify things, we don't allow users of the config flow to
-        # input a window; instead, we make a sane assumption to use the
-        # default (stored as seconds, since timedelta's aren't
-        # JSON-serializable):
-        if CONF_WINDOW not in user_input:
+        # When importing from `configuration.yaml`, we give the user
+        # flexibility by allowing the `window` parameter to be any type
+        # of time period. This will always return a timedelta; unfortunately,
+        # timedeltas aren't JSON-serializable, so we can't store them in a
+        # config entry as-is; instead, we save the total seconds as an int:
+        if CONF_WINDOW in user_input:
+            user_input[CONF_WINDOW] = user_input[CONF_WINDOW].total_seconds()
+        else:
             user_input[CONF_WINDOW] = DEFAULT_WINDOW.total_seconds()
 
         return self.async_create_entry(title=identifier, data=user_input)

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -67,9 +67,7 @@ class WWLLNFlowHandler(config_entries.ConfigFlow):
         # timedeltas aren't JSON-serializable, so we can't store them in a
         # config entry as-is; instead, we save the total seconds as an int:
         if CONF_WINDOW in user_input:
-            if isinstance(user_input[CONF_WINDOW], timedelta):
-                user_input[CONF_WINDOW] = user_input[
-                    CONF_WINDOW].total_seconds()
+            user_input[CONF_WINDOW] = user_input[CONF_WINDOW].total_seconds()
         else:
             user_input[CONF_WINDOW] = DEFAULT_WINDOW.total_seconds()
 

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow to configure the WWLLN integration."""
+from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -66,7 +67,9 @@ class WWLLNFlowHandler(config_entries.ConfigFlow):
         # timedeltas aren't JSON-serializable, so we can't store them in a
         # config entry as-is; instead, we save the total seconds as an int:
         if CONF_WINDOW in user_input:
-            user_input[CONF_WINDOW] = user_input[CONF_WINDOW].total_seconds()
+            if isinstance(user_input[CONF_WINDOW], timedelta):
+                user_input[CONF_WINDOW] = user_input[
+                    CONF_WINDOW].total_seconds()
         else:
             user_input[CONF_WINDOW] = DEFAULT_WINDOW.total_seconds()
 

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -1,5 +1,4 @@
 """Config flow to configure the WWLLN integration."""
-from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -1,4 +1,6 @@
 """Define tests for the WWLLN config flow."""
+from datetime import timedelta
+
 from homeassistant import data_entry_flow
 from homeassistant.components.wwlln import CONF_WINDOW, DOMAIN, config_flow
 from homeassistant.const import (
@@ -36,12 +38,14 @@ async def test_show_form(hass):
 
 async def test_step_import(hass):
     """Test that the import step works."""
+    # `configuration.yaml` will always return a timedelta for the `window`
+    # parameter, FYI:
     conf = {
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
         CONF_UNIT_SYSTEM: 'metric',
-        CONF_WINDOW: 600.0,
+        CONF_WINDOW: timedelta(minutes=10)
     }
 
     flow = config_flow.WWLLNFlowHandler()

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -92,7 +92,7 @@ async def test_custom_window(hass):
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
-        CONF_WINDOW: 300
+        CONF_WINDOW: timedelta(hours=1)
     }
 
     flow = config_flow.WWLLNFlowHandler()
@@ -106,5 +106,5 @@ async def test_custom_window(hass):
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
         CONF_UNIT_SYSTEM: 'metric',
-        CONF_WINDOW: 300,
+        CONF_WINDOW: 3600,
     }


### PR DESCRIPTION
## Description:

When configuring `wwlln` via `configuration.yaml`, the `window` parameter (explicit or implicit) gets cast as a `timedelta` because we allow users to input any `time_period` schema   (for maximum flexibility). Unfortunately, `timedelta`s can't be JSON-serialized, so they can't be saved in config entries as-is. This would cause an unhandled exception.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/25099

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
wwlln:
  window: 300
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
