### PR TITLE
Allow cors for static files

### DIFF
--- a/homeassistant/components/http/cors.py
+++ b/homeassistant/components/http/cors.py
@@ -1,5 +1,5 @@
 """Provide CORS support for the HTTP component."""
-from aiohttp.web_urldispatcher import Resource, ResourceRoute
+from aiohttp.web_urldispatcher import Resource, ResourceRoute, StaticResource
 from aiohttp.hdrs import ACCEPT, CONTENT_TYPE, ORIGIN, AUTHORIZATION
 
 from homeassistant.const import (
@@ -9,7 +9,7 @@ from homeassistant.core import callback
 ALLOWED_CORS_HEADERS = [
     ORIGIN, ACCEPT, HTTP_HEADER_X_REQUESTED_WITH, CONTENT_TYPE,
     HTTP_HEADER_HA_AUTH, AUTHORIZATION]
-VALID_CORS_TYPES = (Resource, ResourceRoute)
+VALID_CORS_TYPES = (Resource, ResourceRoute, StaticResource)
 
 
 @callback
@@ -56,7 +56,7 @@ def setup_cors(app, origins):
 
     async def cors_startup(app):
         """Initialize CORS when app starts up."""
-        for route in list(app.router.routes()):
-            _allow_cors(route)
+        for resource in list(app.router.resources()):
+            _allow_cors(resource)
 
     app.on_startup.append(cors_startup)


### PR DESCRIPTION
## Description:
Make sure that the CORS setting for the HTTP integration also applies to static folders.

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  cors_allowed_origins:
    - https://www.home-assistant.io
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
