### PR TITLE
Correctly set property decorator on preset modes

### DIFF
--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -135,6 +135,7 @@ class FritzboxThermostat(ClimateDevice):
         if self._target_temperature == self._eco_temperature:
             return PRESET_ECO
 
+    @property
     def preset_modes(self):
         """Return supported preset modes."""
         return [PRESET_ECO, PRESET_COMFORT]


### PR DESCRIPTION
## Description:
Forgot to decorate a method with `@property`, causing invalid data in the state machine.

**Related issue (if applicable):** fixes #25150

