### PR TITLE
Fix missing sensor unit in RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -73,7 +73,7 @@ SENSORS = {
     TYPE_FLOW_SENSOR_CONSUMED_LITERS: (
         'Flow Sensor Consumed Liters', 'mdi:water-pump', 'liter', None),
     TYPE_FLOW_SENSOR_START_INDEX: (
-        'Flow Sensor Start Index', 'mdi:water-pump', None),
+        'Flow Sensor Start Index', 'mdi:water-pump', 'index', None),
     TYPE_FLOW_SENSOR_WATERING_CLICKS: (
         'Flow Sensor Clicks', 'mdi:water-pump', 'clicks', None),
     TYPE_FREEZE_TEMP: (


### PR DESCRIPTION
## Description:

The `Flow Sensor Start Index` sensor was missing a unit, which could cause an unhandled exception.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/25098

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_ip
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
