### PR TITLE
Update Google Maps Location Tracker to use locationsharinglib==4.0.2

### DIFF
--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -7,12 +7,12 @@ import voluptuous as vol
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, SOURCE_TYPE_GPS)
 from homeassistant.const import (
-    ATTR_ID, CONF_PASSWORD, CONF_USERNAME, ATTR_BATTERY_CHARGING,
-    ATTR_BATTERY_LEVEL)
+    ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL, ATTR_ID, CONF_PASSWORD,
+    CONF_SCAN_INTERVAL, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import slugify, dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,12 +25,10 @@ CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 
 CREDENTIALS_FILE = '.google_maps_location_sharing.cookies'
 
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Optional(CONF_MAX_GPS_ACCURACY, default=100000): vol.Coerce(float),
+    vol.Optional(CONF_SCAN_INTERVAL, default=60): vol.Coerce(float),
 })
 
 
@@ -46,26 +44,29 @@ class GoogleMapsScanner:
     def __init__(self, hass, config: ConfigType, see) -> None:
         """Initialize the scanner."""
         from locationsharinglib import Service
-        from locationsharinglib.locationsharinglibexceptions import InvalidUser
+        from locationsharinglib.locationsharinglibexceptions import \
+            InvalidCookies
 
         self.see = see
         self.username = config[CONF_USERNAME]
-        self.password = config[CONF_PASSWORD]
         self.max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
+        self.scan_interval = timedelta(seconds=config[CONF_SCAN_INTERVAL])
 
+        credfile = "{}.{}".format(hass.config.path(CREDENTIALS_FILE),
+                                  slugify(self.username))
         try:
-            credfile = "{}.{}".format(hass.config.path(CREDENTIALS_FILE),
-                                      slugify(self.username))
-            self.service = Service(self.username, self.password, credfile)
+            self.service = Service(credfile, self.username)
             self._update_info()
 
             track_time_interval(
-                hass, self._update_info, MIN_TIME_BETWEEN_SCANS)
+                hass, self._update_info, self.scan_interval)
 
             self.success_init = True
 
-        except InvalidUser:
-            _LOGGER.error("You have specified invalid login credentials")
+        except InvalidCookies:
+            _LOGGER.error("You have specified invalid login credentials. "
+                          "Please make sure you have saved your credentials"
+                          " in the following file: %s", credfile)
             self.success_init = False
 
     def _update_info(self, now=None):

--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, SOURCE_TYPE_GPS)
 from homeassistant.const import (
-    ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL, ATTR_ID, CONF_PASSWORD,
+    ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL, ATTR_ID,
     CONF_SCAN_INTERVAL, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval

--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -2,13 +2,15 @@
 from datetime import timedelta
 import logging
 
+from locationsharinglib import Service
+from locationsharinglib.locationsharinglibexceptions import InvalidCookies
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, SOURCE_TYPE_GPS)
 from homeassistant.const import (
-    ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL, ATTR_ID,
-    CONF_SCAN_INTERVAL, CONF_USERNAME)
+    ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL, ATTR_ID, CONF_SCAN_INTERVAL,
+    CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
@@ -28,7 +30,6 @@ CREDENTIALS_FILE = '.google_maps_location_sharing.cookies'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Optional(CONF_MAX_GPS_ACCURACY, default=100000): vol.Coerce(float),
-    vol.Optional(CONF_SCAN_INTERVAL, default=60): vol.Coerce(float),
 })
 
 
@@ -43,14 +44,11 @@ class GoogleMapsScanner:
 
     def __init__(self, hass, config: ConfigType, see) -> None:
         """Initialize the scanner."""
-        from locationsharinglib import Service
-        from locationsharinglib.locationsharinglibexceptions import \
-            InvalidCookies
-
         self.see = see
         self.username = config[CONF_USERNAME]
         self.max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
-        self.scan_interval = timedelta(seconds=config[CONF_SCAN_INTERVAL])
+        self.scan_interval = \
+            timedelta(seconds=config.get(CONF_SCAN_INTERVAL, 60))
 
         credfile = "{}.{}".format(hass.config.path(CREDENTIALS_FILE),
                                   slugify(self.username))

--- a/homeassistant/components/google_maps/manifest.json
+++ b/homeassistant/components/google_maps/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google maps",
   "documentation": "https://www.home-assistant.io/components/google_maps",
   "requirements": [
-    "locationsharinglib==3.0.11"
+    "locationsharinglib==4.0.2"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -733,7 +733,7 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.google_maps
-locationsharinglib==3.0.11
+locationsharinglib==4.0.2
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.2


### PR DESCRIPTION
## Breaking Change:

Google Passwords are no longer required to be provided in your config. An external program is now required to obtain the necessary cookie file to place in your Home Assistant config directory. This is due to the authentication process being removed from the underlying package.  Existing users should remove the `password:` entry from their config file (`username` is still required).  The cookie file previously generated should still be valid and will allow the tracker to continue functioning normally until the cookie is invalidated.  New users will need to follow the instructions on the [Google Maps Location Sharing](https://www.home-assistant.io/components/google_maps/) page to create their cookie file.

## Description:

Update the Google Maps location tracker component to use the most recent version of the underlying package (v4.0.2). 

I am adding this PR on behalf of @costastf and per this forum post: https://community.home-assistant.io/t/google-maps-device-tracking-setup/59944/65

**Related issue (if applicable):**
fixes #23349, fixes #25312, fixes #24490, fixes #24025

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9918 

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [n/a] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
