### PR TITLE
Lutron fans

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -56,7 +56,6 @@ def setup(hass, base_config):
             if output.type == 'SYSTEM_SHADE':
                 hass.data[LUTRON_DEVICES]['cover'].append((area.name, output))
             elif output.type == 'CEILING_FAN_TYPE':
-                # print('---------- Found a ceiling fan: ' +str(output))
                 hass.data[LUTRON_DEVICES]['fan'].append((area.name, output))
             elif output.is_dimmable:
                 hass.data[LUTRON_DEVICES]['light'].append((area.name, output))

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -39,7 +39,8 @@ def setup(hass, base_config):
     hass.data[LUTRON_DEVICES] = {'light': [],
                                  'cover': [],
                                  'switch': [],
-                                 'scene': []}
+                                 'scene': [],
+                                 'fan': []}
 
     config = base_config.get(DOMAIN)
     hass.data[LUTRON_CONTROLLER] = Lutron(
@@ -54,6 +55,9 @@ def setup(hass, base_config):
         for output in area.outputs:
             if output.type == 'SYSTEM_SHADE':
                 hass.data[LUTRON_DEVICES]['cover'].append((area.name, output))
+            elif output.type == 'CEILING_FAN_TYPE':
+                # print('---------- Found a ceiling fan: ' +str(output))
+                hass.data[LUTRON_DEVICES]['fan'].append((area.name, output))
             elif output.is_dimmable:
                 hass.data[LUTRON_DEVICES]['light'].append((area.name, output))
             else:
@@ -73,7 +77,7 @@ def setup(hass, base_config):
                 hass.data[LUTRON_BUTTONS].append(
                     LutronButton(hass, keypad, button))
 
-    for component in ('light', 'cover', 'switch', 'scene'):
+    for component in ('light', 'cover', 'switch', 'scene', 'fan'):
         discovery.load_platform(hass, component, DOMAIN, None, base_config)
     return True
 

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -42,8 +42,8 @@ class LutronFan(LutronDevice, FanEntity):
     @property
     def is_on(self):
         """Return true if device is on."""
-        # return self._lutron_device.last_level() > SPEED_OFF
-        return self._is_on
+        return self._lutron_device.last_level() > SPEED_MAPPING[SPEED_OFF]
+        # return self._is_on
 
     # @property
     # def speed(self) -> str:
@@ -88,10 +88,10 @@ class LutronFan(LutronDevice, FanEntity):
             _LOGGER.debug("Unknown speed %s, setting to %s", speed, SPEED_HIGH)
             self._speed = SPEED_HIGH
         else:
-            self._speed = self._prev_speed                                        # TODO returns 0.0 right now....
+            self._speed = self._prev_speed
             # self._speed = SPEED_MAPPING[SPEED_MEDIUM_HIGH]
             
-        print('+++++++++++++++++++++ ' +str(self._lutron_device)+ ', '+str(self._speed))
+        # print('+++++++++++++++++++++ ' +str(self._lutron_device)+ ', '+str(self._speed))
         self._lutron_device.level = SPEED_MAPPING[self._speed]
 
     def turn_off(self, **kwargs):

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -62,7 +62,8 @@ class LutronFan(LutronDevice, FanEntity):
     @property
     def is_on(self):
         """Return true if fan is on."""
-        return self._is_on
+        return self._lutron_device.last_level() > SPEED_MAPPING[SPEED_OFF]
+        # return self._is_on
 
     @property
     def speed(self) -> str:
@@ -99,11 +100,11 @@ class LutronFan(LutronDevice, FanEntity):
 
     def update(self):
         """Update internal state and fan speed."""
+        print('++++++++++++++++++++++ ' +str(self._lutron_device.level))
+
         value = self._lutron_device.level
+
         self._is_on = value > SPEED_MAPPING[SPEED_OFF]
-
-        print('++++++++++++++++++++++ ' +str(self._is_on))
-
         if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, SPEED_MAPPING[SPEED_HIGH] + 1):
             self._speed = SPEED_HIGH
         elif value in range(SPEED_MAPPING[SPEED_MEDIUM] + 1, SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1):

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -2,7 +2,6 @@
 import logging
 
 from homeassistant.components.fan import (SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SPEED_OFF, SUPPORT_SET_SPEED, FanEntity)
-# from homeassistant.const import (CONF_DEVICES, CONF_HOST, CONF_MAC, CONF_NAME, CONF_ID)
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
 
