### PR TITLE
Bump Python support to min Python 3.6.0

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -14,8 +14,6 @@ pr:
 
 resources:
   containers:
-  - container: 35
-    image: homeassistant/ci-azure:3.5
   - container: 36
     image: homeassistant/ci-azure:3.6
   - container: 37
@@ -24,7 +22,7 @@ variables:
   - name: ArtifactFeed
     value: '2df3ae11-3bf6-49bc-a809-ba0d340d6a6d'
   - name: PythonMain
-    value: '35'
+    value: '36'
   - group: codecov
 
 stages:
@@ -76,8 +74,6 @@ stages:
     strategy:
       maxParallel: 3
       matrix:
-        Python35:
-          python.container: '35'
         Python36:
           python.container: '36'
         Python37:
@@ -92,11 +88,11 @@ stages:
       inputs:
         keyfile: 'requirements_test_all.txt, .cache'
         targetfolder: './venv'
-        vstsFeed: '$(ArtifactFeed)' 
+        vstsFeed: '$(ArtifactFeed)'
     - script: |
         set -e
         python -m venv venv
-        
+
         . venv/bin/activate
         pip install -U pip setuptools
         pip install -r requirements_test_all.txt -c homeassistant/package_constraints.txt
@@ -104,18 +100,18 @@ stages:
       displayName: 'Create Virtual Environment & Install Requirements'
       condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
     # Explicit Cache Save (instead of using RestoreAndSaveCache)
-    # Dont wait with cache save for all the other task in this job to complete (±30 minutes), other parallel jobs might utilize this 
-    - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1	
-      displayName: 'Save artifacts based on Requirements'	
-      inputs:	
-        keyfile: 'requirements_test_all.txt, .cache'	
-        targetfolder: './venv'	
+    # Dont wait with cache save for all the other task in this job to complete (±30 minutes), other parallel jobs might utilize this
+    - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
+      displayName: 'Save artifacts based on Requirements'
+      inputs:
+        keyfile: 'requirements_test_all.txt, .cache'
+        targetfolder: './venv'
         vstsFeed: '$(ArtifactFeed)'
-    - script: | 
+    - script: |
         . venv/bin/activate
         pip install -e .
-      displayName: 'Install Home Assistant for python $(python.container)' 
-    - script: | 
+      displayName: 'Install Home Assistant for python $(python.container)'
+    - script: |
         . venv/bin/activate
         pytest --timeout=9 --durations=10 --junitxml=test-results.xml -qq -o console_output_style=count -p no:sugar tests
       displayName: 'Run pytest for python $(python.container)'
@@ -157,11 +153,11 @@ stages:
       inputs:
         keyfile: 'requirements_all.txt, requirements_test.txt, .cache'
         targetfolder: './venv'
-        vstsFeed: '$(ArtifactFeed)' 
+        vstsFeed: '$(ArtifactFeed)'
     - script: |
         set -e
         python -m venv venv
-        
+
         . venv/bin/activate
         pip install -U pip setuptools
         pip install -r requirements_all.txt -c homeassistant/package_constraints.txt
@@ -174,10 +170,10 @@ stages:
         keyfile: 'requirements_all.txt, requirements_test.txt, .cache'
         targetfolder: './venv'
         vstsFeed: '$(ArtifactFeed)'
-    - script: | 
+    - script: |
         . venv/bin/activate
         pip install -e .
-      displayName: 'Install Home Assistant for python $(PythonMain)' 
+      displayName: 'Install Home Assistant for python $(PythonMain)'
     - script: |
         . venv/bin/activate
         pylint homeassistant

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ MINOR_VERSION = 97
 PATCH_VERSION = '0.dev0'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
-REQUIRED_PYTHON_VER = (3, 5, 3)
+REQUIRED_PYTHON_VER = (3, 6, 0)
 
 # Format for platform files
 PLATFORM_FORMAT = '{platform}.{domain}'

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -139,7 +139,8 @@ class HomeAssistant:
             self,
             loop: Optional[asyncio.events.AbstractEventLoop] = None) -> None:
         """Initialize new Home Assistant object."""
-        self.loop = loop or asyncio.get_event_loop()
+        self.loop: asyncio.events.AbstractEventLoop = (
+            loop or asyncio.get_event_loop())
 
         executor_opts = {'max_workers': None}  # type: Dict[str, Any]
         if sys.version_info[:2] >= (3, 6):
@@ -148,21 +149,21 @@ class HomeAssistant:
         self.executor = ThreadPoolExecutor(**executor_opts)
         self.loop.set_default_executor(self.executor)
         self.loop.set_exception_handler(async_loop_exception_handler)
-        self._pending_tasks = []  # type: list
+        self._pending_tasks: list = []
         self._track_task = True
         self.bus = EventBus(self)
         self.services = ServiceRegistry(self)
         self.states = StateMachine(self.bus, self.loop)
-        self.config = Config(self)  # type: Config
+        self.config = Config(self)
         self.components = loader.Components(self)
         self.helpers = loader.Helpers(self)
         # This is a dictionary that any component can store any data on.
-        self.data = {}  # type: dict
+        self.data: dict = {}
         self.state = CoreState.not_running
-        self.exit_code = 0  # type: int
-        self.config_entries = None  # type: Optional[ConfigEntries]
+        self.exit_code = 0
+        self.config_entries: Optional[ConfigEntries] = None
         # If not None, use to signal end-of-loop
-        self._stopped = None  # type: Optional[asyncio.Event]
+        self._stopped: Optional[asyncio.Event] = None
 
     @property
     def is_running(self) -> bool:
@@ -297,7 +298,7 @@ class HomeAssistant:
 
         target: target to call.
         """
-        task = self.loop.create_task(target)  # type: asyncio.tasks.Task
+        task: asyncio.tasks.Task = self.loop.create_task(target)
 
         if self._track_task:
             self._pending_tasks.append(task)
@@ -461,7 +462,7 @@ class Event:
         self.data = data or {}
         self.origin = origin
         self.time_fired = time_fired or dt_util.utcnow()
-        self.context = context or Context()
+        self.context: Context = context or Context()
 
     def as_dict(self) -> Dict:
         """Create a dict representation of this Event.
@@ -502,7 +503,7 @@ class EventBus:
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize a new event bus."""
-        self._listeners = {}  # type: Dict[str, List[Callable]]
+        self._listeners: Dict[str, List[Callable]] = {}
         self._hass = hass
 
     @callback

--- a/homeassistant/monkey_patch.py
+++ b/homeassistant/monkey_patch.py
@@ -61,9 +61,7 @@ def disable_c_asyncio() -> None:
         def find_module(self, fullname: str, path: Any = None) -> None:
             """Find a module."""
             if fullname == self.PATH_TRIGGER:
-                # We lint in Py35, exception is introduced in Py36
-                # pylint: disable=undefined-variable
-                raise ModuleNotFoundError()  # type: ignore # noqa
+                raise ModuleNotFoundError()
 
     sys.path_hooks.append(AsyncioImportFinder)
     sys.path.insert(0, AsyncioImportFinder.PATH_TRIGGER)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.5
+python_version = 3.6
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,6 +36,6 @@ def test_validate_python(mock_exit):
     mock_exit.reset_mock()
 
     with patch('sys.version_info',
-               new_callable=PropertyMock(return_value=(3, 5, 3))):
+               new_callable=PropertyMock(return_value=(3, 6, 0))):
         main.validate_python()
         assert mock_exit.called is False


### PR DESCRIPTION
## Breaking Change:

Python 3.6.0 is now the minimum supported version.

## Description:
Bump minimum supported version to Python 3.6.0 and update some type annotations to enforce it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
