### PR TITLE
Allow async_register_entity_service to accept a dict schema

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
     SERVICE_ALARM_ARM_HOME, SERVICE_ALARM_ARM_AWAY, SERVICE_ALARM_ARM_NIGHT,
     SERVICE_ALARM_ARM_CUSTOM_BYPASS)
 from homeassistant.helpers.config_validation import (  # noqa
-    ENTITY_SERVICE_SCHEMA, PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
@@ -23,9 +23,9 @@ ATTR_CODE_ARM_REQUIRED = 'code_arm_required'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-ALARM_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+ALARM_SERVICE_SCHEMA = {
     vol.Optional(ATTR_CODE): cv.string,
-})
+}
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.core import Context, CoreState
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition, extract_domain_configs, script
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -86,9 +85,9 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_ACTION): cv.SCRIPT_SCHEMA,
 })
 
-TRIGGER_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+TRIGGER_SERVICE_SCHEMA = {
     vol.Optional(ATTR_VARIABLES, default={}): dict,
-})
+}
 
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
 
@@ -161,12 +160,12 @@ async def async_setup(hass, config):
 
     hass.services.async_register(
         DOMAIN, SERVICE_TOGGLE, toggle_service_handler,
-        schema=ENTITY_SERVICE_SCHEMA)
+        schema={})
 
     for service in (SERVICE_TURN_ON, SERVICE_TURN_OFF):
         hass.services.async_register(
             DOMAIN, service, turn_onoff_service_handler,
-            schema=ENTITY_SERVICE_SCHEMA)
+            schema={})
 
     return True
 

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON, STATE_OFF, STATE_ON, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa
-    ENTITY_SERVICE_SCHEMA, PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.temperature import display_temp as show_temp
@@ -50,34 +50,34 @@ CONVERTIBLE_ATTRIBUTE = [
 
 _LOGGER = logging.getLogger(__name__)
 
-SET_AUX_HEAT_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_AUX_HEAT_SCHEMA = {
     vol.Required(ATTR_AUX_HEAT): cv.boolean,
-})
+}
 SET_TEMPERATURE_SCHEMA = vol.Schema(vol.All(
     cv.has_at_least_one_key(
         ATTR_TEMPERATURE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW),
-    ENTITY_SERVICE_SCHEMA.extend({
+    {
         vol.Exclusive(ATTR_TEMPERATURE, 'temperature'): vol.Coerce(float),
         vol.Inclusive(ATTR_TARGET_TEMP_HIGH, 'temperature'): vol.Coerce(float),
         vol.Inclusive(ATTR_TARGET_TEMP_LOW, 'temperature'): vol.Coerce(float),
         vol.Optional(ATTR_HVAC_MODE): vol.In(HVAC_MODES),
-    })
+    }
 ))
