### PR TITLE
DuckDNS setup backoff

### DIFF
--- a/homeassistant/components/duckdns/__init__.py
+++ b/homeassistant/components/duckdns/__init__.py
@@ -1,13 +1,17 @@
 """Integrate with DuckDNS."""
-from datetime import timedelta
 import logging
+from asyncio import iscoroutinefunction
+from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_ACCESS_TOKEN, CONF_DOMAIN
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_DOMAIN
+from homeassistant.core import callback, CALLBACK_TYPE
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.loader import bind_hass
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,28 +46,25 @@ async def async_setup(hass, config):
     token = config[DOMAIN][CONF_ACCESS_TOKEN]
     session = async_get_clientsession(hass)
 
-    await _update_duckdns(session, domain, token)
-
-    fail = 0
-    enable = 0
-
-    async def update_domain_interval(now):
+    async def update_domain_interval(_now):
         """Update the DuckDNS entry."""
-        nonlocal fail, enable
-        if enable >= 0:
-            if await _update_duckdns(session, domain, token):
-                fail = 0
-            else:
-                fail += 1
-                enable = -11 if fail > 2 else -2
-        else:
-            enable += 1
+        return await _update_duckdns(session, domain, token)
+
+    intervals = (
+        INTERVAL,
+        INTERVAL,
+        INTERVAL,
+        INTERVAL * 3,
+        INTERVAL * 3,
+        INTERVAL * 6,
+        INTERVAL * 12,
+    )
+    async_track_time_interval_backoff(hass, update_domain_interval, intervals)
 
     async def update_domain_service(call):
         """Update the DuckDNS entry."""
         await _update_duckdns(session, domain, token, txt=call.data[ATTR_TXT])
 
-    async_track_time_interval(hass, update_domain_interval, INTERVAL)
     hass.services.async_register(
         DOMAIN, SERVICE_SET_TXT, update_domain_service, schema=SERVICE_TXT_SCHEMA
     )
@@ -93,7 +94,42 @@ async def _update_duckdns(session, domain, token, *, txt=_SENTINEL, clear=False)
     body = await resp.text()
 
     if body != "OK":
+        _LOGGER.debug("time %s", dt_util.utcnow())
         _LOGGER.warning("Updating DuckDNS domain failed: %s", domain)
         return False
 
     return True
+
+
+@callback
+@bind_hass
+def async_track_time_interval_backoff(hass, action, intervals) -> CALLBACK_TYPE:
+    """Add a listener that fires repetitively at every timedelta interval."""
+    if not iscoroutinefunction:
+        _LOGGER.error("action needs to be a coroutine and return True/False")
+        return
+
+    if not isinstance(intervals, (list, tuple)):
+        intervals = (intervals,)
+    remove = None
+    failed = 0
+
+    async def interval_listener(now):
+        """Handle elapsed intervals with backoff."""
+        nonlocal failed, remove
+        try:
+            failed += 1
+            if await action(now):
+                failed = 0
+        finally:
+            delay = intervals[failed] if failed < len(intervals) else intervals[-1]
+            remove = async_track_point_in_utc_time(hass, interval_listener, now + delay)
+
+    hass.async_run_job(interval_listener, dt_util.utcnow())
+
+    def remove_listener():
+        """Remove interval listener."""
+        if remove:
+            remove()  # pylint: disable=not-callable
+
+    return remove_listener

--- a/homeassistant/components/duckdns/__init__.py
+++ b/homeassistant/components/duckdns/__init__.py
@@ -52,12 +52,10 @@ async def async_setup(hass, config):
 
     intervals = (
         INTERVAL,
-        INTERVAL,
-        INTERVAL,
-        INTERVAL * 3,
-        INTERVAL * 3,
-        INTERVAL * 6,
-        INTERVAL * 12,
+        timedelta(minutes=1),
+        timedelta(minutes=5),
+        timedelta(minutes=15),
+        timedelta(minutes=30),
     )
     async_track_time_interval_backoff(hass, update_domain_interval, intervals)
 
@@ -94,7 +92,6 @@ async def _update_duckdns(session, domain, token, *, txt=_SENTINEL, clear=False)
     body = await resp.text()
 
     if body != "OK":
-        _LOGGER.debug("time %s", dt_util.utcnow())
         _LOGGER.warning("Updating DuckDNS domain failed: %s", domain)
         return False
 

--- a/tests/components/duckdns/test_init.py
+++ b/tests/components/duckdns/test_init.py
@@ -1,5 +1,4 @@
 """Test the DuckDNS component."""
-import asyncio
 from datetime import timedelta
 import logging
 import pytest
@@ -19,13 +18,12 @@ INTERVAL = duckdns.INTERVAL
 
 
 @bind_hass
-@asyncio.coroutine
-def async_set_txt(hass, txt):
+async def async_set_txt(hass, txt):
     """Set the txt record. Pass in None to remove it.
 
     This is a legacy helper method. Do not use it for new tests.
     """
