### PR TITLE
Feature zwave preset modes

### DIFF
--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -56,6 +56,9 @@ PRESET_SLEEP = 'sleep'
 # Device is reacting to activity (e.g. movement sensors)
 PRESET_ACTIVITY = 'activity'
 
+# Device is in manufacturer specific mode (e.g. setting the valve manually)
+PRESET_MANUFACTURER_SPECIFIC = 'Manufacturer Specific'
+
 
 # Possible fan state
 FAN_ON = "on"

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -147,17 +147,17 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             if hvac_list:
                 for mode in hvac_list:
                     ha_mode = HVAC_STATE_MAPPINGS.get(mode)
+                    ha_preset = PRESET_MAPPING.get(mode)
                     if ha_mode and ha_mode not in self._hvac_mapping:
                         self._hvac_mapping[ha_mode] = mode
                         self._hvac_list.append(ha_mode)
-                        continue
-                    ha_preset = PRESET_MAPPING.get(mode)
-                    if ha_preset and ha_preset not in self._preset_mapping:
+                    elif ha_preset and ha_preset not in self._preset_mapping:
                         self._preset_mapping[ha_preset] = mode
                         self._preset_list.append(ha_preset)
-                        continue
-                    # If nothing matches
-                    self._hvac_list.append(mode)
+                    else:
+                        # If nothing matches
+                        _LOGGER.debug("%s is nothing", mode)
+                        self._hvac_list.append(mode)
 
             current_mode = self.values.mode.data
             self._hvac_mode = next(
@@ -167,7 +167,10 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                 (key for key, value in self._preset_mapping.items()
                  if value == current_mode), PRESET_NONE)
         _LOGGER.debug("self._hvac_list=%s", self._hvac_list)
+        _LOGGER.debug("self._hvac_mapping=%s", self._hvac_mapping)
         _LOGGER.debug("self._hvac_action=%s", self._hvac_action)
+        _LOGGER.debug("self._preset_list=%s", self._preset_list)
+        _LOGGER.debug("self._preset_mapping=%s", self._preset_mapping)
 
         # Current Temp
         if self.values.temperature:
@@ -305,24 +308,29 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
+        _LOGGER.debug("Set temperature to %s", kwargs.get(ATTR_TEMPERATURE))
         if kwargs.get(ATTR_TEMPERATURE) is None:
             return
         self.values.primary.data = kwargs.get(ATTR_TEMPERATURE)
 
     def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
+        _LOGGER.debug("Set fan mode to %s", fan_mode)
         if not self.values.fan_mode:
             return
         self.values.fan_mode.data = fan_mode
 
     def set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
+        _LOGGER.debug("Set hvac_mode to %s", hvac_mode)
         if not self.values.mode:
             return
-        self.values.mode.data = self._hvac_mapping.get(hvac_mode, hvac_mode)
+        self.values.mode.data = self._hvac_mapping.get(
+            hvac_mode, hvac_mode)
 
     def set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
+        _LOGGER.debug("Set preset_mode to %s", preset_mode)
         if not self.values.mode:
             return
         self.values.mode.data = self._preset_mapping.get(
@@ -330,6 +338,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
 
     def set_swing_mode(self, swing_mode):
         """Set new target swing mode."""
+        _LOGGER.debug("Set swing_mode to %s", swing_mode)
         if self._zxt_120 == 1:
             if self.values.zxt_120_swing_mode:
                 self.values.zxt_120_swing_mode.data = swing_mode

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -100,6 +100,8 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         self._hvac_list = None
         self._hvac_mapping = None
         self._hvac_mode = None
+        self._preset_mapping = None
+        self._preset_list = None
         self._preset_mode = None
         self._current_fan_mode = None
         self._fan_modes = None
@@ -165,6 +167,7 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             self._preset_mode = next(
                 (key for key, value in self._preset_mapping.items()
                  if value == current_mode), PRESET_NONE)
+
         _LOGGER.debug("self._hvac_list=%s", self._hvac_list)
         _LOGGER.debug("self._hvac_mapping=%s", self._hvac_mapping)
         _LOGGER.debug("self._hvac_action=%s", self._hvac_action)

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -156,7 +156,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                         self._preset_list.append(ha_preset)
                     else:
                         # If nothing matches
-                        _LOGGER.debug("%s is nothing", mode)
                         self._hvac_list.append(mode)
 
             current_mode = self.values.mode.data

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -130,6 +130,8 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             support |= SUPPORT_FAN_MODE
         if self._zxt_120 == 1 and self.values.zxt_120_swing_mode:
             support |= SUPPORT_SWING_MODE
+        if self._preset_list:
+            support |= SUPPORT_PRESET_MODE
         return support
 
     def update_properties(self):
@@ -161,7 +163,9 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             self._hvac_mode = next(
                 (key for key, value in self._hvac_mapping.items()
                  if value == current_mode), current_mode)
-            # TODO: Set self._preset_mode
+            self._preset_mode = next(
+                (key for key, value in self._preset_mapping.items()
+                 if value == current_mode), PRESET_NONE)
         _LOGGER.debug("self._hvac_list=%s", self._hvac_list)
         _LOGGER.debug("self._hvac_action=%s", self._hvac_action)
 
@@ -318,7 +322,11 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         self.values.mode.data = self._hvac_mapping.get(hvac_mode, hvac_mode)
 
     def set_preset_mode(self, preset_mode):
-        raise NotImplementedError
+        """Set new target preset mode."""
+        if not self.values.mode:
+            return
+        self.values.mode.data = self._preset_mapping.get(
+            preset_mode, preset_mode)
 
     def set_swing_mode(self, swing_mode):
         """Set new target swing mode."""

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -169,10 +169,8 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
                  if value == current_mode), PRESET_NONE)
 
         _LOGGER.debug("self._hvac_list=%s", self._hvac_list)
