### PR TITLE
Restore Daikin A/C on/off services

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -289,6 +289,17 @@ class DaikinClimate(ClimateDevice):
         """Retrieve latest state."""
         await self._api.async_update()
 
+    async def async_turn_on(self):
+        """Turn device on."""
+        await self._api.device.set({})
+
+    async def async_turn_off(self):
+        """Turn device off."""
+        await self._api.device.set({
+            HA_ATTR_TO_DAIKIN[ATTR_HVAC_MODE]:
+            HA_STATE_TO_DAIKIN[HVAC_MODE_OFF]
+        })
+
     @property
     def device_info(self):
         """Return a device description for device registry."""


### PR DESCRIPTION
## Description:

Add the service turn_on and turn_off implementations back to the Daikin Air Conditioner climate platform. This was removed as support was initially dropped in Climate 1.0 but added back later.

**Related issue (if applicable):** fixes #18578

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
