### PR TITLE
Add usb_path to Z-Wave network_status websocket response

### DIFF
--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -7,7 +7,14 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import callback
 
-from .const import CONF_USB_STICK_PATH, DATA_NETWORK, DATA_ZWAVE_CONFIG
+from .const import (
+    CONF_AUTOHEAL,
+    CONF_DEBUG,
+    CONF_POLLING_INTERVAL,
+    CONF_USB_STICK_PATH,
+    DATA_NETWORK,
+    DATA_ZWAVE_CONFIG,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +35,15 @@ def websocket_network_status(hass, connection, msg):
 def websocket_get_config(hass, connection, msg):
     """Get Z-Wave configuration."""
     config = hass.data[DATA_ZWAVE_CONFIG]
-    connection.send_result(msg[ID], {CONF_USB_STICK_PATH: config[CONF_USB_STICK_PATH]})
+    connection.send_result(
+        msg[ID],
+        {
+            CONF_AUTOHEAL: config[CONF_AUTOHEAL],
+            CONF_DEBUG: config[CONF_DEBUG],
+            CONF_POLLING_INTERVAL: config[CONF_POLLING_INTERVAL],
+            CONF_USB_STICK_PATH: config[CONF_USB_STICK_PATH],
+        },
+    )
 
 
 @callback

--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import callback
 
-from .const import DATA_NETWORK
+from .const import CONF_USB_STICK_PATH, DATA_NETWORK, DATA_ZWAVE_CONFIG
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,7 +20,13 @@ ID = "id"
 def websocket_network_status(hass, connection, msg):
     """Get Z-Wave network status."""
     network = hass.data[DATA_NETWORK]
-    connection.send_result(msg[ID], {"state": network.state})
+    connection.send_result(
+        msg[ID],
+        {
+            "state": network.state,
+            CONF_USB_STICK_PATH: hass.data[DATA_ZWAVE_CONFIG][CONF_USB_STICK_PATH],
+        },
+    )
 
 
 @callback

--- a/homeassistant/components/zwave/websocket_api.py
+++ b/homeassistant/components/zwave/websocket_api.py
@@ -20,16 +20,19 @@ ID = "id"
 def websocket_network_status(hass, connection, msg):
     """Get Z-Wave network status."""
     network = hass.data[DATA_NETWORK]
-    connection.send_result(
-        msg[ID],
-        {
-            "state": network.state,
-            CONF_USB_STICK_PATH: hass.data[DATA_ZWAVE_CONFIG][CONF_USB_STICK_PATH],
-        },
-    )
+    connection.send_result(msg[ID], {"state": network.state})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required(TYPE): "zwave/get_config"})
+def websocket_get_config(hass, connection, msg):
+    """Get Z-Wave configuration."""
+    config = hass.data[DATA_ZWAVE_CONFIG]
+    connection.send_result(msg[ID], {CONF_USB_STICK_PATH: config[CONF_USB_STICK_PATH]})
 
 
 @callback
 def async_load_websocket_api(hass):
     """Set up the web socket API."""
     websocket_api.async_register_command(hass, websocket_network_status)
+    websocket_api.async_register_command(hass, websocket_get_config)

--- a/tests/components/zwave/test_websocket_api.py
+++ b/tests/components/zwave/test_websocket_api.py
@@ -1,0 +1,38 @@
+"""Test Z-Wave Websocket API."""
+from homeassistant.bootstrap import async_setup_component
+
+from homeassistant.components.zwave.const import (
+    CONF_USB_STICK_PATH,
+    CONF_AUTOHEAL,
+    CONF_POLLING_INTERVAL,
+)
+from homeassistant.components.zwave.websocket_api import ID, TYPE
+
+
+async def test_zwave_ws_api(hass, mock_openzwave, hass_ws_client):
+    """Test Z-Wave websocket API."""
+
+    await async_setup_component(
+        hass,
+        "zwave",
+        {
+            "zwave": {
+                CONF_AUTOHEAL: False,
+                CONF_USB_STICK_PATH: "/dev/zwave",
+                CONF_POLLING_INTERVAL: 6000,
+            }
+        },
+    )
+
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({ID: 5, TYPE: "zwave/get_config"})
+
+    msg = await client.receive_json()
+    result = msg["result"]
+
+    assert result[CONF_USB_STICK_PATH] == "/dev/zwave"
+    assert not result[CONF_AUTOHEAL]
+    assert result[CONF_POLLING_INTERVAL] == 6000


### PR DESCRIPTION
## Description:
Adds the `usb_path` to the `network_status` websocket response for Z-Wave. Will be used to show the USB stick path in the Z-Wave configuration panel in the frontend.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
