### PR TITLE
Load requirements for platforms

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -705,8 +705,17 @@ async def async_process_component_config(
 
         try:
             p_integration = await async_get_integration(hass, p_name)
+        except IntegrationNotFound:
+            continue
+
+        if (not hass.config.skip_pip and p_integration.requirements and
+                not await async_process_requirements(
+                    hass, p_integration.domain, p_integration.requirements)):
+            continue
+
+        try:
             platform = p_integration.get_platform(domain)
-        except (IntegrationNotFound, ImportError):
+        except ImportError:
             continue
 
         # Validate platform specific schema


### PR DESCRIPTION
## Description:
Platform requirements where not pre-checked, so must be loaded when we validate and split out configs. This is similar to #25005

**Related issue (if applicable):** fixes #25124 and fixes #25126

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: braviatv
    host: 192.168.10.12
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
