### PR TITLE
Ps4 reformat media data

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -151,6 +151,10 @@ def load_games(hass: HomeAssistantType) -> dict:
         games = {}
         _LOGGER.error("Failed to load games file: %s", error)
 
+    if not isinstance(games, dict):
+        _LOGGER.error("Games file was not parsed correctly")
+        return {}
+
     # If file does not exist, create empty file.
     if not os.path.isfile(g_file):
         _LOGGER.info("Creating PS4 Games File")
@@ -172,9 +176,6 @@ def save_games(hass: HomeAssistantType, games: dict):
 
 def _reformat_data(hass: HomeAssistantType, games: dict) -> dict:
     """Reformat data to correct format."""
-    if not isinstance(games, dict):
-        _LOGGER.error("Games file was not parsed correctly")
-        return {}
     data_reformatted = False
 
     for game, data in games.items():

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -153,7 +153,7 @@ def load_games(hass: HomeAssistantType) -> dict:
 
     if not isinstance(games, dict):
         _LOGGER.error("Games file was not parsed correctly")
-        return {}
+        games = {}
 
     # If file does not exist, create empty file.
     if not os.path.isfile(g_file):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -168,7 +168,7 @@ def save_games(hass: HomeAssistantType, games: dict):
 def _reformat_data(hass: HomeAssistantType, games: dict) -> dict:
     """Reformat data to correct format."""
     data_reformatted = False
-    if games is not None:
+    if not games:
         for game, data in games.items():
 
             # Convert str format to dict format.

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -1,12 +1,15 @@
 """Support for PlayStation 4 consoles."""
 import logging
+import os
 
 import voluptuous as vol
 from pyps4_homeassistant.ddp import async_create_ddp_endpoint
 from pyps4_homeassistant.media_art import COUNTRIES
 
+from homeassistant.components.media_player.const import (
+    ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_TITLE, MEDIA_TYPE_GAME)
 from homeassistant.const import (
-    ATTR_COMMAND, ATTR_ENTITY_ID, CONF_REGION, CONF_TOKEN)
+    ATTR_COMMAND, ATTR_ENTITY_ID, ATTR_LOCKED, CONF_REGION, CONF_TOKEN)
 from homeassistant.core import split_entity_id
 from homeassistant.helpers import entity_registry, config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
@@ -14,7 +17,8 @@ from homeassistant.util import location
 from homeassistant.util.json import load_json, save_json
 
 from .config_flow import PlayStation4FlowHandler  # noqa: pylint: disable=unused-import
-from .const import COMMANDS, DOMAIN, GAMES_FILE, PS4_DATA
+from .const import (
+    ATTR_MEDIA_IMAGE_URL, COMMANDS, DOMAIN, GAMES_FILE, PS4_DATA)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,13 +144,15 @@ def format_unique_id(creds, mac_address):
 def load_games(hass: HomeAssistantType) -> dict:
     """Load games for sources."""
     g_file = hass.config.path(GAMES_FILE)
-    try:
-        games = load_json(g_file)
+    games = load_json(g_file)
 
     # If file does not exist, create empty file.
-    except FileNotFoundError:
+    if not os.path.isfile(g_file):
+        _LOGGER.info("Creating PS4 Games File")
         games = {}
         save_games(hass, games)
+    else:
+        games = _reformat_data(hass, games)
     return games
 
 
@@ -158,9 +164,28 @@ def save_games(hass: HomeAssistantType, games: dict):
     except OSError as error:
         _LOGGER.error("Could not save game list, %s", error)
 
