### PR TITLE
Add area support to lock service schemas

### DIFF
--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -4,8 +4,8 @@ import logging
 from pyhap.const import CATEGORY_DOOR_LOCK
 
 from homeassistant.components.lock import (
-    ATTR_ENTITY_ID, DOMAIN, STATE_LOCKED, STATE_UNLOCKED)
-from homeassistant.const import ATTR_CODE, STATE_UNKNOWN
+    DOMAIN, STATE_LOCKED, STATE_UNLOCKED)
+from homeassistant.const import ATTR_CODE, ATTR_ENTITY_ID, STATE_UNKNOWN
 
 from . import TYPES
 from .accessories import HomeAccessory

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -9,11 +9,11 @@ from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.config_validation import (  # noqa
-    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
+    ENTITY_SERVICE_SCHEMA, PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    ATTR_CODE, ATTR_CODE_FORMAT, ATTR_ENTITY_ID, STATE_LOCKED, STATE_UNLOCKED,
-    SERVICE_LOCK, SERVICE_UNLOCK, SERVICE_OPEN)
+    ATTR_CODE, ATTR_CODE_FORMAT, STATE_LOCKED, STATE_UNLOCKED, SERVICE_LOCK,
+    SERVICE_UNLOCK, SERVICE_OPEN)
 from homeassistant.components import group
 
 ATTR_CHANGED_BY = 'changed_by'
@@ -28,8 +28,7 @@ GROUP_NAME_ALL_LOCKS = 'all locks'
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
-LOCK_SERVICE_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
+LOCK_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA({
     vol.Optional(ATTR_CODE): cv.string,
 })
 

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -28,7 +28,7 @@ GROUP_NAME_ALL_LOCKS = 'all locks'
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
-LOCK_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA({
+LOCK_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_CODE): cv.string,
 })
 

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.core import callback
 from homeassistant import setup
 from homeassistant.components import lock
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.const import STATE_ON, STATE_OFF
 
 from tests.common import (get_test_home_assistant,
@@ -269,7 +270,7 @@ class TestTemplateLock:
         assert state.state == lock.STATE_UNLOCKED
 
         self.hass.services.call(lock.DOMAIN, lock.SERVICE_LOCK, {
-            lock.ATTR_ENTITY_ID: 'lock.template_lock'
+            ATTR_ENTITY_ID: 'lock.template_lock'
         })
         self.hass.block_till_done()
 
@@ -302,7 +303,7 @@ class TestTemplateLock:
         assert state.state == lock.STATE_LOCKED
 
         self.hass.services.call(lock.DOMAIN, lock.SERVICE_UNLOCK, {
-            lock.ATTR_ENTITY_ID: 'lock.template_lock'
+            ATTR_ENTITY_ID: 'lock.template_lock'
         })
         self.hass.block_till_done()
 


### PR DESCRIPTION
## Description:

Part of https://github.com/home-assistant/home-assistant/issues/25155.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