-SET_FAN_MODE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_FAN_MODE_SCHEMA = {
     vol.Required(ATTR_FAN_MODE): cv.string,
-})
-SET_PRESET_MODE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+}
+SET_PRESET_MODE_SCHEMA = {
     vol.Required(ATTR_PRESET_MODE): cv.string,
-})
-SET_HVAC_MODE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+}
+SET_HVAC_MODE_SCHEMA = {
     vol.Required(ATTR_HVAC_MODE): vol.In(HVAC_MODES),
-})
-SET_HUMIDITY_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+}
+SET_HUMIDITY_SCHEMA = {
     vol.Required(ATTR_HUMIDITY): vol.Coerce(float),
-})
-SET_SWING_MODE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+}
+SET_SWING_MODE_SCHEMA = {
     vol.Required(ATTR_SWING_MODE): cv.string,
-})
+}
 
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
@@ -87,11 +87,11 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_TURN_ON, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_ON, {},
         'async_turn_on'
     )
     component.async_register_entity_service(
-        SERVICE_TURN_OFF, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_OFF, {},
         'async_turn_off'
     )
     component.async_register_entity_service(

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -7,7 +7,6 @@ from homeassistant.const import (
     CONF_ICON, CONF_NAME, CONF_MAXIMUM, CONF_MINIMUM)
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -33,11 +32,11 @@ SERVICE_INCREMENT = 'increment'
 SERVICE_RESET = 'reset'
 SERVICE_CONFIGURE = 'configure'
 
-SERVICE_SCHEMA_CONFIGURE = ENTITY_SERVICE_SCHEMA.extend({
+SERVICE_SCHEMA_CONFIGURE = {
     vol.Optional(ATTR_MINIMUM): vol.Any(None, vol.Coerce(int)),
     vol.Optional(ATTR_MAXIMUM): vol.Any(None, vol.Coerce(int)),
     vol.Optional(ATTR_STEP): cv.positive_int,
-})
+}
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: cv.schema_with_slug_keys(
@@ -82,13 +81,13 @@ async def async_setup(hass, config):
         return False
 
     component.async_register_entity_service(
-        SERVICE_INCREMENT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_INCREMENT, {},
         'async_increment')
     component.async_register_entity_service(
-        SERVICE_DECREMENT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_DECREMENT, {},
         'async_decrement')
     component.async_register_entity_service(
-        SERVICE_RESET, ENTITY_SERVICE_SCHEMA,
+        SERVICE_RESET, {},
         'async_reset')
     component.async_register_entity_service(
         SERVICE_CONFIGURE, SERVICE_SCHEMA_CONFIGURE,

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.config_validation import (  # noqa
     PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.components import group
 from homeassistant.helpers import intent
 from homeassistant.const import (
@@ -70,15 +69,15 @@ ATTR_TILT_POSITION = 'tilt_position'
 INTENT_OPEN_COVER = 'HassOpenCover'
 INTENT_CLOSE_COVER = 'HassCloseCover'
 
-COVER_SET_COVER_POSITION_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+COVER_SET_COVER_POSITION_SCHEMA = {
     vol.Required(ATTR_POSITION):
         vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
-})
+}
 
-COVER_SET_COVER_TILT_POSITION_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+COVER_SET_COVER_TILT_POSITION_SCHEMA = {
     vol.Required(ATTR_TILT_POSITION):
         vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
-})
+}
 
 
 @bind_hass
@@ -96,12 +95,12 @@ async def async_setup(hass, config):
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_OPEN_COVER, ENTITY_SERVICE_SCHEMA,
+        SERVICE_OPEN_COVER, {},
         'async_open_cover'
     )
 
     component.async_register_entity_service(
-        SERVICE_CLOSE_COVER, ENTITY_SERVICE_SCHEMA,
+        SERVICE_CLOSE_COVER, {},
         'async_close_cover'
     )
 
@@ -111,27 +110,27 @@ async def async_setup(hass, config):
     )
 
     component.async_register_entity_service(
-        SERVICE_STOP_COVER, ENTITY_SERVICE_SCHEMA,
+        SERVICE_STOP_COVER, {},
         'async_stop_cover'
     )
 
     component.async_register_entity_service(
-        SERVICE_TOGGLE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TOGGLE, {},
         'async_toggle'
     )
 
     component.async_register_entity_service(
-        SERVICE_OPEN_COVER_TILT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_OPEN_COVER_TILT, {},
         'async_open_cover_tilt'
     )
 
     component.async_register_entity_service(
-        SERVICE_CLOSE_COVER_TILT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_CLOSE_COVER_TILT, {},
         'async_close_cover_tilt'
     )
 
     component.async_register_entity_service(
-        SERVICE_STOP_COVER_TILT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_STOP_COVER_TILT, {},
         'async_stop_cover_tilt'
     )
 
@@ -141,7 +140,7 @@ async def async_setup(hass, config):
     )
 
     component.async_register_entity_service(
-        SERVICE_TOGGLE_COVER_TILT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TOGGLE_COVER_TILT, {},
         'async_toggle_tilt'
     )
 

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import (  # noqa
-    ENTITY_SERVICE_SCHEMA, PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,21 +54,21 @@ PROP_TO_ATTR = {
     'direction': ATTR_DIRECTION,
 }  # type: dict
 
-FAN_SET_SPEED_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+FAN_SET_SPEED_SCHEMA = {
     vol.Required(ATTR_SPEED): cv.string
-})  # type: dict
+}  # type: dict
 
