### PR TITLE
Fix SmartThings Light brightness type

### DIFF
--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -133,7 +133,9 @@ class SmartThingsLight(SmartThingsEntity, Light):
         """Update entity attributes when the device status has changed."""
         # Brightness and transition
         if self._supported_features & SUPPORT_BRIGHTNESS:
-            self._brightness = convert_scale(self._device.status.level, 100, 255)
+            self._brightness = int(
+                convert_scale(self._device.status.level, 100, 255, 0)
+            )
         # Color Temperature
         if self._supported_features & SUPPORT_COLOR_TEMP:
             self._color_temp = color_util.color_temperature_kelvin_to_mired(

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -84,6 +84,7 @@ async def test_entity_state(hass, light_devices):
         state.attributes[ATTR_SUPPORTED_FEATURES]
         == SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
     )
+    assert isinstance(state.attributes[ATTR_BRIGHTNESS], int)
     assert state.attributes[ATTR_BRIGHTNESS] == 255
 
     # Color Dimmer 1
@@ -103,6 +104,7 @@ async def test_entity_state(hass, light_devices):
     )
     assert state.attributes[ATTR_BRIGHTNESS] == 255
     assert state.attributes[ATTR_HS_COLOR] == (273.6, 55.0)
+    assert isinstance(state.attributes[ATTR_COLOR_TEMP], int)
     assert state.attributes[ATTR_COLOR_TEMP] == 222
 
 
@@ -191,7 +193,7 @@ async def test_turn_on_with_brightness(hass, light_devices):
     assert state is not None
     assert state.state == "on"
     # round-trip rounding error (expected)
-    assert state.attributes[ATTR_BRIGHTNESS] == 73.95
+    assert state.attributes[ATTR_BRIGHTNESS] == 74
 
 
 async def test_turn_on_with_minimal_brightness(hass, light_devices):
@@ -216,7 +218,7 @@ async def test_turn_on_with_minimal_brightness(hass, light_devices):
     assert state is not None
     assert state.state == "on"
     # round-trip rounding error (expected)
-    assert state.attributes[ATTR_BRIGHTNESS] == 2.55
+    assert state.attributes[ATTR_BRIGHTNESS] == 3
 
 
 async def test_turn_on_with_color(hass, light_devices):


### PR DESCRIPTION
## Description:

Ensures that the `brightness` attribute is of type `int`.

**Related issue (if applicable):** fixes #25792

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
