### PR TITLE
PS4 add media data services

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -278,7 +278,7 @@ def service_handle(hass: HomeAssistantType):
                 await device.async_send_command(command)
 
     async def async_service_media_unlock(call):
-        """Service to lock media data that entity is playing."""
+        """Service to unlock media data."""
         games = load_games(hass)
         media_content_id = call.data[ATTR_MEDIA_CONTENT_ID]
         data = games.get(media_content_id)
@@ -393,7 +393,7 @@ def service_handle(hass: HomeAssistantType):
                     media_content_id))
 
     async def async_service_media_edit_playing(call):
-        """Service call for editing existing media data."""
+        """Service for editing existing media data that entity is playing."""
         games = load_games(hass)
         media_content_id = None
         entity_id = call.data[ATTR_ENTITY_ID]

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -54,42 +54,46 @@ PS4_COMMAND_SCHEMA = vol.Schema(
     }
 )
 
-PS4_MEDIA_ADD_SCHEMA = vol.Schema({
-    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
-    vol.Required(ATTR_MEDIA_TITLE): str,
-    vol.Optional(ATTR_MEDIA_IMAGE_URL, default=""): vol.Any(
-        cv.url, str),
-    vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
-        [MEDIA_TYPE_GAME, MEDIA_TYPE_APP])
-})
+PS4_MEDIA_ADD_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+        vol.Required(ATTR_MEDIA_TITLE): str,
+        vol.Optional(ATTR_MEDIA_IMAGE_URL, default=""): vol.Any(cv.url, str),
+        vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
+            [MEDIA_TYPE_GAME, MEDIA_TYPE_APP]
+        ),
+    }
+)
 
-PS4_MEDIA_REMOVE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
-})
+PS4_MEDIA_REMOVE_SCHEMA = vol.Schema({vol.Required(ATTR_MEDIA_CONTENT_ID): str})
 
-PS4_MEDIA_EDIT_SCHEMA = vol.Schema({
-    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
-    vol.Optional(ATTR_MEDIA_TITLE, default=""): str,
-    vol.Optional(ATTR_MEDIA_IMAGE_URL, default=DEFAULT_URL): cv.url,
-    vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
-        [MEDIA_TYPE_GAME, MEDIA_TYPE_APP])
-})
+PS4_MEDIA_EDIT_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_MEDIA_CONTENT_ID): str,
+        vol.Optional(ATTR_MEDIA_TITLE, default=""): str,
+        vol.Optional(ATTR_MEDIA_IMAGE_URL, default=DEFAULT_URL): cv.url,
+        vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
+            [MEDIA_TYPE_GAME, MEDIA_TYPE_APP]
+        ),
+    }
+)
 
-PS4_MEDIA_EDIT_PLAYING_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-    vol.Optional(ATTR_MEDIA_TITLE, default=""): str,
-    vol.Optional(ATTR_MEDIA_IMAGE_URL, default=DEFAULT_URL): cv.url,
-    vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
-        [MEDIA_TYPE_GAME, MEDIA_TYPE_APP])
-})
+PS4_MEDIA_EDIT_PLAYING_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Optional(ATTR_MEDIA_TITLE, default=""): str,
+        vol.Optional(ATTR_MEDIA_IMAGE_URL, default=DEFAULT_URL): cv.url,
+        vol.Optional(ATTR_MEDIA_CONTENT_TYPE, default=MEDIA_TYPE_GAME): vol.In(
+            [MEDIA_TYPE_GAME, MEDIA_TYPE_APP]
+        ),
+    }
+)
 
-PS4_MEDIA_UNLOCK_SCHEMA = vol.Schema({
-    vol.Required(ATTR_MEDIA_CONTENT_ID): str,
-})
+PS4_MEDIA_UNLOCK_SCHEMA = vol.Schema({vol.Required(ATTR_MEDIA_CONTENT_ID): str})
 
-PS4_MEDIA_UNLOCK_PLAYING_SCHEMA = vol.Schema({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id
-})
+PS4_MEDIA_UNLOCK_PLAYING_SCHEMA = vol.Schema(
+    {vol.Required(ATTR_ENTITY_ID): cv.entity_id}
+)
 
 
 class PS4Data:
