### PR TITLE
Fix Plex configuration field name

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -262,7 +262,7 @@ def request_configuration(host, hass, config, add_entities_callback):
             host,
             data.get("token"),
             cv.boolean(data.get("has_ssl")),
-            cv.boolean(data.get("do_not_verify")),
+            cv.boolean(data.get("do_not_verify_ssl")),
             hass,
             config,
             add_entities_callback,


### PR DESCRIPTION
## Description:

Name of "Do not verify SSL" field mismatch.

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x ] There is no commented out code in this PR.
  - [ x] I have followed the [development checklist][dev-checklist]
