### PR TITLE
Bump ZHA dependencies.

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -7,7 +7,7 @@
     "bellows-homeassistant==0.9.0",
     "zha-quirks==0.0.20",
     "zigpy-deconz==0.2.1",
-    "zigpy-homeassistant==0.7.0",
+    "zigpy-homeassistant==0.7.1",
     "zigpy-xbee-homeassistant==0.4.0",
     "zigpy-zigate==0.1.0"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1983,7 +1983,7 @@ ziggo-mediabox-xl==1.1.0
 zigpy-deconz==0.2.1
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.7.0
+zigpy-homeassistant==0.7.1
 
 # homeassistant.components.zha
 zigpy-xbee-homeassistant==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -403,4 +403,4 @@ wakeonlan==1.1.6
 zeroconf==0.23.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.7.0
+zigpy-homeassistant==0.7.1


### PR DESCRIPTION
## Description:
Bump `zigpy-homeassistant` ZHA dependency.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
Fixes #25700 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
