### PR TITLE
Fix for HomeKit controller state not updating immediately after put

### DIFF
--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -74,6 +74,7 @@ class FakePairing:
                         if char.iid != cid:
                             continue
                         char.set_value(new_val)
+        return {}
 
 
 class FakeController:


### PR DESCRIPTION
## Description:

This is a fix for the regression in #25901.

**Related issue (if applicable):** fixes #25901

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
