### PR TITLE
Mypy config cleanups

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -14,6 +14,9 @@ from homeassistant.exceptions import HomeAssistantError, ConfigEntryNotReady
 from homeassistant.setup import async_setup_component, async_process_deps_reqs
 from homeassistant.util.decorator import Registry
 
+
+# mypy: allow-untyped-defs
+
 _LOGGER = logging.getLogger(__name__)
 _UNDEF = object()
 

--- a/homeassistant/util/yaml/dumper.py
+++ b/homeassistant/util/yaml/dumper.py
@@ -5,6 +5,8 @@ import yaml
 from .objects import NodeListClass
 
 
+# mypy: allow-untyped-calls, no-warn-return-any
+
 def dump(_dict: dict) -> str:
     """Dump YAML to a string and remove null."""
     return yaml.safe_dump(

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -24,6 +24,8 @@ from .const import _SECRET_NAMESPACE, SECRET_YAML
 from .objects import NodeListClass, NodeStrClass
 
 
+# mypy: allow-untyped-calls, no-warn-return-any
+
 _LOGGER = logging.getLogger(__name__)
 __SECRET_CACHE = {}  # type: Dict[str, JSON_TYPE]
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,15 +16,3 @@ warn_unused_ignores = true
 
 [mypy-homeassistant.*]
 disallow_untyped_defs = true
-
-[mypy-homeassistant.config_entries]
-disallow_untyped_defs = false
-
-[mypy-homeassistant.util.yaml.dumper]
-warn_return_any = false
-disallow_untyped_calls = false
-
-[mypy-homeassistant.util.yaml.loader]
-warn_return_any = false
-disallow_untyped_calls = false
-

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@ python_version = 3.5
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true
+disallow_untyped_defs = true
 follow_imports = silent
 ignore_missing_imports = true
 no_implicit_optional = true
@@ -13,6 +14,3 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
-
-[mypy-homeassistant.*]
-disallow_untyped_defs = true


### PR DESCRIPTION
## Description:

Tightens a bit by disallowing uintyped defs by default everywhere (no additional errors), and cleans up by moving file specific config to inline comments.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
