### PR TITLE
Add growatt server integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -249,6 +249,7 @@ omit =
     homeassistant/components/greeneye_monitor/sensor.py
     homeassistant/components/greenwave/light.py
     homeassistant/components/group/notify.py
+    homeassistant/components/growatt_server/sensor.py
     homeassistant/components/gstreamer/media_player.py
     homeassistant/components/gtfs/sensor.py
     homeassistant/components/gtt/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -110,6 +110,7 @@ homeassistant/components/google_travel_time/* @robbiet480
 homeassistant/components/googlehome/* @ludeeus
 homeassistant/components/gpsd/* @fabaff
 homeassistant/components/group/* @home-assistant/core
+homeassistant/components/growatt_server/* @indykoning
 homeassistant/components/gtfs/* @robbiet480
 homeassistant/components/harmony/* @ehendrix23
 homeassistant/components/hassio/* @home-assistant/hass-io

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -1,0 +1,1 @@
+"""The Growatt server PV inverter sensor integration."""

--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "growatt_server",
   "name": "Growatt Server",
-  "documentation": "https://github.com/indykoning/home-assistant-growatt-server/blob/master/README.md",
+  "documentation": "https://www.home-assistant.io/components/growatt_server/",
   "requirements": [
     "growattServer==0.0.1"
   ],

--- a/homeassistant/components/growatt_server/manifest.json
+++ b/homeassistant/components/growatt_server/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "growatt_server",
+  "name": "Growatt Server",
+  "documentation": "https://github.com/indykoning/home-assistant-growatt-server/blob/master/README.md",
+  "requirements": [
+    "growattServer==0.0.1"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@indykoning"
+  ]
+}

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -83,7 +83,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # Get a list of inverters for specified plant to add sensors for.
     inverters = api.inverter_list(plant_id)
     entities = []
-    probe = GrowattData(api, plant_id, True)
+    probe = GrowattData(api, username, password, plant_id, True)
     for sensor in TOTAL_SENSOR_TYPES:
         entities.append(
             GrowattInverter(probe, f"{name} Total", sensor, f"{plant_id}-{sensor}")
@@ -91,7 +91,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Add sensors for each inverter in the specified plant.
     for inverter in inverters:
-        probe = GrowattData(api, inverter["deviceSn"], False)
+        probe = GrowattData(api, username, password, inverter["deviceSn"], False)
         for sensor in INVERTER_SENSOR_TYPES:
             entities.append(
                 GrowattInverter(
@@ -154,18 +154,20 @@ class GrowattInverter(Entity):
 class GrowattData:
     """The class for handling data retrieval."""
 
-    def __init__(self, api, inverter_id, is_total=False):
+    def __init__(self, api, username, password, inverter_id, is_total=False):
         """Initialize the probe."""
 
         self.is_total = is_total
         self.api = api
         self.inverter_id = inverter_id
         self.data = {}
+        self.username = username
+        self.password = password
 
     @Throttle(SCAN_INTERVAL)
     def update(self):
         """Update probe data."""
-
+        self.api.login(self.username, self.password)
         _LOGGER.debug("Updating data for %s", self.inverter_id)
         try:
             if self.is_total:

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -5,8 +5,8 @@ import logging
 import datetime
 
 import growattServer
-
 import voluptuous as vol
+
 from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
@@ -21,32 +21,32 @@ DEFAULT_NAME = "Growatt"
 SCAN_INTERVAL = datetime.timedelta(minutes=5)
 
 TOTAL_SENSOR_TYPES = {
-    "total_money_today": ("Total money today", "€", "plantMoneyText"),
-    "total_money_total": ("Money lifetime", "€", "totalMoneyText"),
-    "total_energy_today": ("Energy Today", "kWh", "todayEnergy"),
-    "total_output_power": ("Output Power", "W", "invTodayPpv"),
-    "total_energy_output": ("Lifetime energy output", "kWh", "totalEnergy"),
-    "total_maximum_output": ("Maximum power", "W", "nominalPower"),
+    "total_money_today": ("Total money today", "€", "plantMoneyText", None),
+    "total_money_total": ("Money lifetime", "€", "totalMoneyText", None),
+    "total_energy_today": ("Energy Today", "kWh", "todayEnergy", "power"),
+    "total_output_power": ("Output Power", "W", "invTodayPpv", "power"),
+    "total_energy_output": ("Lifetime energy output", "kWh", "totalEnergy", "power"),
+    "total_maximum_output": ("Maximum power", "W", "nominalPower", "power"),
 }
 
 INVERTER_SENSOR_TYPES = {
-    "inverter_energy_today": ("Energy today", "kWh", "e_today"),
-    "inverter_energy_total": ("Lifetime energy output", "kWh", "e_total"),
-    "inverter_voltage_input_1": ("Input 1 voltage", "V", "vpv1"),
-    "inverter_amperage_input_1": ("Input 1 Amperage", "A", "ipv1"),
-    "inverter_wattage_input_1": ("Input 1 Wattage", "W", "ppv1"),
-    "inverter_voltage_input_2": ("Input 2 voltage", "V", "vpv2"),
-    "inverter_amperage_input_2": ("Input 2 Amperage", "A", "ipv2"),
-    "inverter_wattage_input_2": ("Input 2 Wattage", "W", "ppv2"),
-    "inverter_voltage_input_3": ("Input 3 voltage", "V", "vpv3"),
-    "inverter_amperage_input_3": ("Input 3 Amperage", "A", "ipv3"),
-    "inverter_wattage_input_3": ("Input 3 Wattage", "W", "ppv3"),
-    "inverter_internal_wattage": ("Internal wattage", "W", "ppv"),
-    "inverter_reactive_voltage": ("Reactive voltage", "V", "vacr"),
-    "inverter_inverter_reactive_amperage": ("Reactive amperage", "A", "iacr"),
-    "inverter_frequency": ("AC frequency", "Hz", "fac"),
-    "inverter_current_wattage": ("Output power", "W", "pac"),
-    "inverter_current_reactive_wattage": ("Reactive wattage", "W", "pacr"),
+    "inverter_energy_today": ("Energy today", "kWh", "e_today", "power"),
+    "inverter_energy_total": ("Lifetime energy output", "kWh", "e_total", "power"),
+    "inverter_voltage_input_1": ("Input 1 voltage", "V", "vpv1", None),
+    "inverter_amperage_input_1": ("Input 1 Amperage", "A", "ipv1", None),
+    "inverter_wattage_input_1": ("Input 1 Wattage", "W", "ppv1", "power"),
+    "inverter_voltage_input_2": ("Input 2 voltage", "V", "vpv2", None),
+    "inverter_amperage_input_2": ("Input 2 Amperage", "A", "ipv2", None),
+    "inverter_wattage_input_2": ("Input 2 Wattage", "W", "ppv2", "power"),
+    "inverter_voltage_input_3": ("Input 3 voltage", "V", "vpv3", None),
+    "inverter_amperage_input_3": ("Input 3 Amperage", "A", "ipv3", None),
+    "inverter_wattage_input_3": ("Input 3 Wattage", "W", "ppv3", "power"),
+    "inverter_internal_wattage": ("Internal wattage", "W", "ppv", "power"),
+    "inverter_reactive_voltage": ("Reactive voltage", "V", "vacr", None),
+    "inverter_inverter_reactive_amperage": ("Reactive amperage", "A", "iacr", None),
+    "inverter_frequency": ("AC frequency", "Hz", "fac", None),
+    "inverter_current_wattage": ("Output power", "W", "pac", "power"),
+    "inverter_current_reactive_wattage": ("Reactive wattage", "W", "pacr", "power"),
 }
 
 SENSOR_TYPES = {**TOTAL_SENSOR_TYPES, **INVERTER_SENSOR_TYPES}
@@ -139,7 +139,7 @@ class GrowattInverter(Entity):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        return "power"
+        return SENSOR_TYPES[self.sensor][3]
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -117,12 +117,12 @@ class GrowattInverter(Entity):
         self._unique_id = unique_id
 
     @property
-    def unique_id(self):
+    def name(self):
         """Return the name of the sensor."""
         return f"{self._name} {SENSOR_TYPES[self.sensor][0]}"
 
     @property
-    def name(self):
+    def unique_id(self):
         """Return the unique id of the sensor."""
         return self._unique_id
 

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -1,37 +1,35 @@
 """Read status of growatt inverters."""
-import logging
-import voluptuous as vol
-import growattServer
 import datetime
+import logging
+import growattServer
+import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME)
+from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-"""Start the logger"""
+
 _LOGGER = logging.getLogger(__name__)
 
-plant_id = 0
-"""configuration for accessing the Unifi Controller"""
-CONF_USERNAME = 'username'
-CONF_PASSWORD = 'password'
-CONF_PLANT_ID = 'plant_id'
-DEFAULT_UNIT = 'kW'
-DEFAULT_NAME = 'Growatt'
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+CONF_PLANT_ID = "plant_id"
+DEFAULT_UNIT = "kW"
+DEFAULT_NAME = "Growatt"
 SCAN_INTERVAL = datetime.timedelta(minutes=5)
 
-"""Define the schema for the Sensor Platform"""
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_PLANT_ID, default='0'): cv.string,
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PLANT_ID, default="0"): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    }
+)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Growatt sensor."""
-    """get all the parameters passed by the user to access the controller"""
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     plant_id = config.get(CONF_PLANT_ID)
@@ -39,22 +37,35 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     api = growattServer.GrowattApi()
 
-    """Log in to api and fetch first plant if no plant id is defined"""
-    user_id = api.login(username, password)['userId']
-    if plant_id == '0':
+    # Log in to api and fetch first plant if no plant id is defined.
+    user_id = api.login(username, password)["userId"]
+    if plant_id == "0":
         plant_info = api.plant_list(user_id)
-        plant_id = plant_info['data'][0]['plantId']
+        plant_id = plant_info["data"][0]["plantId"]
         pass
 
-    """Get a list of inverters for specified plant to add sensors for."""
+    # Get a list of inverters for specified plant to add sensors for.
     inverters = api.inverter_list(plant_id)
 
-    """Add a sensor for the total of the whole plant"""
-    add_devices([GrowattInverter(api, name + '_Total', plant_id, username, password)], True)
+    # Add a sensor for the total of the whole plant.
+    add_devices(
+        [GrowattInverter(api, name + "_Total", plant_id, username, password)], True
+    )
 
-    """Add sensors for each inverter in the specified plant"""
+    # Add sensors for each inverter in the specified plant.
     for inverter in inverters:
-        add_devices([GrowattInverter(api, name + '_' + inverter['deviceAilas'], inverter['deviceSn'], username, password)], True)
+        add_devices(
+            [
+                GrowattInverter(
+                    api,
+                    name + "_" + inverter["deviceAilas"],
+                    inverter["deviceSn"],
+                    username,
+                    password,
+                )
+            ],
+            True,
+        )
 
 
 class GrowattInverter(Entity):
@@ -67,10 +78,10 @@ class GrowattInverter(Entity):
         self.inverter_id = inverter_id
         self.username = u
         self.password = p
-        self.isTotal = 'Total' in name and inverter_id.isdigit()
+        self.is_total = "Total" in name and inverter_id.isdigit()
         self._state = None
         self.attributes = {}
-        self._unit_of_measurement = 'W'
+        self._unit_of_measurement = "W"
 
     @property
     def name(self):
@@ -91,23 +102,22 @@ class GrowattInverter(Entity):
     def device_state_attributes(self):
         """Return the state attributes of the monitored installation."""
         attributes = self.attributes
-        attributes['icon'] = 'mdi:solar-power'
+        attributes["icon"] = "mdi:solar-power"
         return attributes
 
     def update(self):
         """Get the latest data from the Growat API and updates the state."""
         try:
             self.api.login(self.username, self.password)
-            if self.isTotal:
+            if self.is_total:
                 total_info = self.api.plant_info(self.inverter_id)
-                del total_info['deviceList']
-                self._state = total_info['invTodayPpv']
+                del total_info["deviceList"]
+                self._state = total_info["invTodayPpv"]
                 self.attributes = total_info
             else:
                 inverter_info = self.api.inverter_detail(self.inverter_id)
 
-                self.attributes = inverter_info['data']
-                self._state = inverter_info['data']['pac']
+                self.attributes = inverter_info["data"]
+                self._state = inverter_info["data"]["pac"]
         except TypeError:
-            _LOGGER.error(
-                "Unable to fetch data from Growatt server. %s")
+            _LOGGER.error("Unable to fetch data from Growatt server. %s")

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -1,0 +1,113 @@
+"""Read status of growatt inverters."""
+import logging
+import voluptuous as vol
+import growattServer
+import datetime
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_NAME)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+"""Start the logger"""
+_LOGGER = logging.getLogger(__name__)
+
+plant_id = 0
+"""configuration for accessing the Unifi Controller"""
+CONF_USERNAME = 'username'
+CONF_PASSWORD = 'password'
+CONF_PLANT_ID = 'plant_id'
+DEFAULT_UNIT = 'kW'
+DEFAULT_NAME = 'Growatt'
+SCAN_INTERVAL = datetime.timedelta(minutes=5)
+
+"""Define the schema for the Sensor Platform"""
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PLANT_ID, default='0'): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Growatt sensor."""
+    """get all the parameters passed by the user to access the controller"""
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    plant_id = config.get(CONF_PLANT_ID)
+    name = config.get(CONF_NAME)
+
+    api = growattServer.GrowattApi()
+
+    """Log in to api and fetch first plant if no plant id is defined"""
+    user_id = api.login(username, password)['userId']
+    if plant_id == '0':
+        plant_info = api.plant_list(user_id)
+        plant_id = plant_info['data'][0]['plantId']
+        pass
+
+    """Get a list of inverters for specified plant to add sensors for."""
+    inverters = api.inverter_list(plant_id)
+
+    """Add a sensor for the total of the whole plant"""
+    add_devices([GrowattInverter(api, name + '_Total', plant_id, username, password)], True)
+
+    """Add sensors for each inverter in the specified plant"""
+    for inverter in inverters:
+        add_devices([GrowattInverter(api, name + '_' + inverter['deviceAilas'], inverter['deviceSn'], username, password)], True)
+
+
+class GrowattInverter(Entity):
+    """Representation of a Growattt Sensor."""
+
+    def __init__(self, api, name, inverter_id, u, p):
+        """Initialize a PVOutput sensor."""
+        self.api = api
+        self._name = name
+        self.inverter_id = inverter_id
+        self.username = u
+        self.password = p
+        self.isTotal = 'Total' in name and inverter_id.isdigit()
+        self._state = None
+        self.attributes = {}
+        self._unit_of_measurement = 'W'
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the monitored installation."""
+        attributes = self.attributes
+        attributes['icon'] = 'mdi:solar-power'
+        return attributes
+
+    def update(self):
+        """Get the latest data from the Growat API and updates the state."""
+        try:
+            self.api.login(self.username, self.password)
+            if self.isTotal:
+                total_info = self.api.plant_info(self.inverter_id)
+                del total_info['deviceList']
+                self._state = total_info['invTodayPpv']
+                self.attributes = total_info
+            else:
+                inverter_info = self.api.inverter_detail(self.inverter_id)
+
+                self.attributes = inverter_info['data']
+                self._state = inverter_info['data']['pac']
+        except TypeError:
+            _LOGGER.error(
+                "Unable to fetch data from Growatt server. %s")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -577,6 +577,9 @@ greeneye_monitor==1.0
 # homeassistant.components.greenwave
 greenwavereality==0.5.1
 
+# homeassistant.components.growatt_server
+growattServer==0.0.1
+
 # homeassistant.components.gstreamer
 gstreamer-player==1.1.2
 


### PR DESCRIPTION
## Description:
Adds intergration for growatt photovoltaic inverters connected to the [growatt server](http://server.growatt.com/)

**Related issue (if applicable):** [community post](https://community.home-assistant.io/t/anyone-experience-with-connecting-a-growatt-solar-inverter/60430/28)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10032

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: growatt_server
    username: <growatt server username>
    password: <growatt server password>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
