### PR TITLE
Fix Filter Sensor - check existing entity history

### DIFF
--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -243,9 +243,7 @@ class SensorFilter(Entity):
                     )
                 )
                 if self._entity in filter_history:
-                    history_list.extend(
-                        [state for state in filter_history[self._entity]]
-                    )
+                    history_list.extend(filter_history[self._entity])
             if largest_window_time > timedelta(seconds=0):
                 start = dt_util.utcnow() - largest_window_time
                 filter_history = await self.hass.async_add_job(

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -242,7 +242,10 @@ class SensorFilter(Entity):
                         entity_id=self._entity,
                     )
                 )
-                history_list.extend([state for state in filter_history[self._entity]])
+                if self._entity in filter_history:
+                    history_list.extend(
+                        [state for state in filter_history[self._entity]]
+                    )
             if largest_window_time > timedelta(seconds=0):
                 start = dt_util.utcnow() - largest_window_time
                 filter_history = await self.hass.async_add_job(
@@ -253,13 +256,14 @@ class SensorFilter(Entity):
                         entity_id=self._entity,
                     )
                 )
-                history_list.extend(
-                    [
-                        state
-                        for state in filter_history[self._entity]
-                        if state not in history_list
-                    ]
-                )
+                if self._entity in filter_history:
+                    history_list.extend(
+                        [
+                            state
+                            for state in filter_history[self._entity]
+                            if state not in history_list
+                        ]
+                    )
 
             # Sort the window states
             history_list = sorted(history_list, key=lambda s: s.last_updated)

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -60,6 +60,31 @@ class TestFilterSensor(unittest.TestCase):
 
     def test_chain(self):
         """Test if filter chaining works."""
+        config = {
+            "sensor": {
+                "platform": "filter",
+                "name": "test",
+                "entity_id": "sensor.test_monitored",
+                "filters": [
+                    {"filter": "outlier", "window_size": 10, "radius": 4.0},
+                    {"filter": "lowpass", "time_constant": 10, "precision": 2},
+                    {"filter": "throttle", "window_size": 1},
+                ],
+            }
+        }
+
+        with assert_setup_component(1, "sensor"):
+            assert setup_component(self.hass, "sensor", config)
+
+            for value in self.values:
+                self.hass.states.set(config["sensor"]["entity_id"], value.state)
+                self.hass.block_till_done()
+
+            state = self.hass.states.get("sensor.test")
+            assert "18.05" == state.state
+
+    def test_chain_history(self):
+        """Test if filter chaining works."""
         self.init_recorder()
         config = {
             "history": {},

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -139,6 +139,44 @@ class TestFilterSensor(unittest.TestCase):
         """Test if filter chaining works when recorder is enabled but the source is not recorded."""
         return self.test_chain_history(missing=True)
 
+    def test_history_time(self):
+        """Test loading from history based on a time window."""
+        self.init_recorder()
+        config = {
+            "history": {},
+            "sensor": {
+                "platform": "filter",
+                "name": "test",
+                "entity_id": "sensor.test_monitored",
+                "filters": [{"filter": "time_throttle", "window_size": "00:01"}],
+            },
+        }
+        t_0 = dt_util.utcnow() - timedelta(minutes=1)
+        t_1 = dt_util.utcnow() - timedelta(minutes=2)
+        t_2 = dt_util.utcnow() - timedelta(minutes=3)
+
+        fake_states = {
+            "sensor.test_monitored": [
+                ha.State("sensor.test_monitored", 18.0, last_changed=t_0),
+                ha.State("sensor.test_monitored", 19.0, last_changed=t_1),
+                ha.State("sensor.test_monitored", 18.2, last_changed=t_2),
+            ]
+        }
+        with patch(
+            "homeassistant.components.history." "state_changes_during_period",
+            return_value=fake_states,
+        ):
+            with patch(
+                "homeassistant.components.history." "get_last_state_changes",
+                return_value=fake_states,
+            ):
+                with assert_setup_component(1, "sensor"):
+                    assert setup_component(self.hass, "sensor", config)
+
+                self.hass.block_till_done()
+                state = self.hass.states.get("sensor.test")
+                assert "18.0" == state.state
+
     def test_outlier(self):
         """Test if outlier filter works."""
         filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Still don't know how this issue has gone unnoticed for so long, this checks if an entity has history before retrieving it.

**Related issue (if applicable):** fixes #25766

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
recorder:
  include:
    domains:

sensor:
  - platform: random
    name: random
    minimum: 0
    maximum: 10

  - platform: filter
    name: "test"
    entity_id: sensor.random
    filters:
      - filter: outlier
        window_size: 4
        radius: 2.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html