### PR TITLE
Update CT80 Humidity call

### DIFF
--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -224,13 +224,12 @@ class RadioThermostat(ClimateDevice):
 
         if self._is_model_ct80:
             try:
-                humiditydata = self.device.tstat.humidity['raw']
+                humiditydata = self.device.humidity['raw']
             except radiotherm.validate.RadiothermTstatError:
                 _LOGGER.warning('%s (%s) was busy (invalid value returned)',
                                 self._name, self.device.host)
                 return
-            current_humidity = humiditydata['humidity']
-            self._current_humidity = current_humidity
+            self._current_humidity = humiditydata
 
         # Map thermostat values into various STATE_ flags.
         self._current_temperature = current_temp


### PR DESCRIPTION
Last PR was from a few versions before, not sure how I had it working, but functioning properly now on .96

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
