### PR TITLE
[climate] Correct evohome hvac_action

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -193,7 +193,7 @@ class EvoZone(EvoClimateDevice):
             return CURRENT_HVAC_OFF
         if self.target_temperature <= self.min_temp:
             return CURRENT_HVAC_OFF
-        if self.target_temperature <= self.current_temperature:
+        if self.target_temperature < self.current_temperature:
             return CURRENT_HVAC_IDLE
         return CURRENT_HVAC_HEAT
 

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -194,8 +194,8 @@ class EvoZone(EvoClimateDevice):
         if self.target_temperature <= self.min_temp:
             return CURRENT_HVAC_OFF
         if self.target_temperature <= self.current_temperature:
-            return CURRENT_HVAC_HEAT
-        return CURRENT_HVAC_IDLE
+            return CURRENT_HVAC_IDLE
+        return CURRENT_HVAC_HEAT
 
     @property
     def current_temperature(self) -> Optional[float]:


### PR DESCRIPTION
## Breaking Change:

None known

## Description:
Fixes a stupid typo that results in `hvac_action` having the wrong value.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
