### PR TITLE
Tado AIR_CONDITIONING module was not working propertly

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -115,12 +115,15 @@ class TadoDataStore:
         self.tado.resetZoneOverlay(zone_id)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg
 
-    def set_zone_overlay(self, zone_id, mode, temperature=None, duration=None):
+    def set_zone_overlay(self, zone_id, overlayMode, temperature=None, 
+                         duration=None, deviceType='HEATING', mode=None):
         """Wrap for setZoneOverlay(..)."""
-        self.tado.setZoneOverlay(zone_id, mode, temperature, duration)
+        self.tado.setZoneOverlay(zone_id, overlayMode, temperature, 
+                                 duration, deviceType, 'ON', mode)
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg
 
-    def set_zone_off(self, zone_id, mode):
+    def set_zone_off(self, zone_id, overlayMode, deviceType='HEATING'):
         """Set a zone to off."""
-        self.tado.setZoneOverlay(zone_id, mode, None, None, 'HEATING', 'OFF')
+        self.tado.setZoneOverlay(zone_id, overlayMode, None, None, 
+                                 deviceType, 'OFF')
         self.update(no_throttle=True)  # pylint: disable=unexpected-keyword-arg

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -79,7 +79,13 @@ def create_climate_device(tado, hass, zone, name, zone_id):
     ac_mode = capabilities['type'] == 'AIR_CONDITIONING'
 
     if ac_mode:
-        temperatures = capabilities['HEAT']['temperatures']
+        # Only use heat if available 
+        # (you don't have to setup a heat mode, but cool is required)
+        # Heat is preferred as it generally has a lower minimum temperature
+        if 'HEAT' in capabilities:
+            temperatures = capabilities['HEAT']['temperatures']
+        else:
+            temperatures = capabilities['COOL']['temperatures']
     elif 'temperatures' in capabilities:
         temperatures = capabilities['temperatures']
     else:
@@ -371,13 +377,24 @@ class TadoClimate(ClimateDevice):
         if self._current_operation == CONST_MODE_OFF:
             _LOGGER.info("Switching mytado.com to OFF for zone %s",
                          self.zone_name)
-            self._store.set_zone_off(self.zone_id, CONST_OVERLAY_MANUAL)
+            if self.ac_mode:
+                self._store.set_zone_off(self.zone_id, CONST_OVERLAY_MANUAL,
+                    'AIR_CONDITIONING')
+            else:
+                self._store.set_zone_off(self.zone_id, CONST_OVERLAY_MANUAL,
+                    'HEATING')
             self._overlay_mode = self._current_operation
             return
 
         _LOGGER.info("Switching mytado.com to %s mode for zone %s",
                      self._current_operation, self.zone_name)
-        self._store.set_zone_overlay(
-            self.zone_id, self._current_operation, self._target_temp)
+        if self.ac_mode:
+            self._store.set_zone_overlay(self.zone_id, 
+              self._current_operation, 
+              self._target_temp, None, 'AIR_CONDITIONING', 'COOL')
+        else:
+            self._store.set_zone_overlay(self.zone_id, 
+              self._current_operation, 
+              self._target_temp, None, 'HEATING')
 
         self._overlay_mode = self._current_operation


### PR DESCRIPTION
AIR_CONDITIONING modules differs from HEATING module int he parameters.

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
It is NOT a breaking change

## Description:
When AIR_CONDITIONING is configured, some optional parameter needs to be specified.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [ YES] The code change is tested and works locally.
  - [ YES] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ OK] There is no commented out code in this PR.
  - [ OK] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ N/A] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ N/A] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [N/A ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ N/A] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
