### PR TITLE
zha: floating point approximation

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -67,36 +67,35 @@ def illuminance_formatter(value):
     """Convert Illimination data."""
     if value is None:
         return None
-    return round(pow(10, ((value - 1) / 10000)), 1)
+    return '{:.1f}'.format(pow(10, ((value - 1) / 10000)))
 
 
 def temperature_formatter(value):
     """Convert temperature data."""
     if value is None:
         return None
-    return round(value / 100, 1)
+    return '{:.1f}'.format(value / 100)
 
 
 def humidity_formatter(value):
     """Return the state of the entity."""
     if value is None:
         return None
-    return round(float(value) / 100, 1)
+    return '{:.1f}'.format(value / 100)
 
 
 def active_power_formatter(value):
     """Return the state of the entity."""
     if value is None:
         return None
-    return round(float(value) / 10, 1)
+    return '{:.1f}'.format(value / 10)
 
 
 def pressure_formatter(value):
     """Return the state of the entity."""
     if value is None:
         return None
-
-    return round(float(value))
+    return '{:.0f}'.format(value)
 
 
 def battery_percentage_remaining_formatter(value):
@@ -104,9 +103,7 @@ def battery_percentage_remaining_formatter(value):
     # per zcl specs battery percent is reported at 200% ¯\_(ツ)_/¯
     if not isinstance(value, numbers.Number) or value == -1:
         return value
-    value = value / 2
-    value = int(round(value))
-    return value
+    return '{:.0f}'.format(value / 2)
 
 
 async def async_battery_device_state_attr_provider(channel):


### PR DESCRIPTION
Format floating point values as string with known precision.

## Breaking Change:

Automations comparing a string value as a string may need to compare as a number because the formatting changes for some values.

## Description:

Some platforms do not always perform a nice rounding when converting a floating-point value to a string. The fix explicitly converts it.

**Related issue (if applicable):** fixes #24572 (zha part)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sha:
  ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
