### PR TITLE
Notifier specific data on alerts

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -276,7 +276,8 @@ class Alert(ToggleEntity):
         for target in self._notifiers:
             if self._notifier_data.get(target) is not None:
                 data = {}
-                data.update(self._data)
+                if self._data is not None:
+                    data.update(self._data)
                 data.update(self._notifier_data.get(target))
                 msg_payload.update({ATTR_DATA: data})
 

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -80,7 +80,7 @@ async def async_setup(hass, config):
         can_ack = cfg.get(CONF_CAN_ACK)
         title_template = cfg.get(CONF_TITLE)
         data = cfg.get(CONF_DATA)
-        notifier_data = cfg.get(CONF_NOTIFIER_DATA)
+        notifier_data = cfg[CONF_NOTIFIER_DATA]
 
         entities.append(Alert(hass, object_id, name,
                               watched_entity_id, alert_state, repeat,
@@ -278,7 +278,7 @@ class Alert(ToggleEntity):
                 data = {}
                 if self._data is not None:
                     data.update(self._data)
-                data.update(self._notifier_data.get(target))
+                data.update(self._notifier_data[target])
                 msg_payload.update({ATTR_DATA: data})
 
             await self.hass.services.async_call(

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -363,7 +363,6 @@ class TestAlert(unittest.TestCase):
         self.assertEqual(last_event.data[notify.ATTR_DATA],
                          COMBINED_TEST_DATA)
 
-
     def test_skipfirst(self):
         """Test skipping first notification."""
         config = deepcopy(TEST_CONFIG)


### PR DESCRIPTION
## Description:
Different notify integrations accept different additional parameters, so, allow passing through an optional map of data for each notifier with the new config option, `notifier_data`.
If the existing option `data` is set in combination with a specific notifier set of data, the data will be merged from both.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9855

## Example entry for `configuration.yaml` (if applicable):
```yaml
alert:
  garage_door:
    name: Garage is open
    entity_id: input_boolean.garage_door
    state: 'on'   # Optional, 'on' is the default value
    repeat:
      - 15
      - 30
      - 60
    can_acknowledge: True  # Optional, default is True
    skip_first: True # Optional, false is the default
    notifier_data:
      frank_telegram:
        inline_keyboard:
          - 'Close garage:/close_garage, Acknowledge:/garage_acknowledge'
      ryans_phone:
        data:
          thread-id: garage-door
    notifiers:
      - frank_telegram
      - ryans_phone

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
