### PR TITLE
Fix polling HomeKit devices with multiple services per accessory

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -124,7 +124,7 @@ class HomeKitEntity(Entity):
             if "value" not in result:
                 continue
 
-            # Unknown iid - this is probably for a sibling service thats part
+            # Unknown iid - this is probably for a sibling service that is part
             # of the same physical accessory. Ignore it.
             if iid not in self._char_names:
                 continue

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -120,13 +120,21 @@ class HomeKitEntity(Entity):
         """Collect new data from bridge and update the entity state in hass."""
         accessory_state = self._accessory.current_state.get(self._aid, {})
         for iid, result in accessory_state.items():
+            # No value so dont process this result
             if "value" not in result:
                 continue
+
+            # Unknown iid - this is probably for a sibling service thats part
+            # of the same physical accessory. Ignore it.
+            if iid not in self._char_names:
+                continue
+
             # Callback to update the entity with this characteristic value
             char_name = escape_characteristic_name(self._char_names[iid])
             update_fn = getattr(self, "_update_{}".format(char_name), None)
             if not update_fn:
                 continue
+
             # pylint: disable=not-callable
             update_fn(result["value"])
 


### PR DESCRIPTION
## Description:

While testing the new beta to see if #25249 helped with scaling and stability issues with many homekit entities @niemyjski reported seeing this traceback:

```
2019-08-01 07:54:51 ERROR (MainThread) [homeassistant.components.homekit_controller] Exception in async_state_changed when dispatching 'homekit_controller_43:0A:AB:59:F0:BC_state_updated': ()
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/homekit_controller/__init__.py", line 126, in async_state_changed
    char_name = escape_characteristic_name(self._char_names[iid])
KeyError: 66
```

HomeKit accessories are made up of Accessories, Services and Characteristics. Most of the devices i work with are either a single accessory with a single service or for a bridge like Hue, many accessories each with a single service. But there are also devices with many accessories and many services and also 1 accessory with many services. Sensors often have CO2, temperature and humidity as a single accessory with multiple services.

The code in #25249 didn't adequately consider these devices and failed when encountering a characteristic from another service on the same accessory. This PR handles that case.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
