### PR TITLE
Restore Sensibo turn on/off methods

### DIFF
--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -318,6 +318,18 @@ class SensiboClimate(ClimateDevice):
             await self._client.async_set_ac_state_property(
                 self._id, 'swing', swing_mode, self._ac_states)
 
+    async def async_turn_on(self):
+        """Turn Sensibo unit on."""
+        with async_timeout.timeout(TIMEOUT):
+            await self._client.async_set_ac_state_property(
+                self._id, 'on', True, self._ac_states)
+
+    async def async_turn_off(self):
+        """Turn Sensibo unit on."""
+        with async_timeout.timeout(TIMEOUT):
+            await self._client.async_set_ac_state_property(
+                self._id, 'on', False, self._ac_states)
+
     async def async_assume_state(self, state):
         """Set external state."""
         change_needed = \


### PR DESCRIPTION
## Description:
Restore the Sensibo turn on and off methods that accidentally got removed in 0.95.

Maybe related to https://github.com/home-assistant/home-assistant/issues/25276

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
