### PR TITLE
Fix issue with incorrect Notion bridge IDs

### DIFF
--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -235,16 +235,16 @@ class NotionEntity(Entity):
     @property
     def device_info(self):
         """Return device registry information for this entity."""
-        bridge = self._notion.bridges[self._bridge_id]
-        sensor = self._notion.sensors[self._sensor_id]
+        bridge = self._notion.bridges.get(self._bridge_id, {})
+        sensor = self._notion.sensors.get(self._sensor_id, {})
 
         return {
-            "identifiers": {(DOMAIN, sensor["hardware_id"])},
+            "identifiers": {(DOMAIN, sensor.get("hardware_id"))},
             "manufacturer": "Silicon Labs",
-            "model": sensor["hardware_revision"],
-            "name": sensor["name"],
-            "sw_version": sensor["firmware_version"],
-            "via_device": (DOMAIN, bridge["hardware_id"]),
+            "model": sensor.get("hardware_revision"),
+            "name": sensor.get("name"),
+            "sw_version": sensor.get("firmware_version"),
+            "via_device": (DOMAIN, bridge.get("hardware_id")),
         }
 
     @property

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -271,7 +271,14 @@ class NotionEntity(Entity):
         Sensors can move to other bridges based on signal strength, etc.
         """
         sensor = self._notion.sensors[self._sensor_id]
-        if self._bridge_id == sensor["bridge"]["id"]:
+
+        # If the sensor's bridge ID is the same as what we had before or if it points
+        # to a bridge that doesn't exist (which can happen due to a Notion API bug),
+        # return immediately:
+        if (
+            self._bridge_id == sensor["bridge"]["id"]
+            or sensor["bridge"]["id"] not in self._notion.bridges
+        ):
             return
 
         self._bridge_id = sensor["bridge"]["id"]

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -236,14 +236,14 @@ class NotionEntity(Entity):
     def device_info(self):
         """Return device registry information for this entity."""
         bridge = self._notion.bridges.get(self._bridge_id, {})
-        sensor = self._notion.sensors.get(self._sensor_id, {})
+        sensor = self._notion.sensors[self._sensor_id]
 
         return {
-            "identifiers": {(DOMAIN, sensor.get("hardware_id"))},
+            "identifiers": {(DOMAIN, sensor["hardware_id"])},
             "manufacturer": "Silicon Labs",
-            "model": sensor.get("hardware_revision"),
-            "name": sensor.get("name"),
-            "sw_version": sensor.get("firmware_version"),
+            "model": sensor["hardware_revision"],
+            "name": sensor["name"],
+            "sw_version": sensor["firmware_version"],
             "via_device": (DOMAIN, bridge.get("hardware_id")),
         }
 


### PR DESCRIPTION
## Description:

A new bug popped into the Notion API: it's possible for sensors to refer to bridge IDs that don't actually exist. Currently, this throws an exception (because each entity's `device_info` expects this info to be valid) and prevents that sensor from loading. This PR ensures that sensors continue to load even if they refer to a nonexistent bridge.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/25682

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
notion:
  username: !secret notion_username
  password: !secret notion_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