@@ -292,8 +296,8 @@ def service_handle(hass: HomeAssistantType):
             refresh_entity_media(hass, media_content_id)
         else:
             raise HomeAssistantError(
-                "Media ID: {} is not in source list".format(
-                    media_content_id))
+                "Media ID: {} is not in source list".format(media_content_id)
+            )
 
     async def async_service_media_unlock_playing(call):
         """Service to unlock media data that entity is playing."""
@@ -317,11 +321,12 @@ def service_handle(hass: HomeAssistantType):
                 refresh_entity_media(hass, media_content_id)
             else:
                 raise HomeAssistantError(
-                    "Media ID: {} is not in source list".format(
-                        media_content_id))
+                    "Media ID: {} is not in source list".format(media_content_id)
+                )
         else:
             raise HomeAssistantError(
-                "Entity: {} has no current media data".format(entity_id))
+                "Entity: {} has no current media data".format(entity_id)
+            )
 
     async def async_service_media_add(call):
         """Add media data manually."""
@@ -330,15 +335,19 @@ def service_handle(hass: HomeAssistantType):
         media_content_id = call.data[ATTR_MEDIA_CONTENT_ID]
         media_title = call.data[ATTR_MEDIA_TITLE]
 
-        media_url = None if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL\
+        media_url = (
+            None
+            if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL
             else call.data[ATTR_MEDIA_IMAGE_URL]
+        )
 
-        media_type = MEDIA_TYPE_GAME\
-            if call.data[ATTR_MEDIA_CONTENT_TYPE] == ""\
+        media_type = (
+            MEDIA_TYPE_GAME
+            if call.data[ATTR_MEDIA_CONTENT_TYPE] == ""
             else call.data[ATTR_MEDIA_CONTENT_TYPE]
+        )
 
-        _set_media(hass, games, media_content_id, media_title,
-                   media_url, media_type)
+        _set_media(hass, games, media_content_id, media_title, media_url, media_type)
 
     async def async_service_media_remove(call):
         """Remove media data manually."""
@@ -348,8 +357,7 @@ def service_handle(hass: HomeAssistantType):
         if media_content_id in games:
             games.pop(media_content_id)
             save_games(hass, games)
-            _LOGGER.debug(
-                "Removed media from source list: %s", media_content_id)
+            _LOGGER.debug("Removed media from source list: %s", media_content_id)
 
     async def async_service_media_edit(call):
         """Service call for editing existing media data."""
@@ -358,16 +366,23 @@ def service_handle(hass: HomeAssistantType):
         data = games.get(media_content_id)
 
         if data is not None:
-            media_title = None if call.data[ATTR_MEDIA_TITLE] == ""\
+            media_title = (
+                None
+                if call.data[ATTR_MEDIA_TITLE] == ""
                 else call.data[ATTR_MEDIA_TITLE]
+            )
 
-            media_url = None\
-                if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL\
+            media_url = (
+                None
+                if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL
                 else call.data[ATTR_MEDIA_IMAGE_URL]
+            )
 
-            media_type = MEDIA_TYPE_GAME\
-                if call.data[ATTR_MEDIA_CONTENT_TYPE] == ""\
+            media_type = (
+                MEDIA_TYPE_GAME
+                if call.data[ATTR_MEDIA_CONTENT_TYPE] == ""
                 else call.data[ATTR_MEDIA_CONTENT_TYPE]
+            )
 
             if media_title is None:
                 stored_title = data.get(ATTR_MEDIA_TITLE)
@@ -384,13 +399,14 @@ def service_handle(hass: HomeAssistantType):
                 if stored_type is not None:
                     media_type = stored_type
 
-            _set_media(hass, games, media_content_id, media_title,
-                       media_url, media_type)
+            _set_media(
+                hass, games, media_content_id, media_title, media_url, media_type
+            )
             refresh_entity_media(hass, media_content_id)
         else:
             raise HomeAssistantError(
-                "Media ID: {} is not in source list".format(
-                    media_content_id))
+                "Media ID: {} is not in source list".format(media_content_id)
+            )
 
     async def async_service_media_edit_playing(call):
         """Service for editing existing media data that entity is playing."""
