### PR TITLE
Bump androidtv to 0.0.22

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.21"
+    "androidtv==0.0.22"
   ],
   "dependencies": [],
   "codeowners": ["@JeffLIrion"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -194,7 +194,7 @@ ambiclimate==0.2.0
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.21
+androidtv==0.0.22
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:

Bump `androidtv` to 0.0.22.  This fixes the validation for the `state_detection_rules` config entry.  

More specifically, in the backend package I made it so that the `androidtv.basetv.state_detection_rules_validator` function returns the rules that it validates.  Previously, it didn't return anything, and so Home Assistant would set the keys in the `state_detection_rules` parameter to `None`.  

For example, this configuration:

```yaml
- platform: androidtv
  name: Fire TV
  host: 192.168.0.10
  state_detection_rules:
    'com.netflix.ninja':
     - 'media_session_state'
     - 'standby'
```

would have been treated like this:

```python
{'com.netflix.ninja': None}
```

instead of what it should have been:

```python
{'com.netflix.ninja': ['media_session_state', 'standby']}
```

**Related issue (if applicable):** This fixes the validation for the `state_detection_rules` config entry.  

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