-    # Retry loading file
-    if games is None:
-        load_games(hass)
+
+def _reformat_data(hass: HomeAssistantType, games: dict) -> dict:
+    """Reformat data to correct format."""
+    data_reformatted = False
+    if games is not None:
+        for game, data in games.items():
+
+            # Convert str format to dict format.
+            if not isinstance(data, dict):
+                # Use existing title. Assign defaults.
+                games[game] = {ATTR_LOCKED: False,
+                               ATTR_MEDIA_TITLE: data,
+                               ATTR_MEDIA_IMAGE_URL: None,
+                               ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME}
+                data_reformatted = True
+
+                _LOGGER.info(
+                    "Reformatting media data for item: %s, %s", game, data)
+
+        if data_reformatted:
+            save_games(hass, games)
+    return games
 
 
 def service_handle(hass: HomeAssistantType):

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -146,7 +146,7 @@ def load_games(hass: HomeAssistantType) -> dict:
     """Load games for sources."""
     g_file = hass.config.path(GAMES_FILE)
     try:
-        games = load_json(g_file)
+        games = load_json(g_file, dict)
     except HomeAssistantError as error:
         games = {}
         _LOGGER.error("Failed to load games file: %s", error)
@@ -176,23 +176,22 @@ def _reformat_data(hass: HomeAssistantType, games: dict) -> dict:
         _LOGGER.error("Games file was not parsed correctly")
         return {}
     data_reformatted = False
-    if games:
-        for game, data in games.items():
 
-            # Convert str format to dict format.
-            if not isinstance(data, dict):
-                # Use existing title. Assign defaults.
-                games[game] = {ATTR_LOCKED: False,
-                               ATTR_MEDIA_TITLE: data,
-                               ATTR_MEDIA_IMAGE_URL: None,
-                               ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME}
-                data_reformatted = True
+    for game, data in games.items():
+        # Convert str format to dict format.
+        if not isinstance(data, dict):
+            # Use existing title. Assign defaults.
+            games[game] = {ATTR_LOCKED: False,
+                           ATTR_MEDIA_TITLE: data,
+                           ATTR_MEDIA_IMAGE_URL: None,
+                           ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_GAME}
+            data_reformatted = True
 
-                _LOGGER.info(
-                    "Reformatting media data for item: %s, %s", game, data)
+            _LOGGER.debug(
+                "Reformatting media data for item: %s, %s", game, data)
 
-        if data_reformatted:
-            save_games(hass, games)
+    if data_reformatted:
+        save_games(hass, games)
     return games
 
 

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -1,4 +1,5 @@
 """Constants for PlayStation 4."""
+ATTR_MEDIA_IMAGE_URL = 'media_image_url'
 CONFIG_ENTRY_VERSION = 3
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -149,7 +149,7 @@ class PS4Device(MediaPlayerDevice):
 
         if status is not None:
             self._games = load_games(self.hass)
-            if self._games is not None:
+            if self._games:
                 self.get_source_list()
 
             self._retry = 0

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -164,19 +164,8 @@ class PS4Device(MediaPlayerDevice):
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
 
-                        if self._media_content_id in self._games:
-                            store = self._games[self._media_content_id]
-
-                            # If locked get attributes from file.
-                            locked = store.get(ATTR_LOCKED)
-                            if locked:
-                                self._media_title = store.get(ATTR_MEDIA_TITLE)
-                                self._source = self._media_title
-                                self._media_image = store.get(
-                                    ATTR_MEDIA_IMAGE_URL)
-                                self._media_type = store.get(
-                                    ATTR_MEDIA_CONTENT_TYPE)
-                                return
+                        if self._use_saved():
+                            return
 
                         # Get data from PS Store.
                         asyncio.ensure_future(
@@ -192,6 +181,23 @@ class PS4Device(MediaPlayerDevice):
             self.state_unknown()
         else:
             self._retry += 1
+
+    def _use_saved(self) -> bool:
+        """Return True, Set media attrs if data is locked."""
+        if self._media_content_id in self._games:
+            store = self._games[self._media_content_id]
+
+            # If locked get attributes from file.
+            locked = store.get(ATTR_LOCKED)
+            if locked:
+                self._media_title = store.get(ATTR_MEDIA_TITLE)
+                self._source = self._media_title
+                self._media_image = store.get(
+                    ATTR_MEDIA_IMAGE_URL)
+                self._media_type = store.get(
+                    ATTR_MEDIA_CONTENT_TYPE)
+                return True
+        return False
 
     def idle(self):
         """Set states for state idle."""

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -9,17 +9,19 @@ from homeassistant.core import callback
 from homeassistant.components.media_player import (
     ENTITY_IMAGE_URL, MediaPlayerDevice)
 from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_GAME, MEDIA_TYPE_APP, SUPPORT_SELECT_SOURCE,
-    SUPPORT_PAUSE, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
+    ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_TITLE,
+    MEDIA_TYPE_GAME, MEDIA_TYPE_APP, SUPPORT_SELECT_SOURCE, SUPPORT_PAUSE,
+    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
 from homeassistant.components.ps4 import (
     format_unique_id, load_games, save_games)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_REGION,
-    CONF_TOKEN, STATE_IDLE, STATE_OFF, STATE_PLAYING)
+    ATTR_LOCKED, CONF_HOST, CONF_NAME, CONF_REGION, CONF_TOKEN,
+    STATE_IDLE, STATE_OFF, STATE_PLAYING)
 from homeassistant.helpers import device_registry, entity_registry
 
