### PR TITLE
Add config flow for RMV transport

### DIFF
--- a/homeassistant/components/rmvtransport/.translations/de.json
+++ b/homeassistant/components/rmvtransport/.translations/de.json
@@ -21,7 +21,8 @@
           "lines": "Linien",
           "direction": "Richtung",
           "destinations": "Ziele",
-          "max_journeys": "max_journeys"
+          "max_journeys": "Max. Verbindungen",
+          "scan_interval": "Scan interval"
         }
       }
     },

--- a/homeassistant/components/rmvtransport/.translations/de.json
+++ b/homeassistant/components/rmvtransport/.translations/de.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "title": "RMV Transport",
+    "step": {
+      "user": {
+        "title": "RMV Transport einrichten",
+        "data": {
+          "station": "Stations ID",
+          "show_on_map": "Zeige auf Karte",
+          "ICE": "ICE",
+          "U-Bahn": "U-Bahn",
+          "Tram": "Tram",
+          "Bus": "Bus",
+          "S": "S",
+          "RB": "RB",
+          "RE": "RE",
+          "EC": "EC",
+          "IC": "IC",
+          "name": "Name",
+          "time_offset": "Time offset",
+          "lines": "Linien",
+          "direction": "Richtung",
+          "destinations": "Ziele",
+          "max_journeys": "max_journeys"
+        }
+      }
+    },
+    "error": {
+      "sensor_exists": "Sensor bereits registriert",
+      "invalid_sensor": "Sensor nicht verfügbar oder ungültig",
+      "communication_error": "Fehler bei der Kommunikation mit der RMV Transport API"
+    }
+  }
+}

--- a/homeassistant/components/rmvtransport/.translations/en.json
+++ b/homeassistant/components/rmvtransport/.translations/en.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "title": "RMV Transport",
+    "step": {
+      "user": {
+        "title": "Define RMV Transport",
+        "data": {
+          "station": "Station ID",
+          "show_on_map": "Show on map",
+          "ICE": "ICE",
+          "U-Bahn": "U-Bahn",
+          "Tram": "Tram",
+          "Bus": "Bus",
+          "S": "S",
+          "RB": "RB",
+          "RE": "RE",
+          "EC": "EC",
+          "IC": "IC",
+          "name": "Name",
+          "time_offset": "Time offset",
+          "lines": "Lines",
+          "direction": "Direction",
+          "destinations": "Destinations",
+          "max_journeys": "max_journeys"
+        }
+      }
+    },
+    "error": {
+      "sensor_exists": "Sensor already registered",
+      "invalid_sensor": "Sensor not available or invalid",
+      "communication_error": "Unable to communicate with the RMV Transport API"
+    }
+  }
+}

--- a/homeassistant/components/rmvtransport/.translations/en.json
+++ b/homeassistant/components/rmvtransport/.translations/en.json
@@ -21,7 +21,8 @@
           "lines": "Lines",
           "direction": "Direction",
           "destinations": "Destinations",
-          "max_journeys": "max_journeys"
+          "max_journeys": "Max. journeys",
+          "scan_interval": "Scan interval"
         }
       }
     },

--- a/homeassistant/components/rmvtransport/__init__.py
+++ b/homeassistant/components/rmvtransport/__init__.py
@@ -163,7 +163,7 @@ async def async_setup_entry(hass, config_entry):
     session = async_get_clientsession(hass)
 
     try:
-        rmv_rata = RMVDepartureData(
+        rmv_data = RMVDepartureData(
             session,
             config_entry.data[CONF_STATION],
             config_entry.data.get(CONF_DESTINATIONS, []),
@@ -174,8 +174,8 @@ async def async_setup_entry(hass, config_entry):
             config_entry.data.get(CONF_MAX_JOURNEYS, DEFAULT_MAX_JOURNEYS),
             DEFAULT_TIMEOUT,
         )
-        await rmv_rata.async_update()
-        hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][config_entry.entry_id] = rmv_rata
+        await rmv_data.async_update()
+        hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][config_entry.entry_id] = rmv_data
     except RMVtransportApiConnectionError:
         raise ConfigEntryNotReady
 
@@ -185,7 +185,7 @@ async def async_setup_entry(hass, config_entry):
 
     async def refresh_sensors(event_time):
         """Refresh RMV transport data."""
-        await rmv_rata.async_update()
+        await rmv_data.async_update()
         async_dispatcher_send(hass, TOPIC_UPDATE)
 
     hass.data[DOMAIN][DATA_RMVTRANSPORT_LISTENER][

--- a/homeassistant/components/rmvtransport/__init__.py
+++ b/homeassistant/components/rmvtransport/__init__.py
@@ -88,6 +88,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     CONF_MAX_JOURNEYS, default=DEFAULT_MAX_JOURNEYS
                 ): cv.positive_int,
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(CONF_SHOW_ON_MAP, default=False): cv.boolean,
             }
         ],
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
@@ -250,6 +251,9 @@ class RMVDepartureData:
 
         if self.station_info is None:
             stations = await self.rmv.search_station(self._station_id)
+            _LOGGER.debug(
+                "Search station %s", stations.get(str(self._station_id).zfill(9))
+            )
             self.station_info = stations.get(str(self._station_id).zfill(9))
 
         try:

--- a/homeassistant/components/rmvtransport/__init__.py
+++ b/homeassistant/components/rmvtransport/__init__.py
@@ -173,7 +173,6 @@ async def async_setup_entry(hass, config_entry):
             config_entry.data.get(CONF_TIME_OFFSET, DEFAULT_TIME_OFFSET),
             config_entry.data.get(CONF_MAX_JOURNEYS, DEFAULT_MAX_JOURNEYS),
             DEFAULT_TIMEOUT,
-            config_entry.data.get(CONF_SHOW_ON_MAP, False),
         )
         await rmv_rata.async_update()
         hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][config_entry.entry_id] = rmv_rata

