### PR TITLE
Bump simplisafe-python to 4.0.0 + add additional SimpliSafe attributes

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -106,9 +106,9 @@ async def async_setup_entry(hass, config_entry):
 
     async def refresh(event_time):
         """Refresh data from the SimpliSafe account."""
-        tasks = [system.update() for system in systems]
+        tasks = [system.update() for system in systems.values()]
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        for system, result in zip(systems, results):
+        for system, result in zip(systems.values(), results):
             if isinstance(result, SimplipyError):
                 _LOGGER.error(
                     'There was error updating "%s": %s', system.address,

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -59,10 +59,9 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
         for prop in (
                 ATTR_BATTERY_BACKUP_POWER_LEVEL, ATTR_GSM_STRENGTH,
                 ATTR_RF_JAMMING, ATTR_WALL_POWER_LEVEL, ATTR_WIFI_STRENGTH):
-            value = getattr(system, prop, None)
-            if not value:
-                continue
-            self._attrs[prop] = value
+            # value = getattr(system, prop, None)
+            if hasattr(system, prop):
+                self._attrs[prop] = getattr(system, prop)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -17,6 +17,7 @@ ATTR_ALARM_ACTIVE = 'alarm_active'
 ATTR_BATTERY_BACKUP_POWER_LEVEL = 'battery_backup_power_level'
 ATTR_GSM_STRENGTH = 'gsm_strength'
 ATTR_RF_JAMMING = 'rf_jamming'
+ATTR_SYSTEM_ID = 'system_id'
 ATTR_WALL_POWER_LEVEL = 'wall_power_level'
 ATTR_WIFI_STRENGTH = 'wifi_strength'
 
@@ -42,7 +43,7 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
     def __init__(self, system, code):
         """Initialize the SimpliSafe alarm."""
         self._async_unsub_dispatcher_connect = None
-        self._attrs = {}
+        self._attrs = {ATTR_SYSTEM_ID: system.system_id}
         self._code = code
         self._system = system
         self._state = None

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -17,9 +17,6 @@ ATTR_ALARM_ACTIVE = 'alarm_active'
 ATTR_BATTERY_BACKUP_POWER_LEVEL = 'battery_backup_power_level'
 ATTR_GSM_STRENGTH = 'gsm_strength'
 ATTR_RF_JAMMING = 'rf_jamming'
-ATTR_SERIAL = 'serial'
-ATTR_SYSTEM_ID = 'system_id'
-ATTR_VERSION = 'version'
 ATTR_WALL_POWER_LEVEL = 'wall_power_level'
 ATTR_WIFI_STRENGTH = 'wifi_strength'
 
@@ -45,15 +42,10 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
     def __init__(self, system, code):
         """Initialize the SimpliSafe alarm."""
         self._async_unsub_dispatcher_connect = None
+        self._attrs = {}
         self._code = code
         self._system = system
         self._state = None
-
-        self._attrs = {
-            ATTR_SERIAL: system.serial,
-            ATTR_SYSTEM_ID: system.system_id,
-            ATTR_VERSION: system.version,
-        }
 
         # Some properties only exist for V2 or V3 systems:
         for prop in (
@@ -62,16 +54,6 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
             # value = getattr(system, prop, None)
             if hasattr(system, prop):
                 self._attrs[prop] = getattr(system, prop)
-
-    @property
-    def unique_id(self):
-        """Return the unique ID."""
-        return self._system.system_id
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._system.address
 
     @property
     def code_format(self):
@@ -83,14 +65,39 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
         return alarm.FORMAT_TEXT
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
+    def device_info(self):
+        """Return device registry information for this entity."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._system.system_id)
+            },
+            'manufacturer': 'SimpliSafe',
+            'model': self._system.version,
+            # The name should become more dynamic once we deduce a way to
+            # get various other sensors from SimpliSafe in a reliable manner:
+            'name': 'Keypad',
+            'via_device': (DOMAIN, self._system.serial)
+        }
 
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
         return self._attrs
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._system.address
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return self._system.system_id
 
     def _validate_code(self, code, state):
         """Validate given code."""

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/simplisafe",
   "requirements": [
-    "simplisafe-python==3.4.2"
+    "simplisafe-python==4.0.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1676,7 +1676,7 @@ shodan==1.13.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.4.2
+simplisafe-python==4.0.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -334,7 +334,7 @@ ring_doorbell==0.2.3
 rxv==0.6.0
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.4.2
+simplisafe-python==4.0.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
## Description:

This PR bumps `simplisafe-python` to 4.0.0 ([3.5.0 changelog](https://github.com/bachya/simplisafe-python/releases/tag/3.5.0), [4.0.0 changelog](https://github.com/bachya/simplisafe-python/releases/tag/4.0.0)). In addition to laying foundation for future features, this PR adds 8 new attributes to the `alarm_control_panel` entity (3 of which are available to V2 and V3 systems, while the remaining 5 are only available to V3 systems):

* `battery_backup_power_level`: the amount of power capacity left in the backup battery (measured in mAh); will be useful for automations to notify when the battery wears down.
* `gsm_strength`: the signal strength of the onboard 3G antenna (measured in RSSI); will be useful for automations to notify when the signal strength drops.
* `rf_jamming`: whether the base station is experiencing RF jamming; will be useful for automations to notify of potential intrusion attempts.
* `wall_power_level`: the power capacity coming out of the outlet (measured in mAh); will be useful for automations to notify during electrical events (surges, drops, etc.).
* `wifi_strength`: the signal strength of the onboard WiFi antenna (measured in RSSI); will be useful for automations to notify when the signal strength drops.

The PR also adds the `alarm_control_panel` and the SimpliSafe base station to the device registry.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_email
      password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