-    yield from hass.services.async_call(
+    await hass.services.async_call(
         duckdns.DOMAIN, duckdns.SERVICE_SET_TXT, {duckdns.ATTR_TXT: txt}, blocking=True
     )
 
@@ -44,65 +42,60 @@ def setup_duckdns(hass, aioclient_mock):
     )
 
 
-@asyncio.coroutine
-def test_setup(hass, aioclient_mock):
+async def test_setup(hass, aioclient_mock):
     """Test setup works if update passes."""
     aioclient_mock.get(
         duckdns.UPDATE_URL, params={"domains": DOMAIN, "token": TOKEN}, text="OK"
     )
 
-    result = yield from async_setup_component(
+    result = await async_setup_component(
         hass, duckdns.DOMAIN, {"duckdns": {"domain": DOMAIN, "access_token": TOKEN}}
     )
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert result
     assert aioclient_mock.call_count == 1
 
     async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert aioclient_mock.call_count == 2
 
 
-@asyncio.coroutine
-def test_setup_backoff(hass, aioclient_mock):
+async def test_setup_backoff(hass, aioclient_mock):
     """Test setup fails if first update fails."""
     aioclient_mock.get(
         duckdns.UPDATE_URL, params={"domains": DOMAIN, "token": TOKEN}, text="KO"
     )
 
-    result = yield from async_setup_component(
+    result = await async_setup_component(
         hass, duckdns.DOMAIN, {"duckdns": {"domain": DOMAIN, "access_token": TOKEN}}
     )
     assert result
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert aioclient_mock.call_count == 1
 
     # Copy of the DuckDNS intervals from duckdns/__init__.py
     intervals = (
         INTERVAL,
-        INTERVAL,
-        INTERVAL,
-        INTERVAL * 3,
-        INTERVAL * 3,
-        INTERVAL * 6,
-        INTERVAL * 12,
+        timedelta(minutes=1),
+        timedelta(minutes=5),
+        timedelta(minutes=15),
+        timedelta(minutes=30),
     )
     tme = utcnow()
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     _LOGGER.debug("Backoff...")
     for idx in range(1, len(intervals)):
         tme += intervals[idx]
         async_fire_time_changed(hass, tme)
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
         assert aioclient_mock.call_count == idx + 1
 
 
-@asyncio.coroutine
-def test_service_set_txt(hass, aioclient_mock, setup_duckdns):
+async def test_service_set_txt(hass, aioclient_mock, setup_duckdns):
     """Test set txt service call."""
     # Empty the fixture mock requests
     aioclient_mock.clear_requests()
@@ -114,12 +107,11 @@ def test_service_set_txt(hass, aioclient_mock, setup_duckdns):
     )
 
     assert aioclient_mock.call_count == 0
-    yield from async_set_txt(hass, "some-txt")
+    await async_set_txt(hass, "some-txt")
     assert aioclient_mock.call_count == 1
 
 
-@asyncio.coroutine
-def test_service_clear_txt(hass, aioclient_mock, setup_duckdns):
+async def test_service_clear_txt(hass, aioclient_mock, setup_duckdns):
     """Test clear txt service call."""
     # Empty the fixture mock requests
     aioclient_mock.clear_requests()
@@ -131,12 +123,11 @@ def test_service_clear_txt(hass, aioclient_mock, setup_duckdns):
     )
 
     assert aioclient_mock.call_count == 0
-    yield from async_set_txt(hass, None)
+    await async_set_txt(hass, None)
     assert aioclient_mock.call_count == 1
 
 
-@asyncio.coroutine
-def test_async_track_time_interval_backoff(hass):
+async def test_async_track_time_interval_backoff(hass):
     """Test setup fails if first update fails."""
     ret_val = False
     call_count = 0
@@ -160,7 +151,7 @@ def test_async_track_time_interval_backoff(hass):
     )
 
     async_track_time_interval_backoff(hass, _return, intervals)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert call_count == 1
 
@@ -168,7 +159,7 @@ def test_async_track_time_interval_backoff(hass):
     for idx in range(1, len(intervals)):
         tme += intervals[idx]
         async_fire_time_changed(hass, tme)
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
         assert call_count == idx + 1
 
@@ -176,7 +167,7 @@ def test_async_track_time_interval_backoff(hass):
     for _idx in range(1, 10):
         tme += intervals[-1]
         async_fire_time_changed(hass, tme)
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
         assert call_count == idx + 1 + _idx
 
@@ -185,13 +176,13 @@ def test_async_track_time_interval_backoff(hass):
     ret_val = True
     tme += intervals[-1]
     async_fire_time_changed(hass, tme)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert call_count == 1
 
     _LOGGER.debug("No backoff - intervals[0]")
     for _idx in range(2, 10):
         tme += intervals[0]
         async_fire_time_changed(hass, tme)
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
         assert call_count == _idx


### PR DESCRIPTION
## Description:
If Internet connection is not available at startup, backoff DuckDNS update instead of failing component setup

15 minutes between first 3 tries, after that try every hour

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
duckdns:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
