### PR TITLE
Always populate hvac_modes in SmartThings climate platform

### DIFF
--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -228,35 +228,34 @@ class SmartThingsThermostat(SmartThingsEntity, ClimateDevice):
         self._hvac_mode = MODE_TO_STATE.get(thermostat_mode)
         if self._hvac_mode is None:
             _LOGGER.debug(
-                "Device %s (%s) returned an invalid" "hvac mode: %s",
+                "Device %s (%s) returned an invalid hvac mode: %s",
                 self._device.label,
                 self._device.device_id,
                 thermostat_mode,
             )
 
+        modes = set()
         supported_modes = self._device.status.supported_thermostat_modes
         if isinstance(supported_modes, Iterable):
-            operations = set()
             for mode in supported_modes:
                 state = MODE_TO_STATE.get(mode)
                 if state is not None:
-                    operations.add(state)
+                    modes.add(state)
                 else:
                     _LOGGER.debug(
-                        "Device %s (%s) returned an invalid "
-                        "supported thermostat mode: %s",
+                        "Device %s (%s) returned an invalid supported thermostat mode: %s",
                         self._device.label,
                         self._device.device_id,
                         mode,
                     )
-            self._hvac_modes = operations
         else:
             _LOGGER.debug(
-                "Device %s (%s) returned invalid supported " "thermostat modes: %s",
+                "Device %s (%s) returned invalid supported thermostat modes: %s",
                 self._device.label,
                 self._device.device_id,
                 supported_modes,
             )
+        self._hvac_modes = list(modes)
 
     @property
     def current_humidity(self):

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -214,7 +214,7 @@ async def test_legacy_thermostat_entity_state(hass, legacy_thermostat):
         | SUPPORT_TARGET_TEMPERATURE_RANGE
         | SUPPORT_TARGET_TEMPERATURE
     )
-    assert state.attributes[ATTR_HVAC_ACTIONS] == "idle"
+    assert state.attributes[ATTR_HVAC_ACTIONS] == CURRENT_HVAC_IDLE
     assert sorted(state.attributes[ATTR_HVAC_MODES]) == [
         HVAC_MODE_AUTO,
         HVAC_MODE_COOL,
@@ -296,7 +296,7 @@ async def test_buggy_thermostat_invalid_mode(hass, buggy_thermostat):
     )
     await setup_platform(hass, CLIMATE_DOMAIN, devices=[buggy_thermostat])
     state = hass.states.get("climate.buggy_thermostat")
-    assert state.attributes[ATTR_HVAC_MODES] == ["heat"]
+    assert state.attributes[ATTR_HVAC_MODES] == [HVAC_MODE_HEAT]
 
 
 async def test_air_conditioner_entity_state(hass, air_conditioner):

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -215,13 +215,13 @@ async def test_legacy_thermostat_entity_state(hass, legacy_thermostat):
         | SUPPORT_TARGET_TEMPERATURE
     )
     assert state.attributes[ATTR_HVAC_ACTIONS] == "idle"
-    assert state.attributes[ATTR_HVAC_MODES] == {
+    assert sorted(state.attributes[ATTR_HVAC_MODES]) == [
         HVAC_MODE_AUTO,
         HVAC_MODE_COOL,
-        HVAC_MODE_HEAT_COOL,
         HVAC_MODE_HEAT,
+        HVAC_MODE_HEAT_COOL,
         HVAC_MODE_OFF,
-    }
+    ]
     assert state.attributes[ATTR_FAN_MODE] == "auto"
     assert state.attributes[ATTR_FAN_MODES] == ["auto", "on"]
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 20  # celsius
@@ -239,12 +239,12 @@ async def test_basic_thermostat_entity_state(hass, basic_thermostat):
         == SUPPORT_TARGET_TEMPERATURE_RANGE | SUPPORT_TARGET_TEMPERATURE
     )
     assert ATTR_HVAC_ACTIONS not in state.attributes
-    assert state.attributes[ATTR_HVAC_MODES] == {
-        HVAC_MODE_OFF,
-        HVAC_MODE_HEAT_COOL,
-        HVAC_MODE_HEAT,
+    assert sorted(state.attributes[ATTR_HVAC_MODES]) == [
         HVAC_MODE_COOL,
-    }
+        HVAC_MODE_HEAT,
+        HVAC_MODE_HEAT_COOL,
+        HVAC_MODE_OFF,
+    ]
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 21.1  # celsius
 
 
@@ -260,13 +260,13 @@ async def test_thermostat_entity_state(hass, thermostat):
         | SUPPORT_TARGET_TEMPERATURE
     )
     assert state.attributes[ATTR_HVAC_ACTIONS] == CURRENT_HVAC_IDLE
-    assert state.attributes[ATTR_HVAC_MODES] == {
+    assert sorted(state.attributes[ATTR_HVAC_MODES]) == [
         HVAC_MODE_AUTO,
         HVAC_MODE_COOL,
         HVAC_MODE_HEAT,
         HVAC_MODE_HEAT_COOL,
         HVAC_MODE_OFF,
-    }
+    ]
     assert state.attributes[ATTR_FAN_MODE] == "on"
     assert state.attributes[ATTR_FAN_MODES] == ["auto", "on"]
     assert state.attributes[ATTR_TEMPERATURE] == 20  # celsius
@@ -286,6 +286,7 @@ async def test_buggy_thermostat_entity_state(hass, buggy_thermostat):
     assert state.state is STATE_UNKNOWN
     assert state.attributes[ATTR_TEMPERATURE] is None
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 21.1  # celsius
+    assert state.attributes[ATTR_HVAC_MODES] == []
 
 
 async def test_buggy_thermostat_invalid_mode(hass, buggy_thermostat):
@@ -295,7 +296,7 @@ async def test_buggy_thermostat_invalid_mode(hass, buggy_thermostat):
     )
     await setup_platform(hass, CLIMATE_DOMAIN, devices=[buggy_thermostat])
     state = hass.states.get("climate.buggy_thermostat")
-    assert state.attributes[ATTR_HVAC_MODES] == {"heat"}
+    assert state.attributes[ATTR_HVAC_MODES] == ["heat"]
 
 
 async def test_air_conditioner_entity_state(hass, air_conditioner):


### PR DESCRIPTION
## Description:
Ensures that `hvac_modes` is always set to a `list` instance even if the ST device does not populate `supportedThermostatModes`.

**Related issue (if applicable):** fixes #25845 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
