### PR TITLE
Only poll HomeKit connection once for all entities on a single bridge/pairing

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -35,6 +35,8 @@ class HomeKitEntity(Entity):
         self._chars = {}
         self.setup()
 
+        accessory.entities[(self._aid, self._iid)] = self
+
     def setup(self):
         """Configure an entity baed on its HomeKit characterstics metadata."""
         # pylint: disable=import-error

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -227,12 +227,18 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_remove_entry(hass, entry):
-    """Cleanup caches before removing config entry."""
+async def async_unload_entry(hass, entry):
+    """Disconnect from HomeKit devices before unloading entry."""
     hkid = entry.data['AccessoryPairingID']
 
     if hkid in hass.data[KNOWN_DEVICES]:
         connection = hass.data[KNOWN_DEVICES][hkid]
         await connection.async_unload()
 
+    return True
+
+
+async def async_remove_entry(hass, entry):
+    """Cleanup caches before removing config entry."""
+    hkid = entry.data['AccessoryPairingID']
     hass.data[ENTITY_MAP].async_delete_map(hkid)

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -1,6 +1,7 @@
 """Support for Homekit device discovery."""
 import logging
 
+from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -123,7 +124,8 @@ class HomeKitEntity(Entity):
         # pylint: disable=not-callable
         setup_fn(char)
 
-    async def async_state_changed(self):
+    @callback
+    def async_state_changed(self):
         """Collect new data from bridge and update the entity state in hass."""
         accessory_state = self._accessory.current_state.get(self._aid, {})
         for iid, result in accessory_state.items():

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -1,10 +1,14 @@
 """Helpers for managing a pairing with a HomeKit accessory or bridge."""
 import asyncio
+import datetime
 import logging
+
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import HOMEKIT_ACCESSORY_DISPATCH, ENTITY_MAP
 
 
+DEFAULT_SCAN_INTERVAL = datetime.timedelta(seconds=60)
 RETRY_INTERVAL = 60  # seconds
 
 _LOGGER = logging.getLogger(__name__)
@@ -98,6 +102,12 @@ class HKDevice():
 
         self.add_entities()
 
+        async_track_time_interval(
+            self.hass,
+            self.async_update,
+            DEFAULT_SCAN_INTERVAL
+        )
+
         return True
 
     async def async_refresh_entity_map(self, config_num):
@@ -183,6 +193,11 @@ class HKDevice():
                     )
                 )
                 self.platforms.add(platform)
+
+    async def async_update(self):
+        """Poll state of all entities attached to this bridge/accessory."""
+        _LOGGER.debug("Starting HomeKit controller update")
+        _LOGGER.debug("Finished HomeKit controller update")
 
     async def get_characteristics(self, *args, **kwargs):
         """Read latest state from homekit accessory."""

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -79,7 +79,7 @@ class HKDevice():
 
         # This just tracks aid/iid pairs so we know if a HK service has been
         # mapped to a HA entity.
-        self.entities = {}
+        self.entities = []
 
         # There are multiple entities sharing a single connection - only
         # allow one entity to use pairing at once.
@@ -234,6 +234,7 @@ class HKDevice():
 
                 for listener in callbacks:
                     if listener(aid, service):
+                        self.entities.append((aid, iid))
                         break
 
     def async_load_platforms(self):

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -79,7 +79,7 @@ class HKDevice():
 
         # This just tracks aid/iid pairs so we know if a HK service has been
         # mapped to a HA entity.
-        self.entities = []
+        self.entities = {}
 
         # There are multiple entities sharing a single connection - only
         # allow one entity to use pairing at once.
@@ -169,7 +169,6 @@ class HKDevice():
 
                 for listener in callbacks:
                     if listener(aid, service):
-                        self.entities.append((aid, iid))
                         break
 
     def async_load_platforms(self):

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -97,7 +97,7 @@ class HKDevice():
         # Key is a (accessory_id, characteristic_id) tuple.
         self.current_state = {}
 
-        self._pollable_characteristics = []
+        self.pollable_characteristics = []
 
         # If this is set polling is active and can be disabled by calling
         # this method.
