### PR TITLE
Fix Netatmo climate issue

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -114,17 +114,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     except pyatmo.NoDevice:
         return
 
-    home_ids = []
+    home_ids = home_data.get_home_ids()
     rooms = {}
     if homes_conf is not None:
+        home_ids = []
         for home_conf in homes_conf:
             home = home_conf[CONF_NAME]
             home_id = home_data.homedata.gethomeId(home)
             if home_conf[CONF_ROOMS] != []:
                 rooms[home_id] = home_conf[CONF_ROOMS]
             home_ids.append(home_id)
-    else:
-        home_ids = home_data.get_home_ids()
 
     devices = []
     for home_id in home_ids:
@@ -349,7 +348,6 @@ class HomeData:
         self.schedules = []
         self.home = home
         self.home_id = None
-        self.setup()
 
     def get_home_ids(self):
         """Get all the home ids returned by NetAtmo API."""

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -349,6 +349,7 @@ class HomeData:
         self.schedules = []
         self.home = home
         self.home_id = None
+        self.setup()
 
     def get_home_ids(self):
         """Get all the home ids returned by NetAtmo API."""

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -111,19 +111,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     try:
         home_data = HomeData(auth)
+        home_data.setup()
     except pyatmo.NoDevice:
         return
 
-    home_ids = home_data.get_home_ids()
+    home_ids = []
     rooms = {}
     if homes_conf is not None:
-        home_ids = []
         for home_conf in homes_conf:
             home = home_conf[CONF_NAME]
             home_id = home_data.homedata.gethomeId(home)
             if home_conf[CONF_ROOMS] != []:
                 rooms[home_id] = home_conf[CONF_ROOMS]
             home_ids.append(home_id)
+    else:
+        home_ids = home_data.get_home_ids()
 
     devices = []
     for home_id in home_ids:
@@ -351,7 +353,6 @@ class HomeData:
 
     def get_home_ids(self):
         """Get all the home ids returned by NetAtmo API."""
-        self.setup()
         if self.homedata is None:
             return []
         for home_id in self.homedata.homes:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -109,8 +109,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     auth = hass.data[DATA_NETATMO_AUTH]
 
+    home_data = HomeData(auth)
     try:
-        home_data = HomeData(auth)
         home_data.setup()
     except pyatmo.NoDevice:
         return

--- a/homeassistant/components/netatmo/manifest.json
+++ b/homeassistant/components/netatmo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netatmo",
   "documentation": "https://www.home-assistant.io/components/netatmo",
   "requirements": [
-    "pyatmo==2.2.0"
+    "pyatmo==2.2.1"
   ],
   "dependencies": [
     "webhook"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1050,7 +1050,7 @@ pyalarmdotcom==0.3.2
 pyarlo==0.2.3
 
 # homeassistant.components.netatmo
-pyatmo==2.2.0
+pyatmo==2.2.1
 
 # homeassistant.components.apple_tv
 pyatv==0.3.12


### PR DESCRIPTION
## Description:
Climate devices might not be configurable because home_id was not initialised. 

**Related issue (if applicable):** fixes #25778

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html