@@ -80,7 +79,7 @@ class LutronFan(LutronDevice, FanEntity):
         self._speed = speed
         if speed not in SPEED_MAPPING:
             _LOGGER.debug("Unknown speed %s, setting to %s", speed, SPEED_MAPPING[SPEED_HIGH])
-            self._speed = SPEED_MAPPING[SPEED_HIGH]
+            self._speed = SPEED_HIGH
         else:
             self._speed = self._prev_speed
             

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -63,7 +63,6 @@ class LutronFan(LutronDevice, FanEntity):
     def is_on(self):
         """Return true if fan is on."""
         return self._lutron_device.last_level() > SPEED_MAPPING[SPEED_OFF]
-        # return self._is_on
 
     @property
     def speed(self) -> str:
@@ -93,6 +92,7 @@ class LutronFan(LutronDevice, FanEntity):
             _LOGGER.debug("Unknown speed %s, setting to %s", speed, SPEED_HIGH)
             self._speed = SPEED_HIGH
         self._lutron_device.level = SPEED_MAPPING[self._speed]
+        self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs) -> None:
         """Instruct the fan to turn off."""
@@ -100,10 +100,7 @@ class LutronFan(LutronDevice, FanEntity):
 
     def update(self):
         """Update internal state and fan speed."""
-        print('++++++++++++++++++++++ ' +str(self._lutron_device.level))
-
         value = self._lutron_device.level
-
         self._is_on = value > SPEED_MAPPING[SPEED_OFF]
         if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, SPEED_MAPPING[SPEED_HIGH] + 1):
             self._speed = SPEED_HIGH

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -43,12 +43,7 @@ class LutronFan(LutronDevice, FanEntity):
     def is_on(self):
         """Return true if device is on."""
         return self._lutron_device.last_level() > SPEED_MAPPING[SPEED_OFF]
-        # return self._is_on
 
-    # @property
-    # def speed(self) -> str:
-    #     """Return the current speed."""
-    #     return self._speed
     @property
     def speed(self):
         """Return the brightness of the fan."""
@@ -63,7 +58,6 @@ class LutronFan(LutronDevice, FanEntity):
         return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_MEDIUM_HIGH, SPEED_HIGH]
 
     @property
-    # def state_attributes(self):
     def device_state_attributes(self):
         """Return the state attributes."""
         attr = {'lutron_integration_id': self._lutron_device.id}
@@ -77,7 +71,7 @@ class LutronFan(LutronDevice, FanEntity):
     def turn_on(self, speed: str = None, **kwargs):
         """Instruct the fan to turn on."""
         if speed is None:
-            speed = SPEED_HIGH
+            speed = SPEED_MAPPING[SPEED_HIGH]
         self._prev_speed = speed
         self.set_speed(speed)
     
@@ -85,13 +79,11 @@ class LutronFan(LutronDevice, FanEntity):
         """Set speed of the fan"""
         self._speed = speed
         if speed not in SPEED_MAPPING:
-            _LOGGER.debug("Unknown speed %s, setting to %s", speed, SPEED_HIGH)
-            self._speed = SPEED_HIGH
+            _LOGGER.debug("Unknown speed %s, setting to %s", speed, SPEED_MAPPING[SPEED_HIGH])
+            self._speed = SPEED_MAPPING[SPEED_HIGH]
         else:
             self._speed = self._prev_speed
-            # self._speed = SPEED_MAPPING[SPEED_MEDIUM_HIGH]
             
-        # print('+++++++++++++++++++++ ' +str(self._lutron_device)+ ', '+str(self._speed))
         self._lutron_device.level = SPEED_MAPPING[self._speed]
 
     def turn_off(self, **kwargs):
@@ -100,13 +92,9 @@ class LutronFan(LutronDevice, FanEntity):
 
     # def update(self, self._speed):
     def update(self):
-        print('........Inside of update_state...')
         """Update internal state and fan speed."""
         if self._prev_speed is None:
             self._prev_speed = self._lutron_device.level
-
-        print(str(self._lutron_device.level))
-
 
         self._is_on = self._lutron_device.level > SPEED_MAPPING[SPEED_OFF]
         if self._lutron_device.level in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, SPEED_MAPPING[SPEED_HIGH] + 1):

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -35,7 +35,7 @@ class LutronFan(LutronDevice, FanEntity):
         self._area_name = str(area_name)
         self._name = str(area_name) + ' Fan'
         self._is_on = False
-        self._speed = SPEED_OFF
+        self._speed = SPEED_MAPPING[SPEED_OFF]
         self._prev_speed = None
         super().__init__(area_name, lutron_device, controller)
 
