### PR TITLE
Doc lint fixes

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -300,7 +300,10 @@ class EvoController(EvoClimateDevice):
         return TCS_PRESET_TO_HA.get(self._evo_tcs.systemModeStatus['mode'])
 
     def set_temperature(self, **kwargs) -> None:
-        """The evohome Controller doesn't have a targert temperature."""
+        """Do nothing.
+
+        The evohome Controller doesn't have a target temperature.
+        """
         return
 
     def set_hvac_mode(self, hvac_mode: str) -> None:

--- a/homeassistant/components/hive/water_heater.py
+++ b/homeassistant/components/hive/water_heater.py
@@ -77,7 +77,7 @@ class HiveWaterHeater(WaterHeaterDevice):
 
     @property
     def name(self):
-        """Return the name of the water heater """
+        """Return the name of the water heater."""
         if self.node_name is None:
             self.node_name = "Hot Water"
         return self.node_name
@@ -89,7 +89,7 @@ class HiveWaterHeater(WaterHeaterDevice):
 
     @property
     def current_operation(self):
-        """ Return current operation. """
+        """Return current operation."""
         return HIVE_TO_HASS_STATE[self.session.hotwater.get_mode(self.node_id)]
 
     @property


### PR DESCRIPTION
## Description:

Fixes doc lint issues.

These should have been caught in CI, not sure why they're not, maybe there's something wrong with it? They do show up for me locally and in Travis.

```
homeassistant/components/hive/water_heater.py:80:1: D210 No whitespaces allowed surrounding docstring text
homeassistant/components/hive/water_heater.py:80:1: D400 First line should end with a period
homeassistant/components/hive/water_heater.py:92:1: D210 No whitespaces allowed surrounding docstring text
homeassistant/components/evohome/climate.py:303:1: D401 First line should be in imperative mood; try rephrasing
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]