### PR TITLE
Add additional WWLLN test

### DIFF
--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -29,9 +29,6 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the WWLLN component."""
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][DATA_CLIENT] = {}
-
     if DOMAIN not in config:
         return True
 
@@ -66,6 +63,9 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up the WWLLN as config entry."""
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][DATA_CLIENT] = {}
+
     websession = aiohttp_client.async_get_clientsession(hass)
 
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = Client(websession)

--- a/tests/components/wwlln/conftest.py
+++ b/tests/components/wwlln/conftest.py
@@ -1,0 +1,23 @@
+"""Define various utilities for WWLLN tests."""
+import pytest
+
+from homeassistant.components.wwlln import CONF_WINDOW, DOMAIN
+from homeassistant.const import (
+    CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS, CONF_UNIT_SYSTEM)
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def config_entry():
+    """Create a mock WWLLN config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LATITUDE: 39.128712,
+            CONF_LONGITUDE: -104.9812612,
+            CONF_RADIUS: 25,
+            CONF_UNIT_SYSTEM: 'metric',
+            CONF_WINDOW: 3600
+        },
+        title='39.128712, -104.9812612')


### PR DESCRIPTION
## Description:

Per @MartinHjelmare's [suggestion](https://github.com/home-assistant/home-assistant/pull/25100#pullrequestreview-261276803), this PR adds another test to ensure the WWLLN integration starts up with an existing config flow. In so doing, it adjusts when the integration saves objects to `hass.data`; this won't affect anything operational – it is merely a change to help this test.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
