### PR TITLE
 Enable cert_expiry config entries 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -93,6 +93,7 @@ omit =
     homeassistant/components/canary/camera.py
     homeassistant/components/cast/*
     homeassistant/components/cert_expiry/sensor.py
+    homeassistant/components/cert_expiry/helper.py
     homeassistant/components/channels/media_player.py
     homeassistant/components/cisco_ios/device_tracker.py
     homeassistant/components/cisco_mobility_express/device_tracker.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,6 +46,7 @@ homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
 homeassistant/components/buienradar/* @mjj4791 @ties
+homeassistant/components/cert_expiry/* @cereal2nd
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/homeassistant/components/cert_expiry/.translations/en.json
+++ b/homeassistant/components/cert_expiry/.translations/en.json
@@ -4,7 +4,10 @@
             "host_port_exists": "This host and port combination is already configured"
         },
         "error": {
-            "host_port_exists": "This host and port combination is already configured"
+            "certificate_fetch_failed": "Can not fetch certificate from this host and port combination",
+            "connection_timeout": "Timeout whemn connecting to this host",
+            "host_port_exists": "This host and port combination is already configured",
+            "resolve_failed": "This host can not be resolved"
         },
         "step": {
             "user": {

--- a/homeassistant/components/cert_expiry/.translations/en.json
+++ b/homeassistant/components/cert_expiry/.translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "host_port_exists": "This host and port combination is already configured"
+        },
+        "error": {
+            "host_port_exists": "This host and port combination is already configured"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "The hostname of the certificate",
+                    "name": "The name of the certificate",
+                    "port": "The port of the certificate"
+                },
+                "title": "Define the certificate to test"
+            }
+        },
+        "title": "Certificate Expiry"
+    }
+}

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -1,1 +1,34 @@
 """The cert_expiry component."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN
+
+
+async def async_setup(hass, config):
+    """Platform setup, do nothing."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Load the saved entities."""
+    hass.data.setdefault(DOMAIN, {})
+
+    # store the info for later
+    hass.data[DOMAIN][entry.entry_id] = entry
+
+    @callback
+    def async_start(_):
+        """Load the entry after the start event."""
+        for eid in hass.data[DOMAIN]:
+            entry = hass.data[DOMAIN][eid]
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(
+                    entry, 'sensor'))
+        hass.data[DOMAIN] = {}
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start)
+
+    return True

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -25,8 +25,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
         for eid in hass.data[DOMAIN]:
             entry = hass.data[DOMAIN][eid]
             hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(
-                    entry, 'sensor'))
+                hass.config_entries.async_forward_entry_setup(entry, "sensor")
+            )
         hass.data[DOMAIN] = {}
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start)

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -4,8 +4,6 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN
-
 
 async def async_setup(hass, config):
     """Platform setup, do nothing."""
@@ -14,20 +12,13 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Load the saved entities."""
-    hass.data.setdefault(DOMAIN, {})
-
-    # store the info for later
-    hass.data[DOMAIN][entry.entry_id] = entry
 
     @callback
     def async_start(_):
         """Load the entry after the start event."""
-        for eid in hass.data[DOMAIN]:
-            entry = hass.data[DOMAIN][eid]
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, "sensor")
-            )
-        hass.data[DOMAIN] = {}
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, "sensor")
+        )
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start)
 

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -12,8 +12,10 @@ from .const import DOMAIN, DEFAULT_PORT, DEFAULT_NAME
 @callback
 def certexpiry_entries(hass: HomeAssistant):
     """Return the host,port tuples for the domain."""
-    return set((entry.data[CONF_HOST], entry.data[CONF_PORT]) for
-               entry in hass.config_entries.async_entries(DOMAIN))
+    return set(
+        (entry.data[CONF_HOST], entry.data[CONF_PORT])
+        for entry in hass.config_entries.async_entries(DOMAIN)
+    )
 
 
 @config_entries.HANDLERS.register(DOMAIN)
@@ -42,30 +44,25 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow):
             prt = user_input[CONF_PORT]
             if not self._prt_in_configuration_exists(host, prt):
                 return self.async_create_entry(
-                    title=name,
-                    data={
-                        CONF_HOST: host,
-                        CONF_PORT: prt
-                    }
+                    title=name, data={CONF_HOST: host, CONF_PORT: prt}
                 )
-            self._errors[CONF_HOST] = 'host_port_exists'
+            self._errors[CONF_HOST] = "host_port_exists"
         else:
             user_input = {}
             user_input[CONF_NAME] = DEFAULT_NAME
-            user_input[CONF_HOST] = ''
+            user_input[CONF_HOST] = ""
             user_input[CONF_PORT] = DEFAULT_PORT
 
         return self.async_show_form(
-            step_id='user',
-            data_schema=vol.Schema({
-                vol.Required(CONF_NAME,
-                             default=user_input[CONF_NAME]): str,
-                vol.Required(CONF_HOST,
-                             default=user_input[CONF_HOST]): str,
-                vol.Required(CONF_PORT,
-                             default=user_input[CONF_PORT]): int
-            }),
-            errors=self._errors
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=user_input[CONF_NAME]): str,
+                    vol.Required(CONF_HOST, default=user_input[CONF_HOST]): str,
+                    vol.Required(CONF_PORT, default=user_input[CONF_PORT]): int,
+                }
+            ),
+            errors=self._errors,
         )
 
     async def async_step_import(self, user_input=None):
@@ -77,11 +74,7 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow):
         prt = user_input.get(CONF_PORT, DEFAULT_PORT)
         name = user_input.get(CONF_NAME, host)
         if self._prt_in_configuration_exists(host, prt):
-            return self.async_abort(
-                reason='host_port_exists'
-                )
-        return await self.async_step_user({
-            CONF_NAME: name,
-            CONF_HOST: host,
-            CONF_PORT: prt
-            })
+            return self.async_abort(reason="host_port_exists")
+        return await self.async_step_user(
+            {CONF_NAME: name, CONF_HOST: host, CONF_PORT: prt}
+        )

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -1,6 +1,5 @@
 """Config flow for the Cert Expiry platform."""
 import socket
-import ssl
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -9,7 +8,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import slugify
 
 from .const import DOMAIN, DEFAULT_PORT, DEFAULT_NAME
-from .sensor import TIMEOUT
+from .helper import get_cert
 
 
 @callback
@@ -42,11 +41,8 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _test_connection(self, user_input=None):
         """Test connection to the server and try to get the certtificate."""
         try:
-            address = (user_input[CONF_HOST], user_input.get(CONF_PORT, DEFAULT_PORT))
-            with socket.create_connection(address, timeout=TIMEOUT) as sock:
-                ctx = ssl.create_default_context()
-                with ctx.wrap_socket(sock, server_hostname=address[0]):
-                    return True
+            get_cert(user_input[CONF_HOST], user_input.get(CONF_PORT, DEFAULT_PORT))
+            return True
         except socket.gaierror:
             self._errors[CONF_HOST] = "resolve_failed"
         except socket.timeout:

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -1,0 +1,87 @@
+"""Config flow for the Cert Expiry platform."""
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PORT, CONF_NAME, CONF_HOST
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.util import slugify
+
+from .const import DOMAIN, DEFAULT_PORT, DEFAULT_NAME
+
+
+@callback
+def certexpiry_entries(hass: HomeAssistant):
+    """Return the host,port tuples for the domain."""
+    return set((entry.data[CONF_HOST], entry.data[CONF_PORT]) for
+               entry in hass.config_entries.async_entries(DOMAIN))
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class CertexpiryConfigFlow(config_entries.ConfigFlow):
+    """Handle a config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._errors = {}
+
+    def _prt_in_configuration_exists(self, host: str, prt: int) -> bool:
+        """Return True if host, port combination exists in configuration."""
+        if (host, prt) in certexpiry_entries(self.hass):
+            return True
+        return False
+
+    async def async_step_user(self, user_input=None):
+        """Step when user intializes a integration."""
+        self._errors = {}
+        if user_input is not None:
+            name = slugify(user_input[CONF_NAME])
+            host = user_input[CONF_HOST]
+            prt = user_input[CONF_PORT]
+            if not self._prt_in_configuration_exists(host, prt):
+                return self.async_create_entry(
+                    title=name,
+                    data={
+                        CONF_HOST: host,
+                        CONF_PORT: prt
+                    }
+                )
+            self._errors[CONF_HOST] = 'host_port_exists'
+        else:
+            user_input = {}
+            user_input[CONF_NAME] = DEFAULT_NAME
+            user_input[CONF_HOST] = ''
+            user_input[CONF_PORT] = DEFAULT_PORT
+
+        return self.async_show_form(
+            step_id='user',
+            data_schema=vol.Schema({
+                vol.Required(CONF_NAME,
+                             default=user_input[CONF_NAME]): str,
+                vol.Required(CONF_HOST,
+                             default=user_input[CONF_HOST]): str,
+                vol.Required(CONF_PORT,
+                             default=user_input[CONF_PORT]): int
+            }),
+            errors=self._errors
+        )
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry.
+
+        Only host was required in the yaml file all other fields are optional
+        """
+        host = user_input[CONF_HOST]
+        prt = user_input.get(CONF_PORT, DEFAULT_PORT)
+        name = user_input.get(CONF_NAME, host)
+        if self._prt_in_configuration_exists(host, prt):
+            return self.async_abort(
+                reason='host_port_exists'
+                )
+        return await self.async_step_user({
+            CONF_NAME: name,
+            CONF_HOST: host,
+            CONF_PORT: prt
+            })

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -18,8 +18,7 @@ def certexpiry_entries(hass: HomeAssistant):
     )
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class CertexpiryConfigFlow(config_entries.ConfigFlow):
+class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 1
@@ -29,9 +28,9 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow):
         """Initialize the config flow."""
         self._errors = {}
 
-    def _prt_in_configuration_exists(self, host: str, prt: int) -> bool:
+    def _prt_in_configuration_exists(self, host: str, port: int) -> bool:
         """Return True if host, port combination exists in configuration."""
-        if (host, prt) in certexpiry_entries(self.hass):
+        if (host, port) in certexpiry_entries(self.hass):
             return True
         return False
 

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -48,11 +48,11 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 with ctx.wrap_socket(sock, server_hostname=address[0]):
                     return True
         except socket.gaierror:
-            self._errors[CONF_HOST] = 'resolve_failed'
+            self._errors[CONF_HOST] = "resolve_failed"
         except socket.timeout:
-            self._errors[CONF_HOST] = 'connection_timeout'
+            self._errors[CONF_HOST] = "connection_timeout"
         except OSError:
-            self._errors[CONF_HOST] = 'certificate_fetch_failed'
+            self._errors[CONF_HOST] = "certificate_fetch_failed"
         return False
 
     async def async_step_user(self, user_input=None):
@@ -80,9 +80,13 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)): str,
+                    vol.Required(
+                        CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)
+                    ): str,
                     vol.Required(CONF_HOST, default=user_input[CONF_HOST]): str,
-                    vol.Required(CONF_PORT, default=user_input.get(CONF_PORT, DEFAULT_PORT)): int,
+                    vol.Required(
+                        CONF_PORT, default=user_input.get(CONF_PORT, DEFAULT_PORT)
+                    ): int,
                 }
             ),
             errors=self._errors,

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -41,9 +41,9 @@ class CertexpiryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
         if user_input is not None:
             if not self._prt_in_configuration_exists(user_input):
-                name = slugify(user_input[CONF_NAME])
                 host = user_input[CONF_HOST]
-                prt = user_input[CONF_PORT]
+                name = slugify(user_input.get(CONF_NAME, DEFAULT_NAME))
+                prt = user_input.get(CONF_PORT, DEFAULT_PORT)
                 return self.async_create_entry(
                     title=name, data={CONF_HOST: host, CONF_PORT: prt}
                 )

--- a/homeassistant/components/cert_expiry/const.py
+++ b/homeassistant/components/cert_expiry/const.py
@@ -1,5 +1,5 @@
 """Const for Cert Expiry."""
 
 DOMAIN = "cert_expiry"
-DEFAULT_NAME = 'SSL Certificate Expiry'
+DEFAULT_NAME = "SSL Certificate Expiry"
 DEFAULT_PORT = 443

--- a/homeassistant/components/cert_expiry/const.py
+++ b/homeassistant/components/cert_expiry/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "cert_expiry"
 DEFAULT_NAME = "SSL Certificate Expiry"
 DEFAULT_PORT = 443
+TIMEOUT = 10.0

--- a/homeassistant/components/cert_expiry/const.py
+++ b/homeassistant/components/cert_expiry/const.py
@@ -1,0 +1,5 @@
+"""Const for Cert Expiry."""
+
+DOMAIN = "cert_expiry"
+DEFAULT_NAME = 'SSL Certificate Expiry'
+DEFAULT_PORT = 443

--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -8,12 +8,8 @@ from .const import TIMEOUT
 def get_cert(host, port):
     """Get the ssl certificate for the host and port combination."""
     ctx = ssl.create_default_context()
-    try:
-        address = (host, port)
-        with socket.create_connection(address, timeout=TIMEOUT) as sock:
-            with ctx.wrap_socket(sock, server_hostname=address[0]) as ssock:
-                cert = ssock.getpeercert()
-                return cert
-    except Exception as excep:
-        raise excep
-    return None
+    address = (host, port)
+    with socket.create_connection(address, timeout=TIMEOUT) as sock:
+        with ctx.wrap_socket(sock, server_hostname=address[0]) as ssock:
+            cert = ssock.getpeercert()
+            return cert

--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -1,0 +1,19 @@
+"""Helper functions for the Cert Expiry platform."""
+import socket
+import ssl
+
+from .const import TIMEOUT
+
+
+def get_cert(host, port):
+    """Get the ssl certificate for the host and port combination."""
+    ctx = ssl.create_default_context()
+    try:
+        address = (host, port)
+        with socket.create_connection(address, timeout=TIMEOUT) as sock:
+            with ctx.wrap_socket(sock, server_hostname=address[0]) as ssock:
+                cert = ssock.getpeercert()
+                return cert
+    except Exception as excep:
+        raise excep
+    return None

--- a/homeassistant/components/cert_expiry/manifest.json
+++ b/homeassistant/components/cert_expiry/manifest.json
@@ -3,6 +3,7 @@
   "name": "Cert expiry",
   "documentation": "https://www.home-assistant.io/components/cert_expiry",
   "requirements": [],
+  "config_flow": true,
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/cert_expiry/manifest.json
+++ b/homeassistant/components/cert_expiry/manifest.json
@@ -1,9 +1,9 @@
 {
-  "domain": "cert_expiry",
-  "name": "Cert expiry",
-  "documentation": "https://www.home-assistant.io/components/cert_expiry",
-  "requirements": [],
-  "config_flow": true,
-  "dependencies": [],
-  "codeowners": []
+    "domain": "cert_expiry",
+    "name": "Cert expiry",
+    "documentation": "https://www.home-assistant.io/components/cert_expiry",
+    "requirements": [],
+    "config_flow": true,
+    "dependencies": [],
+    "codeowners": [],
 }

--- a/homeassistant/components/cert_expiry/manifest.json
+++ b/homeassistant/components/cert_expiry/manifest.json
@@ -5,5 +5,5 @@
     "requirements": [],
     "config_flow": true,
     "dependencies": [],
-    "codeowners": []
+    "codeowners": ["@cereal2nd"]
 }

--- a/homeassistant/components/cert_expiry/manifest.json
+++ b/homeassistant/components/cert_expiry/manifest.json
@@ -5,5 +5,5 @@
     "requirements": [],
     "config_flow": true,
     "dependencies": [],
-    "codeowners": [],
+    "codeowners": []
 }

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -28,15 +28,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up certificate expiry sensor."""
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config)
         )
     )
-    return True
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -19,9 +19,6 @@ from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT
 
-DEFAULT_NAME = "SSL Certificate Expiry"
-DEFAULT_PORT = 443
-
 SCAN_INTERVAL = timedelta(hours=12)
 
 TIMEOUT = 10.0
@@ -37,19 +34,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up certificate expiry sensor."""
-
-    def run_setup(event):
-        """Wait until Home Assistant is fully initialized before creating.
-
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
+        )
+    )
     return True
 
-        add_entities([SSLCertificate(sensor_name, server_name, server_port)], True)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Add cert-expiry entry."""
-    async_add_entities([SSLCertificate(
-        entry.title, entry.data[CONF_HOST], entry.data[CONF_PORT])],
-                       True)
+    async_add_entities(
+        [SSLCertificate(entry.title, entry.data[CONF_HOST], entry.data[CONF_PORT])],
+        True,
+    )
+    return True
 
 
 class SSLCertificate(Entity):

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -13,11 +13,12 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_HOST,
     CONF_PORT,
-    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT
+
+_LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(hours=12)
 
@@ -36,7 +37,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up certificate expiry sensor."""
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
         )
     )
     return True

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -9,11 +9,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_HOST,
-    CONF_PORT,
-)
+from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_NAME,
@@ -16,7 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity import Entity
 
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT
 
 DEFAULT_NAME = "SSL Certificate Expiry"
 DEFAULT_PORT = 443
@@ -40,16 +41,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     def run_setup(event):
         """Wait until Home Assistant is fully initialized before creating.
 
-        Delay the setup until Home Assistant is fully initialized.
-        """
-        server_name = config.get(CONF_HOST)
-        server_port = config.get(CONF_PORT)
-        sensor_name = config.get(CONF_NAME)
+    return True
 
         add_entities([SSLCertificate(sensor_name, server_name, server_port)], True)
 
-    # To allow checking of the HA certificate we must first be running.
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Add cert-expiry entry."""
+    async_add_entities([SSLCertificate(
+        entry.title, entry.data[CONF_HOST], entry.data[CONF_PORT])],
+                       True)
 
 
 class SSLCertificate(Entity):

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -13,12 +13,11 @@ from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT
+from .helper import get_cert
 
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(hours=12)
-
-TIMEOUT = 10.0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -85,13 +84,8 @@ class SSLCertificate(Entity):
 
     def update(self):
         """Fetch the certificate information."""
-        ctx = ssl.create_default_context()
         try:
-            address = (self.server_name, self.server_port)
-            with socket.create_connection(address, timeout=TIMEOUT) as sock:
-                with ctx.wrap_socket(sock, server_hostname=address[0]) as ssock:
-                    cert = ssock.getpeercert()
-
+            cert = get_cert(self.server_name, self.server_port)
         except socket.gaierror:
             _LOGGER.error("Cannot resolve hostname: %s", self.server_name)
             self._available = False

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -28,6 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up certificate expiry sensor."""
     hass.async_create_task(

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -12,7 +12,10 @@
             }
         },
         "error": {
-            "host_port_exists": "This host and port combination is already configured"
+            "host_port_exists": "This host and port combination is already configured",
+            "resolve_failed": "This host can not be resolved",
+            "connection_timeout": "Timeout whemn connecting to this host",
+            "certificate_fetch_failed": "Can not fetch certificate from this host and port combination"
         },
         "abort": {
             "host_port_exists": "This host and port combination is already configured"

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -2,20 +2,20 @@
     "config": {
         "title": "Certificate Expiry",
         "step": {
-          "user": {
-            "title": "Define the certificate to test",
-            "data": {
-                "name": "The name of the certificate",
-                "host": "The hostname of the certificate",
-                "port": "The port of the certificate"
+            "user": {
+                "title": "Define the certificate to test",
+                "data": {
+                    "name": "The name of the certificate",
+                    "host": "The hostname of the certificate",
+                    "port": "The port of the certificate",
+                },
             }
-          }
         },
         "error": {
-          "host_port_exists": "This host and port combination is already configured"
+            "host_port_exists": "This host and port combination is already configured"
         },
         "abort": {
-          "host_port_exists": "This host and port combination is already configured"
-        }
+            "host_port_exists": "This host and port combination is already configured"
+        },
     }
 }

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "title": "Certificate Expiry",
+        "step": {
+          "user": {
+            "title": "Define the certificate to test",
+            "data": {
+                "name": "The name of the certificate",
+                "host": "The hostname of the certificate",
+                "port": "The port of the certificate"
+            }
+          }
+        },
+        "error": {
+          "host_port_exists": "This host and port combination is already configured"
+        },
+        "abort": {
+          "host_port_exists": "This host and port combination is already configured"
+        }
+    }
+}

--- a/homeassistant/components/cert_expiry/strings.json
+++ b/homeassistant/components/cert_expiry/strings.json
@@ -7,8 +7,8 @@
                 "data": {
                     "name": "The name of the certificate",
                     "host": "The hostname of the certificate",
-                    "port": "The port of the certificate",
-                },
+                    "port": "The port of the certificate"
+                }
             }
         },
         "error": {
@@ -16,6 +16,6 @@
         },
         "abort": {
             "host_port_exists": "This host and port combination is already configured"
-        },
+        }
     }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -10,6 +10,7 @@ FLOWS = [
     "ambient_station",
     "axis",
     "cast",
+    "cert_expiry",
     "daikin",
     "deconz",
     "dialogflow",

--- a/tests/components/cert_expiry/__init__.py
+++ b/tests/components/cert_expiry/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Cert Expiry component."""

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_import(hass):
     assert result["data"][CONF_HOST] == HOST
     assert result["data"][CONF_PORT] == DEFAULT_PORT
 
-    # import with only host
+    # import with host and name
     result = await flow.async_step_import({CONF_HOST: HOST, CONF_NAME: NAME})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "cert_expiry_test_1_2_3"

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -1,0 +1,99 @@
+"""Tests for the Cert Expiry config flow."""
+from homeassistant import data_entry_flow
+from homeassistant.components.cert_expiry import config_flow
+from homeassistant.components.cert_expiry.const import DEFAULT_PORT
+from homeassistant.const import CONF_PORT, CONF_NAME, CONF_HOST
+
+from tests.common import MockConfigEntry
+
+NAME = 'Cert Expiry test 1 2 3'
+PORT = 445
+HOST = 'google.com'
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    flow = config_flow.CertexpiryConfigFlow()
+    flow.hass = hass
+    return flow
+
+
+async def test_user(hass):
+    """Test user config."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user()
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'user'
+
+    # tets with all provided
+    result = await flow.async_step_user({
+        CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['title'] == 'cert_expiry_test_1_2_3'
+    assert result['data'][CONF_HOST] == HOST
+    assert result['data'][CONF_PORT] == PORT
+
+
+async def test_import(hass):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with only host
+    result = await flow.async_step_import({CONF_HOST: HOST})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['title'] == 'google_com'
+    assert result['data'][CONF_HOST] == HOST
+    assert result['data'][CONF_PORT] == DEFAULT_PORT
+
+    # import with only host
+    result = await flow.async_step_import({CONF_HOST: HOST, CONF_NAME: NAME})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['title'] == 'cert_expiry_test_1_2_3'
+    assert result['data'][CONF_HOST] == HOST
+    assert result['data'][CONF_PORT] == DEFAULT_PORT
+
+    # improt with host and port
+    result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['title'] == 'google_com'
+    assert result['data'][CONF_HOST] == HOST
+    assert result['data'][CONF_PORT] == PORT
+
+    # import with all
+    result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT,
+                                           CONF_NAME: NAME})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['title'] == 'cert_expiry_test_1_2_3'
+    assert result['data'][CONF_HOST] == HOST
+    assert result['data'][CONF_PORT] == PORT
+
+
+async def test_abort_if_already_setup(hass):
+    """Test we abort if Daikin is already setup."""
+    pass
+    flow = init_config_flow(hass)
+    MockConfigEntry(domain='cert_expiry',
+                    data={CONF_PORT: DEFAULT_PORT,
+                          CONF_NAME: NAME,
+                          CONF_HOST: HOST}).add_to_hass(hass)
+
+    # Should fail, same HOST and PORT (default)
+    result = await flow.async_step_import(
+        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result['reason'] == 'host_port_exists'
+
+    # Should  same HOST and PORT (default)
+    result = await flow.async_step_user(
+        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['errors'] == {CONF_HOST: 'host_port_exists'}
+
+    # SHOULD pass, same Host diff PORT
+    result = await flow.async_step_import(
+        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: 888})
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['title'] == 'cert_expiry_test_1_2_3'
+    assert result['data'][CONF_HOST] == HOST
+    assert result['data'][CONF_PORT] == 888

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -6,9 +6,9 @@ from homeassistant.const import CONF_PORT, CONF_NAME, CONF_HOST
 
 from tests.common import MockConfigEntry
 
-NAME = 'Cert Expiry test 1 2 3'
+NAME = "Cert Expiry test 1 2 3"
 PORT = 445
-HOST = 'google.com'
+HOST = "google.com"
 
 
 def init_config_flow(hass):
@@ -23,16 +23,17 @@ async def test_user(hass):
     flow = init_config_flow(hass)
 
     result = await flow.async_step_user()
-    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-    assert result['step_id'] == 'user'
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
 
     # tets with all provided
-    result = await flow.async_step_user({
-        CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == 'cert_expiry_test_1_2_3'
-    assert result['data'][CONF_HOST] == HOST
-    assert result['data'][CONF_PORT] == PORT
+    result = await flow.async_step_user(
+        {CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
 
 
 async def test_import(hass):
@@ -41,59 +42,63 @@ async def test_import(hass):
 
     # import with only host
     result = await flow.async_step_import({CONF_HOST: HOST})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == 'google_com'
-    assert result['data'][CONF_HOST] == HOST
-    assert result['data'][CONF_PORT] == DEFAULT_PORT
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "google_com"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
 
     # import with only host
     result = await flow.async_step_import({CONF_HOST: HOST, CONF_NAME: NAME})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == 'cert_expiry_test_1_2_3'
-    assert result['data'][CONF_HOST] == HOST
-    assert result['data'][CONF_PORT] == DEFAULT_PORT
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
 
     # improt with host and port
     result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == 'google_com'
-    assert result['data'][CONF_HOST] == HOST
-    assert result['data'][CONF_PORT] == PORT
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "google_com"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
 
     # import with all
-    result = await flow.async_step_import({CONF_HOST: HOST, CONF_PORT: PORT,
-                                           CONF_NAME: NAME})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == 'cert_expiry_test_1_2_3'
-    assert result['data'][CONF_HOST] == HOST
-    assert result['data'][CONF_PORT] == PORT
+    result = await flow.async_step_import(
+        {CONF_HOST: HOST, CONF_PORT: PORT, CONF_NAME: NAME}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
 
 
 async def test_abort_if_already_setup(hass):
     """Test we abort if Daikin is already setup."""
     pass
     flow = init_config_flow(hass)
-    MockConfigEntry(domain='cert_expiry',
-                    data={CONF_PORT: DEFAULT_PORT,
-                          CONF_NAME: NAME,
-                          CONF_HOST: HOST}).add_to_hass(hass)
+    MockConfigEntry(
+        domain="cert_expiry",
+        data={CONF_PORT: DEFAULT_PORT, CONF_NAME: NAME, CONF_HOST: HOST},
+    ).add_to_hass(hass)
 
     # Should fail, same HOST and PORT (default)
     result = await flow.async_step_import(
-        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result['reason'] == 'host_port_exists'
+        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "host_port_exists"
 
     # Should  same HOST and PORT (default)
     result = await flow.async_step_user(
-        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-    assert result['errors'] == {CONF_HOST: 'host_port_exists'}
+        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "host_port_exists"}
 
     # SHOULD pass, same Host diff PORT
     result = await flow.async_step_import(
-        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: 888})
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == 'cert_expiry_test_1_2_3'
-    assert result['data'][CONF_HOST] == HOST
-    assert result['data'][CONF_PORT] == 888
+        {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: 888}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "cert_expiry_test_1_2_3"
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == 888

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -18,7 +18,10 @@ HOST = "example.com"
 @pytest.fixture(name="test_connect")
 def mock_controller():
     """Mock a successfull _prt_in_configuration_exists."""
-    with patch("homeassistant.components.cert_expiry.config_flow.CertexpiryConfigFlow._test_connection", return_value=True):
+    with patch(
+        "homeassistant.components.cert_expiry.config_flow.CertexpiryConfigFlow._test_connection",
+        return_value=True,
+    ):
         yield
 
 
@@ -119,22 +122,16 @@ async def test_abort_on_socket_failed(hass):
     flow = init_config_flow(hass)
 
     with patch("socket.create_connection", side_effect=socket.gaierror()):
-        result = await flow.async_step_user(
-            {CONF_HOST: HOST}
-        )
+        result = await flow.async_step_user({CONF_HOST: HOST})
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {CONF_HOST: "resolve_failed"}
 
     with patch("socket.create_connection", side_effect=socket.timeout()):
-        result = await flow.async_step_user(
-            {CONF_HOST: HOST}
-        )
+        result = await flow.async_step_user({CONF_HOST: HOST})
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {CONF_HOST: "connection_timeout"}
 
     with patch("socket.create_connection", side_effect=OSError()):
-        result = await flow.async_step_user(
-            {CONF_HOST: HOST}
-        )
+        result = await flow.async_step_user({CONF_HOST: HOST})
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {CONF_HOST: "certificate_fetch_failed"}

--- a/tests/components/cert_expiry/test_config_flow.py
+++ b/tests/components/cert_expiry/test_config_flow.py
@@ -72,8 +72,7 @@ async def test_import(hass):
 
 
 async def test_abort_if_already_setup(hass):
-    """Test we abort if Daikin is already setup."""
-    pass
+    """Test we abort if the cert is already setup."""
     flow = init_config_flow(hass)
     MockConfigEntry(
         domain="cert_expiry",
@@ -87,7 +86,7 @@ async def test_abort_if_already_setup(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "host_port_exists"
 
-    # Should  same HOST and PORT (default)
+    # Should be the same HOST and PORT (default)
     result = await flow.async_step_user(
         {CONF_HOST: HOST, CONF_NAME: NAME, CONF_PORT: DEFAULT_PORT}
     )


### PR DESCRIPTION
## Description:

This enables config entries for the cert_expiry component

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10241

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
