### PR TITLE
Automatically expand WWLLN window to 1 hour (if necessary)

### DIFF
--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -43,8 +43,8 @@ async def async_setup(hass, config):
 
     if conf[CONF_WINDOW] < DEFAULT_WINDOW:
         _LOGGER.warning(
-            'Setting a window smaller than {0} seconds may cause Home Assistant \
-            to miss events'.format(DEFAULT_WINDOW.total_seconds()))
+            'Setting a window smaller than %s seconds may cause Home Assistant \
+            to miss events', DEFAULT_WINDOW.total_seconds())
 
     if hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL:
         unit_system = CONF_UNIT_SYSTEM_IMPERIAL

--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -41,6 +41,11 @@ async def async_setup(hass, config):
     if identifier in configured_instances(hass):
         return True
 
+    if conf[CONF_WINDOW] < DEFAULT_WINDOW:
+        _LOGGER.warning(
+            'Setting a window smaller than {0} seconds may cause Home Assistant \
+            to miss events'.format(DEFAULT_WINDOW.total_seconds()))
+
     if hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL:
         unit_system = CONF_UNIT_SYSTEM_IMPERIAL
     else:
@@ -83,5 +88,22 @@ async def async_unload_entry(hass, config_entry):
 
     await hass.config_entries.async_forward_entry_unload(
         config_entry, 'geo_location')
+
+    return True
+
+
+async def async_migrate_entry(hass, config_entry):
+    """Migrate the config entry upon new versions."""
+    version = config_entry.version
+    data = config_entry.data
+
+    _LOGGER.debug('Migrating WWLLN from version %s', version)
+
+    # Version 1 -> Version 2: Expanding the default window to 1 hour
+    if version == 1:
+        data[CONF_WINDOW] = DEFAULT_WINDOW.total_seconds()
+        version = config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data=data)
+        _LOGGER.info('Migration to version %s successful', version)
 
     return True

--- a/homeassistant/components/wwlln/__init__.py
+++ b/homeassistant/components/wwlln/__init__.py
@@ -97,11 +97,14 @@ async def async_migrate_entry(hass, config_entry):
     version = config_entry.version
     data = config_entry.data
 
-    _LOGGER.debug('Migrating WWLLN from version %s', version)
+    default_total_seconds = DEFAULT_WINDOW.total_seconds()
 
-    # Version 1 -> Version 2: Expanding the default window to 1 hour
+    _LOGGER.debug('Migrating from version %s', version)
+
+    # 1 -> 2: Expanding the default window to 1 hour (if needed):
     if version == 1:
-        data[CONF_WINDOW] = DEFAULT_WINDOW.total_seconds()
+        if data[CONF_WINDOW] < default_total_seconds:
+            data[CONF_WINDOW] = default_total_seconds
         version = config_entry.version = 2
         hass.config_entries.async_update_entry(config_entry, data=data)
         _LOGGER.info('Migration to version %s successful', version)

--- a/homeassistant/components/wwlln/config_flow.py
+++ b/homeassistant/components/wwlln/config_flow.py
@@ -25,7 +25,7 @@ def configured_instances(hass):
 class WWLLNFlowHandler(config_entries.ConfigFlow):
     """Handle a WWLLN config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     async def _show_form(self, errors=None):

--- a/homeassistant/components/wwlln/const.py
+++ b/homeassistant/components/wwlln/const.py
@@ -8,4 +8,4 @@ CONF_WINDOW = 'window'
 DATA_CLIENT = 'client'
 
 DEFAULT_RADIUS = 25
-DEFAULT_WINDOW = timedelta(minutes=10)
+DEFAULT_WINDOW = timedelta(hours=1)

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -1,5 +1,6 @@
 """Define tests for the WWLLN config flow."""
 from datetime import timedelta
+import logging
 
 from asynctest import patch
 
@@ -83,7 +84,7 @@ async def test_step_user(hass):
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
         CONF_UNIT_SYSTEM: 'metric',
-        CONF_WINDOW: 600.0,
+        CONF_WINDOW: 3600.0,
     }
 
 
@@ -93,7 +94,7 @@ async def test_custom_window(hass):
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
-        CONF_WINDOW: timedelta(hours=1)
+        CONF_WINDOW: timedelta(hours=2)
     }
 
     flow = config_flow.WWLLNFlowHandler()
@@ -107,7 +108,7 @@ async def test_custom_window(hass):
         CONF_LONGITUDE: -104.9812612,
         CONF_RADIUS: 25,
         CONF_UNIT_SYSTEM: 'metric',
-        CONF_WINDOW: 3600,
+        CONF_WINDOW: 7200,
     }
 
 

--- a/tests/components/wwlln/test_config_flow.py
+++ b/tests/components/wwlln/test_config_flow.py
@@ -1,6 +1,5 @@
 """Define tests for the WWLLN config flow."""
 from datetime import timedelta
-import logging
 
 from asynctest import patch
 


### PR DESCRIPTION
## Description:

After further investigation of https://github.com/home-assistant/home-assistant/issues/25272, it appears that a combination of (a) the WWLLN not necessarily updating data in real-time and (b) a too-small configured `window` parameter is causing strike data to disappear before HASS has time to register it. This PR expands the default `window` from 10 minutes to 1 hour, which shows a good amount of strike data and should help the primary use case (more timely automations).

If the user has configured a `window` of less than 1 hour, their config entry will automatically be migrated and updated; if their `window` is already an hour or more, it will be untouched (other than bumping its version). Thus, this should not be considered a breaking change, as it will automatically improve the integration under the hood for most users.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/25272

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/9932

## Example entry for `configuration.yaml` (if applicable):
```yaml
wwlln:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
