### PR TITLE
Fix test_install_existing_package

### DIFF
--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -11,12 +11,7 @@ from homeassistant.requirements import (
     _install,
 )
 
-from tests.common import (
-    get_test_home_assistant,
-    MockModule,
-    mock_coro,
-    mock_integration,
-)
+from tests.common import get_test_home_assistant, MockModule, mock_integration
 
 
 class TestRequirements:
@@ -77,7 +72,7 @@ class TestRequirements:
 async def test_install_existing_package(hass):
     """Test an install attempt on an existing package."""
     with patch(
-        "homeassistant.util.package.install_package", return_value=mock_coro(True)
+        "homeassistant.util.package.install_package", return_value=True
     ) as mock_inst:
         assert await async_process_requirements(
             hass, "test_component", ["hello==1.0.0"]


### PR DESCRIPTION
## Description:
homeassistant.util.package.install_package is not
a corutine.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
