### PR TITLE
Update pyvera to 0.3.3

### DIFF
--- a/homeassistant/components/vera/manifest.json
+++ b/homeassistant/components/vera/manifest.json
@@ -3,7 +3,7 @@
   "name": "Vera",
   "documentation": "https://www.home-assistant.io/components/vera",
   "requirements": [
-    "pyvera==0.3.2"
+    "pyvera==0.3.3"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1570,7 +1570,7 @@ pyuptimerobot==0.0.5
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.3.2
+pyvera==0.3.3
 
 # homeassistant.components.vesync
 pyvesync==1.1.0


### PR DESCRIPTION
## Description:

Pyvera version bump. #25490 was rejected because it hadn't hit PyPi yet.

**Related issue (if applicable):** Fixes #24987

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]