--- a/homeassistant/components/rmvtransport/__init__.py
+++ b/homeassistant/components/rmvtransport/__init__.py
@@ -1,1 +1,289 @@
 """The rmvtransport component."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import (
+    CONF_NAME,
+    ATTR_ATTRIBUTION,
+    CONF_SCAN_INTERVAL,
+    CONF_SHOW_ON_MAP,
+)
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import Throttle
+
+# from .config_flow import configured_sensors, duplicate_stations
+from .const import (
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    DEFAULT_TIMEOUT,
+    DEFAULT_MAX_JOURNEYS,
+    DEFAULT_TIME_OFFSET,
+    CONF_STATION,
+    CONF_DESTINATIONS,
+    CONF_DIRECTION,
+    CONF_LINES,
+    CONF_PRODUCTS,
+    CONF_TIME_OFFSET,
+    CONF_MAX_JOURNEYS,
+    CONF_TIMEOUT,
+    VALID_PRODUCTS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_RMVTRANSPORT = "rmvtransport"
+DATA_RMVTRANSPORT_CLIENT = "data_rmvtransport_client"
+DATA_RMVTRANSPORT_LISTENER = "data_rmvtransport_listener"
+
+TOPIC_UPDATE = "{0}_data_update".format(DOMAIN)
+
+CONF_NEXT_DEPARTURE = "next_departure"
+
+DEFAULT_NAME = "RMV Journey"
+
+SCAN_INTERVAL = DEFAULT_SCAN_INTERVAL
+
+ICONS = {
+    "U-Bahn": "mdi:subway",
+    "Tram": "mdi:tram",
+    "Bus": "mdi:bus",
+    "S": "mdi:train",
+    "RB": "mdi:train",
+    "RE": "mdi:train",
+    "EC": "mdi:train",
+    "IC": "mdi:train",
+    "ICE": "mdi:train",
+    "SEV": "mdi:checkbox-blank-circle-outline",
+    None: "mdi:clock",
+}
+
+ATTRIBUTION = "Data provided by opendata.rmv.de"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_NEXT_DEPARTURE): [
+            {
+                vol.Required(CONF_STATION): cv.string,
+                vol.Optional(CONF_DESTINATIONS, default=[]): vol.All(
+                    cv.ensure_list, [cv.string]
+                ),
+                vol.Optional(CONF_DIRECTION): cv.string,
+                vol.Optional(CONF_LINES, default=[]): vol.All(
+                    cv.ensure_list, [cv.positive_int, cv.string]
+                ),
+                vol.Optional(CONF_PRODUCTS, default=VALID_PRODUCTS): vol.All(
+                    cv.ensure_list, [vol.In(VALID_PRODUCTS)]
+                ),
+                vol.Optional(
+                    CONF_TIME_OFFSET, default=DEFAULT_TIME_OFFSET
+                ): cv.positive_int,
+                vol.Optional(
+                    CONF_MAX_JOURNEYS, default=DEFAULT_MAX_JOURNEYS
+                ): cv.positive_int,
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            }
+        ],
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                # vol.Required(CONF_STATION_ID): cv.string,
+                vol.Required(CONF_STATION): cv.string,
+                vol.Optional(CONF_DESTINATIONS, default=[]): vol.All(
+                    cv.ensure_list, [cv.string]
+                ),
+                vol.Optional(CONF_DIRECTION): cv.string,
+                vol.Optional(CONF_LINES, default=[]): vol.All(
+                    cv.ensure_list, [cv.positive_int, cv.string]
+                ),
+                vol.Optional(CONF_PRODUCTS, default=VALID_PRODUCTS): vol.All(
+                    cv.ensure_list, [vol.In(VALID_PRODUCTS)]
+                ),
+                vol.Optional(
+                    CONF_TIME_OFFSET, default=DEFAULT_TIME_OFFSET
+                ): cv.positive_int,
+                vol.Optional(
+                    CONF_MAX_JOURNEYS, default=DEFAULT_MAX_JOURNEYS
+                ): cv.positive_int,
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(CONF_SHOW_ON_MAP, default=False): cv.boolean,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                ): cv.time_period,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """Set up the RMV transport component."""
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT] = {}
+    hass.data[DOMAIN][DATA_RMVTRANSPORT_LISTENER] = {}
+
+    if DOMAIN not in config:
+        return True
+
+    conf = config[DOMAIN]
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_STATION: conf[CONF_STATION],
+                CONF_SHOW_ON_MAP: conf[CONF_SHOW_ON_MAP],
+            },
+        )
+    )
+
+    hass.data[DOMAIN][CONF_SCAN_INTERVAL] = conf[CONF_SCAN_INTERVAL]
+
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set up Luftdaten as config entry."""
+    from RMVtransport.rmvtransport import RMVtransportApiConnectionError
+
+    session = async_get_clientsession(hass)
+
+    try:
+        rmv_rata = RMVDepartureData(
+            session,
+            config_entry.data[CONF_STATION],
+            config_entry.data.get(CONF_DESTINATIONS, []),
+            config_entry.data.get(CONF_DIRECTION),
+            config_entry.data.get(CONF_LINES, []),
+            config_entry.data.get(CONF_PRODUCTS, VALID_PRODUCTS),
+            config_entry.data.get(CONF_TIME_OFFSET, DEFAULT_TIME_OFFSET),
+            config_entry.data.get(CONF_MAX_JOURNEYS, DEFAULT_MAX_JOURNEYS),
+            DEFAULT_TIMEOUT,
+        )
+        await rmv_rata.async_update()
+        hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][config_entry.entry_id] = rmv_rata
+    except RMVtransportApiConnectionError:
+        raise ConfigEntryNotReady
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
+    )
+
+    async def refresh_sensors(event_time):
+        """Refresh RMV transport data."""
+        await rmv_rata.async_update()
+        async_dispatcher_send(hass, TOPIC_UPDATE)
+
+    hass.data[DOMAIN][DATA_RMVTRANSPORT_LISTENER][
+        config_entry.entry_id
+    ] = async_track_time_interval(
+        hass,
+        refresh_sensors,
+        hass.data[DOMAIN].get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+    )
+
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload an Luftdaten config entry."""
+    remove_listener = hass.data[DOMAIN][DATA_RMVTRANSPORT_LISTENER].pop(
+        config_entry.entry_id
+    )
+    remove_listener()
+
+    for component in ("sensor",):
+        await hass.config_entries.async_forward_entry_unload(config_entry, component)
+
+    hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT].pop(config_entry.entry_id)
+
+    return True
+
+
+class RMVDepartureData:
+    """Pull data from the opendata.rmv.de web page."""
+
+    def __init__(
+        self,
+        session,
+        station_id,
+        destinations,
+        direction_id,
+        lines,
+        products,
+        time_offset,
+        max_journeys,
+        timeout,
+    ):
+        """Initialize the sensor."""
+        from RMVtransport import RMVtransport
+
+        self.station = None
+        self._station_id = station_id
+        self._destinations = destinations
+        self._direction_id = direction_id
+        self._lines = lines
+        self._products = products
+        self._time_offset = time_offset
+        self._max_journeys = max_journeys
+        self.rmv = RMVtransport(session, timeout)
+        self.departures = []
+        self.station_info = None
+
+    @Throttle(SCAN_INTERVAL)
+    async def async_update(self):
+        """Update the connection data."""
+        from RMVtransport.rmvtransport import RMVtransportApiConnectionError
+
+        if self.station_info is None:
+            stations = await self.rmv.search_station(self._station_id)
+            self.station_info = stations.get(str(self._station_id).zfill(9))
+
+        try:
+            _data = await self.rmv.get_departures(
+                self._station_id,
+                products=self._products,
+                direction_id=self._direction_id,
+                max_journeys=50,
+            )
+        except RMVtransportApiConnectionError:
+            self.departures = []
+            _LOGGER.warning("Could not retrive data from rmv.de")
+            return
+        self.station = _data.get("station")
+        _deps = []
+        for journey in _data["journeys"]:
+            # find the first departure meeting the criteria
+            _nextdep = {ATTR_ATTRIBUTION: ATTRIBUTION}
+            if self._destinations:
+                dest_found = False
+                for dest in self._destinations:
+                    if dest in journey["stops"]:
+                        dest_found = True
+                        _nextdep["destination"] = dest
+                if not dest_found:
+                    continue
+            elif self._lines and journey["number"] not in self._lines:
+                continue
+            elif journey["minutes"] < self._time_offset:
+                continue
+            for attr in ["direction", "departure_time", "product", "minutes"]:
+                _nextdep[attr] = journey.get(attr, "")
+            _nextdep["line"] = journey.get("number", "")
+            _deps.append(_nextdep)
+            if len(_deps) > self._max_journeys:
+                break
+        self.departures = _deps

--- a/homeassistant/components/rmvtransport/__init__.py
+++ b/homeassistant/components/rmvtransport/__init__.py
@@ -173,6 +173,7 @@ async def async_setup_entry(hass, config_entry):
             config_entry.data.get(CONF_TIME_OFFSET, DEFAULT_TIME_OFFSET),
             config_entry.data.get(CONF_MAX_JOURNEYS, DEFAULT_MAX_JOURNEYS),
             DEFAULT_TIMEOUT,
+            config_entry.data.get(CONF_SHOW_ON_MAP, False),
         )
         await rmv_rata.async_update()
         hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][config_entry.entry_id] = rmv_rata
@@ -251,9 +252,6 @@ class RMVDepartureData:
 
         if self.station_info is None:
             stations = await self.rmv.search_station(self._station_id)
-            _LOGGER.debug(
-                "Search station %s", stations.get(str(self._station_id).zfill(9))
-            )
             self.station_info = stations.get(str(self._station_id).zfill(9))
 
         try:

--- a/homeassistant/components/rmvtransport/config_flow.py
+++ b/homeassistant/components/rmvtransport/config_flow.py
@@ -1,0 +1,157 @@
+"""Config flow to configure the Rhein-Main public transport component."""
+from collections import OrderedDict
+import hashlib
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_MONITORED_CONDITIONS,
+    CONF_SCAN_INTERVAL,
+    CONF_SENSORS,
+    CONF_SHOW_ON_MAP,
+)
+from homeassistant.helpers import aiohttp_client
+
+from .const import (
+    # CONF_STATION_ID,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    CONF_HASH,
+    CONF_STATION,
+    CONF_DESTINATIONS,
+    CONF_DIRECTION,
+    CONF_LINES,
+    CONF_PRODUCTS,
+    CONF_TIME_OFFSET,
+    CONF_MAX_JOURNEYS,
+    VALID_PRODUCTS,
+)
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class RMVTransportFlowHandler(config_entries.ConfigFlow):
+    """Handle a rmv transport config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize the RMV transport config flow."""
+        self.rmv_config = {}
+
+    async def _show_form_lines(self, errors=None):
+        """Show the setup form to the user."""
+        data_schema = OrderedDict()
+        data_schema[vol.Optional(CONF_DESTINATIONS)] = str
+        data_schema[vol.Optional(CONF_LINES, default="")] = str
+        data_schema[vol.Optional(CONF_DIRECTION)] = str
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors or {}
+        )
+
+    async def _show_form_products(self, errors=None):
+        """Show the setup form to the user."""
+        data_schema = OrderedDict()
+
+        for product in VALID_PRODUCTS:
+            data_schema[vol.Optional(product, default=True)] = bool
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors or {}
+        )
+
+    async def _show_form_details(self, errors=None):
+        """Show the form to the user."""
+        data_schema = OrderedDict()
+        data_schema[vol.Optional(CONF_NAME, default=self.rmv_config[CONF_NAME])] = str
+        data_schema[vol.Optional(CONF_SHOW_ON_MAP, default=False)] = bool
+        data_schema[vol.Optional(CONF_TIME_OFFSET, default=0)] = int
+        data_schema[vol.Optional(CONF_MAX_JOURNEYS, default=5)] = int
+        data_schema[
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL.seconds)
+        ] = int
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors or {}
+        )
+
+    async def _show_form_station(self, errors=None):
+        """Show the form to the user."""
+        data_schema = OrderedDict()
+        data_schema[vol.Required(CONF_STATION, default="3006904")] = str
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors or {}
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        from RMVtransport import RMVtransport
+        from RMVtransport.rmvtransport import (
+            RMVtransportApiConnectionError,
+            RMVtransportError,
+        )
+
+        if user_input is not None:
+            self.rmv_config.update(user_input)
+
+        if self.rmv_config.get(CONF_STATION) is None:
+            return await self._show_form_station()
+
+        session = aiohttp_client.async_get_clientsession(self.hass)
+        rmv = RMVtransport(session)
+
+        if self.rmv_config.get(CONF_NAME) is None:
+            try:
+                data = await rmv.get_departures(self.rmv_config[CONF_STATION])
+                self.rmv_config[CONF_NAME] = str(data["station"])
+            except RMVtransportApiConnectionError:
+                return self._show_form_station({CONF_STATION: "communication_error"})
+            except RMVtransportError:
+                return self._show_form_station({CONF_STATION: "invalid_sensor"})
+
+        if (
+            self.rmv_config.get("Bus") is None
+            and self.rmv_config.get(CONF_PRODUCTS) is None
+        ):
+            return await self._show_form_products()
+        elif self.rmv_config.get(CONF_PRODUCTS) is None:
+            self.rmv_config[CONF_PRODUCTS] = []
+            for product in VALID_PRODUCTS:
+                if user_input[product] is True:
+                    self.rmv_config[CONF_PRODUCTS].append(product)
+                del self.rmv_config[product]
+
+        if self.rmv_config.get(CONF_SHOW_ON_MAP) is None:
+            return await self._show_form_details()
+        else:
+            pass
+            # search for station and extract lat/long
+
+        if self.rmv_config.get(CONF_LINES) is None:
+            return await self._show_form_lines()
+        elif isinstance(self.rmv_config.get(CONF_LINES), str):
+            if self.rmv_config[CONF_LINES] == "":
+                self.rmv_config[CONF_LINES] = []
+            else:
+                self.rmv_config[CONF_LINES] = [
+                    x.strip() for x in self.rmv_config[CONF_LINES].split(",")
+                ]
+
+        # if self.rmv_config.get(CONF_HASH) is None:
+        user_input_hash = hashlib.sha224(f"{self.rmv_config}".encode()).hexdigest()
+        self.rmv_config[CONF_HASH] = user_input_hash
+
+        existing_entities = set(
+            entry.data[CONF_HASH]
+            for entry in self.hass.config_entries.async_entries(DOMAIN)
+        )
+        if user_input_hash in existing_entities:
+            return await self._show_form_station({CONF_STATION: "sensor_exists"})
+
+        return self.async_create_entry(
+            title=self.rmv_config[CONF_NAME], data=self.rmv_config
+        )

--- a/homeassistant/components/rmvtransport/config_flow.py
+++ b/homeassistant/components/rmvtransport/config_flow.py
@@ -5,13 +5,7 @@ import hashlib
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_MONITORED_CONDITIONS,
-    CONF_SCAN_INTERVAL,
-    CONF_SENSORS,
-    CONF_SHOW_ON_MAP,
-)
+from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_SHOW_ON_MAP
 from homeassistant.helpers import aiohttp_client
 
 from .const import (

--- a/homeassistant/components/rmvtransport/config_flow.py
+++ b/homeassistant/components/rmvtransport/config_flow.py
@@ -9,7 +9,6 @@ from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_SHOW_ON_MAP
 from homeassistant.helpers import aiohttp_client
 
 from .const import (
-    # CONF_STATION_ID,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     CONF_HASH,
@@ -75,7 +74,7 @@ class RMVTransportFlowHandler(config_entries.ConfigFlow):
     async def _show_form_station(self, errors=None):
         """Show the form to the user."""
         data_schema = OrderedDict()
-        data_schema[vol.Required(CONF_STATION, default="3006904")] = str
+        data_schema[vol.Required(CONF_STATION)] = str
 
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(data_schema), errors=errors or {}
@@ -132,7 +131,6 @@ class RMVTransportFlowHandler(config_entries.ConfigFlow):
                     x.strip() for x in self.rmv_config[CONF_LINES].split(",")
                 ]
 
-        # if self.rmv_config.get(CONF_HASH) is None:
         user_input_hash = hashlib.sha224(f"{self.rmv_config}".encode()).hexdigest()
         self.rmv_config[CONF_HASH] = user_input_hash
 

--- a/homeassistant/components/rmvtransport/config_flow.py
+++ b/homeassistant/components/rmvtransport/config_flow.py
@@ -112,7 +112,7 @@ class RMVTransportFlowHandler(config_entries.ConfigFlow):
             and self.rmv_config.get(CONF_PRODUCTS) is None
         ):
             return await self._show_form_products()
-        elif self.rmv_config.get(CONF_PRODUCTS) is None:
+        if self.rmv_config.get(CONF_PRODUCTS) is None:
             self.rmv_config[CONF_PRODUCTS] = []
             for product in VALID_PRODUCTS:
                 if user_input[product] is True:
@@ -121,13 +121,10 @@ class RMVTransportFlowHandler(config_entries.ConfigFlow):
 
         if self.rmv_config.get(CONF_SHOW_ON_MAP) is None:
             return await self._show_form_details()
-        else:
-            pass
-            # search for station and extract lat/long
 
         if self.rmv_config.get(CONF_LINES) is None:
             return await self._show_form_lines()
-        elif isinstance(self.rmv_config.get(CONF_LINES), str):
+        if isinstance(self.rmv_config.get(CONF_LINES), str):
             if self.rmv_config[CONF_LINES] == "":
                 self.rmv_config[CONF_LINES] = []
             else:

--- a/homeassistant/components/rmvtransport/const.py
+++ b/homeassistant/components/rmvtransport/const.py
@@ -1,0 +1,26 @@
+"""Define constants for the Luftdaten component."""
+from datetime import timedelta
+
+ATTR_STATION_ID = "station_id"
+
+CONF_STATION_ID = "station_id"
+
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
+
+DEFAULT_TIMEOUT = 10
+DEFAULT_MAX_JOURNEYS = 5
+DEFAULT_TIME_OFFSET = 0
+
+DOMAIN = "rmvtransport"
+
+CONF_STATION = "station"
+CONF_DESTINATIONS = "destinations"
+CONF_DIRECTION = "direction"
+CONF_LINES = "lines"
+CONF_PRODUCTS = "products"
+CONF_TIME_OFFSET = "time_offset"
+CONF_MAX_JOURNEYS = "max_journeys"
+CONF_TIMEOUT = "timeout"
+CONF_HASH = "conf_hash"
+
+VALID_PRODUCTS = ["U-Bahn", "Tram", "Bus", "S", "RB", "RE", "EC", "IC", "ICE"]

--- a/homeassistant/components/rmvtransport/manifest.json
+++ b/homeassistant/components/rmvtransport/manifest.json
@@ -3,7 +3,7 @@
   "name": "Rmvtransport",
   "documentation": "https://www.home-assistant.io/components/rmvtransport",
   "requirements": [
-    "PyRMVtransport==0.2.8"
+    "PyRMVtransport==0.2.9"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/rmvtransport/manifest.json
+++ b/homeassistant/components/rmvtransport/manifest.json
@@ -3,10 +3,11 @@
   "name": "Rmvtransport",
   "documentation": "https://www.home-assistant.io/components/rmvtransport",
   "requirements": [
-    "PyRMVtransport==0.1.3"
+    "PyRMVtransport==0.2.8"
   ],
   "dependencies": [],
   "codeowners": [
     "@cgtobi"
-  ]
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -57,7 +57,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 next_departure.get(CONF_PRODUCTS, VALID_PRODUCTS),
                 next_departure.get(CONF_TIME_OFFSET, DEFAULT_TIME_OFFSET),
                 next_departure.get(CONF_MAX_JOURNEYS, DEFAULT_MAX_JOURNEYS),
-                next_departure.get(CONF_NAME),
+                next_departure.get(CONF_NAME, DEFAULT_NAME),
                 timeout,
                 next_departure.get(CONF_SHOW_ON_MAP, False),
             )

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -78,7 +78,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     session = async_get_clientsession(hass)
 
-    rmv_rata = RMVDepartureSensor(
+    rmv_data = RMVDepartureSensor(
         session,
         entry.data[CONF_STATION],
         entry.data.get(CONF_DESTINATIONS, []),
@@ -91,10 +91,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
         timeout,
         entry.data.get(CONF_SHOW_ON_MAP),
     )
-    await rmv_rata.async_update()
-    hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][entry.entry_id] = rmv_rata
+    await rmv_data.async_update()
+    hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][entry.entry_id] = rmv_data
 
-    async_add_entities([rmv_rata])
+    async_add_entities([rmv_data])
 
 
 class RMVDepartureSensor(Entity):

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle, slugify
+from homeassistant.util import slugify
 
 from . import (
     DATA_RMVTRANSPORT_CLIENT,

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -1,75 +1,42 @@
 """Support for departure information for Rhein-Main public transport."""
 import asyncio
 import logging
-from datetime import timedelta
 
-import voluptuous as vol
-
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, ATTR_ATTRIBUTION
+from homeassistant.const import (
+    CONF_NAME,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_SHOW_ON_MAP,
+)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle, slugify
+
+from . import (
+    DATA_RMVTRANSPORT_CLIENT,
+    DEFAULT_NAME,
+    CONF_TIMEOUT,
+    CONF_STATION,
+    CONF_DESTINATIONS,
+    CONF_DIRECTION,
+    CONF_LINES,
+    CONF_PRODUCTS,
+    CONF_TIME_OFFSET,
+    CONF_MAX_JOURNEYS,
+    CONF_NEXT_DEPARTURE,
+    ICONS,
+    RMVDepartureData,
+)
+from .const import (
+    DOMAIN,
+    DEFAULT_MAX_JOURNEYS,
+    DEFAULT_TIME_OFFSET,
+    DEFAULT_TIMEOUT,
+    VALID_PRODUCTS,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_NEXT_DEPARTURE = "next_departure"
-
-CONF_STATION = "station"
-CONF_DESTINATIONS = "destinations"
-CONF_DIRECTION = "direction"
-CONF_LINES = "lines"
-CONF_PRODUCTS = "products"
-CONF_TIME_OFFSET = "time_offset"
-CONF_MAX_JOURNEYS = "max_journeys"
-CONF_TIMEOUT = "timeout"
-
-DEFAULT_NAME = "RMV Journey"
-
-VALID_PRODUCTS = ["U-Bahn", "Tram", "Bus", "S", "RB", "RE", "EC", "IC", "ICE"]
-
-ICONS = {
-    "U-Bahn": "mdi:subway",
-    "Tram": "mdi:tram",
-    "Bus": "mdi:bus",
-    "S": "mdi:train",
-    "RB": "mdi:train",
-    "RE": "mdi:train",
-    "EC": "mdi:train",
-    "IC": "mdi:train",
-    "ICE": "mdi:train",
-    "SEV": "mdi:checkbox-blank-circle-outline",
-    None: "mdi:clock",
-}
-ATTRIBUTION = "Data provided by opendata.rmv.de"
-
-SCAN_INTERVAL = timedelta(seconds=60)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_NEXT_DEPARTURE): [
-            {
-                vol.Required(CONF_STATION): cv.string,
-                vol.Optional(CONF_DESTINATIONS, default=[]): vol.All(
-                    cv.ensure_list, [cv.string]
-                ),
-                vol.Optional(CONF_DIRECTION): cv.string,
-                vol.Optional(CONF_LINES, default=[]): vol.All(
-                    cv.ensure_list, [cv.positive_int, cv.string]
-                ),
-                vol.Optional(CONF_PRODUCTS, default=VALID_PRODUCTS): vol.All(
-                    cv.ensure_list, [vol.In(VALID_PRODUCTS)]
-                ),
-                vol.Optional(CONF_TIME_OFFSET, default=0): cv.positive_int,
-                vol.Optional(CONF_MAX_JOURNEYS, default=5): cv.positive_int,
-                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-            }
-        ],
-        vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int,
-    }
-)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -84,14 +51,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             RMVDepartureSensor(
                 session,
                 next_departure[CONF_STATION],
-                next_departure.get(CONF_DESTINATIONS),
+                next_departure.get(CONF_DESTINATIONS, []),
                 next_departure.get(CONF_DIRECTION),
-                next_departure.get(CONF_LINES),
-                next_departure.get(CONF_PRODUCTS),
-                next_departure.get(CONF_TIME_OFFSET),
-                next_departure.get(CONF_MAX_JOURNEYS),
+                next_departure.get(CONF_LINES, []),
+                next_departure.get(CONF_PRODUCTS, VALID_PRODUCTS),
+                next_departure.get(CONF_TIME_OFFSET, DEFAULT_TIME_OFFSET),
+                next_departure.get(CONF_MAX_JOURNEYS, DEFAULT_MAX_JOURNEYS),
                 next_departure.get(CONF_NAME),
                 timeout,
+                next_departure.get(CONF_SHOW_ON_MAP, False),
             )
         )
 
@@ -102,6 +70,31 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         raise PlatformNotReady
 
     async_add_entities(sensors)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up a RMV departure sensor based on a config entry."""
