### PR TITLE
Tweak evohome migration

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time, track_time_interval)
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util.dt import parse_datetime, utcnow
 
 from .const import DOMAIN, STORAGE_VERSION, STORAGE_KEY, GWS, TCS
@@ -101,7 +102,7 @@ def _handle_exception(err) -> bool:
         raise  # we don't expect/handle any other HTTPErrors
 
 
-def setup(hass, hass_config) -> bool:
+def setup(hass: HomeAssistantType, hass_config: ConfigType) -> bool:
     """Create a (EMEA/EU-based) Honeywell evohome system."""
     broker = EvoBroker(hass, hass_config[DOMAIN])
     if not broker.init_client():

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -278,6 +278,12 @@ class EvoDevice(Entity):
         if packet['signal'] == 'refresh':
             self.async_schedule_update_ha_state(force_refresh=True)
 
+    def _update_schedule(self) -> None:
+        """Get the latest state data."""
+        if not self._schedule.get('DailySchedules') or \
+                parse_datetime(self.setpoints['next']['from']) < utcnow():
+            self._schedule = self._evo_device.schedule()
+
     @property
     def setpoints(self) -> Optional[Dict[str, Any]]:
         """Return the current/next setpoints from the schedule.
@@ -376,6 +382,4 @@ class EvoDevice(Entity):
 
     def update(self) -> None:
         """Get the latest state data."""
-        if not self._schedule or \
-                parse_datetime(self.setpoints['next']['from']) < utcnow():
-            self._schedule = self._evo_device.schedule()
+        self._update_schedule()

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -271,7 +271,7 @@ class EvoDevice(Entity):
         self._state_attributes = []
 
         self._supported_features = None
-        self._schedule: Dict[str, Any] = {}
+        self._schedule = {}
 
     @callback
     def _refresh(self, packet):

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -376,4 +376,6 @@ class EvoDevice(Entity):
 
     def update(self) -> None:
         """Get the latest state data."""
-        self._schedule = self._evo_device.schedule()
+        if not self._schedule or \
+                parse_datetime(self.setpoints['next']['from']) < utcnow():
+            self._schedule = self._evo_device.schedule()

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -279,7 +279,7 @@ class EvoDevice(Entity):
             self.async_schedule_update_ha_state(force_refresh=True)
 
     @property
-    def setpoints(self) -> Optional[Dict[str, Any]]:
+    def setpoints(self) -> Dict[str, Any]:
         """Return the current/next setpoints from the schedule.
 
         Only Zones & DHW controllers (but not the TCS) can have schedules.

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -278,12 +278,6 @@ class EvoDevice(Entity):
         if packet['signal'] == 'refresh':
             self.async_schedule_update_ha_state(force_refresh=True)
 
-    def _update_schedule(self) -> None:
-        """Get the latest state data."""
-        if not self._schedule.get('DailySchedules') or \
-                parse_datetime(self.setpoints['next']['from']) < utcnow():
-            self._schedule = self._evo_device.schedule()
-
     @property
     def setpoints(self) -> Optional[Dict[str, Any]]:
         """Return the current/next setpoints from the schedule.
@@ -379,6 +373,12 @@ class EvoDevice(Entity):
     def temperature_unit(self) -> str:
         """Return the temperature unit to use in the frontend UI."""
         return TEMP_CELSIUS
+
+    def _update_schedule(self) -> None:
+        """Get the latest state data."""
+        if not self._schedule.get('DailySchedules') or \
+                parse_datetime(self.setpoints['next']['from']) < utcnow():
+            self._schedule = self._evo_device.schedule()
 
     def update(self) -> None:
         """Get the latest state data."""

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -293,7 +293,7 @@ class EvoDevice(Entity):
         if not self._schedule['DailySchedules']:
             return {}
 
-        switchpoints: Dict[str, Any] = {}
+        switchpoints = {}
 
         day_time = datetime.now()
         day_of_week = int(day_time.strftime('%w'))  # 0 is Sunday

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -132,7 +132,8 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
         until = None  # EVO_PERMOVER
 
         if op_mode == EVO_TEMPOVER and self._schedule['DailySchedules']:
-                self._schedule = self._evo_device.schedule()
+            self._update_schedule()
+            if self.setpoints:
                 until = parse_datetime(self.setpoints['next']['from'])
 
         self._set_temperature(temperature, until=until)

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -133,7 +133,7 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
 
         if op_mode == EVO_TEMPOVER and self._schedule['DailySchedules']:
             self._update_schedule()
-            if self.setpoints:
+            if self._schedule['DailySchedules']:
                 until = parse_datetime(self.setpoints['next']['from'])
 
         self._set_temperature(temperature, until=until)

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -105,12 +105,12 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
     def _set_zone_mode(self, op_mode: str) -> None:
         """Set a Zone to one of its native EVO_* operating modes.
 
