### PR TITLE
Fix Nest turning off eco

### DIFF
--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -8,7 +8,8 @@ from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW, FAN_AUTO, FAN_ON,
     HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF,
     SUPPORT_PRESET_MODE, SUPPORT_FAN_MODE, SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE, PRESET_AWAY, PRESET_ECO, PRESET_NONE)
+    SUPPORT_TARGET_TEMPERATURE_RANGE, PRESET_AWAY, PRESET_ECO, PRESET_NONE,
+    CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_COOL)
 from homeassistant.const import (
     ATTR_TEMPERATURE, CONF_SCAN_INTERVAL, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -28,14 +29,20 @@ NEST_MODE_HEAT = 'heat'
 NEST_MODE_COOL = 'cool'
 NEST_MODE_OFF = 'off'
 
-HASS_TO_NEST = {
+MODE_HASS_TO_NEST = {
     HVAC_MODE_AUTO: NEST_MODE_HEAT_COOL,
     HVAC_MODE_HEAT: NEST_MODE_HEAT,
     HVAC_MODE_COOL: NEST_MODE_COOL,
     HVAC_MODE_OFF: NEST_MODE_OFF,
 }
 
-NEST_TO_HASS = {v: k for k, v in HASS_TO_NEST.items()}
+MODE_NEST_TO_HASS = {v: k for k, v in MODE_HASS_TO_NEST.items()}
+
+ACTION_NEST_TO_HASS = {
+    'off': CURRENT_HVAC_IDLE,
+    'heating': CURRENT_HVAC_HEAT,
+    'cooling': CURRENT_HVAC_COOL,
+}
 
 PRESET_MODES = [PRESET_NONE, PRESET_AWAY, PRESET_ECO]
 
@@ -104,6 +111,7 @@ class NestThermostat(ClimateDevice):
         self._temperature = None
         self._temperature_scale = None
         self._mode = None
+        self._action = None
         self._fan = None
         self._eco_temperature = None
         self._is_locked = None
@@ -170,7 +178,12 @@ class NestThermostat(ClimateDevice):
             # We assume the first operation in operation list is the main one
             return self._operation_list[0]
 
-        return NEST_TO_HASS[self._mode]
+        return MODE_NEST_TO_HASS[self._mode]
+
+    @property
+    def hvac_action(self):
+        """Return the current hvac action."""
+        return ACTION_NEST_TO_HASS[self._action]
 
     @property
     def target_temperature(self):
@@ -221,7 +234,7 @@ class NestThermostat(ClimateDevice):
 
     def set_hvac_mode(self, hvac_mode):
         """Set operation mode."""
-        self.device.mode = HASS_TO_NEST[hvac_mode]
+        self.device.mode = MODE_HASS_TO_NEST[hvac_mode]
 
     @property
     def hvac_modes(self):
@@ -255,7 +268,7 @@ class NestThermostat(ClimateDevice):
             self.structure.away = True
 
         if self.preset_mode == PRESET_ECO:
-            self.device.mode = HASS_TO_NEST[self._operation_list[0]]
+            self.device.mode = MODE_HASS_TO_NEST[self._operation_list[0]]
         elif preset_mode == PRESET_ECO:
             self.device.mode = NEST_MODE_ECO
 
@@ -297,6 +310,7 @@ class NestThermostat(ClimateDevice):
         self._humidity = self.device.humidity
         self._temperature = self.device.temperature
         self._mode = self.device.mode
+        self._action = self.device.hvac_state
         self._target_temperature = self.device.target
         self._fan = self.device.fan
         self._away = self.structure.away == 'away'


### PR DESCRIPTION
## Description:
If Nest would support both heat and cool, turning eco mode off would result in us trying to write `auto` to the Nest API while it expected `heat_cool`. This cleans up the mapping.

Also adds HVAC action.

**Related issue (if applicable):**  #25427

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
