### PR TITLE
Revert flux_led to 0.89

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -144,7 +144,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if ipaddr in light_ips:
             continue
         device['name'] = '{} {}'.format(device['id'], ipaddr)
-        device[ATTR_MODE] = None
+        device[ATTR_MODE] = MODE_RGBW
         device[CONF_PROTOCOL] = None
         device[CONF_CUSTOM_EFFECT] = None
         light = FluxLight(device)
@@ -251,15 +251,16 @@ class FluxLight(Light):
         for effect, code in EFFECT_MAP.items():
             if current_mode == code:
                 return effect
+
         return None
 
     async def async_turn_on(self, **kwargs):
         """Turn the specified or all lights on and wait for state."""
         await self.hass.async_add_executor_job(partial(self._turn_on,
                                                        **kwargs))
-        # The bulb needs a bit to tell its new values,
-        # so we wait 1 second before updating
-        await sleep(1)
+        # The bulb needs a second to tell its new values,
+        # so we wait 2 seconds before updating
+        await sleep(2)
 
     def _turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
@@ -270,47 +271,55 @@ class FluxLight(Light):
         effect = kwargs.get(ATTR_EFFECT)
         white = kwargs.get(ATTR_WHITE_VALUE)
 
-        if all(item is None for item in [hs_color, brightness, effect, white]):
+        # Show warning if effect set with rgb, brightness, or white level
+        if effect and (brightness or white or hs_color):
+            _LOGGER.warning("RGB, brightness and white level are ignored when"
+                            " an effect is specified for a flux bulb")
+
+        # Random color effect
+        if effect == EFFECT_RANDOM:
+            self._bulb.setRgb(random.randint(0, 255),
+                              random.randint(0, 255),
+                              random.randint(0, 255))
             return
+
+        if effect == EFFECT_CUSTOM:
+            if self._custom_effect:
+                self._bulb.setCustomPattern(
+                    self._custom_effect[CONF_COLORS],
+                    self._custom_effect[CONF_SPEED_PCT],
+                    self._custom_effect[CONF_TRANSITION])
+            return
+
+        # Effect selection
+        if effect in EFFECT_MAP:
+            self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
+            return
+
+        # Preserve current brightness on color/white level change
+        if brightness is None:
+            brightness = self.brightness
+
+        if hs_color:
+            self._color = (hs_color[0], hs_color[1], brightness / 255 * 100)
+        elif brightness and (hs_color is None) and self._mode != MODE_WHITE:
+            self._color = (self._color[0], self._color[1],
+                           brightness / 255 * 100)
 
         # handle W only mode (use brightness instead of white value)
         if self._mode == MODE_WHITE:
-            if brightness is not None:
-                self._bulb.setWarmWhite255(brightness)
-            return
-        if effect is not None:
-            # Random color effect
-            if effect == EFFECT_RANDOM:
-                self._bulb.setRgb(random.randint(0, 255),
-                                  random.randint(0, 255),
-                                  random.randint(0, 255))
-            elif effect == EFFECT_CUSTOM:
-                if self._custom_effect:
-                    self._bulb.setCustomPattern(
-                        self._custom_effect[CONF_COLORS],
-                        self._custom_effect[CONF_SPEED_PCT],
-                        self._custom_effect[CONF_TRANSITION])
-                # Effect selection
-            elif effect in EFFECT_MAP:
-                self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
-            return
-        # Preserve current brightness on color/white level change
-        if hs_color is not None:
-            if brightness is None:
-                brightness = self.brightness
-            color = (hs_color[0], hs_color[1], brightness / 255 * 100)
-        elif brightness is not None:
-            color = (self._color[0], self._color[1],
-                     brightness / 255 * 100)
+            self._bulb.setRgbw(0, 0, 0, w=brightness)
+
         # handle RGBW mode
-        if self._mode == MODE_RGBW:
+        elif self._mode == MODE_RGBW:
             if white is None:
-                self._bulb.setRgbw(*color_util.color_hsv_to_RGB(*color))
+                self._bulb.setRgbw(*color_util.color_hsv_to_RGB(*self._color))
             else:
                 self._bulb.setRgbw(w=white)
         # handle RGB mode
         else:
-            self._bulb.setRgb(*color_util.color_hsv_to_RGB(*color))
+            self._bulb.setRgb(*color_util.color_hsv_to_RGB(*self._color))
+        return
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""
@@ -322,6 +331,10 @@ class FluxLight(Light):
             try:
                 self._connect()
                 self._error_reported = False
+                if self._bulb.getRgb() != (0, 0, 0):
+                    color = self._bulb.getRgbw()
+                    self._color = color_util.color_RGB_to_hsv(*color[0:3])
+                    self._white_value = color[3]
             except socket.error:
                 self._disconnect()
                 if not self._error_reported:
@@ -330,9 +343,7 @@ class FluxLight(Light):
                     self._error_reported = True
                 return
         self._bulb.update_state(retry=2)
-        if self._mode != MODE_WHITE and self._bulb.getRgb() != (0, 0, 0):
+        if self._bulb.getRgb() != (0, 0, 0):
             color = self._bulb.getRgbw()
             self._color = color_util.color_RGB_to_hsv(*color[0:3])
             self._white_value = color[3]