-FAN_TURN_ON_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+FAN_TURN_ON_SCHEMA = {
     vol.Optional(ATTR_SPEED): cv.string
-})  # type: dict
+}  # type: dict
 
-FAN_OSCILLATE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+FAN_OSCILLATE_SCHEMA = {
     vol.Required(ATTR_OSCILLATING): cv.boolean
-})  # type: dict
+}  # type: dict
 
-FAN_SET_DIRECTION_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+FAN_SET_DIRECTION_SCHEMA = {
     vol.Optional(ATTR_DIRECTION): cv.string
-})  # type: dict
+}  # type: dict
 
 
 @bind_hass
@@ -91,11 +91,11 @@ async def async_setup(hass, config: dict):
         'async_turn_on'
     )
     component.async_register_entity_service(
-        SERVICE_TURN_OFF, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_OFF, {},
         'async_turn_off'
     )
     component.async_register_entity_service(
-        SERVICE_TOGGLE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TOGGLE, {},
         'async_toggle'
     )
     component.async_register_entity_service(

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_state_change
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from .reproduce_state import async_reproduce_states  # noqa
@@ -46,9 +45,9 @@ SERVICE_REMOVE = 'remove'
 
 CONTROL_TYPES = vol.In(['hidden', None])
 
-SET_VISIBILITY_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_VISIBILITY_SERVICE_SCHEMA = {
     vol.Required(ATTR_VISIBLE): cv.boolean
-})
+}
 
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
 

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.util.async_ import run_callback_threadsafe
@@ -78,7 +77,7 @@ async def async_setup(hass, config):
 
     hass.services.async_register(
         DOMAIN, SERVICE_SCAN, async_scan_service,
-        schema=ENTITY_SERVICE_SCHEMA)
+        schema={})
 
     return True
 

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -8,7 +8,6 @@ from homeassistant.const import (
     STATE_ON)
 from homeassistant.loader import bind_hass
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -58,17 +57,17 @@ async def async_setup(hass, config):
         return False
 
     component.async_register_entity_service(
-        SERVICE_TURN_ON, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_ON, {},
         'async_turn_on'
     )
 
     component.async_register_entity_service(
-        SERVICE_TURN_OFF, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_OFF, {},
         'async_turn_off'
     )
 
     component.async_register_entity_service(
-        SERVICE_TOGGLE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TOGGLE, {},
         'async_toggle'
     )
 

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 from homeassistant.const import (
     ATTR_DATE, ATTR_TIME, CONF_ICON, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
@@ -28,11 +27,11 @@ ATTR_DATETIME = 'datetime'
 
 SERVICE_SET_DATETIME = 'set_datetime'
 
-SERVICE_SET_DATETIME_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SERVICE_SET_DATETIME_SCHEMA = {
     vol.Optional(ATTR_DATE): cv.date,
     vol.Optional(ATTR_TIME): cv.time,
     vol.Optional(ATTR_DATETIME): cv.datetime,
-})
+}
 
 
 def has_date_or_time(conf):

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -4,7 +4,6 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, CONF_ICON, CONF_NAME, CONF_MODE)
 from homeassistant.helpers.entity_component import EntityComponent
@@ -34,9 +33,9 @@ SERVICE_SET_VALUE = 'set_value'
 SERVICE_INCREMENT = 'increment'
 SERVICE_DECREMENT = 'decrement'
 
-SERVICE_SET_VALUE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SERVICE_SET_VALUE_SCHEMA = {
     vol.Required(ATTR_VALUE): vol.Coerce(float),
-})
+}
 
 
 def _cv_input_number(cfg):
@@ -100,12 +99,12 @@ async def async_setup(hass, config):
     )
 
     component.async_register_entity_service(
-        SERVICE_INCREMENT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_INCREMENT, {},
         'async_increment'
     )
 
     component.async_register_entity_service(
-        SERVICE_DECREMENT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_DECREMENT, {},
         'async_decrement'
     )
 

--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_ICON, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -22,9 +21,9 @@ ATTR_OPTIONS = 'options'
 
 SERVICE_SELECT_OPTION = 'select_option'
 
