### PR TITLE
Bump geniushub client, handle dead devices, handle raise_for_status

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -33,11 +33,11 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def make_debug_log_entries(data):
+def make_debug_log_entries(client):
     """Make any debug log entries as required."""
     # pylint: disable=protected-access
-    _LOGGER.debug("zones_raw = %s", data._client.hub._raw_zones)
-    _LOGGER.debug("devices_raw = %s", data._client.hub._raw_devices)
+    _LOGGER.debug("zones_raw = %s", client.hub._raw_zones)
+    _LOGGER.debug("devices_raw = %s", client.hub._raw_devices)
 
 
 async def async_setup(hass, hass_config):
@@ -56,7 +56,7 @@ async def async_setup(hass, hass_config):
         _LOGGER.error("Setup failed, check your configuration, %s", err)
         return False
 
-    make_debug_log_entries(data)
+    make_debug_log_entries(data._client)  # pylint: disable=protected-access
 
     async_track_time_interval(hass, data.async_update, SCAN_INTERVAL)
 
@@ -92,6 +92,6 @@ class GeniusData:
             _LOGGER.warning("Update failed, %s", err)
             return
 
-        make_debug_log_entries(self)
+        make_debug_log_entries(self._client)
 
         async_dispatcher_send(self._hass, DOMAIN)

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -52,8 +52,8 @@ async def async_setup(hass, hass_config):
     data = hass.data[DOMAIN]["data"] = GeniusData(hass, args, kwargs)
     try:
         await data._client.hub.update()  # pylint: disable=protected-access
-    except AssertionError:  # assert response.status == HTTP_OK
-        _LOGGER.warning("Setup failed, check your configuration.", exc_info=True)
+    except aiohttp.ClientResponseError as err:
+        _LOGGER.error("Setup failed, check your configuration, %s", err)
         return False
 
     make_debug_log_entries(data)
@@ -88,8 +88,8 @@ class GeniusData:
         """Update the geniushub client's data."""
         try:
             await self._client.hub.update()
-        except aiohttp.client_exceptions.ClientResponseError:
-            _LOGGER.warning("Update failed.", exc_info=True)
+        except aiohttp.ClientResponseError as err:
+            _LOGGER.error("Update failed, %s", err)
             return
 
         make_debug_log_entries(self)

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -89,7 +89,7 @@ class GeniusData:
         try:
             await self._client.hub.update()
         except aiohttp.ClientResponseError as err:
-            _LOGGER.error("Update failed, %s", err)
+            _LOGGER.warning("Update failed, %s", err)
             return
 
         make_debug_log_entries(self)

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -17,10 +17,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Genius Hub sensor entities."""
     client = hass.data[DOMAIN]["client"]
 
-    devices = [d for d in client.hub.device_objs if d.type is not None]
-    switches = [
-        GeniusBinarySensor(client, d) for d in devices if d.type[:21] in GH_IS_SWITCH
-    ]
+    switches = []
+    for device in client.hub.device_objs:
+        try:
+            if device.type[:21] in GH_IS_SWITCH:
+                switches.append(GeniusBinarySensor(client, device))
+        except (AttributeError, TypeError):
+            pass
 
     async_add_entities(switches)
 

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -1,14 +1,10 @@
 """Support for Genius Hub binary_sensor devices."""
-import logging
-
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.dt import utc_from_timestamp
 
 from . import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 GH_IS_SWITCH = ["Dual Channel Receiver", "Electric Switch", "Smart Plug"]
 
@@ -17,13 +13,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Genius Hub sensor entities."""
     client = hass.data[DOMAIN]["client"]
 
-    switches = []
-    for device in client.hub.device_objs:
-        try:
-            if device.type[:21] in GH_IS_SWITCH:
-                switches.append(GeniusBinarySensor(client, device))
-        except (AttributeError, TypeError):
-            pass
+    switches = [
+        GeniusBinarySensor(client, d)
+        for d in client.hub.device_objs
+        if d.type[:21] in GH_IS_SWITCH
+    ]
 
     async_add_entities(switches)
 