-        Zones _inherit_ their _effective_ operating mode from the Controller.
+        Zones inherit their _effective_ operating mode from the Controller.
 
         Usually, Zones are in 'FollowSchedule' mode, where their setpoints are
-        a function of their schedule and the Controller's operating mode, e.g.
-        'AutoWithEco' mode means their setpoint is (by default) 3C less than
-        scheduled.
+        a function of their own schedule and the Controller's operating mode,
+        e.g. 'AutoWithEco' mode means their setpoint is (by default) 3C less
+        than scheduled.
 
         However, Zones can _override_ these setpoints, either indefinitely,
         'PermanentOverride' mode, or for a period of time, 'TemporaryOverride',

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -105,16 +105,16 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
     def _set_zone_mode(self, op_mode: str) -> None:
         """Set a Zone to one of its native EVO_* operating modes.
 
-        NB: Zones _inherit_ their effective operating mode from the Controller.
+        Zones _inherit_ their _effective_ operating mode from the Controller.
 
         Usually, Zones are in 'FollowSchedule' mode, where their setpoints are
-        a function of their schedule, and the Controller's operating mode, e.g.
+        a function of their schedule and the Controller's operating mode, e.g.
         'AutoWithEco' mode means their setpoint is (by default) 3C less than
         scheduled.
 
-        However, Zones can _override_ these setpoints, either for a specified
-        period of time, 'TemporaryOverride' mode, after which they will revert
-        back to 'FollowSchedule', or indefinitely, 'PermanentOverride'.
+        However, Zones can _override_ these setpoints, either indefinitely,
+        'PermanentOverride' mode, or for a period of time, 'TemporaryOverride',
+        after which they will revert back to 'FollowSchedule'.
 
         Finally, some of the Controller's operating modes are _forced_ upon the
         Zones, regardless of any override mode, e.g. 'HeatingOff', Zones to

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -132,9 +132,9 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
         until = None  # EVO_PERMOVER
 
         if op_mode == EVO_TEMPOVER:
-            self._setpoints = self.get_setpoints()
-            if self._setpoints:
-                until = parse_datetime(self._setpoints['next']['from'])
+            self._schedule = self._evo_device.schedule()
+            if self.setpoints:
+                until = parse_datetime(self.setpoints['next']['from'])
 
         self._set_temperature(temperature, until=until)
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -8,16 +8,16 @@ import evohomeclient2
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF,
     CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF,
     PRESET_AWAY, PRESET_ECO, PRESET_HOME, PRESET_NONE,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE)
 from homeassistant.const import PRECISION_TENTHS
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util.dt import parse_datetime
 
 from . import CONF_LOCATION_IDX, _handle_exception, EvoDevice
 from .const import (
-    DOMAIN, EVO_RESET, EVO_AUTO, EVO_AUTOECO, EVO_AWAY, EVO_DAYOFF, EVO_CUSTOM,
+    DOMAIN, EVO_RESET, EVO_AUTO, EVO_AUTOECO, EVO_AWAY, EVO_CUSTOM, EVO_DAYOFF,
     EVO_HEATOFF, EVO_FOLLOW, EVO_TEMPOVER, EVO_PERMOVER)
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,14 +30,15 @@ HA_HVAC_TO_TCS = {
     HVAC_MODE_HEAT: EVO_AUTO,
 }
 
-HA_PRESET_TO_TCS = {
-    PRESET_AWAY: EVO_AWAY,
-    PRESET_CUSTOM: EVO_CUSTOM,
-    PRESET_ECO: EVO_AUTOECO,
-    PRESET_HOME: EVO_DAYOFF,
-    PRESET_RESET: EVO_RESET,
-}
-TCS_PRESET_TO_HA = {v: k for k, v in HA_PRESET_TO_TCS.items()}
+TCS_PRESET_TO_HA = {
+    EVO_AWAY: PRESET_AWAY,
+    EVO_CUSTOM: PRESET_CUSTOM,
+    EVO_AUTOECO: PRESET_ECO,
+    EVO_DAYOFF: PRESET_HOME,
+    EVO_RESET: PRESET_RESET,
+}  # EVO_AUTO: None,
+
+HA_PRESET_TO_TCS = {v: k for k, v in TCS_PRESET_TO_HA.items()}
 
 EVO_PRESET_TO_HA = {
     EVO_FOLLOW: PRESET_NONE,
@@ -47,8 +48,8 @@ EVO_PRESET_TO_HA = {
 HA_PRESET_TO_EVO = {v: k for k, v in EVO_PRESET_TO_HA.items()}
 
 
-def setup_platform(hass, hass_config, add_entities,
-                   discovery_info=None) -> None:
+def setup_platform(hass: HomeAssistantType, hass_config: ConfigType,
+                   add_entities, discovery_info=None) -> None:
     """Create the evohome Controller, and its Zones, if any."""
     broker = hass.data[DOMAIN]['broker']
     loc_idx = broker.params[CONF_LOCATION_IDX]
@@ -102,21 +103,22 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
             _handle_exception(err)
 
     def _set_zone_mode(self, op_mode: str) -> None:
-        """Set the Zone to one of its native EVO_* operating modes.
+        """Set a Zone to one of its native EVO_* operating modes.
 
-        NB: evohome Zones 'inherit' their operating mode from the Controller.
+        NB: Zones _inherit_ their effective operating mode from the Controller.
 
         Usually, Zones are in 'FollowSchedule' mode, where their setpoints are
-        a function of their schedule, and the Controller's operating_mode, e.g.
-        Economy mode is their scheduled setpoint less (usually) 3C.
+        a function of their schedule, and the Controller's operating mode, e.g.
+        'AutoWithEco' mode means their setpoint is (by default) 3C less than
+        scheduled.
 
-        However, Zones can override these setpoints, either for a specified
-        period of time, 'TemporaryOverride', after which they will revert back
-        to 'FollowSchedule' mode, or indefinitely, 'PermanentOverride'.
+        However, Zones can _override_ these setpoints, either for a specified
+        period of time, 'TemporaryOverride' mode, after which they will revert
+        back to 'FollowSchedule', or indefinitely, 'PermanentOverride'.
 
-        Some of the Controller's operating_mode are 'forced' upon the Zone,
-        regardless of its override state, e.g. 'HeatingOff' (Zones to min_temp)
-        and 'Away' (Zones to 12C).
+        Finally, some of the Controller's operating modes are _forced_ upon the
+        Zones, regardless of any override mode, e.g. 'HeatingOff', Zones to
+        (by default) 5C, and 'Away', Zones to (by default) 12C.
         """
         if op_mode == EVO_FOLLOW:
             try:
