### PR TITLE
Add network port support for glances component.

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -54,6 +54,10 @@ SENSOR_TYPES = {
     "docker_active": ["Containers active", "", "mdi:docker"],
     "docker_cpu_use": ["Containers CPU used", "%", "mdi:docker"],
     "docker_memory_use": ["Containers RAM used", "MiB", "mdi:docker"],
+    "network_ping": ["Ping", "ms", "mdi:check-network-outline"],
+    "network_port": ["TCP Port", "ms", "mdi:check-network-outline"],
+    "network_web": ["HTTP", "", "mdi:check-network-outline"],
+
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -244,6 +248,29 @@ class GlancesSensor(Entity):
                             mem_use += container["memory"]["usage"]
                         self._state = round(mem_use / 1024 ** 2, 1)
                 except KeyError:
+                    self._state = STATE_UNAVAILABLE
+            elif self.type == "network_ping":
+                try:
+                    for record in value["ports"]:
+                        if record["port"] == 0:
+                            self._state = round(record["status"] * 1000)
+                            break
+                except:
+                    self._state = STATE_UNAVAILABLE
+            elif self.type == "network_port":
+                try:
+                    for record in value["ports"]:
+                        if int(record["port"]) > 0:
+                            self._state = round(record["status"] * 1000)
+                            break
+                except:
+                    self._state = STATE_UNAVAILABLE
+            elif self.type == "network_web":
+                try:
+                    for record in value["ports"]:
+                        if record["indice"] == "web_1":
+                            self._state = "code " + str(record["status"])
+                except:
                     self._state = STATE_UNAVAILABLE
 
 


### PR DESCRIPTION
## Description:
Glances supports network port monitoring, but the home assistant component does not. Added support for one tcp port, one web host and one icmp per instance of each glance sensor. These elements can be configured using the three new keywords shown below. Note that only one of each type is supported: it finds the first of each type, saves that record, and breaks out of the loop. This approach is required because the glances api offers no way to directly address each port entry. 



**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10085

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: glances
    host: 192.168.1.10
    name: My Test Server
    version: 3
    resources:
      - 'network_ping'
      - 'network_port'
      - 'network_web'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) 

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
