### PR TITLE
huawei_lte: try unsupported data retrievals only once

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -7,6 +7,9 @@ from typing import Any, Callable
 
 import voluptuous as vol
 import attr
+from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
+from huawei_lte_api.Client import Client
+from huawei_lte_api.exceptions import ResponseErrorNotSupportedException
 
 from homeassistant.const import (
     CONF_URL, CONF_USERNAME, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP,
@@ -81,8 +84,6 @@ class RouterData:
         self._update()
 
     def _update(self) -> None:
-        from huawei_lte_api.exceptions import \
-            ResponseErrorNotSupportedException
         debugging = _LOGGER.isEnabledFor(logging.DEBUG)
 
         def get_data(path: str, func: Callable[[None], Any]) -> None:
@@ -130,9 +131,6 @@ def setup(hass, config) -> bool:
 
 def _setup_lte(hass, lte_config) -> None:
     """Set up Huawei LTE router."""
-    from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
-    from huawei_lte_api.Client import Client
-
     url = lte_config[CONF_URL]
     username = lte_config[CONF_USERNAME]
     password = lte_config[CONF_PASSWORD]

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from functools import reduce
 import logging
 import operator
+from typing import Any, Callable
 
 import voluptuous as vol
 import attr
@@ -80,21 +81,26 @@ class RouterData:
         self._update()
 
     def _update(self) -> None:
+        from huawei_lte_api.exceptions import \
+            ResponseErrorNotSupportedException
         debugging = _LOGGER.isEnabledFor(logging.DEBUG)
-        if debugging or "device_information" in self._subscriptions:
-            self.device_information = self.client.device.information()
-            _LOGGER.debug("device_information=%s", self.device_information)
-        if debugging or "device_signal" in self._subscriptions:
-            self.device_signal = self.client.device.signal()
-            _LOGGER.debug("device_signal=%s", self.device_signal)
-        if debugging or "monitoring_traffic_statistics" in self._subscriptions:
-            self.monitoring_traffic_statistics = \
-                self.client.monitoring.traffic_statistics()
-            _LOGGER.debug("monitoring_traffic_statistics=%s",
-                          self.monitoring_traffic_statistics)
-        if debugging or "wlan_host_list" in self._subscriptions:
-            self.wlan_host_list = self.client.wlan.host_list()
-            _LOGGER.debug("wlan_host_list=%s", self.wlan_host_list)
+
+        def get_data(path: str, func: Callable[[None], Any]) -> None:
+            if debugging or path in self._subscriptions:
+                try:
+                    setattr(self, path, func())
+                except ResponseErrorNotSupportedException as ex:
+                    _LOGGER.warning(
+                        "%s not supported by device", path, exc_info=ex)
+                    self._subscriptions.discard(path)
+                finally:
+                    _LOGGER.debug("%s=%s", path, getattr(self, path))
+
+        get_data("device_information", self.client.device.information)
+        get_data("device_signal", self.client.device.signal)
+        get_data("monitoring_traffic_statistics",
+                 self.client.monitoring.traffic_statistics)
+        get_data("wlan_host_list", self.client.wlan.host_list)
 
 
 @attr.s

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -177,6 +177,9 @@ homematicip==0.10.9
 # homeassistant.components.remember_the_milk
 httplib2==0.10.3
 
+# homeassistant.components.huawei_lte
+huawei-lte-api==1.2.0
+
 # homeassistant.components.influxdb
 influxdb==5.2.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -87,6 +87,7 @@ TEST_REQUIREMENTS = (
     'homekit[IP]',
     'homematicip',
     'httplib2',
+    'huawei-lte-api',
     'influxdb',
     'jsonpath',
     'libpurecool',


### PR DESCRIPTION
## Description:

Improves behavior when configured to grab data that the device does not support. Paves way for modem support, too.

**Related issue (if applicable):** #23809

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]