### PR TITLE
PS4 Merge async_setup_platform into async_setup_entry

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -68,6 +68,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         device_list.append(PS4Device(config, name, host, region, ps4, creds))
     async_add_entities(device_list, update_before_add=True)
 
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Not Implemented."""
     pass

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -68,6 +68,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         device_list.append(PS4Device(config, name, host, region, ps4, creds))
     async_add_entities(device_list, update_before_add=True)
 
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Not Implemented."""
+    pass
+
 
 class PS4Device(MediaPlayerDevice):
     """Representation of a PS4."""

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -58,11 +58,6 @@ DEFAULT_RETRIES = 2
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up PS4 from a config entry."""
     config = config_entry
-    await async_setup_platform(hass, config, async_add_entities, discovery_info=None)
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up PS4 Platform."""
     creds = config.data[CONF_TOKEN]
     device_list = []
     for device in config.data["devices"]:

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -169,6 +169,11 @@ async def mock_ddp_response(hass, mock_status_data, games=None):
         await hass.async_block_till_done()
 
 
+async def test_async_setup_platform_does_nothing(): 
+    """Test setup platform does nothing (Uses config entries only).""" 
+    await ps4.media_player.async_setup_platform(None, None, None) 
+
+
 async def test_media_player_is_setup_correctly_with_entry(hass):
     """Test entity is setup correctly with entry correctly."""
     mock_entity_id = await setup_mock_component(hass)

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -169,9 +169,9 @@ async def mock_ddp_response(hass, mock_status_data, games=None):
         await hass.async_block_till_done()
 
 
-async def test_async_setup_platform_does_nothing(): 
-    """Test setup platform does nothing (Uses config entries only).""" 
-    await ps4.media_player.async_setup_platform(None, None, None) 
+async def test_async_setup_platform_does_nothing():
+    """Test setup platform does nothing (Uses config entries only)."""
+    await ps4.media_player.async_setup_platform(None, None, None)
 
 
 async def test_media_player_is_setup_correctly_with_entry(hass):


### PR DESCRIPTION
# Description:
Remove async_setup_platform method by merging it into async_setup_entry as config from configuration.yaml is not valid.


**Related issue (if applicable):** fixes #25665 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