-SERVICE_SELECT_OPTION_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SERVICE_SELECT_OPTION_SCHEMA = {
     vol.Required(ATTR_OPTION): cv.string,
-})
+}
 
 SERVICE_SELECT_NEXT = 'select_next'
 
@@ -32,10 +31,10 @@ SERVICE_SELECT_PREVIOUS = 'select_previous'
 
 SERVICE_SET_OPTIONS = 'set_options'
 
-SERVICE_SET_OPTIONS_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SERVICE_SET_OPTIONS_SCHEMA = {
     vol.Required(ATTR_OPTIONS):
         vol.All(cv.ensure_list, vol.Length(min=1), [cv.string]),
-})
+}
 
 
 def _cv_input_select(cfg):
@@ -83,12 +82,12 @@ async def async_setup(hass, config):
     )
 
     component.async_register_entity_service(
-        SERVICE_SELECT_NEXT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_SELECT_NEXT, {},
         lambda entity, call: entity.async_offset_index(1)
     )
 
     component.async_register_entity_service(
-        SERVICE_SELECT_PREVIOUS, ENTITY_SERVICE_SCHEMA,
+        SERVICE_SELECT_PREVIOUS, {},
         lambda entity, call: entity.async_offset_index(-1)
     )
 

--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -4,7 +4,6 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, CONF_ICON, CONF_NAME, CONF_MODE)
 from homeassistant.helpers.entity_component import EntityComponent
@@ -30,9 +29,9 @@ ATTR_MODE = 'mode'
 
 SERVICE_SET_VALUE = 'set_value'
 
-SERVICE_SET_VALUE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SERVICE_SET_VALUE_SCHEMA = {
     vol.Required(ATTR_VALUE): cv.string,
-})
+}
 
 
 def _cv_input_text(cfg):

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import UnknownUser, Unauthorized
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa
-    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE, ENTITY_SERVICE_SCHEMA)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers import intent
@@ -84,7 +84,7 @@ VALID_TRANSITION = vol.All(vol.Coerce(float), vol.Clamp(min=0, max=6553))
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
 VALID_BRIGHTNESS_PCT = vol.All(vol.Coerce(float), vol.Range(min=0, max=100))
 
-LIGHT_TURN_ON_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+LIGHT_TURN_ON_SCHEMA = {
     vol.Exclusive(ATTR_PROFILE, COLOR_GROUP): cv.string,
     ATTR_TRANSITION: VALID_TRANSITION,
     ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
@@ -108,12 +108,12 @@ LIGHT_TURN_ON_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
     ATTR_WHITE_VALUE: vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
     ATTR_EFFECT: cv.string,
-})
+}
 
-LIGHT_TURN_OFF_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+LIGHT_TURN_OFF_SCHEMA = {
     ATTR_TRANSITION: VALID_TRANSITION,
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
-})
+}
 
 LIGHT_TOGGLE_SCHEMA = LIGHT_TURN_ON_SCHEMA
 

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.config_validation import (  # noqa
-    ENTITY_SERVICE_SCHEMA, PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     ATTR_CODE, ATTR_CODE_FORMAT, STATE_LOCKED, STATE_UNLOCKED, SERVICE_LOCK,
@@ -28,9 +28,9 @@ GROUP_NAME_ALL_LOCKS = 'all locks'
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
-LOCK_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+LOCK_SERVICE_SCHEMA = {
     vol.Optional(ATTR_CODE): cv.string,
-})
+}
 
 # Bitfield of features supported by the lock entity
 SUPPORT_OPEN = 1

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa
-    ENTITY_SERVICE_SCHEMA, PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.loader import bind_hass
@@ -78,36 +78,36 @@ DEVICE_CLASSES = [
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 
 # Service call validation schemas
-MEDIA_PLAYER_SET_VOLUME_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+MEDIA_PLAYER_SET_VOLUME_SCHEMA = {
     vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float,
-})
+}
 
-MEDIA_PLAYER_MUTE_VOLUME_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+MEDIA_PLAYER_MUTE_VOLUME_SCHEMA = {
     vol.Required(ATTR_MEDIA_VOLUME_MUTED): cv.boolean,
-})
+}
 
