### PR TITLE
UniFi - Use state to know if device is online

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -294,7 +294,7 @@ class UniFiDeviceTracker(ScannerEntity):
             CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME
         )
 
-        if self.device.last_seen and (
+        if self.device.state == 1 and (
             dt_util.utcnow() - dt_util.utc_from_timestamp(float(self.device.last_seen))
             < detection_time
         ):
@@ -339,15 +339,18 @@ class UniFiDeviceTracker(ScannerEntity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        if not self.device.last_seen:
+        if self.device.state == 0:
             return {}
 
         attributes = {}
 
-        attributes["upgradable"] = self.device.upgradable
-        attributes["overheating"] = self.device.overheating
-
         if self.device.has_fan:
             attributes["fan_level"] = self.device.fan_level
+
+        if self.device.overheating:
+            attributes["overheating"] = self.device.overheating
+
+        if self.device.upgradable:
+            attributes["upgradable"] = self.device.upgradable
 
         return attributes

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/unifi",
   "requirements": [
-    "aiounifi==10"
+    "aiounifi==11"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ aiopvapi==1.6.14
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==10
+aiounifi==11
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -71,7 +71,7 @@ aionotion==1.1.0
 aioswitcher==2019.4.26
 
 # homeassistant.components.unifi
-aiounifi==10
+aiounifi==11
 
 # homeassistant.components.wwlln
 aiowwlln==1.0.0

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -69,6 +69,7 @@ DEVICE_1 = {
     "model": "US16P150",
     "name": "device_1",
     "overheating": False,
+    "state": 1,
     "type": "usw",
     "upgradable": False,
     "version": "4.0.42.10433",
@@ -81,6 +82,7 @@ DEVICE_2 = {
     "mac": "00:00:00:00:01:01",
     "model": "US16P150",
     "name": "device_1",
+    "state": 0,
     "type": "usw",
     "version": "4.0.42.10433",
 }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #25777

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
