### PR TITLE
Add ord() to template filters

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -857,6 +857,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters['regex_findall_index'] = regex_findall_index
         self.filters['bitwise_and'] = bitwise_and
         self.filters['bitwise_or'] = bitwise_or
+        self.filters['ord'] = ord        
         self.globals['log'] = logarithm
         self.globals['sin'] = sine
         self.globals['cos'] = cosine

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -857,7 +857,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters['regex_findall_index'] = regex_findall_index
         self.filters['bitwise_and'] = bitwise_and
         self.filters['bitwise_or'] = bitwise_or
-        self.filters['ord'] = ord        
+        self.filters['ord'] = ord
         self.globals['log'] = logarithm
         self.globals['sin'] = sine
         self.globals['cos'] = cosine

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -388,6 +388,12 @@ def test_max(hass):
                              hass).async_render() == '3'
 
 
+def test_ord(hass):
+    """Test the ord filter."""
+    assert template.Template('{{ "d" | ord }}',
+                             hass).async_render() == '100'
+
+
 def test_base64_encode(hass):
     """Test the base64_encode filter."""
     assert template.Template('{{ "homeassistant" | base64_encode }}',


### PR DESCRIPTION
## Description:

Add ord() to template filters. I use it to convert the SNMP results from my Epson printer from ASCII to decimal values, e.g. `black: {{ states.sensor.snmp_epson_ink_state.state[-85] | ord}}`

Documentation PR: https://github.com/home-assistant/home-assistant.io/pull/9962

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
