### PR TITLE
Improve seventeentrack

### DIFF
--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -33,11 +33,14 @@ DATA_SUMMARY = 'summary_data'
 DEFAULT_ATTRIBUTION = 'Data provided by 17track.net'
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=10)
 
-ENTITY_ID_TEMPLATE = 'package_{0}_{1}'
+UNIQUE_ID_TEMPLATE = 'package_{0}_{1}'
+ENTITY_ID_TEMPLATE = 'sensor.seventeentrack_package_{0}'
 
-NOTIFICATION_DELIVERED_ID_SCAFFOLD = 'package_delivered_{0}'
-NOTIFICATION_DELIVERED_TITLE = 'Package Delivered'
-NOTIFICATION_DELIVERED_URL_SCAFFOLD = 'https://t.17track.net/track#nums={0}'
+NOTIFICATION_DELIVERED_ID = 'package_delivered_{0}'
+NOTIFICATION_DELIVERED_TITLE = 'Package {0} delivered'
+NOTIFICATION_DELIVERED_MESSAGE = 'Package Delivered: {0}<br />' + \
+                                 'Visit 17.track for more information: ' \
+                                 'https://t.17track.net/track#nums={1}'
 
 VALUE_DELIVERED = 'Delivered'
 
@@ -76,16 +79,6 @@ async def async_setup_platform(
         hass, client, async_add_entities, scan_interval,
         config[CONF_SHOW_ARCHIVED], config[CONF_SHOW_DELIVERED])
     await data.async_update()
-
-    sensors = []
-
-    for status, quantity in data.summary.items():
-        sensors.append(SeventeenTrackSummarySensor(data, status, quantity))
-
-    for package in data.packages:
-        sensors.append(SeventeenTrackPackageSensor(data, package))
-
-    async_add_entities(sensors, True)
 
 
 class SeventeenTrackSummarySensor(Entity):
@@ -139,7 +132,7 @@ class SeventeenTrackSummarySensor(Entity):
         await self._data.async_update()
 
         package_data = []
-        for package in self._data.packages:
+        for package in self._data.packages.values():
             if package.status != self._status:
                 continue
 
@@ -175,14 +168,13 @@ class SeventeenTrackPackageSensor(Entity):
         self._friendly_name = package.friendly_name
         self._state = package.status
         self._tracking_number = package.tracking_number
+        self.entity_id = ENTITY_ID_TEMPLATE.format(self._tracking_number)
+        self._removed = False
 
     @property
     def available(self):
         """Return whether the entity is available."""
-        return bool([
-            p for p in self._data.packages
-            if p.tracking_number == self._tracking_number
-        ])
+        return self._data.packages.get(self._tracking_number, None) is not None
 
     @property
     def device_state_attributes(self):
