### PR TITLE
Add volkswagencarnet component

### DIFF
--- a/homeassistant/components/volkswagencarnet/__init__.py
+++ b/homeassistant/components/volkswagencarnet/__init__.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+
+from datetime import timedelta
+from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, CONF_RESOURCES, CONF_NAME, CONF_SCAN_INTERVAL)
+from homeassistant.helpers import discovery
+from homeassistant.helpers.event import track_point_in_utc_time
+from homeassistant.util.dt import utcnow
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.icon import icon_for_battery_level
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'volkswagencarnet'
+DATA_KEY = DOMAIN
+CONF_REGION = 'region'
+DEFAULT_REGION = 'SV'
+CONF_MUTABLE = 'mutable'
+
+REQUIREMENTS = ['volkswagencarnet==4.0.20']
+
+SIGNAL_STATE_UPDATED = '{}.updated'.format(DOMAIN)
+
+MIN_UPDATE_INTERVAL = timedelta(minutes=1)
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
+
+COMPONENTS = {
+    'sensor': 'sensor',
+    'binary_sensor': 'binary_sensor',
+    'lock': 'lock',
+    'device_tracker': 'device_tracker',
+    'switch': 'switch',
+}
+
+RESOURCES = [
+    'position',
+    'distance',
+    'climatisation',
+    'window_heater',
+    'charging',
+    'battery_level',
+    'fuel_level',
+    'service_inspection',
+    'oil_inspection',
+    'last_connected',
+    'charging_time_left',
+    'electric_range',
+    'combustion_range',
+    'combined_range',
+    'charge_max_ampere',
+    'climatisation_target_temperature',
+    'external_power',
+    'parking_light',
+    'climatisation_without_external_power',
+    'door_locked',
+    'trunk_locked',
+    'request_in_progress'
+]
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_REGION, default=DEFAULT_REGION): cv.string,
+        vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): (
+            vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL))),
+        vol.Optional(CONF_NAME, default={}): vol.Schema(
+            {cv.slug: cv.string}),
+        vol.Optional(CONF_RESOURCES): vol.All(
+            cv.ensure_list, [vol.In(RESOURCES)])
+    }),
+}, extra = vol.ALLOW_EXTRA)
+
+def setup(hass, config):
+    """Setup Volkswagen Carnet component"""
+    interval = config[DOMAIN].get(CONF_SCAN_INTERVAL)
+    data = hass.data[DATA_KEY] = VolkswagenData(config)
+    
+    from volkswagencarnet import Connection
+
+    _LOGGER.debug("Creating connection to volkswagen carnet")
+    connection = Connection(
+        username = config[DOMAIN].get(CONF_USERNAME),
+        password = config[DOMAIN].get(CONF_PASSWORD),
+        #region = config[DOMAIN].get(CONF_REGION) # add support for this
+    )
+
+    # login to carnet
+    _LOGGER.debug("Logging in to volkswagen carnet")
+    connection._login()
+    if not connection.logged_in:
+        _LOGGER.warning('Could not login to volkswagen carnet, please check your credentials')
+
+    def is_enabled(attr):
+        """Return true if the user has enabled the resource."""
+        return attr in config[DOMAIN].get(CONF_RESOURCES, [attr])
+
+    def discover_vehicle(vehicle):
+        """Load relevant platforms."""
+        data.vehicles.add(vehicle.vin)
+        data.entities[vehicle.vin] = []
+
+        dashboard = vehicle.dashboard(mutable = config[DOMAIN][CONF_MUTABLE])
+
+        for instrument in (
+                instrument
+                for instrument in dashboard.instruments
+                if instrument.component in COMPONENTS and
+                is_enabled(instrument.slug_attr)):
+
+            data.instruments.add(instrument)
+            discovery.load_platform(hass, COMPONENTS[instrument.component], DOMAIN, (vehicle.vin,instrument.component,instrument.attr), config)
+
+    def update(now):
+        """Update status from Volkswagen Carnet"""
+        try:
+            # check if we can login again
+            if not connection.logged_in:
+                connection._login()
+                if not connection.logged_in:
+                    _LOGGER.warning('Could not login to volkswagen carnet, please check your credentials')
+                    return False
+            else:
+                if not connection.update(request_data = False):
+                    _LOGGER.warning("Could not query update from volkswagen carnet")
+                    return False
+                else:
+                    _LOGGER.debug("Updating data from volkswagen carnet")
+
+                    for vehicle in connection.vehicles:
+                        if vehicle.vin not in data.vehicles:
+                            _LOGGER.info("Adding data for VIN: %s from carnet" % vehicle.vin.lower())
+                            discover_vehicle(vehicle)
+                        
+                        for entity in data.entities[vehicle.vin]:
+                            entity.schedule_update_ha_state()
+
+                        dispatcher_send(hass, SIGNAL_STATE_UPDATED, vehicle)
+            return True
+
+        finally:
+            track_point_in_utc_time(hass, update, utcnow() + interval)
+
+    _LOGGER.info("Starting volkswagencarnet component")
+    return update(utcnow())
+
+
+class VolkswagenData:
+    """Hold component state."""
+
+    def __init__(self, config):
+        """Initialize the component state."""
+        self.vehicles = set()
+        self.instruments = set()
+        self.entities = {}
+        self.config = config[DOMAIN]
+        self.names = self.config.get(CONF_NAME)
+
+    def instrument(self, vin, component, attr):
+        """Return corresponding instrument."""
+        return next((instrument
+                     for instrument in self.instruments
+                     if instrument.vehicle.vin == vin and
+                     instrument.component == component and
+                     instrument.attr == attr), None)
+
+    def vehicle_name(self, vehicle):
+        """Provide a friendly name for a vehicle."""
+        if (vehicle.vin and vehicle.vin.lower() in self.names):
+            return self.names[vehicle.vin.lower()]
+        elif vehicle.vin:
+            return vehicle.vin
+        else:
+            return ''
+
+
+class VolkswagenEntity(Entity):
+    """Base class for all Volkswagen entities."""
+
+    def __init__(self, data, vin, component, attribute):#, attribute):
+        """Initialize the entity."""
+        self.data = data
+        self.vin = vin
+        self.component = component
+        self.attribute = attribute
+
+        self.data.entities[self.vin].append(self)
+
+    @property
+    def instrument(self):
+        """Return corresponding instrument."""
+        return self.data.instrument(self.vin, self.component, self.attribute)
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        if self.instrument.attr in ['battery_level', 'charging']:
+            return icon_for_battery_level(battery_level = self.instrument.state, charging = self.vehicle.charging)
+        else:
+            return self.instrument.icon
+
+    @property
+    def vehicle(self):
+        """Return vehicle."""
+        return self.instrument.vehicle
+
+    @property
+    def _entity_name(self):
+        return self.instrument.name
+
+    @property
+    def _vehicle_name(self):
+        return self.data.vehicle_name(self.vehicle)
+
+    @property
+    def name(self):
+        """Return full name of the entity."""
+        return '{} {}'.format(self._vehicle_name,self._entity_name)
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def assumed_state(self):
+        """Return true if unable to access real state of entity."""
+        return True
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        return dict(self.instrument.attributes, model='{}/{}'.format(self.vehicle.model,self.vehicle.model_year))

