### PR TITLE
[climate-1.0] Add RoundThermostat to evohome

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -216,6 +216,8 @@ class EvoBroker:
         access_token_expires = _local_dt_to_utc(
             self.client.access_token_expires)
 
+        _LOGGER.warn("ABD = %s", access_token_expires)
+
         self._app_storage[CONF_USERNAME] = self.params[CONF_USERNAME]
         self._app_storage[CONF_REFRESH_TOKEN] = self.client.refresh_token
         self._app_storage[CONF_ACCESS_TOKEN] = self.client.access_token

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -112,7 +112,7 @@ def setup(hass, hass_config) -> bool:
         load_platform(hass, 'water_heater', DOMAIN, {}, hass_config)
 
     track_time_interval(
-        hass, broker.update, timedelta(seconds=10)  # TODO: hass_config[DOMAIN][CONF_SCAN_INTERVAL]
+        hass, broker.update, hass_config[DOMAIN][CONF_SCAN_INTERVAL]
     )
 
     return True
@@ -143,7 +143,7 @@ class EvoBroker:
             asyncio.run_coroutine_threadsafe(
                 self._load_auth_tokens(), self.hass.loop).result()
 
-        # evohomeclient2 uses local datetimes
+        # evohomeclient2 uses naive/local datetimes
         if access_token_expires is not None:
             access_token_expires = _utc_to_local_dt(access_token_expires)
 
@@ -212,7 +212,7 @@ class EvoBroker:
         return (None, None, None)  # account switched: so tokens wont be valid
 
     async def _save_auth_tokens(self, *args) -> None:
-        # evohomeclient2 uses local datetimes
+        # evohomeclient2 uses naive/local datetimes
         access_token_expires = _local_dt_to_utc(
             self.client.access_token_expires)
 

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -216,8 +216,6 @@ class EvoBroker:
         access_token_expires = _local_dt_to_utc(
             self.client.access_token_expires)
 
-        _LOGGER.warn("ABD = %s", access_token_expires)
-
         self._app_storage[CONF_USERNAME] = self.params[CONF_USERNAME]
         self._app_storage[CONF_REFRESH_TOKEN] = self.client.refresh_token
         self._app_storage[CONF_ACCESS_TOKEN] = self.client.access_token

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -112,7 +112,7 @@ def setup(hass, hass_config) -> bool:
         load_platform(hass, 'water_heater', DOMAIN, {}, hass_config)
 
     track_time_interval(
-        hass, broker.update, hass_config[DOMAIN][CONF_SCAN_INTERVAL]
+        hass, broker.update, timedelta(seconds=10)  # TODO: hass_config[DOMAIN][CONF_SCAN_INTERVAL]
     )
 
     return True

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -117,11 +117,6 @@ class EvoZone(EvoClimateDevice):
         self._hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT]
         self._preset_modes = list(HA_PRESET_TO_EVO)
 