@@ -147,7 +149,7 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
     @property
     def hvac_modes(self) -> List[str]:
         """Return the list of available hvac operation modes."""
-        return [HVAC_MODE_OFF, HVAC_MODE_HEAT]
+        return list(HA_HVAC_TO_TCS)
 
     @property
     def preset_modes(self) -> Optional[List[str]]:

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -9,6 +9,7 @@ import evohomeclient2
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF,
+    HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF,
     PRESET_AWAY, PRESET_ECO, PRESET_HOME, PRESET_NONE,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE)
 from homeassistant.const import PRECISION_TENTHS

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -131,9 +131,8 @@ class EvoClimateDevice(EvoDevice, ClimateDevice):
         temperature = self._evo_device.setpointStatus['targetHeatTemperature']
         until = None  # EVO_PERMOVER
 
-        if op_mode == EVO_TEMPOVER:
-            self._schedule = self._evo_device.schedule()
-            if self.setpoints:
+        if op_mode == EVO_TEMPOVER and self._schedule['DailySchedules']:
+                self._schedule = self._evo_device.schedule()
                 until = parse_datetime(self.setpoints['next']['from'])
 
         self._set_temperature(temperature, until=until)

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -75,10 +75,10 @@ class EvoDHW(EvoDevice, WaterHeaterDevice):
         state = '' if op_mode == EVO_FOLLOW else HA_STATE_TO_EVO[STATE_OFF]
         until = None  # EVO_FOLLOW, EVO_PERMOVER
 
-        if op_mode == EVO_TEMPOVER:
-            self._setpoints = self.get_setpoints()
-            if self._setpoints:
-                until = parse_datetime(self._setpoints['next']['from'])
+        if op_mode == EVO_TEMPOVER and self._schedule['DailySchedules']:
+            self._update_schedule()
+            if self.setpoints:
+                until = parse_datetime(self.setpoints['next']['from'])
                 until = until.strftime(EVO_STRFTIME)
 
         data = {'Mode': op_mode, 'State': state, 'UntilTime': until}

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -77,7 +77,7 @@ class EvoDHW(EvoDevice, WaterHeaterDevice):
 
         if op_mode == EVO_TEMPOVER and self._schedule['DailySchedules']:
             self._update_schedule()
-            if self.setpoints:
+            if self._schedule['DailySchedules']:
                 until = parse_datetime(self.setpoints['next']['from'])
                 until = until.strftime(EVO_STRFTIME)
 


### PR DESCRIPTION
## Breaking Change:

None

## Description:
 - refactor setpoints: reduce unnecessary I/O and always use up-to-date schedule
 - address potential bug if a device has a null schedule
 - improve docstrings, self-documenting code, etc.
 - de-linting (and remove unneeded code) / adding type hints

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): unchanged

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
