### PR TITLE
Fix bloomsky unit system

### DIFF
--- a/homeassistant/components/bloomsky/__init__.py
+++ b/homeassistant/components/bloomsky/__init__.py
@@ -35,7 +35,7 @@ def setup(hass, config):
 
     global BLOOMSKY
     try:
-        BLOOMSKY = BloomSky(api_key)
+        BLOOMSKY = BloomSky(api_key, hass.config.units.is_metric)
     except RuntimeError:
         return False
 
@@ -51,9 +51,10 @@ class BloomSky:
     # API documentation at http://weatherlution.com/bloomsky-api/
     API_URL = 'http://api.bloomsky.com/api/skydata'
 
-    def __init__(self, api_key):
+    def __init__(self, api_key, is_metric):
         """Initialize the BookSky."""
         self._api_key = api_key
+        self.endpoint_argument = 'unit=intl' if is_metric else ''
         self.devices = {}
         _LOGGER.debug("Initial BloomSky device load...")
         self.refresh_devices()
@@ -63,10 +64,11 @@ class BloomSky:
         """Use the API to retrieve a list of devices."""
         _LOGGER.debug("Fetching BloomSky update")
         response = requests.get(
-            self.API_URL, headers={AUTHORIZATION: self._api_key}, timeout=10)
+            "{}?{}".format(self.API_URL, self.endpoint_argument),
+            headers={AUTHORIZATION: self._api_key}, timeout=10)
         if response.status_code == 401:
             raise RuntimeError("Invalid API_KEY")
-        if response.status_code != 200:
+        elif response.status_code != 200:
             _LOGGER.error("Invalid HTTP response: %s", response.status_code)
             return
         # Create dictionary keyed off of the device unique id

--- a/homeassistant/components/bloomsky/__init__.py
+++ b/homeassistant/components/bloomsky/__init__.py
@@ -69,7 +69,7 @@ class BloomSky:
         if response.status_code == 401:
             raise RuntimeError("Invalid API_KEY")
         if response.status_code == 405:
-            _LOGGER.error("You have no bloomsky devices configured: %s", response.status_code)
+            _LOGGER.error("You have no bloomsky devices configured")
             return
         if response.status_code != 200:
             _LOGGER.error("Invalid HTTP response: %s", response.status_code)

--- a/homeassistant/components/bloomsky/__init__.py
+++ b/homeassistant/components/bloomsky/__init__.py
@@ -54,8 +54,9 @@ class BloomSky:
     def __init__(self, api_key, is_metric):
         """Initialize the BookSky."""
         self._api_key = api_key
-        self.endpoint_argument = 'unit=intl' if is_metric else ''
+        self._endpoint_argument = 'unit=intl' if is_metric else ''
         self.devices = {}
+        self.is_metric = is_metric
         _LOGGER.debug("Initial BloomSky device load...")
         self.refresh_devices()
 
@@ -64,7 +65,7 @@ class BloomSky:
         """Use the API to retrieve a list of devices."""
         _LOGGER.debug("Fetching BloomSky update")
         response = requests.get(
-            "{}?{}".format(self.API_URL, self.endpoint_argument),
+            "{}?{}".format(self.API_URL, self._endpoint_argument),
             headers={AUTHORIZATION: self._api_key}, timeout=10)
         if response.status_code == 401:
             raise RuntimeError("Invalid API_KEY")

--- a/homeassistant/components/bloomsky/__init__.py
+++ b/homeassistant/components/bloomsky/__init__.py
@@ -68,7 +68,10 @@ class BloomSky:
             headers={AUTHORIZATION: self._api_key}, timeout=10)
         if response.status_code == 401:
             raise RuntimeError("Invalid API_KEY")
-        elif response.status_code != 200:
+        if response.status_code == 405:
+            _LOGGER.error("You have no bloomsky devices configured: %s", response.status_code)
+            return
+        if response.status_code != 200:
             _LOGGER.error("Invalid HTTP response: %s", response.status_code)
             return
         # Create dictionary keyed off of the device unique id

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (TEMP_FAHRENHEIT, CONF_MONITORED_CONDITIONS)
+from homeassistant.const import (TEMP_FAHRENHEIT, TEMP_CELSIUS, CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
@@ -21,11 +21,18 @@ SENSOR_TYPES = ['Temperature',
                 'Voltage']
 
 # Sensor units - these do not currently align with the API documentation
-SENSOR_UNITS = {'Temperature': TEMP_FAHRENHEIT,
-                'Humidity': '%',
-                'Pressure': 'inHg',
-                'Luminance': 'cd/m²',
-                'Voltage': 'mV'}
+SENSOR_UNITS_IMPERIAL = {'Temperature': TEMP_FAHRENHEIT,
+                         'Humidity': '%',
+                         'Pressure': 'inHg',
+                         'Luminance': 'cd/m²',
+                         'Voltage': 'mV'}
+
+# Metric units
+SENSOR_UNITS_METRIC = {'Temperature': TEMP_CELSIUS,
+                       'Humidity': '%',
+                       'Pressure': 'mbar',
+                       'Luminance': 'cd/m²',
+                       'Voltage': 'mV'}
 
 # Which sensors to format numerically
 FORMAT_NUMBERS = ['Temperature', 'Pressure', 'Voltage']
@@ -77,7 +84,9 @@ class BloomSkySensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the sensor units."""
-        return SENSOR_UNITS.get(self._sensor_name, None)
+        if self._bloomsky.is_metric:
+            return SENSOR_UNITS_METRIC.get(self._sensor_name, None)
+        return SENSOR_UNITS_IMPERIAL.get(self._sensor_name, None)
 
     def update(self):
         """Request an update from the BloomSky API."""

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -4,7 +4,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (TEMP_FAHRENHEIT, TEMP_CELSIUS, CONF_MONITORED_CONDITIONS)
+from homeassistant.const import (TEMP_FAHRENHEIT,
+                                 TEMP_CELSIUS,
+                                 CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 


### PR DESCRIPTION
## Breaking Change:

Nothing breaks

## Description:

The bloomsky integration chooses the unit system depending on the hass.config.units.is_metric variable. If the unit system is metric, it fetches metric values from the bloomsky api.

**Related issue (if applicable):** fixes #11696

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html

Testing is necessary. Unfortunately I don't have any Bloomsky devices myself. @jdpiguet @RobCranfill Can you please test these changes?
___
Update 24.07.2019 - 18:30

Tested and ready for merging