### PR TITLE
Upgrade mypy to 0.720, turn on unreachability warnings

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -574,7 +574,7 @@ def _recursive_merge(
 
 
 async def merge_packages_config(hass: HomeAssistant, config: Dict,
-                                packages: Dict,
+                                packages: Dict[str, Any],
                                 _log_pkg_error: Callable = _log_pkg_error) \
         -> Dict:
     """Merge packages into the top-level configuration. Mutate config."""
@@ -641,11 +641,6 @@ async def merge_packages_config(hass: HomeAssistant, config: Dict,
                 _log_pkg_error(
                     pack_name, comp_name, config,
                     "cannot be merged. Dict expected in main config.")
-                continue
-            if not isinstance(comp_conf, dict):
-                _log_pkg_error(
-                    pack_name, comp_name, config,
-                    "cannot be merged. Dict expected in package.")
                 continue
 
             error = _recursive_merge(conf=config[comp_name],

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3,7 +3,9 @@ import asyncio
 import logging
 import functools
 import uuid
-from typing import Callable, List, Optional, Set  # noqa pylint: disable=unused-import
+from typing import (
+    Any, Callable, List, Optional, Set  # noqa pylint: disable=unused-import
+)
 import weakref
 
 from homeassistant import data_entry_flow, loader
@@ -121,7 +123,8 @@ class ConfigEntry:
         self.update_listeners = []  # type: list
 
         # Function to cancel a scheduled retry
-        self._async_cancel_retry_setup = None
+        self._async_cancel_retry_setup = \
+            None  # type: Optional[Callable[[], Any]]
 
     async def async_setup(
             self, hass: HomeAssistant, *,

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -155,7 +155,7 @@ class FlowHandler:
     hass = None
     handler = None
     cur_step = None
-    context = None
+    context = None  # type: Optional[Dict]
 
     # Set by _async_create_flow callback
     init_step = 'init'

--- a/homeassistant/helpers/location.py
+++ b/homeassistant/helpers/location.py
@@ -12,7 +12,8 @@ def has_location(state: State) -> bool:
 
     Async friendly.
     """
-    return (isinstance(state, State) and
+    # type ignore: https://github.com/python/mypy/issues/7207
+    return (isinstance(state, State) and  # type: ignore
             isinstance(state.attributes.get(ATTR_LATITUDE), float) and
             isinstance(state.attributes.get(ATTR_LONGITUDE), float))
 

--- a/homeassistant/helpers/temperature.py
+++ b/homeassistant/helpers/temperature.py
@@ -1,13 +1,14 @@
 """Temperature helpers for Home Assistant."""
 from numbers import Number
+from typing import Optional
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.const import PRECISION_HALVES, PRECISION_TENTHS
 
 
-def display_temp(hass: HomeAssistant, temperature: float, unit: str,
-                 precision: float) -> float:
+def display_temp(hass: HomeAssistant, temperature: Optional[float], unit: str,
+                 precision: float) -> Optional[float]:
     """Convert temperature into preferred units/precision for display."""
     temperature_unit = unit
     ha_unit = hass.config.units.temperature_unit
@@ -21,7 +22,8 @@ def display_temp(hass: HomeAssistant, temperature: float, unit: str,
         raise TypeError(
             "Temperature is not a number: {}".format(temperature))
 
-    if temperature_unit != ha_unit:
+    # type ignore: https://github.com/python/mypy/issues/7207
+    if temperature_unit != ha_unit:  # type: ignore
         temperature = convert_temperature(
             temperature, temperature_unit, ha_unit)
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -53,7 +53,7 @@ def repr_helper(inp: Any) -> str:
     return str(inp)
 
 
-def convert(value: T, to_type: Callable[[T], U],
+def convert(value: Optional[T], to_type: Callable[[T], U],
             default: Optional[U] = None) -> Optional[U]:
     """Convert value to to_type, returns default if fails."""
     try:

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 try:
     # pylint: disable=invalid-name
-    asyncio_run = asyncio.run  # type: ignore
+    asyncio_run = asyncio.run
 except AttributeError:
     _T = TypeVar('_T')
 

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -34,7 +34,8 @@ def convert(value: float, unit_1: str, unit_2: str) -> float:
     if not isinstance(value, Number):
         raise TypeError('{} is not of numeric type'.format(value))
 
-    if unit_1 == unit_2 or unit_1 not in VALID_UNITS:
+    # type ignore: https://github.com/python/mypy/issues/7207
+    if unit_1 == unit_2 or unit_1 not in VALID_UNITS:  # type: ignore
         return value
 
     meters = value

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -44,7 +44,8 @@ def convert(value: float, unit_1: str, unit_2: str) -> float:
     if not isinstance(value, Number):
         raise TypeError('{} is not of numeric type'.format(value))
 
-    if unit_1 == unit_2 or unit_1 not in VALID_UNITS:
+    # type ignore: https://github.com/python/mypy/issues/7207
+    if unit_1 == unit_2 or unit_1 not in VALID_UNITS:  # type: ignore
         return value
 
     pascals = value / UNIT_CONVERSION[unit_1]

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -91,7 +91,8 @@ class UnitSystem:
             raise TypeError(
                 '{} is not a numeric value.'.format(str(temperature)))
 
-        return temperature_util.convert(temperature,
+        # type ignore: https://github.com/python/mypy/issues/7207
+        return temperature_util.convert(temperature,  # type: ignore
                                         from_unit, self.temperature_unit)
 
     def length(self, length: Optional[float], from_unit: str) -> float:
@@ -99,7 +100,8 @@ class UnitSystem:
         if not isinstance(length, Number):
             raise TypeError('{} is not a numeric value.'.format(str(length)))
 
-        return distance_util.convert(length, from_unit,
+        # type ignore: https://github.com/python/mypy/issues/7207
+        return distance_util.convert(length, from_unit,  # type: ignore
                                      self.length_unit)
 
     def pressure(self, pressure: Optional[float], from_unit: str) -> float:
@@ -107,7 +109,8 @@ class UnitSystem:
         if not isinstance(pressure, Number):
             raise TypeError('{} is not a numeric value.'.format(str(pressure)))
 
-        return pressure_util.convert(pressure, from_unit,
+        # type ignore: https://github.com/python/mypy/issues/7207
+        return pressure_util.convert(pressure, from_unit,  # type: ignore
                                      self.pressure_unit)
 
     def volume(self, volume: Optional[float], from_unit: str) -> float:
@@ -115,7 +118,9 @@ class UnitSystem:
         if not isinstance(volume, Number):
             raise TypeError('{} is not a numeric value.'.format(str(volume)))
 
-        return volume_util.convert(volume, from_unit, self.volume_unit)
+        # type ignore: https://github.com/python/mypy/issues/7207
+        return volume_util.convert(volume, from_unit,  # type: ignore
+                                   self.volume_unit)
 
     def as_dict(self) -> dict:
         """Convert the unit system to a dictionary."""

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -33,7 +33,8 @@ def convert(volume: float, from_unit: str, to_unit: str) -> float:
     if not isinstance(volume, Number):
         raise TypeError('{} is not of numeric type'.format(volume))
 
-    if from_unit == to_unit:
+    # type ignore: https://github.com/python/mypy/issues/7207
+    if from_unit == to_unit:  # type: ignore
         return volume
 
     result = volume

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ strict_equality = true
 warn_incomplete_stub = true
 warn_redundant_casts = true
 warn_return_any = true
+warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ coveralls==1.2.0
 flake8-docstrings==1.3.0
 flake8==3.7.8
 mock-open==1.3.1
-mypy==0.711
+mypy==0.720
 pydocstyle==3.0.0
 pylint==2.3.1
 pytest-aiohttp==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -8,7 +8,7 @@ coveralls==1.2.0
 flake8-docstrings==1.3.0
 flake8==3.7.8
 mock-open==1.3.1
-mypy==0.711
+mypy==0.720
 pydocstyle==3.0.0
 pylint==2.3.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Description:

http://mypy-lang.blogspot.com/2019/07/mypy-0720-released.html

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
