### PR TITLE
Version sensor update

### DIFF
--- a/homeassistant/components/version/__init__.py
+++ b/homeassistant/components/version/__init__.py
@@ -1,1 +1,1 @@
-"""The version component."""
+"""The version integration."""

--- a/homeassistant/components/version/manifest.json
+++ b/homeassistant/components/version/manifest.json
@@ -3,7 +3,7 @@
   "name": "Version",
   "documentation": "https://www.home-assistant.io/components/version",
   "requirements": [
-    "pyhaversion==2.2.1"
+    "pyhaversion==3.0.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -45,18 +45,33 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the Version sensor platform."""
-    from pyhaversion import Version
+    from pyhaversion import LocalVersion, DockerVersion, HassioVersion, PyPiVersion
     beta = config.get(CONF_BETA)
     image = config.get(CONF_IMAGE)
     name = config.get(CONF_NAME)
     source = config.get(CONF_SOURCE)
 
     session = async_get_clientsession(hass)
+
     if beta:
         branch = 'beta'
     else:
         branch = 'stable'
-    haversion = VersionData(Version(hass.loop, session, branch, image), source)
+
+    if source == 'pypi':
+        haversion = VersionData(PyPiVersion(hass.loop, session, branch))
+    elif source == 'hassio':
+        haversion = VersionData(HassioVersion(hass.loop, session, branch, image))
+    elif source == 'docker':
+        haversion = VersionData(DockerVersion(hass.loop, session, branch, image))
+    else:
+        haversion = VersionData(LocalVersion(hass.loop, session))
+
+    if not name:
+        if source == DEFAULT_SOURCE:
+            name = DEFAULT_NAME_LOCAL
+        else:
+            name = DEFAULT_NAME_LATEST
 
     async_add_entities([VersionSensor(haversion, name)], True)
 
@@ -64,7 +79,7 @@ async def async_setup_platform(
 class VersionSensor(Entity):
     """Representation of a Home Assistant version sensor."""
 
-    def __init__(self, haversion, name=''):
+    def __init__(self, haversion, name):
         """Initialize the Version sensor."""
         self.haversion = haversion
         self._name = name
@@ -77,11 +92,7 @@ class VersionSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        if self._name:
-            return self._name
-        if self.haversion.source == DEFAULT_SOURCE:
-            return DEFAULT_NAME_LOCAL
-        return DEFAULT_NAME_LATEST
+        return self._name
 
     @property
     def state(self):
@@ -102,19 +113,11 @@ class VersionSensor(Entity):
 class VersionData:
     """Get the latest data and update the states."""
 
-    def __init__(self, api, source):
+    def __init__(self, api):
         """Initialize the data object."""
         self.api = api
-        self.source = source
 
     @Throttle(TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Get the latest version information."""
-        if self.source == 'pypi':
-            await self.api.get_pypi_version()
-        elif self.source == 'hassio':
-            await self.api.get_hassio_version()
-        elif self.source == 'docker':
-            await self.api.get_docker_version()
-        else:
-            await self.api.get_local_version()
+        await self.api.get_version()

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -45,7 +45,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the Version sensor platform."""
-    from pyhaversion import LocalVersion, DockerVersion, HassioVersion, PyPiVersion
+    from pyhaversion import (
+        LocalVersion, DockerVersion, HassioVersion, PyPiVersion)
     beta = config.get(CONF_BETA)
     image = config.get(CONF_IMAGE)
     name = config.get(CONF_NAME)
@@ -59,13 +60,17 @@ async def async_setup_platform(
         branch = 'stable'
 
     if source == 'pypi':
-        haversion = VersionData(PyPiVersion(hass.loop, session, branch))
+        haversion = VersionData(
+            PyPiVersion(hass.loop, session, branch))
     elif source == 'hassio':
-        haversion = VersionData(HassioVersion(hass.loop, session, branch, image))
+        haversion = VersionData(
+            HassioVersion(hass.loop, session, branch, image))
     elif source == 'docker':
-        haversion = VersionData(DockerVersion(hass.loop, session, branch, image))
+        haversion = VersionData(
+            DockerVersion(hass.loop, session, branch, image))
     else:
-        haversion = VersionData(LocalVersion(hass.loop, session))
+        haversion = VersionData(
+            LocalVersion(hass.loop, session))
 
     if not name:
         if source == DEFAULT_SOURCE:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1160,7 +1160,7 @@ pygtfs==0.1.5
 pygtt==1.1.2
 
 # homeassistant.components.version
-pyhaversion==2.2.1
+pyhaversion==3.0.2
 
 # homeassistant.components.heos
 pyheos==0.5.2


### PR DESCRIPTION
<!--## Breaking Change:

 What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

- Fixes issue with the new "beta" tag for docker.
- Moves the hassio check from `https://s3.amazonaws.com/hassio-version/` to `https://version.home-assistant.io/`

[changelog `pyhaversion:2.2.1...3.0.2`](https://github.com/ludeeus/pyhaversion/compare/2.2.1...3.0.2)

**Related issue (if applicable):** fixes #25123 
<!--
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
-->
## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor version:
  - platform: version
    source: hassio
    name: test
  - platform: version
    source: hassio
    beta: true
  - platform: version
    source: docker
    name: test
  - platform: version
    source: docker
    beta: true
  - platform: version
    source: pypi
    name: test
  - platform: version
    source: pypi
    beta: true
  - platform: version
    source: local
  - platform: version
    source: local
    name: test
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
-->
If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
<!--
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
