### PR TITLE
bump neato pybotvac version

### DIFF
--- a/homeassistant/components/neato/manifest.json
+++ b/homeassistant/components/neato/manifest.json
@@ -3,7 +3,7 @@
   "name": "Neato",
   "documentation": "https://www.home-assistant.io/components/neato",
   "requirements": [
-    "pybotvac==0.0.13"
+    "pybotvac==0.0.15"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1051,7 +1051,7 @@ pyblackbird==0.5
 # pybluez==0.22
 
 # homeassistant.components.neato
-pybotvac==0.0.13
+pybotvac==0.0.15
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.8


### PR DESCRIPTION
#Description:
As per https://github.com/stianaske/pybotvac/issues/30, pybotvac had issues with non-US locales.
This was fixed, and delivered into version 0.0.15.

https://github.com/stianaske/pybotvac/releases/tag/v0.0.15


## Checklist:
  - [x] The code change is tested and works locally.
  - [pending CI] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [N/A-trivial] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [?] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [N/A] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
