### PR TITLE
UniFi device tracker restore clients

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import unifi
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.core import callback
@@ -87,8 +87,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for entity in registry.entities.values():
 
         if entity.config_entry_id == config_entry.entry_id and \
-                entity.unique_id.startswith('dt-'):
-            _, mac, _ = entity.unique_id.split('-', 2)
+                entity.domain == DOMAIN:
+
+            mac, _ = entity.unique_id.split('-', 1)
 
             if mac in controller.api.clients or \
                     mac not in controller.api.clients_all:
@@ -172,7 +173,7 @@ class UniFiClientTracker(ScannerEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this client."""
-        return 'dt-{}-{}'.format(self.client.mac, self.controller.site)
+        return '{}-{}'.format(self.client.mac, self.controller.site)
 
     @property
     def available(self) -> bool:

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -176,9 +176,9 @@ async def test_restoring_client(hass, mock_controller):
 
     registry = await unifi_dt.entity_registry.async_get_registry(hass)
     registry.async_get_or_create(
-        unifi_dt.UNIFI_DOMAIN, device_tracker.DOMAIN,
-        'dt-{}-mock-site'.format(CLIENT_1['mac']),
-        config_entry_id=1)
+        device_tracker.DOMAIN, unifi_dt.UNIFI_DOMAIN,
+        '{}-mock-site'.format(CLIENT_1['mac']),
+        suggested_object_id=CLIENT_1['hostname'], config_entry_id=1)
 
     await setup_controller(hass, mock_controller)
     assert len(mock_controller.mock_requests) == 3


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
If HASS is restarted and a client isn't a part of the active clients list (~30 minutes offline from network) an entity will not be created until it is a part of the active clients list.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
