### PR TITLE
Zwave Climate: Fan state attribute missing (#25287)

### DIFF
--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -257,6 +257,11 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
         return self._hvac_action
 
     @property
+    def fan_state(self):
+        """Return the current fan state if supported."""
+        return self._fan_state
+
+    @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
         return self._target_temperature


### PR DESCRIPTION
## Description:
Fix missing fan state attribute for Zwave climate devices

**Related issue (if applicable):** fixes #25287

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
