### PR TITLE
Fix mikrotik device re-connect when API connection lost

### DIFF
--- a/homeassistant/components/mikrotik/__init__.py
+++ b/homeassistant/components/mikrotik/__init__.py
@@ -172,7 +172,8 @@ class MikrotikClient:
     def command(self, cmd, params=None):
         """Retrieve data from Mikrotik API."""
         if not self._connected or not self._client:
-            return None
+            if not self.connect_to_device():
+                return None
         try:
             if params:
                 response = self._client(cmd=cmd, **params)


### PR DESCRIPTION
## Description:
Upon further testing the new hub does not always re-connect to the Mikrotik device. This will fix that.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
