### PR TITLE
Add broadlink switch retry time option

### DIFF
--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -34,7 +34,7 @@ TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
 DEFAULT_NAME = "Broadlink switch"
 DEFAULT_TIMEOUT = 10
-DEFAULT_RETRY = 3
+DEFAULT_RETRY = 2
 CONF_SLOTS = "slots"
 CONF_RETRY = "retry"
 

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -120,7 +120,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     broadlink_device,
                     device_config.get(CONF_COMMAND_ON),
                     device_config.get(CONF_COMMAND_OFF),
-                    retry_times
+                    retry_times,
                 )
             )
     elif switch_type in SP1_TYPES:
@@ -135,7 +135,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         parent_device = BroadlinkMP1Switch(broadlink_device, retry_times)
         for i in range(1, 5):
             slot = BroadlinkMP1Slot(
-                _get_mp1_slot_name(friendly_name, i), broadlink_device, i, parent_device, retry_times
+                _get_mp1_slot_name(friendly_name, i),
+                broadlink_device,
+                i,
+                parent_device,
+                retry_times,
             )
             switches.append(slot)
 
@@ -151,7 +155,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class BroadlinkRMSwitch(SwitchDevice, RestoreEntity):
     """Representation of an Broadlink switch."""
 
-    def __init__(self, name, friendly_name, device, command_on, command_off, retry_times):
+    def __init__(
+        self, name, friendly_name, device, command_on, command_off, retry_times
+    ):
         """Initialize the switch."""
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(name))
         self._name = friendly_name


### PR DESCRIPTION
## Description:
add broadlink switch retry time in configuration
Sometimes the network is in bad condition, it will need more retry time.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10150

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: broadlink
    host: 192.168.1.167
    mac: 'B4:43:0D:B0:BC:1B'
    timeout: 30
    retry: 100
    friendly_name: batai_xiaochubao
    type: spminiplus
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

https://github.com/home-assistant/home-assistant.io/pull/10150

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
