### PR TITLE
deCONZ - Add power attribute for consumption sensors

### DIFF
--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/deconz",
   "requirements": [
-    "pydeconz==61"
+    "pydeconz==62"
   ],
   "ssdp": {
     "manufacturer": [

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/deconz",
   "requirements": [
-    "pydeconz==60"
+    "pydeconz==61"
   ],
   "ssdp": {
     "manufacturer": [

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -12,6 +12,7 @@ from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
 ATTR_CURRENT = 'current'
+ATTR_POWER = 'power'
 ATTR_DAYLIGHT = 'daylight'
 ATTR_EVENT_ID = 'event_id'
 
@@ -103,6 +104,9 @@ class DeconzSensor(DeconzDevice):
         if self.unit_of_measurement == 'W':
             attr[ATTR_CURRENT] = self._device.current
             attr[ATTR_VOLTAGE] = self._device.voltage
+
+        if self.unit_of_measurement == 'kWh':
+            attr[ATTR_POWER] = self._device.power
 
         if self._device.SENSOR_CLASS == 'daylight':
             attr[ATTR_DAYLIGHT] = self._device.daylight

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1096,7 +1096,7 @@ pydaikin==1.6.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==61
+pydeconz==62
 
 # homeassistant.components.delijn
 pydelijn==0.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1096,7 +1096,7 @@ pydaikin==1.6.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==60
+pydeconz==61
 
 # homeassistant.components.delijn
 pydelijn==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -251,7 +251,7 @@ pyMetno==0.4.6
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==60
+pydeconz==61
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -251,7 +251,7 @@ pyMetno==0.4.6
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==61
+pydeconz==62
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -63,6 +63,13 @@ SENSOR = {
         "type": "ZHAPower",
         "state": {"current": 2, "power": 6, "voltage": 3},
         "config": {"reachable": True}
+    },
+    "8": {
+        "id": "Sensor 8 id",
+        "name": "Sensor 8 name",
+        "type": "ZHAConsumption",
+        "state": {"consumption": 2, "power": 6},
+        "config": {"reachable": True}
     }
 }
 
@@ -130,7 +137,7 @@ async def test_sensors(hass):
     assert "sensor.sensor_3_name_battery_level" not in gateway.deconz_ids
     assert "sensor.sensor_4_name" not in gateway.deconz_ids
     assert "sensor.sensor_4_name_battery_level" in gateway.deconz_ids
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
 
     gateway.api.sensors['1'].async_update({'state': {'on': False}})
     gateway.api.sensors['4'].async_update({'config': {'battery': 75}})


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Add a new attribute (power) to sensors reporting kWh

**Related issue (if applicable):** fixes #25456

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
