### PR TITLE
Bump androidtv to 0.0.21; add 'state_detection_rules' config parameter

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.19"
+    "androidtv==0.0.20"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.20"
+    "androidtv==0.0.21"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.18"
+    "androidtv==0.0.19"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -64,6 +64,7 @@ CONF_ADB_SERVER_IP = "adb_server_ip"
 CONF_ADB_SERVER_PORT = "adb_server_port"
 CONF_APPS = "apps"
 CONF_GET_SOURCES = "get_sources"
+CONF_STATE_DETECTION_RULES = "state_detection_rules"
 CONF_TURN_ON_COMMAND = "turn_on_command"
 CONF_TURN_OFF_COMMAND = "turn_off_command"
 
@@ -99,6 +100,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_APPS, default=dict()): vol.Schema({cv.string: cv.string}),
         vol.Optional(CONF_TURN_ON_COMMAND): cv.string,
         vol.Optional(CONF_TURN_OFF_COMMAND): cv.string,
+        vol.Optional(CONF_STATE_DETECTION_RULES, default=dict()): vol.Schema(
+            {cv.string: cv.ensure_list}
+        ),
     }
 )
 
@@ -125,12 +129,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         adb_log = "using Python ADB implementation "
         if CONF_ADBKEY in config:
             aftv = setup(
-                host, config[CONF_ADBKEY], device_class=config[CONF_DEVICE_CLASS]
+                host,
+                config[CONF_ADBKEY],
+                device_class=config[CONF_DEVICE_CLASS],
+                state_detection_rules=config[CONF_STATE_DETECTION_RULES],
             )
             adb_log += "with adbkey='{0}'".format(config[CONF_ADBKEY])
 
         else:
-            aftv = setup(host, device_class=config[CONF_DEVICE_CLASS])
+            aftv = setup(
+                host,
+                device_class=config[CONF_DEVICE_CLASS],
+                state_detection_rules=config[CONF_STATE_DETECTION_RULES],
+            )
             adb_log += "without adbkey authentication"
     else:
         # Use "pure-python-adb" (communicate with ADB server)
@@ -139,6 +150,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             adb_server_ip=config[CONF_ADB_SERVER_IP],
             adb_server_port=config[CONF_ADB_SERVER_PORT],
             device_class=config[CONF_DEVICE_CLASS],
+            state_detection_rules=config[CONF_STATE_DETECTION_RULES],
         )
         adb_log = "using ADB server at {0}:{1}".format(
             config[CONF_ADB_SERVER_IP], config[CONF_ADB_SERVER_PORT]

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -3,6 +3,9 @@ import functools
 import logging
 import voluptuous as vol
 
+from androidtv import setup
+from androidtv.constants import APPS, KEYS, VALID_STATES
+
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
@@ -31,9 +34,6 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
-
-from androidtv import setup
-from androidtv.constants import APPS, KEYS, VALID_STATES
 
 ANDROIDTV_DOMAIN = "androidtv"
 
@@ -148,7 +148,7 @@ def valid_state_detection_rules(rules):
                         )
 
                     # The value for the `media_session_state` and `wake_lock_size` properties must be an int
-                    elif not isinstance(value, int):
+                    if condition != "audio_state" and not isinstance(value, int):
                         raise vol.Invalid(
                             "Conditional value for property '{0}' must be an int, not {1}".format(
                                 condition, type(value).__name__

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -89,7 +89,6 @@ SERVICE_ADB_COMMAND_SCHEMA = vol.Schema(
 
 # To be used for config validation
 VALID_PROPERTIES = ("audio_state", "media_session_state")
-VALID_STRINGS = VALID_PROPERTIES + VALID_STATES
 VALID_CONDITIONS = VALID_PROPERTIES + ("wake_lock_size",)
 
 
@@ -104,7 +103,7 @@ def valid_state_detection_rules(rules):
 
         # If a rule is a string, check that it is valid
         if isinstance(rule, str):
-            if rule not in VALID_STATES + VALID_PROPERTIES:
+            if rule not in VALID_PROPERTIES + VALID_STATES:
                 raise vol.Invalid(
                     "Invalid rule '{0}' is not in {1}".format(
                         rule, VALID_STATES + VALID_PROPERTIES

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -103,7 +103,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_APPS, default=dict()): vol.Schema({cv.string: cv.string}),
         vol.Optional(CONF_TURN_ON_COMMAND): cv.string,
         vol.Optional(CONF_TURN_OFF_COMMAND): cv.string,
-        vol.Optional(CONF_STATE_DETECTION_RULES, default=dict()): vol.Schema(
+        vol.Optional(CONF_STATE_DETECTION_RULES, default={}): vol.Schema(
             {cv.string: ha_state_detection_rules_validator(vol.Invalid)}
         ),
     }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -190,7 +190,7 @@ ambiclimate==0.2.0
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.19
+androidtv==0.0.20
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -190,7 +190,7 @@ ambiclimate==0.2.0
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.20
+androidtv==0.0.21
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -190,7 +190,7 @@ ambiclimate==0.2.0
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.18
+androidtv==0.0.19
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:

Bump `androidtv` to 0.0.20 and add the `state_detection_rules` config parameter.

I have tested this code and it works. A tester on the forum also [reported that it works](https://community.home-assistant.io/t/testers-needed-custom-state-detection-rules-for-android-tv-fire-tv/129493/13?u=jefflirion). In addition, I added unit tests to the `androidtv` package to make sure that these user-specified state detection rules work as expected (https://github.com/JeffLIrion/python-androidtv/pull/55). 

I'd really like to get this merged in because there are plenty of posts on the forum about "Android TV reports the wrong state for xyz app," but only a few users have submitted pull requests to the `androidtv` repo to help address this. The logic for determining the state differs from app to app and from one device to the next, so a universal solution is unrealistic. This will allow users to fine tune the state detection logic on their own, without the need for an update to the `androidtv` package followed by a version bump in the HA integration. 

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/23346

It fixes this issue by allowing the user to specify their own rules for determining the state. 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10036

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: androidtv
    name: Fire TV (Bedroom)
    device_class: firetv
    host: 192.168.0.10
    state_detection_rules:
      'com.amazon.tv.launcher':
        - 'standby'
      'com.netflix.ninja':
        - 'media_session_state'
      'com.ellation.vrv':
        - 'audio_state'
      'com.plexapp.android':
        - 'playing':
            'media_session_state': 3  # this indentation is important!
            'wake_lock_size': 3       # this indentation is important!
        - 'paused':
            'media_session_state': 3  # this indentation is important!
            'wake_lock_size': 1       # this indentation is important!
        - 'standby'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html