### PR TITLE
UniFi - handle device not having a name

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -311,7 +311,7 @@ class UniFiDeviceTracker(ScannerEntity):
     @property
     def name(self) -> str:
         """Return the name of the device."""
-        return self.device.name
+        return self.device.name or self.device.model
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -208,7 +208,11 @@ def update_items(controller, async_add_entities, tracked):
 
             tracked[device_id] = UniFiDeviceTracker(device, controller)
             new_tracked.append(tracked[device_id])
-            LOGGER.debug("New UniFi device tracker %s (%s)", device.name, device.mac)
+            LOGGER.debug(
+                "New UniFi device tracker %s (%s)",
+                device.name or device.model,
+                device.mac,
+            )
 
     if new_tracked:
         async_add_entities(new_tracked)

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -188,7 +188,9 @@ def update_items(controller, async_add_entities, tracked):
             tracked[client_id] = UniFiClientTracker(client, controller)
             new_tracked.append(tracked[client_id])
             LOGGER.debug(
-                "New UniFi client tracker %s (%s)", client.hostname, client.mac
+                "New UniFi client tracker %s (%s)",
+                client.name or client.hostname,
+                client.mac,
             )
 
     if not controller.unifi_config.get(CONF_DONT_TRACK_DEVICES, False):
@@ -330,13 +332,17 @@ class UniFiDeviceTracker(ScannerEntity):
     @property
     def device_info(self):
         """Return a device description for device registry."""
-        return {
+        info = {
             "connections": {(CONNECTION_NETWORK_MAC, self.device.mac)},
             "manufacturer": ATTR_MANUFACTURER,
             "model": self.device.model,
-            "name": self.device.name,
             "sw_version": self.device.version,
         }
+
+        if self.device.name:
+            info["name"] = self.device.name
+
+        return info
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/unifi",
   "requirements": [
-    "aiounifi==9"
+    "aiounifi==10"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -169,7 +169,7 @@ aiopvapi==1.6.14
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==9
+aiounifi==10
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -68,7 +68,7 @@ aionotion==1.1.0
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==9
+aiounifi==10
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #25659

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