-        elif self._mode == MODE_WHITE:
-            self._white_value = self._bulb.getRgbw()[3]

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -9,45 +9,33 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ATTR_EFFECT,
-    ATTR_WHITE_VALUE,
-    ATTR_COLOR_TEMP,
-    EFFECT_COLORLOOP,
-    EFFECT_RANDOM,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_EFFECT,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
-    SUPPORT_COLOR_TEMP,
-    Light,
-    PLATFORM_SCHEMA,
-)
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE,
+    ATTR_COLOR_TEMP, EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS,
+    SUPPORT_EFFECT, SUPPORT_COLOR, SUPPORT_WHITE_VALUE, SUPPORT_COLOR_TEMP,
+    Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_AUTOMATIC_ADD = "automatic_add"
-CONF_CUSTOM_EFFECT = "custom_effect"
-CONF_COLORS = "colors"
-CONF_SPEED_PCT = "speed_pct"
-CONF_TRANSITION = "transition"
-ATTR_MODE = "mode"
+CONF_AUTOMATIC_ADD = 'automatic_add'
+CONF_CUSTOM_EFFECT = 'custom_effect'
+CONF_COLORS = 'colors'
+CONF_SPEED_PCT = 'speed_pct'
+CONF_TRANSITION = 'transition'
+ATTR_MODE = 'mode'
 
-DOMAIN = "flux_led"
+DOMAIN = 'flux_led'
 
-SUPPORT_FLUX_LED = (
-    SUPPORT_BRIGHTNESS | SUPPORT_EFFECT | SUPPORT_COLOR | SUPPORT_COLOR_TEMP
-)
+SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
+                    SUPPORT_COLOR | SUPPORT_COLOR_TEMP)
 
-MODE_RGB = "rgb"
-MODE_RGBW = "rgbw"
+MODE_RGB = 'rgb'
+MODE_RGBW = 'rgbw'
 
 # This mode enables white value to be controlled by brightness.
 # RGB value is ignored when this mode is specified.
-MODE_WHITE = "w"
+MODE_WHITE = 'w'
 
 # Constant color temp values for 2 flux_led special modes
 # Warm-white and Cool-white. Details on #23704
@@ -55,107 +43,94 @@ COLOR_TEMP_WARM_WHITE = 333
 COLOR_TEMP_COOL_WHITE = 250
 
 # List of supported effects which aren't already declared in LIGHT
-EFFECT_RED_FADE = "red_fade"
-EFFECT_GREEN_FADE = "green_fade"
-EFFECT_BLUE_FADE = "blue_fade"
-EFFECT_YELLOW_FADE = "yellow_fade"
-EFFECT_CYAN_FADE = "cyan_fade"
-EFFECT_PURPLE_FADE = "purple_fade"
-EFFECT_WHITE_FADE = "white_fade"
-EFFECT_RED_GREEN_CROSS_FADE = "rg_cross_fade"
-EFFECT_RED_BLUE_CROSS_FADE = "rb_cross_fade"
-EFFECT_GREEN_BLUE_CROSS_FADE = "gb_cross_fade"
-EFFECT_COLORSTROBE = "colorstrobe"
-EFFECT_RED_STROBE = "red_strobe"
-EFFECT_GREEN_STROBE = "green_strobe"
-EFFECT_BLUE_STROBE = "blue_strobe"
-EFFECT_YELLOW_STROBE = "yellow_strobe"
-EFFECT_CYAN_STROBE = "cyan_strobe"
-EFFECT_PURPLE_STROBE = "purple_strobe"
-EFFECT_WHITE_STROBE = "white_strobe"
-EFFECT_COLORJUMP = "colorjump"
-EFFECT_CUSTOM = "custom"
+EFFECT_RED_FADE = 'red_fade'
+EFFECT_GREEN_FADE = 'green_fade'
+EFFECT_BLUE_FADE = 'blue_fade'
+EFFECT_YELLOW_FADE = 'yellow_fade'
+EFFECT_CYAN_FADE = 'cyan_fade'
+EFFECT_PURPLE_FADE = 'purple_fade'
+EFFECT_WHITE_FADE = 'white_fade'
+EFFECT_RED_GREEN_CROSS_FADE = 'rg_cross_fade'
+EFFECT_RED_BLUE_CROSS_FADE = 'rb_cross_fade'
+EFFECT_GREEN_BLUE_CROSS_FADE = 'gb_cross_fade'
+EFFECT_COLORSTROBE = 'colorstrobe'
+EFFECT_RED_STROBE = 'red_strobe'
+EFFECT_GREEN_STROBE = 'green_strobe'
+EFFECT_BLUE_STROBE = 'blue_strobe'
+EFFECT_YELLOW_STROBE = 'yellow_strobe'
+EFFECT_CYAN_STROBE = 'cyan_strobe'
+EFFECT_PURPLE_STROBE = 'purple_strobe'
+EFFECT_WHITE_STROBE = 'white_strobe'
+EFFECT_COLORJUMP = 'colorjump'
+EFFECT_CUSTOM = 'custom'
 
 EFFECT_MAP = {
-    EFFECT_COLORLOOP: 0x25,
-    EFFECT_RED_FADE: 0x26,
-    EFFECT_GREEN_FADE: 0x27,
-    EFFECT_BLUE_FADE: 0x28,
-    EFFECT_YELLOW_FADE: 0x29,
-    EFFECT_CYAN_FADE: 0x2A,
-    EFFECT_PURPLE_FADE: 0x2B,
-    EFFECT_WHITE_FADE: 0x2C,
-    EFFECT_RED_GREEN_CROSS_FADE: 0x2D,
-    EFFECT_RED_BLUE_CROSS_FADE: 0x2E,
-    EFFECT_GREEN_BLUE_CROSS_FADE: 0x2F,
-    EFFECT_COLORSTROBE: 0x30,
-    EFFECT_RED_STROBE: 0x31,
-    EFFECT_GREEN_STROBE: 0x32,
-    EFFECT_BLUE_STROBE: 0x33,
-    EFFECT_YELLOW_STROBE: 0x34,
-    EFFECT_CYAN_STROBE: 0x35,
-    EFFECT_PURPLE_STROBE: 0x36,
-    EFFECT_WHITE_STROBE: 0x37,
-    EFFECT_COLORJUMP: 0x38,
+    EFFECT_COLORLOOP:             0x25,
+    EFFECT_RED_FADE:              0x26,
+    EFFECT_GREEN_FADE:            0x27,
+    EFFECT_BLUE_FADE:             0x28,
+    EFFECT_YELLOW_FADE:           0x29,
+    EFFECT_CYAN_FADE:             0x2a,
+    EFFECT_PURPLE_FADE:           0x2b,
+    EFFECT_WHITE_FADE:            0x2c,
+    EFFECT_RED_GREEN_CROSS_FADE:  0x2d,
+    EFFECT_RED_BLUE_CROSS_FADE:   0x2e,
+    EFFECT_GREEN_BLUE_CROSS_FADE: 0x2f,
+    EFFECT_COLORSTROBE:           0x30,
+    EFFECT_RED_STROBE:            0x31,
+    EFFECT_GREEN_STROBE:          0x32,
+    EFFECT_BLUE_STROBE:           0x33,
+    EFFECT_YELLOW_STROBE:         0x34,
+    EFFECT_CYAN_STROBE:           0x35,
+    EFFECT_PURPLE_STROBE:         0x36,
+    EFFECT_WHITE_STROBE:          0x37,
+    EFFECT_COLORJUMP:             0x38
 }
 EFFECT_CUSTOM_CODE = 0x60
 
