### PR TITLE
add icon option to horizon component

### DIFF
--- a/homeassistant/components/horizon/media_player.py
+++ b/homeassistant/components/horizon/media_player.py
@@ -12,13 +12,15 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
+    CONF_HOST, CONF_ICON, CONF_NAME, CONF_PORT, STATE_OFF, STATE_PAUSED,
+    STATE_PLAYING)
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Horizon'
+DEFAULT_ICON = 'mdi:television-box'
 DEFAULT_PORT = 5900
 
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
@@ -31,6 +33,7 @@ SUPPORT_HORIZON = SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PLAY | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
 })
 
@@ -42,6 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     host = config[CONF_HOST]
     name = config[CONF_NAME]
+    icon = config[CONF_ICON]
     port = config[CONF_PORT]
 
     try:
@@ -56,23 +60,29 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     _LOGGER.info("Connection to %s at %s established", name, host)
 
-    add_entities([HorizonDevice(client, name, keys)], True)
+    add_entities([HorizonDevice(client, name, icon, keys)], True)
 
 
 class HorizonDevice(MediaPlayerDevice):
     """Representation of a Horizon HD Recorder."""
 
-    def __init__(self, client, name, keys):
-        """Initialize the remote."""
+    def __init__(self, client, name, icon, keys):
+        """Initialize the entity."""
         self._client = client
         self._name = name
+        self._icon = icon
         self._state = None
         self._keys = keys
 
     @property
     def name(self):
-        """Return the name of the remote."""
+        """Return the name of the entity."""
         return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of the entity."""
+        return self._icon
 
     @property
     def state(self):


### PR DESCRIPTION
## Description:
add icon option to horizon component

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9879

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: horizon
    host: 192.168.0.127
    icon: mdi:television
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x ] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
