### PR TITLE
Fix Netatmo climate battery level

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -83,6 +83,21 @@ DEFAULT_MAX_TEMP = 30
 NA_THERM = 'NATherm1'
 NA_VALVE = 'NRV'
 
+NA_BATTERY_LEVELS = {
+    NA_THERM: {
+        'full': 4100,
+        'high': 3600,
+        'medium': 3300,
+        'low': 3000,
+        'empty': 2800},
+    NA_VALVE: {
+        'full': 3200,
+        'high': 2700,
+        'medium': 2400,
+        'low': 2200,
+        'empty': 2200},
+}
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NetAtmo Thermostat."""
@@ -470,13 +485,40 @@ class ThermostatData:
                             .get("battery_level"))
 
                     if batterylevel:
+                        batterypct = interpolate(
+                            batterylevel, roomstatus["module_type"])
                         if roomstatus.get("battery_level") is None:
-                            roomstatus["battery_level"] = batterylevel
-                        elif batterylevel < roomstatus["battery_level"]:
-                            roomstatus["battery_level"] = batterylevel
+                            roomstatus["battery_level"] = batterypct
+                        elif batterypct < roomstatus["battery_level"]:
+                            roomstatus["battery_level"] = batterypct
                 self.room_status[room] = roomstatus
             except KeyError as err:
                 _LOGGER.error("Update of room %s failed. Error: %s", room, err)
         self.away_temperature = self.homestatus.getAwaytemp(self.home)
         self.hg_temperature = self.homestatus.getHgtemp(self.home)
         self.setpoint_duration = self.homedata.setpoint_duration[self.home]
+
+
+def interpolate(batterylevel, module_type):
+    """Interpolate battery level depending on device type."""
+    levels = list(reversed(list(NA_BATTERY_LEVELS[module_type].values())))
+    steps = [20, 50, 80, 100]
+
+    na_battery_level = NA_BATTERY_LEVELS[module_type]
+    if batterylevel >= na_battery_level['full']:
+        return 100
+    if batterylevel >= na_battery_level['high']:
+        i = 3
+    elif batterylevel >= na_battery_level['medium']:
+        i = 2
+    elif batterylevel >= na_battery_level['low']:
+        i = 1
+    else:
+        return 0
+
+    pct = steps[i-1] + (
+        (steps[i] - steps[i-1]) *
+        (batterylevel - levels[i]) /
+        (levels[i+1] - levels[i])
+    )
+    return int(pct)

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -83,21 +83,6 @@ DEFAULT_MAX_TEMP = 30
 NA_THERM = 'NATherm1'
 NA_VALVE = 'NRV'
 
-NA_BATTERY_LEVELS = {
-    NA_THERM: {
-        'full': 4100,
-        'high': 3600,
-        'medium': 3300,
-        'low': 3000,
-        'empty': 2800},
-    NA_VALVE: {
-        'full': 3200,
-        'high': 2700,
-        'medium': 2400,
-        'low': 2200,
-        'empty': 2200},
-}
-
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NetAtmo Thermostat."""
@@ -501,10 +486,25 @@ class ThermostatData:
 
 def interpolate(batterylevel, module_type):
     """Interpolate battery level depending on device type."""
-    levels = list(reversed(list(NA_BATTERY_LEVELS[module_type].values())))
+    na_battery_levels = {
+        NA_THERM: {
+            'full': 4100,
+            'high': 3600,
+            'medium': 3300,
+            'low': 3000,
+            'empty': 2800},
+        NA_VALVE: {
+            'full': 3200,
+            'high': 2700,
+            'medium': 2400,
+            'low': 2200,
+            'empty': 2200},
+    }
+
+    levels = sorted(na_battery_levels[module_type].values())
     steps = [20, 50, 80, 100]
 
-    na_battery_level = NA_BATTERY_LEVELS[module_type]
+    na_battery_level = na_battery_levels[module_type]
     if batterylevel >= na_battery_level['full']:
         return 100
     if batterylevel >= na_battery_level['high']:


### PR DESCRIPTION
## Description:
The battery level returned by the Netatmo API has to be translated into percentage.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
