### PR TITLE
Add arcus trigonometry functions to templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -714,6 +714,41 @@ def tangent(value):
         return value
 
 
+def arc_sine(value):
+    """Filter to get arc sine of the value."""
+    try:
+        return math.asin(float(value))
+    except (ValueError, TypeError):
+        return value
+
+
+def arc_cosine(value):
+    """Filter to get arc cosine of the value."""
+    try:
+        return math.acos(float(value))
+    except (ValueError, TypeError):
+        return value
+
+
+def arc_tangent(value):
+    """Filter to get arc tangent of the value."""
+    try:
+        return math.atan(float(value))
+    except (ValueError, TypeError):
+        return value
+
+
+def arc_tangent2(*args):
+    """Filter to calculate four quadrant arc tangent of y / x."""
+    try:
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            args = args[0]
+
+        return math.atan2(float(args[0]), float(args[1]))
+    except (ValueError, TypeError):
+        return args
+
+
 def square_root(value):
     """Filter to get square root of the value."""
     try:
@@ -872,6 +907,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["sin"] = sine
         self.filters["cos"] = cosine
         self.filters["tan"] = tangent
+        self.filters["asin"] = arc_sine
+        self.filters["acos"] = arc_cosine
+        self.filters["atan"] = arc_tangent
+        self.filters["atan2"] = arc_tangent2
         self.filters["sqrt"] = square_root
         self.filters["as_timestamp"] = forgiving_as_timestamp
         self.filters["timestamp_custom"] = timestamp_custom
@@ -899,6 +938,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["pi"] = math.pi
         self.globals["tau"] = math.pi * 2
         self.globals["e"] = math.e
+        self.globals["asin"] = arc_sine
+        self.globals["acos"] = arc_cosine
+        self.globals["atan"] = arc_tangent
+        self.globals["atan2"] = arc_tangent2
         self.globals["float"] = forgiving_float
         self.globals["now"] = dt_util.now
         self.globals["utcnow"] = dt_util.utcnow

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -349,6 +349,101 @@ def test_sqrt(hass):
         )
 
 
+def test_arc_sine(hass):
+    """Test arcus sine."""
+    tests = [
+        (-2.0, "-2.0"),  # value error
+        (-1.0, "-1.571"),
+        (-0.5, "-0.524"),
+        (0.0, "0.0"),
+        (0.5, "0.524"),
+        (1.0, "1.571"),
+        (2.0, "2.0"),  # value error
+        ('"error"', "error"),
+    ]
+
+    for value, expected in tests:
+        assert (
+            template.Template("{{ %s | asin | round(3) }}" % value, hass).async_render()
+            == expected
+        )
+
+
+def test_arc_cos(hass):
+    """Test arcus cosine."""
+    tests = [
+        (-2.0, "-2.0"),  # value error
+        (-1.0, "3.142"),
+        (-0.5, "2.094"),
+        (0.0, "1.571"),
+        (0.5, "1.047"),
+        (1.0, "0.0"),
+        (2.0, "2.0"),  # value error
+        ('"error"', "error"),
+    ]
+
+    for value, expected in tests:
+        assert (
+            template.Template("{{ %s | acos | round(3) }}" % value, hass).async_render()
+            == expected
+        )
+
+
+def test_arc_tan(hass):
+    """Test arcus tangent."""
+    tests = [
+        (-10.0, "-1.471"),
+        (-2.0, "-1.107"),
+        (-1.0, "-0.785"),
+        (-0.5, "-0.464"),
+        (0.0, "0.0"),
+        (0.5, "0.464"),
+        (1.0, "0.785"),
+        (2.0, "1.107"),
+        (10.0, "1.471"),
+        ('"error"', "error"),
+    ]
+
+    for value, expected in tests:
+        assert (
+            template.Template("{{ %s | atan | round(3) }}" % value, hass).async_render()
+            == expected
+        )
+
+
+def test_arc_tan2(hass):
+    """Test two parameter version of arcus tangent."""
+    tests = [
+        (-10.0, -10.0, "-2.356"),
+        (-10.0, 0.0, "-1.571"),
+        (-10.0, 10.0, "-0.785"),
+        (0.0, -10.0, "3.142"),
+        (0.0, 0.0, "0.0"),
+        (0.0, 10.0, "0.0"),
+        (10.0, -10.0, "2.356"),
+        (10.0, 0.0, "1.571"),
+        (10.0, 10.0, "0.785"),
+        (-4.0, 3.0, "-0.927"),
+        (-1.0, 2.0, "-0.464"),
+        (2.0, 1.0, "1.107"),
+        ('"duck"', '"goose"', "('duck', 'goose')"),
+    ]
+
+    for y, x, expected in tests:
+        assert (
+            template.Template(
+                "{{ (%s, %s) | atan2 | round(3) }}" % (y, x), hass
+            ).async_render()
+            == expected
+        )
+        assert (
+            template.Template(
+                "{{ atan2(%s, %s) | round(3) }}" % (y, x), hass
+            ).async_render()
+            == expected
+        )
+
+
 def test_strptime(hass):
     """Test the parse timestamp method."""
     tests = [


### PR DESCRIPTION
## Description:

This PR adds arcus trigonometry functions asin, acos, atan and atan2 to template functions.

Atan function is required for example to calculate wet bulb temperature, which more closely describes how temperature feels, from (dry bulb) temperature and relative humidity.

For more info about wet bulb temperature:
https://en.wikipedia.org/wiki/Wet-bulb_temperature
https://journals.ametsoc.org/doi/full/10.1175/JAMC-D-11-0143.1

**Related issue (if applicable):**

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9982

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
