### PR TITLE
Log platform import errors and correct reqs for config check

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -707,7 +707,6 @@ async def async_process_component_config(
                 not await async_process_requirements(
                     hass, p_integration.domain, p_integration.requirements)):
             _LOGGER.error(
-                domain, p_name, config,
                 "Unable to install all requirements for %s.%s", domain, p_name)
             continue
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -713,7 +713,7 @@ async def async_process_component_config(
 
         try:
             platform = p_integration.get_platform(domain)
-        except ImportError as ex:
+        except ImportError:
             _LOGGER.exception("Failed to get platform %s.%s", domain, p_name)
             continue
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -706,11 +706,15 @@ async def async_process_component_config(
         if (not hass.config.skip_pip and p_integration.requirements and
                 not await async_process_requirements(
                     hass, p_integration.domain, p_integration.requirements)):
+            _LOGGER.error(
+                domain, p_name, config,
+                "Unable to install all requirements for %s.%s", domain, p_name)
             continue
 
         try:
             platform = p_integration.get_platform(domain)
-        except ImportError:
+        except ImportError as ex:
+            _LOGGER.exception("Failed to get platform %s.%s", domain, p_name)
             continue
 
         # Validate platform specific schema

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -159,6 +159,13 @@ async def async_check_ha_config_file(hass: HomeAssistant) -> \
                     "platform.".format(p_name, domain))
                 continue
 
+            if (not hass.config.skip_pip and p_integration.requirements and
+                    not await requirements.async_process_requirements(
+                        hass, p_integration.domain, p_integration.requirements)):
+                result.add_error("Unable to install all requirements: {}".format(
+                    ', '.join(integration.requirements)))
+                continue
+
             try:
                 platform = p_integration.get_platform(domain)
             except ImportError:

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -161,7 +161,8 @@ async def async_check_ha_config_file(hass: HomeAssistant) -> \
 
             if (not hass.config.skip_pip and p_integration.requirements and
                     not await requirements.async_process_requirements(
-                        hass, p_integration.domain, p_integration.requirements)):
+                        hass, p_integration.domain,
+                        p_integration.requirements)):
                 result.add_error(
                     "Unable to install all requirements: {}".format(
                         ', '.join(integration.requirements)))

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -162,8 +162,9 @@ async def async_check_ha_config_file(hass: HomeAssistant) -> \
             if (not hass.config.skip_pip and p_integration.requirements and
                     not await requirements.async_process_requirements(
                         hass, p_integration.domain, p_integration.requirements)):
-                result.add_error("Unable to install all requirements: {}".format(
-                    ', '.join(integration.requirements)))
+                result.add_error(
+                    "Unable to install all requirements: {}".format(
+                        ', '.join(integration.requirements)))
                 continue
 
             try:


### PR DESCRIPTION
## Description:
Make sure we log import errors instaed of silently ignoring these errors. It is very hard to detect a invalid import (like missing dependency) in platform integration without any output.

Also pip install dependencies when doing check config.

Note. This still does not log anything if the manifest is invalid.

**Related issue (if applicable):** #25049, #25124


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