+    timeout = entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+
+    session = async_get_clientsession(hass)
+
+    rmv_rata = RMVDepartureSensor(
+        session,
+        entry.data[CONF_STATION],
+        entry.data.get(CONF_DESTINATIONS, []),
+        entry.data.get(CONF_DIRECTION),
+        entry.data.get(CONF_LINES, []),
+        entry.data.get(CONF_PRODUCTS),
+        entry.data.get(CONF_TIME_OFFSET, DEFAULT_TIME_OFFSET),
+        entry.data.get(CONF_MAX_JOURNEYS, DEFAULT_MAX_JOURNEYS),
+        entry.title,
+        timeout,
+        entry.data.get(CONF_SHOW_ON_MAP),
+    )
+    await rmv_rata.async_update()
+    hass.data[DOMAIN][DATA_RMVTRANSPORT_CLIENT][entry.entry_id] = rmv_rata
+
+    async_add_entities([rmv_rata])
 
 
 class RMVDepartureSensor(Entity):
@@ -119,6 +112,7 @@ class RMVDepartureSensor(Entity):
         max_journeys,
         name,
         timeout,
+        show_on_map=False,
     ):
         """Initialize the sensor."""
         self._station = station
@@ -135,7 +129,12 @@ class RMVDepartureSensor(Entity):
             max_journeys,
             timeout,
         )
