### PR TITLE
Add add_torrent service to Transmission

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -93,7 +93,9 @@ def setup(hass, config):
     def add_torrent(service):
         """Add new torrent to download."""
         torrent = service.data[ATTR_TORRENT]
-        api.add_torrent(torrent)
+        if torrent.startswith(('http:', 'https:', 'ftp:', 'magnet:')) or \
+           hass.config.is_allowed_path(torrent):
+            api.add_torrent(torrent)
 
     hass.services.register(DOMAIN, SERVICE_ADD_TORRENT, add_torrent,
                            schema=SERVICE_ADD_TORRENT_SCHEMA)

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -34,6 +34,14 @@ SENSOR_TYPES = {
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=120)
 
+ATTR_TORRENT = 'torrent'
+
+SERVICE_ADD_TORRENT = 'add_torrent'
+
+SERVICE_ADD_TORRENT_SCHEMA = vol.Schema({
+    vol.Required(ATTR_TORRENT): cv.string,
+})
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
@@ -81,6 +89,14 @@ def setup(hass, config):
         tm_data.update()
 
     track_time_interval(hass, refresh, scan_interval)
+
+    def add_torrent(service):
+        """Add new torrent to download."""
+        torrent = service.data[ATTR_TORRENT]
+        api.add_torrent(torrent)
+
+    hass.services.register(DOMAIN, SERVICE_ADD_TORRENT, add_torrent,
+                           schema=SERVICE_ADD_TORRENT_SCHEMA)
 
     sensorconfig = {
         'sensors': config[DOMAIN][CONF_MONITORED_CONDITIONS],

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -93,9 +93,12 @@ def setup(hass, config):
     def add_torrent(service):
         """Add new torrent to download."""
         torrent = service.data[ATTR_TORRENT]
-        if torrent.startswith(('http:', 'https:', 'ftp:', 'magnet:')) or \
+        if torrent.startswith(('http', 'ftp:', 'magnet:')) or \
            hass.config.is_allowed_path(torrent):
             api.add_torrent(torrent)
+        else:
+            _LOGGER.warn('Could not add torrent: '
+                         'unsupported type or no permission')
 
     hass.services.register(DOMAIN, SERVICE_ADD_TORRENT, add_torrent,
                            schema=SERVICE_ADD_TORRENT_SCHEMA)

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -97,8 +97,8 @@ def setup(hass, config):
            hass.config.is_allowed_path(torrent):
             api.add_torrent(torrent)
         else:
-            _LOGGER.warn('Could not add torrent: '
-                         'unsupported type or no permission')
+            _LOGGER.warning('Could not add torrent: '
+                            'unsupported type or no permission')
 
     hass.services.register(DOMAIN, SERVICE_ADD_TORRENT, add_torrent,
                            schema=SERVICE_ADD_TORRENT_SCHEMA)

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -1,0 +1,4 @@
+add_torrent:
+  description: Add a new torrent to download (URL, magnet link or Base64 encoded).
+  fields:
+    torrent: {description: URL, magnet link or Base64 encoded file., example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent}

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -1,4 +1,6 @@
 add_torrent:
   description: Add a new torrent to download (URL, magnet link or Base64 encoded).
   fields:
-    torrent: {description: URL, magnet link or Base64 encoded file., example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent}
+    torrent:
+      description: URL, magnet link or Base64 encoded file.
+      example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent}


### PR DESCRIPTION
## Description:
This PR adds a new service called `add_torrent` to Transmission, which makes it possible to add new torrent files that Transmission should download.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9854

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