-from .const import (DEFAULT_ALIAS, DOMAIN as PS4_DOMAIN, PS4_DATA,
-                    REGIONS as deprecated_regions)
+from .const import (
+    ATTR_MEDIA_IMAGE_URL, DEFAULT_ALIAS, DOMAIN as PS4_DOMAIN,
+    PS4_DATA, REGIONS as deprecated_regions)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,19 +150,35 @@ class PS4Device(MediaPlayerDevice):
         if status is not None:
             self._games = load_games(self.hass)
             if self._games is not None:
-                self._source_list = list(sorted(self._games.values()))
+                self.get_source_list()
+
             self._retry = 0
             self._disconnected = False
             if status.get('status') == 'Ok':
                 title_id = status.get('running-app-titleid')
                 name = status.get('running-app-name')
+
                 if title_id and name is not None:
                     self._state = STATE_PLAYING
+
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
-                        self._media_title = name
-                        self._source = self._media_title
-                        self._media_type = None
+
+                        if self._media_content_id in self._games:
+                            store = self._games[self._media_content_id]
+
+                            # If locked get attributes from file.
+                            locked = store.get(ATTR_LOCKED)
+                            if locked:
+                                self._media_title = store.get(ATTR_MEDIA_TITLE)
+                                self._source = self._media_title
+                                self._media_image = store.get(
+                                    ATTR_MEDIA_IMAGE_URL)
+                                self._media_type = store.get(
+                                    ATTR_MEDIA_CONTENT_TYPE)
+                                return
+
+                        # Get data from PS Store.
                         asyncio.ensure_future(
                             self.async_get_title_data(title_id, name))
                 else:
@@ -246,20 +264,33 @@ class PS4Device(MediaPlayerDevice):
         """Update Game List, Correct data if different."""
         if self._media_content_id in self._games:
             store = self._games[self._media_content_id]
-            if store != self._media_title:
+
+            if store.get(ATTR_MEDIA_TITLE) != self._media_title or\
+                    store.get(ATTR_MEDIA_IMAGE_URL) != self._media_image:
                 self._games.pop(self._media_content_id)
 
         if self._media_content_id not in self._games:
-            self.add_games(self._media_content_id, self._media_title)
+            self.add_games(
+                self._media_content_id, self._media_title,
+                self._media_image, self._media_type)
             self._games = load_games(self.hass)
 
-        self._source_list = list(sorted(self._games.values()))
+        self.get_source_list()
 
-    def add_games(self, title_id, app_name):
+    def get_source_list(self):
+        """Parse data entry and update source list."""
+        games = []
+        for data in self._games.values():
+            games.append(data[ATTR_MEDIA_TITLE])
+        self._source_list = sorted(games)
+
+    def add_games(self, title_id, app_name, image, g_type, is_locked=False):
         """Add games to list."""
         games = self._games
         if title_id is not None and title_id not in games:
