### PR TITLE
Fix 64-bit modbus sensor register reads

### DIFF
--- a/tests/components/modbus/__init__.py
+++ b/tests/components/modbus/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for Modbus platforms."""

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -1,0 +1,360 @@
+"""The tests for the Modbus sensor component."""
+import pytest
+from datetime import timedelta
+from unittest import mock
+
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_OFFSET,
+    CONF_PLATFORM,
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.components.modbus import DEFAULT_HUB, DOMAIN as MODBUS_DOMAIN
+from homeassistant.components.modbus.sensor import (
+    CONF_COUNT,
+    CONF_DATA_TYPE,
+    CONF_PRECISION,
+    CONF_REGISTER,
+    CONF_REGISTER_TYPE,
+    CONF_REGISTERS,
+    CONF_REVERSE_ORDER,
+    CONF_SCALE,
+    DATA_TYPE_FLOAT,
+    DATA_TYPE_INT,
+    DATA_TYPE_UINT,
+    REGISTER_TYPE_HOLDING,
+    REGISTER_TYPE_INPUT,
+)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+from tests.common import MockModule, mock_integration, async_fire_time_changed
+
+
+@pytest.fixture()
+def mock_hub(hass):
+    """Mock hub."""
+    mock_integration(hass, MockModule(MODBUS_DOMAIN))
+    hub = mock.MagicMock()
+    hub.name = "hub"
+    hass.data[MODBUS_DOMAIN] = {DEFAULT_HUB: hub}
+    return hub
+
+
+common_register_config = {CONF_NAME: "test-config", CONF_REGISTER: 1234}
+
+
+class ReadResult:
+    """Storage class for register read results."""
+    def __init__(self, register_words):
+        """Init."""
+        self.registers = register_words
+
+
+async def run_test(hass, mock_hub, register_config, register_words, expected):
+    """Run test for given config and check that sensor outputs expected result."""
+
+    # Full sensor configuration
+    sensor_name = "modbus_test_sensor"
+    scan_interval = 5
+    config = {
+        SENSOR_DOMAIN: {
+            CONF_PLATFORM: "modbus",
+            CONF_SCAN_INTERVAL: scan_interval,
+            CONF_REGISTERS: [
+                dict(**{CONF_NAME: sensor_name, CONF_REGISTER: 1234}, **register_config)
+            ],
+        }
+    }
+
+    # Setup inputs for the sensor
+    read_result = ReadResult(register_words)
+    if register_config.get(CONF_REGISTER_TYPE) == REGISTER_TYPE_INPUT:
+        mock_hub.read_input_registers.return_value = read_result
+    else:
+        mock_hub.read_holding_registers.return_value = read_result
+
+    # Initialize sensor
+    now = dt_util.utcnow()
+    with mock.patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+        assert await async_setup_component(hass, SENSOR_DOMAIN, config)
+
+    # Trigger update call with time_changed event
+    now += timedelta(seconds=scan_interval + 1)
+    with mock.patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+    # Check state
+    entity_id = SENSOR_DOMAIN + "." + sensor_name
+    state = hass.states.get(entity_id).state
+    assert state == expected
+
+
+async def test_simple_word_register(hass, mock_hub):
+    """Test conversion of single word register."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(hass, mock_hub, register_config, register_words=[0], expected="0")
+
+
+async def test_optional_conf_keys(hass, mock_hub):
+    """Test handling of optional configuration keys."""
+    register_config = {}
+    await run_test(
+        hass, mock_hub, register_config, register_words=[0x8000], expected="-32768"
+    )
+
+
+async def test_offset(hass, mock_hub):
+    """Test offset calculation."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 13,
+        CONF_PRECISION: 0,
+    }
+    await run_test(hass, mock_hub, register_config, register_words=[7], expected="20")
+
+
+async def test_scale_and_offset(hass, mock_hub):
+    """Test handling of scale and offset."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: 3,
+        CONF_OFFSET: 13,
+        CONF_PRECISION: 0,
+    }
+    await run_test(hass, mock_hub, register_config, register_words=[7], expected="34")
+
+
+async def test_ints_can_have_precision(hass, mock_hub):
+    """Test precision can be specified event if using integer values only."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_SCALE: 3,
+        CONF_OFFSET: 13,
+        CONF_PRECISION: 4,
+    }
+    await run_test(
+        hass, mock_hub, register_config, register_words=[7], expected="34.0000"
+    )
+
+
+async def test_floats_get_rounded_correctly(hass, mock_hub):
+    """Test that floating point values get rounded correctly."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: 1.5,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(hass, mock_hub, register_config, register_words=[1], expected="2")
+
+
+async def test_parameters_as_strings(hass, mock_hub):
+    """Test that scale, offset and precision can be given as strings."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: "1.5",
+        CONF_OFFSET: "5",
+        CONF_PRECISION: "1",
+    }
+    await run_test(hass, mock_hub, register_config, register_words=[9], expected="18.5")
+
+
+async def test_floating_point_scale(hass, mock_hub):
+    """Test use of floating point scale."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: 2.4,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 2,
+    }
+    await run_test(hass, mock_hub, register_config, register_words=[1], expected="2.40")
+
+
+async def test_floating_point_offset(hass, mock_hub):
+    """Test use of floating point scale."""
+    register_config = {
+        CONF_COUNT: 1,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: -10.3,
+        CONF_PRECISION: 1,
+    }
+    await run_test(hass, mock_hub, register_config, register_words=[2], expected="-8.3")
+
+
+async def test_signed_two_word_register(hass, mock_hub):
+    """Test reading of signed register with two words."""
+    register_config = {
+        CONF_COUNT: 2,
+        CONF_DATA_TYPE: DATA_TYPE_INT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x89AB, 0xCDEF],
+        expected="-1985229329",
+    )
+
+
+async def test_unsigned_two_word_register(hass, mock_hub):
+    """Test reading of unsigned register with two words."""
+    register_config = {
+        CONF_COUNT: 2,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x89AB, 0xCDEF],
+        expected=str(0x89ABCDEF),
+    )
+
+
+async def test_reversed(hass, mock_hub):
+    """Test handling of reversed register words."""
+    register_config = {
+        CONF_COUNT: 2,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_REVERSE_ORDER: True,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x89AB, 0xCDEF],
+        expected=str(0xCDEF89AB),
+    )
+
+
+async def test_four_word_register(hass, mock_hub):
+    """Test reading of 64-bit register."""
+    register_config = {
+        CONF_COUNT: 4,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x89AB, 0xCDEF, 0x0123, 0x4567],
+        expected="9920249030613615975",
+    )
+
+
+async def test_four_word_register_precision_is_intact_with_int_params(hass, mock_hub):
+    """Test that precision is not lost when doing integer arithmetic for 64-bit register."""
+    register_config = {
+        CONF_COUNT: 4,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_SCALE: 2,
+        CONF_OFFSET: 3,
+        CONF_PRECISION: 0,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x0123, 0x4567, 0x89AB, 0xCDEF],
+        expected="163971058432973793",
+    )
+
+
+async def test_four_word_register_precision_is_lost_with_float_params(hass, mock_hub):
+    """Test that precision is affected when floating point conversion is done."""
+    register_config = {
+        CONF_COUNT: 4,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_SCALE: 2.0,
+        CONF_OFFSET: 3.0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x0123, 0x4567, 0x89AB, 0xCDEF],
+        expected="163971058432973792",
+    )
+
+
+async def test_two_word_input_register(hass, mock_hub):
+    """Test reaging of input register."""
+    register_config = {
+        CONF_COUNT: 2,
+        CONF_REGISTER_TYPE: REGISTER_TYPE_INPUT,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x89AB, 0xCDEF],
+        expected=str(0x89ABCDEF),
+    )
+
+
+async def test_two_word_holding_register(hass, mock_hub):
+    """Test reaging of holding register."""
+    register_config = {
+        CONF_COUNT: 2,
+        CONF_REGISTER_TYPE: REGISTER_TYPE_HOLDING,
+        CONF_DATA_TYPE: DATA_TYPE_UINT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 0,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[0x89AB, 0xCDEF],
+        expected=str(0x89ABCDEF),
+    )
+
+
+async def test_float_data_type(hass, mock_hub):
+    """Test floating point register data type."""
+    register_config = {
+        CONF_COUNT: 2,
+        CONF_REGISTER_TYPE: REGISTER_TYPE_HOLDING,
+        CONF_DATA_TYPE: DATA_TYPE_FLOAT,
+        CONF_SCALE: 1,
+        CONF_OFFSET: 0,
+        CONF_PRECISION: 5,
+    }
+    await run_test(
+        hass,
+        mock_hub,
+        register_config,
+        register_words=[16286, 1617],
+        expected="1.23457",
+    )

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -77,21 +77,17 @@ async def run_test(hass, mock_hub, register_config, register_words, expected):
 
     # Initialize sensor
     now = dt_util.utcnow()