@@ -53,7 +53,7 @@ class LutronFan(LutronDevice, FanEntity):
     def speed(self):
         """Return the brightness of the fan."""
         new_speed = self._lutron_device.last_level()
-        if new_speed != SPEED_OFF:
+        if new_speed != SPEED_MAPPING[SPEED_OFF]:
             self._prev_speed = new_speed
         return new_speed
 
@@ -90,32 +90,37 @@ class LutronFan(LutronDevice, FanEntity):
         else:
             self._speed = self._prev_speed                                        # TODO returns 0.0 right now....
             # self._speed = SPEED_MAPPING[SPEED_MEDIUM_HIGH]
-            print('+++++++++++++++++++++ ' +str(self._speed))
+            
+        print('+++++++++++++++++++++ ' +str(self._lutron_device)+ ', '+str(self._speed))
         self._lutron_device.level = SPEED_MAPPING[self._speed]
 
     def turn_off(self, **kwargs):
         """Turn the fan off."""
-        self._lutron_device.level = SPEED_OFF
+        self._lutron_device.level = SPEED_MAPPING[SPEED_OFF]
 
-    def update_state(self, value):
+    # def update(self, self._speed):
+    def update(self):
         print('........Inside of update_state...')
         """Update internal state and fan speed."""
         if self._prev_speed is None:
             self._prev_speed = self._lutron_device.level
 
-        self._is_on = value > SPEED_MAPPING[SPEED_OFF]
-        if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, SPEED_MAPPING[SPEED_HIGH] + 1):
-            self._speed = SPEED_HIGH
-        elif value in range(SPEED_MAPPING[SPEED_MEDIUM] + 1, SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1):
+        print(str(self._lutron_device.level))
+
+
+        self._is_on = self._lutron_device.level > SPEED_MAPPING[SPEED_OFF]
+        if self._lutron_device.level in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, SPEED_MAPPING[SPEED_HIGH] + 1):
+            self._lutron_device.level = SPEED_MAPPING[SPEED_HIGH]
+        elif self._lutron_device.level in range(SPEED_MAPPING[SPEED_MEDIUM] + 1, SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1):
             # 51% - 55% are missing from Lutron integration protocol
             # we will treat as medium_high
-            self._speed = SPEED_MEDIUM_HIGH
-        elif value in range(SPEED_MAPPING[SPEED_LOW] + 1, SPEED_MAPPING[SPEED_MEDIUM] + 1):
-            self._speed = SPEED_MEDIUM
-        elif value in range(SPEED_MAPPING[SPEED_OFF] + 1, SPEED_MAPPING[SPEED_LOW] + 1):
-            self._speed = SPEED_LOW
-        elif value == SPEED_MAPPING[SPEED_OFF]:
-            self._speed = SPEED_OFF
+            self._lutron_device.level = SPEED_MAPPING[SPEED_MEDIUM_HIGH]
+        elif self._lutron_device.level in range(SPEED_MAPPING[SPEED_LOW] + 1, SPEED_MAPPING[SPEED_MEDIUM] + 1):
+            self._lutron_device.level = SPEED_MAPPING[SPEED_MEDIUM]
+        elif self._lutron_device.level in range(SPEED_MAPPING[SPEED_OFF] + 1, SPEED_MAPPING[SPEED_LOW] + 1):
+            self._lutron_device.level = SPEED_MAPPING[SPEED_LOW]
+        elif self._lutron_device.level == SPEED_MAPPING[SPEED_OFF]:
+            self._lutron_device.level = SPEED_MAPPING[SPEED_OFF]
         _LOGGER.debug("Fan speed is %s", self._speed)
 
     @property

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -45,11 +45,6 @@ class LutronFan(LutronDevice, FanEntity):
         super().__init__(area_name, lutron_device, controller)
 
     @property
-    def integration(self):
-        """Return the Integration ID."""
-        return self._integration
-
-    @property
     def name(self):
         """Return the display name of this fan."""
         return self._name

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,11 +1,11 @@
 """Support for Lutron fans."""
 import logging
 
