### PR TITLE
Add scan interval to config of Environment Canada sensor

### DIFF
--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -12,10 +12,9 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE, CONF_SCAN_INTERVAL,
-    ATTR_ATTRIBUTION, ATTR_LOCATION)
+    TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE, ATTR_ATTRIBUTION,
+    ATTR_LOCATION)
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,7 +41,6 @@ def validate_station(station):
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_LANGUAGE, default='english'):
         vol.In(['english', 'french']),
-    vol.Required(CONF_SCAN_INTERVAL, default=10): int,
     vol.Optional(CONF_STATION): validate_station,
     vol.Inclusive(CONF_LATITUDE, 'latlon'): cv.latitude,
     vol.Inclusive(CONF_LONGITUDE, 'latlon'): cv.longitude,
@@ -52,8 +50,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Environment Canada sensor."""
     from env_canada import ECData
-
-    scan_interval = timedelta(minutes=config[CONF_SCAN_INTERVAL])
 
     if config.get(CONF_STATION):
         ec_data = ECData(station_id=config[CONF_STATION],
@@ -67,7 +63,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     sensor_list = list(ec_data.conditions.keys()) + list(ec_data.alerts.keys())
     sensor_list.remove('icon_code')
     add_entities([ECSensor(sensor_type,
-                           scan_interval,
                            ec_data)
                   for sensor_type in sensor_list],
                  True)
@@ -76,7 +71,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ECSensor(Entity):
     """Implementation of an Environment Canada sensor."""
 
-    def __init__(self, sensor_type, scan_interval, ec_data):
+    SCAN_INTERVAL = timedelta(minutes=10)
+
+    def __init__(self, sensor_type, ec_data):
         """Initialize the sensor."""
         self.sensor_type = sensor_type
         self.ec_data = ec_data
@@ -86,8 +83,6 @@ class ECSensor(Entity):
         self._state = None
         self._attr = None
         self._unit = None
-
-        self.update = Throttle(scan_interval)(self._update)
 
     @property
     def unique_id(self) -> str:
@@ -114,7 +109,7 @@ class ECSensor(Entity):
         """Return the units of measurement."""
         return self._unit
 
-    def _update(self):
+    def update(self):
         """Update current conditions."""
         self.ec_data.update()
         self.ec_data.conditions.update(self.ec_data.alerts)

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -19,6 +19,8 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL = timedelta(minutes=10)
+
 ATTR_UPDATED = 'updated'
 ATTR_STATION = 'station'
 ATTR_DETAIL = 'alert detail'
@@ -70,8 +72,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 class ECSensor(Entity):
     """Implementation of an Environment Canada sensor."""
-
-    SCAN_INTERVAL = timedelta(minutes=10)
 
     def __init__(self, sensor_type, ec_data):
         """Initialize the sensor."""


### PR DESCRIPTION
## Description:

Adds a configuration item to set the scan interval in minutes, with a default of 10 minutes.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9950

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: environment_canada
    scan_interval: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
