### PR TITLE
Improve geniushub logging and bump client

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -54,6 +54,9 @@ async def async_setup(hass, hass_config):
             exc_info=True)
         return False
 
+    _LOGGER.debug("zones_raw = %s", data._client.hub._zones_raw)
+    _LOGGER.debug("devices_raw = %s", data._client.hub._devices_raw)
+
     async_track_time_interval(hass, data.async_update, SCAN_INTERVAL)
 
     for platform in ['climate', 'water_heater']:
@@ -84,4 +87,9 @@ class GeniusData:
         except AssertionError:  # assert response.status == HTTP_OK
             _LOGGER.warning("Update failed.", exc_info=True)
             return
+
+        _LOGGER.debug("zones_raw = %s", self._client.hub._zones_raw)
+        _LOGGER.debug("devices_raw = %s", self._client.hub._devices_raw)
+
         async_dispatcher_send(self._hass, DOMAIN)
+

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -54,8 +54,8 @@ async def async_setup(hass, hass_config):
             exc_info=True)
         return False
 
-    _LOGGER.debug("zones_raw = %s", data._client.hub._zones_raw)
-    _LOGGER.debug("devices_raw = %s", data._client.hub._devices_raw)
+    _LOGGER.debug("zones_raw = %s", data._client.hub._zones_raw)  # noqa; pylint: disable=protected-access
+    _LOGGER.debug("devices_raw = %s", data._client.hub._devices_raw)  # noqa; pylint: disable=protected-access
 
     async_track_time_interval(hass, data.async_update, SCAN_INTERVAL)
 
@@ -88,8 +88,7 @@ class GeniusData:
             _LOGGER.warning("Update failed.", exc_info=True)
             return
 
-        _LOGGER.debug("zones_raw = %s", self._client.hub._zones_raw)
-        _LOGGER.debug("devices_raw = %s", self._client.hub._devices_raw)
+        _LOGGER.debug("zones_raw = %s", self._client.hub._zones_raw)  # noqa; pylint: disable=protected-access
+        _LOGGER.debug("devices_raw = %s", self._client.hub._devices_raw)  # noqa; pylint: disable=protected-access
 
         async_dispatcher_send(self._hass, DOMAIN)
-

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.4.13"
+    "geniushub-client==0.4.14"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.4.12"
+    "geniushub-client==0.4.13"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.4.14"
+    "geniushub-client==0.4.15"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -511,7 +511,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.4.14
+geniushub-client==0.4.15
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -511,7 +511,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.4.12
+geniushub-client==0.4.13
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -511,7 +511,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.4.13
+geniushub-client==0.4.14
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
## Breaking Change:

None

## Description:
Adds DEBUG logging to **geniushub**.  Without this, it will be difficult to address issues such as #25343 (note that this is not a fix for that issue)

**Related issue (if applicable):** see above

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
logger:
  logs:
    geniushubclient: debug
    homeassistant.components.geniushub: debug
    homeassistant.components.geniushub.climate: debug
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
