### PR TITLE
OpenWrt Luci RPC Device Tracker Module Bump

### DIFF
--- a/homeassistant/components/luci/manifest.json
+++ b/homeassistant/components/luci/manifest.json
@@ -3,7 +3,7 @@
   "name": "Luci",
   "documentation": "https://www.home-assistant.io/components/luci",
   "requirements": [
-    "openwrt-luci-rpc==1.0.5"
+    "openwrt-luci-rpc==1.1.0"
   ],
   "dependencies": [],
   "codeowners": ["@fbradyirl"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -872,7 +872,7 @@ opensensemap-api==0.1.5
 openwebifpy==3.1.1
 
 # homeassistant.components.luci
-openwrt-luci-rpc==1.0.5
+openwrt-luci-rpc==1.1.0
 
 # homeassistant.components.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
## Description:

Pip module bump contains fix for older OpenWrt 15.05 based routers.

**Related issue:** fixes https://github.com/fbradyirl/openwrt-luci-rpc/issues/25

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html