### PR TITLE
Deprecates linksys_ap integration (ADR-0004)

### DIFF
--- a/homeassistant/components/linksys_ap/device_tracker.py
+++ b/homeassistant/components/linksys_ap/device_tracker.py
@@ -30,6 +30,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_scanner(hass, config):
     """Validate the configuration and return a Linksys AP scanner."""
+    _LOGGER.warning(
+        "The linksys_ap integration is deprecated and will be removed "
+        "in Home Assistant 0.100.0. For more information see ADR-0004:"
+        "https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md"
+    )
+
     try:
         return LinksysAPDeviceScanner(config[DOMAIN])
     except ConnectionError:


### PR DESCRIPTION
## Breaking Change:

The Linksys Access Points integration has been deprecated and is pending for removal in Home Assistant 0.100.0.

## Description:

This PR deprecates the Linksys Access Points integration since it relies on web scraping to function.
As per [ADR-0004](https://github.com/home-assistant/architecture/blob/master/adr/0004-webscraping.md) this is no longer allowed. The integration should now be deprecated for 2 releases before permanent removal.

Evidence: <https://github.com/home-assistant/home-assistant/blob/4de97ab/homeassistant/components/linksys_ap/device_tracker.py#L82>

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10092

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
