### PR TITLE
Add a unique identifier to deCONZ groups

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -5,7 +5,6 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT,
     SUPPORT_FLASH, SUPPORT_TRANSITION, Light)
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.util.color as color_util
 

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -196,8 +196,8 @@ class DeconzGroup(DeconzLight):
         bridgeid = self.gateway.api.config.bridgeid
 
         return {
-            'connections': {(CONNECTION_ZIGBEE, self.unique_id)},
             'identifiers': {(DECONZ_DOMAIN, self.unique_id)},
+            'manufacturer': 'Dresden Elektronik',
             'model': 'deCONZ group',
             'name': self._device.name,
             'via_device': (DECONZ_DOMAIN, bridgeid),

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -5,10 +5,12 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT,
     SUPPORT_FLASH, SUPPORT_TRANSITION, Light)
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.util.color as color_util
 
-from .const import COVER_TYPES, NEW_GROUP, NEW_LIGHT, SWITCH_TYPES
+from .const import (
+    COVER_TYPES, DOMAIN as DECONZ_DOMAIN, NEW_GROUP, NEW_LIGHT, SWITCH_TYPES)
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -44,7 +46,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for group in groups:
             if group.lights and gateway.allow_deconz_groups:
-                entities.append(DeconzLight(group, gateway))
+                entities.append(DeconzGroup(group, gateway))
 
         async_add_entities(entities, True)
 
@@ -59,7 +61,7 @@ class DeconzLight(DeconzDevice, Light):
     """Representation of a deCONZ light."""
 
     def __init__(self, device, gateway):
-        """Set up light and add update callback to get data from websocket."""
+        """Set up light."""
         super().__init__(device, gateway)
 
         self._features = SUPPORT_BRIGHTNESS
@@ -170,3 +172,33 @@ class DeconzLight(DeconzDevice, Light):
             attributes['all_on'] = self._device.all_on
 
         return attributes
+
+
+class DeconzGroup(DeconzLight):
+    """Representation of a deCONZ group."""
+
+    def __init__(self, device, gateway):
+        """Set up group and create an unique id."""
+        super().__init__(device, gateway)
+
+        self._unique_id = '{}-{}'.format(
+            self.gateway.api.config.bridgeid,
+            self._device.deconz_id)
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier for this device."""
+        return self._unique_id
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        bridgeid = self.gateway.api.config.bridgeid
+
+        return {
+            'connections': {(CONNECTION_ZIGBEE, self.unique_id)},
+            'identifiers': {(DECONZ_DOMAIN, self.unique_id)},
+            'model': 'deCONZ group',
+            'name': self._device.name,
+            'via_device': (DECONZ_DOMAIN, bridgeid),
+        }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #25192

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
