### PR TITLE
Bump homekit dependency to 0.15

### DIFF
--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/homekit_controller",
   "requirements": [
-    "homekit[IP]==0.14.0"
+    "homekit[IP]==0.15.0"
   ],
   "dependencies": [],
   "zeroconf": ["_hap._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -628,7 +628,7 @@ home-assistant-frontend==20190731.0
 homeassistant-pyozw==0.1.4
 
 # homeassistant.components.homekit_controller
-homekit[IP]==0.14.0
+homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -172,7 +172,7 @@ holidays==0.9.11
 home-assistant-frontend==20190731.0
 
 # homeassistant.components.homekit_controller
-homekit[IP]==0.14.0
+homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.9


### PR DESCRIPTION
## Description:

Switch to latest release of the python homekit client. This should fix support for some newer devices we have encountered where extra attributes have been seen on their discovery info.

This one doesn't fix a regression, but it does fix a class of devices that haven't worked before so if possible i'd like to slip it into 0.97 as well.

**Related issue (if applicable):** fixes #25118

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
