### PR TITLE
Return Ambient PWS brightness sensor unit and remove CONF_MONITORED_CONDITIONS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -428,6 +428,13 @@ class AmbientWeatherEntity(Entity):
     @property
     def available(self):
         """Return True if entity is available."""
+        # Since the solarradiation_lx sensor is created only if the
+        # user shows a solarradiation sensor, ensure that the
+        # solarradiation_lx sensor shows as available if the solarradiation
+        # sensor is available:
+        if self._sensor_type == TYPE_SOLARRADIATION_LX:
+            return self._ambient.stations[self._mac_address][
+                ATTR_LAST_DATA].get(TYPE_SOLARRADIATION) is not None
         return self._ambient.stations[self._mac_address][ATTR_LAST_DATA].get(
             self._sensor_type) is not None
 

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -183,7 +183,7 @@ SENSOR_TYPES = {
     TYPE_SOILTEMP7F: ('Soil Temp 7', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP8F: ('Soil Temp 8', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP9F: ('Soil Temp 9', '°F', TYPE_SENSOR, 'temperature'),
-    TYPE_SOLARRADIATION: ('Solar Rad', 'lx', TYPE_SENSOR, 'illuminance'),
+    TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, None),
     TYPE_TEMP10F: ('Temp 10', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_TEMP1F: ('Temp 1', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_TEMP2F: ('Temp 2', '°F', TYPE_SENSOR, 'temperature'),

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -183,7 +183,7 @@ SENSOR_TYPES = {
     TYPE_SOILTEMP7F: ('Soil Temp 7', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP8F: ('Soil Temp 8', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP9F: ('Soil Temp 9', '°F', TYPE_SENSOR, 'temperature'),
-    TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, 'illuminance'),
+    TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, None),
     TYPE_SOLARRADIATION_LX: (
         'Solar Rad (lx)', 'lx', TYPE_SENSOR, 'illuminance'),
     TYPE_TEMP10F: ('Temp 10', '°F', TYPE_SENSOR, 'temperature'),
@@ -356,7 +356,7 @@ class AmbientStation:
                 _LOGGER.debug('New station subscription: %s', data)
 
                 self.monitored_conditions = [
-                    k for k in station['lastData'].keys()
+                    k for k in station['lastData']
                     if k in SENSOR_TYPES
                 ]
 

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -93,6 +93,7 @@ TYPE_SOILTEMP7F = 'soiltemp7f'
 TYPE_SOILTEMP8F = 'soiltemp8f'
 TYPE_SOILTEMP9F = 'soiltemp9f'
 TYPE_SOLARRADIATION = 'solarradiation'
+TYPE_SOLARRADIATION_LX = 'solarradiation_lx'
 TYPE_TEMP10F = 'temp10f'
 TYPE_TEMP1F = 'temp1f'
 TYPE_TEMP2F = 'temp2f'
@@ -183,7 +184,9 @@ SENSOR_TYPES = {
     TYPE_SOILTEMP7F: ('Soil Temp 7', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP8F: ('Soil Temp 8', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_SOILTEMP9F: ('Soil Temp 9', '°F', TYPE_SENSOR, 'temperature'),
-    TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, None),
+    TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, 'illuminance'),
+    TYPE_SOLARRADIATION_LX: (
+        'Solar Rad (lx)', 'lx', TYPE_SENSOR, 'illuminance'),
     TYPE_TEMP10F: ('Temp 10', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_TEMP1F: ('Temp 1', '°F', TYPE_SENSOR, 'temperature'),
     TYPE_TEMP2F: ('Temp 2', '°F', TYPE_SENSOR, 'temperature'),
@@ -366,6 +369,13 @@ class AmbientStation:
                         if k in SENSOR_TYPES
                     ]
 
+                # If the user is monitoring brightness (in W/m^2),
+                # make sure we also add a calculated sensor for the
+                # same data measured in lx:
+                if TYPE_SOLARRADIATION in self.monitored_conditions:
+                    self.monitored_conditions.append(
+                        TYPE_SOLARRADIATION_LX)
+
                 self.stations[station['macAddress']] = {
                     ATTR_LAST_DATA: station['lastData'],
                     ATTR_LOCATION: station.get('info', {}).get('location'),
@@ -450,7 +460,7 @@ class AmbientWeatherEntity(Entity):
     @property
     def unique_id(self):
         """Return a unique, unchanging string that represents this sensor."""
-        return '{0}_{1}'.format(self._mac_address, self._sensor_name)
+        return '{0}_{1}'.format(self._mac_address, self._sensor_type)
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.const import ATTR_NAME
 
-from . import SENSOR_TYPES, TYPE_SOLARRADIATION, AmbientWeatherEntity
+from . import SENSOR_TYPES, AmbientWeatherEntity
 from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TYPE_SENSOR
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,13 +61,5 @@ class AmbientWeatherSensor(AmbientWeatherEntity):
 
     async def async_update(self):
         """Fetch new state data for the sensor."""
-        new_state = self._ambient.stations[
+        self._state = self._ambient.stations[
             self._mac_address][ATTR_LAST_DATA].get(self._sensor_type)
-
-        if self._sensor_type == TYPE_SOLARRADIATION:
-            # Ambient's units for solar radiation (illuminance) are
-            # W/m^2; since those aren't commonly used in the HASS
-            # world, transform them to lx:
-            self._state = round(float(new_state)/0.0079)
-        else:
-            self._state = new_state

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -3,7 +3,9 @@ import logging
 
 from homeassistant.const import ATTR_NAME
 
-from . import SENSOR_TYPES, AmbientWeatherEntity
+from . import (
+    SENSOR_TYPES, TYPE_SOLARRADIATION, TYPE_SOLARRADIATION_LX,
+    AmbientWeatherEntity)
 from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TYPE_SENSOR
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,5 +63,12 @@ class AmbientWeatherSensor(AmbientWeatherEntity):
 
     async def async_update(self):
         """Fetch new state data for the sensor."""
-        self._state = self._ambient.stations[
-            self._mac_address][ATTR_LAST_DATA].get(self._sensor_type)
+        if self._sensor_type == TYPE_SOLARRADIATION_LX:
+            # Converting W/m^2 to lx isn't a direct formula, but a very
+            # accurate approximation exists for sunlight:
+            w_m2_brightness_val = self._ambient.stations[
+                self._mac_address][ATTR_LAST_DATA].get(TYPE_SOLARRADIATION)
+            self._state = round(float(w_m2_brightness_val)/0.0079)
+        else:
+            self._state = self._ambient.stations[
+                self._mac_address][ATTR_LAST_DATA].get(self._sensor_type)

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -64,8 +64,9 @@ class AmbientWeatherSensor(AmbientWeatherEntity):
     async def async_update(self):
         """Fetch new state data for the sensor."""
         if self._sensor_type == TYPE_SOLARRADIATION_LX:
-            # Converting W/m^2 to lx isn't a direct formula, but a very
-            # accurate approximation exists for sunlight:
+            # If the user requests the solarradiation_lx sensor, use the
+            # value of the solarradiation sensor and apply a very accurate
+            # approximation of converting sunlight W/m^2 to lx:
             w_m2_brightness_val = self._ambient.stations[
                 self._mac_address][ATTR_LAST_DATA].get(TYPE_SOLARRADIATION)
             self._state = round(float(w_m2_brightness_val)/0.0079)


### PR DESCRIPTION
## Breaking Change:

The `unique_id` for Ambient sensors uses a new formula, meaning that even though they have the same friendly names, new sensors will be created. The integration will automatically perform this migration under the hood, but if you've altered the entity IDs of any Ambient PWS entities, you'll need do the same to the new entities upon creation.

Additionally, the `monitored_keys` configuration option is no longer supported in `configuration.yaml`. The integration will now create sensors for all conditions supported by the particular device.

## Description:

Following up on https://github.com/home-assistant/home-assistant/pull/24690, [some Reddit users mentioned](https://www.reddit.com/r/homeassistant/comments/cekmjj/096_notion_updated_sidebar_advanced_mode_home/eu3dmau/?utm_source=share&utm_medium=web2x) they preferred the old unit for the Ambient brightness sensor (`Wm^2`) instead of the new unit (`lx`). This PR gives users both: anytime a `Wm^2` brightness sensor is created, a `lx` variant is created, as well.

This work also revealed an erroneous pattern in the `unique_id` property of Ambient sensors: they relied on the sensor name. Since the name can change, this PR also corrects `unique_id` to use the sensor type. This is a breaking change, as it will produce different entities than what users had before.

Lastly, based on feedback, this PR removes the `monitored_conditions` configuration key (per [ADR-0003](https://github.com/home-assistant/architecture/blob/master/adr/0003-monitor-condition-and-data-selectors.md)).

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9903

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
