### PR TITLE
Plugwise haanna 0.10.1

### DIFF
--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://www.home-assistant.io/components/plugwise",
   "dependencies": [],
   "codeowners": ["@laetificat","@CoMPaTech"],
-  "requirements": ["haanna==0.10.0"]
+  "requirements": ["haanna==0.10.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -587,7 +587,7 @@ ha-ffmpeg==2.0
 ha-philipsjs==0.0.8
 
 # homeassistant.components.plugwise
-haanna==0.10.0
+haanna==0.10.1
 
 # homeassistant.components.habitica
 habitipy==0.2.0


### PR DESCRIPTION
## Description:

Update for already merged #25533 to include newer module dependency. (Fixes `strptime` `%z/%Z` between py36 and 37).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.
