### PR TITLE
Update pyhomematic to 0.1.60

### DIFF
--- a/homeassistant/components/homematic/manifest.json
+++ b/homeassistant/components/homematic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Homematic",
   "documentation": "https://www.home-assistant.io/components/homematic",
   "requirements": [
-    "pyhomematic==0.1.59"
+    "pyhomematic==0.1.60"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1172,7 +1172,7 @@ pyhik==0.2.3
 pyhiveapi==0.2.18.1
 
 # homeassistant.components.homematic
-pyhomematic==0.1.59
+pyhomematic==0.1.60
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -260,7 +260,7 @@ pydispatcher==2.0.5
 pyheos==0.5.2
 
 # homeassistant.components.homematic
-pyhomematic==0.1.59
+pyhomematic==0.1.60
 
 # homeassistant.components.iqvia
 pyiqvia==0.2.1


### PR DESCRIPTION
## Description:
Update pyhomematic to 0.1.60. Adds support for devices: HmIP-PCBS-BAT, HB-UNI-Sensor1, HmIP-SCI  
It also gets rid of some uncritical warnings that were displayed during startup.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
