### PR TITLE
Add MQTT climate precision

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -15,7 +15,8 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE_RANGE)
 from homeassistant.components.fan import SPEED_HIGH, SPEED_LOW, SPEED_MEDIUM
 from homeassistant.const import (
-    ATTR_TEMPERATURE, CONF_DEVICE, CONF_NAME, CONF_VALUE_TEMPLATE, STATE_ON)
+    ATTR_TEMPERATURE, CONF_DEVICE, CONF_NAME, CONF_VALUE_TEMPLATE,
+    PRECISION_HALVES, PRECISION_TENTHS, PRECISION_WHOLE, STATE_ON)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -58,6 +59,7 @@ CONF_PAYLOAD_ON = 'payload_on'
 CONF_POWER_COMMAND_TOPIC = 'power_command_topic'
 CONF_POWER_STATE_TEMPLATE = 'power_state_template'
 CONF_POWER_STATE_TOPIC = 'power_state_topic'
+CONF_PRECISION = 'precision'
 CONF_SEND_IF_OFF = 'send_if_off'
 CONF_SWING_MODE_COMMAND_TOPIC = 'swing_mode_command_topic'
 CONF_SWING_MODE_LIST = 'swing_modes'
@@ -151,6 +153,8 @@ PLATFORM_SCHEMA = SCHEMA_BASE.extend({
     vol.Optional(CONF_POWER_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_POWER_STATE_TEMPLATE): cv.template,
     vol.Optional(CONF_POWER_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_PRECISION): vol.In(
+        [PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]),
     vol.Optional(CONF_RETAIN, default=mqtt.DEFAULT_RETAIN): cv.boolean,
     vol.Optional(CONF_SEND_IF_OFF, default=True): cv.boolean,
     vol.Optional(CONF_ACTION_TEMPLATE): cv.template,
@@ -779,3 +783,12 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     def max_temp(self):
         """Return the maximum temperature."""
         return self._config[CONF_TEMP_MAX]
+
+    @property
+    def precision(self):
+        """Return the precision of the system."""
+        # p = self._config[CONF_PRECISION]
+        # return p if p else super().precision
+        if self._config.get(CONF_PRECISION) is not None:
+            return self._config.get(CONF_PRECISION)
+        return super().precision

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -787,8 +787,6 @@ class MqttClimate(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     @property
     def precision(self):
         """Return the precision of the system."""
-        # p = self._config[CONF_PRECISION]
-        # return p if p else super().precision
         if self._config.get(CONF_PRECISION) is not None:
             return self._config.get(CONF_PRECISION)
         return super().precision

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -1012,3 +1012,40 @@ async def test_entity_id_update(hass, mqtt_mock):
     assert mock_mqtt.async_subscribe.call_count == 2
     mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, 'utf-8')
     mock_mqtt.async_subscribe.assert_any_call('avty-topic', ANY, 0, 'utf-8')
+
+
+async def test_precision_default(hass, mqtt_mock):
+    """Test that setting precision to tenths works as intended."""
+    assert await async_setup_component(hass, CLIMATE_DOMAIN, DEFAULT_CONFIG)
+
+    await common.async_set_temperature(hass, temperature=23.67,
+                                       entity_id=ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get('temperature') == 23.7
+    mqtt_mock.async_publish.reset_mock()
+
+
+async def test_precision_halves(hass, mqtt_mock):
+    """Test that setting precision to halves works as intended."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config['climate']['precision'] = 0.5
+    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+
+    await common.async_set_temperature(hass, temperature=23.67,
+                                       entity_id=ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get('temperature') == 23.5
+    mqtt_mock.async_publish.reset_mock()
+
+
+async def test_precision_whole(hass, mqtt_mock):
+    """Test that setting precision to whole works as intended."""
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config['climate']['precision'] = 1.0
+    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
+
+    await common.async_set_temperature(hass, temperature=23.67,
+                                       entity_id=ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get('temperature') == 24.0
+    mqtt_mock.async_publish.reset_mock()


### PR DESCRIPTION
## Description:
Add precision to MQTT climate devices ~~for when https://github.com/home-assistant/home-assistant-polymer/issues/3109 gets fixed~~.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9896

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: mqtt
    name: Study
    modes:
      - "off"
      - "cool"
      - "fan_only"
    swing_modes:
      - "on"
      - "off"
    fan_modes:
      - "high"
      - "medium"
      - "low"
    power_command_topic: "study/ac/power/set"
    mode_command_topic: "study/ac/mode/set"
    temperature_command_topic: "study/ac/temperature/set"
    fan_mode_command_topic: "study/ac/fan/set"
    swing_mode_command_topic: "study/ac/swing/set"
    precision: 1.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
