### PR TITLE
Fix schema validation for service calls

### DIFF
--- a/homeassistant/components/wunderlist/__init__.py
+++ b/homeassistant/components/wunderlist/__init__.py
@@ -73,7 +73,7 @@ class Wunderlist:
         """Create a new task on a list of Wunderlist."""
         list_name = call.data.get(CONF_LIST_NAME)
         task_title = call.data.get(CONF_NAME)
-        starred = call.data.get(CONF_STARRED)
+        starred = call.data[CONF_STARRED]
         list_id = self._list_by_name(list_name)
         self._client.create_task(list_id, task_title, starred=starred)
         return True

--- a/homeassistant/components/wunderlist/__init__.py
+++ b/homeassistant/components/wunderlist/__init__.py
@@ -71,8 +71,8 @@ class Wunderlist:
 
     def create_task(self, call):
         """Create a new task on a list of Wunderlist."""
-        list_name = call.data.get(CONF_LIST_NAME)
-        task_title = call.data.get(CONF_NAME)
+        list_name = call.data[CONF_LIST_NAME]
+        task_title = call.data[CONF_NAME]
         starred = call.data[CONF_STARRED]
         list_id = self._list_by_name(list_name)
         self._client.create_task(list_id, task_title, starred=starred)

--- a/homeassistant/components/wunderlist/__init__.py
+++ b/homeassistant/components/wunderlist/__init__.py
@@ -28,7 +28,7 @@ SERVICE_CREATE_TASK = 'create_task'
 SERVICE_SCHEMA_CREATE_TASK = vol.Schema({
     vol.Required(CONF_LIST_NAME): cv.string,
     vol.Required(CONF_NAME): cv.string,
-    vol.Optional(CONF_STARRED): cv.boolean,
+    vol.Optional(CONF_STARRED, default=False): cv.boolean,
 })
 
 
@@ -42,7 +42,10 @@ def setup(hass, config):
         _LOGGER.error("Invalid credentials")
         return False
 
-    hass.services.register(DOMAIN, 'create_task', data.create_task)
+    hass.services.register(
+        DOMAIN, 'create_task', data.create_task,
+        schema=SERVICE_SCHEMA_CREATE_TASK
+    )
     return True
 
 


### PR DESCRIPTION
## Description:
Add schema validation for service calls and default value for the `starred`option.

**Related issue (if applicable):** fixes #25110

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- service: wunderlist.create_task
    data:
      list_name: 'Shoppinglist'
      name: "{{states.input_text.shoppinglist}}"
      starred: false
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html