@@ -210,44 +202,24 @@ class SeventeenTrackPackageSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique, HASS-friendly identifier for this entity."""
-        return ENTITY_ID_TEMPLATE.format(
+        return UNIQUE_ID_TEMPLATE.format(
             self._data.account_id, self._tracking_number)
 
     async def async_update(self):
         """Update the sensor."""
         await self._data.async_update()
 
-        if not self._data.packages:
+        if not self.available:
+            await self._remove()
             return
 
-        try:
-            package = next((
-                p for p in self._data.packages
-                if p.tracking_number == self._tracking_number))
-        except StopIteration:
-            # If the package no longer exists in the data, log a message and
-            # delete this entity:
-            _LOGGER.info(
-                'Deleting entity for stale package: %s', self._tracking_number)
-            reg = await self.hass.helpers.entity_registry.async_get_registry()
-            self.hass.async_create_task(reg.async_remove(self.entity_id))
-            self.hass.async_create_task(self.async_remove())
-            return
+        package = self._data.packages.get(self._tracking_number, None)
 
-        # If the user has elected to not see delivered packages and one gets
+        # If the user has selected to not see delivered packages and one gets
         # delivered, post a notification:
         if package.status == VALUE_DELIVERED and not self._data.show_delivered:
-            _LOGGER.info('Package delivered: %s', self._tracking_number)
-            self.hass.components.persistent_notification.create(
-                'Package Delivered: {0}<br />'
-                'Visit 17.track for more infomation: {1}'
-                ''.format(
-                    self._tracking_number,
-                    NOTIFICATION_DELIVERED_URL_SCAFFOLD.format(
-                        self._tracking_number)),
-                title=NOTIFICATION_DELIVERED_TITLE,
-                notification_id=NOTIFICATION_DELIVERED_ID_SCAFFOLD.format(
-                    self._tracking_number))
+            self._notify_delivered()
+            await self._remove()
             return
 
         self._attrs.update({
@@ -255,6 +227,41 @@ class SeventeenTrackPackageSensor(Entity):
             ATTR_LOCATION: package.location,
         })
         self._state = package.status
+        self._friendly_name = package.friendly_name
+
+    def _async_write_ha_state(self):
+        """Avoid writing state, so the entity is really removed."""
+        if not self._removed:
+            return super()._async_write_ha_state()
+
+    async def _remove(self):
+        """Remove entity itself."""
+        await self.async_remove()
+
+        reg = await self.hass.helpers.entity_registry.async_get_registry()
+        entity_id = reg.async_get_entity_id(
+            'sensor', 'seventeentrack',
+            UNIQUE_ID_TEMPLATE.format(
+                self._data.account_id, self._tracking_number))
+        if entity_id:
+            reg.async_remove(entity_id)
+
+        self._removed = True
+
+    def _notify_delivered(self):
+        """Notify when package is delivered."""
+        _LOGGER.info('Package delivered: %s', self._tracking_number)
+
+        identification = self._friendly_name if self._friendly_name else \
+            self._tracking_number
+        message = NOTIFICATION_DELIVERED_MESSAGE.format(self._tracking_number,
+                                                        identification)
+        title = NOTIFICATION_DELIVERED_TITLE.format(identification)
+        notification_id = NOTIFICATION_DELIVERED_TITLE\
+            .format(self._tracking_number)
+
+        self.hass.components.persistent_notification\
+            .create(message, title=title, notification_id=notification_id)
 
 
 class SeventeenTrackData:
@@ -270,11 +277,12 @@ class SeventeenTrackData:
         self._scan_interval = scan_interval
         self._show_archived = show_archived
         self.account_id = client.profile.account_id
-        self.packages = []
+        self.packages = {}
         self.show_delivered = show_delivered
         self.summary = {}
 
         self.async_update = Throttle(self._scan_interval)(self._async_update)
+        self.first_update = True
 
     async def _async_update(self):
         """Get updated data from 17track.net."""
@@ -285,46 +293,36 @@ class SeventeenTrackData:
                 show_archived=self._show_archived)
             _LOGGER.debug('New package data received: %s', packages)
 
-            if not self.show_delivered:
-                packages = [p for p in packages if p.status != VALUE_DELIVERED]
+            new_packages = {p.tracking_number: p for p in packages}
 
-            packages_map = {p.tracking_number: p for p in packages}
-            # Add new packages:
+            to_add = set(new_packages.keys()) - set(self.packages.keys())
 
-            already_tracked_nbr = [p.tracking_number for p in self.packages]
-            received_tracked_nbr = [p.tracking_number for p in packages]
-
-            to_add = set(received_tracked_nbr) - set(already_tracked_nbr)
             _LOGGER.debug('Will add new tracking numbers: %s', to_add)
-            if self.packages and to_add:
+            if to_add:
                 self._async_add_entities([
                     SeventeenTrackPackageSensor(self,
-                                                packages_map[tracking_number])
+                                                new_packages[tracking_number])
                     for tracking_number in to_add
                 ], True)
 
-            # Remove archived packages from the entity registry:
-            to_remove = set(received_tracked_nbr) - set(already_tracked_nbr)
-            _LOGGER.debug('Will remove tracking number: %s', to_remove)
-            reg = await self._hass.helpers.entity_registry.async_get_registry()
-            for tracking_number in to_remove:
-                entity_id = reg.async_get_entity_id(
-                    'sensor', 'seventeentrack',
-                    ENTITY_ID_TEMPLATE.format(
-                        self.account_id, tracking_number))
-                if not entity_id:
-                    continue
-                self._hass.async_create_task(reg.async_remove(entity_id))
-
-            self.packages = packages
+            self.packages = new_packages
         except SeventeenTrackError as err:
             _LOGGER.error('There was an error retrieving packages: %s', err)
-            self.packages = []
 
         try:
             self.summary = await self._client.profile.summary(
                 show_archived=self._show_archived)
             _LOGGER.debug('New summary data received: %s', self.summary)
+
+            # creating summary sensors on first update
+            if self.first_update:
+                self.first_update = False
+
+                self._async_add_entities([
+                    SeventeenTrackSummarySensor(self, status, quantity)
+                    for status, quantity in self.summary.items()
+                ], True)
+
         except SeventeenTrackError as err:
             _LOGGER.error('There was an error retrieving the summary: %s', err)
             self.summary = {}

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -173,7 +173,7 @@ class SeventeenTrackPackageSensor(Entity):
     @property
     def available(self):
         """Return whether the entity is available."""
-        return self._data.packages.get(self._tracking_number, None) is not None
+        return self._data.packages.get(self._tracking_number) is not None
 
     @property
     def device_state_attributes(self):
@@ -285,7 +285,7 @@ class SeventeenTrackData:
 
             new_packages = {p.tracking_number: p for p in packages}
 
-            to_add = set(new_packages.keys()) - set(self.packages.keys())
+            to_add = set(new_packages) - set(self.packages)
 
             _LOGGER.debug('Will add new tracking numbers: %s', to_add)
             if to_add:

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -240,6 +240,9 @@ pushbullet.py==0.11.0
 # homeassistant.components.canary
 py-canary==0.5.0
 
+# homeassistant.components.seventeentrack
+py17track==2.2.2
+
 # homeassistant.components.tplink
 pyHS100==0.3.5
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -161,6 +161,7 @@ TEST_REQUIREMENTS = (
     'zeroconf',
     'zigpy-homeassistant',
     'bellows-homeassistant',
+    'py17track',
 )
 
 IGNORE_PIN = ('colorlog>2.1,<3', 'keyring>=9.3,<10.0', 'urllib3')

--- a/tests/components/seventeentrack/__init__.py
+++ b/tests/components/seventeentrack/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the seventeentrack component."""

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -1,0 +1,382 @@
+"""Tests for the seventeentrack sensor."""
+
+import os
+import shutil
+import unittest
+from unittest.mock import patch
+from typing import Union
+
+from mock import MagicMock
+from py17track.package import Package
+
+from homeassistant.components.seventeentrack.sensor \
+    import CONF_SHOW_ARCHIVED, CONF_SHOW_DELIVERED, SeventeenTrackData
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.setup import setup_component
+from tests.common import get_test_home_assistant, MockDependency, \
+    get_test_config_dir
+
+VALID_CONFIG_MINIMAL = {
+    'sensor': {
+        'platform': 'seventeentrack',
+        CONF_USERNAME: 'test',
+        CONF_PASSWORD: 'test'
+    }
+}
+
+INVALID_CONFIG = {
+    'sensor': {
+        'platform': 'seventeentrack',
+        'boom': 'test',
+    }
+}
+
+VALID_CONFIG_FULL = {
+    'sensor': {
+        'platform': 'seventeentrack',
+        CONF_USERNAME: 'test',
+        CONF_PASSWORD: 'test',
+        CONF_SHOW_ARCHIVED: True,
+        CONF_SHOW_DELIVERED: True
+    }
+}
+
+VALID_CONFIG_FULL_NO_DELIVERED = {
+    'sensor': {
+        'platform': 'seventeentrack',
+        CONF_USERNAME: 'test',
+        CONF_PASSWORD: 'test',
+        CONF_SHOW_ARCHIVED: False,
+        CONF_SHOW_DELIVERED: False
+    }
+}
+
+DEFAULT_SUMMARY = {
+    "Not Found": 0,
+    "In Transit": 0,
+    "Expired": 0,
+    "Ready to be Picked Up": 0,
+    "Undelivered": 0,
+    "Delivered": 0,
+    "Returned": 0
+}
+
+NEW_SUMMARY_DATA = {
+    "Not Found": 1,
+    "In Transit": 1,
+    "Expired": 1,
+    "Ready to be Picked Up": 1,
+    "Undelivered": 1,
+    "Delivered": 1,
+    "Returned": 1
+}
+
+
+class ClientMock:
+    """Mock the py17track client to inject the ProfileMock."""
+
+    def __init__(self, websession) -> None:
+        """Mock the profile."""
+        self.profile = ProfileMock()
+
+
+class ProfileMock:
+    """ProfileMock will mock data coming from 17track."""
+
+    package_list = []
+    login_result = True
+    summary_data = DEFAULT_SUMMARY
+    account_id = '123'
+
+    @classmethod
+    def reset(cls):
+        """Reset data to defaults."""
+        cls.package_list = []
+        cls.login_result = True
+        cls.summary_data = DEFAULT_SUMMARY
+        cls.account_id = '123'
+
+    def __init__(self) -> None:
+        """Override Account id."""
+        self.account_id = self.__class__.account_id
+
+    async def login(self, email: str, password: str) -> bool:
+        """Login mock."""
+        return self.__class__.login_result
+
+    async def packages(self, package_state: Union[int, str] = '',
+                       show_archived: bool = False) -> list:
+        """Packages mock."""
+        return self.__class__.package_list[:]
+
+    async def summary(self, show_archived: bool = False) -> dict:
+        """Summary mock."""
+        return self.__class__.summary_data
+
+
+class SeventeenTrackDataMock(SeventeenTrackData):
+    """Remove the throttling on the async_update function."""
+
+    block = True
+    first = True
+
+    @classmethod
+    def reset(cls):
+        """Block update as throttling would do."""
+        SeventeenTrackDataMock.block = True
+        SeventeenTrackDataMock.first = True
+
+    def __init__(self, hass, client, async_add_entities, scan_interval,
+                 show_archived, show_delivered):
+        """Override constructor to preserve _async_update."""
+        super().__init__(hass, client, async_add_entities, scan_interval,
+                         show_archived, show_delivered)
+        self.async_update = self.new_async_update
+
+    async def new_async_update(self):
+        """Mock method for update."""
+        if SeventeenTrackDataMock.block and not SeventeenTrackDataMock.first:
+            return
+        SeventeenTrackDataMock.first = False
+        return await super()._async_update()
+
+
+class TestSeventeentrack(unittest.TestCase):
+    """Main test class."""
+
+    def setUp(self):
+        """Start hass."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Clean stuff."""
+        ProfileMock.reset()
+        SeventeenTrackDataMock.reset()
+        self.hass.stop()
+        storage_dir = get_test_config_dir('.storage')
+        if os.path.isdir(storage_dir):
+            shutil.rmtree(storage_dir)
+
+    def setup_component(self, config):
+        """Set up component using config."""
+        ProfileMock.summary_data = {}
+        assert setup_component(self.hass, 'sensor', config)
+        self.hass.block_till_done()
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    def test_full_valid_config(self, py17track_mock):
+        """Ensure everything starts correctly."""
+        assert setup_component(self.hass, 'sensor', VALID_CONFIG_FULL)
+        self.hass.block_till_done()
+
+        assert len(self.hass.states.entity_ids()) == len(
+            ProfileMock.summary_data.keys())
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    def test_valid_config(self, py17track_mock):
+        """Ensure everything starts correctly."""
+        assert setup_component(self.hass, 'sensor', VALID_CONFIG_MINIMAL)
+        self.hass.block_till_done()
+
+        assert len(self.hass.states.entity_ids()) == len(
+            ProfileMock.summary_data.keys())
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    def test_invalid_config(self, py17track_mock):
+        """Ensure nothing is created when config is wrong."""
+        assert setup_component(self.hass, 'sensor', INVALID_CONFIG)
+        self.hass.block_till_done()
+
+        assert not self.hass.states.entity_ids()
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
+           new=SeventeenTrackDataMock)
+    def test_add_package(self, py17track_mock):
+        """Ensure package is added correctly when user add a new package."""
+        package = Package('456', 206, 'friendly name 1', 'info text 1',
+                          'location 1', 206, 2)
+        ProfileMock.package_list = [package]
+
+        self.setup_component(VALID_CONFIG_MINIMAL)
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_456') is not None
+        assert len(self.hass.states.entity_ids()) == 1
+
+        package2 = Package('789', 206, 'friendly name 2', 'info text 2',
+                           'location 2', 206, 2)
+        ProfileMock.package_list = [package, package2]
+        SeventeenTrackDataMock.reset()
+
+        self.hass.async_create_task(
+            self.hass.data['entity_components']['sensor'].get_entity(
+                'sensor.seventeentrack_package_456')
+            .async_update_ha_state(force_refresh=True))
+        self.hass.block_till_done()
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_789') is not None
+        assert len(self.hass.states.entity_ids()) == 2
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
+           new=SeventeenTrackDataMock)
+    def test_remove_package(self, py17track_mock):
+        """Ensure entity is not there anymore if package is not there."""
+        package1 = Package('456', 206, 'friendly name 1', 'info text 1',
+                           'location 1', 206, 2)
+        package2 = Package('789', 206, 'friendly name 2', 'info text 2',
+                           'location 2', 206, 2)
+
+        ProfileMock.package_list = [package1, package2]
+
+        self.setup_component(VALID_CONFIG_MINIMAL)
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_456') is not None
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_789') is not None
+        assert len(self.hass.states.entity_ids()) == 2
+
+        ProfileMock.package_list = [package2]
+        SeventeenTrackDataMock.reset()
+
+        self.hass.async_create_task(
+            self.hass.data['entity_components']['sensor'].get_entity(
+                'sensor.seventeentrack_package_456')
+            .async_update_ha_state(force_refresh=True))
+        self.hass.block_till_done()
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_456') is None
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_789') is not None
+        assert len(self.hass.states.entity_ids()) == 1
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
+           new=SeventeenTrackDataMock)
+    def test_friendly_name_changed(self, py17track_mock):
+        """Test friendly name change"""
+        package = Package('456', 206, 'friendly name 1', 'info text 1',
+                          'location 1', 206, 2)
+        ProfileMock.package_list = [package]
+
+        self.setup_component(VALID_CONFIG_MINIMAL)
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_456') is not None
+        assert len(self.hass.states.entity_ids()) == 1
+
+        package = Package('456', 206, 'friendly name 2', 'info text 1',
+                          'location 1', 206, 2)
+        ProfileMock.package_list = [package]
+        SeventeenTrackDataMock.reset()
+
+        self.hass.async_create_task(
+            self.hass.data['entity_components']['sensor'].get_entity(
+                'sensor.seventeentrack_package_456')
+            .async_update_ha_state(force_refresh=True))
+        self.hass.block_till_done()
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_456') is not None
+        entity = self.hass.data['entity_components']['sensor'].get_entity(
+            'sensor.seventeentrack_package_456')
+        assert entity.name == 'Seventeentrack Package: friendly name 2'
+        assert len(self.hass.states.entity_ids()) == 1
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
+           new=SeventeenTrackDataMock)
+    def test_delivered_not_shown(self, py17track_mock):
+        """Ensure delivered packages are not shown."""
+        package = Package('456', 206, 'friendly name 1', 'info text 1',
+                          'location 1', 206, 2, 40)
+        ProfileMock.package_list = [package]
+
+        self.hass.components.persistent_notification = MagicMock()
+        self.setup_component(VALID_CONFIG_FULL_NO_DELIVERED)
+        assert not self.hass.states.entity_ids()
+        self.hass.components.persistent_notification.create.assert_called()
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
+           new=SeventeenTrackDataMock)
+    def test_delivered_shown(self, py17track_mock):
+        """Ensure delivered packages are show when user choose to show them."""
+        package = Package('456', 206, 'friendly name 1', 'info text 1',
+                          'location 1', 206, 2, 40)
+        ProfileMock.package_list = [package]
+        self.hass.components.persistent_notification = MagicMock()
+        self.setup_component(VALID_CONFIG_FULL)
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_456') is not None
+        assert len(self.hass.states.entity_ids()) == 1
+        self.hass.components.persistent_notification.create.assert_not_called()
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
+           new=SeventeenTrackDataMock)
+    def test_becomes_delivered_not_shown_notification(self, py17track_mock):
+        """Ensure notification is triggered when package becomes delivered."""
+        package = Package('456', 206, 'friendly name 1', 'info text 1',
+                          'location 1', 206, 2)
+        ProfileMock.package_list = [package]
+
+        self.setup_component(VALID_CONFIG_FULL_NO_DELIVERED)
+
+        assert self.hass.states.get(
+            'sensor.seventeentrack_package_456') is not None
+        assert len(self.hass.states.entity_ids()) == 1
+
+        package_delivered = Package('456', 206, 'friendly name 1',
+                                    'info text 1', 'location 1', 206, 2, 40)
+        ProfileMock.package_list = [package_delivered]
+        self.hass.components.persistent_notification = MagicMock()
+        SeventeenTrackDataMock.reset()
+
+        self.hass.async_create_task(
+            self.hass.data['entity_components']['sensor'].get_entity(
+                'sensor.seventeentrack_package_456')
+            .async_update_ha_state(force_refresh=True))
+        self.hass.block_till_done()
+
+        self.hass.components.persistent_notification.create.assert_called()
+
+    @MockDependency('py17track')
+    @patch('py17track.Client', new=ClientMock)
+    @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
+           new=SeventeenTrackDataMock)
+    def test_summary_no_correctly_updated(self, py17track_mock):
+        """Ensure summary entities are not duplicated."""
+        assert setup_component(self.hass, 'sensor', VALID_CONFIG_MINIMAL)
+        self.hass.block_till_done()
+
+        assert len(self.hass.states.entity_ids()) == 7
+        for state in self.hass.states.all():
+            assert state.state == '0'
+
+        SeventeenTrackDataMock.reset()
+        ProfileMock.summary_data = NEW_SUMMARY_DATA
+
+        for entity_id in self.hass.states.entity_ids():
+            self.hass.async_create_task(
+                self.hass.data['entity_components']['sensor'].get_entity(
+                    entity_id).async_update_ha_state(force_refresh=True))
+        self.hass.block_till_done()
+
+        assert len(self.hass.states.entity_ids()) == 7
+        for state in self.hass.states.all():
+            assert state.state == '1'

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -135,7 +135,6 @@ async def _setup_seventeentrack(hass, config=None, summary_data=None):
 
     ProfileMock.summary_data = summary_data
     assert await async_setup_component(hass, 'sensor', config)
