### PR TITLE
Fix handling of empty results from Rejseplanen

### DIFF
--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -111,10 +111,7 @@ class RejseplanenTransportSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         if not self._times:
-            return {
-                ATTR_STOP_ID: self._stop_id,
-                ATTR_ATTRIBUTION: ATTRIBUTION
-            }
+            return {ATTR_STOP_ID: self._stop_id, ATTR_ATTRIBUTION: ATTRIBUTION}
 
         next_up = []
         if len(self._times) > 1:

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -112,18 +112,11 @@ class RejseplanenTransportSensor(Entity):
         """Return the state attributes."""
         if not self._times:
             return {
-                ATTR_DUE_IN: None,
-                ATTR_DUE_AT: None,
-                ATTR_TYPE: None,
-                ATTR_ROUTE: None,
-                ATTR_DIRECTION: None,
-                ATTR_STOP_NAME: None,
                 ATTR_STOP_ID: self._stop_id,
-                ATTR_ATTRIBUTION: ATTRIBUTION,
-                ATTR_NEXT_UP: None
+                ATTR_ATTRIBUTION: ATTRIBUTION
             }
 
-        next_up = None
+        next_up = []
         if len(self._times) > 1:
             next_up = self._times[1:]
 
@@ -181,7 +174,7 @@ class PublicTransportData:
         self.info = []
 
         def intersection(lst1, lst2):
-            """Return items contained in both lists."""
+            """Return items contained in both lists"""
             return list(set(lst1) & set(lst2))
 
         # Limit search to selected types, to get more results

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -174,7 +174,7 @@ class PublicTransportData:
         self.info = []
 
         def intersection(lst1, lst2):
-            """Return items contained in both lists"""
+            """Return items contained in both lists."""
             return list(set(lst1) & set(lst2))
 
         # Limit search to selected types, to get more results


### PR DESCRIPTION
## Breaking Change:
When there are no upcoming departures, the sensor now returns state `unknown`, and removes attributes instead of setting them to `n/a`.

Any existing templates looking for the `n/a` state should be updated to look for `unknown` instead, and all templates should be altered to handle potentially missing attributes.

## Description:
Remove `"n/a"` attributes, and return `None` for state, when no upcoming departures are returned from API.

**Related issue (if applicable):** fixes #25566

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
