### PR TITLE
ecobee Preset Fix

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -326,7 +326,7 @@ class Thermostat(ClimateDevice):
             self.set_temp_hold(self.current_temperature)
 
         elif preset_mode in (
-            PRESET_HOLD_NEXT_TRANSITION, PRESET_HOLD_INDEFINITE):
+                PRESET_HOLD_NEXT_TRANSITION, PRESET_HOLD_INDEFINITE):
             self.data.ecobee.set_climate_hold(
                 self.thermostat_index, PRESET_TO_ECOBEE_HOLD[preset_mode],
                 self.hold_preference())

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -169,9 +169,6 @@ class Thermostat(ClimateDevice):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        if self.thermostat['settings']['useCelsius']:
-            return TEMP_CELSIUS
-
         return TEMP_FAHRENHEIT
 
     @property

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -31,6 +31,8 @@ PRESET_AUX_HEAT_ONLY = 'aux_heat_only'
 PRESET_HOLD_NEXT_TRANSITION = 'next_transition'
 PRESET_HOLD_INDEFINITE = 'indefinite'
 AWAY_MODE = 'awayMode'
+PRESET_HOME = 'home'
+PRESET_SLEEP = 'sleep'
 
 # Order matters, because for reverse mapping we don't want to map HEAT to AUX
 ECOBEE_HVAC_TO_HASS = collections.OrderedDict([
@@ -48,9 +50,8 @@ PRESET_TO_ECOBEE_HOLD = {
 
 PRESET_MODES = [
     PRESET_AWAY,
-    PRESET_TEMPERATURE,
-    PRESET_HOLD_NEXT_TRANSITION,
-    PRESET_HOLD_INDEFINITE
+    PRESET_HOME,
+    PRESET_SLEEP
 ]
 
 SERVICE_SET_FAN_MIN_ON_TIME = 'ecobee_set_fan_min_on_time'
@@ -168,6 +169,9 @@ class Thermostat(ClimateDevice):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
+        if self.thermostat['settings']['useCelsius']:
+            return TEMP_CELSIUS
+
         return TEMP_FAHRENHEIT
 
     @property
@@ -305,9 +309,9 @@ class Thermostat(ClimateDevice):
         """Return true if aux heater."""
         return 'auxHeat' in self.thermostat['equipmentStatus']
 
-    def set_preset(self, preset):
+    def set_preset_mode(self, preset_mode):
         """Activate a preset."""
-        if preset == self.preset_mode:
+        if preset_mode == self.preset_mode:
             return
 
         self.update_without_throttle = True
@@ -317,23 +321,25 @@ class Thermostat(ClimateDevice):
             self.data.ecobee.delete_vacation(
                 self.thermostat_index, self.vacation)
 
-        if preset == PRESET_AWAY:
+        if preset_mode == PRESET_AWAY:
             self.data.ecobee.set_climate_hold(self.thermostat_index, 'away',
                                               'indefinite')
 
-        elif preset == PRESET_TEMPERATURE:
+        elif preset_mode == PRESET_TEMPERATURE:
             self.set_temp_hold(self.current_temperature)
 
-        elif preset in (PRESET_HOLD_NEXT_TRANSITION, PRESET_HOLD_INDEFINITE):
+        elif preset_mode in (PRESET_HOLD_NEXT_TRANSITION, PRESET_HOLD_INDEFINITE):
             self.data.ecobee.set_climate_hold(
-                self.thermostat_index, PRESET_TO_ECOBEE_HOLD[preset],
+                self.thermostat_index, PRESET_TO_ECOBEE_HOLD[preset_mode],
                 self.hold_preference())
 
-        elif preset is None:
+        elif preset_mode is None:
             self.data.ecobee.resume_program(self.thermostat_index)
 
         else:
-            _LOGGER.warning("Received invalid preset: %s", preset)
+          self.data.ecobee.set_climate_hold(
+            self.thermostat_index, preset_mode, self.hold_preference())
+          self.update_without_throttle = True
 
     @property
     def preset_modes(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -325,7 +325,8 @@ class Thermostat(ClimateDevice):
         elif preset_mode == PRESET_TEMPERATURE:
             self.set_temp_hold(self.current_temperature)
 
-        elif preset_mode in (PRESET_HOLD_NEXT_TRANSITION, PRESET_HOLD_INDEFINITE):
+        elif preset_mode in (PRESET_HOLD_NEXT_TRANSITION,
+        PRESET_HOLD_INDEFINITE):
             self.data.ecobee.set_climate_hold(
                 self.thermostat_index, PRESET_TO_ECOBEE_HOLD[preset_mode],
                 self.hold_preference())
@@ -334,9 +335,9 @@ class Thermostat(ClimateDevice):
             self.data.ecobee.resume_program(self.thermostat_index)
 
         else:
-          self.data.ecobee.set_climate_hold(
-            self.thermostat_index, preset_mode, self.hold_preference())
-          self.update_without_throttle = True
+            self.data.ecobee.set_climate_hold(
+                self.thermostat_index, preset_mode, self.hold_preference())
+            self.update_without_throttle = True
 
     @property
     def preset_modes(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -325,8 +325,8 @@ class Thermostat(ClimateDevice):
         elif preset_mode == PRESET_TEMPERATURE:
             self.set_temp_hold(self.current_temperature)
 
-        elif preset_mode in (PRESET_HOLD_NEXT_TRANSITION,
-        PRESET_HOLD_INDEFINITE):
+        elif preset_mode in (
+            PRESET_HOLD_NEXT_TRANSITION, PRESET_HOLD_INDEFINITE):
             self.data.ecobee.set_climate_hold(
                 self.thermostat_index, PRESET_TO_ECOBEE_HOLD[preset_mode],
                 self.hold_preference())


### PR DESCRIPTION
## Description:
This is to resolve not being able to set presets with the Ecobee Integration.  Currently using or setting presets does not work, fix restores basic functionality.

**Related issue (if applicable):** fixes #25222


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html