### PR TITLE
Fix device types for some HomeMatic IP sensors

### DIFF
--- a/homeassistant/components/homematic/binary_sensor.py
+++ b/homeassistant/components/homematic/binary_sensor.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES_CLASS = {
     'IPShutterContact': 'opening',
+    'IPShutterContactSabotage': 'opening',
     'MaxShutterContact': 'opening',
     'Motion': 'motion',
     'MotionV2': 'motion',

--- a/homeassistant/components/homematic/manifest.json
+++ b/homeassistant/components/homematic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Homematic",
   "documentation": "https://www.home-assistant.io/components/homematic",
   "requirements": [
-    "pyhomematic==0.1.59"
+    "pyhomematic==0.1.60"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1172,7 +1172,7 @@ pyhik==0.2.3
 pyhiveapi==0.2.18.1
 
 # homeassistant.components.homematic
-pyhomematic==0.1.59
+pyhomematic==0.1.60
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -260,7 +260,7 @@ pydispatcher==2.0.5
 pyheos==0.5.2
 
 # homeassistant.components.homematic
-pyhomematic==0.1.59
+pyhomematic==0.1.60
 
 # homeassistant.components.iqvia
 pyiqvia==0.2.1


### PR DESCRIPTION
## Description:
A change in the pyhomematic library introduced a separate class for sepcific binary sensors, which lead to the mapping to `opening` type to break. This slipped by unnoticed and is fixed by this PR.

**Related issue (if applicable):** fixes #24080

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
