### PR TITLE
Improve and align Rejseplanen with other transport components (Breaking)

### DIFF
--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -42,6 +42,10 @@ ICON = 'mdi:bus'
 
 SCAN_INTERVAL = timedelta(minutes=1)
 
+BUS_TYPES = ['BUS', 'EXB', 'TB']
+TRAIN_TYPES = ['LET', 'S', 'REG', 'IC', 'LYN', 'TOG']
+METRO_TYPES = ['M']
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STOP_ID): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -51,23 +55,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_DEPARTURE_TYPE, default=[]):
         vol.All(cv.ensure_list,
-                [vol.In([
-                    'BUS',
-                    'EXB',
-                    'TB',
-                    'LET',
-                    'M',
-                    'S',
-                    'REG',
-                    'IC',
-                    'LYN',
-                    'TOG'
-                ])])
+                [vol.In([*BUS_TYPES, *TRAIN_TYPES, *METRO_TYPES])])
 })
-
-BUS_TYPES = ['BUS', 'EXB', 'TB']
-TRAIN_TYPES = ['LET', 'S', 'REG', 'IC', 'LYN', 'TOG']
-METRO_TYPES = ['M']
 
 
 def due_in_minutes(timestamp):

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -108,22 +108,25 @@ class RejseplanenTransportSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        if isinstance(self._times, list) and bool(self._times):
-            next_up = []
-            if len(self._times) > 1:
-                next_up = self._times[1:]
-            params = {
-                ATTR_DUE_IN: str(self._times[0][ATTR_DUE_IN]),
-                ATTR_DUE_AT: self._times[0][ATTR_DUE_AT],
-                ATTR_TYPE: self._times[0][ATTR_TYPE],
-                ATTR_ROUTE: self._times[0][ATTR_ROUTE],
-                ATTR_DIRECTION: self._times[0][ATTR_DIRECTION],
-                ATTR_STOP_NAME: self._times[0][ATTR_STOP_NAME],
-                ATTR_STOP_ID: self._stop_id,
-                ATTR_ATTRIBUTION: ATTRIBUTION,
-                ATTR_NEXT_UP: next_up
-            }
-            return {k: v for k, v in params.items() if v}
+        if not self._times:
+            return None
+
+        next_up = []
+        if len(self._times) > 1:
+            next_up = self._times[1:]
+
+        params = {
+            ATTR_DUE_IN: str(self._times[0][ATTR_DUE_IN]),
+            ATTR_DUE_AT: self._times[0][ATTR_DUE_AT],
+            ATTR_TYPE: self._times[0][ATTR_TYPE],
+            ATTR_ROUTE: self._times[0][ATTR_ROUTE],
+            ATTR_DIRECTION: self._times[0][ATTR_DIRECTION],
+            ATTR_STOP_NAME: self._times[0][ATTR_STOP_NAME],
+            ATTR_STOP_ID: self._stop_id,
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            ATTR_NEXT_UP: next_up
+        }
+        return {k: v for k, v in params.items() if v}
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -119,7 +119,7 @@ class RejseplanenTransportSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        if self._times is not []:
+        if isinstance(self._times, list) and bool(self._times):
             next_up = []
             if len(self._times) > 1:
                 next_up = self._times[1:]

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -171,6 +171,7 @@ class PublicTransportData():
         self.info = []
 
         def intersection(lst1, lst2):
+            """Return items contained in both lists"""
             return list(set(lst1) & set(lst2))
 
         # Limit search to selected types, to get more results

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_DEPARTURE_TYPE, default=[]):
         vol.All(cv.ensure_list,
-                [vol.In(list([
+                [vol.In([
                     'BUS',
                     'EXB',
                     'TB',
@@ -62,7 +62,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                     'IC',
                     'LYN',
                     'TOG'
-                ]))])
+                ])])
 })
 
 BUS_TYPES = ['BUS', 'EXB', 'TB']


### PR DESCRIPTION
## Breaking Change:

- All attributes changed to snake_case.
- `Later departure` attribute has been removed.
- Added `next_departures` which contains a list of all later departures returned from the search, as dictionaries with the same fields as the next departure.

Any existing templates using the sensor's attributes will need to be updated as follows:
`Stop ID` -> `stop_id`
`Stop` -> `stop`
`Route` -> `route`
`Type` -> `type`
`Direction` -> `direction`
`Due in` -> `due_in`
`Due at` -> `due_at`

To get a similar output as `Later departure` returned, you can use a [Template Sensor](https://www.home-assistant.io/components/template/) with this template:
```jinja2
"{% set next = state_attr('sensor.next_departure', 'next_departures')[0] %}{{ next['route'] }} towards {{ next['direction'] }} in {{ next['due_in'] }} from {{ next['stop'] }}"
```

## Documentation
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#9939

## Description:

Additional Changes:
- Additional transport types added.
- Restricts the search to just the relevant types to return more results.

Configuration remains unchanged, and the current documentation does not mention the output.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
