### PR TITLE
[climate 1.0] Remove check in tado restoring temp/mode changes

### DIFF
--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -361,9 +361,6 @@ class TadoClimate(ClimateDevice):
             _LOGGER.info("Obtained current and target temperature. "
                          "Tado thermostat active")
 
-        if not self._active or self._current_operation == self._overlay_mode:
-            return
-
         if self._current_operation == CONST_MODE_SMART_SCHEDULE:
             _LOGGER.info("Switching mytado.com to SCHEDULE (default) "
                          "for zone %s", self.zone_name)


### PR DESCRIPTION
## Description:
mode and temp changes were not working with the climate 1.0 changes due to this, now removed, check.


## Example entry for `configuration.yaml` (if applicable):
```yaml
tado:
  username: blah
  password: blah
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
