### PR TITLE
UniFi - Fix last seen on device tracker on certain devices

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -301,11 +301,10 @@ class UniFiDeviceTracker(ScannerEntity):
             CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME
         )
 
-        if (
-            self.device.last_seen
-            and dt_util.utcnow()
-            - dt_util.utc_from_timestamp(float(self.device.last_seen))
-        ) < detection_time:
+        if self.device.last_seen and (
+            dt_util.utcnow() - dt_util.utc_from_timestamp(float(self.device.last_seen))
+            < detection_time
+        ):
             return True
         return False
 
@@ -347,6 +346,9 @@ class UniFiDeviceTracker(ScannerEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
+        if not self.device.last_seen:
+            return {}
+
         attributes = {}
 
         attributes["upgradable"] = self.device.upgradable

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -73,6 +73,17 @@ DEVICE_1 = {
     "upgradable": False,
     "version": "4.0.42.10433",
 }
+DEVICE_2 = {
+    "board_rev": 3,
+    "device_id": "mock-id",
+    "has_fan": True,
+    "ip": "10.0.1.1",
+    "mac": "00:00:00:00:01:01",
+    "model": "US16P150",
+    "name": "device_1",
+    "type": "usw",
+    "version": "4.0.42.10433",
+}
 
 CONTROLLER_DATA = {
     CONF_HOST: "mock-host",
@@ -167,7 +178,7 @@ async def test_no_clients(hass, mock_controller):
 async def test_tracked_devices(hass, mock_controller):
     """Test the update_items function with some clients."""
     mock_controller.mock_client_responses.append([CLIENT_1, CLIENT_2, CLIENT_3])
-    mock_controller.mock_device_responses.append([DEVICE_1])
+    mock_controller.mock_device_responses.append([DEVICE_1, DEVICE_2])
     mock_controller.unifi_config = {unifi_dt.CONF_SSID_FILTER: ["ssid"]}
 
     await setup_controller(hass, mock_controller)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