-        _LOGGER.debug("self._hvac_mapping=%s", self._hvac_mapping)
         _LOGGER.debug("self._hvac_action=%s", self._hvac_action)
         _LOGGER.debug("self._preset_list=%s", self._preset_list)
-        _LOGGER.debug("self._preset_mapping=%s", self._preset_mapping)
 
         # Current Temp
         if self.values.temperature:

--- a/tests/components/zwave/test_climate.py
+++ b/tests/components/zwave/test_climate.py
@@ -2,7 +2,7 @@
 import pytest
 
 from homeassistant.components.climate.const import (
-    HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF)
+    HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF, PRESET_BOOST, PRESET_ECO)
 from homeassistant.components.zwave import climate
 from homeassistant.const import (
     ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT)
@@ -55,7 +55,8 @@ def device_mapping(hass, mock_openzwave):
     values = MockEntityValues(
         primary=MockValue(data=1, node=node),
         temperature=MockValue(data=5, node=node, units=None),
-        mode=MockValue(data='Off', data_items=['Off', 'Cool', 'Heat'],
+        mode=MockValue(data='Off', data_items=[
+                       'Off', 'Cool', 'Heat', 'Heat Eco', 'Full Power'],
                        node=node),
         fan_mode=MockValue(data='test2', data_items=[3, 4, 5], node=node),
         operating_state=MockValue(data=6, node=node),
@@ -111,6 +112,13 @@ def test_data_lists(device):
     assert device.hvac_modes == [0, 1, 2]
 
 
+def test_data_lists_mapping(device_mapping):
+    """Test data lists from zwave value items."""
+    device = device_mapping
+    assert device.hvac_modes == ['off', 'cool', 'heat']
+    assert device.preset_modes == ['eco', 'boost']
+
+
 def test_target_value_set(device):
     """Test values changed for climate device."""
     assert device.values.primary.data == 1
@@ -127,6 +135,8 @@ def test_operation_value_set(device):
     assert device.values.mode.data == 'test1'
     device.set_hvac_mode('test_set')
     assert device.values.mode.data == 'test_set'
+    device.set_preset_mode('another_test')
+    assert device.values.mode.data == 'another_test'
 
 
 def test_operation_value_set_mapping(device_mapping):
@@ -139,6 +149,10 @@ def test_operation_value_set_mapping(device_mapping):
     assert device.values.mode.data == 'Cool'
     device.set_hvac_mode(HVAC_MODE_OFF)
     assert device.values.mode.data == 'Off'
+    device.set_preset_mode(PRESET_BOOST)
+    assert device.values.mode.data == 'Full Power'
+    device.set_preset_mode(PRESET_ECO)
+    assert device.values.mode.data == 'Heat Eco'
 
 
 def test_fan_mode_value_set(device):


### PR DESCRIPTION
## Breaking Change:
Nothing

## Description:

This is my approach to add preset modes to the zwave climate integration. At the moment the code is neither completed nor tested. I have created this PR because I want to share my approach and discuss it with others. 

If someone knows zwave integration better than I do, please leave some hints. So far I don't have any experience with zwave and its integration into home assistance.

If incomplete PR are not allowed, please close it.

____
### UPDATE 28.07.2019:
The code works locally and local tests are passing. The PR is ready to be reviewed.

**Related issue (if applicable):** fixes  #25322

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
The documentation can stay unchanged

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
