### PR TITLE
Add PRESET_AWAY to HomematicIP Cloud climate

### DIFF
--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -15,9 +15,9 @@ from homeassistant.components.climate.const import (
     PRESET_AWAY,
     PRESET_BOOST,
     PRESET_ECO,
+    PRESET_NONE,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
-    PRESET_NONE,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
@@ -122,10 +122,14 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
             absence_type = self._home.get_functionalHome(IndoorClimateHome).absenceType
             if absence_type == AbsenceType.VACATION:
                 return PRESET_AWAY
-            if absence_type in [AbsenceType.PERIOD, AbsenceType.PERMANENT]:
+            if absence_type in [
+                AbsenceType.PERIOD,
+                AbsenceType.PERMANENT,
+                AbsenceType.PARTY,
+            ]:
                 return PRESET_ECO
 
-        return None
+        return PRESET_NONE
 
     @property
     def preset_modes(self):

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -5,11 +5,14 @@ from typing import Awaitable
 from homematicip.aio.device import AsyncHeatingThermostat, AsyncHeatingThermostatCompact
 from homematicip.aio.group import AsyncHeatingGroup
 from homematicip.aio.home import AsyncHome
+from homematicip.base.enums import AbsenceType
+from homematicip.functionalHomes import IndoorClimateHome
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
+    PRESET_AWAY,
     PRESET_BOOST,
     PRESET_ECO,
     SUPPORT_PRESET_MODE,
@@ -116,7 +119,11 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         if self._device.boostMode:
             return PRESET_BOOST
         if self._device.controlMode == HMIP_ECO_CM:
-            return PRESET_ECO
+            absence_type = self._home.get_functionalHome(IndoorClimateHome).absenceType
+            if absence_type == AbsenceType.VACATION:
+                return PRESET_AWAY
+            if absence_type in [AbsenceType.PERIOD, AbsenceType.PERMANENT]:
+                return PRESET_ECO
 
         return None
 

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -110,10 +110,13 @@ class HomematicipHAP:
 
         Triggered when the HMIP HOME_CHANGED event has fired.
         There are several occasions for this event to happen.
-        We are only interested to check whether the access point
+        1. We are interested to check whether the access point
         is still connected. If not, device state changes cannot
         be forwarded to hass. So if access point is disconnected all devices
         are set to unavailable.
+        2. We need to update home including devices and groups after a reconnect.
+        3. We need to update home without devices and groups in all other cases.
+
         """
         if not self.home.connected:
             _LOGGER.error("HMIP access point has lost connection with the cloud")
@@ -127,6 +130,12 @@ class HomematicipHAP:
 
             job = self.hass.async_create_task(self.get_state())
             job.add_done_callback(self.get_state_finished)
+            self._accesspoint_connected = True
+        else:
+            # Update home with the given json from arg[0],
+            # without devices and groups.
+
+            self.home.update_home_only(args[0])
 
     async def get_state(self):
         """Update HMIP state and tell Home Assistant."""


### PR DESCRIPTION
## Description:
Add PRESET_AWAY to HomematicIP Cloud.
Vacation can be set by a call service (homematicip_cloud.activate_vacation), and will now displayed by the individual climate entity.

This PR fixes also the missing refresh for HOME.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
