### PR TITLE
Add Netatmo climate battery level

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -470,10 +470,9 @@ class ThermostatData:
                             .get("battery_level"))
 
                     if batterylevel:
-                        if (roomstatus.get("battery_level") and
-                                batterylevel < roomstatus["battery_level"]):
+                        if roomstatus.get("battery_level") is None:
                             roomstatus["battery_level"] = batterylevel
-                        else:
+                        elif batterylevel < roomstatus["battery_level"]:
                             roomstatus["battery_level"] = batterylevel
                 self.room_status[room] = roomstatus
             except KeyError as err:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -16,7 +16,9 @@ from homeassistant.components.climate.const import (
     DEFAULT_MIN_TEMP
 )
 from homeassistant.const import (
-    TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_NAME, PRECISION_HALVES, STATE_OFF)
+    TEMP_CELSIUS, ATTR_TEMPERATURE, CONF_NAME, PRECISION_HALVES, STATE_OFF,
+    ATTR_BATTERY_LEVEL
+)
 from homeassistant.util import Throttle
 
 from .const import DATA_NETATMO_AUTH
@@ -142,6 +144,7 @@ class NetatmoThermostat(ClimateDevice):
         self._operation_list = [HVAC_MODE_AUTO, HVAC_MODE_HEAT]
         self._support_flags = SUPPORT_FLAGS
         self._hvac_mode = None
+        self._battery_level = None
         self.update_without_throttle = False
         self._module_type = \
             self._data.room_status.get(room_id, {}).get('module_type')
@@ -274,6 +277,16 @@ class NetatmoThermostat(ClimateDevice):
         self.update_without_throttle = True
         self.schedule_update_ha_state()
 
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the thermostat."""
+        attr = {}
+
+        if self._battery_level is not None:
+            attr[ATTR_BATTERY_LEVEL] = self._battery_level
+
+        return attr
+
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""
         try:
@@ -297,6 +310,8 @@ class NetatmoThermostat(ClimateDevice):
             self._preset = \
                 self._data.room_status[self._room_id]["setpoint_mode"]
             self._hvac_mode = HVAC_MAP_NETATMO[self._preset]
+            self._battery_level = \
+                self._data.room_status[self._room_id].get('battery_level')
         except KeyError:
             _LOGGER.error(
                 "The thermostat in room %s seems to be out of reach.",
@@ -423,6 +438,7 @@ class ThermostatData:
                     roomstatus["module_id"] = None
                     roomstatus["heating_status"] = None
                     roomstatus["heating_power_request"] = None
+                    batterylevel = None
                     for module_id in homedata_room["module_ids"]:
                         if (self.homedata.modules[self.home][module_id]["type"]
                                 == NA_THERM
@@ -433,6 +449,10 @@ class ThermostatData:
                             rid=roomstatus["module_id"]
                         )
                         roomstatus["heating_status"] = self.boilerstatus
+                        batterylevel = (
+                            self.homestatus
+                            .thermostats[roomstatus["module_id"]]
+                            .get("battery_level"))
                     elif roomstatus["module_type"] == NA_VALVE:
                         roomstatus["heating_power_request"] = homestatus_room[
                             "heating_power_request"
@@ -445,6 +465,16 @@ class ThermostatData:
                                 self.boilerstatus
                                 and roomstatus["heating_status"]
                             )
+                        batterylevel = (
+                            self.homestatus.valves[roomstatus["module_id"]]
+                            .get("battery_level"))
+
+                    if batterylevel:
+                        if (roomstatus.get("battery_level") and
+                                batterylevel < roomstatus["battery_level"]):
+                            roomstatus["battery_level"] = batterylevel
+                        else:
+                            roomstatus["battery_level"] = batterylevel
                 self.room_status[room] = roomstatus
             except KeyError as err:
                 _LOGGER.error("Update of room %s failed. Error: %s", room, err)


### PR DESCRIPTION
## Description:
Add battery level to Netatmo climate devices.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
