### PR TITLE
Add login_method config option to fix login issue with RouterOS Version > 6.43

### DIFF
--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_METHOD): cv.string,
-    vol.Optional(CONF_LOGIN_METHOD, default=MTK_LOGIN_PLAIN):
+    vol.Optional(CONF_LOGIN_METHOD):
         vol.Any(MTK_LOGIN_PLAIN, MTK_LOGIN_TOKEN),
     vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -16,6 +16,10 @@ _LOGGER = logging.getLogger(__name__)
 MTK_DEFAULT_API_PORT = '8728'
 MTK_DEFAULT_API_SSL_PORT = '8729'
 
+CONF_LOGIN_METHOD = 'login_method'
+MTK_LOGIN_PLAIN = 'plain'
+MTK_LOGIN_TOKEN = 'token'
+
 CONF_ENCODING = 'encoding'
 DEFAULT_ENCODING = 'utf-8'
 
@@ -24,6 +28,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_METHOD): cv.string,
+    vol.Optional(CONF_LOGIN_METHOD, default=MTK_LOGIN_PLAIN):
+        vol.Any(MTK_LOGIN_PLAIN, MTK_LOGIN_TOKEN),
     vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
@@ -54,6 +60,7 @@ class MikrotikScanner(DeviceScanner):
                 self.port = MTK_DEFAULT_API_PORT
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
+        self.login_method = config.get(CONF_LOGIN_METHOD)
         self.method = config.get(CONF_METHOD)
         self.encoding = config[CONF_ENCODING]
 
@@ -72,10 +79,21 @@ class MikrotikScanner(DeviceScanner):
     def connect_to_device(self):
         """Connect to Mikrotik method."""
         import librouteros
+        from librouteros.login import login_plain, login_token
+
+        login_methods = {
+            MTK_LOGIN_PLAIN: login_plain,
+            MTK_LOGIN_TOKEN: login_token
+        }
+
         try:
             kwargs = {
                 'port': self.port,
-                'encoding': self.encoding
+                'encoding': self.encoding,
+                'login_methods': (
+                    login_methods.get(self.login_method),
+                    login_plain
+                )
             }
             if self.ssl:
                 ssl_context = ssl.create_default_context()

--- a/homeassistant/components/mikrotik/device_tracker.py
+++ b/homeassistant/components/mikrotik/device_tracker.py
@@ -81,20 +81,20 @@ class MikrotikScanner(DeviceScanner):
         import librouteros
         from librouteros.login import login_plain, login_token
 
-        login_methods = {
-            MTK_LOGIN_PLAIN: login_plain,
-            MTK_LOGIN_TOKEN: login_token
-        }
+        if self.login_method == MTK_LOGIN_PLAIN:
+            login_method = (login_plain,)
+        elif self.login_method == MTK_LOGIN_TOKEN:
+            login_method = (login_token,)
+        else:
+            login_method = (login_plain, login_token)
 
         try:
             kwargs = {
                 'port': self.port,
                 'encoding': self.encoding,
-                'login_methods': (
-                    login_methods.get(self.login_method),
-                    login_plain
-                )
+                'login_methods': login_method
             }
+
             if self.ssl:
                 ssl_context = ssl.create_default_context()
                 ssl_context.check_hostname = False


### PR DESCRIPTION
## Description:
Mikrotik changed the used login method with version 6.43 of their RouterOS and disabled the old token login method with version 6.45.1. Therefore the mikrotik component was no longer able to login and use the API.

**Related issue:** fixes #25189 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) :** home-assistant/home-assistant.io#9877

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: mikrotik
  host: 192.168.23.1
  track_new_devices: false
  login_method: plain
  username: !secret mikrotik_username
  password: !secret mikrotik_password
```

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x ] There is no commented out code in this PR.
  - [ x ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ x ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