-    # hass.block_till_done()()
 
 
 async def _goto_future(hass, future=None):
@@ -157,7 +156,6 @@ async def test_full_valid_config(hass):
 async def test_valid_config(hass):
     """Ensure everything starts correctly."""
     assert await async_setup_component(hass, 'sensor', VALID_CONFIG_MINIMAL)
-    # hass.block_till_done()()
 
     assert len(hass.states.async_entity_ids()) == len(
         ProfileMock.summary_data.keys())
@@ -166,7 +164,6 @@ async def test_valid_config(hass):
 async def test_invalid_config(hass):
     """Ensure nothing is created when config is wrong."""
     assert await async_setup_component(hass, 'sensor', INVALID_CONFIG)
-    # hass.block_till_done()()
 
     assert not hass.states.async_entity_ids()
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -126,10 +126,10 @@ class SeventeenTrackDataMock(SeventeenTrackData):
         SeventeenTrackDataMock.block = True
         SeventeenTrackDataMock.first = True
 
-    def __init__(self, hass, client, async_add_entities, scan_interval,
+    def __init__(self, client, async_add_entities, scan_interval,
                  show_archived, show_delivered):
         """Override constructor to preserve _async_update."""
-        super().__init__(hass, client, async_add_entities, scan_interval,
+        super().__init__(client, async_add_entities, scan_interval,
                          show_archived, show_delivered)
         self.async_update = self.new_async_update
 
@@ -264,7 +264,7 @@ class TestSeventeentrack(unittest.TestCase):
     @patch('homeassistant.components.seventeentrack.sensor.SeventeenTrackData',
            new=SeventeenTrackDataMock)
     def test_friendly_name_changed(self, py17track_mock):
-        """Test friendly name change"""
+        """Test friendly name change."""
         package = Package('456', 206, 'friendly name 1', 'info text 1',
                           'location 1', 206, 2)
         ProfileMock.package_list = [package]


### PR DESCRIPTION
## Breaking Change:

No breaking changes

## Description:

No related issue, just have some problems using the component. Here is a list of encountered problems:
- friendly name was never updated
- no notification when packages switch to delivered and `show_delivered` was `False`
- sometimes, an error appears when trying to remove entity (when package was removed from 17track)

Here is a list of small improvements I made:
- entity_id is now based on `tracking_number`
- code cleaning
- adding tests

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
