### PR TITLE
Add services to set and remove Simplisafe PINs

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.service import verify_domain_control
 
 from homeassistant.helpers import config_validation as cv
 
@@ -22,8 +23,23 @@ from .const import DATA_CLIENT, DEFAULT_SCAN_INTERVAL, DOMAIN, TOPIC_UPDATE
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ACCOUNTS = 'accounts'
+CONF_PIN_LABEL = 'label'
+CONF_PIN_LABEL_OR_VALUE = 'label_or_pin'
+CONF_PIN_VALUE = 'pin'
+CONF_SYSTEM_ID = 'system_id'
 
 DATA_LISTENER = 'listener'
+
+SERVICE_REMOVE_PIN_SCHEMA = vol.Schema({
+    vol.Required(CONF_SYSTEM_ID): cv.string,
+    vol.Required(CONF_PIN_LABEL_OR_VALUE): cv.string,
+})
+
+SERVICE_SET_PIN_SCHEMA = vol.Schema({
+    vol.Required(CONF_SYSTEM_ID): cv.string,
+    vol.Required(CONF_PIN_LABEL): cv.string,
+    vol.Required(CONF_PIN_VALUE): cv.string,
+})
 
 ACCOUNT_CONFIG_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
@@ -97,6 +113,8 @@ async def async_setup_entry(hass, config_entry):
     from simplipy import API
     from simplipy.errors import InvalidCredentialsError, SimplipyError
 
+    _verify_domain_control = verify_domain_control(hass, DOMAIN)
+
     websession = aiohttp_client.async_get_clientsession(hass)
 
     try:
@@ -148,6 +166,25 @@ async def async_setup_entry(hass, config_entry):
         hass.async_create_task(
             async_register_base_station(
                 hass, system, config_entry.entry_id))
+
+    @_verify_domain_control
+    async def remove_pin(call):
+        """Remove a PIN."""
+        system = systems[call.data[CONF_SYSTEM_ID]]
+        await system.remove_pin(call.data[CONF_PIN_LABEL_OR_VALUE])
+
+    @_verify_domain_control
+    async def set_pin(call):
+        """Set a PIN."""
+        system = systems[call.data[CONF_SYSTEM_ID]]
+        await system.set_pin(
+            call.data[CONF_PIN_LABEL], call.data[CONF_PIN_VALUE])
+
+    for service, method, schema in [
+            ('remove_pin', remove_pin, SERVICE_REMOVE_PIN_SCHEMA),
+            ('set_pin', set_pin, SERVICE_SET_PIN_SCHEMA),
+    ]:
+        hass.services.async_register(DOMAIN, service, method, schema=schema)
 
     return True
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -170,13 +170,13 @@ async def async_setup_entry(hass, config_entry):
     @_verify_domain_control
     async def remove_pin(call):
         """Remove a PIN."""
-        system = systems[call.data[CONF_SYSTEM_ID]]
+        system = systems[int(call.data[CONF_SYSTEM_ID])]
         await system.remove_pin(call.data[CONF_PIN_LABEL_OR_VALUE])
 
     @_verify_domain_control
     async def set_pin(call):
         """Set a PIN."""
-        system = systems[call.data[CONF_SYSTEM_ID]]
+        system = systems[int(call.data[CONF_SYSTEM_ID])]
         await system.set_pin(
             call.data[CONF_PIN_LABEL], call.data[CONF_PIN_VALUE])
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -25,9 +25,9 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_PIN_LABEL = 'label'
 ATTR_PIN_LABEL_OR_VALUE = 'label_or_pin'
 ATTR_PIN_VALUE = 'pin'
+ATTR_SYSTEM_ID = 'system_id'
 
 CONF_ACCOUNTS = 'accounts'
-CONF_SYSTEM_ID = 'system_id'
 
 DATA_LISTENER = 'listener'
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -22,23 +22,24 @@ from .const import DATA_CLIENT, DEFAULT_SCAN_INTERVAL, DOMAIN, TOPIC_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_PIN_LABEL = 'label'
+ATTR_PIN_LABEL_OR_VALUE = 'label_or_pin'
+ATTR_PIN_VALUE = 'pin'
+
 CONF_ACCOUNTS = 'accounts'
