### PR TITLE
Expose last_video_id as property for Ring camera

### DIFF
--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -104,6 +104,7 @@ class RingCam(Camera):
             'timezone': self._camera.timezone,
             'type': self._camera.family,
             'video_url': self._video_url,
+            'last_video_id': self._last_video_id,
         }
 
     async def async_camera_image(self):


### PR DESCRIPTION
## Description:

Expose last_video_id as component property for automation purpose.

This change was discussed (but not added to PR by mistake) in https://github.com/home-assistant/home-assistant/pull/22526

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
