### PR TITLE
UniFi - Handle disabled devices

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -304,7 +304,7 @@ class UniFiDeviceTracker(ScannerEntity):
     @property
     def available(self) -> bool:
         """Return if controller is available."""
-        return self.controller.available
+        return not self.device.disabled and self.controller.available
 
     @property
     def device_info(self):

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/unifi",
   "requirements": [
-    "aiounifi==8"
+    "aiounifi==9"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -169,7 +169,7 @@ aiopvapi==1.6.14
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==8
+aiounifi==9
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -68,7 +68,7 @@ aionotion==1.1.0
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==8
+aiounifi==9
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -203,6 +203,16 @@ async def test_tracked_devices(hass, mock_controller):
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1.state == "home"
 
+    device_1_copy = copy(DEVICE_1)
+    device_1_copy["disabled"] = True
+    mock_controller.mock_client_responses.append({})
+    mock_controller.mock_device_responses.append([device_1_copy])
+    await mock_controller.async_update()
+    await hass.async_block_till_done()
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1.state == "unavailable"
+
 
 async def test_restoring_client(hass, mock_controller):
     """Test the update_items function with some clients."""


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #25623

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