-MEDIA_PLAYER_MEDIA_SEEK_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+MEDIA_PLAYER_MEDIA_SEEK_SCHEMA = {
     vol.Required(ATTR_MEDIA_SEEK_POSITION):
         vol.All(vol.Coerce(float), vol.Range(min=0)),
-})
+}
 
-MEDIA_PLAYER_SELECT_SOURCE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+MEDIA_PLAYER_SELECT_SOURCE_SCHEMA = {
     vol.Required(ATTR_INPUT_SOURCE): cv.string,
-})
+}
 
-MEDIA_PLAYER_SELECT_SOUND_MODE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+MEDIA_PLAYER_SELECT_SOUND_MODE_SCHEMA = {
     vol.Required(ATTR_SOUND_MODE): cv.string,
-})
+}
 
-MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+MEDIA_PLAYER_PLAY_MEDIA_SCHEMA = {
     vol.Required(ATTR_MEDIA_CONTENT_TYPE): cv.string,
     vol.Required(ATTR_MEDIA_CONTENT_ID): cv.string,
     vol.Optional(ATTR_MEDIA_ENQUEUE): cv.boolean,
-})
+}
 
-MEDIA_PLAYER_SET_SHUFFLE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+MEDIA_PLAYER_SET_SHUFFLE_SCHEMA = {
     vol.Required(ATTR_MEDIA_SHUFFLE): cv.boolean,
-})
+}
 
 ATTR_TO_PROPERTY = [
     ATTR_MEDIA_VOLUME_LEVEL,
@@ -170,51 +170,51 @@ async def async_setup(hass, config):
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_TURN_ON, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_ON, {},
         'async_turn_on', [SUPPORT_TURN_ON]
     )
     component.async_register_entity_service(
-        SERVICE_TURN_OFF, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_OFF, {},
         'async_turn_off', [SUPPORT_TURN_OFF]
     )
     component.async_register_entity_service(
-        SERVICE_TOGGLE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TOGGLE, {},
         'async_toggle', [SUPPORT_TURN_OFF | SUPPORT_TURN_ON]
     )
     component.async_register_entity_service(
-        SERVICE_VOLUME_UP, ENTITY_SERVICE_SCHEMA,
+        SERVICE_VOLUME_UP, {},
         'async_volume_up', [SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP]
     )
     component.async_register_entity_service(
-        SERVICE_VOLUME_DOWN, ENTITY_SERVICE_SCHEMA,
+        SERVICE_VOLUME_DOWN, {},
         'async_volume_down', [SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP]
     )
     component.async_register_entity_service(
-        SERVICE_MEDIA_PLAY_PAUSE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_MEDIA_PLAY_PAUSE, {},
         'async_media_play_pause', [SUPPORT_PLAY | SUPPORT_PAUSE]
     )
     component.async_register_entity_service(
-        SERVICE_MEDIA_PLAY, ENTITY_SERVICE_SCHEMA,
+        SERVICE_MEDIA_PLAY, {},
         'async_media_play', [SUPPORT_PLAY]
     )
     component.async_register_entity_service(
-        SERVICE_MEDIA_PAUSE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_MEDIA_PAUSE, {},
         'async_media_pause', [SUPPORT_PAUSE]
     )
     component.async_register_entity_service(
-        SERVICE_MEDIA_STOP, ENTITY_SERVICE_SCHEMA,
+        SERVICE_MEDIA_STOP, {},
         'async_media_stop', [SUPPORT_STOP]
     )
     component.async_register_entity_service(
-        SERVICE_MEDIA_NEXT_TRACK, ENTITY_SERVICE_SCHEMA,
+        SERVICE_MEDIA_NEXT_TRACK, {},
         'async_media_next_track', [SUPPORT_NEXT_TRACK]
     )
     component.async_register_entity_service(
-        SERVICE_MEDIA_PREVIOUS_TRACK, ENTITY_SERVICE_SCHEMA,
+        SERVICE_MEDIA_PREVIOUS_TRACK, {},
         'async_media_previous_track', [SUPPORT_PREVIOUS_TRACK]
     )
     component.async_register_entity_service(
-        SERVICE_CLEAR_PLAYLIST, ENTITY_SERVICE_SCHEMA,
+        SERVICE_CLEAR_PLAYLIST, {},
         'async_clear_playlist', [SUPPORT_CLEAR_PLAYLIST]
     )
     component.async_register_entity_service(

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE)
 from homeassistant.components import group
 from homeassistant.helpers.config_validation import (  # noqa
-    ENTITY_SERVICE_SCHEMA, PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,25 +46,25 @@ DEFAULT_HOLD_SECS = 0
 
 SUPPORT_LEARN_COMMAND = 1
 
-REMOTE_SERVICE_ACTIVITY_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+REMOTE_SERVICE_ACTIVITY_SCHEMA = {
     vol.Optional(ATTR_ACTIVITY): cv.string
-})
+}
 
