### PR TITLE
Allow rfxtrx network usage

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -28,6 +28,7 @@ CONF_DATA_TYPE = 'data_type'
 CONF_SIGNAL_REPETITIONS = 'signal_repetitions'
 CONF_FIRE_EVENT = 'fire_event'
 CONF_DUMMY = 'dummy'
+CONF_NETWORK = 'network'
 CONF_DEBUG = 'debug'
 CONF_OFF_DELAY = 'off_delay'
 EVENT_BUTTON_PRESSED = 'button_pressed'
@@ -73,6 +74,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_DEVICE): cv.string,
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
         vol.Optional(CONF_DUMMY, default=False): cv.boolean,
+        vol.Optional(CONF_NETWORK, default=False): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -102,11 +104,16 @@ def setup(hass, config):
     device = config[DOMAIN][ATTR_DEVICE]
     debug = config[DOMAIN][ATTR_DEBUG]
     dummy_connection = config[DOMAIN][ATTR_DUMMY]
+    network_connection = config[DOMAIN][ATTR_NETWORK]
 
     if dummy_connection:
         rfx_object = rfxtrxmod.Connect(
             device, None, debug=debug,
             transport_protocol=rfxtrxmod.DummyTransport2)
+    elif network_connection:
+        rfx_object = rfxtrxmod.Connect(
+            device, None, debug=debug,
+            transport_protocol=rfxtrxmod.PyNetworkTransport)
     else:
         rfx_object = rfxtrxmod.Connect(device, None, debug=debug)
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -110,7 +110,7 @@ def setup(hass, config):
     dummy_connection = config[DOMAIN].get(CONF_DUMMY, False)
 
     if dummy_connection:
-        rfx_object = rfxtrxmod.Connect(device, None, debug=debug,
+        rfx_object = rfxtrxmod.Connect('dummy', None, debug=debug,
                                        transport_protocol=rfxtrxmod.DummyTransport2)
     elif device != NO_DEVICE:
         rfx_object = rfxtrxmod.Connect(device, None, debug=debug,

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -22,13 +22,14 @@ ATTR_DEBUG = 'debug'
 ATTR_FIRE_EVENT = 'fire_event'
 ATTR_DATA_TYPE = 'data_type'
 ATTR_DUMMY = 'dummy'
+ATTR_NETWORKPORT = 'networkport'
 CONF_DATA_BITS = 'data_bits'
 CONF_AUTOMATIC_ADD = 'automatic_add'
 CONF_DATA_TYPE = 'data_type'
 CONF_SIGNAL_REPETITIONS = 'signal_repetitions'
 CONF_FIRE_EVENT = 'fire_event'
 CONF_DUMMY = 'dummy'
-CONF_NETWORK = 'network'
+CONF_NETWORKPORT = 'networkport'
 CONF_DEBUG = 'debug'
 CONF_OFF_DELAY = 'off_delay'
 EVENT_BUTTON_PRESSED = 'button_pressed'
@@ -74,7 +75,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_DEVICE): cv.string,
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
         vol.Optional(CONF_DUMMY, default=False): cv.boolean,
-        vol.Optional(CONF_NETWORK, default=False): cv.boolean,
+        vol.Optional(CONF_NETWORKPORT, default=0): cv.positive_int,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -104,15 +105,15 @@ def setup(hass, config):
     device = config[DOMAIN][ATTR_DEVICE]
     debug = config[DOMAIN][ATTR_DEBUG]
     dummy_connection = config[DOMAIN][ATTR_DUMMY]
-    network_connection = config[DOMAIN][ATTR_NETWORK]
+    networkport = config[DOMAIN][ATTR_NETWORKPORT]
 
     if dummy_connection:
         rfx_object = rfxtrxmod.Connect(
             device, None, debug=debug,
             transport_protocol=rfxtrxmod.DummyTransport2)
-    elif network_connection:
+    elif networkport > 0:
         rfx_object = rfxtrxmod.Connect(
-            device, None, debug=debug,
+            (device, networkport), None, debug=debug,
             transport_protocol=rfxtrxmod.PyNetworkTransport)
     else:
         rfx_object = rfxtrxmod.Connect(device, None, debug=debug)


### PR DESCRIPTION
# WIP asking for feedback :bulb:

## Description:

I wanted to use rfxcom device via network. Started with this [HA forum thread](https://community.home-assistant.io/t/adding-network-to-rfxtrx-component/125615/2), then [a PR to pyRFXtrx](https://github.com/Danielhiversen/pyRFXtrx/issues/84), and now this (concept) PR to Home Assistant.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** todo on checklist

## Example entry for `configuration.yaml`:
```yaml
rfxtrx:
  host: '192.168.0.123'
  port: 10001
```
So changed:
- previously only `device: /dev/ttyUSB0` was supported, the above is an alternative.
- added voluptuous indication that only 1 connection config is allowed (device / host / dummy)

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] Make a PR with updated documentation
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
