### PR TITLE
Expose comfort presets as HA presets

### DIFF
--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -97,7 +97,7 @@ class EcobeeData:
     def update(self):
         """Get the latest data from pyecobee."""
         self.ecobee.update()
-        _LOGGER.info("Ecobee data updated successfully")
+        _LOGGER.debug("Ecobee data updated successfully")
 
 
 def setup(hass, config):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -217,6 +217,11 @@ class Thermostat(ClimateDevice):
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
 
     @property
+    def available(self):
+        """Return if device is available."""
+        return self.thermostat["runtime"]["connected"]
+
+    @property
     def supported_features(self):
         """Return the list of supported features."""
         return SUPPORT_FLAGS

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -294,9 +294,9 @@ class Thermostat(ClimateDevice):
             if event["type"] == "hold":
                 if event["holdClimateRef"] in self._preset_modes:
                     return self._preset_modes[event["holdClimateRef"]]
-                else:
-                    # Any hold not based on a climate is a temp hold
-                    return PRESET_TEMPERATURE
+
+                # Any hold not based on a climate is a temp hold
+                return PRESET_TEMPERATURE
             if event["type"].startswith("auto"):
                 # All auto modes are treated as holds
                 return event["type"][4:].lower()

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -88,16 +88,6 @@ PRESET_TO_ECOBEE_HOLD = {
     PRESET_HOLD_INDEFINITE: "indefinite",
 }
 
-PRESET_MODES = [
-    PRESET_NONE,
-    PRESET_AWAY,
-    PRESET_TEMPERATURE,
-    PRESET_HOME,
-    PRESET_SLEEP,
-    PRESET_HOLD_NEXT_TRANSITION,
-    PRESET_HOLD_INDEFINITE,
-]
-
 SERVICE_SET_FAN_MIN_ON_TIME = "ecobee_set_fan_min_on_time"
 SERVICE_RESUME_PROGRAM = "ecobee_resume_program"
 
@@ -199,7 +189,6 @@ class Thermostat(ClimateDevice):
         self._name = self.thermostat["name"]
         self.hold_temp = hold_temp
         self.vacation = None
-        self._climate_list = self.climate_list
 
         self._operation_list = []
         if self.thermostat["settings"]["heatStages"]:
@@ -209,6 +198,11 @@ class Thermostat(ClimateDevice):
         if len(self._operation_list) == 2:
             self._operation_list.insert(0, HVAC_MODE_AUTO)
         self._operation_list.append(HVAC_MODE_OFF)
+
+        self._preset_modes = [PRESET_NONE]
+        self._preset_modes.extend(
+            [comfort["name"] for comfort in self.thermostat["program"]["climates"]]
+        )
 
         self._fan_modes = [FAN_AUTO, FAN_ON]
         self.update_without_throttle = False
@@ -325,14 +319,6 @@ class Thermostat(ClimateDevice):
         return self._operation_list
 
     @property
-    def climate_mode(self):
-        """Return current mode, as the user-visible name."""
-        cur = self.thermostat["program"]["currentClimateRef"]
-        climates = self.thermostat["program"]["climates"]
-        current = list(filter(lambda x: x["climateRef"] == cur, climates))
-        return current[0]["name"]
-
-    @property
     def current_humidity(self) -> Optional[int]:
         """Return the current humidity."""
         return self.thermostat["runtime"]["actualHumidity"]
@@ -373,9 +359,7 @@ class Thermostat(ClimateDevice):
         status = self.thermostat["equipmentStatus"]
         return {
             "fan": self.fan,
-            "climate_mode": self.climate_mode,
             "equipment_running": status,
-            "climate_list": self.climate_list,
             "fan_min_on_time": self.thermostat["settings"]["fanMinOnTime"],
         }
 
@@ -413,6 +397,21 @@ class Thermostat(ClimateDevice):
         elif preset_mode == PRESET_NONE:
             self.data.ecobee.resume_program(self.thermostat_index)
 
