### PR TITLE
Add person to device_sun_light_trigger

### DIFF
--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -63,12 +63,14 @@ async def async_setup(hass, config):
     device_tracker = hass.components.device_tracker
     group = hass.components.group
     light = hass.components.light
+    person = hass.components.person
     conf = config[DOMAIN]
     disable_turn_off = conf.get(CONF_DISABLE_TURN_OFF)
     light_group = conf.get(CONF_LIGHT_GROUP, light.ENTITY_ID_ALL_LIGHTS)
     light_profile = conf.get(CONF_LIGHT_PROFILE)
     device_group = conf.get(CONF_DEVICE_GROUP, device_tracker.ENTITY_ID_ALL_DEVICES)
     device_entity_ids = group.get_entity_ids(device_group, device_tracker.DOMAIN)
+    device_entity_ids.extend(group.get_entity_ids(device_group, person.DOMAIN))
 
     if not device_entity_ids:
         logger.error("No devices found to track")

--- a/homeassistant/components/device_sun_light_trigger/manifest.json
+++ b/homeassistant/components/device_sun_light_trigger/manifest.json
@@ -6,7 +6,8 @@
   "dependencies": [
     "device_tracker",
     "group",
-    "light"
+    "light",
+    "person"
   ],
   "codeowners": []
 }

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -6,7 +6,12 @@ import pytest
 
 from homeassistant.setup import async_setup_component
 from homeassistant.const import CONF_PLATFORM, STATE_HOME, STATE_NOT_HOME
-from homeassistant.components import device_tracker, light, device_sun_light_trigger
+from homeassistant.components import (
+    device_tracker,
+    light,
+    device_sun_light_trigger,
+    group,
+)
 from homeassistant.components.device_tracker.const import (
     ENTITY_ID_FORMAT as DT_ENTITY_ID_FORMAT,
 )
@@ -90,6 +95,8 @@ async def test_lights_turn_off_when_everyone_leaves(hass, scanner):
         hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
     )
 
+    assert light.is_on(hass)
+
     hass.states.async_set(device_tracker.ENTITY_ID_ALL_DEVICES, STATE_NOT_HOME)
 
     await hass.async_block_till_done()
@@ -115,38 +122,54 @@ async def test_lights_turn_on_when_coming_home_after_sun_set(hass, scanner):
 
 async def test_lights_turn_on_when_coming_home_after_sun_set_person(hass, scanner):
     """Test lights turn on when coming home after sun set."""
+    device_1 = DT_ENTITY_ID_FORMAT.format("device_1")
+    device_2 = DT_ENTITY_ID_FORMAT.format("device_2")
+
     test_time = datetime(2017, 4, 5, 3, 2, 3, tzinfo=dt_util.UTC)
     with patch("homeassistant.util.dt.utcnow", return_value=test_time):
         await common_light.async_turn_off(hass)
+        hass.states.async_set(device_1, STATE_NOT_HOME)
+        hass.states.async_set(device_2, STATE_NOT_HOME)
+        await hass.async_block_till_done()
+
+        assert not light.is_on(hass)
+        assert hass.states.get(device_tracker.ENTITY_ID_ALL_DEVICES).state == "not_home"
+        assert hass.states.get(device_1).state == "not_home"
+        assert hass.states.get(device_2).state == "not_home"
 
         assert await async_setup_component(
             hass,
             "person",
-            {
-                "person": {
-                    "me": {
-                        "name": "Me",
-                        "device_entities": [DT_ENTITY_ID_FORMAT.format("device_1")],
-                    }
-                }
-            },
+            {"person": [{"id": "me", "name": "Me", "device_trackers": [device_1]}]},
         )
+
+        await group.Group.async_create_group(hass, "person_me", ["person.me"])
 
         assert await async_setup_component(
             hass,
-            "group",
-            {"group": {"a_person": {"name": "A person", "entities": "person.me"}}},
+            device_sun_light_trigger.DOMAIN,
+            {device_sun_light_trigger.DOMAIN: {"device_group": "group.person_me"}},
         )
 
-        assert await async_setup_component(
-            hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
-        )
-
-        # Person is device 1, so device 2 should have no impact
-        hass.states.async_set(DT_ENTITY_ID_FORMAT.format("device_2"), STATE_HOME)
-        await hass.async_block_till_done()
         assert not light.is_on(hass)
+        assert hass.states.get(device_1).state == "not_home"
+        assert hass.states.get(device_2).state == "not_home"
+        assert hass.states.get("person.me").state == "not_home"
 
-        hass.states.async_set(DT_ENTITY_ID_FORMAT.format("device_1"), STATE_HOME)
+        # Unrelated device has no impact
+        hass.states.async_set(device_2, STATE_HOME)
         await hass.async_block_till_done()
+
+        assert not light.is_on(hass)
+        assert hass.states.get(device_1).state == "not_home"
+        assert hass.states.get(device_2).state == "home"
+        assert hass.states.get("person.me").state == "not_home"
+
+        # person home switches on
+        hass.states.async_set(device_1, STATE_HOME)
+        await hass.async_block_till_done()
+
         assert light.is_on(hass)
+        assert hass.states.get(device_1).state == "home"
+        assert hass.states.get(device_2).state == "home"
+        assert hass.states.get("person.me").state == "home"


### PR DESCRIPTION
## Description:
Allow person to be tracked by device_sun_ligt_trigger

Does this make sense? (requires some tests)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10237

## Example entry for `configuration.yaml` (if applicable):
```yaml
person:

device_sun_light_trigger:
  light_group: group.living
  light_profile: relax
  device_group: group.devices

group:
  devices:
    entities:
      - person.johann
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
