### PR TITLE
Add support for contact binary sensors in homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -2,6 +2,7 @@
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
+from homekit.model.characteristics import CharacteristicsTypes
 
 from . import KNOWN_DEVICES, HomeKitEntity
 
@@ -18,9 +19,6 @@ class HomeKitMotionSensor(HomeKitEntity, BinarySensorDevice):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity is tracking."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.MOTION_DETECTED,
         ]
@@ -49,9 +47,6 @@ class HomeKitContactSensor(HomeKitEntity, BinarySensorDevice):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity is tracking."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.CONTACT_STATE,
         ]

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -65,6 +65,7 @@ class HomeKitMotionSensor(HomeKitEntity, BinarySensorDevice):
         """Has motion been detected."""
         return self._on
 
+
 class HomeKitContactSensor(HomeKitEntity, BinarySensorDevice):
     """Representation of a Homekit contact sensor."""
 

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -1,8 +1,9 @@
 """Support for Homekit motion sensors."""
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
 from homekit.model.characteristics import CharacteristicsTypes
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
 
 from . import KNOWN_DEVICES, HomeKitEntity
 
@@ -57,7 +58,7 @@ class HomeKitContactSensor(HomeKitEntity, BinarySensorDevice):
     @property
     def is_on(self):
         """Return true if the binary sensor is on/open."""
-        return True if self._state == 1 else False
+        return self._state == 1
 
 
 ENTITY_TYPES = {

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -19,6 +19,7 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     'window': 'cover',
     'window-covering': 'cover',
     'lock-mechanism': 'lock',
+    'contact': 'binary_sensor',
     'motion': 'binary_sensor',
     'humidity': 'sensor',
     'light': 'sensor',

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -1,8 +1,9 @@
-"""Basic checks for HomeKitLock."""
+"""Basic checks for HomeKit motion sensors and contact sensors."""
 from tests.components.homekit_controller.common import (
     FakeService, setup_test_component)
 
 MOTION_DETECTED = ('motion', 'motion-detected')
+CONTACT_STATE = ('contact', 'contact-state')
 
 
 def create_sensor_motion_service():
@@ -15,7 +16,7 @@ def create_sensor_motion_service():
     return service
 
 
-async def test_sensor_read_state(hass, utcnow):
+async def test_motion_sensor_read_state(hass, utcnow):
     """Test that we can read the state of a HomeKit motion sensor accessory."""
     sensor = create_sensor_motion_service()
     helper = await setup_test_component(hass, [sensor])
@@ -25,5 +26,29 @@ async def test_sensor_read_state(hass, utcnow):
     assert state.state == 'off'
 
     helper.characteristics[MOTION_DETECTED].value = True
+    state = await helper.poll_and_get_state()
+    assert state.state == 'on'
+
+
+def create_sensor_contact_service():
+    """Define contact characteristics."""
+    service = FakeService('public.hap.service.sensor.contact')
+
+    cur_state = service.add_characteristic('contact-state')
+    cur_state.value = 0
+
+    return service
+
+
+async def test_contact_sensor_read_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit contact accessory."""
+    sensor = create_sensor_contact_service()
+    helper = await setup_test_component(hass, [sensor])
+
+    helper.characteristics[CONTACT_STATE].value = False
+    state = await helper.poll_and_get_state()
+    assert state.state == 'off'
+
+    helper.characteristics[CONTACT_STATE].value = True
     state = await helper.poll_and_get_state()
     assert state.state == 'on'

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -6,7 +6,7 @@ MOTION_DETECTED = ('motion', 'motion-detected')
 CONTACT_STATE = ('contact', 'contact-state')
 
 
-def create_sensor_motion_service():
+def create_motion_sensor_service():
     """Define motion characteristics as per page 225 of HAP spec."""
     service = FakeService('public.hap.service.sensor.motion')
 
@@ -18,7 +18,7 @@ def create_sensor_motion_service():
 
 async def test_motion_sensor_read_state(hass, utcnow):
     """Test that we can read the state of a HomeKit motion sensor accessory."""
-    sensor = create_sensor_motion_service()
+    sensor = create_motion_sensor_service()
     helper = await setup_test_component(hass, [sensor])
 
     helper.characteristics[MOTION_DETECTED].value = False
@@ -30,7 +30,7 @@ async def test_motion_sensor_read_state(hass, utcnow):
     assert state.state == 'on'
 
 
-def create_sensor_contact_service():
+def create_contact_sensor_service():
     """Define contact characteristics."""
     service = FakeService('public.hap.service.sensor.contact')
 
@@ -42,13 +42,13 @@ def create_sensor_contact_service():
 
 async def test_contact_sensor_read_state(hass, utcnow):
     """Test that we can read the state of a HomeKit contact accessory."""
-    sensor = create_sensor_contact_service()
+    sensor = create_contact_sensor_service()
     helper = await setup_test_component(hass, [sensor])
 
-    helper.characteristics[CONTACT_STATE].value = False
+    helper.characteristics[CONTACT_STATE].value = 0
     state = await helper.poll_and_get_state()
     assert state.state == 'off'
 
-    helper.characteristics[CONTACT_STATE].value = True
+    helper.characteristics[CONTACT_STATE].value = 1
     state = await helper.poll_and_get_state()
     assert state.state == 'on'


### PR DESCRIPTION
## Description:

Add support for homekit accessories with type of `contact`. Currently these accessories are ignored.

I haven't tested this yet, still trying to figure out how to get this change loaded into my environment.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9931

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
