### PR TITLE
Fix status of lutron switches/lights after HA reboot

### DIFF
--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -35,6 +35,7 @@ class LutronLight(LutronDevice, Light):
     def __init__(self, area_name, lutron_device, controller):
         """Initialize the light."""
         self._prev_brightness = None
+        self._is_on = False
         super().__init__(area_name, lutron_device, controller)
 
     @property
@@ -78,5 +79,6 @@ class LutronLight(LutronDevice, Light):
 
     def update(self):
         """Call when forcing a refresh of the device."""
+        self._is_on = self._lutron_device.level > 0
         if self._prev_brightness is None:
             self._prev_brightness = to_hass_level(self._lutron_device.level)

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -21,6 +21,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class LutronSwitch(LutronDevice, SwitchDevice):
     """Representation of a Lutron Switch."""
 
+    def __init__(self, area_name, lutron_device, controller):
+        """Initialize the switch."""
+        self._is_on = False
+        super().__init__(area_name, lutron_device, controller)
+
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._lutron_device.level = 100
@@ -40,3 +45,7 @@ class LutronSwitch(LutronDevice, SwitchDevice):
     def is_on(self):
         """Return true if device is on."""
         return self._lutron_device.last_level() > 0
+
+    def update(self):
+        """Call when forcing a refresh of the device."""
+        self._is_on = self._lutron_device.level > 0


### PR DESCRIPTION
## Breaking Change:
n/a

## Description:
currently, after a reboot, the status of all lutron (radio ra2) lights and switches show as off, regardless of their actual state. This fix makes it so that the status is reflected correctly after a HA reboot.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
