### PR TITLE
Add support for Roku TVs to be powered on or off

### DIFF
--- a/homeassistant/components/roku/__init__.py
+++ b/homeassistant/components/roku/__init__.py
@@ -74,7 +74,7 @@ def scan_for_rokus(hass):
             continue
         devices.append('Name: {0}<br />Host: {1}<br />'.format(
             r_info.userdevicename if r_info.userdevicename
-            else "{} {}".format(r_info.modelname, r_info.sernum),
+            else "{} {}".format(r_info.modelname, r_info.serial_num),
             roku.host))
     if not devices:
         devices = ['No device(s) found']
@@ -98,7 +98,7 @@ def _setup_roku(hass, hass_config, roku_config):
     r_info = roku.device_info
 
     hass.data[DATA_ROKU][host] = {
-        ATTR_ROKU: r_info.sernum
+        ATTR_ROKU: r_info.serial_num
     }
 
     discovery.load_platform(

--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -3,7 +3,7 @@
   "name": "Roku",
   "documentation": "https://www.home-assistant.io/components/roku",
   "requirements": [
-    "python-roku==3.1.5"
+    "roku==3.0.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/roku/remote.py
+++ b/homeassistant/components/roku/remote.py
@@ -36,14 +36,14 @@ class RokuRemote(remote.RemoteDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        if self._device_info.userdevicename:
-            return self._device_info.userdevicename
-        return "Roku {}".format(self._device_info.sernum)
+        if self._device_info.user_device_name:
+            return self._device_info.user_device_name
+        return "Roku {}".format(self._device_info.serial_num)
 
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._device_info.sernum
+        return self._device_info.serial_num
 
     @property
     def is_on(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1494,9 +1494,6 @@ python-qbittorrent==0.3.1
 # homeassistant.components.ripple
 python-ripple-api==0.0.3
 
-# homeassistant.components.roku
-python-roku==3.1.5
-
 # homeassistant.components.sochain
 python-sochain-api==0.0.2
 
@@ -1641,6 +1638,9 @@ rjpl==0.3.5
 
 # homeassistant.components.rocketchat
 rocketchat-API==0.6.1
+
+# homeassistant.components.roku
+roku==3.0.0
 
 # homeassistant.components.roomba
 roombapy==1.3.1


### PR DESCRIPTION
## Description:

Adds support for Roku TVs to be powered on or off. Changes the roku dependency to [roku](https://github.com/jcarbaugh/python-roku), which is actively developed and includes extra functionality.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
