### PR TITLE
updated telegram trusted IPs

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -77,12 +77,8 @@ PARSER_HTML = 'html'
 PARSER_MD = 'markdown'
 
 DEFAULT_TRUSTED_NETWORKS = [
-    ip_network('149.154.167.197/32'),
-    ip_network('149.154.167.198/31'),
-    ip_network('149.154.167.200/29'),
-    ip_network('149.154.167.208/28'),
-    ip_network('149.154.167.224/29'),
-    ip_network('149.154.167.232/31')
+    ip_network('149.154.160.0/20'),
+    ip_network('91.108.4.0/22')
 ]
 
 CONFIG_SCHEMA = vol.Schema({


### PR DESCRIPTION
## Description:

Telegram IPs have changed and 91.108.4.0/22 is missing from the default trusted networks for component telegram_bot
see https://core.telegram.org/bots/webhooks ("The short version")

**Related issue (if applicable):** fixes #25562