-REMOTE_SERVICE_SEND_COMMAND_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+REMOTE_SERVICE_SEND_COMMAND_SCHEMA = {
     vol.Required(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(ATTR_DEVICE): cv.string,
     vol.Optional(
         ATTR_NUM_REPEATS, default=DEFAULT_NUM_REPEATS): cv.positive_int,
     vol.Optional(ATTR_DELAY_SECS): vol.Coerce(float),
     vol.Optional(ATTR_HOLD_SECS, default=DEFAULT_HOLD_SECS): vol.Coerce(float),
-})
+}
 
-REMOTE_SERVICE_LEARN_COMMAND_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+REMOTE_SERVICE_LEARN_COMMAND_SCHEMA = {
     vol.Optional(ATTR_DEVICE): cv.string,
     vol.Optional(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(ATTR_ALTERNATIVE): cv.boolean,
     vol.Optional(ATTR_TIMEOUT): cv.positive_int
-})
+}
 
 
 @bind_hass

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -6,7 +6,6 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import CONF_PLATFORM, SERVICE_TURN_ON
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.state import HASS_DOMAIN
@@ -70,7 +69,7 @@ async def async_setup(hass, config):
 
     hass.services.async_register(
         DOMAIN, SERVICE_TURN_ON, async_handle_scene_service,
-        schema=ENTITY_SERVICE_SCHEMA)
+        schema={})
 
     return True
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -12,7 +12,6 @@ from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 
 from homeassistant.helpers.script import Script
 
@@ -40,9 +39,9 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 SCRIPT_SERVICE_SCHEMA = vol.Schema(dict)
-SCRIPT_TURN_ONOFF_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SCRIPT_TURN_ONOFF_SCHEMA = {
     vol.Optional(ATTR_VARIABLES): dict,
-})
+}
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
 
 

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.loader import bind_hass
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.config_validation import (  # noqa
-    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE, ENTITY_SERVICE_SCHEMA)
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 from homeassistant.const import (
     STATE_ON, SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE)
 from homeassistant.components import group
@@ -61,17 +61,17 @@ async def async_setup(hass, config):
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_TURN_OFF, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_OFF, {},
         'async_turn_off'
     )
 
     component.async_register_entity_service(
-        SERVICE_TURN_ON, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_ON, {},
         'async_turn_on'
     )
 
     component.async_register_entity_service(
-        SERVICE_TOGGLE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TOGGLE, {},
         'async_toggle'
     )
 

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_ICON, CONF_NAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -37,10 +36,10 @@ SERVICE_PAUSE = 'pause'
 SERVICE_CANCEL = 'cancel'
 SERVICE_FINISH = 'finish'
 
-SERVICE_SCHEMA_DURATION = ENTITY_SERVICE_SCHEMA.extend({
-    vol.Optional(ATTR_DURATION,
-                 default=timedelta(DEFAULT_DURATION)): cv.time_period,
-})
+SERVICE_SCHEMA_DURATION = {
+    vol.Optional(
+        ATTR_DURATION, default=timedelta(DEFAULT_DURATION)): cv.time_period,
+}
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: cv.schema_with_slug_keys(
@@ -77,13 +76,13 @@ async def async_setup(hass, config):
         SERVICE_START, SERVICE_SCHEMA_DURATION,
         'async_start')
     component.async_register_entity_service(
-        SERVICE_PAUSE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_PAUSE, {},
         'async_pause')
     component.async_register_entity_service(
-        SERVICE_CANCEL, ENTITY_SERVICE_SCHEMA,
+        SERVICE_CANCEL, {},
         'async_cancel')
     component.async_register_entity_service(
-        SERVICE_FINISH, ENTITY_SERVICE_SCHEMA,
+        SERVICE_FINISH, {},
         'async_finish')
 
     await component.async_add_entities(entities)

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -27,11 +26,11 @@ ATTR_TARIFFS = 'tariffs'
 
 DEFAULT_OFFSET = timedelta(hours=0)
 