-TRANSITION_GRADUAL = "gradual"
-TRANSITION_JUMP = "jump"
-TRANSITION_STROBE = "strobe"
+TRANSITION_GRADUAL = 'gradual'
+TRANSITION_JUMP = 'jump'
+TRANSITION_STROBE = 'strobe'
 
 FLUX_EFFECT_LIST = sorted(list(EFFECT_MAP)) + [EFFECT_RANDOM]
 
-CUSTOM_EFFECT_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_COLORS): vol.All(
-            cv.ensure_list,
-            vol.Length(min=1, max=16),
-            [
-                vol.All(
-                    vol.ExactSequence((cv.byte, cv.byte, cv.byte)), vol.Coerce(tuple)
-                )
-            ],
-        ),
-        vol.Optional(CONF_SPEED_PCT, default=50): vol.All(
-            vol.Range(min=0, max=100), vol.Coerce(int)
-        ),
-        vol.Optional(CONF_TRANSITION, default=TRANSITION_GRADUAL): vol.All(
-            cv.string, vol.In([TRANSITION_GRADUAL, TRANSITION_JUMP, TRANSITION_STROBE])
-        ),
-    }
-)
+CUSTOM_EFFECT_SCHEMA = vol.Schema({
+    vol.Required(CONF_COLORS):
+        vol.All(cv.ensure_list, vol.Length(min=1, max=16),
+                [vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
+                         vol.Coerce(tuple))]),
+    vol.Optional(CONF_SPEED_PCT, default=50):
+        vol.All(vol.Range(min=0, max=100), vol.Coerce(int)),
+    vol.Optional(CONF_TRANSITION, default=TRANSITION_GRADUAL):
+        vol.All(cv.string, vol.In(
+            [TRANSITION_GRADUAL, TRANSITION_JUMP, TRANSITION_STROBE])),
+})
 