-        for _zone in evo_broker.config['zones']:
-            if _zone['zoneId'] == self._id:
-                self._config = _zone
-                break
-
     @property
     def hvac_mode(self) -> str:
         """Return the current operating mode of the evohome Zone.
@@ -255,18 +250,6 @@ class EvoController(EvoClimateDevice):
         self._supported_features = SUPPORT_PRESET_MODE
         self._hvac_modes = list(HA_HVAC_TO_TCS)
 
-        self._config = dict(evo_broker.config)
-
-        # special case of RoundThermostat
-        if self._config['zones'][0]['modelType'] == 'RoundModulation':
-            self._preset_modes = [PRESET_AWAY, PRESET_ECO]
-        else:
-            self._preset_modes = list(HA_PRESET_TO_TCS)
-
-        self._config['zones'] = '...'
-        if 'dhw' in self._config:
-            self._config['dhw'] = '...'
-
     @property
     def hvac_mode(self) -> str:
         """Return the current operating mode of the evohome Controller."""
@@ -343,23 +326,22 @@ class EvoController(EvoClimateDevice):
 
 
 class EvoThermostat(EvoZone):
-    """Base for a Honeywell evohome Zone."""
+    """Base for a Honeywell Round Thermostat.
+
+    Implemented as a combined Controller/Zone.
+    """
 
     def __init__(self, evo_broker, evo_device) -> None:
         """Initialize the evohome Zone."""
         super().__init__(evo_broker, evo_device)
 
         self._id = evo_device.zoneId
-        self._name = "_" + evo_device.name
+        self._name = evo_broker.tcs.location.name
         self._icon = 'mdi:radiator'
 
         self._hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT]
         self._preset_modes = list(HA_PRESET_TO_EVO)
 
-        for _zone in evo_broker.config['zones']:
-            if _zone['zoneId'] == self._id:
-                self._config = _zone
-                break
 
     @property
     def hvac_mode(self) -> str:

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -194,10 +194,8 @@ class EvoZone(EvoClimateDevice):
     @property
     def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
-        if self._evo_tcs.systemModeStatus['mode'] == EVO_HEATOFF:
-            return None
-        if self._evo_tcs.systemModeStatus['mode'] == EVO_AWAY:
-            return PRESET_AWAY
+        if self._evo_tcs.systemModeStatus['mode'] in [EVO_HEATOFF, EVO_AWAY]:
+            return TCS_PRESET_TO_HA.get(self._evo_tcs.systemModeStatus['mode'])
         return EVO_PRESET_TO_HA.get(
             self._evo_device.setpointStatus['setpointMode'], 'follow')
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -258,7 +258,8 @@ class EvoController(EvoClimateDevice):
             'systemId', 'activeFaults', 'systemModeStatus']
 
         self._supported_features = SUPPORT_PRESET_MODE
-        self._hvac_modes = list(HA_HVAC_TO_TCS)
+        self._hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT]
+        self._preset_modes = list(HA_PRESET_TO_TCS)
 
     @property
     def hvac_mode(self) -> str:
@@ -341,7 +342,7 @@ class EvoThermostat(EvoZone):
         self._name = evo_broker.tcs.location.name
         self._icon = 'mdi:radiator'
 
-        self._hvac_modes = list(HA_HVAC_TO_TCS)
+        self._hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT]
         self._preset_modes = [PRESET_AWAY, PRESET_ECO]
 
     @property

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -194,7 +194,7 @@ class EvoZone(EvoClimateDevice):
     @property
     def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
-        if self._evo_tcs.systemModeStatus['mode'] in [EVO_HEATOFF, EVO_AWAY]:
+        if self._evo_tcs.systemModeStatus['mode'] in [EVO_AWAY, EVO_HEATOFF]:
             return TCS_PRESET_TO_HA.get(self._evo_tcs.systemModeStatus['mode'])
         return EVO_PRESET_TO_HA.get(
             self._evo_device.setpointStatus['setpointMode'], 'follow')

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -103,7 +103,6 @@ class EvoZone(EvoClimateDevice):
         """Initialize the evohome Zone."""
         super().__init__(evo_broker, evo_device)
 
-        self._id = evo_device.zoneId
         self._name = evo_device.name
         self._icon = 'mdi:radiator'
 
@@ -240,7 +239,6 @@ class EvoController(EvoClimateDevice):
         """Initialize the evohome Controller (hub)."""
         super().__init__(evo_broker, evo_device)
 
-        self._id = evo_device.systemId
         self._name = evo_device.location.name
         self._icon = 'mdi:thermostat'
 
@@ -335,7 +333,6 @@ class EvoThermostat(EvoZone):
         """Initialize the evohome Zone."""
         super().__init__(evo_broker, evo_device)
 
-        self._id = evo_device.zoneId
         self._name = evo_broker.tcs.location.name
         self._icon = 'mdi:radiator'
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -38,11 +38,13 @@ HA_PRESET_TO_TCS = {
 }
 TCS_PRESET_TO_HA = {v: k for k, v in HA_PRESET_TO_TCS.items()}
 
-HA_PRESET_TO_EVO = {
-    'temporary': EVO_TEMPOVER,
-    'permanent': EVO_PERMOVER,
+EVO_PRESET_TO_HA = {
+    EVO_FOLLOW: None,
+    EVO_TEMPOVER: 'temporary',
+    EVO_PERMOVER: 'permanent',
 }
-EVO_PRESET_TO_HA = {v: k for k, v in HA_PRESET_TO_EVO.items()}
+HA_PRESET_TO_EVO = {v: k for k, v in EVO_PRESET_TO_HA.items()
+                    if v is not None}
 
 
 def setup_platform(hass, hass_config, add_entities,
@@ -85,7 +87,7 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
         """Initialize the evohome Climate device."""
         super().__init__(evo_broker, evo_device)
 
-        self._hvac_modes = self._preset_modes = None
+        self._preset_modes = None
 
     def _set_temperature(self, temperature: float,
                          until: Optional[datetime] = None) -> None:
@@ -145,7 +147,7 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
     @property
     def hvac_modes(self) -> List[str]:
         """Return the list of available hvac operation modes."""
-        return self._hvac_modes
+        return [HVAC_MODE_OFF, HVAC_MODE_HEAT]
 
     @property
     def preset_modes(self) -> Optional[List[str]]:
@@ -171,7 +173,6 @@ class EvoZone(EvoClimateDevice):
 
         self._supported_features = SUPPORT_PRESET_MODE | \
             SUPPORT_TARGET_TEMPERATURE
-        self._hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT]
         self._preset_modes = list(HA_PRESET_TO_EVO)
 
     @property
@@ -262,7 +263,6 @@ class EvoController(EvoClimateDevice):
             'systemId', 'activeFaults', 'systemModeStatus']
 
         self._supported_features = SUPPORT_PRESET_MODE
-        self._hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT]
         self._preset_modes = list(HA_PRESET_TO_TCS)
 
     @property
@@ -346,7 +346,6 @@ class EvoThermostat(EvoZone):
         self._name = evo_broker.tcs.location.name
         self._icon = 'mdi:radiator'
 
-        self._hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT]
         self._preset_modes = [PRESET_AWAY, PRESET_ECO]
 
     @property

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF,
     PRESET_AWAY, PRESET_ECO, PRESET_HOME,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE)
+from homeassistant.const import PRECISION_TENTHS
 from homeassistant.util.dt import parse_datetime
 
 from . import CONF_LOCATION_IDX, _handle_exception, EvoDevice
@@ -243,7 +244,7 @@ class EvoController(EvoClimateDevice):
         self._name = evo_device.location.name
         self._icon = 'mdi:thermostat'
 
-        self._precision = None
+        self._precision = PRECISION_TENTHS
         self._state_attributes = [
             'systemId', 'activeFaults', 'systemModeStatus']
 
@@ -262,8 +263,9 @@ class EvoController(EvoClimateDevice):
 
         Controllers do not have a current temp, but one is expected by HA.
         """