-SERVICE_SELECT_TARIFF_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SERVICE_SELECT_TARIFF_SCHEMA = {
     vol.Required(ATTR_TARIFF): cv.string
-})
+}
 
-METER_CONFIG_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+METER_CONFIG_SCHEMA = vol.Schema({
     vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_METER_TYPE): vol.In(METER_TYPES),
@@ -87,7 +86,7 @@ async def async_setup(hass, config):
 
     if register_services:
         component.async_register_entity_service(
-            SERVICE_RESET, ENTITY_SERVICE_SCHEMA,
+            SERVICE_RESET, {},
             'async_reset_meters'
         )
 
@@ -97,7 +96,7 @@ async def async_setup(hass, config):
         )
 
         component.async_register_entity_service(
-            SERVICE_SELECT_NEXT_TARIFF, ENTITY_SERVICE_SCHEMA,
+            SERVICE_SELECT_NEXT_TARIFF, {},
             'async_next_tariff'
         )
 

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -42,14 +42,14 @@ SERVICE_START = 'start'
 SERVICE_PAUSE = 'pause'
 SERVICE_STOP = 'stop'
 
-VACUUM_SET_FAN_SPEED_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+VACUUM_SET_FAN_SPEED_SERVICE_SCHEMA = {
     vol.Required(ATTR_FAN_SPEED): cv.string,
-})
+}
 
-VACUUM_SEND_COMMAND_SERVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+VACUUM_SEND_COMMAND_SERVICE_SCHEMA = {
     vol.Required(ATTR_COMMAND): cv.string,
     vol.Optional(ATTR_PARAMS): vol.Any(dict, cv.ensure_list),
-})
+}
 
 STATE_CLEANING = 'cleaning'
 STATE_DOCKED = 'docked'
@@ -91,43 +91,43 @@ async def async_setup(hass, config):
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_TURN_ON, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_ON, {},
         'async_turn_on'
     )
     component.async_register_entity_service(
-        SERVICE_TURN_OFF, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TURN_OFF, {},
         'async_turn_off'
     )
     component.async_register_entity_service(
-        SERVICE_TOGGLE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_TOGGLE, {},
         'async_toggle'
     )
     component.async_register_entity_service(
-        SERVICE_START_PAUSE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_START_PAUSE, {},
         'async_start_pause'
     )
     component.async_register_entity_service(
-        SERVICE_START, ENTITY_SERVICE_SCHEMA,
+        SERVICE_START, {},
         'async_start'
     )
     component.async_register_entity_service(
-        SERVICE_PAUSE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_PAUSE, {},
         'async_pause'
     )
     component.async_register_entity_service(
-        SERVICE_RETURN_TO_BASE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_RETURN_TO_BASE, {},
         'async_return_to_base'
     )
     component.async_register_entity_service(
-        SERVICE_CLEAN_SPOT, ENTITY_SERVICE_SCHEMA,
+        SERVICE_CLEAN_SPOT, {},
         'async_clean_spot'
     )
     component.async_register_entity_service(
-        SERVICE_LOCATE, ENTITY_SERVICE_SCHEMA,
+        SERVICE_LOCATE, {},
         'async_locate'
     )
     component.async_register_entity_service(
-        SERVICE_STOP, ENTITY_SERVICE_SCHEMA,
+        SERVICE_STOP, {},
         'async_stop'
     )
     component.async_register_entity_service(

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import track_time_interval
@@ -107,11 +106,9 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
-RENAME_DEVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+RENAME_DEVICE_SCHEMA = {
     vol.Required(ATTR_NAME): cv.string,
-}, extra=vol.ALLOW_EXTRA)
-
-DELETE_DEVICE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
+}
 
 SET_PAIRING_MODE_SCHEMA = vol.Schema({
     vol.Required(ATTR_HUB_NAME): cv.string,
@@ -119,31 +116,31 @@ SET_PAIRING_MODE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_KIDDE_RADIO_CODE): cv.string,
 }, extra=vol.ALLOW_EXTRA)
 