@@ -62,16 +56,16 @@ class GeniusBinarySensor(BinarySensorDevice):
     @property
     def is_on(self):
         """Return the status of the sensor."""
-        return self._device.state["outputOnOff"]
+        return self._device.data["state"]["outputOnOff"]
 
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
         attrs = {}
-        attrs["assigned_zone"] = self._device.assignedZones[0]["name"]
+        attrs["assigned_zone"] = self._device.data["assignedZones"][0]["name"]
 
         # noqa; pylint: disable=protected-access
-        last_comms = self._device._raw_json["childValues"]["lastComms"]["val"]
+        last_comms = self._device._raw_data["childValues"]["lastComms"]["val"]
         if last_comms != 0:
             attrs["last_comms"] = utc_from_timestamp(last_comms).isoformat()
 

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.5.7"
+    "geniushub-client==0.5.8"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.5.5"
+    "geniushub-client==0.5.6"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.5.6"
+    "geniushub-client==0.5.7"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.5.4"
+    "geniushub-client==0.5.5"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -25,18 +25,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Genius Hub sensor entities."""
     client = hass.data[DOMAIN]["client"]
 
-    sensors = [
-        GeniusDevice(client, d)
-        for d in client.hub.device_objs
-        if d.type in GH_HAS_BATTERY
-    ]
+    sensors = []
+    for device in client.hub.device_objs:
+        try:
+            if device.type in GH_HAS_BATTERY:
+                sensors.append(GeniusBattery(client, device))
+        except (AttributeError, TypeError):
+            pass
 
     issues = [GeniusIssue(client, i) for i in list(GH_LEVEL_MAPPING)]
 
     async_add_entities(sensors + issues, update_before_add=True)
 
 
-class GeniusDevice(Entity):
+class GeniusBattery(Entity):
     """Representation of a Genius Hub sensor."""
 
     def __init__(self, client, device):

--- a/homeassistant/components/geniushub/water_heater.py
+++ b/homeassistant/components/geniushub/water_heater.py
@@ -1,6 +1,4 @@
 """Support for Genius Hub water_heater devices."""
-import logging
-
 from homeassistant.components.water_heater import (
     WaterHeaterDevice,
     SUPPORT_TARGET_TEMPERATURE,
@@ -14,8 +12,6 @@ from . import DOMAIN
 
 STATE_AUTO = "auto"
 STATE_MANUAL = "manual"
-
-_LOGGER = logging.getLogger(__name__)
 
 GH_HEATERS = ["hot water temperature"]
 
@@ -82,7 +78,7 @@ class GeniusWaterHeater(WaterHeaterDevice):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        tmp = self._boiler.__dict__.items()
+        tmp = self._boiler.data.items()
         return {"status": {k: v for k, v in tmp if k in GH_STATE_ATTRS}}
 
     @property
@@ -93,15 +89,12 @@ class GeniusWaterHeater(WaterHeaterDevice):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        try:
-            return self._boiler.temperature
-        except AttributeError:
-            return None
+        return self._boiler.data.get("temperature")
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._boiler.setpoint
+        return self._boiler.data["setpoint"]
 
     @property
     def min_temp(self):
@@ -131,7 +124,7 @@ class GeniusWaterHeater(WaterHeaterDevice):
     @property
     def current_operation(self):
         """Return the current operation mode."""
-        return GH_STATE_TO_HA[self._boiler.mode]
+        return GH_STATE_TO_HA[self._boiler.data["mode"]]
 
     async def async_set_operation_mode(self, operation_mode):
         """Set a new operation mode for this boiler."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -517,7 +517,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.5.7
+geniushub-client==0.5.8
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -517,7 +517,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.5.6
+geniushub-client==0.5.7
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -517,7 +517,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.5.5
+geniushub-client==0.5.6
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -517,7 +517,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.5.4
+geniushub-client==0.5.5
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
## Breaking Change:

None

## Description:
Bump geniushub client (less logging, improved device typing, better handling of edge cases)
handle more edge cases, such as dead devices, 
handle raise_for_status exceptions correction

**Related issue (if applicable):** None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** None

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
