### PR TITLE
Add available attribute to ZHA device info that is accessible via API

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -59,6 +59,7 @@ ATTR_COMMAND = 'command'
 ATTR_COMMAND_TYPE = 'command_type'
 ATTR_ARGS = 'args'
 ATTR_ENDPOINT_ID = 'endpoint_id'
+ATTR_AVAILABLE = 'available'
 
 IN = 'in'
 OUT = 'out'

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -23,7 +23,7 @@ from .const import (
     MANUFACTURER_CODE, MODEL, NAME, NWK, OUT, POWER_CONFIGURATION_CHANNEL,
     POWER_SOURCE, QUIRK_APPLIED, QUIRK_CLASS, SERVER, SERVER_COMMANDS,
     SIGNAL_AVAILABLE, UNKNOWN_MANUFACTURER, UNKNOWN_MODEL, ZDO_CHANNEL,
-    LQI, RSSI, LAST_SEEN)
+    LQI, RSSI, LAST_SEEN, ATTR_AVAILABLE)
 
 _LOGGER = logging.getLogger(__name__)
 _KEEP_ALIVE_INTERVAL = 7200
@@ -213,7 +213,8 @@ class ZHADevice:
             POWER_SOURCE: self.power_source,
             LQI: self.lqi,
             RSSI: self.rssi,
-            LAST_SEEN: update_time
+            LAST_SEEN: update_time,
+            ATTR_AVAILABLE: self.available
         }
 
     def add_cluster_channel(self, cluster_channel):


### PR DESCRIPTION
## Description:
This PR adds device availability to the info returned by the API for ZHA devices.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]