@@ -105,12 +105,12 @@ class HKDevice():
 
     def add_pollable_characteristics(self, characteristics):
         """Add (aid, iid) pairs that we need to poll."""
-        self._pollable_characteristics.extend(characteristics)
+        self.pollable_characteristics.extend(characteristics)
 
     def remove_pollable_characteristics(self, accessory_id):
         """Remove all pollable characteristics by accessory id."""
-        self._pollable_characteristics = [
-            char for char in self._pollable_characteristics
+        self.pollable_characteristics = [
+            char for char in self.pollable_characteristics
             if char[0] != accessory_id
         ]
 
@@ -266,7 +266,7 @@ class HKDevice():
             AccessoryDisconnectedError, AccessoryNotFoundError,
             EncryptionError)
 
-        if not self._pollable_characteristics:
+        if not self.pollable_characteristics:
             _LOGGER.debug(
                 "HomeKit connection not polling any characteristics."
             )
@@ -276,7 +276,7 @@ class HKDevice():
 
         try:
             new_values_dict = await self.get_characteristics(
-                self._pollable_characteristics,
+                self.pollable_characteristics,
             )
         except AccessoryNotFoundError:
             # Not only did the connection fail, but also the accessory is not

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -226,6 +226,9 @@ class HKDevice():
             for char in entity.pollable_characteristics:
                 chars_to_poll[char] = entity
 
+        if not chars_to_poll:
+            return
+
         try:
             new_values_dict = await self.get_characteristics(
                 list(chars_to_poll.keys())

--- a/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
@@ -14,7 +14,7 @@ async def test_aqara_gateway_setup(hass):
     """Test that a Aqara Gateway can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(
         hass, 'aqara_gateway.json')
-    pairing = await setup_test_accessories(hass, accessories)
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
@@ -24,7 +24,9 @@ async def test_aqara_gateway_setup(hass):
     assert alarm.unique_id == 'homekit-0000000123456789-66304'
 
     alarm_helper = Helper(
-        hass, 'alarm_control_panel.aqara_hub_1563', pairing, accessories[0])
+        hass, 'alarm_control_panel.aqara_hub_1563', pairing, accessories[0],
+        config_entry
+    )
     alarm_state = await alarm_helper.poll_and_get_state()
     assert alarm_state.attributes['friendly_name'] == 'Aqara Hub-1563'
 
@@ -33,7 +35,7 @@ async def test_aqara_gateway_setup(hass):
     assert light.unique_id == 'homekit-0000000123456789-65792'
 
     light_helper = Helper(
-        hass, 'light.aqara_hub_1563', pairing, accessories[0])
+        hass, 'light.aqara_hub_1563', pairing, accessories[0], config_entry)
     light_state = await light_helper.poll_and_get_state()
     assert light_state.attributes['friendly_name'] == 'Aqara Hub-1563'
     assert light_state.attributes['supported_features'] == (

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -19,7 +19,7 @@ LIGHT_ON = ('lightbulb', 'on')
 async def test_koogeek_ls1_setup(hass):
     """Test that a Koogeek LS1 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, 'koogeek_ls1.json')
-    pairing = await setup_test_accessories(hass, accessories)
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
@@ -27,7 +27,13 @@ async def test_koogeek_ls1_setup(hass):
     entry = entity_registry.async_get('light.koogeek_ls1_20833f')
     assert entry.unique_id == 'homekit-AAAA011111111111-7'
 
-    helper = Helper(hass, 'light.koogeek_ls1_20833f', pairing, accessories[0])
+    helper = Helper(
+        hass,
+        'light.koogeek_ls1_20833f',
+        pairing,
+        accessories[0],
+        config_entry
+    )
     state = await helper.poll_and_get_state()
 
     # Assert that the friendly name is detected correctly
