### PR TITLE
Fix unique_id in ZHA cluster channels

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -23,7 +23,7 @@ from ..const import (
     REPORT_CONFIG_RPT_CHANGE,
     SIGNAL_ATTR_UPDATED,
 )
-from ..helpers import LogMixin, construct_unique_id, get_attr_id_by_name, safe_read
+from ..helpers import LogMixin, get_attr_id_by_name, safe_read
 from ..registries import CLUSTER_REPORT_CONFIGS
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,7 +89,13 @@ class ZigbeeChannel(LogMixin):
         self._generic_id = "channel_0x{:04x}".format(cluster.cluster_id)
         self._cluster = cluster
         self._zha_device = device
-        self._unique_id = construct_unique_id(cluster)
+        self._unique_id = "{}:{}:0x{:04x}".format(
+            str(device.ieee), cluster.endpoint.endpoint_id, cluster.cluster_id
+        )
+        # this keeps logs consistent with zigpy logging
+        self._log_id = "0x{:04x}:{}:0x{:04x}".format(
+            device.nwk, cluster.endpoint.endpoint_id, cluster.cluster_id
+        )
         self._report_config = CLUSTER_REPORT_CONFIGS.get(
             self._cluster.cluster_id, self.REPORT_CONFIG
         )
@@ -260,7 +266,7 @@ class ZigbeeChannel(LogMixin):
     def log(self, level, msg, *args):
         """Log a message."""
         msg = "[%s]: " + msg
-        args = (self.unique_id,) + args
+        args = (self._log_id,) + args
         _LOGGER.log(level, msg, *args)
 
     def __getattr__(self, name):
@@ -313,7 +319,7 @@ class ZDOChannel(LogMixin):
         self._cluster = cluster
         self._zha_device = device
         self._status = ChannelStatus.CREATED
-        self._unique_id = "{}_ZDO".format(device.name)
+        self._unique_id = "{}:{}_ZDO".format(str(device.ieee), device.name)
         self._cluster.add_listener(self)
 
     @property

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -75,13 +75,6 @@ def convert_ieee(ieee_str):
     return EUI64([uint8_t(p, base=16) for p in ieee_str.split(":")])
 
 
-def construct_unique_id(cluster):
-    """Construct a unique id from a cluster."""
-    return "0x{:04x}:{}:0x{:04x}".format(
-        cluster.endpoint.device.nwk, cluster.endpoint.endpoint_id, cluster.cluster_id
-    )
-
-
 def get_attr_id_by_name(cluster, attr_name):
     """Get the attribute id for a cluster attribute by its name."""
     return next(


### PR DESCRIPTION
## Breaking Change:

This change fixes unique id's that weren't stable. They could change when nwk addresses of nodes changed. Anyone who opted to use unique_id on events will have to update their automations to account for the change.

Previous format:
`unique_id=0x0b64:1:0x0006`

New format:
`unique_id=00:0d:6f:00:0e:c8:d4:e7:1:0x0006`

## Description:

This PR corrects a stability issue with unique_id on cluster channels. If a node received a new nwk address the unique_id would change. This PR changes the unique_id to use the ieee address instead of the nwk address. The ieee address is static and therefore the unique_id will be stable now. 

Previous format:
`unique_id=0x0b64:1:0x0006`

New format:
`unique_id=00:0d:6f:00:0e:c8:d4:e7:1:0x0006`

**Related issue (if applicable):
Issue #25700 may be related but based on the symptoms I do not expect this PR to fix the issue experienced in the ticket.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]