### PR TITLE
Fix fritzbox climate HVAC mode / temperature

### DIFF
--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -93,9 +93,10 @@ class FritzboxThermostat(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self._target_temperature in (ON_API_TEMPERATURE,
-                                        OFF_API_TEMPERATURE):
-            return None
+        if self._target_temperature == ON_API_TEMPERATURE:
+            return ON_REPORT_SET_TEMPERATURE
+        if self._target_temperature == OFF_API_TEMPERATURE:
+            return OFF_REPORT_SET_TEMPERATURE
         return self._target_temperature
 
     def set_temperature(self, **kwargs):

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -112,8 +112,8 @@ class FritzboxThermostat(ClimateDevice):
     def hvac_mode(self):
         """Return the current operation mode."""
         if (
-            self._target_temperature == OFF_REPORT_SET_TEMPERATURE or
-            self._target_temperature == OFF_API_TEMPERATURE
+                self._target_temperature == OFF_REPORT_SET_TEMPERATURE or
+                self._target_temperature == OFF_API_TEMPERATURE
         ):
             return HVAC_MODE_OFF
 

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -111,7 +111,10 @@ class FritzboxThermostat(ClimateDevice):
     @property
     def hvac_mode(self):
         """Return the current operation mode."""
-        if self._target_temperature == OFF_REPORT_SET_TEMPERATURE:
+        if (
+            self._target_temperature == OFF_REPORT_SET_TEMPERATURE or
+            self._target_temperature == OFF_API_TEMPERATURE
+        ):
             return HVAC_MODE_OFF
 
         return HVAC_MODE_HEAT

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -66,10 +66,10 @@ class TestFritzboxClimate(unittest.TestCase):
         assert 19.5 == self.thermostat.target_temperature
 
         self.thermostat._target_temperature = 126.5
-        assert self.thermostat.target_temperature is None
+        assert self.thermostat.target_temperature == 0.0
 
         self.thermostat._target_temperature = 127.0
-        assert self.thermostat.target_temperature is None
+        assert self.thermostat.target_temperature == 30.0
 
     @patch.object(FritzboxThermostat, 'set_hvac_mode')
     def test_set_temperature_operation_mode(self, mock_set_op):

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -103,7 +103,7 @@ class TestFritzboxClimate(unittest.TestCase):
         self.thermostat._target_temperature = 127.0
         assert 'heat' == self.thermostat.hvac_mode
         self.thermostat._target_temperature = 126.5
-        assert 'heat' == self.thermostat.hvac_mode
+        assert 'off' == self.thermostat.hvac_mode
         self.thermostat._target_temperature = 22.0
         assert 'heat' == self.thermostat.hvac_mode
         self.thermostat._target_temperature = 16.0


### PR DESCRIPTION
## Description:
Set the target temperature according to the reported state.

**Related issue (if applicable):** fixes #25255

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
