### PR TITLE
Allow configuring sources for older Pioneer receivers

### DIFF
--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -42,8 +42,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Pioneer platform."""
     pioneer = PioneerDevice(
-        config.get(CONF_NAME), config.get(CONF_HOST), config.get(CONF_PORT),
-        config.get(CONF_TIMEOUT), config.get(CONF_SOURCES))
+        config[CONF_NAME], config[CONF_HOST], config[CONF_PORT],
+        config[CONF_TIMEOUT], config[CONF_SOURCES])
 
     if pioneer.update():
         add_entities([pioneer])

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -15,9 +15,12 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_SOURCES = 'sources'
+
 DEFAULT_NAME = 'Pioneer AVR'
 DEFAULT_PORT = 23   # telnet default. Some Pioneer AVRs use 8102
 DEFAULT_TIMEOUT = None
+DEFAULT_SOURCES = {}
 
 SUPPORT_PIONEER = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
                   SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
@@ -31,6 +34,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.socket_timeout,
+    vol.Optional(CONF_SOURCES, default=DEFAULT_SOURCES):
+        {cv.string: cv.string},
 })
 
 
@@ -38,7 +43,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Pioneer platform."""
     pioneer = PioneerDevice(
         config.get(CONF_NAME), config.get(CONF_HOST), config.get(CONF_PORT),
-        config.get(CONF_TIMEOUT))
+        config.get(CONF_TIMEOUT), config.get(CONF_SOURCES))
 
     if pioneer.update():
         add_entities([pioneer])
@@ -47,7 +52,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class PioneerDevice(MediaPlayerDevice):
     """Representation of a Pioneer device."""
 
-    def __init__(self, name, host, port, timeout):
+    def __init__(self, name, host, port, timeout, sources):
         """Initialize the Pioneer device."""
         self._name = name
         self._host = host
@@ -57,8 +62,8 @@ class PioneerDevice(MediaPlayerDevice):
         self._volume = 0
         self._muted = False
         self._selected_source = ''
-        self._source_name_to_number = {}
-        self._source_number_to_name = {}
+        self._source_name_to_number = sources
+        self._source_number_to_name = dict((v, k) for k, v in sources.items())
 
     @classmethod
     def telnet_request(cls, telnet, command, expected_prefix):


### PR DESCRIPTION
## Description:
Allows configuring sources for older Pioneer receivers

This PR allows configuring sources for older Pioneer receivers. Prior to this PR it was not possible to change sources on such receivers without modifying the `media_player.py` file of the `Pioneer` component.

The configuration is done via a new `sources` dictionary. The keys are user friendly names for the sources, while the values are the codes used when sending commands via telnet. Due to different receivers giving different names to these codes it is difficult to provide/expect more user friendly names than just the codes. 

This change is backwards compatible.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: pioneer
    host: 192.168.178.2
    port: 8102
    sources:
      SAT: '06'
      TV: '05'
      Game: '49'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io): home-assistant/home-assistant.io#9937

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
