### PR TITLE
Add HmIP-SCI to Homematic IP Cloud, Fix HmIP-SWDM

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -11,6 +11,7 @@ from homematicip.aio.device import (
     AsyncPresenceDetectorIndoor,
     AsyncRotaryHandleSensor,
     AsyncShutterContact,
+    AsyncShutterContactMagnetic,
     AsyncSmokeDetector,
     AsyncWaterSensor,
     AsyncWeatherSensor,
@@ -64,10 +65,12 @@ async def async_setup_entry(
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:
-        if isinstance(device, (AsyncContactInterface,
-                               AsyncFullFlushContactInterface)):
+        if isinstance(device, (AsyncContactInterface, AsyncFullFlushContactInterface)):
             devices.append(HomematicipContactInterface(home, device))
-        if isinstance(device, (AsyncShutterContact, AsyncRotaryHandleSensor)):
+        if isinstance(
+            device,
+            (AsyncShutterContact, AsyncShutterContactMagnetic, AsyncRotaryHandleSensor),
+        ):
             devices.append(HomematicipShutterContact(home, device))
         if isinstance(
             device,

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -2,6 +2,7 @@
 import logging
 
 from homematicip.aio.device import (
+    AsyncContactInterface,
     AsyncDevice,
     AsyncFullFlushContactInterface,
     AsyncMotionDetectorIndoor,
@@ -63,7 +64,8 @@ async def async_setup_entry(
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:
-        if isinstance(device, AsyncFullFlushContactInterface):
+        if isinstance(device, (AsyncContactInterface,
+                               AsyncFullFlushContactInterface)):
             devices.append(HomematicipContactInterface(home, device))
         if isinstance(device, (AsyncShutterContact, AsyncRotaryHandleSensor)):
             devices.append(HomematicipShutterContact(home, device))

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/homematicip_cloud",
   "requirements": [
-    "homematicip==0.10.9"
+    "homematicip==0.10.10"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -632,7 +632,7 @@ homeassistant-pyozw==0.1.4
 homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.9
+homematicip==0.10.10
 
 # homeassistant.components.horizon
 horimote==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -180,7 +180,7 @@ home-assistant-frontend==20190731.0
 homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.9
+homematicip==0.10.10
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk


### PR DESCRIPTION
## Description:
Add HmIP-SCI to Homematic IP Cloud
Fix HmIP-SWDM (fix in upstream lib, does not support sabotage)
Bump dependency to 0.10.10

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10033

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
