### PR TITLE
Fix Broadlink MP1 unavailable error

### DIFF
--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -337,6 +337,10 @@ class BroadlinkMP1Slot(BroadlinkRMSwitch):
         """Trigger update for all switches on the parent device."""
         self._parent_device.update()
         self._state = self._parent_device.get_outlet_status(self._slot)
+        if self._state is None:
+            self._is_available = False
+        else:
+            self._is_available = True
 
 
 class BroadlinkMP1Switch:


### PR DESCRIPTION
## Description:
This PR corrects problem with unavailable of Broadlink MP1 switch slots.

**Related issue (if applicable):** fixes #25297

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]