### PR TITLE
Ps4 reformat saved media attributes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -472,7 +472,6 @@ omit =
     homeassistant/components/prometheus/*
     homeassistant/components/prowl/notify.py
     homeassistant/components/proxy/camera.py
-    homeassistant/components/ps4/__init__.py
     homeassistant/components/ps4/media_player.py
     homeassistant/components/ptvsd/*
     homeassistant/components/pulseaudio_loopback/switch.py

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -1,5 +1,6 @@
 """Support for PlayStation 4 consoles."""
 import logging
+import os
 
 import voluptuous as vol
 from pyps4_homeassistant.ddp import async_create_ddp_endpoint
@@ -143,11 +144,11 @@ def format_unique_id(creds, mac_address):
 def load_games(hass: HomeAssistantType) -> dict:
     """Load games for sources."""
     g_file = hass.config.path(GAMES_FILE)
-    try:
-        games = load_json(g_file)
+    games = load_json(g_file)
 
     # If file does not exist, create empty file.
-    except FileNotFoundError:
+    if not os.path.isfile(g_file):
+        _LOGGER.info("Creating PS4 Games File")
         games = {}
         save_games(hass, games)
     else:
@@ -162,10 +163,6 @@ def save_games(hass: HomeAssistantType, games: dict):
         save_json(g_file, games)
     except OSError as error:
         _LOGGER.error("Could not save game list, %s", error)
-
-    # Retry loading file
-    if games is None:
-        load_games(hass)
 
 
 def _reformat_data(hass: HomeAssistantType, games: dict) -> dict:

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -1,4 +1,5 @@
 """Constants for PlayStation 4."""
+ATTR_MEDIA_IMAGE_URL = 'media_image_url'
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
 DEFAULT_ALIAS = 'Home-Assistant'

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -9,17 +9,19 @@ from homeassistant.core import callback
 from homeassistant.components.media_player import (
     ENTITY_IMAGE_URL, MediaPlayerDevice)
 from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_GAME, MEDIA_TYPE_APP, SUPPORT_SELECT_SOURCE,
-    SUPPORT_PAUSE, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
+    ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_TITLE,
+    MEDIA_TYPE_GAME, MEDIA_TYPE_APP, SUPPORT_SELECT_SOURCE, SUPPORT_PAUSE,
+    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
 from homeassistant.components.ps4 import (
     format_unique_id, load_games, save_games)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_REGION,
-    CONF_TOKEN, STATE_IDLE, STATE_OFF, STATE_PLAYING)
+    ATTR_LOCKED, CONF_HOST, CONF_NAME, CONF_REGION, CONF_TOKEN,
+    STATE_IDLE, STATE_OFF, STATE_PLAYING)
 from homeassistant.helpers import device_registry, entity_registry
 
-from .const import (DEFAULT_ALIAS, DOMAIN as PS4_DOMAIN, PS4_DATA,
-                    REGIONS as deprecated_regions)
+from .const import (
+    ATTR_MEDIA_IMAGE_URL, DEFAULT_ALIAS, DOMAIN as PS4_DOMAIN,
+    PS4_DATA, REGIONS as deprecated_regions)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,19 +150,35 @@ class PS4Device(MediaPlayerDevice):
         if status is not None:
             self._games = load_games(self.hass)
             if self._games is not None:
-                self._source_list = list(sorted(self._games.values()))
+                self.get_source_list()
+
             self._retry = 0
             self._disconnected = False
             if status.get('status') == 'Ok':
                 title_id = status.get('running-app-titleid')
                 name = status.get('running-app-name')
+
                 if title_id and name is not None:
                     self._state = STATE_PLAYING
+
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
-                        self._media_title = name
-                        self._source = self._media_title
-                        self._media_type = None
+
+                        if self._media_content_id in self._games:
+                            store = self._games[self._media_content_id]
+
+                            # If locked get attributes from file.
+                            locked = store.get(ATTR_LOCKED)
+                            if locked:
+                                self._media_title = store.get(ATTR_MEDIA_TITLE)
+                                self._source = self._media_title
+                                self._media_image = store.get(
+                                    ATTR_MEDIA_IMAGE_URL)
+                                self._media_type = store.get(
+                                    ATTR_MEDIA_CONTENT_TYPE)
+                                return
+
+                        # Get data from PS Store.
                         asyncio.ensure_future(
                             self.async_get_title_data(title_id, name))
                 else:
@@ -246,20 +264,33 @@ class PS4Device(MediaPlayerDevice):
         """Update Game List, Correct data if different."""
         if self._media_content_id in self._games:
             store = self._games[self._media_content_id]
-            if store != self._media_title:
+
+            if store.get(ATTR_MEDIA_TITLE) != self._media_title or\
+                    store.get(ATTR_MEDIA_IMAGE_URL) != self._media_image:
                 self._games.pop(self._media_content_id)
 
         if self._media_content_id not in self._games:
-            self.add_games(self._media_content_id, self._media_title)
+            self.add_games(
+                self._media_content_id, self._media_title,
+                self._media_image, self._media_type)
             self._games = load_games(self.hass)
 
-        self._source_list = list(sorted(self._games.values()))
+        self._get_source_list()
 
-    def add_games(self, title_id, app_name):
+    def get_source_list(self):
+        """Parse data entry and update source list."""
+        games = []
+        for data in self._games.values():
+            games.append(data[ATTR_MEDIA_TITLE])
+        self._source_list = sorted(games)
+
+    def add_games(self, title_id, app_name, image, g_type, is_locked=False):
         """Add games to list."""
         games = self._games
         if title_id is not None and title_id not in games:
-            game = {title_id: app_name}
+            game = {title_id: {
+                ATTR_MEDIA_TITLE: app_name, ATTR_MEDIA_IMAGE_URL: image,
+                ATTR_MEDIA_CONTENT_TYPE: g_type, ATTR_LOCKED: is_locked}}
             games.update(game)
             save_games(self.hass, games)
 

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -275,7 +275,7 @@ class PS4Device(MediaPlayerDevice):
                 self._media_image, self._media_type)
             self._games = load_games(self.hass)
 
-        self._get_source_list()
+        self.get_source_list()
 
     def get_source_list(self):
         """Parse data entry and update source list."""

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -164,7 +164,7 @@ async def test_config_flow_entry_migrate(hass):
 
 
 class TestPS4Integration(unittest.TestCase):
-    """Test services for PS4."""
+    """Test methods for PS4 Integration."""
 
     def cleanup(self):
         """Cleanup any data created from the tests."""

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -203,13 +203,15 @@ class TestPS4Integration(unittest.TestCase):
 
     def test_file_created_if_none(self):
         """Test that games file is created if it does not exist."""
+        # Test that file does not exist.
         self.cleanup()
+        assert not os.path.isfile(self.mock_file)
+
         mock_empty = ps4.load_games(self.hass)
 
+        # Test that file is created and empty.
         assert isinstance(mock_empty, dict)
-        assert not mock_empty
-        assert self.mock_file == '{}/{}'.format(
-            self.hass.config.path(), GAMES_FILE)
+        assert os.path.isfile(self.mock_file)
 
     def test_games_reformat_to_dict(self):
         """Test old data format is converted to new format."""

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -1,0 +1,264 @@
+"""Tests for the PS4 Integration."""
+import os
+import unittest
+from unittest.mock import patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.media_player.const import (
+    ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_TITLE, MEDIA_TYPE_GAME)
+from homeassistant.components import ps4
+from homeassistant.components.ps4.const import (
+    ATTR_MEDIA_IMAGE_URL, COMMANDS, CONFIG_ENTRY_VERSION as VERSION,
+    DEFAULT_REGION, DOMAIN, GAMES_FILE, PS4_DATA)
+from homeassistant.const import (
+    ATTR_COMMAND, ATTR_LOCKED, ATTR_ENTITY_ID, CONF_HOST,
+    CONF_NAME, CONF_REGION, CONF_TOKEN)
+from homeassistant.util import location
+from homeassistant.util.json import save_json
+from homeassistant.setup import setup_component
+from tests.common import (
+    get_test_config_dir, get_test_home_assistant, MockConfigEntry, mock_coro,
+    mock_registry)
+
+MOCK_ID = 'CUSA00123'
+MOCK_URL = 'http://someurl.jpeg'
+MOCK_TITLE = 'Some Title'
+MOCK_TYPE = MEDIA_TYPE_GAME
+
+MOCK_GAMES_DATA_OLD_STR_FORMAT = {'mock_id': 'mock_title',
+                                  'mock_id2': 'mock_title2'}
+
+MOCK_GAMES_DATA = {
+    ATTR_LOCKED: False,
+    ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME,
+    ATTR_MEDIA_IMAGE_URL: MOCK_URL,
+    ATTR_MEDIA_TITLE: MOCK_TITLE}
+
+MOCK_GAMES_DATA_LOCKED = {
+    ATTR_LOCKED: True,
+    ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME,
+    ATTR_MEDIA_IMAGE_URL: MOCK_URL,
+    ATTR_MEDIA_TITLE: MOCK_TITLE}
+
+MOCK_GAMES = {MOCK_ID: MOCK_GAMES_DATA}
+MOCK_GAMES_LOCKED = {MOCK_ID: MOCK_GAMES_DATA_LOCKED}
+
+MOCK_HOST = '192.168.0.1'
+MOCK_NAME = 'test_ps4'
+MOCK_REGION = 'Some Region'
+MOCK_CREDS = '1234567890A'
+MOCK_PS4 = None
+
+MOCK_DEVICE = {
+    CONF_HOST: MOCK_HOST,
+    CONF_NAME: MOCK_NAME,
+    CONF_REGION: MOCK_REGION
+}
+
+MOCK_DATA = {
+    CONF_TOKEN: MOCK_CREDS,
+    'devices': [MOCK_DEVICE]
+}
+
+MOCK_FLOW_RESULT = {
+    'version': VERSION, 'handler': DOMAIN,
+    'type': data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
+    'title': 'test_ps4', 'data': MOCK_DATA
+}
+
+MOCK_ENTRY_ID = 'SomeID'
+
+MOCK_CONFIG = MockConfigEntry(
+    domain=DOMAIN, data=MOCK_DATA, entry_id=MOCK_ENTRY_ID)
+
+MOCK_LOCATION = location.LocationInfo(
+    '0.0.0.0', 'US', 'United States', 'CA', 'California',
+    'San Diego', '92122', 'America/Los_Angeles', 32.8594,
+    -117.2073, True)
+
+MOCK_DEVICE_VERSION_1 = {
+    CONF_HOST: MOCK_HOST,
+    CONF_NAME: MOCK_NAME,
+    CONF_REGION: "Some Region"
+}
+
+MOCK_DATA_VERSION_1 = {
+    CONF_TOKEN: MOCK_CREDS,
+    'devices': [MOCK_DEVICE_VERSION_1]
+}
+
+MOCK_DEVICE_ID = 'somedeviceid'
+
+MOCK_ENTRY_VERSION_1 = MockConfigEntry(
+    domain=DOMAIN, data=MOCK_DATA_VERSION_1, entry_id=MOCK_ENTRY_ID, version=1)
+
+MOCK_UNIQUE_ID = 'someuniqueid'
+
+
+async def test_ps4_integration_setup(hass):
+    """Test PS4 integration is setup."""
+    await ps4.async_setup(hass, {})
+    await hass.async_block_till_done()
+    assert hass.data[PS4_DATA].protocol is not None
+
+
+async def test_creating_entry_sets_up_media_player(hass):
+    """Test setting up PS4 loads the media player."""
+    mock_flow =\
+        'homeassistant.components.ps4.PlayStation4FlowHandler.async_step_user'
+    with patch('homeassistant.components.ps4.media_player.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup,\
+            patch(mock_flow, return_value=mock_coro(MOCK_FLOW_RESULT)):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={'source': config_entries.SOURCE_USER})
+        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 1
+
+
+async def test_config_flow_entry_migrate(hass):
+    """Test that config flow entry is migrated correctly."""
+    # Start with the config entry at Version 1.
+    manager = hass.config_entries
+    mock_entry = MOCK_ENTRY_VERSION_1
+    mock_entry.add_to_manager(manager)
+    mock_e_registry = mock_registry(hass)
+    mock_entity_id = 'media_player.ps4_{}'.format(
+        MOCK_UNIQUE_ID)
+    mock_e_entry = mock_e_registry.async_get_or_create(
+        'media_player', 'ps4', MOCK_UNIQUE_ID, config_entry_id=MOCK_ENTRY_ID,
+        device_id=MOCK_DEVICE_ID)
+    assert len(mock_e_registry.entities) == 1
+    assert mock_e_entry.entity_id == mock_entity_id
+    assert mock_e_entry.unique_id == MOCK_UNIQUE_ID
+
+    with patch('homeassistant.util.location.async_detect_location_info',
+               return_value=mock_coro(MOCK_LOCATION)), \
+            patch('homeassistant.helpers.entity_registry.async_get_registry',
+                  return_value=mock_coro(mock_e_registry)):
+        await ps4.async_migrate_entry(hass, mock_entry)
+
+    await hass.async_block_till_done()
+
+    assert len(mock_e_registry.entities) == 1
+    for entity in mock_e_registry.entities.values():
+        mock_entity = entity
+
+    # Test that entity_id remains the same.
+    assert mock_entity.entity_id == mock_entity_id
+    assert mock_entity.device_id == MOCK_DEVICE_ID
+
+    # Test that last four of credentials is appended to the unique_id.
+    assert mock_entity.unique_id == '{}_{}'.format(
+        MOCK_UNIQUE_ID, MOCK_CREDS[-4:])
+
+    # Test that config entry is at the current version.
+    assert mock_entry.version == VERSION
+    assert mock_entry.data[CONF_TOKEN] == MOCK_CREDS
+    assert mock_entry.data['devices'][0][CONF_HOST] == MOCK_HOST
+    assert mock_entry.data['devices'][0][CONF_NAME] == MOCK_NAME
+    assert mock_entry.data['devices'][0][CONF_REGION] ==\
+        DEFAULT_REGION
+
+
+class TestPS4Integration(unittest.TestCase):
+    """Test services for PS4."""
+
+    def cleanup(self):
+        """Cleanup any data created from the tests."""
+        if os.path.isfile(self.mock_file):
+            os.remove(self.mock_file)
+
+    def set_games_data(self, mock_data):
+        """Set data in games file for tests."""
+        save_json(self.mock_file, mock_data)
+        self.hass.block_till_done()
+
+    def setUp(self):
+        """Set up test environment."""
+        self.hass = get_test_home_assistant()
+        self.hass.start()
+        self.hass.block_till_done()
+        self.mock_file = get_test_config_dir(GAMES_FILE)
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+        self.cleanup()
+
+    def setup_mock_component(self):
+        """Set up Mock Media Player."""
+        entry = MockConfigEntry(
+            domain=ps4.DOMAIN, data=MOCK_DATA, version=VERSION)
+        entry.add_to_manager(self.hass.config_entries)
+        setup_component(self.hass, DOMAIN, {DOMAIN: {}})
+        self.hass.block_till_done()
+
+    def test_media_player_is_setup(self):
+        """Test media_player is setup correctly."""
+        self.setup_mock_component()
+        assert len(self.hass.data[PS4_DATA].devices) == 1
+
+    def test_file_created_if_none(self):
+        """Test that games file is created if it does not exist."""
+        self.cleanup()
+        mock_empty = ps4.load_games(self.hass)
+
+        assert isinstance(mock_empty, dict)
+        assert not mock_empty
+        assert self.mock_file == '{}/{}'.format(
+            self.hass.config.path(), GAMES_FILE)
+
+    def test_games_reformat_to_dict(self):
+        """Test old data format is converted to new format."""
+        self.set_games_data(MOCK_GAMES_DATA_OLD_STR_FORMAT)
+        mock_games = ps4.load_games(self.hass)
+
+        # New format is a nested dict.
+        assert isinstance(mock_games, dict)
+        assert mock_games['mock_id'][ATTR_MEDIA_TITLE] == 'mock_title'
+        assert mock_games['mock_id2'][ATTR_MEDIA_TITLE] == 'mock_title2'
+        for mock_game in mock_games:
+            mock_data = mock_games[mock_game]
+            assert isinstance(mock_data, dict)
+            assert mock_data
+            assert mock_data[ATTR_MEDIA_IMAGE_URL] is None
+            assert mock_data[ATTR_LOCKED] is False
+            assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_GAME
+
+    def test_load_games(self):
+        """Test that games are loaded correctly."""
+        self.set_games_data(MOCK_GAMES)
+        mock_games = ps4.load_games(self.hass)
+        assert isinstance(mock_games, dict)
+
+        mock_data = mock_games[MOCK_ID]
+        assert isinstance(mock_data, dict)
+        assert mock_data[ATTR_MEDIA_TITLE] == MOCK_TITLE
+        assert mock_data[ATTR_MEDIA_IMAGE_URL] == MOCK_URL
+        assert mock_data[ATTR_LOCKED] is False
+        assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_GAME
+
+    def test_send_command(self):
+        """Test send_command service."""
+        self.setup_mock_component()
+        mock_func = '{}{}'.format('homeassistant.components.ps4',
+                                  '.media_player.PS4Device.async_send_command')
+
+        mock_devices = self.hass.data[PS4_DATA].devices
+        assert len(mock_devices) == 1
+        mock_entity = mock_devices[0]
+        assert mock_entity.entity_id == 'media_player.{}'.format(MOCK_NAME)
+
+        # Test that all commands call service function.
+        with patch(mock_func, return_value=mock_coro(True)) as mock_service:
+            for mock_command in COMMANDS:
+                self.hass.services.call(
+                    DOMAIN, 'send_command',
+                    {ATTR_ENTITY_ID: mock_entity.entity_id,
+                     ATTR_COMMAND: mock_command})
+                self.hass.block_till_done()
+
+        assert len(mock_service.mock_calls) == len(COMMANDS)


### PR DESCRIPTION
## Description:

Reformat media data. Save all attributes as a dict. 
Allow locking of data and manual edits for attributes..
Improve json helpers.

Prep for editing of attributes via services.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
