### PR TITLE
Fix condition in entity.py for entity registry update event handling

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -433,7 +433,7 @@ class Entity:
     async def _async_registry_updated(self, event):
         """Handle entity registry update."""
         data = event.data
-        if data['action'] != 'update' and data.get(
+        if data['action'] != 'update' or data.get(
                 'old_entity_id', data['entity_id']) != self.entity_id:
             return
 


### PR DESCRIPTION
## Description:
I may be wrong here so feel free to close this if I am but I think the condition here: https://github.com/home-assistant/home-assistant/blob/a6e3cc6617f76ae50443ac8299276ebb0f83b704/homeassistant/helpers/entity.py#L436-L438 is incorrect. 

I think this is trying to say: return if this is not an update **OR** if the update is not for me but as currently written it says return if this is not an update **AND** the update is not for me... that causes any entity update event (such as changing an entity id) to remove and re-add all entities in the system.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]