-from homeassistant.components.fan import (SPEED_LOW, 
-                                          SPEED_MEDIUM, 
-                                          SPEED_HIGH, 
-                                          SPEED_OFF, 
-                                          SUPPORT_SET_SPEED, 
+from homeassistant.components.fan import (SPEED_LOW,
+                                          SPEED_MEDIUM,
+                                          SPEED_HIGH,
+                                          SPEED_OFF,
+                                          SUPPORT_SET_SPEED,
                                           FanEntity)
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
 
@@ -31,7 +31,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(devs, True)
 
-    
+
 class LutronFan(LutronDevice, FanEntity):
     """Representation of a Lutron Fan, including dimmable."""
 
@@ -78,8 +78,9 @@ class LutronFan(LutronDevice, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, 
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM,
                 SPEED_MEDIUM_HIGH, SPEED_HIGH]
+
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
@@ -108,18 +109,18 @@ class LutronFan(LutronDevice, FanEntity):
         """Update internal state and fan speed."""
         value = self._lutron_device.level
         self._is_on = value > SPEED_MAPPING[SPEED_OFF]
-        if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, 
+        if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1,
                           SPEED_MAPPING[SPEED_HIGH] + 1):
             self._speed = SPEED_HIGH
-        elif value in range(SPEED_MAPPING[SPEED_MEDIUM] + 1, 
+        elif value in range(SPEED_MAPPING[SPEED_MEDIUM] + 1,
                             SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1):
             # 51% - 55% are missing from Lutron integration protocol
             # we will treat as medium_high
             self._speed = SPEED_MEDIUM_HIGH
-        elif value in range(SPEED_MAPPING[SPEED_LOW] + 1, 
+        elif value in range(SPEED_MAPPING[SPEED_LOW] + 1,
                             SPEED_MAPPING[SPEED_MEDIUM] + 1):
             self._speed = SPEED_MEDIUM
-        elif value in range(SPEED_MAPPING[SPEED_OFF] + 1, 
+        elif value in range(SPEED_MAPPING[SPEED_OFF] + 1,
                             SPEED_MAPPING[SPEED_LOW] + 1):
             self._speed = SPEED_LOW
         elif value == SPEED_MAPPING[SPEED_OFF]:

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,8 +1,12 @@
 """Support for Lutron fans."""
 import logging
 
-from homeassistant.components.fan import (SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SPEED_OFF, SUPPORT_SET_SPEED, FanEntity)
-
+from homeassistant.components.fan import (SPEED_LOW, 
+                                          SPEED_MEDIUM, 
+                                          SPEED_HIGH, 
+                                          SPEED_OFF, 
+                                          SUPPORT_SET_SPEED, 
+                                          FanEntity)
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -16,6 +20,7 @@ SPEED_MAPPING = {
     SPEED_HIGH: 100
 }
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Lutron fans."""
     devs = []
@@ -26,6 +31,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(devs, True)
 
+    
 class LutronFan(LutronDevice, FanEntity):
     """Representation of a Lutron Fan, including dimmable."""
 
@@ -72,8 +78,8 @@ class LutronFan(LutronDevice, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_MEDIUM_HIGH, SPEED_HIGH]
-
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, 
+                SPEED_MEDIUM_HIGH, SPEED_HIGH]
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
@@ -102,15 +108,19 @@ class LutronFan(LutronDevice, FanEntity):
         """Update internal state and fan speed."""
         value = self._lutron_device.level
         self._is_on = value > SPEED_MAPPING[SPEED_OFF]
-        if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, SPEED_MAPPING[SPEED_HIGH] + 1):
+        if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, 
+                          SPEED_MAPPING[SPEED_HIGH] + 1):
             self._speed = SPEED_HIGH
-        elif value in range(SPEED_MAPPING[SPEED_MEDIUM] + 1, SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1):
+        elif value in range(SPEED_MAPPING[SPEED_MEDIUM] + 1, 
+                            SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1):
             # 51% - 55% are missing from Lutron integration protocol
             # we will treat as medium_high
             self._speed = SPEED_MEDIUM_HIGH
-        elif value in range(SPEED_MAPPING[SPEED_LOW] + 1, SPEED_MAPPING[SPEED_MEDIUM] + 1):
+        elif value in range(SPEED_MAPPING[SPEED_LOW] + 1, 
+                            SPEED_MAPPING[SPEED_MEDIUM] + 1):
             self._speed = SPEED_MEDIUM
-        elif value in range(SPEED_MAPPING[SPEED_OFF] + 1, SPEED_MAPPING[SPEED_LOW] + 1):
+        elif value in range(SPEED_MAPPING[SPEED_OFF] + 1, 
+                            SPEED_MAPPING[SPEED_LOW] + 1):
             self._speed = SPEED_LOW
         elif value == SPEED_MAPPING[SPEED_OFF]:
             self._speed = SPEED_OFF

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,0 +1,124 @@
+"""Support for Lutron fans."""
+import logging
+
+from homeassistant.components.fan import (SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SPEED_OFF, SUPPORT_SET_SPEED, FanEntity)
+# from homeassistant.const import (CONF_DEVICES, CONF_HOST, CONF_MAC, CONF_NAME, CONF_ID)
+
+from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+SPEED_MEDIUM_HIGH = 'medium_high'
+SPEED_MAPPING = {
+    SPEED_OFF: 0,
+    SPEED_LOW: 25,
+    SPEED_MEDIUM: 50,
+    SPEED_MEDIUM_HIGH: 75,
+    SPEED_HIGH: 100
+}
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Lutron fans."""
+    devs = []
+
+    for (area_name, device) in hass.data[LUTRON_DEVICES]['fan']:
+        dev = LutronFan(area_name, device, hass.data[LUTRON_CONTROLLER])
+        devs.append(dev)
+
+    add_entities(devs, True)
+
+class LutronFan(LutronDevice, FanEntity):
+    """Representation of a Lutron Fan, including dimmable."""
+
+    def __init__(self, area_name, lutron_device, controller):
+        """Initialize the fan."""
+        self._area_name = str(area_name)
+        self._name = str(area_name) + ' Fan'
+        self._is_on = False
+        self._speed = SPEED_OFF
+        self._prev_speed = None
+        super().__init__(area_name, lutron_device, controller)
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        # return self._lutron_device.last_level() > SPEED_OFF
+        return self._is_on
+
+    # @property
+    # def speed(self) -> str:
+    #     """Return the current speed."""
+    #     return self._speed
+    @property
+    def speed(self):
+        """Return the brightness of the fan."""
+        new_speed = self._lutron_device.last_level()
+        if new_speed != SPEED_OFF:
+            self._prev_speed = new_speed
+        return new_speed
+
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_MEDIUM_HIGH, SPEED_HIGH]
+
+    @property
+    # def state_attributes(self):
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {'lutron_integration_id': self._lutron_device.id}
+        return attr
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_SET_SPEED
+
+    def turn_on(self, speed: str = None, **kwargs):
+        """Instruct the fan to turn on."""
+        if speed is None:
+            speed = SPEED_HIGH
+        self._prev_speed = speed
+        self.set_speed(speed)
+    
+    def set_speed(self, speed: str):
+        """Set speed of the fan"""
+        self._speed = speed
+        if speed not in SPEED_MAPPING:
+            _LOGGER.debug("Unknown speed %s, setting to %s", speed, SPEED_HIGH)
+            self._speed = SPEED_HIGH
+        else:
+            self._speed = self._prev_speed                                        # TODO returns 0.0 right now....
+            # self._speed = SPEED_MAPPING[SPEED_MEDIUM_HIGH]
+            print('+++++++++++++++++++++ ' +str(self._speed))
+        self._lutron_device.level = SPEED_MAPPING[self._speed]
+
+    def turn_off(self, **kwargs):
+        """Turn the fan off."""
+        self._lutron_device.level = SPEED_OFF
+
+    def update_state(self, value):
+        print('........Inside of update_state...')
+        """Update internal state and fan speed."""
+        if self._prev_speed is None:
+            self._prev_speed = self._lutron_device.level
+
+        self._is_on = value > SPEED_MAPPING[SPEED_OFF]
+        if value in range(SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1, SPEED_MAPPING[SPEED_HIGH] + 1):
+            self._speed = SPEED_HIGH
+        elif value in range(SPEED_MAPPING[SPEED_MEDIUM] + 1, SPEED_MAPPING[SPEED_MEDIUM_HIGH] + 1):
+            # 51% - 55% are missing from Lutron integration protocol
+            # we will treat as medium_high
+            self._speed = SPEED_MEDIUM_HIGH
+        elif value in range(SPEED_MAPPING[SPEED_LOW] + 1, SPEED_MAPPING[SPEED_MEDIUM] + 1):
+            self._speed = SPEED_MEDIUM
+        elif value in range(SPEED_MAPPING[SPEED_OFF] + 1, SPEED_MAPPING[SPEED_LOW] + 1):
+            self._speed = SPEED_LOW
+        elif value == SPEED_MAPPING[SPEED_OFF]:
+            self._speed = SPEED_OFF
+        _LOGGER.debug("Fan speed is %s", self._speed)
+
+    @property
+    def name(self):
+        """Return the display name of this fan."""
+        return self._name


### PR DESCRIPTION
## Breaking Change:
Yes. Currently fans with the Lutron component are treated as dimmers. If this PR gets merged, they'll be treated (properly) as a fan

## Description:
Extended support for Lutron Radio Ra2 fans

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9895

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
