### PR TITLE
Fixed python-wink method names

### DIFF
--- a/homeassistant/components/wink/climate.py
+++ b/homeassistant/components/wink/climate.py
@@ -192,7 +192,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         """Return true if aux heater."""
         if 'aux' not in self.wink.hvac_modes():
             return None
-        if self.wink.hvac_action_mode() == 'aux':
+        if self.wink.current_hvac_mode() == 'aux':
             return True
         return False
 

--- a/homeassistant/components/wink/climate.py
+++ b/homeassistant/components/wink/climate.py
@@ -137,7 +137,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
     @property
     def preset_mode(self):
         """Return the current preset mode, e.g., home, away, temp."""
-        mode = self.wink.current_mode()
+        mode = self.wink.current_hvac_mode()
         if mode == "eco":
             return PRESET_ECO
         if self.wink.away():
@@ -205,7 +205,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         if not self.wink.is_on():
             return HVAC_MODE_OFF
 
-        wink_mode = self.wink.current_mode()
+        wink_mode = self.wink.current_hvac_mode()
         if wink_mode == "aux":
             return HVAC_MODE_HEAT
         if wink_mode == "eco":
@@ -220,7 +220,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         """
         hvac_list = [HVAC_MODE_OFF]
 
-        modes = self.wink.modes()
+        modes = self.wink.hvac_modes()
         for mode in modes:
             if mode in ("eco", "aux"):
                 continue
@@ -409,7 +409,7 @@ class WinkAC(WinkDevice, ClimateDevice):
         if not self.wink.is_on():
             return HVAC_MODE_OFF
 
-        wink_mode = self.wink.current_mode()
+        wink_mode = self.wink.current_hvac_mode()
         if wink_mode == "auto_eco":
             return HVAC_MODE_AUTO
         return WINK_HVAC_TO_HA.get(wink_mode)
@@ -422,7 +422,7 @@ class WinkAC(WinkDevice, ClimateDevice):
         """
         hvac_list = [HVAC_MODE_OFF]
 
-        modes = self.wink.modes()
+        modes = self.wink.hvac_modes()
         for mode in modes:
             if mode == "auto_eco":
                 continue


### PR DESCRIPTION
## Description:
Looks like during the climate update some of the python-wink method names were renamed on accident. This fixes the calls.

**Related issue (if applicable):** fixes #25232 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