-SET_VOLUME_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_VOLUME_SCHEMA = {
     vol.Required(ATTR_VOLUME): vol.In(VOLUMES),
-})
+}
 
-SET_SIREN_TONE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_SIREN_TONE_SCHEMA = {
     vol.Required(ATTR_TONE): vol.In(TONES),
-})
+}
 
-SET_CHIME_MODE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_CHIME_MODE_SCHEMA = {
     vol.Required(ATTR_TONE): vol.In(CHIME_TONES),
-})
+}
 
-SET_AUTO_SHUTOFF_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_AUTO_SHUTOFF_SCHEMA = {
     vol.Required(ATTR_AUTO_SHUTOFF): vol.In(AUTO_SHUTOFF_TIMES),
-})
+}
 
-SET_STROBE_ENABLED_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+SET_STROBE_ENABLED_SCHEMA = {
     vol.Required(ATTR_ENABLED): cv.boolean,
-})
+}
 
-ENABLED_SIREN_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+ENABLED_SIREN_SCHEMA = {
     vol.Required(ATTR_ENABLED): cv.boolean
-})
+}
 
-DIAL_CONFIG_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+DIAL_CONFIG_SCHEMA = {
     vol.Optional(ATTR_MIN_VALUE): vol.Coerce(int),
     vol.Optional(ATTR_MAX_VALUE): vol.Coerce(int),
     vol.Optional(ATTR_MIN_POSITION): cv.positive_int,
@@ -151,12 +148,12 @@ DIAL_CONFIG_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_ROTATION): vol.In(ROTATIONS),
     vol.Optional(ATTR_SCALE): vol.In(SCALES),
     vol.Optional(ATTR_TICKS): cv.positive_int,
-})
+}
 
-DIAL_STATE_SCHEMA = ENTITY_SERVICE_SCHEMA.extend({
+DIAL_STATE_SCHEMA = {
     vol.Required(ATTR_VALUE): vol.Coerce(int),
     vol.Optional(ATTR_LABELS): cv.ensure_list(cv.string),
-})
+}
 
 WINK_COMPONENTS = [
     'binary_sensor', 'sensor', 'light', 'switch', 'lock', 'cover', 'climate',
@@ -437,7 +434,7 @@ def setup(hass, config):
             found_device.wink.remove_device()
 
     hass.services.register(DOMAIN, SERVICE_DELETE_DEVICE, delete_device,
-                           schema=DELETE_DEVICE_SCHEMA)
+                           schema={})
 
     hubs = pywink.get_hubs()
     for hub in hubs:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 from itertools import chain
 import logging
 
+import voluptuous as vol
+
 from homeassistant import config as conf_util
 from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.const import (
@@ -12,6 +14,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform, discovery
+from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.helpers.service import async_extract_entity_ids
 from homeassistant.loader import bind_hass, async_get_integration
 from homeassistant.util import slugify
@@ -189,6 +192,10 @@ class EntityComponent:
     def async_register_entity_service(self, name, schema, func,
                                       required_features=None):
         """Register an entity service."""
+        if isinstance(schema, dict):
+            schema = ENTITY_SERVICE_SCHEMA.extend(
+                schema, extra=vol.ALLOW_EXTRA)
+
         async def handle_service(call):
             """Handle the service."""
             service_name = "{}.{}".format(self.domain, name)


### PR DESCRIPTION
## Description:

Following up on https://github.com/home-assistant/home-assistant/issues/25155 (and per [a request from @balloob](https://github.com/home-assistant/home-assistant/pull/25436#discussion_r306581583)), this PR allows `async_register_entity_service` to accept a `dict` for its `schema` argument. When a `dict` is passed, it is automatically extended from `ENTITY_SERVICE_SCHEMA`. This cleans up our code a good amount and removes the burden of remembering to extend `ENTITY_SERVICE_SCHEMA` from future entity component authors.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