-            game = {title_id: app_name}
+            game = {title_id: {
+                ATTR_MEDIA_TITLE: app_name, ATTR_MEDIA_IMAGE_URL: image,
+                ATTR_MEDIA_CONTENT_TYPE: g_type, ATTR_LOCKED: is_locked}}
             games.update(game)
             save_games(self.hass, games)
 

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -163,6 +163,9 @@ class PS4Device(MediaPlayerDevice):
 
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
+                        self._media_title = name
+                        self._source = self._media_title
+                        self._media_type = None
 
                         if self._use_saved():
                             return

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -440,7 +440,8 @@ class PS4Device(MediaPlayerDevice):
 
     async def async_select_source(self, source):
         """Select input source."""
-        for title_id, game in self._games.items():
+        for title_id, data in self._games.items():
+            game = data[ATTR_MEDIA_TITLE]
             if source.lower().encode(encoding='utf-8') == \
                game.lower().encode(encoding='utf-8') \
                or source == title_id:

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -163,13 +163,14 @@ class PS4Device(MediaPlayerDevice):
 
                     if self._media_content_id != title_id:
                         self._media_content_id = title_id
+                        if self._use_saved():
+                            _LOGGER.debug(
+                                "Using saved data for media: %s", title_id)
+                            return
+
                         self._media_title = name
                         self._source = self._media_title
                         self._media_type = None
-
-                        if self._use_saved():
-                            return
-
                         # Get data from PS Store.
                         asyncio.ensure_future(
                             self.async_get_title_data(title_id, name))

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -217,16 +217,6 @@ def test_load_games(hass):
 def test_loading_games_returns_dict(hass):
     """Test that loading games always returns a dict."""
     with patch('homeassistant.components.ps4.load_json',
-               return_value=None),\
-            patch('homeassistant.components.ps4.save_json',
-                  side_effect=MagicMock()),\
-            patch('os.path.isfile', return_value=True):
-        mock_games = ps4.load_games(hass)
-
-    assert isinstance(mock_games, dict)
-    assert not mock_games
-
-    with patch('homeassistant.components.ps4.load_json',
                side_effect=HomeAssistantError),\
             patch('homeassistant.components.ps4.save_json',
                   side_effect=MagicMock()),\

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -216,6 +216,49 @@ def test_load_games(hass):
     assert mock_data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_GAME
 
 
+def test_loading_games_returns_dict(hass):
+    """Test that loading games always returns a dict."""
+    with patch('homeassistant.components.ps4.load_json',
+               return_value=None),\
+            patch('homeassistant.components.ps4.save_json',
+                  side_effect=MagicMock()),\
+            patch('os.path.isfile', return_value=True):
+        mock_games = ps4.load_games(hass)
+
+    assert isinstance(mock_games, dict)
+    assert not mock_games
+
+    with patch('homeassistant.components.ps4.load_json',
+               side_effect=HomeAssistantError),\
+            patch('homeassistant.components.ps4.save_json',
+                  side_effect=MagicMock()),\
+            patch('os.path.isfile', return_value=True):
+        mock_games = ps4.load_games(hass)
+
+    assert isinstance(mock_games, dict)
+    assert not mock_games
+
+    with patch('homeassistant.components.ps4.load_json',
+               return_value='Some String'),\
+            patch('homeassistant.components.ps4.save_json',
+                  side_effect=MagicMock()),\
+            patch('os.path.isfile', return_value=True):
+        mock_games = ps4.load_games(hass)
+
+    assert isinstance(mock_games, dict)
+    assert not mock_games
+
+    with patch('homeassistant.components.ps4.load_json',
+               return_value=[]),\
+            patch('homeassistant.components.ps4.save_json',
+                  side_effect=MagicMock()),\
+            patch('os.path.isfile', return_value=True):
+        mock_games = ps4.load_games(hass)
+
+    assert isinstance(mock_games, dict)
+    assert not mock_games
+
+
 async def test_send_command(hass):
     """Test send_command service."""
     await setup_mock_component(hass)

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -1,5 +1,5 @@
 """Tests for the PS4 Integration."""
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import ps4
@@ -178,7 +178,10 @@ async def setup_mock_component(hass):
 def test_games_reformat_to_dict(hass):
     """Test old data format is converted to new format."""
     with patch('homeassistant.components.ps4.load_json',
-               return_value=MOCK_GAMES_DATA_OLD_STR_FORMAT):
+               return_value=MOCK_GAMES_DATA_OLD_STR_FORMAT),\
+            patch('homeassistant.components.ps4.save_json',
+                  side_effect=MagicMock()),\
+            patch('os.path.isfile', return_value=True):
         mock_games = ps4.load_games(hass)
 
     # New format is a nested dict.