-CONF_PIN_LABEL = 'label'
-CONF_PIN_LABEL_OR_VALUE = 'label_or_pin'
-CONF_PIN_VALUE = 'pin'
 CONF_SYSTEM_ID = 'system_id'
 
 DATA_LISTENER = 'listener'
 
 SERVICE_REMOVE_PIN_SCHEMA = vol.Schema({
-    vol.Required(CONF_SYSTEM_ID): cv.string,
-    vol.Required(CONF_PIN_LABEL_OR_VALUE): cv.string,
+    vol.Required(ATTR_SYSTEM_ID): cv.string,
+    vol.Required(ATTR_PIN_LABEL_OR_VALUE): cv.string,
 })
 
 SERVICE_SET_PIN_SCHEMA = vol.Schema({
-    vol.Required(CONF_SYSTEM_ID): cv.string,
-    vol.Required(CONF_PIN_LABEL): cv.string,
-    vol.Required(CONF_PIN_VALUE): cv.string,
+    vol.Required(ATTR_SYSTEM_ID): cv.string,
+    vol.Required(ATTR_PIN_LABEL): cv.string,
+    vol.Required(ATTR_PIN_VALUE): cv.string,
 })
 
 ACCOUNT_CONFIG_SCHEMA = vol.Schema({
@@ -170,15 +171,15 @@ async def async_setup_entry(hass, config_entry):
     @_verify_domain_control
     async def remove_pin(call):
         """Remove a PIN."""
-        system = systems[int(call.data[CONF_SYSTEM_ID])]
-        await system.remove_pin(call.data[CONF_PIN_LABEL_OR_VALUE])
+        system = systems[int(call.data[ATTR_SYSTEM_ID])]
+        await system.remove_pin(call.data[ATTR_PIN_LABEL_OR_VALUE])
 
     @_verify_domain_control
     async def set_pin(call):
         """Set a PIN."""
-        system = systems[int(call.data[CONF_SYSTEM_ID])]
+        system = systems[int(call.data[ATTR_SYSTEM_ID])]
         await system.set_pin(
-            call.data[CONF_PIN_LABEL], call.data[CONF_PIN_VALUE])
+            call.data[ATTR_PIN_LABEL], call.data[ATTR_PIN_VALUE])
 
     for service, method, schema in [
             ('remove_pin', remove_pin, SERVICE_REMOVE_PIN_SCHEMA),

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/simplisafe",
   "requirements": [
-    "simplisafe-python==4.0.0"
+    "simplisafe-python==4.0.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -1,0 +1,64 @@
+# Describes the format for available RainMachine services
+
+---
+disable_program:
+  description: Disable a program.
+  fields:
+    program_id:
+      description: The program to disable.
+      example: 3
+disable_zone:
+  description: Disable a zone.
+  fields:
+    zone_id:
+      description: The zone to disable.
+      example: 3
+enable_program:
+  description: Enable a program.
+  fields:
+    program_id:
+      description: The program to enable.
+      example: 3
+enable_zone:
+  description: Enable a zone.
+  fields:
+    zone_id:
+      description: The zone to enable.
+      example: 3
+pause_watering:
+  description: Pause all watering for a number of seconds.
+  fields:
+    seconds:
+      description: The number of seconds to pause.
+      example: 30
+start_program:
+  description: Start a program.
+  fields:
+    program_id:
+      description: The program to start.
+      example: 3
+start_zone:
+  description: Start a zone for a set number of seconds.
+  fields:
+    zone_id:
+      description: The zone to start.
+      example: 3
+    zone_run_time:
+      description: The number of seconds to run the zone.
+      example: 120
+stop_all:
+  description: Stop all watering activities.
+stop_program:
+  description: Stop a program.
+  fields:
+    program_id:
+      description: The program to stop.
+      example: 3
+stop_zone:
+  description: Stop a zone.
+  fields:
+    zone_id:
+      description: The zone to stop.
+      example: 3
+unpause_watering:
+  description: Unpause all watering.

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -1,64 +1,24 @@
-# Describes the format for available RainMachine services
+# Describes the format for available SimpliSafe services
 
 ---
-disable_program:
-  description: Disable a program.
+remove_pin:
+  description: Remove a PIN by its label or value.
   fields:
-    program_id:
-      description: The program to disable.
-      example: 3
-disable_zone:
-  description: Disable a zone.
+    system_id:
+      description: The SimpliSafe system ID to affect.
+      example: 123987
+    label_or_pin:
+      description: The label/value to remove.
+      example: Test PIN
+set_pin:
+  description: Set/update a PIN
   fields:
-    zone_id:
-      description: The zone to disable.
-      example: 3
-enable_program:
-  description: Enable a program.
-  fields:
-    program_id:
-      description: The program to enable.
-      example: 3
-enable_zone:
-  description: Enable a zone.
-  fields:
-    zone_id:
-      description: The zone to enable.
-      example: 3
-pause_watering:
-  description: Pause all watering for a number of seconds.
-  fields:
-    seconds:
-      description: The number of seconds to pause.
-      example: 30
-start_program:
-  description: Start a program.
-  fields:
-    program_id:
-      description: The program to start.
-      example: 3
-start_zone:
-  description: Start a zone for a set number of seconds.
-  fields:
-    zone_id:
-      description: The zone to start.
-      example: 3
-    zone_run_time:
-      description: The number of seconds to run the zone.
-      example: 120
-stop_all:
-  description: Stop all watering activities.
-stop_program:
-  description: Stop a program.
-  fields:
-    program_id:
-      description: The program to stop.
-      example: 3
-stop_zone:
-  description: Stop a zone.
-  fields:
-    zone_id:
-      description: The zone to stop.
-      example: 3
-unpause_watering:
-  description: Unpause all watering.
+    system_id:
+      description: The SimpliSafe system ID to affect.
+      example: 123987
+    label:
+      description: The label of the PIN
+      example: Test PIN
+    pin:
+      description: The value of the PIN
+      example: 1256

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1679,7 +1679,7 @@ shodan==1.13.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==4.0.0
+simplisafe-python==4.0.1
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -334,7 +334,7 @@ ring_doorbell==0.2.3
 rxv==0.6.0
 
 # homeassistant.components.simplisafe
-simplisafe-python==4.0.0
+simplisafe-python==4.0.1
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
## Description:

This PR adds two new services for SimpliSafe:

1. `remove_pin`: remove a user-defined PIN
2. `set_pin`: set user-defined PINs _or_ set master/duress PINs

Lots of great automation potential with these: one-time PINs, etc.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9887

## Example entry for `configuration.yaml` (if applicable):
```yaml
simplisafe:
  accounts:
    - username: !secret simplisafe_username
      password: !secret simplisafe_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