-        temps = [z.temperatureStatus['temperature'] for z in
-                 self._evo_device._zones if z.temperatureStatus['isAvailable']]  # noqa: E501; pylint: disable=protected-access
+        temps = [z.temperatureStatus['temperature']
+                 for z in self._evo_device.zones.values()
+                 if z.temperatureStatus['isAvailable']]
         return round(sum(temps) / len(temps), 1) if temps else None
 
     @property
@@ -273,7 +275,7 @@ class EvoController(EvoClimateDevice):
         Controllers do not have a target temp, but one is expected by HA.
         """
         temps = [z.setpointStatus['targetHeatTemperature']
-                 for z in self._evo_device._zones]  # noqa: E501; pylint: disable=protected-access
+                 for z in self._evo_device.zones.values()]
         return round(sum(temps) / len(temps), 1) if temps else None
 
     @property
@@ -288,7 +290,7 @@ class EvoController(EvoClimateDevice):
         Controllers do not have a min target temp, but one is required by HA.
         """
         temps = [z.setpointCapabilities['minHeatSetpoint']
-                 for z in self._evo_device._zones]  # noqa: E501; pylint: disable=protected-access
+                 for z in self._evo_device.zones.values()]
         return min(temps) if temps else 5
 
     @property
@@ -298,7 +300,7 @@ class EvoController(EvoClimateDevice):
         Controllers do not have a max target temp, but one is required by HA.
         """
         temps = [z.setpointCapabilities['maxHeatSetpoint']
-                 for z in self._evo_device._zones]  # noqa: E501; pylint: disable=protected-access
+                 for z in self._evo_device.zones.values()]
         return max(temps) if temps else 35
 
     def _set_operation_mode(self, op_mode: str) -> None:

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -50,7 +50,7 @@ def setup_platform(hass, hass_config, add_entities,
     broker = hass.data[DOMAIN]['broker']
     loc_idx = broker.params[CONF_LOCATION_IDX]
 
-    _LOGGER.warn(
+    _LOGGER.debug(
         "Found Location/Controller, id=%s [%s], name=%s (location_idx=%s)",
         broker.tcs.systemId, broker.tcs.modelType, broker.tcs.location.name,
         loc_idx)
@@ -58,7 +58,7 @@ def setup_platform(hass, hass_config, add_entities,
     # special case of RoundThermostat (is single zone)
     if broker.config['zones'][0]['modelType'] == 'RoundModulation':
         zone = list(broker.tcs.zones.values())[0]
-        _LOGGER.warn(
+        _LOGGER.debug(
             "Found %s, id=%s [%s], name=%s",
             zone.zoneType, zone.zoneId, zone.modelType, zone.name)
 
@@ -69,7 +69,7 @@ def setup_platform(hass, hass_config, add_entities,
 
     zones = []
     for zone in broker.tcs.zones.values():
-        _LOGGER.warn(
+        _LOGGER.debug(
             "Found %s, id=%s [%s], name=%s",
             zone.zoneType, zone.zoneId, zone.modelType, zone.name)
         zones.append(EvoZone(broker, zone))

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -47,7 +47,8 @@ class EvoDHW(EvoDevice, WaterHeaterDevice):
 
         self._precision = PRECISION_WHOLE
         self._state_attributes = [
-            'activeFaults', 'stateStatus', 'temperatureStatus', 'setpoints']
+            'dhwId', 'activeFaults', 'stateStatus', 'temperatureStatus',
+            'setpoints']
 
         self._supported_features = SUPPORT_OPERATION_MODE
         self._operation_list = list(HA_OPMODE_TO_DHW)

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -27,8 +27,8 @@ def setup_platform(hass, hass_config, add_entities,
     broker = hass.data[DOMAIN]['broker']
 
     _LOGGER.debug(
-        "Found DHW device, id: %s [%s]",
-        broker.tcs.hotwater.zoneId, broker.tcs.hotwater.zone_type)
+        "Found %s, id: %s",
+        broker.tcs.hotwater.zone_type, broker.tcs.hotwater.zoneId)
 
     evo_dhw = EvoDHW(broker, broker.tcs.hotwater)
 

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -53,8 +53,6 @@ class EvoDHW(EvoDevice, WaterHeaterDevice):
         self._supported_features = SUPPORT_OPERATION_MODE
         self._operation_list = list(HA_OPMODE_TO_DHW)
 
-        self._config = evo_broker.config['dhw']
-
     @property
     def current_operation(self) -> str:
         """Return the current operating mode (On, or Off)."""

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -42,7 +42,6 @@ class EvoDHW(EvoDevice, WaterHeaterDevice):
         """Initialize the evohome DHW controller."""
         super().__init__(evo_broker, evo_device)
 
-        self._id = evo_device.dhwId
         self._name = 'DHW controller'
         self._icon = 'mdi:thermometer-lines'
 


### PR DESCRIPTION
## Description:

This PR adds RoundThermostat support to evohome.

Round Thermostat _is_ **evohome**-compatible, but is a special case: it is always single-zone, rather than multi-zone. In the special case of Round Thermostat, this PR will merge the Controller and the Zone into _one_ Climate entity, reflecting the fact that it is a single-zone product.

This PR also: 
 - removes some orphan code (`self._id`, `self._config`) left over from before it was refactored for `climate-1.0`
 - implements several tweaks (e.g. less reliance upon `pylint: disable=protected-access`)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
