### PR TITLE
Support zbar in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_SSOCR no
 #ENV INSTALL_DLIB no
 #ENV INSTALL_IPERF3 no
+#ENV INSTALL_ZBAR_TOOLS no
 
 VOLUME /config
 

--- a/virtualization/Docker/scripts/zbartools
+++ b/virtualization/Docker/scripts/zbartools
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Sets up zbar tools.
+
+# Stop on errors
+set -e
+
+PACKAGES=(
+  # homeassistant.components.image_processing.qrcode
+  libzbar0 zbar-tools
+)
+
+apt-get install -y --no-install-recommends ${PACKAGES[@]}
+

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -9,6 +9,7 @@ INSTALL_OPENALPR="${INSTALL_OPENALPR:-yes}"
 INSTALL_LIBCEC="${INSTALL_LIBCEC:-yes}"
 INSTALL_SSOCR="${INSTALL_SSOCR:-yes}"
 INSTALL_DLIB="${INSTALL_DLIB:-yes}"
+INSTALL_ZBAR_TOOLS="${INSTALL_ZBAR_TOOLS:-yes}"
 
 # Required debian packages for running hass or components
 PACKAGES=(
@@ -68,6 +69,10 @@ fi
 
 if [ "$INSTALL_DLIB" == "yes" ]; then
   pip3 install --no-cache-dir "dlib>=19.5"
+fi
+
+if [ "$INSTALL_ZBAR_TOOLS" == "yes" ]; then
+  virtualization/Docker/scripts/zbartools
 fi
 
 # Remove packages


### PR DESCRIPTION
## Description:
Wanted to read a QR Code using a dockerized install.  It doesn't work because libzbar isn't there. 
  That made me sad. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
