### PR TITLE
0.96.2

### DIFF
--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -93,9 +93,10 @@ class FritzboxThermostat(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self._target_temperature in (ON_API_TEMPERATURE,
-                                        OFF_API_TEMPERATURE):
-            return None
+        if self._target_temperature == ON_API_TEMPERATURE:
+            return ON_REPORT_SET_TEMPERATURE
+        if self._target_temperature == OFF_API_TEMPERATURE:
+            return OFF_REPORT_SET_TEMPERATURE
         return self._target_temperature
 
     def set_temperature(self, **kwargs):
@@ -110,7 +111,10 @@ class FritzboxThermostat(ClimateDevice):
     @property
     def hvac_mode(self):
         """Return the current operation mode."""
-        if self._target_temperature == OFF_REPORT_SET_TEMPERATURE:
+        if (
+                self._target_temperature == OFF_REPORT_SET_TEMPERATURE or
+                self._target_temperature == OFF_API_TEMPERATURE
+        ):
             return HVAC_MODE_OFF
 
         return HVAC_MODE_HEAT

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/components/frontend",
   "requirements": [
-    "home-assistant-frontend==20190718.0"
+    "home-assistant-frontend==20190719.0"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/components/homematic/climate.py
+++ b/homeassistant/components/homematic/climate.py
@@ -66,7 +66,7 @@ class HMThermostat(HMDevice, ClimateDevice):
 
         Need to be one of HVAC_MODE_*.
         """
-        if self.current_temperature <= self._hmdevice.OFF_VALUE + 0.5:
+        if self.target_temperature <= self._hmdevice.OFF_VALUE + 0.5:
             return HVAC_MODE_OFF
         if "MANU_MODE" in self._hmdevice.ACTIONNODE:
             if self._hm_controll_mode == self._hmdevice.MANU_MODE:

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -11,9 +11,8 @@ from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     FAN_AUTO, FAN_DIFFUSE, FAN_ON,
-    SUPPORT_AUX_HEAT, SUPPORT_FAN_MODE,
-    SUPPORT_PRESET_MODE, SUPPORT_TARGET_HUMIDITY, SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE,
+    SUPPORT_AUX_HEAT, SUPPORT_FAN_MODE, SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_HUMIDITY, SUPPORT_TARGET_TEMPERATURE_RANGE,
     CURRENT_HVAC_COOL, CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF,
     HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_HEAT_COOL,
     PRESET_AWAY,
@@ -128,7 +127,6 @@ class HoneywellUSThermostat(ClimateDevice):
         self._password = password
 
         self._supported_features = (SUPPORT_PRESET_MODE |
-                                    SUPPORT_TARGET_TEMPERATURE |
                                     SUPPORT_TARGET_TEMPERATURE_RANGE)
 
         # pylint: disable=protected-access

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -363,7 +363,7 @@ class DailyHistory:
     def add_measurement(self, value, timestamp=None):
         """Add a new measurement for a certain day."""
         day = (timestamp or datetime.now()).date()
-        if value is None:
+        if not isinstance(value, (int, float)):
             return
         if self._days is None:
             self._days = deque()
@@ -388,4 +388,6 @@ class DailyHistory:
             oldest = self._days.popleft()
             del self._max_dict[oldest]
         self._days.append(day)
+        if not isinstance(value, (int, float)):
+            return
         self._max_dict[day] = value

--- a/homeassistant/components/wink/climate.py
+++ b/homeassistant/components/wink/climate.py
@@ -137,7 +137,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
     @property
     def preset_mode(self):
         """Return the current preset mode, e.g., home, away, temp."""
-        mode = self.wink.current_mode()
+        mode = self.wink.current_hvac_mode()
         if mode == "eco":
             return PRESET_ECO
         if self.wink.away():
@@ -192,7 +192,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         """Return true if aux heater."""
         if 'aux' not in self.wink.hvac_modes():
             return None
-        if self.wink.hvac_action_mode() == 'aux':
+        if self.wink.current_hvac_mode() == 'aux':
             return True
         return False
 
@@ -205,7 +205,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         if not self.wink.is_on():
             return HVAC_MODE_OFF
 
-        wink_mode = self.wink.current_mode()
+        wink_mode = self.wink.current_hvac_mode()
         if wink_mode == "aux":
             return HVAC_MODE_HEAT
         if wink_mode == "eco":
@@ -220,7 +220,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         """
         hvac_list = [HVAC_MODE_OFF]
 
-        modes = self.wink.modes()
+        modes = self.wink.hvac_modes()
         for mode in modes:
             if mode in ("eco", "aux"):
                 continue
@@ -409,7 +409,7 @@ class WinkAC(WinkDevice, ClimateDevice):
         if not self.wink.is_on():
             return HVAC_MODE_OFF
 
-        wink_mode = self.wink.current_mode()
+        wink_mode = self.wink.current_hvac_mode()
         if wink_mode == "auto_eco":
             return HVAC_MODE_AUTO
         return WINK_HVAC_TO_HA.get(wink_mode)
@@ -422,7 +422,7 @@ class WinkAC(WinkDevice, ClimateDevice):
         """
         hvac_list = [HVAC_MODE_OFF]
 
-        modes = self.wink.modes()
+        modes = self.wink.hvac_modes()
         for mode in modes:
             if mode == "auto_eco":
                 continue

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 96
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,7 +10,7 @@ certifi>=2019.6.16
 cryptography==2.7
 distro==1.4.0
 hass-nabucasa==0.15
-home-assistant-frontend==20190718.0
+home-assistant-frontend==20190719.0
 importlib-metadata==0.18
 jinja2>=2.10.1
 netdisco==2.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -610,7 +610,7 @@ hole==0.3.0
 holidays==0.9.10
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190718.0
+home-assistant-frontend==20190719.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -165,7 +165,7 @@ hdate==0.8.8
 holidays==0.9.10
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190718.0
+home-assistant-frontend==20190719.0
 
 # homeassistant.components.homekit_controller
 homekit[IP]==0.14.0

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -66,10 +66,10 @@ class TestFritzboxClimate(unittest.TestCase):
         assert 19.5 == self.thermostat.target_temperature
 
         self.thermostat._target_temperature = 126.5
-        assert self.thermostat.target_temperature is None
+        assert self.thermostat.target_temperature == 0.0
 
         self.thermostat._target_temperature = 127.0
-        assert self.thermostat.target_temperature is None
+        assert self.thermostat.target_temperature == 30.0
 
     @patch.object(FritzboxThermostat, 'set_hvac_mode')
     def test_set_temperature_operation_mode(self, mock_set_op):
@@ -103,7 +103,7 @@ class TestFritzboxClimate(unittest.TestCase):
         self.thermostat._target_temperature = 127.0
         assert 'heat' == self.thermostat.hvac_mode
         self.thermostat._target_temperature = 126.5
-        assert 'heat' == self.thermostat.hvac_mode
+        assert 'off' == self.thermostat.hvac_mode
         self.thermostat._target_temperature = 22.0
         assert 'heat' == self.thermostat.hvac_mode
         self.thermostat._target_temperature = 16.0


### PR DESCRIPTION
- Fix fritzbox climate HVAC mode / temperature ([@cgtobi] - [#25275]) ([fritzbox docs])
- Fixed python-wink method names ([@w1ll1am23] - [#25285]) ([wink docs])
- [climate] Correct honeywell supported_features ([@zxdavb] - [#25292]) ([honeywell docs])
- Fix HM with use wrong datapoint for off ([@pvizeli] - [#25298]) ([homematic docs])
- Fix plant error when adding new value ([@cgtobi] - [#25302]) ([plant docs])

[#25275]: https://github.com/home-assistant/home-assistant/pull/25275
[#25285]: https://github.com/home-assistant/home-assistant/pull/25285
[#25292]: https://github.com/home-assistant/home-assistant/pull/25292
[#25298]: https://github.com/home-assistant/home-assistant/pull/25298
[#25302]: https://github.com/home-assistant/home-assistant/pull/25302
[@cgtobi]: https://github.com/cgtobi
[@pvizeli]: https://github.com/pvizeli
[@w1ll1am23]: https://github.com/w1ll1am23
[@zxdavb]: https://github.com/zxdavb
[fritzbox docs]: https://www.home-assistant.io/components/fritzbox/
[homematic docs]: https://www.home-assistant.io/components/homematic/
[honeywell docs]: https://www.home-assistant.io/components/honeywell/
[plant docs]: https://www.home-assistant.io/components/plant/
[wink docs]: https://www.home-assistant.io/components/wink/