### PR TITLE
Make Netatmo climate presets prettier

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -25,8 +25,8 @@ from .const import DATA_NETATMO_AUTH
 
 _LOGGER = logging.getLogger(__name__)
 
-PRESET_FROST_GUARD = 'frost guard'
-PRESET_SCHEDULE = 'schedule'
+PRESET_FROST_GUARD = 'Frost Guard'
+PRESET_SCHEDULE = 'Schedule'
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE)
 SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF]
@@ -50,9 +50,19 @@ PRESET_MAP_NETATMO = {
     STATE_NETATMO_OFF: STATE_NETATMO_OFF
 }
 
+NETATMO_MAP_PRESET = {
+    STATE_NETATMO_HG: PRESET_FROST_GUARD,
+    STATE_NETATMO_MAX: PRESET_BOOST,
+    STATE_NETATMO_SCHEDULE: PRESET_SCHEDULE,
+    STATE_NETATMO_AWAY: PRESET_AWAY,
+    STATE_NETATMO_OFF: STATE_NETATMO_OFF,
+    STATE_NETATMO_MANUAL: 'Manual',
+}
+
 HVAC_MAP_NETATMO = {
     STATE_NETATMO_SCHEDULE: HVAC_MODE_AUTO,
     STATE_NETATMO_HG: HVAC_MODE_AUTO,
+    PRESET_FROST_GUARD: HVAC_MODE_AUTO,
     STATE_NETATMO_MAX: HVAC_MODE_HEAT,
     STATE_NETATMO_OFF: HVAC_MODE_OFF,
     STATE_NETATMO_MANUAL: HVAC_MODE_AUTO,
@@ -307,8 +317,9 @@ class NetatmoThermostat(ClimateDevice):
                 self._data.room_status[self._room_id]['current_temperature']
             self._target_temperature = \
                 self._data.room_status[self._room_id]['target_temperature']
-            self._preset = \
+            self._preset = NETATMO_MAP_PRESET[
                 self._data.room_status[self._room_id]["setpoint_mode"]
+            ]
             self._hvac_mode = HVAC_MAP_NETATMO[self._preset]
             self._battery_level = \
                 self._data.room_status[self._room_id].get('battery_level')


### PR DESCRIPTION
## Description:
Make the preset text more user friendly.

**Related issue (if applicable):** fixes #25229

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
