### PR TITLE
Add zigate support to zha

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -123,6 +123,7 @@ ZHA = 'homeassistant.components.zha'
 ZIGPY = 'zigpy'
 ZIGPY_XBEE = 'zigpy_xbee'
 ZIGPY_DECONZ = 'zigpy_deconz'
+ZIGPY_ZIGATE = 'zigpy_zigate'
 ORIGINAL = 'original'
 CURRENT = 'current'
 DEBUG_LEVELS = {
@@ -131,6 +132,7 @@ DEBUG_LEVELS = {
     ZIGPY: logging.DEBUG,
     ZIGPY_XBEE: logging.DEBUG,
     ZIGPY_DECONZ: logging.DEBUG,
+    ZIGPY_ZIGATE: logging.DEBUG,
 }
 ADD_DEVICE_RELAY_LOGGERS = [ZHA, ZIGPY]
 TYPE = 'type'
@@ -153,6 +155,7 @@ class RadioType(enum.Enum):
     ezsp = 'ezsp'
     xbee = 'xbee'
     deconz = 'deconz'
+    zigate = 'zigate'
 
     @classmethod
     def list(cls):

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -27,7 +27,7 @@ from .const import (
     DEVICE_INFO, DEVICE_JOINED, DEVICE_REMOVED, DOMAIN, IEEE, LOG_ENTRY,
     LOG_OUTPUT, MODEL, NWK, ORIGINAL, RADIO, RADIO_DESCRIPTION, RAW_INIT,
     SIGNAL_REMOVE, SIGNATURE, TYPE, UNKNOWN_MANUFACTURER, UNKNOWN_MODEL, ZHA,
-    ZHA_GW_MSG, ZIGPY, ZIGPY_DECONZ, ZIGPY_XBEE)
+    ZHA_GW_MSG, ZIGPY, ZIGPY_DECONZ, ZIGPY_XBEE, ZIGPY_ZIGATE)
 from .device import DeviceStatus, ZHADevice
 from .discovery import (
     async_dispatch_discovery_info, async_process_endpoint
@@ -368,6 +368,7 @@ def async_capture_log_levels():
         ZIGPY: logging.getLogger(ZIGPY).getEffectiveLevel(),
         ZIGPY_XBEE: logging.getLogger(ZIGPY_XBEE).getEffectiveLevel(),
         ZIGPY_DECONZ: logging.getLogger(ZIGPY_DECONZ).getEffectiveLevel(),
+        ZIGPY_ZIGATE: logging.getLogger(ZIGPY_ZIGATE).getEffectiveLevel(),
     }
 
 
@@ -379,6 +380,7 @@ def async_set_logger_levels(levels):
     logging.getLogger(ZIGPY).setLevel(levels[ZIGPY])
     logging.getLogger(ZIGPY_XBEE).setLevel(levels[ZIGPY_XBEE])
     logging.getLogger(ZIGPY_DECONZ).setLevel(levels[ZIGPY_DECONZ])
+    logging.getLogger(ZIGPY_ZIGATE).setLevel(levels[ZIGPY_ZIGATE])
 
 
 class LogRelayHandler(logging.Handler):

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -135,6 +135,11 @@ async def check_zigpy_connection(usb_path, radio_type, database_path):
         import zigpy_deconz.api
         from zigpy_deconz.zigbee.application import ControllerApplication
         radio = zigpy_deconz.api.Deconz()
+    elif radio_type == RadioType.zigate.name:
+        import zigpy_zigate.api
+        from zigpy_zigate.zigbee.application import ControllerApplication
+        radio = zigpy_zigate.api.ZiGate()
+    import traceback
     try:
         await radio.connect(usb_path, DEFAULT_BAUDRATE)
         controller = ControllerApplication(radio, database_path)

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -139,7 +139,6 @@ async def check_zigpy_connection(usb_path, radio_type, database_path):
         import zigpy_zigate.api
         from zigpy_zigate.zigbee.application import ControllerApplication
         radio = zigpy_zigate.api.ZiGate()
-    import traceback
     try:
         await radio.connect(usb_path, DEFAULT_BAUDRATE)
         controller = ControllerApplication(radio, database_path)

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -109,6 +109,19 @@ def establish_device_mappings():
         RADIO: get_deconz_radio,
         RADIO_DESCRIPTION: 'Deconz'
     }
+    
+    def get_zigate_radio():
+        import zigpy_zigate.api
+        from zigpy_zigate.zigbee.application import ControllerApplication
+        return {
+            RADIO: zigpy_zigate.api.ZiGate(),
+            CONTROLLER: ControllerApplication
+        }
+
+    RADIO_TYPES[RadioType.zigate.name] = {
+        RADIO: get_zigate_radio,
+        RADIO_DESCRIPTION: 'ZiGate'
+    }
 
     EVENT_RELAY_CLUSTERS.append(zcl.clusters.general.LevelControl.cluster_id)
     EVENT_RELAY_CLUSTERS.append(zcl.clusters.general.OnOff.cluster_id)

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -109,7 +109,7 @@ def establish_device_mappings():
         RADIO: get_deconz_radio,
         RADIO_DESCRIPTION: 'Deconz'
     }
-    
+
     def get_zigate_radio():
         import zigpy_zigate.api
         from zigpy_zigate.zigbee.application import ControllerApplication

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -9,6 +9,7 @@
     "zigpy-deconz==0.2.1",
     "zigpy-homeassistant==0.7.0",
     "zigpy-xbee-homeassistant==0.4.0"
+    "zigpy-zigate==0.1.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -14,7 +14,6 @@
   "dependencies": [],
   "codeowners": [
     "@dmulcahey",
-    "@adminiuga",
-    "@doudz"
+    "@adminiuga"
   ]
 }

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -8,12 +8,13 @@
     "zha-quirks==0.0.19",
     "zigpy-deconz==0.2.1",
     "zigpy-homeassistant==0.7.0",
-    "zigpy-xbee-homeassistant==0.4.0"
+    "zigpy-xbee-homeassistant==0.4.0",
     "zigpy-zigate==0.1.0"
   ],
   "dependencies": [],
   "codeowners": [
     "@dmulcahey",
-    "@adminiuga"
+    "@adminiuga",
+    "@doudz"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1980,5 +1980,8 @@ zigpy-homeassistant==0.7.0
 # homeassistant.components.zha
 zigpy-xbee-homeassistant==0.4.0
 
+# homeassistant.components.zha
+zigpy-zigate==0.1.0
+
 # homeassistant.components.zoneminder
 zm-py==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -383,3 +383,6 @@ zeroconf==0.23.0
 
 # homeassistant.components.zha
 zigpy-homeassistant==0.7.0
+
+# homeassistant.components.zha
+zigpy-zigate==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -383,6 +383,3 @@ zeroconf==0.23.0
 
 # homeassistant.components.zha
 zigpy-homeassistant==0.7.0
-
-# homeassistant.components.zha
-zigpy-zigate==0.1.0


### PR DESCRIPTION
## Description:

Add zigate support to zha component
zigate is a universal zigbee gateway http://www.zigate.fr


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#9990

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
