### PR TITLE
UniFi - reverse connectivity logic

### DIFF
--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -266,8 +266,8 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchDevice):
 
     @property
     def is_on(self):
-        """Return true if client is blocked."""
-        return self.client.blocked
+        """Return true if client is allowed to connect."""
+        return not self.client.blocked
 
     @property
     def available(self):
@@ -275,9 +275,9 @@ class UniFiBlockClientSwitch(UniFiClient, SwitchDevice):
         return self.controller.available
 
     async def async_turn_on(self, **kwargs):
-        """Block client."""
-        await self.controller.api.clients.async_block(self.client.mac)
+        """Turn on connectivity for client."""
+        await self.controller.api.clients.async_unblock(self.client.mac)
 
     async def async_turn_off(self, **kwargs):
-        """Unblock client."""
-        await self.controller.api.clients.async_unblock(self.client.mac)
+        """Turn off connectivity for client."""
+        await self.controller.api.clients.async_block(self.client.mac)

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -342,11 +342,11 @@ async def test_switches(hass, mock_controller):
 
     blocked = hass.states.get("switch.block_client_1")
     assert blocked is not None
-    assert blocked.state == "on"
+    assert blocked.state == "off"
 
     unblocked = hass.states.get("switch.block_client_2")
     assert unblocked is not None
-    assert unblocked.state == "off"
+    assert unblocked.state == "on"
 
 
 async def test_new_client_discovered(hass, mock_controller):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
@arsaboo pointed out inconsistencies with other definitions of connectivity in HASS. So I'm reversing the logic. This also puts it inline with how the POE switch represents on/off state in component.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html