### PR TITLE
Fix bug with WWLLN update interval

### DIFF
--- a/homeassistant/components/wwlln/geo_location.py
+++ b/homeassistant/components/wwlln/geo_location.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.dt import utc_from_timestamp
 
-from .const import CONF_WINDOW, DATA_CLIENT, DEFAULT_WINDOW, DOMAIN
+from .const import CONF_WINDOW, DATA_CLIENT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ ATTR_PUBLICATION_DATE = 'publication_date'
 DEFAULT_ATTRIBUTION = 'Data provided by the WWLLN'
 DEFAULT_EVENT_NAME = 'Lightning Strike: {0}'
 DEFAULT_ICON = 'mdi:flash'
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
 
 SIGNAL_DELETE_ENTITY = 'delete_entity_{0}'
 
@@ -105,7 +106,7 @@ class WWLLNEventManager:
             await self.async_update()
 
         await self.async_update()
-        async_track_time_interval(self._hass, update, DEFAULT_WINDOW)
+        async_track_time_interval(self._hass, update, DEFAULT_UPDATE_INTERVAL)
 
     async def async_update(self):
         """Refresh data."""

--- a/homeassistant/components/wwlln/geo_location.py
+++ b/homeassistant/components/wwlln/geo_location.py
@@ -25,7 +25,7 @@ ATTR_PUBLICATION_DATE = 'publication_date'
 DEFAULT_ATTRIBUTION = 'Data provided by the WWLLN'
 DEFAULT_EVENT_NAME = 'Lightning Strike: {0}'
 DEFAULT_ICON = 'mdi:flash'
-DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=10)
 
 SIGNAL_DELETE_ENTITY = 'delete_entity_{0}'
 


### PR DESCRIPTION
## Description:

https://github.com/home-assistant/home-assistant/pull/25357 came with an unintended side effect: in addition to the default `window` being expanded to 1 hour, the update interval for grabbing data from the WWLLN was also expanded to 1 hour – not good. This PR ensures that the update interval mentioned in the docs (10 minutes) is used.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
wwlln:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
