### PR TITLE
Verify cloud user exists during boot

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -157,7 +157,13 @@ async def async_setup(hass, config):
     await prefs.async_initialize()
 
     # Cloud user
-    if not prefs.cloud_user:
+    user = None
+    if prefs.cloud_user:
+        # Fetch the user. It can happen that the user no longer exists if
+        # an image was restored without restoring the cloud prefs.
+        user = await hass.auth.async_get_user(prefs.cloud_user)
+
+    if user is None:
         user = await hass.auth.async_create_system_user(
             'Home Assistant Cloud', [GROUP_ID_ADMIN])
         await prefs.async_update(cloud_user=user.id)


### PR DESCRIPTION
## Description:
Verify that the cloud user exists during boot. This sometimes goes wrong when people are restoring cloud prefs but not the auth.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
