### PR TITLE
Change updater to include current_version in it's status

### DIFF
--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -12,25 +12,23 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import __version__ as current_version
+from homeassistant.const import ATTR_FRIENDLY_NAME, __version__ as current_version
 from homeassistant.helpers import event
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers import discovery
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_RELEASE_NOTES = "release_notes"
-ATTR_NEWEST_VERSION = "newest_version"
+ATTR_CURRENT_VERSION = "current_version"
 
 CONF_REPORTING = "reporting"
 CONF_COMPONENT_REPORTING = "include_used_components"
 
 DOMAIN = "updater"
 
-DISPATCHER_REMOTE_UPDATE = "updater_remote_update"
+ENTITY_ID = "updater.updater"
 
 UPDATER_URL = "https://updater.home-assistant.io/"
 UPDATER_UUID_FILE = ".uuid"
@@ -48,16 +46,6 @@ CONFIG_SCHEMA = vol.Schema(
 RESPONSE_SCHEMA = vol.Schema(
     {vol.Required("version"): cv.string, vol.Required("release-notes"): cv.url}
 )
-
-
-class Updater:
-    """Updater class for data exchange."""
-
-    def __init__(self, update_available: bool, newest_version: str, release_notes: str):
-        """Initialize attributes."""
-        self.update_available = update_available
-        self.release_notes = release_notes
-        self.newest_version = newest_version
 
 
 def _create_uuid(hass, filename=UPDATER_UUID_FILE):
@@ -86,10 +74,6 @@ async def async_setup(hass, config):
         # This component only makes sense in release versions
         _LOGGER.info("Running on 'dev', only analytics will be submitted")
 
-    hass.async_create_task(
-        discovery.async_load_platform(hass, "binary_sensor", DOMAIN, {}, config)
-    )
-
     config = config.get(DOMAIN, {})
     if config.get(CONF_REPORTING):
         huuid = await hass.async_add_job(_load_uuid, hass)
@@ -105,7 +89,7 @@ async def async_setup(hass, config):
         if result is None:
             return
 
-        newest, release_notes = result
+        newest, releasenotes = result
 
         # Skip on dev
         if newest is None or "dev" in current_version:
@@ -116,17 +100,19 @@ async def async_setup(hass, config):
             newest = hass.components.hassio.get_homeassistant_version()
 
         # Validate version
-        update_available = False
         if StrictVersion(newest) > StrictVersion(current_version):
-            _LOGGER.info("The latest available version of Home Assistant is %s", newest)
-            update_available = True
+            _LOGGER.info("The latest available version is %s", newest)
+            hass.states.async_set(
+                ENTITY_ID,
+                newest,
+                {
+                    ATTR_FRIENDLY_NAME: "Update Available",
+                    ATTR_RELEASE_NOTES: releasenotes,
+                    ATTR_CURRENT_VERSION: current_version
+                },
+            )
         elif StrictVersion(newest) == StrictVersion(current_version):
             _LOGGER.info("You are on the latest version (%s) of Home Assistant", newest)
-        elif StrictVersion(newest) < StrictVersion(current_version):
-            _LOGGER.debug("Local version is newer than the latest version (%s)", newest)
-
-        updater = Updater(update_available, newest, release_notes)
-        async_dispatcher_send(hass, DISPATCHER_REMOTE_UPDATE, updater)
 
     # Update daily, start 1 hour after startup
     _dt = dt_util.utcnow() + timedelta(hours=1)
@@ -167,7 +153,7 @@ async def get_newest_version(hass, huuid, include_components):
             info_object,
         )
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        _LOGGER.error("Could not contact Home Assistant Update to check for updates")
+        _LOGGER.error("Could not contact Home Assistant Update to check " "for updates")
         return None
 
     try:


### PR DESCRIPTION
## Description:

Change the updater so that it's state also includes the current version. This makes it easier to have notifications like "Update available, new version 97.0, current version 87.1"

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

No follow

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