-DEVICE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(ATTR_MODE, default=MODE_RGBW): vol.All(
-            cv.string, vol.In([MODE_RGBW, MODE_RGB, MODE_WHITE])
-        ),
-        vol.Optional(CONF_PROTOCOL): vol.All(cv.string, vol.In(["ledenet"])),
-        vol.Optional(CONF_CUSTOM_EFFECT): CUSTOM_EFFECT_SCHEMA,
-    }
-)
+DEVICE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(ATTR_MODE, default=MODE_RGBW):
+        vol.All(cv.string, vol.In([MODE_RGBW, MODE_RGB, MODE_WHITE])),
+    vol.Optional(CONF_PROTOCOL):
+        vol.All(cv.string, vol.In(['ledenet'])),
+    vol.Optional(CONF_CUSTOM_EFFECT): CUSTOM_EFFECT_SCHEMA,
+})
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
-        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
-    }
-)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+    vol.Optional(CONF_AUTOMATIC_ADD, default=False):  cv.boolean,
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Flux lights."""
     import flux_led
-
     lights = []
     light_ips = []
 
     for ipaddr, device_config in config.get(CONF_DEVICES, {}).items():
         device = {}
-        device["name"] = device_config[CONF_NAME]
-        device["ipaddr"] = ipaddr
+        device['name'] = device_config[CONF_NAME]
+        device['ipaddr'] = ipaddr
         device[CONF_PROTOCOL] = device_config.get(CONF_PROTOCOL)
         device[ATTR_MODE] = device_config[ATTR_MODE]
         device[CONF_CUSTOM_EFFECT] = device_config.get(CONF_CUSTOM_EFFECT)
@@ -171,10 +146,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     scanner = flux_led.BulbScanner()
     scanner.scan(timeout=10)
     for device in scanner.getBulbInfo():
-        ipaddr = device["ipaddr"]
+        ipaddr = device['ipaddr']
         if ipaddr in light_ips:
             continue
-        device["name"] = "{} {}".format(device["id"], ipaddr)
+        device['name'] = '{} {}'.format(device['id'], ipaddr)
         device[ATTR_MODE] = None
         device[CONF_PROTOCOL] = None
         device[CONF_CUSTOM_EFFECT] = None
@@ -189,8 +164,8 @@ class FluxLight(Light):
 
     def __init__(self, device):
         """Initialize the light."""
-        self._name = device["name"]
-        self._ipaddr = device["ipaddr"]
+        self._name = device['name']
+        self._ipaddr = device['ipaddr']
         self._protocol = device[CONF_PROTOCOL]
         self._mode = device[ATTR_MODE]
         self._custom_effect = device[CONF_CUSTOM_EFFECT]
@@ -286,7 +261,8 @@ class FluxLight(Light):
 
     async def async_turn_on(self, **kwargs):
         """Turn the specified or all lights on and wait for state."""
-        await self.hass.async_add_executor_job(partial(self._turn_on, **kwargs))
+        await self.hass.async_add_executor_job(partial(self._turn_on,
+                                                       **kwargs))
         # The bulb needs a bit to tell its new values,
         # so we wait 1 second before updating
         await sleep(1)
@@ -301,9 +277,8 @@ class FluxLight(Light):
         white = kwargs.get(ATTR_WHITE_VALUE)
         color_temp = kwargs.get(ATTR_COLOR_TEMP)
 
-        if all(
-            item is None for item in [hs_color, brightness, effect, white, color_temp]
-        ):
+        if all(item is None for item in
+               [hs_color, brightness, effect, white, color_temp]):
             return
 
         # handle W only mode (use brightness instead of white value)
@@ -316,18 +291,15 @@ class FluxLight(Light):
         if effect is not None:
             # Random color effect
             if effect == EFFECT_RANDOM:
-                self._bulb.setRgb(
-                    random.randint(0, 255),
-                    random.randint(0, 255),
-                    random.randint(0, 255),
-                )
+                self._bulb.setRgb(random.randint(0, 255),
+                                  random.randint(0, 255),
+                                  random.randint(0, 255))
             elif effect == EFFECT_CUSTOM:
                 if self._custom_effect:
                     self._bulb.setCustomPattern(
                         self._custom_effect[CONF_COLORS],
                         self._custom_effect[CONF_SPEED_PCT],
-                        self._custom_effect[CONF_TRANSITION],
-                    )
+                        self._custom_effect[CONF_TRANSITION])
                 # Effect selection
             elif effect in EFFECT_MAP:
                 self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
@@ -342,7 +314,8 @@ class FluxLight(Light):
             elif color_temp == COLOR_TEMP_COOL_WHITE:
                 self._bulb.setRgbw(w2=brightness)
             else:
-                self._bulb.setRgbw(*color_util.color_temperature_to_rgb(color_temp))
+                self._bulb.setRgbw(
+                    *color_util.color_temperature_to_rgb(color_temp))
             return
 
         # Preserve current brightness on color/white level change
@@ -351,7 +324,8 @@ class FluxLight(Light):
                 brightness = self.brightness
             color = (hs_color[0], hs_color[1], brightness / 255 * 100)
         elif brightness is not None:
-            color = (self._color[0], self._color[1], brightness / 255 * 100)
+            color = (self._color[0], self._color[1],
+                     brightness / 255 * 100)
         # handle RGBW mode
         if self._mode == MODE_RGBW:
             if white is None:
@@ -375,9 +349,8 @@ class FluxLight(Light):
             except socket.error:
                 self._disconnect()
                 if not self._error_reported:
-                    _LOGGER.warning(
-                        "Failed to connect to bulb %s, %s", self._ipaddr, self._name
-                    )
+                    _LOGGER.warning("Failed to connect to bulb %s, %s",
+                                    self._ipaddr, self._name)
                     self._error_reported = True
                 return
         self._bulb.update_state(retry=2)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -164,7 +164,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if ipaddr in light_ips:
             continue
         device["name"] = "{} {}".format(device["id"], ipaddr)
-        device[ATTR_MODE] = MODE_RGBW
+        device[ATTR_MODE] = None
         device[CONF_PROTOCOL] = None
         device[CONF_CUSTOM_EFFECT] = None
         light = FluxLight(device)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -7,122 +7,144 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE,
-    EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
-    SUPPORT_COLOR, SUPPORT_WHITE_VALUE, Light, PLATFORM_SCHEMA)
+    ATTR_BRIGHTNESS,
+    ATTR_HS_COLOR,
+    ATTR_EFFECT,
+    ATTR_WHITE_VALUE,
+    EFFECT_COLORLOOP,
+    EFFECT_RANDOM,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_EFFECT,
+    SUPPORT_COLOR,
+    SUPPORT_WHITE_VALUE,
+    Light,
+    PLATFORM_SCHEMA,
+)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_AUTOMATIC_ADD = 'automatic_add'
-CONF_CUSTOM_EFFECT = 'custom_effect'
-CONF_COLORS = 'colors'
-CONF_SPEED_PCT = 'speed_pct'
-CONF_TRANSITION = 'transition'
-ATTR_MODE = 'mode'
+CONF_AUTOMATIC_ADD = "automatic_add"
+CONF_CUSTOM_EFFECT = "custom_effect"
+CONF_COLORS = "colors"
+CONF_SPEED_PCT = "speed_pct"
+CONF_TRANSITION = "transition"
+ATTR_MODE = "mode"
 
-DOMAIN = 'flux_led'
+DOMAIN = "flux_led"
 
-SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
-                    SUPPORT_COLOR)
+SUPPORT_FLUX_LED = SUPPORT_BRIGHTNESS | SUPPORT_EFFECT | SUPPORT_COLOR
 
-MODE_RGB = 'rgb'
-MODE_RGBW = 'rgbw'
+MODE_RGB = "rgb"
+MODE_RGBW = "rgbw"
 
 # This mode enables white value to be controlled by brightness.
 # RGB value is ignored when this mode is specified.
-MODE_WHITE = 'w'
+MODE_WHITE = "w"
 
 # List of supported effects which aren't already declared in LIGHT
-EFFECT_RED_FADE = 'red_fade'
-EFFECT_GREEN_FADE = 'green_fade'
-EFFECT_BLUE_FADE = 'blue_fade'
-EFFECT_YELLOW_FADE = 'yellow_fade'
-EFFECT_CYAN_FADE = 'cyan_fade'
-EFFECT_PURPLE_FADE = 'purple_fade'
-EFFECT_WHITE_FADE = 'white_fade'
-EFFECT_RED_GREEN_CROSS_FADE = 'rg_cross_fade'
-EFFECT_RED_BLUE_CROSS_FADE = 'rb_cross_fade'
-EFFECT_GREEN_BLUE_CROSS_FADE = 'gb_cross_fade'
-EFFECT_COLORSTROBE = 'colorstrobe'
-EFFECT_RED_STROBE = 'red_strobe'
-EFFECT_GREEN_STROBE = 'green_strobe'
-EFFECT_BLUE_STROBE = 'blue_strobe'
-EFFECT_YELLOW_STROBE = 'yellow_strobe'
-EFFECT_CYAN_STROBE = 'cyan_strobe'
-EFFECT_PURPLE_STROBE = 'purple_strobe'
-EFFECT_WHITE_STROBE = 'white_strobe'
-EFFECT_COLORJUMP = 'colorjump'
-EFFECT_CUSTOM = 'custom'
+EFFECT_RED_FADE = "red_fade"
+EFFECT_GREEN_FADE = "green_fade"
+EFFECT_BLUE_FADE = "blue_fade"
+EFFECT_YELLOW_FADE = "yellow_fade"
+EFFECT_CYAN_FADE = "cyan_fade"
+EFFECT_PURPLE_FADE = "purple_fade"
+EFFECT_WHITE_FADE = "white_fade"
+EFFECT_RED_GREEN_CROSS_FADE = "rg_cross_fade"
+EFFECT_RED_BLUE_CROSS_FADE = "rb_cross_fade"
+EFFECT_GREEN_BLUE_CROSS_FADE = "gb_cross_fade"
+EFFECT_COLORSTROBE = "colorstrobe"
+EFFECT_RED_STROBE = "red_strobe"
+EFFECT_GREEN_STROBE = "green_strobe"
+EFFECT_BLUE_STROBE = "blue_strobe"
+EFFECT_YELLOW_STROBE = "yellow_strobe"
+EFFECT_CYAN_STROBE = "cyan_strobe"
+EFFECT_PURPLE_STROBE = "purple_strobe"
+EFFECT_WHITE_STROBE = "white_strobe"
+EFFECT_COLORJUMP = "colorjump"
+EFFECT_CUSTOM = "custom"
 
 EFFECT_MAP = {
-    EFFECT_COLORLOOP:             0x25,
-    EFFECT_RED_FADE:              0x26,
-    EFFECT_GREEN_FADE:            0x27,
-    EFFECT_BLUE_FADE:             0x28,
-    EFFECT_YELLOW_FADE:           0x29,
-    EFFECT_CYAN_FADE:             0x2a,
-    EFFECT_PURPLE_FADE:           0x2b,
-    EFFECT_WHITE_FADE:            0x2c,
-    EFFECT_RED_GREEN_CROSS_FADE:  0x2d,
-    EFFECT_RED_BLUE_CROSS_FADE:   0x2e,
-    EFFECT_GREEN_BLUE_CROSS_FADE: 0x2f,
-    EFFECT_COLORSTROBE:           0x30,
-    EFFECT_RED_STROBE:            0x31,
-    EFFECT_GREEN_STROBE:          0x32,
-    EFFECT_BLUE_STROBE:           0x33,
-    EFFECT_YELLOW_STROBE:         0x34,
-    EFFECT_CYAN_STROBE:           0x35,
-    EFFECT_PURPLE_STROBE:         0x36,
-    EFFECT_WHITE_STROBE:          0x37,
-    EFFECT_COLORJUMP:             0x38
+    EFFECT_COLORLOOP: 0x25,
+    EFFECT_RED_FADE: 0x26,
+    EFFECT_GREEN_FADE: 0x27,
+    EFFECT_BLUE_FADE: 0x28,
+    EFFECT_YELLOW_FADE: 0x29,
+    EFFECT_CYAN_FADE: 0x2A,
+    EFFECT_PURPLE_FADE: 0x2B,
+    EFFECT_WHITE_FADE: 0x2C,
+    EFFECT_RED_GREEN_CROSS_FADE: 0x2D,
+    EFFECT_RED_BLUE_CROSS_FADE: 0x2E,
+    EFFECT_GREEN_BLUE_CROSS_FADE: 0x2F,
+    EFFECT_COLORSTROBE: 0x30,
+    EFFECT_RED_STROBE: 0x31,
+    EFFECT_GREEN_STROBE: 0x32,
+    EFFECT_BLUE_STROBE: 0x33,
+    EFFECT_YELLOW_STROBE: 0x34,
+    EFFECT_CYAN_STROBE: 0x35,
+    EFFECT_PURPLE_STROBE: 0x36,
+    EFFECT_WHITE_STROBE: 0x37,
+    EFFECT_COLORJUMP: 0x38,
 }
 EFFECT_CUSTOM_CODE = 0x60
 
-TRANSITION_GRADUAL = 'gradual'
-TRANSITION_JUMP = 'jump'
-TRANSITION_STROBE = 'strobe'
+TRANSITION_GRADUAL = "gradual"
+TRANSITION_JUMP = "jump"
+TRANSITION_STROBE = "strobe"
 
 FLUX_EFFECT_LIST = sorted(list(EFFECT_MAP)) + [EFFECT_RANDOM]
 
-CUSTOM_EFFECT_SCHEMA = vol.Schema({
-    vol.Required(CONF_COLORS):
-        vol.All(cv.ensure_list, vol.Length(min=1, max=16),
-                [vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
-                         vol.Coerce(tuple))]),
-    vol.Optional(CONF_SPEED_PCT, default=50):
-        vol.All(vol.Range(min=0, max=100), vol.Coerce(int)),
-    vol.Optional(CONF_TRANSITION, default=TRANSITION_GRADUAL):
-        vol.All(cv.string, vol.In(
-            [TRANSITION_GRADUAL, TRANSITION_JUMP, TRANSITION_STROBE])),
-})
+CUSTOM_EFFECT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_COLORS): vol.All(
+            cv.ensure_list,
+            vol.Length(min=1, max=16),
+            [
+                vol.All(
+                    vol.ExactSequence((cv.byte, cv.byte, cv.byte)), vol.Coerce(tuple)
+                )
+            ],
+        ),
+        vol.Optional(CONF_SPEED_PCT, default=50): vol.All(
+            vol.Range(min=0, max=100), vol.Coerce(int)
+        ),
+        vol.Optional(CONF_TRANSITION, default=TRANSITION_GRADUAL): vol.All(
+            cv.string, vol.In([TRANSITION_GRADUAL, TRANSITION_JUMP, TRANSITION_STROBE])
+        ),
+    }
+)
 
-DEVICE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(ATTR_MODE, default=MODE_RGBW):
-        vol.All(cv.string, vol.In([MODE_RGBW, MODE_RGB, MODE_WHITE])),
-    vol.Optional(CONF_PROTOCOL):
-        vol.All(cv.string, vol.In(['ledenet'])),
-    vol.Optional(CONF_CUSTOM_EFFECT): CUSTOM_EFFECT_SCHEMA,
-})
+DEVICE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(ATTR_MODE, default=MODE_RGBW): vol.All(
+            cv.string, vol.In([MODE_RGBW, MODE_RGB, MODE_WHITE])
+        ),
+        vol.Optional(CONF_PROTOCOL): vol.All(cv.string, vol.In(["ledenet"])),
+        vol.Optional(CONF_CUSTOM_EFFECT): CUSTOM_EFFECT_SCHEMA,
+    }
+)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
-    vol.Optional(CONF_AUTOMATIC_ADD, default=False):  cv.boolean,
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+        vol.Optional(CONF_AUTOMATIC_ADD, default=False): cv.boolean,
+    }
+)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Flux lights."""
     import flux_led
