### PR TITLE
Add container settings for YAML extension to avoid Hass specific custom tags errors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
 		"python.linting.enabled": true,
 		"files.trimTrailingWhitespace": true,
 		"editor.rulers": [80],
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"yaml.customTags": ["!secret scalar"]
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,12 @@
 		"files.trimTrailingWhitespace": true,
 		"editor.rulers": [80],
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"yaml.customTags": ["!secret scalar"]
+		"yaml.customTags": [
+			"!secret scalar",
+			"!include_dir_named scalar",
+			"!include_dir_list scalar",
+			"!include_dir_merge_list scalar",
+			"!include_dir_merge_named scalar"
+		]
 	}
 }


### PR DESCRIPTION
## Description:
Add settings in the container description file to add the custom tags used in HA configuration yaml files. This will avoid YAML linting error messages.
Cutoms tags are:

- `!secret`
- `!include_dir_named`
- `!include_dir_list`
- `!include_dir_merge_list`
- `!include_dir_merge_named`

**Related issue (if applicable): N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):N/A

## Example entry for `configuration.yaml` (if applicable):N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html