### PR TITLE
Fix for hvac_modes list being null

### DIFF
--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -244,7 +244,9 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
 
         Need to be a subset of HVAC_MODES.
         """
-        return self._hvac_list
+        if self.values.mode:
+            return self._hvac_list
+        return [HVAC_MODE_HEAT]
 
     @property
     def hvac_action(self):

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -246,7 +246,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         """
         if self.values.mode:
             return self._hvac_list
-        return [HVAC_MODE_HEAT]
+        return []
 
     @property
     def hvac_action(self):


### PR DESCRIPTION
## Breaking Change:
None.

## Description:
I tried to solve the issue the way it's solved in the hvac_mode()-function, that's why the if-case is stated like that.

**Related issue (if applicable):** fixes #25345

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
