### PR TITLE
Do not reverse open/close calls

### DIFF
--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -19,9 +19,11 @@ ATTR_LOCK_END_TS = 'lock_end_ts'
 ATTR_LOCK_LEVEL = 'lock_level'
 ATTR_LOCK_ORIG = 'lock_originator'
 
+HORIZONTAL_AWNING = 'io:HorizontalAwningIOComponent'
+
 TAHOMA_DEVICE_CLASSES = {
     'io:ExteriorVenetianBlindIOComponent': DEVICE_CLASS_BLIND,
-    'io:HorizontalAwningIOComponent': DEVICE_CLASS_AWNING,
+    HORIZONTAL_AWNING: DEVICE_CLASS_AWNING,
     'io:RollerShutterGenericIOComponent': DEVICE_CLASS_SHUTTER,
     'io:RollerShutterUnoIOComponent': DEVICE_CLASS_SHUTTER,
     'io:RollerShutterVeluxIOComponent': DEVICE_CLASS_SHUTTER,
@@ -130,18 +132,16 @@ class TahomaCover(TahomaDevice, CoverDevice):
         #   _position: 0 is closed, 100 is fully open.
         #   'core:ClosureState': 100 is closed, 0 is fully open.
         if self._closure is not None:
-            if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            if self.tahoma_device.type == HORIZONTAL_AWNING:
                 self._position = self._closure
+                self._closed = self._position == 0
             else:
                 self._position = 100 - self._closure
+                self._closed = self._position == 100
             if self._position <= 5:
                 self._position = 0
             if self._position >= 95:
                 self._position = 100
-            if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-                self._closed = self._position == 0
-            else:
-                self._closed = self._position == 100
         else:
             self._position = None
             if 'core:OpenClosedState' in self.tahoma_device.active_states:
@@ -160,7 +160,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+        if self.tahoma_device.type == HORIZONTAL_AWNING:
             self.apply_action('setPosition', kwargs.get(ATTR_POSITION, 0))
         else:
             self.apply_action('setPosition',
@@ -206,17 +206,11 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-            self.apply_action('close')
-        else:
-            self.apply_action('open')
+        self.apply_action('open')
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
-            self.apply_action('open')
-        else:
-            self.apply_action('close')
+        self.apply_action('close')
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -232,7 +226,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
                  'rts:BlindRTSComponent'):
             self.apply_action('my')
         elif self.tahoma_device.type in \
-                ('io:HorizontalAwningIOComponent',
+                (HORIZONTAL_AWNING,
                  'io:RollerShutterGenericIOComponent',
                  'io:VerticalExteriorAwningIOComponent'):
             self.apply_action('stop')


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
