### PR TITLE
Add last_run_success boolean attribute to Switchbot for error trapping

### DIFF
--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -1,5 +1,6 @@
 """Support for Switchbot."""
 import logging
+from typing import Any, Dict
 
 import voluptuous as vol
 
@@ -36,7 +37,7 @@ class SwitchBot(SwitchDevice, RestoreEntity):
         import switchbot
 
         self._state = None
-        self._last_run_error = None
+        self._last_run_success = None
         self._name = name
         self._mac = mac
         self._device = switchbot.Switchbot(mac=mac)
@@ -53,17 +54,17 @@ class SwitchBot(SwitchDevice, RestoreEntity):
         """Turn device on."""
         if self._device.turn_on():
             self._state = True
-            self._last_run_error = False
+            self._last_run_success = True
         else:
-            self._last_run_error = True
+            self._last_run_success = False
 
     def turn_off(self, **kwargs) -> None:
         """Turn device off."""
         if self._device.turn_off():
             self._state = False
-            self._last_run_error = False
+            self._last_run_success = True
         else:
-            self._last_run_error = True
+            self._last_run_success = False
 
     @property
     def assumed_state(self) -> bool:
@@ -86,8 +87,6 @@ class SwitchBot(SwitchDevice, RestoreEntity):
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def device_state_attributes(self) -> Dict[str, Any]:
         """Return the state attributes."""
-        return {
-            'last_run_error': self._last_run_error,
-        }
+        return {'last_run_success': self._last_run_success}

--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -36,6 +36,7 @@ class SwitchBot(SwitchDevice, RestoreEntity):
         import switchbot
 
         self._state = None
+        self._last_run_error = None
         self._name = name
         self._mac = mac
         self._device = switchbot.Switchbot(mac=mac)
@@ -52,11 +53,17 @@ class SwitchBot(SwitchDevice, RestoreEntity):
         """Turn device on."""
         if self._device.turn_on():
             self._state = True
+            self._last_run_error = False
+        else:
+            self._last_run_error = True
 
     def turn_off(self, **kwargs) -> None:
         """Turn device off."""
         if self._device.turn_off():
             self._state = False
+            self._last_run_error = False
+        else:
+            self._last_run_error = True
 
     @property
     def assumed_state(self) -> bool:
@@ -77,3 +84,10 @@ class SwitchBot(SwitchDevice, RestoreEntity):
     def name(self) -> str:
         """Return the name of the switch."""
         return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'last_run_error': self._last_run_error,
+        }


### PR DESCRIPTION
## Description:
The switchbot component uses bluetooth packets to send messages to the device. If the device has connectivity issues, errors are logged but not discoverable by the device state or attributes.  This makes trapping errors and retrying impossible.  While it is possible infer success by checking if the state has changed, it is not guaranteed since there is an assumption via "assumed_state" settings.  Furthermore, some non-standard deployments may trigger ON even when physically turning a device off such that no device state change will occur.  Without this PR, there is no method to determine if the bluetooth message was successfully received.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