+
     lights = []
     light_ips = []
 
     for ipaddr, device_config in config.get(CONF_DEVICES, {}).items():
         device = {}
-        device['name'] = device_config[CONF_NAME]
-        device['ipaddr'] = ipaddr
+        device["name"] = device_config[CONF_NAME]
+        device["ipaddr"] = ipaddr
         device[CONF_PROTOCOL] = device_config.get(CONF_PROTOCOL)
         device[ATTR_MODE] = device_config[ATTR_MODE]
         device[CONF_CUSTOM_EFFECT] = device_config.get(CONF_CUSTOM_EFFECT)
@@ -138,10 +160,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     scanner = flux_led.BulbScanner()
     scanner.scan(timeout=10)
     for device in scanner.getBulbInfo():
-        ipaddr = device['ipaddr']
+        ipaddr = device["ipaddr"]
         if ipaddr in light_ips:
             continue
-        device['name'] = '{} {}'.format(device['id'], ipaddr)
+        device["name"] = "{} {}".format(device["id"], ipaddr)
         device[ATTR_MODE] = MODE_RGBW
         device[CONF_PROTOCOL] = None
         device[CONF_CUSTOM_EFFECT] = None
@@ -156,8 +178,8 @@ class FluxLight(Light):
 
     def __init__(self, device):
         """Initialize the light."""
