### PR TITLE
Unifi: Don't track unstable device attributes

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -41,11 +41,7 @@ LOGGER = logging.getLogger(__name__)
 
 DEVICE_ATTRIBUTES = [
     "_is_guest_by_uap",
-    "ap_mac",
     "authorized",
-    "bssid",
-    "ccq",
-    "channel",
     "essid",
     "hostname",
     "ip",
@@ -54,14 +50,11 @@ DEVICE_ATTRIBUTES = [
     "is_wired",
     "mac",
     "name",
-    "noise",
     "noted",
     "oui",
     "qos_policy_applied",
     "radio",
     "radio_proto",
-    "rssi",
-    "signal",
     "site_id",
     "vlan",
 ]


### PR DESCRIPTION
## Breaking Change:

7 attributes with a high rate of change were removed.  There is no current workaround.  The removed attributes were: `ap_mac`, `bssid`, `ccm`, `channel`, `noise`, `rssi`, and `signal`.

## Description:
With the changes to the Unifi device_tracker in 0.97 (https://github.com/home-assistant/home-assistant/pull/24367), several unstable values are stored as attributes on each device. That change reverted behavior added in https://github.com/home-assistant/home-assistant/pull/15888 (from Issue https://github.com/home-assistant/home-assistant/issues/14745). This removes them to prevent recorder databases from filling up unnecessarily.

A future PR can be created to allow these to used in an opt-in way.

**Related issue (if applicable):** fixes #25782

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html