### PR TITLE
Fix Netatmo preset service call

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -27,6 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PRESET_FROST_GUARD = 'Frost Guard'
 PRESET_SCHEDULE = 'Schedule'
+PRESET_MANUAL = 'Manual'
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE)
 SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF]
@@ -34,7 +35,7 @@ SUPPORT_PRESET = [
     PRESET_AWAY, PRESET_BOOST, PRESET_FROST_GUARD, PRESET_SCHEDULE,
 ]
 
-STATE_NETATMO_SCHEDULE = PRESET_SCHEDULE
+STATE_NETATMO_SCHEDULE = 'schedule'
 STATE_NETATMO_HG = 'hg'
 STATE_NETATMO_MAX = 'max'
 STATE_NETATMO_AWAY = PRESET_AWAY
@@ -44,7 +45,6 @@ STATE_NETATMO_MANUAL = 'manual'
 PRESET_MAP_NETATMO = {
     PRESET_FROST_GUARD: STATE_NETATMO_HG,
     PRESET_BOOST: STATE_NETATMO_MAX,
-    STATE_NETATMO_MAX: STATE_NETATMO_MAX,
     PRESET_SCHEDULE: STATE_NETATMO_SCHEDULE,
     PRESET_AWAY: STATE_NETATMO_AWAY,
     STATE_NETATMO_OFF: STATE_NETATMO_OFF
@@ -56,16 +56,17 @@ NETATMO_MAP_PRESET = {
     STATE_NETATMO_SCHEDULE: PRESET_SCHEDULE,
     STATE_NETATMO_AWAY: PRESET_AWAY,
     STATE_NETATMO_OFF: STATE_NETATMO_OFF,
-    STATE_NETATMO_MANUAL: 'Manual',
+    STATE_NETATMO_MANUAL: STATE_NETATMO_MANUAL,
 }
 
 HVAC_MAP_NETATMO = {
-    STATE_NETATMO_SCHEDULE: HVAC_MODE_AUTO,
+    PRESET_SCHEDULE: HVAC_MODE_AUTO,
     STATE_NETATMO_HG: HVAC_MODE_AUTO,
     PRESET_FROST_GUARD: HVAC_MODE_AUTO,
-    STATE_NETATMO_MAX: HVAC_MODE_HEAT,
+    PRESET_BOOST: HVAC_MODE_HEAT,
     STATE_NETATMO_OFF: HVAC_MODE_OFF,
     STATE_NETATMO_MANUAL: HVAC_MODE_AUTO,
+    PRESET_MANUAL: HVAC_MODE_AUTO,
     STATE_NETATMO_AWAY: HVAC_MODE_AUTO
 }
 
@@ -221,9 +222,9 @@ class NetatmoThermostat(ClimateDevice):
         if hvac_mode == HVAC_MODE_OFF:
             mode = STATE_NETATMO_OFF
         elif hvac_mode == HVAC_MODE_AUTO:
-            mode = STATE_NETATMO_SCHEDULE
+            mode = PRESET_SCHEDULE
         elif hvac_mode == HVAC_MODE_HEAT:
-            mode = STATE_NETATMO_MAX
+            mode = PRESET_BOOST
 
         self.set_preset_mode(mode)
 
@@ -262,6 +263,8 @@ class NetatmoThermostat(ClimateDevice):
             self._data.homestatus.setThermmode(
                 self._data.home_id, PRESET_MAP_NETATMO[preset_mode]
             )
+        else:
+            _LOGGER.error("Preset mode '%s' not available", preset_mode)
         self.update_without_throttle = True
         self.schedule_update_ha_state()
 
@@ -323,10 +326,10 @@ class NetatmoThermostat(ClimateDevice):
             self._hvac_mode = HVAC_MAP_NETATMO[self._preset]
             self._battery_level = \
                 self._data.room_status[self._room_id].get('battery_level')
-        except KeyError:
+        except KeyError as err:
             _LOGGER.error(
-                "The thermostat in room %s seems to be out of reach.",
-                self._room_id
+                "The thermostat in room %s seems to be out of reach. (%s)",
+                self._room_id, err
             )
         self._away = self._hvac_mode == HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
 


### PR DESCRIPTION
## Description:
Some presets did not work when set via service. Log an error message when preset name is not valid.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