-        self._name = device['name']
-        self._ipaddr = device['ipaddr']
+        self._name = device["name"]
+        self._ipaddr = device["ipaddr"]
         self._protocol = device[CONF_PROTOCOL]
         self._mode = device[ATTR_MODE]
         self._custom_effect = device[CONF_CUSTOM_EFFECT]
@@ -268,14 +290,16 @@ class FluxLight(Light):
 
         # Show warning if effect set with rgb, brightness, or white level
         if effect and (brightness or white or rgb):
-            _LOGGER.warning("RGB, brightness and white level are ignored when"
-                            " an effect is specified for a flux bulb")
+            _LOGGER.warning(
+                "RGB, brightness and white level are ignored when"
+                " an effect is specified for a flux bulb"
+            )
 
         # Random color effect
         if effect == EFFECT_RANDOM:
-            self._bulb.setRgb(random.randint(0, 255),
-                              random.randint(0, 255),
-                              random.randint(0, 255))
+            self._bulb.setRgb(
+                random.randint(0, 255), random.randint(0, 255), random.randint(0, 255)
+            )
             return
 
         if effect == EFFECT_CUSTOM:
@@ -283,7 +307,8 @@ class FluxLight(Light):
                 self._bulb.setCustomPattern(
                     self._custom_effect[CONF_COLORS],
                     self._custom_effect[CONF_SPEED_PCT],
-                    self._custom_effect[CONF_TRANSITION])
+                    self._custom_effect[CONF_TRANSITION],
+                )
             return
 
         # Effect selection
