### PR TITLE
Add pip-wheel-metadata in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+pip-wheel-metadata
 
 # Logs
 *.log


### PR DESCRIPTION
## Description:
When developing in a container with VSC, the folder `pip-wheel-metadata` is created during the container building process.


**Related issue (if applicable): NA

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable): NA

## Example entry for `configuration.yaml` (if applicable):
NA

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
