### PR TITLE
Return history for entities in the order they were requested

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -1,5 +1,6 @@
 """Provide pre-made queries on top of the recorder component."""
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import timedelta
 from itertools import groupby
 import logging
@@ -210,7 +211,10 @@ def states_to_json(
     each list of states, otherwise our graphs won't start on the Y
     axis correctly.
     """
-    result = {ent_id: [] for ent_id in entity_ids}
+    result = defaultdict(list)
+    if isinstance(entity_ids, Iterable):
+        for ent_id in entity_ids:
+            result[ent_id] = []
 
     # Get the states at the start time
     timer_start = time.perf_counter()

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -210,7 +210,7 @@ def states_to_json(
     each list of states, otherwise our graphs won't start on the Y
     axis correctly.
     """
-    result = defaultdict(list)
+    result = {ent_id: [] for ent_id in entity_ids}
 
     # Get the states at the start time
     timer_start = time.perf_counter()

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -1,6 +1,5 @@
 """Provide pre-made queries on top of the recorder component."""
 from collections import defaultdict
-from collections.abc import Iterable
 from datetime import timedelta
 from itertools import groupby
 import logging
@@ -212,7 +211,7 @@ def states_to_json(
     axis correctly.
     """
     result = defaultdict(list)
-    if isinstance(entity_ids, Iterable):
+    if entity_ids is not None:
         for ent_id in entity_ids:
             result[ent_id] = []
 

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -428,6 +428,22 @@ class TestComponentHistory(unittest.TestCase):
                     history.CONF_ENTITIES: ['media_player.test']}}})
         self.check_significant_states(zero, four, states, config)
 
+    def test_get_significant_states_are_ordered(self):
+        """Test order of results from get_significant_states
+
+        When entity ids are given, the results should be returned with the data
+        in the same order.
+        """
+        zero, four, states = self.record_states()
+        entity_ids = ['media_player.test', 'media_player.test2']
+        hist = history.get_significant_states(
+            self.hass, zero, four, entity_ids, filters=history.Filters())
+        assert list(hist.keys()) == entity_ids
+        entity_ids = ['media_player.test2', 'media_player.test']
+        hist = history.get_significant_states(
+            self.hass, zero, four, entity_ids, filters=history.Filters())
+        assert list(hist.keys()) == entity_ids
+
     def check_significant_states(self, zero, four, states, config):
         """Check if significant states are retrieved."""
         filters = history.Filters()


### PR DESCRIPTION
## Description:
Return history data in order

Also see home-assistant/home-assistant-polymer#3436

**Related issue (if applicable):** fixes home-assistant/ui-schema#213

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