@@ -327,8 +352,9 @@ class FluxLight(Light):
             except socket.error:
                 self._disconnect()
                 if not self._error_reported:
-                    _LOGGER.warning("Failed to connect to bulb %s, %s",
-                                    self._ipaddr, self._name)
+                    _LOGGER.warning(
+                        "Failed to connect to bulb %s, %s", self._ipaddr, self._name
+                    )
                     self._error_reported = True
                 return
 

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -2,8 +2,6 @@
 import logging
 import socket
 import random
-from asyncio import sleep
-from functools import partial
 
 import voluptuous as vol
 
@@ -165,8 +163,6 @@ class FluxLight(Light):
         self._custom_effect = device[CONF_CUSTOM_EFFECT]
         self._bulb = None
         self._error_reported = False
-        self._color = (0, 0, 100)
-        self._white_value = 0
 
     def _connect(self):
         """Connect to Flux light."""
@@ -207,14 +203,14 @@ class FluxLight(Light):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         if self._mode == MODE_WHITE:
-            return self._white_value
+            return self.white_value
 
-        return int(self._color[2] / 100 * 255)
+        return self._bulb.brightness
 
     @property
     def hs_color(self):
         """Return the color property."""
-        return self._color[0:2]
+        return color_util.color_RGB_to_hs(*self._bulb.getRgb())
 
     @property
     def supported_features(self):
@@ -230,7 +226,7 @@ class FluxLight(Light):
     @property
     def white_value(self):
         """Return the white value of this light between 0..255."""
-        return self._white_value
+        return self._bulb.getRgbw()[3]
 
     @property
     def effect_list(self):
@@ -254,25 +250,24 @@ class FluxLight(Light):
 
         return None
 
-    async def async_turn_on(self, **kwargs):
-        """Turn the specified or all lights on and wait for state."""
-        await self.hass.async_add_executor_job(partial(self._turn_on,
-                                                       **kwargs))
-        # The bulb needs a second to tell its new values,
-        # so we wait 2 seconds before updating
-        await sleep(2)
-
-    def _turn_on(self, **kwargs):
+    def turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
-        self._bulb.turnOn()
+        if not self.is_on:
+            self._bulb.turnOn()
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
+
+        if hs_color:
+            rgb = color_util.color_hs_to_RGB(*hs_color)
+        else:
+            rgb = None
+
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         effect = kwargs.get(ATTR_EFFECT)
         white = kwargs.get(ATTR_WHITE_VALUE)
 
         # Show warning if effect set with rgb, brightness, or white level
-        if effect and (brightness or white or hs_color):
+        if effect and (brightness or white or rgb):
             _LOGGER.warning("RGB, brightness and white level are ignored when"
                             " an effect is specified for a flux bulb")
 
@@ -300,11 +295,12 @@ class FluxLight(Light):
         if brightness is None:
             brightness = self.brightness
 
-        if hs_color:
-            self._color = (hs_color[0], hs_color[1], brightness / 255 * 100)
-        elif brightness and (hs_color is None) and self._mode != MODE_WHITE:
-            self._color = (self._color[0], self._color[1],
-                           brightness / 255 * 100)
+        # Preserve color on brightness/white level change
+        if rgb is None:
+            rgb = self._bulb.getRgb()
+
+        if white is None and self._mode == MODE_RGBW:
+            white = self.white_value
 
         # handle W only mode (use brightness instead of white value)
         if self._mode == MODE_WHITE:
