### PR TITLE
UniFi - option to not track wired clients

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -13,6 +13,7 @@ from .const import (
     CONF_DETECTION_TIME,
     CONF_DONT_TRACK_CLIENTS,
     CONF_DONT_TRACK_DEVICES,
+    CONF_DONT_TRACK_WIRED_CLIENTS,
     CONF_SITE_ID,
     CONF_SSID_FILTER,
     CONTROLLER_ID,
@@ -32,6 +33,7 @@ CONTROLLER_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_DONT_TRACK_CLIENTS): cv.boolean,
         vol.Optional(CONF_DONT_TRACK_DEVICES): cv.boolean,
+        vol.Optional(CONF_DONT_TRACK_WIRED_CLIENTS): cv.boolean,
         vol.Optional(CONF_DETECTION_TIME): vol.All(
             cv.time_period, cv.positive_timedelta
         ),

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -15,6 +15,7 @@ CONF_BLOCK_CLIENT = "block_client"
 CONF_DETECTION_TIME = "detection_time"
 CONF_DONT_TRACK_CLIENTS = "dont_track_clients"
 CONF_DONT_TRACK_DEVICES = "dont_track_devices"
+CONF_DONT_TRACK_WIRED_CLIENTS = "dont_track_wired_clients"
 CONF_SSID_FILTER = "ssid_filter"
 
 ATTR_MANUFACTURER = "Ubiquiti Networks"

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_DETECTION_TIME,
     CONF_DONT_TRACK_CLIENTS,
     CONF_DONT_TRACK_DEVICES,
+    CONF_DONT_TRACK_WIRED_CLIENTS,
     CONF_SITE_ID,
     CONF_SSID_FILTER,
     CONTROLLER_ID,
@@ -175,6 +176,12 @@ def update_items(controller, async_add_entities, tracked):
                 not client.is_wired
                 and CONF_SSID_FILTER in controller.unifi_config
                 and client.essid not in controller.unifi_config[CONF_SSID_FILTER]
+            ):
+                continue
+
+            if (
+                controller.unifi_config.get(CONF_DONT_TRACK_WIRED_CLIENTS, False)
+                and client.is_wired
             ):
                 continue
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -280,3 +280,21 @@ async def test_dont_track_devices(hass, mock_controller):
 
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1 is None
+
+
+async def test_dont_track_wired_clients(hass, mock_controller):
+    """Test dont track wired clients config works."""
+    mock_controller.mock_client_responses.append([CLIENT_1, CLIENT_2])
+    mock_controller.mock_device_responses.append({})
+    mock_controller.unifi_config = {unifi.CONF_DONT_TRACK_WIRED_CLIENTS: True}
+
+    await setup_controller(hass, mock_controller)
+    assert len(mock_controller.mock_requests) == 2
+    assert len(hass.states.async_all()) == 3
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+    assert client_1.state == "not_home"
+
+    client_2 = hass.states.get("device_tracker.client_2")
+    assert client_2 is None


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #25654

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10040

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