-    with mock.patch(
-        ("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now
-    ):
+    with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         assert await async_setup_component(hass, SENSOR_DOMAIN, config)
 
     # Trigger update call with time_changed event
     now += timedelta(seconds=scan_interval + 1)
-    with mock.patch(
-        ("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now
-    ):
+    with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
 
     # Check state
-    entity_id = SENSOR_DOMAIN + "." + sensor_name
+    entity_id = f"{SENSOR_DOMAIN}.{sensor_name}"
     state = hass.states.get(entity_id).state
     assert state == expected
 

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -46,6 +46,7 @@ common_register_config = {CONF_NAME: "test-config", CONF_REGISTER: 1234}
 
 class ReadResult:
     """Storage class for register read results."""
+
     def __init__(self, register_words):
         """Init."""
         self.registers = register_words
@@ -76,12 +77,16 @@ async def run_test(hass, mock_hub, register_config, register_words, expected):
 
     # Initialize sensor
     now = dt_util.utcnow()
-    with mock.patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+    with mock.patch(
+        ("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now
+    ):
         assert await async_setup_component(hass, SENSOR_DOMAIN, config)
 
     # Trigger update call with time_changed event
     now += timedelta(seconds=scan_interval + 1)
-    with mock.patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+    with mock.patch(
+        ("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now
+    ):
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Description:
Previously when reading four 16-bit modbus registers as a sensor
value, slave output was stored first as 64-bit integer, but before returning
that value was converted to double precision floating point. This
caused rounding errors for integer values bigger than 2^53.

After this change floating point conversion is done only if user
has configured scaling or offset to use floating points. In the case
where scale and offset are integers (also the default) only integer
arithmetic is used and 64-bit register values will be read correctly.

This PR adds also unit tests for modbus sensor value conversions
that were missing completely.

**Related issue (if applicable):** fixes #25671 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10043

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: modbus
    registers:
     # default good
      - name: nilan_date
        slave: 1
        register: 4722
        register_type: holding
        count: 4
        data_type: uint
     # still good with integer scale and offset
      - name: nilan_date
        slave: 1
        register: 4722
        register_type: holding
        count: 4
        data_type: uint
        scale: 1
        offset: 86400
     # bad when floating point scale or offset
      - name: nilan_date
        slave: 1
        register: 4722
        register_type: holding
        count: 4
        data_type: uint
        scale: 1.0
        offset: 0.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
