### PR TITLE
pylutron PyPI update

### DIFF
--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -3,7 +3,7 @@
   "name": "Lutron",
   "documentation": "https://www.home-assistant.io/components/lutron",
   "requirements": [
-    "pylutron==0.2.0"
+    "pylutron==0.2.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1250,7 +1250,7 @@ pyloopenergy==0.1.3
 pylutron-caseta==0.5.0
 
 # homeassistant.components.lutron
-pylutron==0.2.0
+pylutron==0.2.1
 
 # homeassistant.components.mailgun
 pymailgunner==1.4


### PR DESCRIPTION
## Breaking Change:
n/a

## Description:
We've been working with the original maintainer of pylutron, and they've published an update to PyPI to support a couple different things: homeowner keypads, main repeater keypads


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10003

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