@@ -197,7 +200,10 @@ def test_games_reformat_to_dict(hass):
 def test_load_games(hass):
     """Test that games are loaded correctly."""
     with patch('homeassistant.components.ps4.load_json',
-               return_value=MOCK_GAMES):
+               return_value=MOCK_GAMES),\
+            patch('homeassistant.components.ps4.save_json',
+                  side_effect=MagicMock()),\
+            patch('os.path.isfile', return_value=True):
         mock_games = ps4.load_games(hass)
 
     assert isinstance(mock_games, dict)

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -1,5 +1,4 @@
 """Tests for the PS4 Integration."""
-import os
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
@@ -12,7 +11,7 @@ from homeassistant.components.ps4.const import (
 from homeassistant.const import (
     ATTR_COMMAND, ATTR_ENTITY_ID, ATTR_LOCKED, CONF_HOST,
     CONF_NAME, CONF_REGION, CONF_TOKEN)
-from homeassistant.util import location, json
+from homeassistant.util import location
 from homeassistant.setup import async_setup_component
 from tests.common import (
     get_test_config_dir, MockConfigEntry, mock_coro, mock_registry)

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -7,14 +7,15 @@ from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_TYPE, ATTR_MEDIA_TITLE, MEDIA_TYPE_GAME)
 from homeassistant.components.ps4.const import (
     ATTR_MEDIA_IMAGE_URL, COMMANDS, CONFIG_ENTRY_VERSION as VERSION,
-    DEFAULT_REGION, DOMAIN, GAMES_FILE, PS4_DATA)
+    DEFAULT_REGION, DOMAIN, PS4_DATA)
 from homeassistant.const import (
     ATTR_COMMAND, ATTR_ENTITY_ID, ATTR_LOCKED, CONF_HOST,
     CONF_NAME, CONF_REGION, CONF_TOKEN)
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import location
 from homeassistant.setup import async_setup_component
 from tests.common import (
-    get_test_config_dir, MockConfigEntry, mock_coro, mock_registry)
+    MockConfigEntry, mock_coro, mock_registry)
 
 MOCK_HOST = '192.168.0.1'
 MOCK_NAME = 'test_ps4'
@@ -65,8 +66,6 @@ MOCK_ENTRY_VERSION_1 = MockConfigEntry(
     domain=DOMAIN, data=MOCK_DATA_VERSION_1, entry_id=MOCK_ENTRY_ID, version=1)
 
 MOCK_UNIQUE_ID = 'someuniqueid'
-
-MOCK_FILE = get_test_config_dir(GAMES_FILE)
 
 MOCK_ID = 'CUSA00123'
 MOCK_URL = 'http://someurl.jpeg'

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -14,8 +14,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import location
 from homeassistant.setup import async_setup_component
-from tests.common import (
-    MockConfigEntry, mock_coro, mock_registry)
+from tests.common import (MockConfigEntry, mock_coro, mock_registry)
 
 MOCK_HOST = '192.168.0.1'
 MOCK_NAME = 'test_ps4'


### PR DESCRIPTION
## Description:

Reformat media data. Save all attributes as a dict. 
Allow locking of data and manual edits for attributes..
Improve json helpers.

Prep for editing of attributes via services.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
