### PR TITLE
Use package constraints in Azure CI mypy setup

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -191,7 +191,7 @@ stages:
         python -m venv venv
 
         . venv/bin/activate
-        pip install -r requirements_test.txt
+        pip install -r requirements_test.txt -c homeassistant/package_constraints.txt
       displayName: 'Setup Env'
     - script: |
         . venv/bin/activate

--- a/homeassistant/util/ruamel_yaml.py
+++ b/homeassistant/util/ruamel_yaml.py
@@ -83,7 +83,8 @@ def load_yaml(fname: str, round_trip: bool = False) -> JSON_TYPE:
     """Load a YAML file."""
     if round_trip:
         yaml = YAML(typ='rt')
-        yaml.preserve_quotes = True
+        # type ignore: https://bitbucket.org/ruamel/yaml/pull-requests/42
+        yaml.preserve_quotes = True  # type: ignore
     else:
         if ExtSafeConstructor.name is None:
             ExtSafeConstructor.name = fname


### PR DESCRIPTION
## Description:

Makes Azure CI use same config as tox/travis, addresses one related mypy error.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
