### PR TITLE
Add migration notification for Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -1,6 +1,8 @@
 """Support for Ambient Weather Station Service."""
 import logging
 
+from aioambient import Client
+from aioambient.errors import WebsocketError
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
@@ -251,9 +253,6 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up the Ambient PWS as config entry."""
-    from aioambient import Client
-    from aioambient.errors import WebsocketError
-
     session = aiohttp_client.async_get_clientsession(hass)
 
     try:
@@ -324,8 +323,6 @@ class AmbientStation:
 
     async def _attempt_connect(self):
         """Attempt to connect to the socket (retrying later on fail)."""
-        from aioambient.errors import WebsocketError
-
         try:
             await self.client.websocket.connect()
         except WebsocketError as err:

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -300,7 +300,7 @@ async def async_migrate_entry(hass, config_entry):
     if version == 1:
         config_entry.version = 2
         hass.config_entries.async_update_entry(
-            config_entry, data=config_entry.data)
+            config_entry)
         _LOGGER.info('Migration to version %s successful', version)
 
     msg = """{0}

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -286,6 +286,35 @@ async def async_unload_entry(hass, config_entry):
     return True
 
 
+async def async_migrate_entry(hass, config_entry):
+    """Migrate old entry."""
+    version = config_entry.version
+
+    _LOGGER.debug('Migrating from version %s', version)
+
+    reasons_to_re_add = {
+        1: "The format for unique IDs (in the entity registry) has changed."
+    }
+
+    # 1 -> 2: Unique ID format changed:
+    if version == 1:
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(
+            config_entry, data=config_entry.data)
+        _LOGGER.info('Migration to version %s successful', version)
+
+    msg = """{0}
+            Please remove the Ambient PWS Integration and re-configure
+            [here](/config/integrations).""".format(reasons_to_re_add[version])
+
+    hass.components.persistent_notification.async_create(
+        title="Ambient PWS Requires Update",
+        message=msg,
+        notification_id='config_entry_migration'
+    )
+    return False
+
+
 class AmbientStation:
     """Define a class to handle the Ambient websocket."""
 

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -21,7 +21,7 @@ def configured_instances(hass):
 class AmbientStationFlowHandler(config_entries.ConfigFlow):
     """Handle an Ambient PWS config flow."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
     async def _show_form(self, errors=None):


### PR DESCRIPTION
## Description:

https://github.com/home-assistant/home-assistant/pull/25284 introduced a breaking change due to alterations in this integration's unique ID format. The PS4 integration gave me an inspiration: assuming that many people won't read the breaking change docs, it might be nice to automatically recreate it under the hood. This PR takes care of that.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
