### PR TITLE
Introduce support for color temperature

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -278,7 +278,7 @@ class FluxLight(Light):
         color_temp = kwargs.get(ATTR_COLOR_TEMP)
 
         if all(item is None for item in
-                [hs_color, brightness, effect, white, color_temp]):
+               [hs_color, brightness, effect, white, color_temp]):
             return
 
         # handle W only mode (use brightness instead of white value)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -9,9 +9,10 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE, ATTR_COLOR_TEMP,
-    EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
-    SUPPORT_COLOR, SUPPORT_WHITE_VALUE, SUPPORT_COLOR_TEMP, Light, PLATFORM_SCHEMA)
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE,
+    ATTR_COLOR_TEMP, EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS,
+    SUPPORT_EFFECT, SUPPORT_COLOR, SUPPORT_WHITE_VALUE, SUPPORT_COLOR_TEMP,
+    Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
@@ -269,14 +270,15 @@ class FluxLight(Light):
     def _turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
         self._bulb.turnOn()
-        
+
         hs_color = kwargs.get(ATTR_HS_COLOR)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         effect = kwargs.get(ATTR_EFFECT)
         white = kwargs.get(ATTR_WHITE_VALUE)
         color_temp = kwargs.get(ATTR_COLOR_TEMP)
 
-        if all(item is None for item in [hs_color, brightness, effect, white, color_temp]):
+        if all(item is None for item in
+                [hs_color, brightness, effect, white, color_temp]):
             return
 
         # handle W only mode (use brightness instead of white value)
@@ -302,7 +304,7 @@ class FluxLight(Light):
             elif effect in EFFECT_MAP:
                 self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
             return
-        
+
         # handle special modes
         if color_temp is not None:
             if brightness is None:
@@ -312,7 +314,8 @@ class FluxLight(Light):
             elif color_temp == COLOR_TEMP_COOL_WHITE:
                 self._bulb.setRgbw(w2=brightness)
             else:
-                self._bulb.setRgbw(*color_util.color_temperature_to_rgb(color_temp))
+                self._bulb.setRgbw(
+                    *color_util.color_temperature_to_rgb(color_temp))
             return
 
         # Preserve current brightness on color/white level change

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -9,9 +9,9 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE,
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE, ATTR_COLOR_TEMP,
     EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
-    SUPPORT_COLOR, SUPPORT_WHITE_VALUE, Light, PLATFORM_SCHEMA)
+    SUPPORT_COLOR, SUPPORT_WHITE_VALUE, SUPPORT_COLOR_TEMP, Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
@@ -27,7 +27,7 @@ ATTR_MODE = 'mode'
 DOMAIN = 'flux_led'
 
 SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
-                    SUPPORT_COLOR)
+                    SUPPORT_COLOR | SUPPORT_COLOR_TEMP)
 
 MODE_RGB = 'rgb'
 MODE_RGBW = 'rgbw'
@@ -35,6 +35,11 @@ MODE_RGBW = 'rgbw'
 # This mode enables white value to be controlled by brightness.
 # RGB value is ignored when this mode is specified.
 MODE_WHITE = 'w'
+
+# Constant color temp values for 2 flux_led special modes
+# Warm-white and Cool-white. Details on #23704
+COLOR_TEMP_WARM_WHITE = 333
+COLOR_TEMP_COOL_WHITE = 250
 
 # List of supported effects which aren't already declared in LIGHT
 EFFECT_RED_FADE = 'red_fade'
@@ -264,13 +269,14 @@ class FluxLight(Light):
     def _turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
         self._bulb.turnOn()
-
+        
         hs_color = kwargs.get(ATTR_HS_COLOR)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         effect = kwargs.get(ATTR_EFFECT)
         white = kwargs.get(ATTR_WHITE_VALUE)
+        color_temp = kwargs.get(ATTR_COLOR_TEMP)
 
-        if all(item is None for item in [hs_color, brightness, effect, white]):
+        if all(item is None for item in [hs_color, brightness, effect, white, color_temp]):
             return
 
         # handle W only mode (use brightness instead of white value)
@@ -278,6 +284,8 @@ class FluxLight(Light):
             if brightness is not None:
                 self._bulb.setWarmWhite255(brightness)
             return
+
+        # handle effects
         if effect is not None:
             # Random color effect
             if effect == EFFECT_RANDOM:
@@ -294,6 +302,19 @@ class FluxLight(Light):
             elif effect in EFFECT_MAP:
                 self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
             return
+        
+        # handle special modes
+        if color_temp is not None:
+            if brightness is None:
+                brightness = self.brightness
+            if color_temp == COLOR_TEMP_WARM_WHITE:
+                self._bulb.setRgbw(w=brightness)
+            elif color_temp == COLOR_TEMP_COOL_WHITE:
+                self._bulb.setRgbw(w2=brightness)
+            else:
+                self._bulb.setRgbw(*color_util.color_temperature_to_rgb(color_temp))
+            return
+
         # Preserve current brightness on color/white level change
         if hs_color is not None:
             if brightness is None:


### PR DESCRIPTION
## Description:
flux_led component does not properly support all available modes that Flux Led Lights can operate in. In particular: warm-white mode (when controlled from a smart assistants Alexa/Google Home) and cool-white mode (cannot be set from Homeassistant at all).

**Related issue (if applicable):** fixes #23704

## Checklist:
  - [✓ ] The code change is tested and works locally.
  - [✓ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ✓] There is no commented out code in this PR.

If the code does not interact with devices:
  - [✓ ] Tests have been added to verify that the new code works.
