### PR TITLE
UniFi - Track devices

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -7,8 +7,9 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
-    CONF_BLOCK_CLIENT, CONF_CONTROLLER, CONF_DETECTION_TIME, CONF_SITE_ID,
-    CONF_SSID_FILTER, CONTROLLER_ID, DOMAIN, UNIFI_CONFIG)
+    ATTR_MANUFACTURER, CONF_BLOCK_CLIENT, CONF_CONTROLLER,
+    CONF_DETECTION_TIME, CONF_SITE_ID, CONF_SSID_FILTER, CONTROLLER_ID,
+    DOMAIN, UNIFI_CONFIG)
 from .controller import UniFiController
 
 CONF_CONTROLLERS = 'controllers'
@@ -66,7 +67,7 @@ async def async_setup_entry(hass, config_entry):
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(CONNECTION_NETWORK_MAC, controller.mac)},
-        manufacturer='Ubiquiti',
+        manufacturer=ATTR_MANUFACTURER,
         model="UniFi Controller",
         name="UniFi Controller",
         # sw_version=config.raw['swversion'],

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -14,3 +14,5 @@ UNIFI_CONFIG = 'unifi_config'
 CONF_BLOCK_CLIENT = 'block_client'
 CONF_DETECTION_TIME = 'detection_time'
 CONF_SSID_FILTER = 'ssid_filter'
+
+ATTR_MANUFACTURER = 'Ubiquiti Networks'

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -20,8 +20,8 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
 from .const import (
-    CONF_CONTROLLER, CONF_DETECTION_TIME, CONF_SITE_ID, CONF_SSID_FILTER,
-    CONTROLLER_ID, DOMAIN as UNIFI_DOMAIN)
+    ATTR_MANUFACTURER, CONF_CONTROLLER, CONF_DETECTION_TIME, CONF_SITE_ID,
+    CONF_SSID_FILTER, CONTROLLER_ID, DOMAIN as UNIFI_DOMAIN)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for entity in registry.entities.values():
 
         if entity.config_entry_id == config_entry.entry_id and \
-                entity.domain == DOMAIN:
+                entity.domain == DOMAIN and '-' in entity.unique_id:
 
             mac, _ = entity.unique_id.split('-', 1)
 
@@ -116,7 +116,7 @@ def update_items(controller, async_add_entities, tracked):
     for client_id in controller.api.clients:
 
         if client_id in tracked:
