### PR TITLE
Add area support to input datetime service schemas

### DIFF
--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -5,8 +5,9 @@ import datetime
 import voluptuous as vol
 
 from homeassistant.const import (
-    ATTR_DATE, ATTR_ENTITY_ID, ATTR_TIME, CONF_ICON, CONF_NAME)
+    ATTR_DATE, ATTR_TIME, CONF_ICON, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
@@ -27,8 +28,7 @@ ATTR_DATETIME = 'datetime'
 
 SERVICE_SET_DATETIME = 'set_datetime'
 
-SERVICE_SET_DATETIME_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+SERVICE_SET_DATETIME_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_DATE): cv.date,
     vol.Optional(ATTR_TIME): cv.time,
     vol.Optional(ATTR_DATETIME): cv.datetime,

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -9,8 +9,8 @@ import voluptuous as vol
 from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import async_setup_component
 from homeassistant.components.input_datetime import (
-    DOMAIN, ATTR_ENTITY_ID, ATTR_DATE, ATTR_DATETIME, ATTR_TIME,
-    SERVICE_SET_DATETIME)
+    DOMAIN, ATTR_DATE, ATTR_DATETIME, ATTR_TIME, SERVICE_SET_DATETIME)
+from homeassistant.const import ATTR_ENTITY_ID
 
 from tests.common import mock_restore_cache
 


### PR DESCRIPTION
## Description:

Part of https://github.com/home-assistant/home-assistant/issues/25155.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
