### PR TITLE
Move Kodi services from 'media_player' domain to 'kodi'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -317,6 +317,7 @@ omit =
     homeassistant/components/knx/*
     homeassistant/components/knx/climate.py
     homeassistant/components/knx/cover.py
+    homeassistant/components/kodi/__init__.py
     homeassistant/components/kodi/const.py
     homeassistant/components/kodi/media_player.py
     homeassistant/components/kodi/notify.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -317,6 +317,7 @@ omit =
     homeassistant/components/knx/*
     homeassistant/components/knx/climate.py
     homeassistant/components/knx/cover.py
+    homeassistant/components/kodi/const.py
     homeassistant/components/kodi/media_player.py
     homeassistant/components/kodi/notify.py
     homeassistant/components/konnected/*

--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -1,1 +1,58 @@
 """The kodi component."""
+
+import asyncio
+import logging
+
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.components.kodi.const import DOMAIN
+from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+SERVICE_ADD_MEDIA = "add_to_playlist"
+SERVICE_CALL_METHOD = "call_method"
+
+ATTR_MEDIA_TYPE = "media_type"
+ATTR_MEDIA_NAME = "media_name"
+ATTR_MEDIA_ARTIST_NAME = "artist_name"
+ATTR_MEDIA_ID = "media_id"
+ATTR_METHOD = "method"
+
+MEDIA_PLAYER_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.comp_entity_ids})
+
+KODI_ADD_MEDIA_SCHEMA = MEDIA_PLAYER_SCHEMA.extend(
+    {
+        vol.Required(ATTR_MEDIA_TYPE): cv.string,
+        vol.Optional(ATTR_MEDIA_ID): cv.string,
+        vol.Optional(ATTR_MEDIA_NAME): cv.string,
+        vol.Optional(ATTR_MEDIA_ARTIST_NAME): cv.string,
+    }
+)
+KODI_PLAYER_CALL_METHOD_SCHEMA = MEDIA_PLAYER_SCHEMA.extend(
+    {vol.Required(ATTR_METHOD): cv.string}, extra=vol.ALLOW_EXTRA
+)
+
+SERVICE_TO_METHOD = {
+    SERVICE_ADD_MEDIA: {
+        "method": "async_add_media_to_playlist",
+        "schema": KODI_ADD_MEDIA_SCHEMA,
+    },
+    SERVICE_CALL_METHOD: {
+        "method": "async_call_method",
+        "schema": KODI_CALL_METHOD_SCHEMA,
+    },
+}
+
+
+async def async_setup(hass, config):
+    """Setup the Kodi integration."""
+    if any(
+        ((CONF_PLATFORM, DOMAIN) in cfg.items() for cfg in config.get(MP_DOMAIN, []))
+    ):
+        # Register the Kodi media_player services
+        _LOGGER.critical("Has Kodi media_player")
+
+    # Return boolean to indicate that initialization was successful.
+    return True

--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -1,7 +1,6 @@
 """The kodi component."""
 
 import asyncio
-import logging
 import voluptuous as vol
 
 from homeassistant.const import CONF_PLATFORM
@@ -10,8 +9,6 @@ from homeassistant.components.kodi.const import DOMAIN
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
 
 from homeassistant.const import ATTR_ENTITY_ID
-
-_LOGGER = logging.getLogger(__name__)
 
 
 SERVICE_ADD_MEDIA = "add_to_playlist"
@@ -55,8 +52,6 @@ async def async_setup(hass, config):
         ((CONF_PLATFORM, DOMAIN) in cfg.items() for cfg in config.get(MP_DOMAIN, []))
     ):
         # Register the Kodi media_player services
-        _LOGGER.critical("Has Kodi media_player")
-
         async def async_service_handler(service):
             """Map services to methods on MediaPlayerDevice."""
             method = SERVICE_TO_METHOD.get(service.service)

--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -3,12 +3,10 @@
 import asyncio
 import voluptuous as vol
 
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
 from homeassistant.helpers import config_validation as cv
 from homeassistant.components.kodi.const import DOMAIN
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
-
-from homeassistant.const import ATTR_ENTITY_ID
 
 
 SERVICE_ADD_MEDIA = "add_to_playlist"

--- a/homeassistant/components/kodi/const.py
+++ b/homeassistant/components/kodi/const.py
@@ -1,0 +1,2 @@
+"""Constants for the Kodi platform."""
+DOMAIN = "kodi"

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -137,8 +137,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 SERVICE_ADD_MEDIA = "add_to_playlist"
 SERVICE_CALL_METHOD = "call_method"
 
-DATA_KODI = "kodi"
-
 ATTR_MEDIA_TYPE = "media_type"
 ATTR_MEDIA_NAME = "media_name"
 ATTR_MEDIA_ARTIST_NAME = "artist_name"
@@ -205,8 +203,8 @@ def _check_deprecated_turn_off(hass, turn_off_action):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Kodi platform."""
-    if DATA_KODI not in hass.data:
-        hass.data[DATA_KODI] = dict()
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = dict()
 
     unique_id = None
     # Is this a manual configuration?
@@ -231,14 +229,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Only add a device once, so discovered devices do not override manual
     # config.
     ip_addr = socket.gethostbyname(host)
-    if ip_addr in hass.data[DATA_KODI]:
+    if ip_addr in hass.data[DOMAIN]:
         return
 
     # If we got an unique id, check that it does not exist already.
     # This is necessary as netdisco does not deterministally return the same
     # advertisement when the service is offered over multiple IP addresses.
     if unique_id is not None:
-        for device in hass.data[DATA_KODI].values():
+        for device in hass.data[DOMAIN].values():
             if device.unique_id == unique_id:
                 return
 
@@ -258,7 +256,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         unique_id=unique_id,
     )
 
-    hass.data[DATA_KODI][ip_addr] = entity
+    hass.data[DOMAIN][ip_addr] = entity
     async_add_entities([entity], update_before_add=True)
 
     async def async_service_handler(service):
@@ -274,11 +272,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         if entity_ids:
             target_players = [
                 player
-                for player in hass.data[DATA_KODI].values()
+                for player in hass.data[DOMAIN].values()
                 if player.entity_id in entity_ids
             ]
         else:
-            target_players = hass.data[DATA_KODI].values()
+            target_players = hass.data[DOMAIN].values()
 
         update_tasks = []
         for player in target_players:

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -134,40 +134,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-SERVICE_ADD_MEDIA = "add_to_playlist"
-SERVICE_CALL_METHOD = "call_method"
-
-ATTR_MEDIA_TYPE = "media_type"
-ATTR_MEDIA_NAME = "media_name"
-ATTR_MEDIA_ARTIST_NAME = "artist_name"
-ATTR_MEDIA_ID = "media_id"
-ATTR_METHOD = "method"
-
-MEDIA_PLAYER_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.comp_entity_ids})
-
-MEDIA_PLAYER_ADD_MEDIA_SCHEMA = MEDIA_PLAYER_SCHEMA.extend(
-    {
-        vol.Required(ATTR_MEDIA_TYPE): cv.string,
-        vol.Optional(ATTR_MEDIA_ID): cv.string,
-        vol.Optional(ATTR_MEDIA_NAME): cv.string,
-        vol.Optional(ATTR_MEDIA_ARTIST_NAME): cv.string,
-    }
-)
-MEDIA_PLAYER_CALL_METHOD_SCHEMA = MEDIA_PLAYER_SCHEMA.extend(
-    {vol.Required(ATTR_METHOD): cv.string}, extra=vol.ALLOW_EXTRA
-)
-
-SERVICE_TO_METHOD = {
-    SERVICE_ADD_MEDIA: {
-        "method": "async_add_media_to_playlist",
-        "schema": MEDIA_PLAYER_ADD_MEDIA_SCHEMA,
-    },
-    SERVICE_CALL_METHOD: {
-        "method": "async_call_method",
-        "schema": MEDIA_PLAYER_CALL_METHOD_SCHEMA,
-    },
-}
-
 
 def _check_deprecated_turn_off(hass, turn_off_action):
     """Create an equivalent script for old turn off actions."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -10,9 +10,9 @@ import urllib
 import aiohttp
 import voluptuous as vol
 
+from homeassistant.components.kodi.const import DOMAIN
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
-    DOMAIN,
     MEDIA_TYPE_CHANNEL,
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
@@ -134,8 +134,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-SERVICE_ADD_MEDIA = "kodi_add_to_playlist"
-SERVICE_CALL_METHOD = "kodi_call_method"
+SERVICE_ADD_MEDIA = "add_to_playlist"
+SERVICE_CALL_METHOD = "call_method"
 
 DATA_KODI = "kodi"
 

--- a/homeassistant/components/kodi/services.yaml
+++ b/homeassistant/components/kodi/services.yaml
@@ -1,0 +1,30 @@
+# Describes the format for available Kodi services
+
+add_to_playlist:
+  description: Add music to the default playlist (i.e. playlistid=0).
+  fields:
+    entity_id:
+      description: Name(s) of the Kodi entities where to add the media.
+      example: 'media_player.living_room_kodi'
+    media_type:
+      description: Media type identifier. It must be one of SONG or ALBUM.
+      example: ALBUM
+    media_id:
+      description: Unique Id of the media entry to add (`songid` or albumid`). If not defined, `media_name` and `artist_name` are needed to search the Kodi music library.
+      example: 123456
+    media_name:
+      description: Optional media name for filtering media. Can be 'ALL' when `media_type` is 'ALBUM' and `artist_name` is specified, to add all songs from one artist.
+      example: 'Highway to Hell'
+    artist_name:
+      description: Optional artist name for filtering media.
+      example: 'AC/DC'
+
+call_method:
+  description: 'Call a Kodi JSONRPC API method with optional parameters. Results of the Kodi API call will be redirected in a Home Assistant event: `kodi_call_method_result`.'
+  fields:
+    entity_id:
+      description: Name(s) of the Kodi entities where to run the API method.
+      example: 'media_player.living_room_kodi'
+    method:
+      description: Name of the Kodi JSONRPC API method to be called.
+      example: 'VideoLibrary.GetRecentlyAddedEpisodes'

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -232,35 +232,6 @@ soundtouch_remove_zone_slave:
       description: Name of slaves entities to remove from the existing zone.
       example: 'media_player.soundtouch_bedroom'
 
-kodi_add_to_playlist:
-  description: Add music to the default playlist (i.e. playlistid=0).
-  fields:
-    entity_id:
-      description: Name(s) of the Kodi entities where to add the media.
-      example: 'media_player.living_room_kodi'
-    media_type:
-      description: Media type identifier. It must be one of SONG or ALBUM.
-      example: ALBUM
-    media_id:
-      description: Unique Id of the media entry to add (`songid` or albumid`). If not defined, `media_name` and `artist_name` are needed to search the Kodi music library.
-      example: 123456
-    media_name:
-      description: Optional media name for filtering media. Can be 'ALL' when `media_type` is 'ALBUM' and `artist_name` is specified, to add all songs from one artist.
-      example: 'Highway to Hell'
-    artist_name:
-      description: Optional artist name for filtering media.
-      example: 'AC/DC'
-
-kodi_call_method:
-  description: 'Call a Kodi JSONRPC API method with optional parameters. Results of the Kodi API call will be redirected in a Home Assistant event: `kodi_call_method_result`.'
-  fields:
-    entity_id:
-      description: Name(s) of the Kodi entities where to run the API method.
-      example: 'media_player.living_room_kodi'
-    method:
-      description: Name of the Kodi JSONRPC API method to be called.
-      example: 'VideoLibrary.GetRecentlyAddedEpisodes'
-
 squeezebox_call_method:
   description: 'Call a Squeezebox JSON/RPC API method.'
   fields:


### PR DESCRIPTION
## Breaking Change:

The `media_player.kodi_*` services are now `kodi.*`.  

* `media_player.kodi_add_to_playlist` is now `kodi.add_to_playlist`
* `media_player.kodi_call_method` is now `kodi.call_method`


## Description:

Move the Kodi services to their own domain. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10081

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