--- a/homeassistant/components/volkswagencarnet/binary_sensor.py
+++ b/homeassistant/components/volkswagencarnet/binary_sensor.py
@@ -1,0 +1,30 @@
+"""
+Support for Volkswagen Carnet.
+"""
+import logging
+from . import VolkswagenEntity, DATA_KEY
+from homeassistant.components.binary_sensor import BinarySensorDevice, DEVICE_CLASSES
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Volkswagen binary sensors."""
+    if discovery_info is None:
+        return
+    add_devices([VolkswagenBinarySensor(hass.data[DATA_KEY], *discovery_info)])
+
+class VolkswagenBinarySensor(VolkswagenEntity, BinarySensorDevice):
+    """Representation of a Volkswagen Binary Sensor """
+
+    @property
+    def is_on(self):
+        """Return True if the binary sensor is on."""
+        _LOGGER.debug('Getting state of %s' % self.instrument.attr)
+        return self.instrument.is_on
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor, from DEVICE_CLASSES."""
+        if self.instrument.device_class in DEVICE_CLASSES:
+            return self.instrument.device_class
+        return None

--- a/homeassistant/components/volkswagencarnet/device_tracker.py
+++ b/homeassistant/components/volkswagencarnet/device_tracker.py
@@ -1,0 +1,34 @@
+"""
+Support for Volkswagen Carnet Platform
+"""
+import logging
+from homeassistant.util import slugify
+from homeassistant.helpers.dispatcher import (dispatcher_connect, dispatcher_send)
+from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+
+from . import SIGNAL_STATE_UPDATED, DATA_KEY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_scanner(hass, config, see, discovery_info=None):
+    """Set up the Volkswagen tracker."""
+    if discovery_info is None:
+        return
+
+    vin, component, attr = discovery_info
+    data = hass.data[DATA_KEY]
+    instrument = data.instrument(vin, component, attr)
+    vehicle = instrument.vehicle
+
+    def see_vehicle(vehicle):
+        """Handle the reporting of the vehicle position."""
+        host_name = data.vehicle_name(vehicle)
+        dev_id = '{}'.format(slugify(host_name))
+        _LOGGER.debug('Updating location of %s' % host_name)
+        if instrument.state:
+            see(dev_id=dev_id, host_name=host_name, source_type=SOURCE_TYPE_GPS, gps=instrument.state, icon='mdi:car')
+            
+    dispatcher_connect(hass, SIGNAL_STATE_UPDATED, see_vehicle)
+    #dispatcher_send(hass, SIGNAL_STATE_UPDATED)
+    return True

