### PR TITLE
Bump incomfort client to 0.3.1

### DIFF
--- a/homeassistant/components/incomfort/manifest.json
+++ b/homeassistant/components/incomfort/manifest.json
@@ -3,7 +3,7 @@
   "name": "Intergas InComfort/Intouch Lan2RF gateway",
   "documentation": "https://www.home-assistant.io/components/incomfort",
   "requirements": [
-    "incomfort-client==0.3.0"
+    "incomfort-client==0.3.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -668,7 +668,7 @@ iglo==1.2.7
 ihcsdk==2.3.0
 
 # homeassistant.components.incomfort
-incomfort-client==0.3.0
+incomfort-client==0.3.1
 
 # homeassistant.components.influxdb
 influxdb==5.2.0


### PR DESCRIPTION
## Description:
Bump the incomfort client to v0.3.1

**Related issue (if applicable):** fixes #25295

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
