### PR TITLE
Improve Sonos error handling on slow networks

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/sonos",
   "requirements": [
-    "pysonos==0.0.22"
+    "pysonos==0.0.23"
   ],
   "dependencies": [],
   "ssdp": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1396,7 +1396,7 @@ pysmarty==0.8
 pysnmp==4.4.9
 
 # homeassistant.components.sonos
-pysonos==0.0.22
+pysonos==0.0.23
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -308,7 +308,7 @@ pysmartapp==0.3.2
 pysmartthings==0.6.9
 
 # homeassistant.components.sonos
-pysonos==0.0.22
+pysonos==0.0.23
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
# Description:

This fixes a number of uncaught exceptions that I discovered while running with a network conditioner causing 25%-50% packet loss. It handles crazy situations like this:

1. A speaker is discovered.
2. Creating the entity and getting current state takes a long time.
3. The same speaker is rediscovered so it is set "available". However, it is actually not yet ready because it is still being added.

I hope avoiding the exceptions will fix some reports about the Sonos discovery thread stopping but I do not have enough information to be sure.

Changelog: [pysonos 0.0.23](https://github.com/amelchio/pysonos/releases/tag/v0.0.23)

**Related issue (if applicable):** [chatter in the forum](https://community.home-assistant.io/t/sonos-no-longer-working-after-update-to-0-91/111343/4)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html