### PR TITLE
Add more public Netatmo rain sensors

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -41,7 +41,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
 
 SUPPORTED_PUBLIC_SENSOR_TYPES = [
     'temperature', 'pressure', 'humidity', 'rain', 'windstrength',
-    'guststrength'
+    'guststrength', 'sum_rain_1', 'sum_rain_24'
 ]
 
 SENSOR_TYPES = {
@@ -467,6 +467,10 @@ class NetatmoPublicSensor(Entity):
             data = self.netatmo_data.data.getLatestHumidities()
         elif self.type == 'rain':
             data = self.netatmo_data.data.getLatestRain()
+        elif self.type == 'sum_rain_1':
+            data = self.netatmo_data.data.get60minRain()
+        elif self.type == 'sum_rain_24':
+            data = self.netatmo_data.data.get24hRain()
         elif self.type == 'windstrength':
             data = self.netatmo_data.data.getLatestWindStrengths()
         elif self.type == 'guststrength':


### PR DESCRIPTION
## Description:
Add additional sensors for rain in the past hour and past 24 hours from public Netatmo weather stations. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: netatmo
    areas:
      - lat_ne: 40.719
        lon_ne: -73.735
        lat_sw: 40.552
        lon_sw: -74.105
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
