### PR TITLE
Fix climate is_aux_heat type hint.

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -307,7 +307,7 @@ class ClimateDevice(Entity):
         raise NotImplementedError
 
     @property
-    def is_aux_heat(self) -> Optional[str]:
+    def is_aux_heat(self) -> Optional[bool]:
         """Return true if aux heater.
 
         Requires SUPPORT_AUX_HEAT.


### PR DESCRIPTION
## Description:
`ClimateDevice.is_aux_heat` property should return `bool`, so fix type hinting to reflect it

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
