### PR TITLE
Fix util.ruamel_yaml type errors

### DIFF
--- a/homeassistant/util/ruamel_yaml.py
+++ b/homeassistant/util/ruamel_yaml.py
@@ -3,7 +3,7 @@ import logging
 import os
 from os import O_CREAT, O_TRUNC, O_WRONLY, stat_result
 from collections import OrderedDict
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Optional
 
 import ruamel.yaml
 from ruamel.yaml import YAML
@@ -22,6 +22,8 @@ JSON_TYPE = Union[List, Dict, str]  # pylint: disable=invalid-name
 class ExtSafeConstructor(SafeConstructor):
     """Extended SafeConstructor."""
 
+    name = None  # type: Optional[str]
+
 
 class UnsupportedYamlError(HomeAssistantError):
     """Unsupported YAML."""
@@ -31,22 +33,25 @@ class WriteError(HomeAssistantError):
     """Error writing the data."""
 
 
-def _include_yaml(constructor: SafeConstructor, node: ruamel.yaml.nodes.Node) \
-        -> JSON_TYPE:
+def _include_yaml(constructor: ExtSafeConstructor,
+                  node: ruamel.yaml.nodes.Node) -> JSON_TYPE:
     """Load another YAML file and embeds it using the !include tag.
 
     Example:
         device_tracker: !include device_tracker.yaml
     """
+    if constructor.name is None:
+        raise HomeAssistantError(
+            "YAML include error: filename not set for %s" % node.value)
     fname = os.path.join(os.path.dirname(constructor.name), node.value)
     return load_yaml(fname, False)
 
 
-def _yaml_unsupported(constructor: SafeConstructor, node:
+def _yaml_unsupported(constructor: ExtSafeConstructor, node:
                       ruamel.yaml.nodes.Node) -> None:
     raise UnsupportedYamlError(
         'Unsupported YAML, you can not use {} in {}'
-        .format(node.tag, os.path.basename(constructor.name)))
+        .format(node.tag, os.path.basename(constructor.name or '(None)')))
 
 
 def object_to_yaml(data: JSON_TYPE) -> str:
@@ -80,7 +85,7 @@ def load_yaml(fname: str, round_trip: bool = False) -> JSON_TYPE:
         yaml = YAML(typ='rt')
         yaml.preserve_quotes = True
     else:
-        if not hasattr(ExtSafeConstructor, 'name'):
+        if ExtSafeConstructor.name is None:
             ExtSafeConstructor.name = fname
         yaml = YAML(typ='safe')
         yaml.Constructor = ExtSafeConstructor


### PR DESCRIPTION
## Description:

Fixes errors that started appearing after #25175 I guess. Untested beyond tests run.

These should have been caught in CI, not sure why they're not, maybe there's something wrong with it? They do show up for me locally and in Travis.

```
homeassistant/util/ruamel_yaml.py:41: error: "SafeConstructor" has no attribute "name"
homeassistant/util/ruamel_yaml.py:49: error: "SafeConstructor" has no attribute "name"
homeassistant/util/ruamel_yaml.py:81: error: Incompatible types in assignment (expression has type "bool", variable has type "None")
homeassistant/util/ruamel_yaml.py:84: error: "Type[ExtSafeConstructor]" has no attribute "name"
```

**Related issue (if applicable):** #25175

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
