### PR TITLE
Bump hdate==0.9.0 (use pytz instead of dateutil)

### DIFF
--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jewish calendar",
   "documentation": "https://www.home-assistant.io/components/jewish_calendar",
   "requirements": [
-    "hdate==0.8.8"
+    "hdate==0.9.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -603,7 +603,7 @@ hass-nabucasa==0.16
 hbmqtt==0.9.4
 
 # homeassistant.components.jewish_calendar
-hdate==0.8.8
+hdate==0.9.0
 
 # homeassistant.components.heatmiser
 heatmiserV3==0.9.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -168,7 +168,7 @@ hass-nabucasa==0.16
 hbmqtt==0.9.4
 
 # homeassistant.components.jewish_calendar
-hdate==0.8.8
+hdate==0.9.0
 
 # homeassistant.components.workday
 holidays==0.9.11


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Use new hdate version of library which uses pytz for timezones.
dateutil expects /usr/share/timezone files, as these are not available
in the docker image and in HASSIO, the timezone offsets are broken.

**Related issue (if applicable):**
fixes #23032, fixes #18731

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
