### PR TITLE
Restore SmartThings A/C on/off services

### DIFF
--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -323,6 +323,9 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateDevice):
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target operation mode."""
+        if hvac_mode == HVAC_MODE_OFF:
+            await self.async_turn_off()
+            return
         await self._device.set_air_conditioner_mode(
             STATE_TO_AC_MODE[hvac_mode], set_status=True)
         # State is set optimistically in the command above, therefore update
@@ -360,16 +363,16 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateDevice):
 
     async def async_update(self):
         """Update the calculated fields of the AC."""
-        operations = set()
+        modes = {HVAC_MODE_OFF}
         for mode in self._device.status.supported_ac_modes:
             state = AC_MODE_TO_STATE.get(mode)
             if state is not None:
-                operations.add(state)
+                modes.add(state)
             else:
                 _LOGGER.debug('Device %s (%s) returned an invalid supported '
                               'AC mode: %s', self._device.label,
                               self._device.device_id, mode)
-        self._hvac_modes = operations
+        self._hvac_modes = modes
 
     @property
     def current_temperature(self):

--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -344,6 +344,20 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateDevice):
         # the entity state ahead of receiving the confirming push updates
         self.async_schedule_update_ha_state()
 
+    async def async_turn_on(self):
+        """Turn device on."""
+        await self._device.switch_on(set_status=True)
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_schedule_update_ha_state()
+
+    async def async_turn_off(self):
+        """Turn device off."""
+        await self._device.switch_off(set_status=True)
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_schedule_update_ha_state()
+
     async def async_update(self):
         """Update the calculated fields of the AC."""
         operations = set()
@@ -400,6 +414,8 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateDevice):
     @property
     def hvac_mode(self):
         """Return current operation ie. heat, cool, idle."""
+        if not self._device.status.switch:
+            return HVAC_MODE_OFF
         return AC_MODE_TO_STATE.get(self._device.status.air_conditioner_mode)
 
     @property

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -245,7 +245,7 @@ async def test_air_conditioner_entity_state(hass, air_conditioner):
         SUPPORT_TARGET_TEMPERATURE
     assert sorted(state.attributes[ATTR_HVAC_MODES]) == [
         HVAC_MODE_COOL, HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT,
-        HVAC_MODE_HEAT_COOL]
+        HVAC_MODE_HEAT_COOL, HVAC_MODE_OFF]
     assert state.attributes[ATTR_FAN_MODE] == 'medium'
     assert sorted(state.attributes[ATTR_FAN_MODES]) == \
         ['auto', 'high', 'low', 'medium', 'turbo']
@@ -277,8 +277,8 @@ async def test_set_fan_mode(hass, thermostat, air_conditioner):
         assert state.attributes[ATTR_FAN_MODE] == 'auto', entity_id
 
 
-async def test_set_operation_mode(hass, thermostat, air_conditioner):
-    """Test the operation mode is set successfully."""
+async def test_set_hvac_mode(hass, thermostat, air_conditioner):
+    """Test the hvac mode is set successfully."""
     await setup_platform(hass, CLIMATE_DOMAIN,
                          devices=[thermostat, air_conditioner])
     entity_ids = ['climate.thermostat', 'climate.air_conditioner']
@@ -291,6 +291,20 @@ async def test_set_operation_mode(hass, thermostat, air_conditioner):
     for entity_id in entity_ids:
         state = hass.states.get(entity_id)
         assert state.state == HVAC_MODE_COOL, entity_id
+
+
+async def test_ac_set_hvac_mode_off(hass, air_conditioner):
+    """Test the AC HVAC mode can be turned off set successfully."""
+    await setup_platform(hass, CLIMATE_DOMAIN, devices=[air_conditioner])
+    state = hass.states.get('climate.air_conditioner')
+    assert state.state != HVAC_MODE_OFF
+    await hass.services.async_call(
+        CLIMATE_DOMAIN, SERVICE_SET_HVAC_MODE, {
+            ATTR_ENTITY_ID: 'climate.air_conditioner',
+            ATTR_HVAC_MODE: HVAC_MODE_OFF},
+        blocking=True)
+    state = hass.states.get('climate.air_conditioner')
+    assert state.state == HVAC_MODE_OFF
 
 
 async def test_set_temperature_heat_mode(hass, thermostat):

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -20,8 +20,8 @@ from homeassistant.components.climate.const import (
 from homeassistant.components.smartthings import climate
 from homeassistant.components.smartthings.const import DOMAIN
 from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, ATTR_TEMPERATURE, STATE_OFF,
-    STATE_UNKNOWN)
+    ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, ATTR_TEMPERATURE,
+    SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_UNKNOWN)
 
 from .conftest import setup_platform
 
@@ -375,6 +375,31 @@ async def test_set_temperature_with_mode(hass, thermostat):
     state = hass.states.get('climate.thermostat')
     assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 25.5
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 22.2
+    assert state.state == HVAC_MODE_HEAT_COOL
+
+
+async def test_set_turn_off(hass, air_conditioner):
+    """Test the a/c is turned off successfully."""
+    await setup_platform(hass, CLIMATE_DOMAIN, devices=[air_conditioner])
+    state = hass.states.get('climate.air_conditioner')
+    assert state.state == HVAC_MODE_HEAT_COOL
+    await hass.services.async_call(
+        CLIMATE_DOMAIN, SERVICE_TURN_OFF,
+        blocking=True)
+    state = hass.states.get('climate.air_conditioner')
+    assert state.state == STATE_OFF
+
+
+async def test_set_turn_on(hass, air_conditioner):
+    """Test the a/c is turned on successfully."""
+    air_conditioner.status.update_attribute_value(Attribute.switch, 'off')
+    await setup_platform(hass, CLIMATE_DOMAIN, devices=[air_conditioner])
+    state = hass.states.get('climate.air_conditioner')
+    assert state.state == STATE_OFF
+    await hass.services.async_call(
+        CLIMATE_DOMAIN, SERVICE_TURN_ON,
+        blocking=True)
+    state = hass.states.get('climate.air_conditioner')
     assert state.state == HVAC_MODE_HEAT_COOL
 
 

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -13,7 +13,7 @@ from homeassistant.components.climate.const import (
     ATTR_FAN_MODES, ATTR_HVAC_ACTIONS, ATTR_HVAC_MODE, ATTR_HVAC_MODES,
     ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW, CURRENT_HVAC_IDLE,
     DOMAIN as CLIMATE_DOMAIN, HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL, HVAC_MODE_OFF,
     SERVICE_SET_FAN_MODE, SERVICE_SET_HVAC_MODE, SERVICE_SET_TEMPERATURE,
     SUPPORT_FAN_MODE, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE)
@@ -21,7 +21,7 @@ from homeassistant.components.smartthings import climate
 from homeassistant.components.smartthings.const import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES, ATTR_TEMPERATURE,
-    SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_UNKNOWN)
+    SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_UNKNOWN)
 
 from .conftest import setup_platform
 
@@ -172,7 +172,7 @@ async def test_legacy_thermostat_entity_state(hass, legacy_thermostat):
     assert state.attributes[ATTR_HVAC_ACTIONS] == 'idle'
     assert state.attributes[ATTR_HVAC_MODES] == {
         HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_HEAT_COOL, HVAC_MODE_HEAT,
-        STATE_OFF}
+        HVAC_MODE_OFF}
     assert state.attributes[ATTR_FAN_MODE] == 'auto'
     assert state.attributes[ATTR_FAN_MODES] == ['auto', 'on']
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 20  # celsius
@@ -184,12 +184,12 @@ async def test_basic_thermostat_entity_state(hass, basic_thermostat):
     """Tests the state attributes properly match the thermostat type."""
     await setup_platform(hass, CLIMATE_DOMAIN, devices=[basic_thermostat])
     state = hass.states.get('climate.basic_thermostat')
-    assert state.state == STATE_OFF
+    assert state.state == HVAC_MODE_OFF
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == \
         SUPPORT_TARGET_TEMPERATURE_RANGE | SUPPORT_TARGET_TEMPERATURE
     assert ATTR_HVAC_ACTIONS not in state.attributes
     assert state.attributes[ATTR_HVAC_MODES] == {
-        STATE_OFF, HVAC_MODE_HEAT_COOL, HVAC_MODE_HEAT, HVAC_MODE_COOL}
+        HVAC_MODE_OFF, HVAC_MODE_HEAT_COOL, HVAC_MODE_HEAT, HVAC_MODE_COOL}
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 21.1  # celsius
 
 
@@ -205,7 +205,7 @@ async def test_thermostat_entity_state(hass, thermostat):
     assert state.attributes[ATTR_HVAC_ACTIONS] == CURRENT_HVAC_IDLE
     assert state.attributes[ATTR_HVAC_MODES] == {
         HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL,
-        STATE_OFF}
+        HVAC_MODE_OFF}
     assert state.attributes[ATTR_FAN_MODE] == 'on'
     assert state.attributes[ATTR_FAN_MODES] == ['auto', 'on']
     assert state.attributes[ATTR_TEMPERATURE] == 20  # celsius
@@ -387,7 +387,7 @@ async def test_set_turn_off(hass, air_conditioner):
         CLIMATE_DOMAIN, SERVICE_TURN_OFF,
         blocking=True)
     state = hass.states.get('climate.air_conditioner')
-    assert state.state == STATE_OFF
+    assert state.state == HVAC_MODE_OFF
 
 
 async def test_set_turn_on(hass, air_conditioner):
@@ -395,7 +395,7 @@ async def test_set_turn_on(hass, air_conditioner):
     air_conditioner.status.update_attribute_value(Attribute.switch, 'off')
     await setup_platform(hass, CLIMATE_DOMAIN, devices=[air_conditioner])
     state = hass.states.get('climate.air_conditioner')
-    assert state.state == STATE_OFF
+    assert state.state == HVAC_MODE_OFF
     await hass.services.async_call(
         CLIMATE_DOMAIN, SERVICE_TURN_ON,
         blocking=True)


### PR DESCRIPTION
## Description:
Add the service `turn_on` and `turn_off` implementations back to the SmartThings Air Conditioner climate platform.  This was removed as support was initially dropped in Climate 1.0 but added back later.

**Related issue (if applicable):** fixes #25233

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