@@ -408,16 +424,23 @@ def service_handle(hass: HomeAssistantType):
             data = games.get(media_content_id)
             if data is not None:
 
-                media_title = None if call.data[ATTR_MEDIA_TITLE] == ""\
+                media_title = (
+                    None
+                    if call.data[ATTR_MEDIA_TITLE] == ""
                     else call.data[ATTR_MEDIA_TITLE]
+                )
 
-                media_url = None\
-                    if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL\
+                media_url = (
+                    None
+                    if call.data[ATTR_MEDIA_IMAGE_URL] == DEFAULT_URL
                     else call.data[ATTR_MEDIA_IMAGE_URL]
+                )
 
-                media_type = MEDIA_TYPE_GAME\
-                    if call.data[ATTR_MEDIA_CONTENT_TYPE] == ""\
+                media_type = (
+                    MEDIA_TYPE_GAME
+                    if call.data[ATTR_MEDIA_CONTENT_TYPE] == ""
                     else call.data[ATTR_MEDIA_CONTENT_TYPE]
+                )
 
                 if media_title is None:
                     stored_title = data.get(ATTR_MEDIA_TITLE)
@@ -434,46 +457,66 @@ def service_handle(hass: HomeAssistantType):
                     if stored_type is not None:
                         media_type = stored_type
 
-                _set_media(hass, games, media_content_id, media_title,
-                           media_url, media_type)
+                _set_media(
+                    hass, games, media_content_id, media_title, media_url, media_type
+                )
                 refresh_entity_media(hass, media_content_id)
 
             else:
                 raise HomeAssistantError(
-                    "Media ID: {} is not in source list".format(
-                        media_content_id))
+                    "Media ID: {} is not in source list".format(media_content_id)
+                )
         else:
             raise HomeAssistantError(
-                "Entity: {} has no current media data".format(entity_id))
+                "Entity: {} has no current media data".format(entity_id)
+            )
 
     hass.services.async_register(
         DOMAIN, SERVICE_COMMAND, async_service_command, schema=PS4_COMMAND_SCHEMA
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_MEDIA_ADD, async_service_media_add,
-        schema=PS4_MEDIA_ADD_SCHEMA)
+        DOMAIN, SERVICE_MEDIA_ADD, async_service_media_add, schema=PS4_MEDIA_ADD_SCHEMA
+    )
     hass.services.async_register(
-        DOMAIN, SERVICE_MEDIA_REMOVE,
+        DOMAIN,
+        SERVICE_MEDIA_REMOVE,
         async_service_media_remove,
-        schema=PS4_MEDIA_REMOVE_SCHEMA)
+        schema=PS4_MEDIA_REMOVE_SCHEMA,
+    )
     hass.services.async_register(
-        DOMAIN, SERVICE_MEDIA_EDIT, async_service_media_edit,
-        schema=PS4_MEDIA_EDIT_SCHEMA)
+        DOMAIN,
+        SERVICE_MEDIA_EDIT,
+        async_service_media_edit,
+        schema=PS4_MEDIA_EDIT_SCHEMA,
+    )
     hass.services.async_register(
-        DOMAIN, SERVICE_MEDIA_EDIT_PLAYING, async_service_media_edit_playing,
-        schema=PS4_MEDIA_EDIT_PLAYING_SCHEMA)
+        DOMAIN,
+        SERVICE_MEDIA_EDIT_PLAYING,
+        async_service_media_edit_playing,
+        schema=PS4_MEDIA_EDIT_PLAYING_SCHEMA,
+    )
     hass.services.async_register(
-        DOMAIN, SERVICE_MEDIA_UNLOCK,
+        DOMAIN,
+        SERVICE_MEDIA_UNLOCK,
         async_service_media_unlock,
-        schema=PS4_MEDIA_UNLOCK_SCHEMA)
+        schema=PS4_MEDIA_UNLOCK_SCHEMA,
+    )
     hass.services.async_register(
-        DOMAIN, SERVICE_MEDIA_UNLOCK_PLAYING,
+        DOMAIN,
+        SERVICE_MEDIA_UNLOCK_PLAYING,
         async_service_media_unlock_playing,
-        schema=PS4_MEDIA_UNLOCK_PLAYING_SCHEMA)
+        schema=PS4_MEDIA_UNLOCK_PLAYING_SCHEMA,
+    )
 
 
-def _set_media(hass: HomeAssistantType, games: dict, media_content_id,
-               media_title, media_url, media_type):
+def _set_media(
+    hass: HomeAssistantType,
+    games: dict,
+    media_content_id,
+    media_title,
+    media_url,
+    media_type,
+):
     """Set media data."""
     if games.get(media_content_id) is not None:
         data = games[media_content_id]
