### PR TITLE
Fix deconz allow_clip_sensor and allow_deconz_groups options

### DIFF
--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -63,12 +63,12 @@ class DeconzGateway:
     @property
     def allow_clip_sensor(self) -> bool:
         """Allow loading clip sensor from gateway."""
-        return self.config_entry.data.get(CONF_ALLOW_CLIP_SENSOR, True)
+        return self.config_entry.options.get(CONF_ALLOW_CLIP_SENSOR, True)
 
     @property
     def allow_deconz_groups(self) -> bool:
         """Allow loading deCONZ groups from gateway."""
-        return self.config_entry.data.get(CONF_ALLOW_DECONZ_GROUPS, True)
+        return self.config_entry.options.get(CONF_ALLOW_DECONZ_GROUPS, True)
 
     async def async_update_device_registry(self):
         """Update device registry."""

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -31,12 +31,15 @@ SENSOR = {
 
 
 ENTRY_CONFIG = {
-    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
-    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
     deconz.config_flow.CONF_API_KEY: "ABCDEF",
     deconz.config_flow.CONF_BRIDGEID: "0123456789",
     deconz.config_flow.CONF_HOST: "1.2.3.4",
     deconz.config_flow.CONF_PORT: 80,
+}
+
+ENTRY_OPTIONS = {
+    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
+    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
 }
 
 
@@ -47,7 +50,7 @@ async def setup_gateway(hass, data, allow_clip_sensor=True):
     loop = Mock()
     session = Mock()
 
-    ENTRY_CONFIG[deconz.const.CONF_ALLOW_CLIP_SENSOR] = allow_clip_sensor
+    ENTRY_OPTIONS[deconz.const.CONF_ALLOW_CLIP_SENSOR] = allow_clip_sensor
 
     config_entry = config_entries.ConfigEntry(
         1,
@@ -56,6 +59,7 @@ async def setup_gateway(hass, data, allow_clip_sensor=True):
         ENTRY_CONFIG,
         "test",
         config_entries.CONN_CLASS_LOCAL_PUSH,
+        ENTRY_OPTIONS,
     )
     gateway = deconz.DeconzGateway(hass, config_entry)
     gateway.api = DeconzSession(loop, session, **config_entry.data)

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -39,12 +39,15 @@ SENSOR = {
 }
 
 ENTRY_CONFIG = {
-    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
-    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
     deconz.config_flow.CONF_API_KEY: "ABCDEF",
     deconz.config_flow.CONF_BRIDGEID: "0123456789",
     deconz.config_flow.CONF_HOST: "1.2.3.4",
     deconz.config_flow.CONF_PORT: 80,
+}
+
+ENTRY_OPTIONS = {
+    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
+    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
 }
 
 
@@ -59,7 +62,7 @@ async def setup_gateway(hass, data, allow_clip_sensor=True):
 
     session = Mock(put=asynctest.CoroutineMock(return_value=response))
 
-    ENTRY_CONFIG[deconz.const.CONF_ALLOW_CLIP_SENSOR] = allow_clip_sensor
+    ENTRY_OPTIONS[deconz.const.CONF_ALLOW_CLIP_SENSOR] = allow_clip_sensor
 
     config_entry = config_entries.ConfigEntry(
         1,
@@ -68,6 +71,7 @@ async def setup_gateway(hass, data, allow_clip_sensor=True):
         ENTRY_CONFIG,
         "test",
         config_entries.CONN_CLASS_LOCAL_PUSH,
+        ENTRY_OPTIONS,
     )
     gateway = deconz.DeconzGateway(hass, config_entry)
     gateway.api = DeconzSession(hass.loop, session, **config_entry.data)

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -62,12 +62,15 @@ SWITCH = {
 
 
 ENTRY_CONFIG = {
-    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
-    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
     deconz.config_flow.CONF_API_KEY: "ABCDEF",
     deconz.config_flow.CONF_BRIDGEID: "0123456789",
     deconz.config_flow.CONF_HOST: "1.2.3.4",
     deconz.config_flow.CONF_PORT: 80,
+}
+
+ENTRY_OPTIONS = {
+    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
+    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
 }
 
 
@@ -78,7 +81,7 @@ async def setup_gateway(hass, data, allow_deconz_groups=True):
     loop = Mock()
     session = Mock()
 
-    ENTRY_CONFIG[deconz.const.CONF_ALLOW_DECONZ_GROUPS] = allow_deconz_groups
+    ENTRY_OPTIONS[deconz.const.CONF_ALLOW_DECONZ_GROUPS] = allow_deconz_groups
 
     config_entry = config_entries.ConfigEntry(
         1,
@@ -87,6 +90,7 @@ async def setup_gateway(hass, data, allow_deconz_groups=True):
         ENTRY_CONFIG,
         "test",
         config_entries.CONN_CLASS_LOCAL_PUSH,
+        ENTRY_OPTIONS,
     )
     gateway = deconz.DeconzGateway(hass, config_entry)
     gateway.api = DeconzSession(loop, session, **config_entry.data)

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -75,12 +75,15 @@ SENSOR = {
 
 
 ENTRY_CONFIG = {
-    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
-    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
     deconz.config_flow.CONF_API_KEY: "ABCDEF",
     deconz.config_flow.CONF_BRIDGEID: "0123456789",
     deconz.config_flow.CONF_HOST: "1.2.3.4",
     deconz.config_flow.CONF_PORT: 80,
+}
+
+ENTRY_OPTIONS = {
+    deconz.const.CONF_ALLOW_CLIP_SENSOR: True,
+    deconz.const.CONF_ALLOW_DECONZ_GROUPS: True,
 }
 
 
@@ -91,7 +94,7 @@ async def setup_gateway(hass, data, allow_clip_sensor=True):
     loop = Mock()
     session = Mock()
 
-    ENTRY_CONFIG[deconz.const.CONF_ALLOW_CLIP_SENSOR] = allow_clip_sensor
+    ENTRY_OPTIONS[deconz.const.CONF_ALLOW_CLIP_SENSOR] = allow_clip_sensor
 
     config_entry = config_entries.ConfigEntry(
         1,
@@ -100,6 +103,7 @@ async def setup_gateway(hass, data, allow_clip_sensor=True):
         ENTRY_CONFIG,
         "test",
         config_entries.CONN_CLASS_LOCAL_PUSH,
+        ENTRY_OPTIONS,
     )
     gateway = deconz.DeconzGateway(hass, config_entry)
     gateway.api = DeconzSession(loop, session, **config_entry.data)


### PR DESCRIPTION
## Description:
I found that options `allow_clip_sensor` and `allow_deconz_groups` in `core.config_entries` don't work.
It started from [PR](https://github.com/home-assistant/home-assistant/pull/22449) and `async_populate_options` function that moved these values from `config_entry.data` to `config_entry.options`.
According to [this comment](https://github.com/home-assistant/home-assistant/issues/23975#issuecomment-493705562) there is no way to change this options via UI.
But now they works and i can change them in `core.config_entries`.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
