### PR TITLE
Bump insteonplm to 0 16 3

### DIFF
--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -3,7 +3,7 @@
   "name": "Insteon",
   "documentation": "https://www.home-assistant.io/components/insteon",
   "requirements": [
-    "insteonplm==0.16.0"
+    "insteonplm==0.16.3"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -661,7 +661,7 @@ incomfort-client==0.3.0
 influxdb==5.2.0
 
 # homeassistant.components.insteon
-insteonplm==0.16.0
+insteonplm==0.16.3
 
 # homeassistant.components.iperf3
 iperf3==0.1.10


### PR DESCRIPTION
## Description:
Fix issue with the Insteon Hub failing on value errors. 

This is not a true fix to the underlying issue. It only allows the Insteon component to recover gracefully and it better logs the error for future debugging.

**Related issue (if applicable):** fixes #25107


## Example entry for `configuration.yaml` (if applicable):
```yaml
insteon:
  port: /dev/ttyUSB0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
