### PR TITLE
Bump envoy_reader to 0.8.6, fix missing dependency 

### DIFF
--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -3,7 +3,7 @@
   "name": "Enphase envoy",
   "documentation": "https://www.home-assistant.io/components/enphase_envoy",
   "requirements": [
-    "envoy_reader==0.8"
+    "envoy_reader==0.8.6"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -442,7 +442,7 @@ env_canada==0.0.20
 # envirophat==0.0.6
 
 # homeassistant.components.enphase_envoy
-envoy_reader==0.8
+envoy_reader==0.8.6
 
 # homeassistant.components.season
 ephem==3.7.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -439,7 +439,7 @@ env_canada==0.0.18
 # envirophat==0.0.6
 
 # homeassistant.components.enphase_envoy
-envoy_reader==0.8
+envoy_reader==0.8.6
 
 # homeassistant.components.season
 ephem==3.7.6.0


### PR DESCRIPTION
## Description: Bump envoy_reader to 0.8.6, fix missing dependency 


**Related issue (if applicable):** fixes #25331 


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
