### PR TITLE
Simplify Alexa/Google for new climate turn_on/off

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -249,8 +249,8 @@ class ClimateCapabilities(AlexaEntity):
     def interfaces(self):
         """Yield the supported interfaces."""
         # If we support two modes, one being off, we allow turning on too.
-        if len([v for v in self.entity.attributes[climate.ATTR_HVAC_MODES]
-                if v != climate.HVAC_MODE_OFF]) == 1:
+        if (climate.HVAC_MODE_OFF in
+                self.entity.attributes[climate.ATTR_HVAC_MODES]):
             yield AlexaPowerController(self.entity)
 
         yield AlexaThermostatController(self.hass, self.entity)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -855,6 +855,7 @@ async def test_thermostat(hass):
 
     assert_endpoint_capabilities(
         appliance,
+        'Alexa.PowerController',
         'Alexa.ThermostatController',
         'Alexa.TemperatureSensor',
         'Alexa.EndpointHealth',

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -627,24 +627,22 @@ async def test_temperature_setting_climate_onoff(hass):
             climate.ATTR_MAX_TEMP: None,
         }), BASIC_CONFIG)
     assert trt.sync_attributes() == {
-        'availableThermostatModes': 'off,cool,heat,heatcool',
+        'availableThermostatModes': 'off,cool,heat,heatcool,on',
         'thermostatTemperatureUnit': 'F',
     }
     assert trt.can_execute(trait.COMMAND_THERMOSTAT_SET_MODE, {})
 
-    calls = async_mock_service(
-        hass, climate.DOMAIN, climate.SERVICE_SET_HVAC_MODE)
+    calls = async_mock_service(hass, climate.DOMAIN, SERVICE_TURN_ON)
     await trt.execute(trait.COMMAND_THERMOSTAT_SET_MODE, BASIC_DATA, {
         'thermostatMode': 'on',
     }, {})
     assert len(calls) == 1
-    assert calls[0].data[climate.ATTR_HVAC_MODE] == climate.HVAC_MODE_HEAT_COOL
 
+    calls = async_mock_service(hass, climate.DOMAIN, SERVICE_TURN_OFF)
     await trt.execute(trait.COMMAND_THERMOSTAT_SET_MODE, BASIC_DATA, {
         'thermostatMode': 'off',
     }, {})
-    assert len(calls) == 2
-    assert calls[1].data[climate.ATTR_HVAC_MODE] == climate.HVAC_MODE_OFF
+    assert len(calls) == 1
 
 
 async def test_temperature_setting_climate_range(hass):
@@ -671,7 +669,7 @@ async def test_temperature_setting_climate_range(hass):
             climate.ATTR_MAX_TEMP: 80
         }), BASIC_CONFIG)
     assert trt.sync_attributes() == {
-        'availableThermostatModes': 'off,cool,heat,auto',
+        'availableThermostatModes': 'off,cool,heat,auto,on',
         'thermostatTemperatureUnit': 'F',
     }
     assert trt.query_attributes() == {


### PR DESCRIPTION
## Description:
Now that we have added fallback turn on/off climate services in #25026, we can remove the fallbacks that we had in Alexa and Google.



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
