### PR TITLE
implemented timeout setting for telnet switch

### DIFF
--- a/homeassistant/components/telnet/switch.py
+++ b/homeassistant/components/telnet/switch.py
@@ -9,12 +9,13 @@ from homeassistant.components.switch import (
     ENTITY_ID_FORMAT, PLATFORM_SCHEMA, SwitchDevice)
 from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_COMMAND_STATE, CONF_NAME,
-    CONF_PORT, CONF_RESOURCE, CONF_SWITCHES, CONF_VALUE_TEMPLATE)
+    CONF_PORT, CONF_TIMEOUT, CONF_RESOURCE, CONF_SWITCHES, CONF_VALUE_TEMPLATE)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 23
+DEFAULT_TIMEOUT = 0.2
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Required(CONF_COMMAND_OFF): cv.string,
@@ -24,6 +25,7 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_COMMAND_STATE): cv.string,
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(float),
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -54,7 +56,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 device_config.get(CONF_COMMAND_ON),
                 device_config.get(CONF_COMMAND_OFF),
                 device_config.get(CONF_COMMAND_STATE),
-                value_template
+                value_template,
+                device_config.get(CONF_TIMEOUT)
             )
         )
 
@@ -69,7 +72,8 @@ class TelnetSwitch(SwitchDevice):
     """Representation of a switch that can be toggled using telnet commands."""
 
     def __init__(self, hass, object_id, resource, port, friendly_name,
-                 command_on, command_off, command_state, value_template):
+                 command_on, command_off, command_state,
+                 value_template, timeout):
         """Initialize the switch."""
         self._hass = hass
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
@@ -81,12 +85,15 @@ class TelnetSwitch(SwitchDevice):
         self._command_off = command_off
         self._command_state = command_state
         self._value_template = value_template
+        self._timeout = timeout
 
     def _telnet_command(self, command):
         try:
             telnet = telnetlib.Telnet(self._resource, self._port)
             telnet.write(command.encode('ASCII') + b'\r')
-            response = telnet.read_until(b'\r', timeout=0.2)
+            response = telnet.read_until(b'\r', timeout=self._timeout)
+            _LOGGER.debug(
+                "telnet response: %s", response.decode('ASCII').strip())
             return response.decode('ASCII').strip()
         except IOError as error:
             _LOGGER.error(


### PR DESCRIPTION
## Description:

I have a telnet device (optoma projector) that needs more than the default 0.2 seconds to send a meaningfull reply. so I extended the telnet switch component with an optional timeout option.
if no timeout is set the default 0.2 seconds are used

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10019

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)