### PR TITLE
Improve handling of Z-Wave config entry vs yaml config

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -32,7 +32,7 @@ from .const import (
     CONF_USB_STICK_PATH, CONF_CONFIG_PATH, CONF_NETWORK_KEY,
     DEFAULT_CONF_AUTOHEAL, DEFAULT_CONF_USB_STICK_PATH,
     DEFAULT_POLLING_INTERVAL, DEFAULT_DEBUG, DOMAIN,
-    DATA_DEVICES, DATA_NETWORK, DATA_ENTITY_VALUES)
+    DATA_DEVICES, DATA_NETWORK, DATA_ENTITY_VALUES, DATA_ZWAVE_CONFIG)
 from .node_entity import ZWaveBaseEntity, ZWaveNodeEntity
 from . import workaround
 from .discovery_schemas import DISCOVERY_SCHEMAS
@@ -55,8 +55,6 @@ CONF_REFRESH_DELAY = 'delay'
 CONF_DEVICE_CONFIG = 'device_config'
 CONF_DEVICE_CONFIG_GLOB = 'device_config_glob'
 CONF_DEVICE_CONFIG_DOMAIN = 'device_config_domain'
-
-DATA_ZWAVE_CONFIG = 'zwave_config'
 
 DEFAULT_CONF_IGNORED = False
 DEFAULT_CONF_INVERT_OPENCLOSE_BUTTONS = False
@@ -266,9 +264,13 @@ async def async_setup_entry(hass, config_entry):
     from openzwave.network import ZWaveNetwork
     from openzwave.group import ZWaveGroup
 
-    config = {}
+    # Merge config entry and yaml config
+    config = config_entry.data
     if DATA_ZWAVE_CONFIG in hass.data:
-        config = hass.data[DATA_ZWAVE_CONFIG]
+        config.update(hass.data[DATA_ZWAVE_CONFIG])
+
+    # Update hass.data with merged config so we can access it elsewhere
+    hass.data[DATA_ZWAVE_CONFIG] = config
 
     # Load configuration
     use_debug = config.get(CONF_DEBUG, DEFAULT_DEBUG)
@@ -279,8 +281,7 @@ async def async_setup_entry(hass, config_entry):
         config.get(CONF_DEVICE_CONFIG_DOMAIN),
         config.get(CONF_DEVICE_CONFIG_GLOB))
 
-    usb_path = config.get(
-        CONF_USB_STICK_PATH, config_entry.data[CONF_USB_STICK_PATH])
+    usb_path = config[CONF_USB_STICK_PATH]
 
     _LOGGER.info('Z-Wave USB path is %s', usb_path)
 
@@ -292,8 +293,8 @@ async def async_setup_entry(hass, config_entry):
 
     options.set_console_output(use_debug)
 
-    if config_entry.data.get(CONF_NETWORK_KEY):
-        options.addOption("NetworkKey", config_entry.data[CONF_NETWORK_KEY])
+    if config.get(CONF_NETWORK_KEY):
+        options.addOption("NetworkKey", config[CONF_NETWORK_KEY])
 
     await hass.async_add_executor_job(options.lock)
     network = hass.data[DATA_NETWORK] = ZWaveNetwork(options, autostart=False)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -267,7 +267,7 @@ async def async_setup_entry(hass, config_entry):
     # Merge config entry and yaml config
     config = config_entry.data
     if DATA_ZWAVE_CONFIG in hass.data:
-        config.update(hass.data[DATA_ZWAVE_CONFIG])
+        config = {**config, **hass.data[DATA_ZWAVE_CONFIG]}
 
     # Update hass.data with merged config so we can access it elsewhere
     hass.data[DATA_ZWAVE_CONFIG] = config

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -19,27 +19,28 @@ ATTR_CONFIG_VALUE = "value"
 ATTR_POLL_INTENSITY = "poll_intensity"
 ATTR_VALUE_INDEX = "value_index"
 ATTR_VALUE_INSTANCE = "value_instance"
-ATTR_UPDATE_IDS = 'update_ids'
+ATTR_UPDATE_IDS = "update_ids"
 NETWORK_READY_WAIT_SECS = 300
 NODE_READY_WAIT_SECS = 30
 
-CONF_AUTOHEAL = 'autoheal'
-CONF_DEBUG = 'debug'
-CONF_POLLING_INTERVAL = 'polling_interval'
-CONF_USB_STICK_PATH = 'usb_path'
-CONF_CONFIG_PATH = 'config_path'
-CONF_NETWORK_KEY = 'network_key'
+CONF_AUTOHEAL = "autoheal"
+CONF_DEBUG = "debug"
+CONF_POLLING_INTERVAL = "polling_interval"
+CONF_USB_STICK_PATH = "usb_path"
+CONF_CONFIG_PATH = "config_path"
+CONF_NETWORK_KEY = "network_key"
 
 DEFAULT_CONF_AUTOHEAL = False
-DEFAULT_CONF_USB_STICK_PATH = '/zwaveusbstick'
+DEFAULT_CONF_USB_STICK_PATH = "/zwaveusbstick"
 DEFAULT_POLLING_INTERVAL = 60000
 DEFAULT_DEBUG = False
 
-DISCOVERY_DEVICE = 'device'
+DISCOVERY_DEVICE = "device"
 
-DATA_DEVICES = 'zwave_devices'
-DATA_NETWORK = 'zwave_network'
-DATA_ENTITY_VALUES = 'zwave_entity_values'
+DATA_DEVICES = "zwave_devices"
+DATA_NETWORK = "zwave_network"
+DATA_ENTITY_VALUES = "zwave_entity_values"
+DATA_ZWAVE_CONFIG = "zwave_config"
 
 SERVICE_CHANGE_ASSOCIATION = "change_association"
 SERVICE_ADD_NODE = "add_node"


### PR DESCRIPTION
## Breaking Change:
If a Z-Wave `network_key` is specified in configuration.yaml it will override a `network_key` specified in the Z-Wave config entry.

## Description:
Currently `usb_path` and `network_key` are stored in the Z-Wave config entry. There was a PR last fall to allow `usb_path` in configuration.yaml to override the config entry `usb_path`

This PR merges both sets of configuration into one config dict, with YAML config overriding config entry config if there is a duplicate. The merged config is then stuck in hass.data for future access for the Z-Wave websocket API.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
