### PR TITLE
More ZHA Core registries refactoring

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -13,7 +13,6 @@ from random import uniform
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.util.decorator import Registry
 
 from ..const import (
     CHANNEL_ATTRIBUTE,
@@ -25,12 +24,13 @@ from ..const import (
     REPORT_CONFIG_RPT_CHANGE,
     SIGNAL_ATTR_UPDATED,
 )
+from ..decorators import DictRegistry
 from ..helpers import LogMixin, get_attr_id_by_name, safe_read
 from ..registries import CLUSTER_REPORT_CONFIGS
 
 _LOGGER = logging.getLogger(__name__)
 
-ZIGBEE_CHANNEL_REGISTRY = Registry()
+ZIGBEE_CHANNEL_REGISTRY = DictRegistry()
 
 
 def parse_and_log_command(channel, tsn, command_id, args):
@@ -83,6 +83,7 @@ class ZigbeeChannel(LogMixin):
     """Base channel for a Zigbee cluster."""
 
     CHANNEL_NAME = None
+    CLUSTER_ID = None
     REPORT_CONFIG = ()
 
     def __init__(self, cluster, device):

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -24,13 +24,10 @@ from ..const import (
     REPORT_CONFIG_RPT_CHANGE,
     SIGNAL_ATTR_UPDATED,
 )
-from ..decorators import DictRegistry
 from ..helpers import LogMixin, get_attr_id_by_name, safe_read
 from ..registries import CLUSTER_REPORT_CONFIGS
 
 _LOGGER = logging.getLogger(__name__)
-
-ZIGBEE_CHANNEL_REGISTRY = DictRegistry()
 
 
 def parse_and_log_command(channel, tsn, command_id, args):

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -17,11 +17,12 @@ from ..const import REPORT_CONFIG_IMMEDIATE, SIGNAL_ATTR_UPDATED
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(closures.DoorLock.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class DoorLockChannel(ZigbeeChannel):
     """Door lock channel."""
 
     _value_attribute = 0
+    CLUSTER_ID = closures.DoorLock.cluster_id
     REPORT_CONFIG = ({"attr": "lock_state", "config": REPORT_CONFIG_IMMEDIATE},)
 
     async def async_update(self):
@@ -54,15 +55,17 @@ class DoorLockChannel(ZigbeeChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(closures.Shade.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Shade(ZigbeeChannel):
     """Shade channel."""
 
+    CLUSTER_ID = closures.Shade.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(closures.WindowCovering.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class WindowCovering(ZigbeeChannel):
     """Window channel."""
 
+    CLUSTER_ID = closures.WindowCovering.cluster_id
     pass

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -11,13 +11,14 @@ import zigpy.zcl.clusters.closures as closures
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from . import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
+from . import ZigbeeChannel
+from .. import registries
 from ..const import REPORT_CONFIG_IMMEDIATE, SIGNAL_ATTR_UPDATED
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class DoorLockChannel(ZigbeeChannel):
     """Door lock channel."""
 
@@ -55,7 +56,7 @@ class DoorLockChannel(ZigbeeChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Shade(ZigbeeChannel):
     """Shade channel."""
 
@@ -63,7 +64,7 @@ class Shade(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class WindowCovering(ZigbeeChannel):
     """Window channel."""
 

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -12,12 +12,8 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 
-from . import (
-    ZIGBEE_CHANNEL_REGISTRY,
-    AttributeListeningChannel,
-    ZigbeeChannel,
-    parse_and_log_command,
-)
+from . import AttributeListeningChannel, ZigbeeChannel, parse_and_log_command
+from .. import registries
 from ..const import (
     REPORT_CONFIG_ASAP,
     REPORT_CONFIG_BATTERY_SAVE,
@@ -32,7 +28,7 @@ from ..helpers import get_attr_id_by_name
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Alarms(ZigbeeChannel):
     """Alarms channel."""
 
@@ -40,7 +36,7 @@ class Alarms(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogInput(AttributeListeningChannel):
     """Analog Input channel."""
 
@@ -48,7 +44,7 @@ class AnalogInput(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogOutput(AttributeListeningChannel):
     """Analog Output channel."""
 
@@ -56,7 +52,7 @@ class AnalogOutput(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogValue(AttributeListeningChannel):
     """Analog Value channel."""
 
@@ -64,7 +60,7 @@ class AnalogValue(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceContorl(ZigbeeChannel):
     """Appliance Control channel."""
 
@@ -72,7 +68,7 @@ class ApplianceContorl(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BasicChannel(ZigbeeChannel):
     """Channel to interact with the basic cluster."""
 
@@ -112,7 +108,7 @@ class BasicChannel(ZigbeeChannel):
         return self._power_source
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryInput(AttributeListeningChannel):
     """Binary Input channel."""
 
@@ -120,7 +116,7 @@ class BinaryInput(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryOutput(AttributeListeningChannel):
     """Binary Output channel."""
 
@@ -128,7 +124,7 @@ class BinaryOutput(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryValue(AttributeListeningChannel):
     """Binary Value channel."""
 
@@ -136,7 +132,7 @@ class BinaryValue(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Commissioning(ZigbeeChannel):
     """Commissioning channel."""
 
@@ -144,15 +140,15 @@ class Commissioning(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class DeviceTemperature(ZigbeeChannel):
-    """Device Temperatur channel."""
+    """Device Temperature channel."""
 
     CLUSTER_ID = general.DeviceTemperature.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class GreenPowerProxy(ZigbeeChannel):
     """Green Power Proxy channel."""
 
@@ -160,7 +156,7 @@ class GreenPowerProxy(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Groups(ZigbeeChannel):
     """Groups channel."""
 
@@ -168,7 +164,7 @@ class Groups(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Identify(ZigbeeChannel):
     """Identify channel."""
 
@@ -176,7 +172,7 @@ class Identify(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class LevelControlChannel(ZigbeeChannel):
     """Channel for the LevelControl Zigbee cluster."""
 
@@ -222,7 +218,7 @@ class LevelControlChannel(ZigbeeChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultistateInput(AttributeListeningChannel):
     """Multistate Input channel."""
 
@@ -230,7 +226,7 @@ class MultistateInput(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultistateOutput(AttributeListeningChannel):
     """Multistate Output channel."""
 
@@ -238,7 +234,7 @@ class MultistateOutput(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultistateValue(AttributeListeningChannel):
     """Multistate Value channel."""
 
@@ -246,7 +242,7 @@ class MultistateValue(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class OnOffChannel(ZigbeeChannel):
     """Channel for the OnOff Zigbee cluster."""
 
@@ -321,7 +317,7 @@ class OnOffChannel(ZigbeeChannel):
         await super().async_update()
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class OnOffConfiguration(ZigbeeChannel):
     """OnOff Configuration channel."""
 
@@ -329,7 +325,7 @@ class OnOffConfiguration(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Ota(ZigbeeChannel):
     """OTA Channel."""
 
@@ -337,7 +333,7 @@ class Ota(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Partition(ZigbeeChannel):
     """Partition channel."""
 
@@ -345,7 +341,7 @@ class Partition(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class PollControl(ZigbeeChannel):
     """Poll Control channel."""
 
@@ -353,7 +349,7 @@ class PollControl(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class PowerConfigurationChannel(ZigbeeChannel):
     """Channel for the zigbee power configuration cluster."""
 
@@ -397,7 +393,7 @@ class PowerConfigurationChannel(ZigbeeChannel):
         await self.get_attribute_value("battery_quantity", from_cache=from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class PowerProfile(ZigbeeChannel):
     """Power Profile channel."""
 
@@ -405,7 +401,7 @@ class PowerProfile(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class RSSILocation(ZigbeeChannel):
     """RSSI Location channel."""
 
@@ -413,7 +409,7 @@ class RSSILocation(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Scenes(ZigbeeChannel):
     """Scenes channel."""
 
@@ -421,7 +417,7 @@ class Scenes(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Time(ZigbeeChannel):
     """Time channel."""
 

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -32,45 +32,51 @@ from ..helpers import get_attr_id_by_name
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Alarms.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Alarms(ZigbeeChannel):
     """Alarms channel."""
 
+    CLUSTER_ID = general.Alarms.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.AnalogInput.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogInput(AttributeListeningChannel):
     """Analog Input channel."""
 
+    CLUSTER_ID = general.AnalogInput.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.AnalogOutput.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogOutput(AttributeListeningChannel):
     """Analog Output channel."""
 
+    CLUSTER_ID = general.AnalogOutput.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.AnalogValue.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogValue(AttributeListeningChannel):
     """Analog Value channel."""
 
+    CLUSTER_ID = general.AnalogValue.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.ApplianceControl.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceContorl(ZigbeeChannel):
     """Appliance Control channel."""
 
+    CLUSTER_ID = general.ApplianceControl.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Basic.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BasicChannel(ZigbeeChannel):
     """Channel to interact with the basic cluster."""
 
+    CLUSTER_ID = general.Basic.cluster_id
     UNKNOWN = 0
     BATTERY = 3
 
@@ -106,66 +112,75 @@ class BasicChannel(ZigbeeChannel):
         return self._power_source
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryInput.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryInput(AttributeListeningChannel):
     """Binary Input channel."""
 
+    CLUSTER_ID = general.BinaryInput.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryOutput.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryOutput(AttributeListeningChannel):
     """Binary Output channel."""
 
+    CLUSTER_ID = general.BinaryOutput.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.BinaryValue.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryValue(AttributeListeningChannel):
     """Binary Value channel."""
 
+    CLUSTER_ID = general.BinaryValue.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Commissioning.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Commissioning(ZigbeeChannel):
     """Commissioning channel."""
 
+    CLUSTER_ID = general.Commissioning.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.DeviceTemperature.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class DeviceTemperature(ZigbeeChannel):
     """Device Temperatur channel."""
 
+    CLUSTER_ID = general.DeviceTemperature.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.GreenPowerProxy.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class GreenPowerProxy(ZigbeeChannel):
     """Green Power Proxy channel."""
 
+    CLUSTER_ID = general.GreenPowerProxy.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Groups.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Groups(ZigbeeChannel):
     """Groups channel."""
 
+    CLUSTER_ID = general.Groups.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Identify.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Identify(ZigbeeChannel):
     """Identify channel."""
 
+    CLUSTER_ID = general.Identify.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.LevelControl.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class LevelControlChannel(ZigbeeChannel):
     """Channel for the LevelControl Zigbee cluster."""
 
+    CLUSTER_ID = general.LevelControl.cluster_id
     CURRENT_LEVEL = 0
     REPORT_CONFIG = ({"attr": "current_level", "config": REPORT_CONFIG_ASAP},)
 
@@ -207,31 +222,35 @@ class LevelControlChannel(ZigbeeChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateInput.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultistateInput(AttributeListeningChannel):
     """Multistate Input channel."""
 
+    CLUSTER_ID = general.MultistateInput.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateOutput.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultistateOutput(AttributeListeningChannel):
     """Multistate Output channel."""
 
+    CLUSTER_ID = general.MultistateOutput.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.MultistateValue.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultistateValue(AttributeListeningChannel):
     """Multistate Value channel."""
 
+    CLUSTER_ID = general.MultistateValue.cluster_id
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.OnOff.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class OnOffChannel(ZigbeeChannel):
     """Channel for the OnOff Zigbee cluster."""
 
+    CLUSTER_ID = general.OnOff.cluster_id
     ON_OFF = 0
     REPORT_CONFIG = ({"attr": "on_off", "config": REPORT_CONFIG_IMMEDIATE},)
 
@@ -302,38 +321,43 @@ class OnOffChannel(ZigbeeChannel):
         await super().async_update()
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.OnOffConfiguration.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class OnOffConfiguration(ZigbeeChannel):
     """OnOff Configuration channel."""
 
+    CLUSTER_ID = general.OnOffConfiguration.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Ota.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Ota(ZigbeeChannel):
     """OTA Channel."""
 
+    CLUSTER_ID = general.Ota.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Partition.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Partition(ZigbeeChannel):
     """Partition channel."""
 
+    CLUSTER_ID = general.Partition.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.PollControl.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class PollControl(ZigbeeChannel):
     """Poll Control channel."""
 
+    CLUSTER_ID = general.PollControl.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.PowerConfiguration.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class PowerConfigurationChannel(ZigbeeChannel):
     """Channel for the zigbee power configuration cluster."""
 
+    CLUSTER_ID = general.PowerConfiguration.cluster_id
     REPORT_CONFIG = (
         {"attr": "battery_voltage", "config": REPORT_CONFIG_BATTERY_SAVE},
         {"attr": "battery_percentage_remaining", "config": REPORT_CONFIG_BATTERY_SAVE},
@@ -373,29 +397,33 @@ class PowerConfigurationChannel(ZigbeeChannel):
         await self.get_attribute_value("battery_quantity", from_cache=from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.PowerProfile.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class PowerProfile(ZigbeeChannel):
     """Power Profile channel."""
 
+    CLUSTER_ID = general.PowerProfile.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.RSSILocation.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class RSSILocation(ZigbeeChannel):
     """RSSI Location channel."""
 
+    CLUSTER_ID = general.RSSILocation.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Scenes.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Scenes(ZigbeeChannel):
     """Scenes channel."""
 
+    CLUSTER_ID = general.Scenes.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(general.Time.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Time(ZigbeeChannel):
     """Time channel."""
 
+    CLUSTER_ID = general.Time.cluster_id
     pass

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -68,6 +68,7 @@ class ApplianceContorl(ZigbeeChannel):
     pass
 
 
+@registries.CHANNEL_ONLY_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BasicChannel(ZigbeeChannel):
     """Channel to interact with the basic cluster."""
@@ -172,6 +173,9 @@ class Identify(ZigbeeChannel):
     pass
 
 
+@registries.BINDABLE_CLUSTERS.register
+@registries.EVENT_RELAY_CLUSTERS.register
+@registries.LIGHT_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class LevelControlChannel(ZigbeeChannel):
     """Channel for the LevelControl Zigbee cluster."""
@@ -242,6 +246,11 @@ class MultistateValue(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
+@registries.BINARY_SENSOR_CLUSTERS.register
+@registries.BINDABLE_CLUSTERS.register
+@registries.EVENT_RELAY_CLUSTERS.register
+@registries.LIGHT_CLUSTERS.register
+@registries.SWITCH_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class OnOffChannel(ZigbeeChannel):
     """Channel for the OnOff Zigbee cluster."""
@@ -349,6 +358,7 @@ class PollControl(ZigbeeChannel):
     pass
 
 
+@registries.DEVICE_TRACKER_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class PowerConfigurationChannel(ZigbeeChannel):
     """Channel for the zigbee power configuration cluster."""
@@ -409,6 +419,7 @@ class RSSILocation(ZigbeeChannel):
     pass
 
 
+@registries.OUTPUT_CHANNEL_ONLY_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Scenes(ZigbeeChannel):
     """Scenes channel."""

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -20,39 +20,44 @@ from ..const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(homeautomation.ApplianceEventAlerts.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceEventAlerts(ZigbeeChannel):
     """Appliance Event Alerts channel."""
 
+    CLUSTER_ID = homeautomation.ApplianceEventAlerts.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(homeautomation.ApplianceIdentification.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceIdentification(ZigbeeChannel):
     """Appliance Identification channel."""
 
+    CLUSTER_ID = homeautomation.ApplianceIdentification.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(homeautomation.ApplianceStatistics.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceStatistics(ZigbeeChannel):
     """Appliance Statistics channel."""
 
+    CLUSTER_ID = homeautomation.ApplianceStatistics.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(homeautomation.Diagnostic.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Diagnostic(ZigbeeChannel):
     """Diagnostic channel."""
 
+    CLUSTER_ID = homeautomation.Diagnostic.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(homeautomation.ElectricalMeasurement.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class ElectricalMeasurementChannel(AttributeListeningChannel):
     """Channel that polls active power level."""
 
     CHANNEL_NAME = CHANNEL_ELECTRICAL_MEASUREMENT
+    CLUSTER_ID = homeautomation.ElectricalMeasurement.cluster_id
     REPORT_CONFIG = ({"attr": "active_power", "config": REPORT_CONFIG_DEFAULT},)
 
     async def async_update(self):
@@ -73,8 +78,9 @@ class ElectricalMeasurementChannel(AttributeListeningChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(homeautomation.MeterIdentification.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MeterIdentification(ZigbeeChannel):
     """Metering Identification channel."""
 
+    CLUSTER_ID = homeautomation.MeterIdentification.cluster_id
     pass

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -10,7 +10,8 @@ import zigpy.zcl.clusters.homeautomation as homeautomation
 
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from . import ZIGBEE_CHANNEL_REGISTRY, AttributeListeningChannel, ZigbeeChannel
+from . import AttributeListeningChannel, ZigbeeChannel
+from .. import registries
 from ..const import (
     CHANNEL_ELECTRICAL_MEASUREMENT,
     REPORT_CONFIG_DEFAULT,
@@ -20,7 +21,7 @@ from ..const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceEventAlerts(ZigbeeChannel):
     """Appliance Event Alerts channel."""
 
@@ -28,7 +29,7 @@ class ApplianceEventAlerts(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceIdentification(ZigbeeChannel):
     """Appliance Identification channel."""
 
@@ -36,7 +37,7 @@ class ApplianceIdentification(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class ApplianceStatistics(ZigbeeChannel):
     """Appliance Statistics channel."""
 
@@ -44,7 +45,7 @@ class ApplianceStatistics(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Diagnostic(ZigbeeChannel):
     """Diagnostic channel."""
 
@@ -52,7 +53,7 @@ class Diagnostic(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class ElectricalMeasurementChannel(AttributeListeningChannel):
     """Channel that polls active power level."""
 
@@ -78,7 +79,7 @@ class ElectricalMeasurementChannel(AttributeListeningChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MeterIdentification(ZigbeeChannel):
     """Metering Identification channel."""
 

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -11,13 +11,14 @@ import zigpy.zcl.clusters.hvac as hvac
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from . import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
+from . import ZigbeeChannel
+from .. import registries
 from ..const import REPORT_CONFIG_OP, SIGNAL_ATTR_UPDATED
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Dehumidification(ZigbeeChannel):
     """Dehumidification channel."""
 
@@ -25,7 +26,7 @@ class Dehumidification(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class FanChannel(ZigbeeChannel):
     """Fan channel."""
 
@@ -73,7 +74,7 @@ class FanChannel(ZigbeeChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Pump(ZigbeeChannel):
     """Pump channel."""
 
@@ -81,7 +82,7 @@ class Pump(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Thermostat(ZigbeeChannel):
     """Thermostat channel."""
 
@@ -89,7 +90,7 @@ class Thermostat(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class UserInterface(ZigbeeChannel):
     """User interface (thermostat) channel."""
 

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -17,18 +17,20 @@ from ..const import REPORT_CONFIG_OP, SIGNAL_ATTR_UPDATED
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(hvac.Dehumidification.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Dehumidification(ZigbeeChannel):
     """Dehumidification channel."""
 
+    CLUSTER_ID = hvac.Dehumidification.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(hvac.Fan.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class FanChannel(ZigbeeChannel):
     """Fan channel."""
 
     _value_attribute = 0
+    CLUSTER_ID = hvac.Fan.cluster_id
     REPORT_CONFIG = ({"attr": "fan_mode", "config": REPORT_CONFIG_OP},)
 
     async def async_set_speed(self, value) -> None:
@@ -71,22 +73,25 @@ class FanChannel(ZigbeeChannel):
         await super().async_initialize(from_cache)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(hvac.Pump.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Pump(ZigbeeChannel):
     """Pump channel."""
 
+    CLUSTER_ID = hvac.Pump.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(hvac.Thermostat.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Thermostat(ZigbeeChannel):
     """Thermostat channel."""
 
+    CLUSTER_ID = hvac.Thermostat.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(hvac.UserInterface.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class UserInterface(ZigbeeChannel):
     """User interface (thermostat) channel."""
 
+    CLUSTER_ID = hvac.UserInterface.cluster_id
     pass

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -14,19 +14,21 @@ from ..const import REPORT_CONFIG_DEFAULT
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(lighting.Ballast.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Ballast(ZigbeeChannel):
     """Ballast channel."""
 
+    CLUSTER_ID = lighting.Ballast.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(lighting.Color.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class ColorChannel(ZigbeeChannel):
     """Color channel."""
 
     CAPABILITIES_COLOR_XY = 0x08
     CAPABILITIES_COLOR_TEMP = 0x10
+    CLUSTER_ID = lighting.Color.cluster_id
     UNSUPPORTED_ATTRIBUTE = 0x86
     REPORT_CONFIG = (
         {"attr": "current_x", "config": REPORT_CONFIG_DEFAULT},

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -8,13 +8,14 @@ import logging
 
 import zigpy.zcl.clusters.lighting as lighting
 
-from . import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
+from . import ZigbeeChannel
+from .. import registries
 from ..const import REPORT_CONFIG_DEFAULT
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Ballast(ZigbeeChannel):
     """Ballast channel."""
 
@@ -22,7 +23,7 @@ class Ballast(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class ColorChannel(ZigbeeChannel):
     """Color channel."""
 

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -23,6 +23,9 @@ class Ballast(ZigbeeChannel):
     pass
 
 
+@registries.BINDABLE_CLUSTERS.register
+@registries.EVENT_RELAY_CLUSTERS.register
+@registries.LIGHT_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class ColorChannel(ZigbeeChannel):
     """Color channel."""

--- a/homeassistant/components/zha/core/channels/lightlink.py
+++ b/homeassistant/components/zha/core/channels/lightlink.py
@@ -8,12 +8,13 @@ import logging
 
 import zigpy.zcl.clusters.lightlink as lightlink
 
-from . import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
+from . import ZigbeeChannel
+from .. import registries
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class LightLink(ZigbeeChannel):
     """Lightlink channel."""
 

--- a/homeassistant/components/zha/core/channels/lightlink.py
+++ b/homeassistant/components/zha/core/channels/lightlink.py
@@ -14,6 +14,7 @@ from .. import registries
 _LOGGER = logging.getLogger(__name__)
 
 
+@registries.CHANNEL_ONLY_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class LightLink(ZigbeeChannel):
     """Lightlink channel."""

--- a/homeassistant/components/zha/core/channels/lightlink.py
+++ b/homeassistant/components/zha/core/channels/lightlink.py
@@ -13,8 +13,9 @@ from . import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(lightlink.LightLink.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class LightLink(ZigbeeChannel):
     """Lightlink channel."""
 
+    CLUSTER_ID = lightlink.LightLink.cluster_id
     pass

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -44,6 +44,7 @@ class IlluminanceMeasurement(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
+@registries.BINARY_SENSOR_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class OccupancySensing(AttributeListeningChannel):
     """Occupancy Sensing channel."""

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -8,7 +8,8 @@ import logging
 
 import zigpy.zcl.clusters.measurement as measurement
 
-from . import ZIGBEE_CHANNEL_REGISTRY, AttributeListeningChannel
+from . import AttributeListeningChannel
+from .. import registries
 from ..const import (
     REPORT_CONFIG_DEFAULT,
     REPORT_CONFIG_IMMEDIATE,
@@ -19,7 +20,7 @@ from ..const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class FlowMeasurement(AttributeListeningChannel):
     """Flow Measurement channel."""
 
@@ -27,7 +28,7 @@ class FlowMeasurement(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class IlluminanceLevelSensing(AttributeListeningChannel):
     """Illuminance Level Sensing channel."""
 
@@ -35,7 +36,7 @@ class IlluminanceLevelSensing(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "level_status", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class IlluminanceMeasurement(AttributeListeningChannel):
     """Illuminance Measurement channel."""
 
@@ -43,7 +44,7 @@ class IlluminanceMeasurement(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class OccupancySensing(AttributeListeningChannel):
     """Occupancy Sensing channel."""
 
@@ -51,7 +52,7 @@ class OccupancySensing(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "occupancy", "config": REPORT_CONFIG_IMMEDIATE}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class PressureMeasurement(AttributeListeningChannel):
     """Pressure measurement channel."""
 
@@ -59,7 +60,7 @@ class PressureMeasurement(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class RelativeHumidity(AttributeListeningChannel):
     """Relative Humidity measurement channel."""
 
@@ -72,7 +73,7 @@ class RelativeHumidity(AttributeListeningChannel):
     ]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class TemperatureMeasurement(AttributeListeningChannel):
     """Temperature measurement channel."""
 

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -19,45 +19,51 @@ from ..const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(measurement.FlowMeasurement.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class FlowMeasurement(AttributeListeningChannel):
     """Flow Measurement channel."""
 
+    CLUSTER_ID = measurement.FlowMeasurement.cluster_id
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(measurement.IlluminanceLevelSensing.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class IlluminanceLevelSensing(AttributeListeningChannel):
     """Illuminance Level Sensing channel."""
 
+    CLUSTER_ID = measurement.IlluminanceLevelSensing.cluster_id
     REPORT_CONFIG = [{"attr": "level_status", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(measurement.IlluminanceMeasurement.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class IlluminanceMeasurement(AttributeListeningChannel):
     """Illuminance Measurement channel."""
 
+    CLUSTER_ID = measurement.IlluminanceMeasurement.cluster_id
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(measurement.OccupancySensing.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class OccupancySensing(AttributeListeningChannel):
     """Occupancy Sensing channel."""
 
+    CLUSTER_ID = measurement.OccupancySensing.cluster_id
     REPORT_CONFIG = [{"attr": "occupancy", "config": REPORT_CONFIG_IMMEDIATE}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(measurement.PressureMeasurement.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class PressureMeasurement(AttributeListeningChannel):
     """Pressure measurement channel."""
 
+    CLUSTER_ID = measurement.PressureMeasurement.cluster_id
     REPORT_CONFIG = [{"attr": "measured_value", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(measurement.RelativeHumidity.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class RelativeHumidity(AttributeListeningChannel):
     """Relative Humidity measurement channel."""
 
+    CLUSTER_ID = measurement.RelativeHumidity.cluster_id
     REPORT_CONFIG = [
         {
             "attr": "measured_value",
@@ -66,10 +72,11 @@ class RelativeHumidity(AttributeListeningChannel):
     ]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(measurement.TemperatureMeasurement.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class TemperatureMeasurement(AttributeListeningChannel):
     """Temperature measurement channel."""
 
+    CLUSTER_ID = measurement.TemperatureMeasurement.cluster_id
     REPORT_CONFIG = [
         {
             "attr": "measured_value",

--- a/homeassistant/components/zha/core/channels/protocol.py
+++ b/homeassistant/components/zha/core/channels/protocol.py
@@ -8,12 +8,13 @@ import logging
 
 import zigpy.zcl.clusters.protocol as protocol
 
-from ..channels import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
+from .. import registries
+from ..channels import ZigbeeChannel
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogInputExtended(ZigbeeChannel):
     """Analog Input Extended channel."""
 
@@ -21,7 +22,7 @@ class AnalogInputExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogInputRegular(ZigbeeChannel):
     """Analog Input Regular channel."""
 
@@ -29,7 +30,7 @@ class AnalogInputRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogOutputExtended(ZigbeeChannel):
     """Analog Output Regular channel."""
 
@@ -37,7 +38,7 @@ class AnalogOutputExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogOutputRegular(ZigbeeChannel):
     """Analog Output Regular channel."""
 
@@ -45,7 +46,7 @@ class AnalogOutputRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogValueExtended(ZigbeeChannel):
     """Analog Value Extended edition channel."""
 
@@ -53,7 +54,7 @@ class AnalogValueExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogValueRegular(ZigbeeChannel):
     """Analog Value Regular channel."""
 
@@ -61,7 +62,7 @@ class AnalogValueRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BacnetProtocolTunnel(ZigbeeChannel):
     """Bacnet Protocol Tunnel channel."""
 
@@ -69,7 +70,7 @@ class BacnetProtocolTunnel(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryInputExtended(ZigbeeChannel):
     """Binary Input Extended channel."""
 
@@ -77,7 +78,7 @@ class BinaryInputExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryInputRegular(ZigbeeChannel):
     """Binary Input Regular channel."""
 
@@ -85,7 +86,7 @@ class BinaryInputRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryOutputExtended(ZigbeeChannel):
     """Binary Output Extended channel."""
 
@@ -93,7 +94,7 @@ class BinaryOutputExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryOutputRegular(ZigbeeChannel):
     """Binary Output Regular channel."""
 
@@ -101,7 +102,7 @@ class BinaryOutputRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryValueExtended(ZigbeeChannel):
     """Binary Value Extended channel."""
 
@@ -109,7 +110,7 @@ class BinaryValueExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryValueRegular(ZigbeeChannel):
     """Binary Value Regular channel."""
 
@@ -117,7 +118,7 @@ class BinaryValueRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class GenericTunnel(ZigbeeChannel):
     """Generic Tunnel channel."""
 
@@ -125,7 +126,7 @@ class GenericTunnel(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateInputExtended(ZigbeeChannel):
     """Multistate Input Extended channel."""
 
@@ -133,7 +134,7 @@ class MultiStateInputExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateInputRegular(ZigbeeChannel):
     """Multistate Input Regular channel."""
 
@@ -141,7 +142,7 @@ class MultiStateInputRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateOutputExtended(ZigbeeChannel):
     """Multistate Output Extended channel."""
 
@@ -149,7 +150,7 @@ class MultiStateOutputExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateOutputRegular(ZigbeeChannel):
     """Multistate Output Regular channel."""
 
@@ -157,7 +158,7 @@ class MultiStateOutputRegular(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateValueExtended(ZigbeeChannel):
     """Multistate Value Extended channel."""
 
@@ -165,7 +166,7 @@ class MultiStateValueExtended(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateValueRegular(ZigbeeChannel):
     """Multistate Value Regular channel."""
 

--- a/homeassistant/components/zha/core/channels/protocol.py
+++ b/homeassistant/components/zha/core/channels/protocol.py
@@ -13,141 +13,161 @@ from ..channels import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.AnalogInputExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogInputExtended(ZigbeeChannel):
     """Analog Input Extended channel."""
 
+    CLUSTER_ID = protocol.AnalogInputExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.AnalogInputRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogInputRegular(ZigbeeChannel):
     """Analog Input Regular channel."""
 
+    CLUSTER_ID = protocol.AnalogInputRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.AnalogOutputExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogOutputExtended(ZigbeeChannel):
     """Analog Output Regular channel."""
 
+    CLUSTER_ID = protocol.AnalogOutputExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.AnalogOutputRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogOutputRegular(ZigbeeChannel):
     """Analog Output Regular channel."""
 
+    CLUSTER_ID = protocol.AnalogOutputRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.AnalogValueExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogValueExtended(ZigbeeChannel):
     """Analog Value Extended edition channel."""
 
+    CLUSTER_ID = protocol.AnalogValueExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.AnalogValueRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class AnalogValueRegular(ZigbeeChannel):
     """Analog Value Regular channel."""
 
+    CLUSTER_ID = protocol.AnalogValueRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.BacnetProtocolTunnel.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BacnetProtocolTunnel(ZigbeeChannel):
     """Bacnet Protocol Tunnel channel."""
 
+    CLUSTER_ID = protocol.BacnetProtocolTunnel.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.BinaryInputExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryInputExtended(ZigbeeChannel):
     """Binary Input Extended channel."""
 
+    CLUSTER_ID = protocol.BinaryInputExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.BinaryInputRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryInputRegular(ZigbeeChannel):
     """Binary Input Regular channel."""
 
+    CLUSTER_ID = protocol.BinaryInputRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.BinaryOutputExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryOutputExtended(ZigbeeChannel):
     """Binary Output Extended channel."""
 
+    CLUSTER_ID = protocol.BinaryOutputExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.BinaryOutputRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryOutputRegular(ZigbeeChannel):
     """Binary Output Regular channel."""
 
+    CLUSTER_ID = protocol.BinaryOutputRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.BinaryValueExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryValueExtended(ZigbeeChannel):
     """Binary Value Extended channel."""
 
+    CLUSTER_ID = protocol.BinaryValueExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.BinaryValueRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class BinaryValueRegular(ZigbeeChannel):
     """Binary Value Regular channel."""
 
+    CLUSTER_ID = protocol.BinaryValueRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.GenericTunnel.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class GenericTunnel(ZigbeeChannel):
     """Generic Tunnel channel."""
 
+    CLUSTER_ID = protocol.GenericTunnel.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.MultistateInputExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateInputExtended(ZigbeeChannel):
     """Multistate Input Extended channel."""
 
+    CLUSTER_ID = protocol.MultistateInputExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.MultistateInputRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateInputRegular(ZigbeeChannel):
     """Multistate Input Regular channel."""
 
+    CLUSTER_ID = protocol.MultistateInputRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.MultistateOutputExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateOutputExtended(ZigbeeChannel):
     """Multistate Output Extended channel."""
 
+    CLUSTER_ID = protocol.MultistateOutputExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.MultistateOutputRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateOutputRegular(ZigbeeChannel):
     """Multistate Output Regular channel."""
 
+    CLUSTER_ID = protocol.MultistateOutputRegular.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.MultistateValueExtended.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateValueExtended(ZigbeeChannel):
     """Multistate Value Extended channel."""
 
+    CLUSTER_ID = protocol.MultistateValueExtended.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(protocol.MultistateValueRegular.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MultiStateValueRegular(ZigbeeChannel):
     """Multistate Value Regular channel."""
 
+    CLUSTER_ID = protocol.MultistateValueRegular.cluster_id
     pass

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -11,13 +11,14 @@ import zigpy.zcl.clusters.security as security
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from . import ZIGBEE_CHANNEL_REGISTRY, ZigbeeChannel
+from . import ZigbeeChannel
+from .. import registries
 from ..const import SIGNAL_ATTR_UPDATED
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class IasAce(ZigbeeChannel):
     """IAS Ancillary Control Equipment channel."""
 
@@ -25,7 +26,7 @@ class IasAce(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class IasWd(ZigbeeChannel):
     """IAS Warning Device channel."""
 
@@ -33,7 +34,7 @@ class IasWd(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class IASZoneChannel(ZigbeeChannel):
     """Channel for the IASZone Zigbee cluster."""
 

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -34,6 +34,7 @@ class IasWd(ZigbeeChannel):
     pass
 
 
+@registries.BINARY_SENSOR_CLUSTERS.register
 @registries.ZIGBEE_CHANNEL_REGISTRY.register
 class IASZoneChannel(ZigbeeChannel):
     """Channel for the IASZone Zigbee cluster."""

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -17,23 +17,27 @@ from ..const import SIGNAL_ATTR_UPDATED
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(security.IasAce.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class IasAce(ZigbeeChannel):
     """IAS Ancillary Control Equipment channel."""
 
+    CLUSTER_ID = security.IasAce.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(security.IasWd.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class IasWd(ZigbeeChannel):
     """IAS Warning Device channel."""
 
+    CLUSTER_ID = security.IasWd.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(security.IasZone.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class IASZoneChannel(ZigbeeChannel):
     """Channel for the IASZone Zigbee cluster."""
+
+    CLUSTER_ID = security.IasZone.cluster_id
 
     @callback
     def cluster_command(self, tsn, command_id, args):

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -14,85 +14,97 @@ from ..const import REPORT_CONFIG_DEFAULT
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Calendar.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Calendar(ZigbeeChannel):
     """Calendar channel."""
 
+    CLUSTER_ID = smartenergy.Calendar.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.DeviceManagement.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class DeviceManagement(ZigbeeChannel):
     """Device Management channel."""
 
+    CLUSTER_ID = smartenergy.DeviceManagement.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Drlc.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Drlc(ZigbeeChannel):
     """Demand Response and Load Control channel."""
 
+    CLUSTER_ID = smartenergy.Drlc.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.EnergyManagement.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class EnergyManagement(ZigbeeChannel):
     """Energy Management channel."""
 
+    CLUSTER_ID = smartenergy.EnergyManagement.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Events.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Events(ZigbeeChannel):
     """Event channel."""
 
+    CLUSTER_ID = smartenergy.Events.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.KeyEstablishment.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class KeyEstablishment(ZigbeeChannel):
     """Key Establishment channel."""
 
+    CLUSTER_ID = smartenergy.KeyEstablishment.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.MduPairing.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class MduPairing(ZigbeeChannel):
     """Pairing channel."""
 
+    CLUSTER_ID = smartenergy.MduPairing.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Messaging.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Messaging(ZigbeeChannel):
     """Messaging channel."""
 
+    CLUSTER_ID = smartenergy.Messaging.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Metering.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Metering(AttributeListeningChannel):
     """Metering channel."""
 
+    CLUSTER_ID = smartenergy.Metering.cluster_id
     REPORT_CONFIG = [{"attr": "instantaneous_demand", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Prepayment.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Prepayment(ZigbeeChannel):
     """Prepayment channel."""
 
+    CLUSTER_ID = smartenergy.Prepayment.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Price.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Price(ZigbeeChannel):
     """Price channel."""
 
+    CLUSTER_ID = smartenergy.Price.cluster_id
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Tunneling.cluster_id)
+@ZIGBEE_CHANNEL_REGISTRY.register
 class Tunneling(ZigbeeChannel):
     """Tunneling channel."""
 
+    CLUSTER_ID = smartenergy.Tunneling.cluster_id
     pass

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -8,13 +8,14 @@ import logging
 
 import zigpy.zcl.clusters.smartenergy as smartenergy
 
-from ..channels import ZIGBEE_CHANNEL_REGISTRY, AttributeListeningChannel, ZigbeeChannel
+from .. import registries
+from ..channels import AttributeListeningChannel, ZigbeeChannel
 from ..const import REPORT_CONFIG_DEFAULT
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Calendar(ZigbeeChannel):
     """Calendar channel."""
 
@@ -22,7 +23,7 @@ class Calendar(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class DeviceManagement(ZigbeeChannel):
     """Device Management channel."""
 
@@ -30,7 +31,7 @@ class DeviceManagement(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Drlc(ZigbeeChannel):
     """Demand Response and Load Control channel."""
 
@@ -38,7 +39,7 @@ class Drlc(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class EnergyManagement(ZigbeeChannel):
     """Energy Management channel."""
 
@@ -46,7 +47,7 @@ class EnergyManagement(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Events(ZigbeeChannel):
     """Event channel."""
 
@@ -54,7 +55,7 @@ class Events(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class KeyEstablishment(ZigbeeChannel):
     """Key Establishment channel."""
 
@@ -62,7 +63,7 @@ class KeyEstablishment(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class MduPairing(ZigbeeChannel):
     """Pairing channel."""
 
@@ -70,7 +71,7 @@ class MduPairing(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Messaging(ZigbeeChannel):
     """Messaging channel."""
 
@@ -78,7 +79,7 @@ class Messaging(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Metering(AttributeListeningChannel):
     """Metering channel."""
 
@@ -86,7 +87,7 @@ class Metering(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "instantaneous_demand", "config": REPORT_CONFIG_DEFAULT}]
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Prepayment(ZigbeeChannel):
     """Prepayment channel."""
 
@@ -94,7 +95,7 @@ class Prepayment(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Price(ZigbeeChannel):
     """Price channel."""
 
@@ -102,7 +103,7 @@ class Price(ZigbeeChannel):
     pass
 
 
-@ZIGBEE_CHANNEL_REGISTRY.register
+@registries.ZIGBEE_CHANNEL_REGISTRY.register
 class Tunneling(ZigbeeChannel):
     """Tunneling channel."""
 

--- a/homeassistant/components/zha/core/decorators.py
+++ b/homeassistant/components/zha/core/decorators.py
@@ -1,0 +1,28 @@
+"""Decorators for ZHA core registries."""
+from typing import Callable, TypeVar
+
+CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)  # noqa pylint: disable=invalid-name
+
+
+class DictRegistry(dict):
+    """Dict Registry of items."""
+
+    def register(self, channel: CALLABLE_T) -> Callable[[CALLABLE_T], CALLABLE_T]:
+        """Register channel."""
+
+        if hasattr(channel, "CLUSTER_ID") and channel.CLUSTER_ID is not None:
+            self[channel.CLUSTER_ID] = channel
+
+        return channel
+
+
+class SetRegistry(set):
+    """Set Registry of items."""
+
+    def register(self, channel: CALLABLE_T) -> Callable[[CALLABLE_T], CALLABLE_T]:
+        """Register channel cluster id."""
+
+        if hasattr(channel, "CLUSTER_ID") and channel.CLUSTER_ID is not None:
+            self.add(channel.CLUSTER_ID)
+
+        return channel

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -13,12 +13,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .channels import (
-    ZIGBEE_CHANNEL_REGISTRY,
-    AttributeListeningChannel,
-    EventRelayChannel,
-    ZDOChannel,
-)
+from .channels import AttributeListeningChannel, EventRelayChannel, ZDOChannel
 from .const import (
     COMPONENTS,
     CONF_DEVICE_CONFIG,
@@ -39,6 +34,7 @@ from .registries import (
     SENSOR_TYPES,
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS,
     SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS,
+    ZIGBEE_CHANNEL_REGISTRY,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -122,13 +122,12 @@ def async_is_bindable_target(source_zha_device, target_zha_device):
     source_clusters = source_zha_device.async_get_std_clusters()
     target_clusters = target_zha_device.async_get_std_clusters()
 
-    bindables = set(BINDABLE_CLUSTERS)
     for endpoint_id in source_clusters:
         for t_endpoint_id in target_clusters:
             matches = set(
                 source_clusters[endpoint_id][CLUSTER_TYPE_OUT].keys()
             ).intersection(target_clusters[t_endpoint_id][CLUSTER_TYPE_IN].keys())
-            if any(bindable in bindables for bindable in matches):
+            if any(bindable in BINDABLE_CLUSTERS for bindable in matches):
                 return True
     return False
 

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -12,7 +12,7 @@ from homeassistant.components.light import DOMAIN as LIGHT
 from homeassistant.components.lock import DOMAIN as LOCK
 from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
-from homeassistant.components.zha.core.decorators import DictRegistry
+from homeassistant.components.zha.core.decorators import DictRegistry, SetRegistry
 
 from .const import (
     CONTROLLER,
@@ -35,23 +35,23 @@ from .const import (
     RadioType,
 )
 
-BINARY_SENSOR_CLUSTERS = set()
+BINARY_SENSOR_CLUSTERS = SetRegistry()
 BINARY_SENSOR_TYPES = {}
-BINDABLE_CLUSTERS = []
-CHANNEL_ONLY_CLUSTERS = []
+BINDABLE_CLUSTERS = SetRegistry()
+CHANNEL_ONLY_CLUSTERS = SetRegistry()
 CLUSTER_REPORT_CONFIGS = {}
 CUSTOM_CLUSTER_MAPPINGS = {}
 DEVICE_CLASS = {}
-DEVICE_TRACKER_CLUSTERS = set()
-EVENT_RELAY_CLUSTERS = []
-LIGHT_CLUSTERS = set()
-OUTPUT_CHANNEL_ONLY_CLUSTERS = []
+DEVICE_TRACKER_CLUSTERS = SetRegistry()
+EVENT_RELAY_CLUSTERS = SetRegistry()
+LIGHT_CLUSTERS = SetRegistry()
+OUTPUT_CHANNEL_ONLY_CLUSTERS = SetRegistry()
 RADIO_TYPES = {}
 REMOTE_DEVICE_TYPES = {}
 SENSOR_TYPES = {}
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {}
-SWITCH_CLUSTERS = set()
+SWITCH_CLUSTERS = SetRegistry()
 SMARTTHINGS_ACCELERATION_CLUSTER = 0xFC02
 SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE = 0x8000
 SMARTTHINGS_HUMIDITY_CLUSTER = 0xFC45
@@ -138,9 +138,6 @@ def establish_device_mappings():
     }
 
     BINARY_SENSOR_CLUSTERS.add(SMARTTHINGS_ACCELERATION_CLUSTER)
-    BINARY_SENSOR_CLUSTERS.add(zcl.clusters.general.OnOff.cluster_id)
-    BINARY_SENSOR_CLUSTERS.add(zcl.clusters.measurement.OccupancySensing.cluster_id)
-    BINARY_SENSOR_CLUSTERS.add(zcl.clusters.security.IasZone.cluster_id)
 
     BINARY_SENSOR_TYPES.update(
         {
@@ -150,13 +147,6 @@ def establish_device_mappings():
             zcl.clusters.security.IasZone.cluster_id: ZONE,
         }
     )
-
-    BINDABLE_CLUSTERS.append(zcl.clusters.general.LevelControl.cluster_id)
-    BINDABLE_CLUSTERS.append(zcl.clusters.general.OnOff.cluster_id)
-    BINDABLE_CLUSTERS.append(zcl.clusters.lighting.Color.cluster_id)
-
-    CHANNEL_ONLY_CLUSTERS.append(zcl.clusters.general.Basic.cluster_id)
-    CHANNEL_ONLY_CLUSTERS.append(zcl.clusters.lightlink.LightLink.cluster_id)
 
     CLUSTER_REPORT_CONFIGS.update(
         {
@@ -205,17 +195,6 @@ def establish_device_mappings():
         }
     )
 
-    DEVICE_TRACKER_CLUSTERS.add(zcl.clusters.general.PowerConfiguration.cluster_id)
-
-    EVENT_RELAY_CLUSTERS.append(zcl.clusters.general.LevelControl.cluster_id)
-    EVENT_RELAY_CLUSTERS.append(zcl.clusters.general.OnOff.cluster_id)
-
-    OUTPUT_CHANNEL_ONLY_CLUSTERS.append(zcl.clusters.general.Scenes.cluster_id)
-
-    LIGHT_CLUSTERS.add(zcl.clusters.general.LevelControl.cluster_id)
-    LIGHT_CLUSTERS.add(zcl.clusters.general.OnOff.cluster_id)
-    LIGHT_CLUSTERS.add(zcl.clusters.lighting.Color.cluster_id)
-
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update(
         {
             # this works for now but if we hit conflicts we can break it out to
@@ -255,8 +234,6 @@ def establish_device_mappings():
             zcl.clusters.smartenergy.Metering.cluster_id: SENSOR_METERING,
         }
     )
-
-    SWITCH_CLUSTERS.add(zcl.clusters.general.OnOff.cluster_id)
 
     zhap = zha.PROFILE_ID
     REMOTE_DEVICE_TYPES[zhap].append(zha.DeviceType.COLOR_CONTROLLER)

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -12,6 +12,7 @@ from homeassistant.components.light import DOMAIN as LIGHT
 from homeassistant.components.lock import DOMAIN as LOCK
 from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
+from homeassistant.components.zha.core.decorators import DictRegistry
 
 from .const import (
     CONTROLLER,
@@ -61,6 +62,10 @@ COMPONENT_CLUSTERS = {
     LIGHT: LIGHT_CLUSTERS,
     SWITCH: SWITCH_CLUSTERS,
 }
+
+ZIGBEE_CHANNEL_REGISTRY = DictRegistry()
+# importing channels updates registries
+from . import channels  # noqa pylint: disable=wrong-import-position
 
 
 def establish_device_mappings():

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -1,5 +1,4 @@
 """Test ZHA Core channels."""
-import homeassistant.components.zha.core.channels
 import pytest
 import zigpy.types as t
 
@@ -136,7 +135,7 @@ async def test_out_channel_config(cluster_id, bind_count, zha_gateway, hass):
 
     cluster = zigpy_dev.endpoints[1].out_clusters[cluster_id]
     cluster.bind_only = True
-    channel_class = homeassistant.components.zha.core.channels.ZIGBEE_CHANNEL_REGISTRY.get(
+    channel_class = channels.ZIGBEE_CHANNEL_REGISTRY.get(
         cluster_id, channels.AttributeListeningChannel
     )
     channel = channel_class(cluster, zha_dev)
@@ -149,7 +148,7 @@ async def test_out_channel_config(cluster_id, bind_count, zha_gateway, hass):
 
 def test_channel_registry():
     """Test ZIGBEE Channel Registry."""
-    for cluster_id, channel in channels.ZIGBEE_CHANNEL_REGISTRY.items():
+    for (cluster_id, channel) in channels.ZIGBEE_CHANNEL_REGISTRY.items():
         assert isinstance(cluster_id, int)
         assert 0 <= cluster_id <= 0xFFFF
         assert issubclass(channel, channels.ZigbeeChannel)

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -4,6 +4,7 @@ import zigpy.types as t
 
 import homeassistant.components.zha.core.channels as channels
 import homeassistant.components.zha.core.device as zha_device
+import homeassistant.components.zha.core.registries as registries
 
 from .common import make_device
 
@@ -76,7 +77,7 @@ async def test_in_channel_config(cluster_id, bind_count, attrs, zha_gateway, has
     zha_dev = zha_device.ZHADevice(hass, zigpy_dev, zha_gateway)
 
     cluster = zigpy_dev.endpoints[1].in_clusters[cluster_id]
-    channel_class = channels.ZIGBEE_CHANNEL_REGISTRY.get(
+    channel_class = registries.ZIGBEE_CHANNEL_REGISTRY.get(
         cluster_id, channels.AttributeListeningChannel
     )
     channel = channel_class(cluster, zha_dev)
@@ -135,7 +136,7 @@ async def test_out_channel_config(cluster_id, bind_count, zha_gateway, hass):
 
     cluster = zigpy_dev.endpoints[1].out_clusters[cluster_id]
     cluster.bind_only = True
-    channel_class = channels.ZIGBEE_CHANNEL_REGISTRY.get(
+    channel_class = registries.ZIGBEE_CHANNEL_REGISTRY.get(
         cluster_id, channels.AttributeListeningChannel
     )
     channel = channel_class(cluster, zha_dev)
@@ -148,7 +149,7 @@ async def test_out_channel_config(cluster_id, bind_count, zha_gateway, hass):
 
 def test_channel_registry():
     """Test ZIGBEE Channel Registry."""
-    for (cluster_id, channel) in channels.ZIGBEE_CHANNEL_REGISTRY.items():
+    for (cluster_id, channel) in registries.ZIGBEE_CHANNEL_REGISTRY.items():
         assert isinstance(cluster_id, int)
         assert 0 <= cluster_id <= 0xFFFF
         assert issubclass(channel, channels.ZigbeeChannel)


### PR DESCRIPTION
## Description:
Refactor some of ZHA Core registries to use decorators. The following registries are using decorators now:
- BINARY_SENSOR_CLUSTERS
- BINDABLE_CLUSTERS
- CHANNEL_ONLY_CLUSTERS
- DEVICE_TRACKER_CLUSTERS
- EVENT_RELAY_CLUSTERS
- LIGHT_CLUSTERS
- OUTPUT_CHANNEL_ONLY_CLUSTERS
- SWITCH_CLUSTERS

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
