### PR TITLE
Update Daikin preset modes

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -273,16 +273,16 @@ class DaikinClimate(ClimateDevice):
 
     @property
     def preset_mode(self):
-        """Return the fan setting."""
+        """Return the preset_mode."""
         return self.get(ATTR_PRESET_MODE)
 
     async def async_set_preset_mode(self, preset_mode):
-        """Set new target temperature."""
+        """Set new preset mode."""
         await self._set({ATTR_PRESET_MODE: preset_mode})
 
     @property
     def preset_modes(self):
-        """List of available swing modes."""
+        """List of available preset modes."""
         return list(HA_PRESET_TO_DAIKIN)
 
     async def async_update(self):

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_SWING_MODE,
     HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_HEAT_COOL,
     HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY,
-    PRESET_AWAY, PRESET_HOME,
+    PRESET_AWAY, PRESET_NONE,
     ATTR_CURRENT_TEMPERATURE, ATTR_FAN_MODE,
     ATTR_HVAC_MODE, ATTR_SWING_MODE,
     ATTR_PRESET_MODE)
@@ -20,7 +20,8 @@ import homeassistant.helpers.config_validation as cv
 
 from . import DOMAIN as DAIKIN_DOMAIN
 from .const import (
-    ATTR_INSIDE_TEMPERATURE, ATTR_OUTSIDE_TEMPERATURE, ATTR_TARGET_TEMPERATURE)
+    ATTR_INSIDE_TEMPERATURE, ATTR_OUTSIDE_TEMPERATURE, ATTR_STATE_OFF,
+    ATTR_STATE_ON, ATTR_TARGET_TEMPERATURE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ DAIKIN_TO_HA_STATE = {
 
 HA_PRESET_TO_DAIKIN = {
     PRESET_AWAY: 'on',
-    PRESET_HOME: 'off'
+    PRESET_NONE: 'off'
 }
 
 HA_ATTR_TO_DAIKIN = {
@@ -142,9 +143,10 @@ class DaikinClimate(ClimateDevice):
             ha_mode = DAIKIN_TO_HA_STATE.get(daikin_mode)
             value = ha_mode
         elif key == ATTR_PRESET_MODE:
-            away = (self._api.device.represent(daikin_attr)[1]
-                    != HA_STATE_TO_DAIKIN[HVAC_MODE_OFF])
-            value = PRESET_AWAY if away else PRESET_HOME
+            if self._api.device.represent(
+                    daikin_attr)[1] == HA_PRESET_TO_DAIKIN[PRESET_AWAY]:
+                return PRESET_AWAY
+            return PRESET_NONE
 
         if value is None:
             _LOGGER.error("Invalid value requested for key %s", key)
@@ -164,7 +166,7 @@ class DaikinClimate(ClimateDevice):
         values = {}
 
         for attr in [ATTR_TEMPERATURE, ATTR_FAN_MODE, ATTR_SWING_MODE,
-                     ATTR_HVAC_MODE, ATTR_PRESET_MODE]:
+                     ATTR_HVAC_MODE]:
             value = settings.get(attr)
             if value is None:
                 continue
@@ -173,8 +175,6 @@ class DaikinClimate(ClimateDevice):
             if daikin_attr is not None:
                 if attr == ATTR_HVAC_MODE:
                     values[daikin_attr] = HA_STATE_TO_DAIKIN[value]
-                elif attr == ATTR_PRESET_MODE:
-                    values[daikin_attr] = HA_PRESET_TO_DAIKIN[value]
                 elif value in self._list[attr]:
                     values[daikin_attr] = value.lower()
                 else:
@@ -277,8 +277,11 @@ class DaikinClimate(ClimateDevice):
         return self.get(ATTR_PRESET_MODE)
 
     async def async_set_preset_mode(self, preset_mode):
-        """Set new preset mode."""
-        await self._set({ATTR_PRESET_MODE: preset_mode})
+        """Set preset mode."""
+        if preset_mode == PRESET_AWAY:
+            await self._api.device.set_holiday(ATTR_STATE_ON)
+        else:
+            await self._api.device.set_holiday(ATTR_STATE_OFF)
 
     @property
     def preset_modes(self):

--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -5,6 +5,9 @@ ATTR_TARGET_TEMPERATURE = 'target_temperature'
 ATTR_INSIDE_TEMPERATURE = 'inside_temperature'
 ATTR_OUTSIDE_TEMPERATURE = 'outside_temperature'
 
+ATTR_STATE_ON = 'on'
+ATTR_STATE_OFF = 'off'
+
 SENSOR_TYPE_TEMPERATURE = 'temperature'
 
 SENSOR_TYPES = {

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/daikin",
   "requirements": [
-    "pydaikin==1.4.6"
+    "pydaikin==1.5.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1084,7 +1084,7 @@ pycsspeechtts==1.0.2
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-pydaikin==1.4.6
+pydaikin==1.5.1
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0


### PR DESCRIPTION
## Description:

Daikin preset modes does not have a **Home** option.

Also cleaned up some codes as the pydaikin 1.5.x have a `set_holiday` method.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