@@ -490,13 +533,11 @@ def _set_media(hass: HomeAssistantType, games: dict, media_content_id,
     _LOGGER.debug("Setting media data, %s: %s", media_content_id, data)
 
 
-def refresh_entity_media(
-        hass: HomeAssistantType, media_content_id, update_entity=True):
+def refresh_entity_media(hass: HomeAssistantType, media_content_id, update_entity=True):
     """Refresh media properties if data is changed.."""
     for device in hass.data[PS4_DATA].devices:
         if device.media_content_id == media_content_id:
             device.reset_title()
             if update_entity:
                 device.schedule_update()
-            _LOGGER.debug(
-                "Refreshing media data for: %s", device.entity_id)
+            _LOGGER.debug("Refreshing media data for: %s", device.entity_id)

--- a/homeassistant/components/ps4/const.py
+++ b/homeassistant/components/ps4/const.py
@@ -4,6 +4,7 @@ CONFIG_ENTRY_VERSION = 3
 DEFAULT_NAME = "PlayStation 4"
 DEFAULT_REGION = "United States"
 DEFAULT_ALIAS = "Home-Assistant"
+DEFAULT_URL = "http://localhost"
 DOMAIN = "ps4"
 GAMES_FILE = ".ps4-games.json"
 PS4_DATA = "ps4_data"

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -7,3 +7,71 @@ send_command:
     command:
       description: Button to press.
       example: 'ps'
+
+media_add:
+  description: Manually add media data to source list. Media data will be locked and not be updated automatically.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title.
+      example: 'CUSA00123'
+    media_title:
+      description: The name for the media title. Defaults to the current title.
+      example: 'A Title: The Name'
+    media_image_url:
+      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      example: 'http://localhost:8123/local/image.jpg'
+    media_content_type:
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
+      example: 'game'
+
+media_remove:
+  description: Remove media data from source list.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title.
+      example: 'CUSA00123'
+
+media_edit:
+  description: Edit or correct media data attributes. Media data will no longer be updated automatically.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
+      example: 'CUSA00123'
+    media_title:
+      description: The name for the media title.
+      example: 'A Title: The Name'
+    media_image_url:
+      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      example: 'http://localhost:8123/local/image.jpg'
+    media_content_type:
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
+      example: 'game'
+
+media_edit_playing:
+  description: Edit or correct media data attributes of the media which is currently playing. Media data will be locked and not be updated automatically.
+  fields:
+    entity_id:
+      description: The entity that is playing media.
+      example: 'media_player.playstation_4'
+    media_title:
+      description: The name for the media title.
+      example: 'A Title: The Name'
+    media_image_url:
+      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      example: 'http://localhost:8123/local/image.jpg'
+    media_content_type:
+      description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
+      example: 'game'
+
+media_unlock:
+  description: Unlock media data attributes to allow automatic updates to media data.
+  fields:
+    media_content_id:
+      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
+      example: 'CUSA00123'
+
+media_unlock_playing:
+  description: Unlock the attributes of the media which is currently playing.
+    entity_id: 
+      description: The entity that is playing media.
+      example: 'media_player.playstation_4'

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -18,7 +18,7 @@ media_add:
       description: The name for the media title.
       example: 'A Title: The Name'
     media_image_url:
-      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      description: A remote or local URL directing to an image that will be displayed.
       example: 'http://localhost:8123/local/image.jpg'
     media_content_type:
       description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
@@ -41,7 +41,7 @@ media_edit:
       description: The name for the media title.
       example: 'A Title: The Name'
     media_image_url:
-      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      description: A remote or local URL directing to an image that will be displayed.
       example: 'http://localhost:8123/local/image.jpg'
     media_content_type:
       description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
@@ -57,7 +57,7 @@ media_edit_playing:
       description: The name for the media title.
       example: 'A Title: The Name'
     media_image_url:
-      description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
+      description: A remote or local URL directing to an image that will be displayed.
       example: 'http://localhost:8123/local/image.jpg'
     media_content_type:
       description: The type of media. Must be 'game' or 'app'. Defaults to 'game'.
@@ -72,6 +72,7 @@ media_unlock:
 
 media_unlock_playing:
   description: Unlock the attributes of the media which is currently playing.
+  fields:
     entity_id: 
       description: The entity that is playing media.
       example: 'media_player.playstation_4'

--- a/homeassistant/components/ps4/services.yaml
+++ b/homeassistant/components/ps4/services.yaml
@@ -12,10 +12,10 @@ media_add:
   description: Manually add media data to source list. Media data will be locked and not be updated automatically.
   fields:
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title.
+      description: The SKU ID of the media.
       example: 'CUSA00123'
     media_title:
-      description: The name for the media title. Defaults to the current title.
+      description: The name for the media title.
       example: 'A Title: The Name'
     media_image_url:
       description: A remote or local URL directing to an image that will be displayed. You may use images in the local (/config/www/) folder.
@@ -28,14 +28,14 @@ media_remove:
   description: Remove media data from source list.
   fields:
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title.
+      description: The SKU ID of the media. Must be in source list.
       example: 'CUSA00123'
 
 media_edit:
   description: Edit or correct media data attributes. Media data will no longer be updated automatically.
   fields:
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
+      description: The SKU ID of the media. Must be in source list.
       example: 'CUSA00123'
     media_title:
       description: The name for the media title.
@@ -67,7 +67,7 @@ media_unlock:
   description: Unlock media data attributes to allow automatic updates to media data.
   fields:
     media_content_id:
-      description: The ID or the PlayStation Store SKU ID of the title. Must be in source list.
+      description: The SKU ID of the media. Must be in source list.
       example: 'CUSA00123'
 
 media_unlock_playing:

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -481,7 +481,7 @@ async def test_media_unlock_playing(hass):
     assert mock_games[MOCK_ID2] is MOCK_GAMES_DATA_LOCKED2
 
 
-async def test_remove_media(hass):
+async def test_media_remove(hass):
     """Test media entry is removed."""
     service = "media_remove"
     original = MOCK_GAMES
@@ -495,7 +495,7 @@ async def test_remove_media(hass):
     assert MOCK_ID2 in mock_games
 
 
-async def test_add_media(hass):
+async def test_media_add(hass):
     """Test media entry is added."""
     service = "media_add"
     original = {}

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -121,9 +121,7 @@ MOCK_GAMES_DATA_LOCKED2 = {
 
 MOCK_GAMES = {MOCK_ID: MOCK_GAMES_DATA, MOCK_ID2: MOCK_GAMES_DATA2}
 
-MOCK_GAMES_LOCKED = {
-    MOCK_ID: MOCK_GAMES_DATA_LOCKED, MOCK_ID2: MOCK_GAMES_DATA_LOCKED2
-}
+MOCK_GAMES_LOCKED = {MOCK_ID: MOCK_GAMES_DATA_LOCKED, MOCK_ID2: MOCK_GAMES_DATA_LOCKED2}
 
 MOCK_HOST_NAME = "Fake PS4"
 MOCK_HOST_ID = "A0000A0AA000"
@@ -148,7 +146,7 @@ MOCK_STATUS_PLAYING = {
     "status": MOCK_STATUS_ON,
     "status_code": MOCK_ON_CODE,
     "device-discovery-protocol-version": MOCK_DDP_VERSION,
-    "system-version": MOCK_HOST_VERSION
+    "system-version": MOCK_HOST_VERSION,
 }
 
 MOCK_LOAD_GAMES = "homeassistant.components.ps4.media_player.load_games"
@@ -245,12 +243,9 @@ async def setup_mock_component(hass):
 
 def test_games_reformat_to_dict(hass):
     """Test old data format is converted to new format."""
-    with patch(
-        MOCK_LOAD,
-        return_value=MOCK_GAMES_DATA_OLD_STR_FORMAT,
-    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
+    with patch(MOCK_LOAD, return_value=MOCK_GAMES_DATA_OLD_STR_FORMAT), patch(
+        MOCK_SAVE, side_effect=MagicMock()
+    ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass)
 
     # New format is a nested dict.
@@ -268,11 +263,9 @@ def test_games_reformat_to_dict(hass):
 
 def test_load_games(hass):
     """Test that games are loaded correctly."""
-    with patch(
-        MOCK_LOAD, return_value=MOCK_GAMES
-    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
+    with patch(MOCK_LOAD, return_value=MOCK_GAMES), patch(
+        MOCK_SAVE, side_effect=MagicMock()
+    ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass)
 
     assert isinstance(mock_games, dict)
@@ -287,21 +280,17 @@ def test_load_games(hass):
 
 def test_loading_games_returns_dict(hass):
     """Test that loading games always returns a dict."""
-    with patch(
-        MOCK_LOAD, side_effect=HomeAssistantError
-    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
+    with patch(MOCK_LOAD, side_effect=HomeAssistantError), patch(
+        MOCK_SAVE, side_effect=MagicMock()
+    ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass)
 
     assert isinstance(mock_games, dict)
     assert not mock_games
 
-    with patch(
-        MOCK_LOAD, return_value="Some String"
-    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
-        "os.path.isfile", return_value=True
-    ):
+    with patch(MOCK_LOAD, return_value="Some String"), patch(
+        MOCK_SAVE, side_effect=MagicMock()
+    ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass)
 
     assert isinstance(mock_games, dict)
@@ -343,13 +332,10 @@ async def test_send_command(hass):
 
 async def mock_service_call(hass, service, data, original):
     """Mock media service call."""
-    with patch(MOCK_LOAD,
-               return_value=original),\
-            patch(MOCK_SAVE,
-                  side_effect=MagicMock()) as mock_save,\
-            patch("os.path.isfile", return_value=True):
-        await hass.services.async_call(
-            DOMAIN, service, data)
+    with patch(MOCK_LOAD, return_value=original), patch(
+        MOCK_SAVE, side_effect=MagicMock()
+    ) as mock_save, patch("os.path.isfile", return_value=True):
+        await hass.services.async_call(DOMAIN, service, data)
         await hass.async_block_till_done()
     assert len(mock_save.mock_calls) == 1
     args, _ = mock_save.call_args
@@ -371,7 +357,7 @@ async def test_media_edit(hass):
         ATTR_MEDIA_CONTENT_ID: MOCK_ID,
         ATTR_MEDIA_TITLE: mock_title,
         ATTR_MEDIA_IMAGE_URL: mock_url,
-        ATTR_MEDIA_CONTENT_TYPE: mock_type
+        ATTR_MEDIA_CONTENT_TYPE: mock_type,
     }
 
     await ps4.async_setup(hass, {})
@@ -394,9 +380,9 @@ async def test_media_edit_playing(hass):
     mock_url = "http://somenewurl.jpeg"
     mock_type = MEDIA_TYPE_APP
 
-    with patch("pyps4_homeassistant.ps4.get_status",
-               return_value=MOCK_STATUS_PLAYING),\
-            patch(MOCK_LOAD_GAMES, return_value=original):
+    with patch(
+        "pyps4_homeassistant.ps4.get_status", return_value=MOCK_STATUS_PLAYING
+    ), patch(MOCK_LOAD_GAMES, return_value=original):
         await setup_mock_component(hass)
 
     mock_entities = hass.states.async_entity_ids()
@@ -408,11 +394,12 @@ async def test_media_edit_playing(hass):
         ATTR_ENTITY_ID: mock_entity_id,
         ATTR_MEDIA_TITLE: mock_title,
         ATTR_MEDIA_IMAGE_URL: mock_url,
-        ATTR_MEDIA_CONTENT_TYPE: mock_type
+        ATTR_MEDIA_CONTENT_TYPE: mock_type,
     }
 
-    with patch("homeassistant.components.ps4.refresh_entity_media",
-               side_effect=MagicMock()) as mock_refresh:
+    with patch(
+        "homeassistant.components.ps4.refresh_entity_media", side_effect=MagicMock()
+    ) as mock_refresh:
         mock_games = await mock_service_call(hass, service, data, original)
         await hass.async_block_till_done()
 
@@ -450,10 +437,11 @@ async def test_media_unlock_playing(hass):
     service = "media_unlock_playing"
     original = MOCK_GAMES_LOCKED
 
-    with patch("pyps4_homeassistant.ps4.get_status",
-               return_value=MOCK_STATUS_PLAYING),\
-            patch(MOCK_LOAD, return_value=original),\
-            patch(MOCK_SAVE, side_effect=MagicMock()):
+    with patch(
+        "pyps4_homeassistant.ps4.get_status", return_value=MOCK_STATUS_PLAYING
+    ), patch(MOCK_LOAD, return_value=original), patch(
+        MOCK_SAVE, side_effect=MagicMock()
+    ):
         await setup_mock_component(hass)
         await hass.async_block_till_done()
 
@@ -464,8 +452,9 @@ async def test_media_unlock_playing(hass):
 
     data = {ATTR_ENTITY_ID: mock_entity_id}
 
-    with patch("homeassistant.components.ps4.refresh_entity_media",
-               side_effect=MagicMock()) as mock_refresh:
+    with patch(
+        "homeassistant.components.ps4.refresh_entity_media", side_effect=MagicMock()
+    ) as mock_refresh:
         mock_games = await mock_service_call(hass, service, data, original)
         await hass.async_block_till_done()
     await hass.async_block_till_done()

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -246,9 +246,9 @@ async def setup_mock_component(hass):
 def test_games_reformat_to_dict(hass):
     """Test old data format is converted to new format."""
     with patch(
-        "homeassistant.components.ps4.load_json",
+        MOCK_LOAD,
         return_value=MOCK_GAMES_DATA_OLD_STR_FORMAT,
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
+    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
         mock_games = ps4.load_games(hass)
@@ -269,8 +269,8 @@ def test_games_reformat_to_dict(hass):
 def test_load_games(hass):
     """Test that games are loaded correctly."""
     with patch(
-        "homeassistant.components.ps4.load_json", return_value=MOCK_GAMES
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
+        MOCK_LOAD, return_value=MOCK_GAMES
+    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
         mock_games = ps4.load_games(hass)
@@ -288,8 +288,8 @@ def test_load_games(hass):
 def test_loading_games_returns_dict(hass):
     """Test that loading games always returns a dict."""
     with patch(
-        "homeassistant.components.ps4.load_json", side_effect=HomeAssistantError
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
+        MOCK_LOAD, side_effect=HomeAssistantError
+    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
         mock_games = ps4.load_games(hass)
@@ -298,8 +298,8 @@ def test_loading_games_returns_dict(hass):
     assert not mock_games
 
     with patch(
-        "homeassistant.components.ps4.load_json", return_value="Some String"
-    ), patch("homeassistant.components.ps4.save_json", side_effect=MagicMock()), patch(
+        MOCK_LOAD, return_value="Some String"
+    ), patch(MOCK_SAVE, side_effect=MagicMock()), patch(
         "os.path.isfile", return_value=True
     ):
         mock_games = ps4.load_games(hass)
@@ -307,8 +307,8 @@ def test_loading_games_returns_dict(hass):
     assert isinstance(mock_games, dict)
     assert not mock_games
 
-    with patch("homeassistant.components.ps4.load_json", return_value=[]), patch(
-        "homeassistant.components.ps4.save_json", side_effect=MagicMock()
+    with patch(MOCK_LOAD, return_value=[]), patch(
+        MOCK_SAVE, side_effect=MagicMock()
     ), patch("os.path.isfile", return_value=True):
         mock_games = ps4.load_games(hass)
 


### PR DESCRIPTION
## Description:
Feature - Adds services for allowing editing of media data that is saved. Services can be used to correct media data.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10115

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