@@ -58,9 +64,11 @@ async def test_recover_from_failure(hass, utcnow, failure_cls):
     See https://github.com/home-assistant/home-assistant/issues/18949
     """
     accessories = await setup_accessories_from_file(hass, 'koogeek_ls1.json')
-    pairing = await setup_test_accessories(hass, accessories)
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    helper = Helper(hass, 'light.koogeek_ls1_20833f', pairing, accessories[0])
+    helper = Helper(
+        hass, 'light.koogeek_ls1_20833f', pairing, accessories[0], config_entry
+    )
 
     # Set light state on fake device to off
     helper.characteristics[LIGHT_ON].set_value(False)

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -80,7 +80,8 @@ async def test_recover_from_failure(hass, utcnow, failure_cls):
         state = await helper.poll_and_get_state()
         assert state.state == 'off'
 
-        get_char.assert_called_with([(1, 8), (1, 9), (1, 10), (1, 11)])
+        chars = get_char.call_args[0][0]
+        assert set(chars) == {(1, 8), (1, 9), (1, 10), (1, 11)}
 
     # Test that entity changes state when network error goes away
     next_update += timedelta(seconds=60)

--- a/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
+++ b/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
@@ -14,14 +14,16 @@ from tests.components.homekit_controller.common import (
 async def test_lennox_e30_setup(hass):
     """Test that a Lennox E30 can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, 'lennox_e30.json')
-    pairing = await setup_test_accessories(hass, accessories)
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
     climate = entity_registry.async_get('climate.lennox')
     assert climate.unique_id == 'homekit-XXXXXXXX-100'
 
-    climate_helper = Helper(hass, 'climate.lennox', pairing, accessories[0])
+    climate_helper = Helper(
+        hass, 'climate.lennox', pairing, accessories[0], config_entry
+    )
     climate_state = await climate_helper.poll_and_get_state()
     assert climate_state.attributes['friendly_name'] == 'Lennox'
     assert climate_state.attributes['supported_features'] == (

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -152,3 +152,16 @@ async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
     assert state.state == 'on'
     assert state.attributes['brightness'] == 255
     assert state.attributes['color_temp'] == 400
+
+
+async def test_light_unloaded(hass, utcnow):
+    """Test transition to and from unavailable state."""
+    bulb = create_lightbulb_service_with_color_temp()
+    helper = await setup_test_component(hass, [bulb])
+
+    # Initial state is that the light is off
+    state = await helper.poll_and_get_state()
+    assert state.state == 'off'
+
+    unload_result = await helper.config_entry.async_unload(hass)
+    assert unload_result is True

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -1,4 +1,6 @@
 """Basic checks for HomeKitSwitch."""
+from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
+
 from tests.components.homekit_controller.common import (
     FakeService, setup_test_component)
 
@@ -155,7 +157,7 @@ async def test_light_becomes_unavailable_but_recovers(hass, utcnow):
 
 
 async def test_light_unloaded(hass, utcnow):
-    """Test transition to and from unavailable state."""
+    """Test entity and HKDevice are correctly unloaded."""
     bulb = create_lightbulb_service_with_color_temp()
     helper = await setup_test_component(hass, [bulb])
 
@@ -165,3 +167,10 @@ async def test_light_unloaded(hass, utcnow):
 
     unload_result = await helper.config_entry.async_unload(hass)
     assert unload_result is True
+
+    # Make sure entity is unloaded
+    assert hass.states.get(helper.entity_id) is None
+
+    # Make sure HKDevice is no longer set to poll this accessory
+    conn = hass.data[KNOWN_DEVICES]['00:00:00:00:00:00']
+    assert not conn.pollable_characteristics


### PR DESCRIPTION
## Description:

This moves the bulk of HomeKitEntity.async_update to the connection object. It is then run once for all entities on the same connection, rather than once for each entity. For example, if you have 15 bridges with 5 sensors each, right now we will need to execute 75 polls on the thread pool. This is a setup a real user has (#25178). If some of these sensors were low power enough and don't have multi-threaded HTTP implementations some of these polls could end up being serialized, and block other threads from starting.

This is also groundwork for moving from polling to event based updates - we'll hold open one connection to the bridge rather than one for each entity.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