-            LOGGER.debug("Updating UniFi tracked device %s (%s)",
+            LOGGER.debug("Updating UniFi tracked client %s (%s)",
                          tracked[client_id].entity_id,
                          tracked[client_id].client.mac)
             tracked[client_id].async_schedule_update_ha_state()
@@ -131,17 +131,34 @@ def update_items(controller, async_add_entities, tracked):
 
         tracked[client_id] = UniFiClientTracker(client, controller)
         new_tracked.append(tracked[client_id])
-        LOGGER.debug("New UniFi switch %s (%s)", client.hostname, client.mac)
+        LOGGER.debug("New UniFi client tracker %s (%s)",
+                     client.hostname, client.mac)
+
+    for device_id in controller.api.devices:
+
+        if device_id in tracked:
+            LOGGER.debug("Updating UniFi tracked device %s (%s)",
+                         tracked[device_id].entity_id,
+                         tracked[device_id].device.mac)
+            tracked[device_id].async_schedule_update_ha_state()
+            continue
+
+        device = controller.api.devices[device_id]
+
+        tracked[device_id] = UniFiDeviceTracker(device, controller)
+        new_tracked.append(tracked[device_id])
+        LOGGER.debug("New UniFi device tracker %s (%s)",
+                     device.name, device.mac)
 
     if new_tracked:
         async_add_entities(new_tracked)
 
 
 class UniFiClientTracker(ScannerEntity):
-    """Representation of a network device."""
+    """Representation of a network client."""
 
     def __init__(self, client, controller):
-        """Set up tracked device."""
+        """Set up tracked client."""
         self.client = client
         self.controller = controller
 
@@ -151,7 +168,7 @@ class UniFiClientTracker(ScannerEntity):
 
     @property
     def is_connected(self):
-        """Return true if the device is connected to the network."""
+        """Return true if the client is connected to the network."""
         detection_time = self.controller.unifi_config.get(
             CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
 
@@ -162,12 +179,12 @@ class UniFiClientTracker(ScannerEntity):
 
     @property
     def source_type(self):
-        """Return the source type of the device."""
+        """Return the source type of the client."""
         return SOURCE_TYPE_ROUTER
 
     @property
     def name(self) -> str:
-        """Return the name of the device."""
+        """Return the name of the client."""
         return self.client.name or self.client.hostname
 
     @property
@@ -182,9 +199,75 @@ class UniFiClientTracker(ScannerEntity):
 
     @property
     def device_info(self):
-        """Return a device description for device registry."""
+        """Return a client description for device registry."""
         return {
             'connections': {(CONNECTION_NETWORK_MAC, self.client.mac)}
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the client state attributes."""
+        attributes = {}
+
+        for variable in DEVICE_ATTRIBUTES:
+            if variable in self.client.raw:
+                attributes[variable] = self.client.raw[variable]
+
+        return attributes
+
+
+class UniFiDeviceTracker(ScannerEntity):
+    """Representation of a network infrastructure device."""
+
+    def __init__(self, device, controller):
+        """Set up tracked device."""
+        self.device = device
+        self.controller = controller
+
+    async def async_update(self):
+        """Synchronize state with controller."""
+        await self.controller.request_update()
+
+    @property
+    def is_connected(self):
+        """Return true if the device is connected to the network."""
+        detection_time = self.controller.unifi_config.get(
+            CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
+
+        if (dt_util.utcnow() - dt_util.utc_from_timestamp(float(
+                self.device.last_seen))) < detection_time:
+            return True
+        return False
+
+    @property
+    def source_type(self):
+        """Return the source type of the device."""
+        return SOURCE_TYPE_ROUTER
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return self.device.name
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique identifier for this device."""
+        return self.device.mac
+
+    @property
+    def available(self) -> bool:
+        """Return if controller is available."""
+        return self.controller.available
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return {
+            'connections': {(CONNECTION_NETWORK_MAC, self.device.mac)},
+            'manufacturer': ATTR_MANUFACTURER,
+            'model': self.device.model,
+            'name': self.device.name,
+            'sw_version': self.device.version
         }
 
     @property
@@ -192,8 +275,14 @@ class UniFiClientTracker(ScannerEntity):
         """Return the device state attributes."""
         attributes = {}
 
-        for variable in DEVICE_ATTRIBUTES:
-            if variable in self.client.raw:
-                attributes[variable] = self.client.raw[variable]
+        attributes['mac'] = self.device.mac
+        attributes['model'] = self.device.model
+        attributes['board_rev'] = self.device.board_rev
+        attributes['upgradable'] = self.device.upgradable
+        attributes['overheating'] = self.device.overheating
+        attributes['version'] = self.device.version
+
+        if self.device.has_fan:
+            attributes['fan_level'] = self.device.fan_level
 
         return attributes

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -275,7 +275,6 @@ class UniFiDeviceTracker(ScannerEntity):
         """Return the device state attributes."""
         attributes = {}
 
-        attributes['board_rev'] = self.device.board_rev
         attributes['upgradable'] = self.device.upgradable
         attributes['overheating'] = self.device.overheating
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -275,12 +275,9 @@ class UniFiDeviceTracker(ScannerEntity):
         """Return the device state attributes."""
         attributes = {}
 
-        attributes['mac'] = self.device.mac
-        attributes['model'] = self.device.model
         attributes['board_rev'] = self.device.board_rev
         attributes['upgradable'] = self.device.upgradable
         attributes['overheating'] = self.device.overheating
-        attributes['version'] = self.device.version
 
         if self.device.has_fan:
             attributes['fan_level'] = self.device.fan_level

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/unifi",
   "requirements": [
-    "aiounifi==7"
+    "aiounifi==8"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -169,7 +169,7 @@ aiopvapi==1.6.14
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==7
+aiounifi==8
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -64,7 +64,7 @@ aionotion==1.1.0
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==7
+aiounifi==8
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -77,7 +77,7 @@ async def test_successful_config_entry(hass):
         'connections': {
             ('mac', '00:11:22:33:44:55')
         },
-        'manufacturer': 'Ubiquiti',
+        'manufacturer': unifi.ATTR_MANUFACTURER,
         'model': "UniFi Controller",
         'name': "UniFi Controller",
     }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
UniFi component will now also track devices (network infrastructure)

**Related issue (if applicable):** fixes #25396

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
