### PR TITLE
Install requirements_test.txt for flake8 in Azure CI

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -40,7 +40,7 @@ stages:
         python -m venv venv
 
         . venv/bin/activate
-        pip install flake8
+        pip install -r requirements_test.txt
       displayName: 'Setup Env'
     - script: |
         . venv/bin/activate


### PR DESCRIPTION
## Description:

Was missing specified versions, as well as flake8-docstrings altogether. I'm guessing this fixes the flake8 part of #25353. And I suppose this PR will now fail in CI, but #25462 should fix it.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
