### PR TITLE
Fix deprecation warning in test

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -269,7 +269,7 @@ class HomeAssistantHTTP:
         for the redirect, otherwise it has to be a string with placeholders in
         rule syntax.
         """
-        def redirect(request):
+        async def redirect(request):
             """Redirect to location."""
             raise HTTPMovedPermanently(redirect_to)
 


### PR DESCRIPTION
## Description:
We were registering redirects with bare functions, this was printed as warning, making our test output unreadable. This fixes it.

