### PR TITLE
Updated Workday Binary Sensor to use Holidays 0.9.11 and added support for Aruba Holidays.

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 # List of all countries currently supported by holidays
 # There seems to be no way to get the list out at runtime
 ALL_COUNTRIES = [
-    'Argentina', 'AR', 'Australia', 'AU', 'Austria', 'AT',
+    'Argentina', 'AR', 'Aruba', 'AW', 'Australia', 'AU', 'Austria', 'AT',
     'Brazil', 'BR', 'Belarus', 'BY', 'Belgium', 'BE', 'Bulgaria', 'BG',
     'Canada', 'CA', 'Colombia', 'CO', 'Croatia', 'HR', 'Czech', 'CZ',
     'Denmark', 'DK',

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -3,7 +3,7 @@
   "name": "Workday",
   "documentation": "https://www.home-assistant.io/components/workday",
   "requirements": [
-    "holidays==0.9.10"
+    "holidays==0.9.11"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -619,7 +619,7 @@ hlk-sw16==0.0.7
 hole==0.3.0
 
 # homeassistant.components.workday
-holidays==0.9.10
+holidays==0.9.11
 
 # homeassistant.components.frontend
 home-assistant-frontend==20190721.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -162,7 +162,7 @@ hbmqtt==0.9.4
 hdate==0.8.8
 
 # homeassistant.components.workday
-holidays==0.9.10
+holidays==0.9.11
 
 # homeassistant.components.frontend
 home-assistant-frontend==20190721.1


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

**A very minor update to the Workday Binary Sensor to use Holidays 0.9.11 which added support for Aruba Holidays.**

**I only made 2 changes, I don't even know how to do any of the things in the checklist below... Maybe someone can help?**

**What I did was added support for the Aruba Holidays in the Holidays library, which is now updated to 0.9.11. So I just updated the manifests file to use Holidays 0.9.11 and added Aruba in the list of supported Countries.**






**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
