### PR TITLE
[climate 1.0] Remove comfort mode from Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -9,7 +9,7 @@ from homematicip.aio.home import AsyncHome
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO, HVAC_MODE_HEAT, PRESET_BOOST, PRESET_COMFORT, PRESET_ECO,
+    HVAC_MODE_AUTO, HVAC_MODE_HEAT, PRESET_BOOST, PRESET_ECO,
     SUPPORT_PRESET_MODE, SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
@@ -110,8 +110,6 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         """
         if self._device.boostMode:
             return PRESET_BOOST
-        if self._device.controlMode == HMIP_AUTOMATIC_CM:
-            return PRESET_COMFORT
         if self._device.controlMode == HMIP_ECO_CM:
             return PRESET_ECO
 
@@ -123,7 +121,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
         Requires SUPPORT_PRESET_MODE.
         """
-        return [PRESET_BOOST, PRESET_COMFORT]
+        return [PRESET_BOOST]
 
     @property
     def min_temp(self) -> float:
@@ -155,8 +153,6 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
             await self._device.set_boost(False)
         if preset_mode == PRESET_BOOST:
             await self._device.set_boost()
-        elif preset_mode == PRESET_COMFORT:
-            await self._device.set_control_mode(HMIP_AUTOMATIC_CM)
 
 
 def _get_first_heating_thermostat(heating_group: AsyncHeatingGroup):


### PR DESCRIPTION
##Description:
This PR removes comfort_mode from presets, because functionality is already covered by hvac_mode_auto.
Keeping preset_comfort_mode might be confusing for users.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