+        elif preset_mode in self.preset_modes:
+            climate_ref = None
+
+            for comfort in self.thermostat["program"]["climates"]:
+                if comfort["name"] == preset_mode:
+                    climate_ref = comfort["climateRef"]
+                    break
+
+            if climate_ref is None:
+                self.data.ecobee.set_climate_hold(
+                    self.thermostat_index, climate_ref, self.hold_preference()
+                )
+            else:
+                _LOGGER.warning("Received unknown preset mode: %s", preset_mode)
+
         else:
             self.data.ecobee.set_climate_hold(
                 self.thermostat_index, preset_mode, self.hold_preference()
@@ -421,7 +420,7 @@ class Thermostat(ClimateDevice):
     @property
     def preset_modes(self):
         """Return available preset modes."""
-        return PRESET_MODES
+        return self._preset_modes
 
     def set_auto_temp_hold(self, heat_temp, cool_temp):
         """Set temperature hold in auto mode."""
@@ -543,9 +542,3 @@ class Thermostat(ClimateDevice):
         # supported; note that this should not include 'indefinite'
         # as an indefinite away hold is interpreted as away_mode
         return "nextTransition"
-
-    @property
-    def climate_list(self):
-        """Return the list of climates currently available."""
-        climates = self.thermostat["program"]["climates"]
-        return list(map((lambda x: x["name"]), climates))

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -130,44 +130,34 @@ class TestEcobee(unittest.TestCase):
         """Test device state attributes property."""
         self.ecobee["equipmentStatus"] = "heatPump2"
         assert {
-            "climate_list": ["Climate1", "Climate2"],
             "fan": "off",
             "fan_min_on_time": 10,
-            "climate_mode": "Climate1",
             "equipment_running": "heatPump2",
         } == self.thermostat.device_state_attributes
 
         self.ecobee["equipmentStatus"] = "auxHeat2"
         assert {
-            "climate_list": ["Climate1", "Climate2"],
             "fan": "off",
             "fan_min_on_time": 10,
-            "climate_mode": "Climate1",
             "equipment_running": "auxHeat2",
         } == self.thermostat.device_state_attributes
         self.ecobee["equipmentStatus"] = "compCool1"
         assert {
-            "climate_list": ["Climate1", "Climate2"],
             "fan": "off",
             "fan_min_on_time": 10,
-            "climate_mode": "Climate1",
             "equipment_running": "compCool1",
         } == self.thermostat.device_state_attributes
         self.ecobee["equipmentStatus"] = ""
         assert {
-            "climate_list": ["Climate1", "Climate2"],
             "fan": "off",
             "fan_min_on_time": 10,
-            "climate_mode": "Climate1",
             "equipment_running": "",
         } == self.thermostat.device_state_attributes
 
         self.ecobee["equipmentStatus"] = "Unknown"
         assert {
-            "climate_list": ["Climate1", "Climate2"],
             "fan": "off",
             "fan_min_on_time": 10,
-            "climate_mode": "Climate1",
             "equipment_running": "Unknown",
         } == self.thermostat.device_state_attributes
 
@@ -266,10 +256,6 @@ class TestEcobee(unittest.TestCase):
         ]:
             self.ecobee["settings"]["holdAction"] = action
             assert "nextTransition" == self.thermostat.hold_preference()
-
-    def test_climate_list(self):
-        """Test climate list property."""
-        assert ["Climate1", "Climate2"] == self.thermostat.climate_list
 
     def test_set_fan_mode_on(self):
         """Test set fan mode to on."""


### PR DESCRIPTION
## Breaking Change:

- Remove attributes `climate_list` and `climate_mode`. That's now part of preset.
- Expose all Ecobee programs as presets

<img width="406" alt="image" src="https://user-images.githubusercontent.com/1444314/61914799-9f575780-aef6-11e9-821e-7afdffdcff75.png">


## Description:

Expose the Ecobee comfort settings as presets in Home Assistant.

CC @geekofweek


**Related issue (if applicable):** #25488

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
