### PR TITLE
Fix aggregation in Netatmo public sensor

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -484,7 +484,7 @@ class NetatmoPublicSensor(Entity):
 
         values = [x for x in data.values() if x is not None]
         if self._mode == 'avg':
-            self._state = round(sum(values) / len(data), 1)
+            self._state = round(sum(values) / len(values), 1)
         elif self._mode == 'max':
             self._state = max(values)
 

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -482,10 +482,11 @@ class NetatmoPublicSensor(Entity):
             self._state = None
             return
 
+        values = [x for x in data.values() if x is not None]
         if self._mode == 'avg':
-            self._state = round(sum(data.values()) / len(data), 1)
+            self._state = round(sum(values) / len(data), 1)
         elif self._mode == 'max':
-            self._state = max(data.values())
+            self._state = max(values)
 
 
 class NetatmoPublicData:


### PR DESCRIPTION
## Description:
Clean up values of public Netatmo sensors if they contain None before calculating max or average.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
