### PR TITLE
[climate-1.0] Bugfix evohome showstopper

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -129,7 +129,7 @@ class EvoBroker:
         self.config = self.status = self.timers = {}
 
         self.client = self.tcs = None
-        self._app_storage = None
+        self._app_storage = {}
 
         hass.data[DOMAIN] = {}
         hass.data[DOMAIN]['broker'] = self

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -195,6 +195,9 @@ class EvoBroker:
         store = self.hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
         app_storage = self._app_storage = await store.async_load()
 
+        if app_storage is None:
+            app_storage = self._app_storage = {}
+
         if app_storage.get(CONF_USERNAME) == self.params[CONF_USERNAME]:
             refresh_token = app_storage.get(CONF_REFRESH_TOKEN)
             access_token = app_storage.get(CONF_ACCESS_TOKEN)


### PR DESCRIPTION
## Description: 

Please **cherry-pick** this PR for 0.96.

This fixes an **critical issue** that causes a catastrophic failure of `evohome`.  Without this fix, `app_storage` is `None` instead of `{}` (during first run) and the `setup()` fails.

The following Exception prevents `evohome` from starting, and _until_ it has loaded at least once, evohome will never start successfully. Thus, *all* users will be affected.

This bug passed through testing because I did not test the code against a 'new' installation of HA.
```
2019-07-13 21:07:53 ERROR (MainThread) [homeassistant.setup] Error during setup of component evohome
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 153, in _async_setup_component
    hass, processed_config)
  File "/usr/src/homeassistant/homeassistant/components/evohome/__init__.py", line 98, in async_setup
    if not await broker.init_client():
  File "/usr/src/homeassistant/homeassistant/components/evohome/__init__.py", line 135, in init_client
    await self._load_auth_tokens()
  File "/usr/src/homeassistant/homeassistant/components/evohome/__init__.py", line 185, in _load_auth_tokens
    if app_storage.get(CONF_USERNAME) == self.params[CONF_USERNAME]:
AttributeError: 'NoneType' object has no attribute 'get'
```

**Related issue (if applicable):** No issue submitted presently

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
