### PR TITLE
Increase vallox robustness on startup

### DIFF
--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -7,6 +7,7 @@ import logging
 from vallox_websocket_api import PROFILE as VALLOX_PROFILE, Vallox
 from vallox_websocket_api.constants import vlxDevConstants
 import voluptuous as vol
+from websockets.exceptions import InvalidMessage
 
 from homeassistant.const import CONF_HOST, CONF_NAME
 import homeassistant.helpers.config_validation as cv
@@ -110,9 +111,6 @@ async def async_setup(hass, config):
                                      service_handler.async_handle,
                                      schema=schema)
 
-    # Fetch initial state once before bringing up the platforms.
-    await state_proxy.async_update(None)
-
     hass.async_create_task(
         async_load_platform(hass, 'sensor', DOMAIN, {}, config))
     hass.async_create_task(
@@ -164,7 +162,7 @@ class ValloxStateProxy:
             self._profile = await self._client.get_profile()
             self._valid = True
 
-        except OSError as err:
+        except (OSError, InvalidMessage) as err:
             _LOGGER.error("Error during state cache update: %s", err)
             self._valid = False
 

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -6,6 +6,7 @@ import logging
 
 from vallox_websocket_api import PROFILE as VALLOX_PROFILE, Vallox
 from vallox_websocket_api.constants import vlxDevConstants
+from vallox_websocket_api.exceptions import ValloxApiException
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_NAME
@@ -110,6 +111,13 @@ async def async_setup(hass, config):
                                      service_handler.async_handle,
                                      schema=schema)
 
+    # The vallox hardware expects quite strict timings for websocket
+    # requests. Timings that machines with less processing power, like
+    # Raspberries, cannot live up to during the busy start phase of Home
+    # Asssistant. Hence, async_add_entities() for fan and sensor in respective
+    # code will be called with update_before_add=False to intentionally delay
+    # the first request, increasing chance that it is issued only when the
+    # machine is less busy again.
     hass.async_create_task(
         async_load_platform(hass, 'sensor', DOMAIN, {}, config))
     hass.async_create_task(
@@ -161,7 +169,7 @@ class ValloxStateProxy:
             self._profile = await self._client.get_profile()
             self._valid = True
 
-        except OSError as err:
+        except (OSError, ValloxApiException) as err:
             _LOGGER.error("Error during state cache update: %s", err)
             self._valid = False
 
@@ -184,7 +192,7 @@ class ValloxServiceHandler:
             await self._client.set_profile(STR_TO_PROFILE[profile])
             return True
 
-        except OSError as err:
+        except (OSError, ValloxApiException) as err:
             _LOGGER.error("Error setting ventilation profile: %s", err)
             return False
 
@@ -198,7 +206,7 @@ class ValloxServiceHandler:
                 {METRIC_KEY_PROFILE_FAN_SPEED_HOME: fan_speed})
             return True
 
-        except OSError as err:
+        except (OSError, ValloxApiException) as err:
             _LOGGER.error("Error setting fan speed for Home profile: %s", err)
             return False
 
@@ -212,7 +220,7 @@ class ValloxServiceHandler:
                 {METRIC_KEY_PROFILE_FAN_SPEED_AWAY: fan_speed})
             return True
 
-        except OSError as err:
+        except (OSError, ValloxApiException) as err:
             _LOGGER.error("Error setting fan speed for Away profile: %s", err)
             return False
 
@@ -226,7 +234,7 @@ class ValloxServiceHandler:
                 {METRIC_KEY_PROFILE_FAN_SPEED_BOOST: fan_speed})
             return True
 
-        except OSError as err:
+        except (OSError, ValloxApiException) as err:
             _LOGGER.error("Error setting fan speed for Boost profile: %s",
                           err)
             return False

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -7,7 +7,6 @@ import logging
 from vallox_websocket_api import PROFILE as VALLOX_PROFILE, Vallox
 from vallox_websocket_api.constants import vlxDevConstants
 import voluptuous as vol
-from websockets.exceptions import InvalidMessage
 
 from homeassistant.const import CONF_HOST, CONF_NAME
 import homeassistant.helpers.config_validation as cv
@@ -162,7 +161,7 @@ class ValloxStateProxy:
             self._profile = await self._client.get_profile()
             self._valid = True
 
-        except (OSError, InvalidMessage) as err:
+        except OSError as err:
             _LOGGER.error("Error during state cache update: %s", err)
             self._valid = False
 

--- a/homeassistant/components/vallox/fan.py
+++ b/homeassistant/components/vallox/fan.py
@@ -42,7 +42,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                        client,
                        hass.data[DOMAIN]['state_proxy'])
 
-    async_add_entities([device], update_before_add=True)
+    async_add_entities([device], update_before_add=False)
 
 
 class ValloxFan(FanEntity):

--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -3,7 +3,7 @@
   "name": "Vallox",
   "documentation": "https://www.home-assistant.io/components/vallox",
   "requirements": [
-    "vallox-websocket-api==2.0.0"
+    "vallox-websocket-api==2.1.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/vallox/manifest.json
+++ b/homeassistant/components/vallox/manifest.json
@@ -3,7 +3,7 @@
   "name": "Vallox",
   "documentation": "https://www.home-assistant.io/components/vallox",
   "requirements": [
-    "vallox-websocket-api==2.1.0"
+    "vallox-websocket-api==2.2.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -90,7 +90,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         ),
     ]
 
-    async_add_entities(sensors, update_before_add=True)
+    async_add_entities(sensors, update_before_add=False)
 
 
 class ValloxSensor(Entity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1855,7 +1855,7 @@ uscisstatus==0.1.1
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==2.1.0
+vallox-websocket-api==2.2.0
 
 # homeassistant.components.venstar
 venstarcolortouch==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1855,7 +1855,7 @@ uscisstatus==0.1.1
 uvcclient==0.11.0
 
 # homeassistant.components.vallox
-vallox-websocket-api==2.0.0
+vallox-websocket-api==2.1.0
 
 # homeassistant.components.venstar
 venstarcolortouch==0.7


### PR DESCRIPTION
## Breaking Change:

No breaking.

## Description:

Experiments showed that timing of websocket requests to the Vallox firmware is
critical when fetching new metrics. Tests on different Raspberry Pis and x86
machines showed that those machines with little processing power tend to fail
the timing requirments during the busy startup phase of Home Assistant,
resulting in the Vallox integration failing to set itself up.

This patch catches Websocket's InvalidMessage, which is a symptom of failing the
timing requirements. Experiments again showed that on the Raspberrys, this
exception is catched once at startup, but the integration is running fine
afterwards.

Issue discussion and tests on:
  - https://github.com/home-assistant/home-assistant/issues/25335
  - https://community.home-assistant.io/t/vallox-valloplus-350mv-partial-success-work-in-progress-on-vallox-component/52588/30

**Related issue (if applicable):** fixes #25335

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
vallox:
  host: IP
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
