### PR TITLE
Fix KNXClimate mode change not updating the UI

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -209,6 +209,7 @@ class KNXClimate(ClimateDevice):
             await self.async_update_ha_state()
 
         self.device.register_device_updated_cb(after_update_callback)
+        self.device.mode.register_device_updated_cb(after_update_callback)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Description:

Fix KNXClimate not updating the UI after receiving mode change telegram from KNX bus.

For example: If a mode change event was received (STANDBY, COMFORT, etc.) the UI component was not updated. Component only got updated when temperature change was received.
