### PR TITLE
UniFi - allow configuration to not track clients or devices

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -11,6 +11,8 @@ from .const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
     CONF_DETECTION_TIME,
+    CONF_DONT_TRACK_CLIENTS,
+    CONF_DONT_TRACK_DEVICES,
     CONF_SITE_ID,
     CONF_SSID_FILTER,
     CONTROLLER_ID,
@@ -28,6 +30,8 @@ CONTROLLER_SCHEMA = vol.Schema(
         vol.Optional(CONF_BLOCK_CLIENT, default=[]): vol.All(
             cv.ensure_list, [cv.string]
         ),
+        vol.Optional(CONF_DONT_TRACK_CLIENTS): cv.boolean,
+        vol.Optional(CONF_DONT_TRACK_DEVICES): cv.boolean,
         vol.Optional(CONF_DETECTION_TIME): vol.All(
             cv.time_period, cv.positive_timedelta
         ),

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -13,6 +13,8 @@ UNIFI_CONFIG = "unifi_config"
 
 CONF_BLOCK_CLIENT = "block_client"
 CONF_DETECTION_TIME = "detection_time"
+CONF_DONT_TRACK_CLIENTS = "dont_track_clients"
+CONF_DONT_TRACK_DEVICES = "dont_track_devices"
 CONF_SSID_FILTER = "ssid_filter"
 
 ATTR_MANUFACTURER = "Ubiquiti Networks"

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -66,16 +66,6 @@ class UniFiController:
         return self.unifi_config.get(CONF_BLOCK_CLIENT, [])
 
     @property
-    def dont_track_clients(self):
-        """Return if clients should be tracked."""
-        return self.unifi_config.get(CONF_DONT_TRACK_CLIENTS, False)
-
-    @property
-    def dont_track_devices(self):
-        """Return if devices should be tracked."""
-        return self.unifi_config.get(CONF_DONT_TRACK_DEVICES, False)
-
-    @property
     def mac(self):
         """Return the mac address of this controller."""
         for client in self.api.clients.values():

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
+    CONF_DONT_TRACK_CLIENTS,
+    CONF_DONT_TRACK_DEVICES,
     CONF_SITE_ID,
     CONTROLLER_ID,
     LOGGER,
@@ -62,6 +64,16 @@ class UniFiController:
     def block_clients(self):
         """Return list of clients to block."""
         return self.unifi_config.get(CONF_BLOCK_CLIENT, [])
+
+    @property
+    def dont_track_clients(self):
+        """Return if clients should be tracked."""
+        return self.unifi_config.get(CONF_DONT_TRACK_CLIENTS, False)
+
+    @property
+    def dont_track_devices(self):
+        """Return if devices should be tracked."""
+        return self.unifi_config.get(CONF_DONT_TRACK_DEVICES, False)
 
     @property
     def mac(self):

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -15,8 +15,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
-    CONF_DONT_TRACK_CLIENTS,
-    CONF_DONT_TRACK_DEVICES,
     CONF_SITE_ID,
     CONTROLLER_ID,
     LOGGER,

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -28,6 +28,8 @@ from .const import (
     ATTR_MANUFACTURER,
     CONF_CONTROLLER,
     CONF_DETECTION_TIME,
+    CONF_DONT_TRACK_CLIENTS,
+    CONF_DONT_TRACK_DEVICES,
     CONF_SITE_ID,
     CONF_SSID_FILTER,
     CONTROLLER_ID,
@@ -154,7 +156,7 @@ def update_items(controller, async_add_entities, tracked):
     """Update tracked device state from the controller."""
     new_tracked = []
 
-    if not controller.dont_track_clients:
+    if not controller.unifi_config.get(CONF_DONT_TRACK_CLIENTS, False):
 
         for client_id in controller.api.clients:
 
@@ -182,7 +184,7 @@ def update_items(controller, async_add_entities, tracked):
                 "New UniFi client tracker %s (%s)", client.hostname, client.mac
             )
 
-    if not controller.dont_track_devices:
+    if not controller.unifi_config.get(CONF_DONT_TRACK_DEVICES, False):
 
         for device_id in controller.api.devices:
 

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -154,46 +154,52 @@ def update_items(controller, async_add_entities, tracked):
     """Update tracked device state from the controller."""
     new_tracked = []
 
-    for client_id in controller.api.clients:
+    if not controller.dont_track_clients:
 
-        if client_id in tracked:
+        for client_id in controller.api.clients:
+
+            if client_id in tracked:
+                LOGGER.debug(
+                    "Updating UniFi tracked client %s (%s)",
+                    tracked[client_id].entity_id,
+                    tracked[client_id].client.mac,
+                )
+                tracked[client_id].async_schedule_update_ha_state()
+                continue
+
+            client = controller.api.clients[client_id]
+
+            if (
+                not client.is_wired
+                and CONF_SSID_FILTER in controller.unifi_config
+                and client.essid not in controller.unifi_config[CONF_SSID_FILTER]
+            ):
+                continue
+
+            tracked[client_id] = UniFiClientTracker(client, controller)
+            new_tracked.append(tracked[client_id])
             LOGGER.debug(
-                "Updating UniFi tracked client %s (%s)",
-                tracked[client_id].entity_id,
-                tracked[client_id].client.mac,
+                "New UniFi client tracker %s (%s)", client.hostname, client.mac
             )
-            tracked[client_id].async_schedule_update_ha_state()
-            continue
 
-        client = controller.api.clients[client_id]
+    if not controller.dont_track_devices:
 
-        if (
-            not client.is_wired
-            and CONF_SSID_FILTER in controller.unifi_config
-            and client.essid not in controller.unifi_config[CONF_SSID_FILTER]
-        ):
-            continue
+        for device_id in controller.api.devices:
 
-        tracked[client_id] = UniFiClientTracker(client, controller)
-        new_tracked.append(tracked[client_id])
-        LOGGER.debug("New UniFi client tracker %s (%s)", client.hostname, client.mac)
+            if device_id in tracked:
+                LOGGER.debug(
+                    "Updating UniFi tracked device %s (%s)",
+                    tracked[device_id].entity_id,
+                    tracked[device_id].device.mac,
+                )
+                tracked[device_id].async_schedule_update_ha_state()
+                continue
 
-    for device_id in controller.api.devices:
+            device = controller.api.devices[device_id]
 
-        if device_id in tracked:
-            LOGGER.debug(
-                "Updating UniFi tracked device %s (%s)",
-                tracked[device_id].entity_id,
-                tracked[device_id].device.mac,
-            )
-            tracked[device_id].async_schedule_update_ha_state()
-            continue
-
-        device = controller.api.devices[device_id]
-
-        tracked[device_id] = UniFiDeviceTracker(device, controller)
-        new_tracked.append(tracked[device_id])
-        LOGGER.debug("New UniFi device tracker %s (%s)", device.name, device.mac)
+            tracked[device_id] = UniFiDeviceTracker(device, controller)
+            new_tracked.append(tracked[device_id])
+            LOGGER.debug("New UniFi device tracker %s (%s)", device.name, device.mac)
 
     if new_tracked:
         async_add_entities(new_tracked)

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -247,7 +247,7 @@ async def test_restoring_client(hass, mock_controller):
 
 
 async def test_dont_track_clients(hass, mock_controller):
-    """Test the update_items function with some clients."""
+    """Test dont track clients config works."""
     mock_controller.mock_client_responses.append([CLIENT_1])
     mock_controller.mock_device_responses.append([DEVICE_1])
     mock_controller.unifi_config = {unifi.CONF_DONT_TRACK_CLIENTS: True}
@@ -265,7 +265,7 @@ async def test_dont_track_clients(hass, mock_controller):
 
 
 async def test_dont_track_devices(hass, mock_controller):
-    """Test the update_items function with some clients."""
+    """Test dont track devices config works."""
     mock_controller.mock_client_responses.append([CLIENT_1])
     mock_controller.mock_device_responses.append([DEVICE_1])
     mock_controller.unifi_config = {unifi.CONF_DONT_TRACK_DEVICES: True}

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
@@ -211,7 +212,7 @@ async def test_tracked_devices(hass, mock_controller):
     await hass.async_block_till_done()
 
     device_1 = hass.states.get("device_tracker.device_1")
-    assert device_1.state == "unavailable"
+    assert device_1.state == STATE_UNAVAILABLE
 
 
 async def test_restoring_client(hass, mock_controller):
@@ -243,3 +244,39 @@ async def test_restoring_client(hass, mock_controller):
 
     device_1 = hass.states.get("device_tracker.client_1")
     assert device_1 is not None
+
+
+async def test_dont_track_clients(hass, mock_controller):
+    """Test the update_items function with some clients."""
+    mock_controller.mock_client_responses.append([CLIENT_1])
+    mock_controller.mock_device_responses.append([DEVICE_1])
+    mock_controller.unifi_config = {unifi.CONF_DONT_TRACK_CLIENTS: True}
+
+    await setup_controller(hass, mock_controller)
+    assert len(mock_controller.mock_requests) == 2
+    assert len(hass.states.async_all()) == 3
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is None
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is not None
+    assert device_1.state == "not_home"
+
+
+async def test_dont_track_devices(hass, mock_controller):
+    """Test the update_items function with some clients."""
+    mock_controller.mock_client_responses.append([CLIENT_1])
+    mock_controller.mock_device_responses.append([DEVICE_1])
+    mock_controller.unifi_config = {unifi.CONF_DONT_TRACK_DEVICES: True}
+
+    await setup_controller(hass, mock_controller)
+    assert len(mock_controller.mock_requests) == 2
+    assert len(hass.states.async_all()) == 3
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+    assert client_1.state == "not_home"
+
+    device_1 = hass.states.get("device_tracker.device_1")
+    assert device_1 is None


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #25638

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10034

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