--- a/homeassistant/components/volkswagencarnet/lock.py
+++ b/homeassistant/components/volkswagencarnet/lock.py
@@ -1,0 +1,35 @@
+"""
+Support for Volkswagen Carnet Platform
+"""
+import logging
+from homeassistant.components.lock import LockDevice
+from . import VolkswagenEntity, DATA_KEY
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """ Setup the volkswagen lock """
+    if discovery_info is None:
+        return
+    add_devices([VolkswagenLock(hass.data[DATA_KEY], *discovery_info)])
+
+class VolkswagenLock(VolkswagenEntity, LockDevice):
+    """Represents a Volkswagen Carnet Lock."""
+
+    @property
+    def is_locked(self):
+        """Return true if lock is locked."""
+        _LOGGER.debug('Getting state of %s' % self.instrument.attr)
+        return self.instrument.is_locked
+
+    def lock(self, **kwargs):
+        """Lock the car."""
+        self.instrument.lock()
+
+    def unlock(self, **kwargs):
+        """Unlock the car."""
+        self.instrument.unlock()
+
+    @property
+    def assumed_state(self):
+        return self.instrument.assumed_state

--- a/homeassistant/components/volkswagencarnet/manifest.json
+++ b/homeassistant/components/volkswagencarnet/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "volkswagencarnet",
+  "name": "Volkswagencarnet",
+  "documentation": "https://www.home-assistant.io/components/volkswagencarnet",
+  "requirements": [
+    "volkswagencarnet==4.0.20"
+  ],
+  "dependencies": [],
+  "codeowners": ["@robinostlund"]
+}

--- a/homeassistant/components/volkswagencarnet/sensor.py
+++ b/homeassistant/components/volkswagencarnet/sensor.py
@@ -1,0 +1,29 @@
+"""
+Support for Volkswagen Carnet Platform
+"""
+import logging
+from homeassistant.helpers.icon import icon_for_battery_level
+
+from . import VolkswagenEntity, DATA_KEY
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Volkswagen sensors."""
+    if discovery_info is None:
+        return
+    add_devices([VolkswagenSensor(hass.data[DATA_KEY], *discovery_info)])
+
+class VolkswagenSensor(VolkswagenEntity):
+    """Representation of a Volkswagen Carnet Sensor."""
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        _LOGGER.debug('Getting state of %s' % self.instrument.attr)
+        return self.instrument.state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self.instrument.unit

--- a/homeassistant/components/volkswagencarnet/switch.py
+++ b/homeassistant/components/volkswagencarnet/switch.py
@@ -1,0 +1,37 @@
+"""
+Support for Volkswagen Carnet Platform
+"""
+import logging
+from homeassistant.helpers.entity import ToggleEntity
+from . import VolkswagenEntity, DATA_KEY
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """ Setup the volkswagen switch."""
+    if discovery_info is None:
+        return
+    add_devices([VolkswagenSwitch(hass.data[DATA_KEY], *discovery_info)])
+
+class VolkswagenSwitch(VolkswagenEntity, ToggleEntity):
+    """Representation of a Volkswagen Carnet Switch."""
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        _LOGGER.debug('Getting state of %s' % self.instrument.attr)
+        return self.instrument.state
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        _LOGGER.debug("Turning ON %s." % self.instrument.attr)
+        self.instrument.turn_on()
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        _LOGGER.debug("Turning OFF %s." % self.instrument.attr)
+        self.instrument.turn_off()
+
+    @property
+    def assumed_state(self):
+        return self.instrument.assumed_state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1970,3 +1970,6 @@ zigpy-xbee-homeassistant==0.4.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.3
+
+# homeassistant.components.volkswagencarnet
+volkswagencarnet==4.0.20


### PR DESCRIPTION
## Description:
Adds support for volkswagen carnet.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
volkswagencarnet:
    username: <username to volkswagen carnet>
    password: <password to volkswagen carnet>
    scan_interval: 
        minutes: 2
    name:
        wvw1234567812356: 'Passat GTE'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
