### PR TITLE
Add on_off_inverted to KNX climate

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -193,7 +193,7 @@ def async_add_entities_config(hass, config, async_add_entities):
 class KNXClimate(ClimateDevice):
     """Representation of a KNX climate device."""
 
-    def __init__(self, device, on_off_inverted = False):
+    def __init__(self, device, on_off_inverted=False):
         """Initialize of a KNX climate device."""
         self.device = device
         self._unit_of_measurement = TEMP_CELSIUS

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -52,6 +52,7 @@ DEFAULT_NAME = "KNX Climate"
 DEFAULT_SETPOINT_SHIFT_STEP = 0.5
 DEFAULT_SETPOINT_SHIFT_MAX = 6
 DEFAULT_SETPOINT_SHIFT_MIN = -6
+DEFAULT_ON_OFF_INVERT = False
 # Map KNX operation modes to HA modes. This list might not be full.
 OPERATION_MODES = {
     # Map DPT 201.105 HVAC control modes
@@ -103,7 +104,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_OPERATION_MODE_COMFORT_ADDRESS): cv.string,
         vol.Optional(CONF_ON_OFF_ADDRESS): cv.string,
         vol.Optional(CONF_ON_OFF_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_ON_OFF_INVERT, default=False): cv.boolean,
+        vol.Optional(CONF_ON_OFF_INVERT, default=DEFAULT_ON_OFF_INVERT): cv.boolean,
         vol.Optional(CONF_OPERATION_MODES): vol.All(
             cv.ensure_list, [vol.In(OPERATION_MODES)]
         ),
@@ -184,7 +185,7 @@ def async_add_entities_config(hass, config, async_add_entities):
         min_temp=config.get(CONF_MIN_TEMP),
         max_temp=config.get(CONF_MAX_TEMP),
         mode=climate_mode,
-        on_off_invert=config.get(CONF_ON_OFF_INVERT),
+        on_off_invert=config[CONF_ON_OFF_INVERT],
     )
     hass.data[DATA_KNX].xknx.devices.add(climate)
 


### PR DESCRIPTION
## Description:

Some KNX Room controllers (RCD 20xx, 2178) have inverted power ON/OFF value. ON means disable controller, OFF means enable controller.

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/10126

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: knx
    on_off_address: '1/1/1'
    on_off_state_address: '1/1/101'
    on_off_invert: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
