### PR TITLE
Make cool_on and heat_on method calls. They aren't properties in python-wink

### DIFF
--- a/homeassistant/components/wink/climate.py
+++ b/homeassistant/components/wink/climate.py
@@ -241,9 +241,9 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         """
         if not self.wink.is_on():
             return CURRENT_HVAC_OFF
-        if self.wink.cool_on:
+        if self.wink.cool_on():
             return CURRENT_HVAC_COOL
-        if self.wink.heat_on:
+        if self.wink.heat_on():
             return CURRENT_HVAC_HEAT
         return CURRENT_HVAC_IDLE
 


### PR DESCRIPTION
## Description:
See title

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/wink-sensi-thermostat-climate-component-additional-attributes-request/58540/19

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