+        self._show_on_map = show_on_map
         self._icon = ICONS[None]
+        self._uniqueid = slugify(
+            f"s{station}-d{direction}-l{''.join(lines)}-"
+            f"p{''.join(products)}-t{time_offset}-mj{max_journeys}-{name}"
+        )
 
     @property
     def name(self):
@@ -156,7 +155,7 @@ class RMVDepartureSensor(Entity):
     def state_attributes(self):
         """Return the state attributes."""
         try:
-            return {
+            attrs = {
                 "next_departures": [val for val in self.data.departures[1:]],
                 "direction": self.data.departures[0].get("direction"),
                 "line": self.data.departures[0].get("line"),
@@ -164,8 +163,33 @@ class RMVDepartureSensor(Entity):
                 "departure_time": self.data.departures[0].get("departure_time"),
                 "product": self.data.departures[0].get("product"),
             }
+            on_map = ATTR_LATITUDE, ATTR_LONGITUDE
+            no_map = "lat", "long"
+            lat_format, lon_format = on_map if self._show_on_map else no_map
+            try:
+                attrs[lon_format] = self.data.station_info["long"]
+                attrs[lat_format] = self.data.station_info["lat"]
+            except (KeyError, TypeError):
+                pass
+
+            return attrs
         except IndexError:
             return {}
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return {
+            "next_departures": [val for val in self.data.departures[1:]],
+            "direction": self.data.departures[0].get("direction"),
+            "line": self.data.departures[0].get("line"),
+            "product": self.data.departures[0].get("product"),
+        }
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier for this device."""
+        return self._uniqueid
 
     @property
     def icon(self):
@@ -190,74 +214,3 @@ class RMVDepartureSensor(Entity):
         self._station = self.data.station
         self._state = self.data.departures[0].get("minutes")
         self._icon = ICONS[self.data.departures[0].get("product")]
-
-
-class RMVDepartureData:
-    """Pull data from the opendata.rmv.de web page."""
-
-    def __init__(
-        self,
-        session,
-        station_id,
-        destinations,
-        direction,
-        lines,
-        products,
-        time_offset,
-        max_journeys,
-        timeout,
-    ):
-        """Initialize the sensor."""
-        from RMVtransport import RMVtransport
-
-        self.station = None
-        self._station_id = station_id
-        self._destinations = destinations
-        self._direction = direction
-        self._lines = lines
-        self._products = products
-        self._time_offset = time_offset
-        self._max_journeys = max_journeys
-        self.rmv = RMVtransport(session, timeout)
-        self.departures = []
-
-    @Throttle(SCAN_INTERVAL)
-    async def async_update(self):
-        """Update the connection data."""
-        from RMVtransport.rmvtransport import RMVtransportApiConnectionError
-
-        try:
-            _data = await self.rmv.get_departures(
-                self._station_id,
-                products=self._products,
-                directionId=self._direction,
-                maxJourneys=50,
-            )
-        except RMVtransportApiConnectionError:
-            self.departures = []
-            _LOGGER.warning("Could not retrive data from rmv.de")
-            return
-        self.station = _data.get("station")
-        _deps = []
-        for journey in _data["journeys"]:
-            # find the first departure meeting the criteria
-            _nextdep = {ATTR_ATTRIBUTION: ATTRIBUTION}
-            if self._destinations:
-                dest_found = False
-                for dest in self._destinations:
-                    if dest in journey["stops"]:
-                        dest_found = True
-                        _nextdep["destination"] = dest
-                if not dest_found:
-                    continue
-            elif self._lines and journey["number"] not in self._lines:
-                continue
-            elif journey["minutes"] < self._time_offset:
-                continue
-            for attr in ["direction", "departure_time", "product", "minutes"]:
-                _nextdep[attr] = journey.get(attr, "")
-            _nextdep["line"] = journey.get("number", "")
-            _deps.append(_nextdep)
-            if len(_deps) > self._max_journeys:
-                break
-        self.departures = _deps

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -132,7 +132,7 @@ class RMVDepartureSensor(Entity):
         self._show_on_map = show_on_map
         self._icon = ICONS[None]
         self._uniqueid = slugify(
-            f"s{station}-d{direction}-l{''.join(lines)}-"
+            f"s{station}-d{direction}-l{''.join([str(l) for l in lines])}-"
             f"p{''.join(products)}-t{time_offset}-mj{max_journeys}-{name}"
         )
 

--- a/homeassistant/components/rmvtransport/strings.json
+++ b/homeassistant/components/rmvtransport/strings.json
@@ -21,8 +21,8 @@
           "lines": "Lines",
           "direction": "Direction",
           "destinations": "Destinations",
-          "max_journeys": "max_journeys",
-          "scan_interval": "scan_interval"
+          "max_journeys": "Max. journeys",
+          "scan_interval": "Scan interval"
         }
       }
     },

--- a/homeassistant/components/rmvtransport/strings.json
+++ b/homeassistant/components/rmvtransport/strings.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "title": "RMV Transport",
+    "step": {
+      "user": {
+        "title": "Define RMV Transport",
+        "data": {
+          "station": "Station ID",
+          "show_on_map": "Show on map",
+          "ICE": "ICE",
+          "U-Bahn": "U-Bahn",
+          "Tram": "Tram",
+          "Bus": "Bus",
+          "S": "S",
+          "RB": "RB",
+          "RE": "RE",
+          "EC": "EC",
+          "IC": "IC",
+          "name": "Name",
+          "time_offset": "Time offset",
+          "lines": "Lines",
+          "direction": "Direction",
+          "destinations": "Destinations",
+          "max_journeys": "max_journeys",
+          "scan_interval": "scan_interval"
+        }
+      }
+    },
+    "error": {
+      "sensor_exists": "Sensor already registered",
+      "invalid_sensor": "Sensor not available or invalid",
+      "communication_error": "Unable to communicate with the RMV Transport API"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -43,6 +43,7 @@ FLOWS = [
     "point",
     "ps4",
     "rainmachine",
+    "rmvtransport",
     "simplisafe",
     "smartthings",
     "smhi",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -65,7 +65,7 @@ PyNaCl==1.3.0
 PyQRCode==1.2.1
 
 # homeassistant.components.rmvtransport
-PyRMVtransport==0.1.3
+PyRMVtransport==0.2.8
 
 # homeassistant.components.switchbot
 # PySwitchbot==0.6.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -65,7 +65,7 @@ PyNaCl==1.3.0
 PyQRCode==1.2.1
 
 # homeassistant.components.rmvtransport
-PyRMVtransport==0.2.8
+PyRMVtransport==0.2.9
 
 # homeassistant.components.switchbot
 # PySwitchbot==0.6.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -31,7 +31,7 @@ HAP-python==2.5.0
 PyNaCl==1.3.0
 
 # homeassistant.components.rmvtransport
-PyRMVtransport==0.2.8
+PyRMVtransport==0.2.9
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -31,7 +31,7 @@ HAP-python==2.5.0
 PyNaCl==1.3.0
 
 # homeassistant.components.rmvtransport
-PyRMVtransport==0.1.3
+PyRMVtransport==0.2.8
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/tests/components/rmvtransport/test_config_flow.py
+++ b/tests/components/rmvtransport/test_config_flow.py
@@ -1,27 +1,14 @@
 """Tests for rmvtransport config flow."""
 from unittest.mock import patch
 
-import asyncio
-
 from homeassistant.components.rmvtransport import config_flow
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import mock_coro
 
 from .test_sensor import get_departures_mock, search_station_mock
 
 
 async def test_flow_works(hass, aioclient_mock):
     """Test that config flow works."""
-    # aioclient_mock.get(
-    #     pydeconz.utils.URL_DISCOVER,
-    #     json=[{"id": "id", "internalipaddress": "1.2.3.4", "internalport": 80}],
-    #     headers={"content-type": "application/json"},
-    # )
-    # aioclient_mock.post(
-    #     "http://1.2.3.4:80/api",
-    #     json=[{"success": {"username": "1234567890ABCDEF"}}],
-    #     headers={"content-type": "application/json"},
-    # )
-
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": "user"}
     )

--- a/tests/components/rmvtransport/test_config_flow.py
+++ b/tests/components/rmvtransport/test_config_flow.py
@@ -1,0 +1,65 @@
+"""Tests for rmvtransport config flow."""
+from unittest.mock import patch
+
+import asyncio
+
+from homeassistant.components.rmvtransport import config_flow
+from tests.common import MockConfigEntry, mock_coro
+
+from .test_sensor import get_departures_mock, search_station_mock
+
+
+async def test_flow_works(hass, aioclient_mock):
+    """Test that config flow works."""
+    # aioclient_mock.get(
+    #     pydeconz.utils.URL_DISCOVER,
+    #     json=[{"id": "id", "internalipaddress": "1.2.3.4", "internalport": 80}],
+    #     headers={"content-type": "application/json"},
+    # )
+    # aioclient_mock.post(
+    #     "http://1.2.3.4:80/api",
+    #     json=[{"success": {"username": "1234567890ABCDEF"}}],
+    #     headers={"content-type": "application/json"},
+    # )
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    with patch(
+        "RMVtransport.RMVtransport.get_departures",
+        return_value=mock_coro(get_departures_mock()),
+    ):
+        with patch(
+            "RMVtransport.RMVtransport.search_station",
+            return_value=mock_coro(search_station_mock()),
+        ):
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={config_flow.CONF_STATION: "3000010"}
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={"ICE": False, "IC": False, "RE": False, "EC": False},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={config_flow.CONF_SHOW_ON_MAP: True}
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={}
+            )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Frankfurt (Main) Hauptbahnhof"
+    assert result["data"][config_flow.CONF_STATION] == "3000010"
+    assert result["data"][config_flow.CONF_SHOW_ON_MAP] is True
+    assert result["data"][config_flow.CONF_PRODUCTS] == [
+        "U-Bahn",
+        "Tram",
+        "Bus",
+        "S",
+        "RB",
+    ]

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -2,6 +2,7 @@
 import datetime
 from unittest.mock import patch
 
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro
@@ -27,6 +28,7 @@ VALID_CONFIG_MISC = {
                 "lines": [21, "S8"],
                 "max_journeys": 2,
                 "time_offset": 10,
+                "show_on_map": True,
             }
         ],
     }
@@ -235,6 +237,8 @@ async def test_rmvtransport_misc_config(hass):
     # state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     # assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
     assert state.attributes["line"] == 21
+    assert state.attributes[ATTR_LATITUDE] == 50.106808
+    assert state.attributes[ATTR_LONGITUDE] == 8.662653
 
 
 async def test_rmvtransport_dest_config(hass):

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -50,8 +50,14 @@ VALID_CONFIG_DEST = {
 
 def search_station_mock():
     """Mock rmvtransport station search."""
-    data = {}
-    return data
+    return {
+        "003000010": {
+            "id": "003000010",
+            "name": "Frankfurt (Main) Hauptbahnhof",
+            "lat": 50.106808,
+            "long": 8.662653,
+        }
+    }
 
 
 def get_departures_mock():
@@ -195,6 +201,8 @@ async def test_rmvtransport_min_config(hass):
     assert state.attributes["line"] == 12
     assert state.attributes["icon"] == "mdi:tram"
     # assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
+    assert state.attributes["lat"] == 50.106808
+    assert state.attributes["long"] == 8.662653
 
 
 async def test_rmvtransport_name_config(hass):

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -48,6 +48,12 @@ VALID_CONFIG_DEST = {
 }
 
 
+def search_station_mock():
+    """Mock rmvtransport station search."""
+    data = {}
+    return data
+
+
 def get_departures_mock():
     """Mock rmvtransport departures loading."""
     data = {
@@ -167,9 +173,19 @@ async def test_rmvtransport_min_config(hass):
         "RMVtransport.RMVtransport.get_departures",
         return_value=mock_coro(get_departures_mock()),
     ):
-        assert await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL) is True
+        with patch(
+            "RMVtransport.RMVtransport.search_station",
+            return_value=mock_coro(search_station_mock()),
+        ):
+            assert (
+                await async_setup_component(hass, "sensor", VALID_CONFIG_MINIMAL)
+                is True
+            )
 
-    state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
+    state = hass.states.get(
+        "sensor.rmvtransport_s3000010_dnone_l_pu_bahntrambussrbreecicice_t0_mj5_none"
+    )
+    # state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert state.state == "7"
     assert state.attributes["departure_time"] == datetime.datetime(2018, 8, 6, 14, 21)
     assert (
@@ -178,7 +194,7 @@ async def test_rmvtransport_min_config(hass):
     assert state.attributes["product"] == "Tram"
     assert state.attributes["line"] == 12
     assert state.attributes["icon"] == "mdi:tram"
-    assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
+    # assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
 
 
 async def test_rmvtransport_name_config(hass):
@@ -199,10 +215,17 @@ async def test_rmvtransport_misc_config(hass):
         "RMVtransport.RMVtransport.get_departures",
         return_value=mock_coro(get_departures_mock()),
     ):
-        assert await async_setup_component(hass, "sensor", VALID_CONFIG_MISC)
+        with patch(
+            "RMVtransport.RMVtransport.search_station",
+            return_value=mock_coro(search_station_mock()),
+        ):
+            assert await async_setup_component(hass, "sensor", VALID_CONFIG_MISC)
 
-    state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
-    assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
+    state = hass.states.get(
+        "sensor.rmvtransport_s3000010_dnone_l21s8_pu_bahntrambussrbreecicice_t10_mj2_none"
+    )
+    # state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
+    # assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
     assert state.attributes["line"] == 21
 
 
@@ -212,9 +235,16 @@ async def test_rmvtransport_dest_config(hass):
         "RMVtransport.RMVtransport.get_departures",
         return_value=mock_coro(get_departures_mock()),
     ):
-        assert await async_setup_component(hass, "sensor", VALID_CONFIG_DEST)
+        with patch(
+            "RMVtransport.RMVtransport.search_station",
+            return_value=mock_coro(search_station_mock()),
+        ):
+            assert await async_setup_component(hass, "sensor", VALID_CONFIG_DEST)
 
-    state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
+    state = hass.states.get(
+        "sensor.rmvtransport_s3000010_dnone_l_pu_bahntrambussrbreecicice_t0_mj5_none"
+    )
+    # state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert state.state == "11"
     assert (
         state.attributes["direction"] == "Frankfurt (Main) Hugo-Junkers-Straße/Schleife"

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -190,10 +190,7 @@ async def test_rmvtransport_min_config(hass):
                 is True
             )
 
-    state = hass.states.get(
-        "sensor.rmvtransport_s3000010_dnone_l_pu_bahntrambussrbreecicice_t0_mj5_none"
-    )
-    # state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
+    state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert state.state == "7"
     assert state.attributes["departure_time"] == datetime.datetime(2018, 8, 6, 14, 21)
     assert (
@@ -202,7 +199,7 @@ async def test_rmvtransport_min_config(hass):
     assert state.attributes["product"] == "Tram"
     assert state.attributes["line"] == 12
     assert state.attributes["icon"] == "mdi:tram"
-    # assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
+    assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
     assert state.attributes["lat"] == 50.106808
     assert state.attributes["long"] == 8.662653
 
@@ -231,11 +228,8 @@ async def test_rmvtransport_misc_config(hass):
         ):
             assert await async_setup_component(hass, "sensor", VALID_CONFIG_MISC)
 
-    state = hass.states.get(
-        "sensor.rmvtransport_s3000010_dnone_l21s8_pu_bahntrambussrbreecicice_t10_mj2_none"
-    )
-    # state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
-    # assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
+    state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
+    assert state.attributes["friendly_name"] == "Frankfurt (Main) Hauptbahnhof"
     assert state.attributes["line"] == 21
     assert state.attributes[ATTR_LATITUDE] == 50.106808
     assert state.attributes[ATTR_LONGITUDE] == 8.662653
@@ -253,10 +247,7 @@ async def test_rmvtransport_dest_config(hass):
         ):
             assert await async_setup_component(hass, "sensor", VALID_CONFIG_DEST)
 
-    state = hass.states.get(
-        "sensor.rmvtransport_s3000010_dnone_l_pu_bahntrambussrbreecicice_t0_mj5_none"
-    )
-    # state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
+    state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
     assert state.state == "11"
     assert (
         state.attributes["direction"] == "Frankfurt (Main) Hugo-Junkers-Straße/Schleife"


### PR DESCRIPTION
## Description:
This bumps the version of PyRMVtransport to v0.2.8 and adds a config flow for RMV transport. The sensors can now also be shown on the map.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10052
 
## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: rmvtransport
    next_departure:
     - station: 3000010
     - show_on_map: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
