### PR TITLE
Add error handling to !include command in yaml

### DIFF
--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -118,9 +118,8 @@ def _include_yaml(loader: SafeLineLoader, node: yaml.nodes.Node) -> JSON_TYPE:
     fname = os.path.join(os.path.dirname(loader.name), node.value)
     try:
         return _add_reference(load_yaml(fname), loader, node)
-    except FileNotFoundError as exc:
-        _LOGGER.error("Unable to read file %s: %s", fname, exc)
-        raise HomeAssistantError(exc)
+    except FileNotFoundError:
+        raise HomeAssistantError(f"Unable to read file {fname}")
 
 
 def _is_file_valid(name: str) -> bool:

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -119,7 +119,7 @@ def _include_yaml(loader: SafeLineLoader, node: yaml.nodes.Node) -> JSON_TYPE:
     try:
         return _add_reference(load_yaml(fname), loader, node)
     except FileNotFoundError:
-        raise HomeAssistantError(f"Unable to read file {fname}")
+        raise HomeAssistantError(f"{node.start_mark}: Unable to read file {fname}.")
 
 
 def _is_file_valid(name: str) -> bool:

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -116,7 +116,11 @@ def _include_yaml(loader: SafeLineLoader, node: yaml.nodes.Node) -> JSON_TYPE:
 
     """
     fname = os.path.join(os.path.dirname(loader.name), node.value)
-    return _add_reference(load_yaml(fname), loader, node)
+    try:
+        return _add_reference(load_yaml(fname), loader, node)
+    except FileNotFoundError as exc:
+        _LOGGER.error("Unable to read file %s: %s", fname, exc)
+        raise HomeAssistantError(exc)
 
 
 def _is_file_valid(name: str) -> bool:


### PR DESCRIPTION
## Description:

```yaml
- !include nofile.yaml
```
`!include`ing a file that doesn't exist fails without a `HomeAssistantError`.
In lovelace this means the failure is silent, and the user is thrown back to the `/states/` interface.
In configuration check this means that you get a non-descriptive general "Error loading /config/configuration.yaml".

This fixes both.

Note: `!secret` relies on catching `FileNotFoundError` itself. I may have missed something else that does the same thing, but I hope not...

**Related issue (if applicable):** fixes #24446


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
