### PR TITLE
Fix locale bug with neato integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_SSOCR no
 #ENV INSTALL_DLIB no
 #ENV INSTALL_IPERF3 no
+#ENV INSTALL_LOCALES no
 
 VOLUME /config
 

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -14,6 +14,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_SSOCR no
 #ENV INSTALL_DLIB no
 #ENV INSTALL_IPERF3 no
+#ENV INSTALL_LOCALES no
 
 VOLUME /config
 

--- a/virtualization/Docker/scripts/locales
+++ b/virtualization/Docker/scripts/locales
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Sets up locales.
+
+# Stop on errors
+set -e
+
+apt-get update
+apt-get install -y --no-install-recommends locales
+
+# Set the locale
+sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+locale-gen

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -9,6 +9,7 @@ INSTALL_OPENALPR="${INSTALL_OPENALPR:-yes}"
 INSTALL_LIBCEC="${INSTALL_LIBCEC:-yes}"
 INSTALL_SSOCR="${INSTALL_SSOCR:-yes}"
 INSTALL_DLIB="${INSTALL_DLIB:-yes}"
+INSTALL_LOCALES="${INSTALL_LOCALES:-yes}"
 
 # Required debian packages for running hass or components
 PACKAGES=(
@@ -68,6 +69,10 @@ fi
 
 if [ "$INSTALL_DLIB" == "yes" ]; then
   pip3 install --no-cache-dir "dlib>=19.5"
+fi
+
+if [ "$INSTALL_LOCALES" == "yes" ]; then
+  virtualization/Docker/scripts/locales
 fi
 
 # Remove packages


### PR DESCRIPTION
## Breaking Change:
Nothing breaks
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
The neato integration with the default docker image is currently broken because a locale is missing. This PR installs the locale en_US.utf-8 into the docker image. I know that this image will be migrated to an alpine-based image soon, but it would help people with this problem until then.

It can also be a reminder for the people who migrate the Docker images to include this locale in the alpine image as well. Please tell me when I can help with the migration.

**Related issue (if applicable):** fixes #25773

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: !secret email
  password: !secret neato
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