@@ -312,14 +308,11 @@ class FluxLight(Light):
 
         # handle RGBW mode
         elif self._mode == MODE_RGBW:
-            if white is None:
-                self._bulb.setRgbw(*color_util.color_hsv_to_RGB(*self._color))
-            else:
-                self._bulb.setRgbw(w=white)
+            self._bulb.setRgbw(*tuple(rgb), w=white, brightness=brightness)
+
         # handle RGB mode
         else:
-            self._bulb.setRgb(*color_util.color_hsv_to_RGB(*self._color))
-        return
+            self._bulb.setRgb(*tuple(rgb), brightness=brightness)
 
     def turn_off(self, **kwargs):
         """Turn the specified or all lights off."""
@@ -331,10 +324,6 @@ class FluxLight(Light):
             try:
                 self._connect()
                 self._error_reported = False
-                if self._bulb.getRgb() != (0, 0, 0):
-                    color = self._bulb.getRgbw()
-                    self._color = color_util.color_RGB_to_hsv(*color[0:3])
-                    self._white_value = color[3]
             except socket.error:
                 self._disconnect()
                 if not self._error_reported:
@@ -342,8 +331,5 @@ class FluxLight(Light):
                                     self._ipaddr, self._name)
                     self._error_reported = True
                 return
+
         self._bulb.update_state(retry=2)
-        if self._bulb.getRgb() != (0, 0, 0):
-            color = self._bulb.getRgbw()
-            self._color = color_util.color_RGB_to_hsv(*color[0:3])
-            self._white_value = color[3]

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -10,9 +10,8 @@ import voluptuous as vol
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE,
-    ATTR_COLOR_TEMP, EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS,
-    SUPPORT_EFFECT, SUPPORT_COLOR, SUPPORT_WHITE_VALUE, SUPPORT_COLOR_TEMP,
-    Light, PLATFORM_SCHEMA)
+    EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
+    SUPPORT_COLOR, SUPPORT_WHITE_VALUE, Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
@@ -28,7 +27,7 @@ ATTR_MODE = 'mode'
 DOMAIN = 'flux_led'
 
 SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
-                    SUPPORT_COLOR | SUPPORT_COLOR_TEMP)
+                    SUPPORT_COLOR)
 
 MODE_RGB = 'rgb'
 MODE_RGBW = 'rgbw'
@@ -36,11 +35,6 @@ MODE_RGBW = 'rgbw'
 # This mode enables white value to be controlled by brightness.
 # RGB value is ignored when this mode is specified.
 MODE_WHITE = 'w'
-
-# Constant color temp values for 2 flux_led special modes
-# Warm-white and Cool-white. Details on #23704
-COLOR_TEMP_WARM_WHITE = 333
-COLOR_TEMP_COOL_WHITE = 250
 
 # List of supported effects which aren't already declared in LIGHT
 EFFECT_RED_FADE = 'red_fade'
@@ -275,10 +269,8 @@ class FluxLight(Light):
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         effect = kwargs.get(ATTR_EFFECT)
         white = kwargs.get(ATTR_WHITE_VALUE)
-        color_temp = kwargs.get(ATTR_COLOR_TEMP)
 
-        if all(item is None for item in
-               [hs_color, brightness, effect, white, color_temp]):
+        if all(item is None for item in [hs_color, brightness, effect, white]):
             return
 
         # handle W only mode (use brightness instead of white value)
@@ -286,8 +278,6 @@ class FluxLight(Light):
             if brightness is not None:
                 self._bulb.setWarmWhite255(brightness)
             return
-
-        # handle effects
         if effect is not None:
             # Random color effect
             if effect == EFFECT_RANDOM:
@@ -304,20 +294,6 @@ class FluxLight(Light):
             elif effect in EFFECT_MAP:
                 self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
             return
-
-        # handle special modes
-        if color_temp is not None:
-            if brightness is None:
-                brightness = self.brightness
-            if color_temp == COLOR_TEMP_WARM_WHITE:
-                self._bulb.setRgbw(w=brightness)
-            elif color_temp == COLOR_TEMP_COOL_WHITE:
-                self._bulb.setRgbw(w2=brightness)
-            else:
-                self._bulb.setRgbw(
-                    *color_util.color_temperature_to_rgb(color_temp))
-            return
-
         # Preserve current brightness on color/white level change
         if hs_color is not None:
             if brightness is None:


### PR DESCRIPTION
## Description:

This reverts three previous flux_led PRs:
* #20733 – which addressed [a real bug](https://github.com/home-assistant/home-assistant/pull/20733#issuecomment-461152293) but unfortunately broke other setups.
* #22210 – which cleaned up some of the #20733 breakage but not all of it. @autinerd has since been MIA.
* #25503 – which was merged prematurely but only to beta. I believe @yeralin is working on completing it.

The reverts bring flux_led back to the 0.89 level, as suggested in https://github.com/home-assistant/home-assistant/issues/22161#issuecomment-500235555. This includes the bug that #20733 tried to fix but I think it has become clear that it must be fixed in a different way.

I kept in a single fix that seems unrelated, https://github.com/home-assistant/home-assistant/issues/22161#issuecomment-474714306.

The commits cross both Black and The Great Migration so this does not exactly match the original PRs.

**Related issue (if applicable):** fixes #23322

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]