### PR TITLE
Websocket call for rendering jinja2 templates subscription

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -7,6 +7,7 @@ from homeassistant.core import callback, DOMAIN as HASS_DOMAIN
 from homeassistant.exceptions import Unauthorized, ServiceNotFound, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_get_all_descriptions
+from homeassistant.helpers.event import async_track_state_change
 
 from . import const, decorators, messages
 
@@ -21,6 +22,7 @@ def async_register_commands(hass, async_reg):
     async_reg(hass, handle_get_services)
     async_reg(hass, handle_get_config)
     async_reg(hass, handle_ping)
+    async_reg(hass, handle_render_template)
 
 
 def pong_message(iden):
@@ -202,3 +204,40 @@ def handle_ping(hass, connection, msg):
     Async friendly.
     """
     connection.send_message(pong_message(msg["id"]))
+
+
+@callback
+@decorators.websocket_command(
+    {
+        vol.Required("type"): "render_template",
+        vol.Required("template"): cv.template,
+        vol.Optional("entity_ids"): cv.entity_ids,
+    }
+)
+def handle_render_template(hass, connection, msg):
+    """Handle render_template command.
+
+    Async friendly.
+    """
+    template = msg["template"]
+    if template is not None:
+        template.hass = hass
+
+        entity_ids = msg.get("entity_ids")
+        if entity_ids is None:
+            entity_ids = list(set(template.extract_entities()))
+
+        @callback
+        def state_listener(entity, old_state, new_state):
+            connection.send_message(
+                messages.event_message(msg["id"], {"result": template.async_render()})
+            )
+
+        connection.subscriptions[msg["id"]] = async_track_state_change(
+            hass, entity_ids, state_listener
+        )
+
+        connection.send_message(messages.result_message(msg["id"]))
+        state_listener(None, None, None)
+    else:
+        connection.send_message(messages.result_message(msg["id"]))

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -228,13 +228,6 @@ def handle_render_template(hass, connection, msg):
     entity_ids = msg.get("entity_ids")
     if entity_ids is None:
         entity_ids = template.extract_entities(variables)
-    if entity_ids == MATCH_ALL:
-        connection.send_error(
-            msg["id"],
-            const.ERR_UNAUTHORIZED,
-            "Updating on all state changes not allowed",
-        )
-        return
 
     @callback
     def state_listener(*_):
@@ -244,9 +237,10 @@ def handle_render_template(hass, connection, msg):
             )
         )
 
-    connection.subscriptions[msg["id"]] = async_track_state_change(
-        hass, entity_ids, state_listener
-    )
+    if entity_ids and entity_ids != MATCH_ALL:
+        connection.subscriptions[msg["id"]] = async_track_state_change(
+            hass, entity_ids, state_listener
+        )
 
     connection.send_result(msg["id"])
     state_listener()

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -241,6 +241,8 @@ def handle_render_template(hass, connection, msg):
         connection.subscriptions[msg["id"]] = async_track_state_change(
             hass, entity_ids, state_listener
         )
+    else:
+        connection.subscriptions[msg["id"]] = lambda: None
 
     connection.send_result(msg["id"])
     state_listener()

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -227,7 +227,14 @@ def handle_render_template(hass, connection, msg):
 
     entity_ids = msg.get("entity_ids")
     if entity_ids is None:
-        entity_ids = list(set(template.extract_entities(variables)))
+        entity_ids = template.extract_entities(variables)
+    if entity_ids == MATCH_ALL:
+        connection.send_error(
+            msg["id"],
+            const.ERR_UNAUTHORIZED,
+            "Updating on all state changes not allowed",
+        )
+        return
 
     @callback
     def state_listener(*_):
@@ -241,5 +248,5 @@ def handle_render_template(hass, connection, msg):
         hass, entity_ids, state_listener
     )
 
-    connection.send_message(messages.result_message(msg["id"]))
+    connection.send_result(msg["id"])
     state_listener()

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -389,3 +389,71 @@ async def test_subscribe_unsubscribe_events_state_changed(
     assert msg["type"] == "event"
     assert msg["event"]["event_type"] == "state_changed"
     assert msg["event"]["data"]["entity_id"] == "light.permitted"
+
+
+async def test_render_template_renders_template(
+    hass, websocket_client, hass_admin_user
+):
+    """Test simple template is rendered and updated."""
+    hass.states.async_set("light.test", "on")
+
+    await websocket_client.send_json(
+        {
+            "id": 5,
+            "type": "render_template",
+            "template": "State is: {{ states('light.test') }}",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    event = msg["event"]
+    assert event == {"result": "State is: on"}
+
+    hass.states.async_set("light.test", "off")
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    event = msg["event"]
+    assert event == {"result": "State is: off"}
+
+
+async def test_render_template_with_manual_entity_ids(
+    hass, websocket_client, hass_admin_user
+):
+    """Test that updates to specified entity ids cause a template rerender."""
+    hass.states.async_set("light.test", "on")
+    hass.states.async_set("light.test2", "on")
+
+    await websocket_client.send_json(
+        {
+            "id": 5,
+            "type": "render_template",
+            "template": "State is: {{ states('light.test') }}",
+            "entity_ids": ["light.test2"],
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    event = msg["event"]
+    assert event == {"result": "State is: on"}
+
+    hass.states.async_set("light.test2", "off")
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "event"
+    event = msg["event"]
+    assert event == {"result": "State is: on"}

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -457,3 +457,17 @@ async def test_render_template_with_manual_entity_ids(
     assert msg["type"] == "event"
     event = msg["event"]
     assert event == {"result": "State is: on"}
+
+
+async def test_render_template_returns_with_match_all(
+    hass, websocket_client, hass_admin_user
+):
+    """Test that a template that would match with all entities still return success."""
+    await websocket_client.send_json(
+        {"id": 5, "type": "render_template", "template": "State is: {{ 42 }}"}
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]


### PR DESCRIPTION
## Description:

Add a websocket command for rendering jinja2 templates. Subscribing to this will send a message with the rendered template whenever it needs updating.

Will be used for the markdown-card in lovelace.  
Marked WIP until this is done and tested.

I have used an `event_message` to return the rendered template. Perhaps it should be a new message type instead (maybe even defined in `commands.py`, like the pong message)?

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
