### PR TITLE
[climate] Tweak evohome migration

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -369,9 +369,9 @@ class EvoThermostat(EvoZone):
     @property
     def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
-        if self._evo_tcs.systemModeStatus['mode'] == EVO_AUTOECO:
-            if self._evo_device.setpointStatus['setpointMode'] == EVO_FOLLOW:
-                return PRESET_ECO
+        if self._evo_tcs.systemModeStatus['mode'] == EVO_AUTOECO and \
+                self._evo_device.setpointStatus['setpointMode'] == EVO_FOLLOW:
+            return PRESET_ECO
 
         return super().preset_mode
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -192,8 +192,8 @@ class EvoZone(EvoClimateDevice):
         if self.target_temperature <= self.min_temp:
             return CURRENT_HVAC_OFF
         elif self.target_temperature <= self.current_temperature:
-            return CURRENT_HVAC_IDLE
-        return CURRENT_HVAC_HEAT
+            return CURRENT_HVAC_HEAT
+        return CURRENT_HVAC_IDLE
 
     @property
     def current_temperature(self) -> Optional[float]:

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -191,7 +191,7 @@ class EvoZone(EvoClimateDevice):
             return CURRENT_HVAC_OFF
         if self.target_temperature <= self.min_temp:
             return CURRENT_HVAC_OFF
-        elif self.target_temperature <= self.current_temperature:
+        if self.target_temperature <= self.current_temperature:
             return CURRENT_HVAC_HEAT
         return CURRENT_HVAC_IDLE
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -9,6 +9,7 @@ import evohomeclient2
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF,
+    CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF,
     PRESET_AWAY, PRESET_ECO, PRESET_HOME,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE)
 from homeassistant.const import PRECISION_TENTHS
@@ -184,6 +185,17 @@ class EvoZone(EvoClimateDevice):
         return HVAC_MODE_OFF if is_off else HVAC_MODE_HEAT
 
     @property
+    def hvac_action(self) -> Optional[str]:
+        """Return the current running hvac operation if supported."""
+        if self._evo_tcs.systemModeStatus['mode'] == EVO_HEATOFF:
+            return CURRENT_HVAC_OFF
+        if self.target_temperature <= self.min_temp:
+            return CURRENT_HVAC_OFF
+        elif self.target_temperature <= self.current_temperature:
+            return CURRENT_HVAC_IDLE
+        return CURRENT_HVAC_HEAT
+
+    @property
     def current_temperature(self) -> Optional[float]:
         """Return the current temperature of the evohome Zone."""
         return (self._evo_device.temperatureStatus['temperature']
@@ -221,7 +233,7 @@ class EvoZone(EvoClimateDevice):
         return self._evo_device.setpointCapabilities['maxHeatSetpoint']
 
     def set_temperature(self, **kwargs) -> None:
-        """Set a new target temperature for an hour."""
+        """Set a new target temperature."""
         until = kwargs.get('until')
         if until:
             until = parse_datetime(until)
@@ -283,39 +295,13 @@ class EvoController(EvoClimateDevice):
         return round(sum(temps) / len(temps), 1) if temps else None
 
     @property
-    def target_temperature(self) -> Optional[float]:
-        """Return the average target temperature of the heating Zones.
-
-        Controllers do not have a target temp, but one is expected by HA.
-        """
-        temps = [z.setpointStatus['targetHeatTemperature']
-                 for z in self._evo_tcs.zones.values()]
-        return round(sum(temps) / len(temps), 1) if temps else None
-
-    @property
     def preset_mode(self) -> Optional[str]:
         """Return the current preset mode, e.g., home, away, temp."""
         return TCS_PRESET_TO_HA.get(self._evo_tcs.systemModeStatus['mode'])
 
-    @property
-    def min_temp(self) -> float:
-        """Return the minimum target temperature  of the heating Zones.
-
-        Controllers do not have a min target temp, but one is required by HA.
-        """
-        temps = [z.setpointCapabilities['minHeatSetpoint']
-                 for z in self._evo_tcs.zones.values()]
-        return min(temps) if temps else 5
-
-    @property
-    def max_temp(self) -> float:
-        """Return the maximum target temperature  of the heating Zones.
-
-        Controllers do not have a max target temp, but one is required by HA.
-        """
-        temps = [z.setpointCapabilities['maxHeatSetpoint']
-                 for z in self._evo_tcs.zones.values()]
-        return max(temps) if temps else 35
+    def set_temperature(self, **kwargs) -> None:
+        """The evohome Controller doesn't have a targert temperature."""
+        return
 
     def set_hvac_mode(self, hvac_mode: str) -> None:
         """Set an operating mode for the Controller."""
@@ -330,7 +316,7 @@ class EvoController(EvoClimateDevice):
 
     def update(self) -> None:
         """Get the latest state data."""
-        pass
+        return
 
 
 class EvoThermostat(EvoZone):


### PR DESCRIPTION
## Description:
For the Controller, removes the ability to set target temperature from web UI by: `target_temperature == None`, and: 
 - removes min/max temp properties from the controller (hub) entity
 - add `hvac.action` property to the zones
 - various tweaks, de-lints

Note that the Controller has `supported_features & SUPPORT_TARGET_TEMPERATURE == 0` and `set_temperature` was never overridden (i.e. throws `NotImplementedError()` exception.  However, only when the fake `target_temperature` was removed, did the UI remove this feature.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
