### PR TITLE
Refactor ZHA device initialized logic

### DIFF
--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -57,7 +57,7 @@ class IASZoneChannel(ZigbeeChannel):
         """Configure IAS device."""
         # Xiaomi devices don't need this and it disrupts pairing
         if self._zha_device.manufacturer == "LUMI":
-            self.debug("%s: finished IASZoneChannel configuration")
+            self.debug("finished IASZoneChannel configuration")
             return
         from zigpy.exceptions import DeliveryError
 
@@ -81,7 +81,7 @@ class IASZoneChannel(ZigbeeChannel):
                 self._cluster.ep_attribute,
                 str(ex),
             )
-        self.debug("%s: finished IASZoneChannel configuration")
+        self.debug("finished IASZoneChannel configuration")
 
         await self.get_attribute_value("zone_type", from_cache=False)
 

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -336,8 +336,8 @@ class ZHAGateway:
         zha_device = self._async_get_or_create_device(device)
 
         _LOGGER.debug(
-            "device - ieee: %s entering async_device_initialized - is_new_join: %s",
-            device.ieee,
+            "device - %s entering async_device_initialized - is_new_join: %s",
+            "0x{:04x}:{}".format(device.nwk, device.ieee),
             zha_device.status is not DeviceStatus.INITIALIZED,
         )
 
@@ -345,13 +345,14 @@ class ZHAGateway:
             # ZHA already has an initialized device so either the device was assigned a
             # new nwk or device was physically reset and added again without being removed
             _LOGGER.debug(
-                "device - ieee: %s has been reset and readded or its nwk address changed",
-                zha_device.ieee,
+                "device - %s has been reset and readded or its nwk address changed",
+                "0x{:04x}:{}".format(device.nwk, device.ieee),
             )
             await self._async_device_rejoined(zha_device)
         else:
             _LOGGER.debug(
-                "device - ieee: %s has joined the ZHA zigbee network", zha_device.ieee
+                "device - %s has joined the ZHA zigbee network",
+                "0x{:04x}:{}".format(device.nwk, device.ieee),
             )
             await self._async_device_joined(device, zha_device)
 
@@ -413,7 +414,8 @@ class ZHAGateway:
             # the device isn't a battery powered device so we should be able
             # to update it now
             _LOGGER.debug(
-                "attempting to request fresh state for %s %s",
+                "attempting to request fresh state for device - %s %s %s",
+                "0x{:04x}:{}".format(zha_device.nwk, zha_device.ieee),
                 zha_device.name,
                 "with power source: {}".format(zha_device.power_source),
             )
@@ -426,8 +428,8 @@ class ZHAGateway:
 
     async def _async_device_rejoined(self, zha_device):
         _LOGGER.debug(
-            "skipping discovery for previously discovered device: %s",
-            "{} - is rejoin: {}".format(zha_device.ieee, True),
+            "skipping discovery for previously discovered device - %s",
+            "0x{:04x}:{}".format(zha_device.nwk, zha_device.ieee),
         )
         # we don't have to do this on a nwk swap but we don't have a way to tell currently
         await zha_device.async_configure()

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -140,7 +140,10 @@ async def async_init_zigpy_device(
     device = make_device(
         in_cluster_ids, out_cluster_ids, device_type, ieee, manufacturer, model
     )
-    await gateway.async_device_initialized(device, is_new_join)
+    if is_new_join:
+        await gateway.async_device_initialized(device)
+    else:
+        await gateway.async_device_restored(device)
     await hass.async_block_till_done()
     return device
 


### PR DESCRIPTION
## Description:
This PR refactors the device initialization logic in ZHA.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
