### PR TITLE
Add path option to SABnzbd component

### DIFF
--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -104,7 +104,7 @@ async def async_configure_sabnzbd(
 
     host = config[CONF_HOST]
     port = config[CONF_PORT]
-    web_root = config[CONF_PATH]
+    web_root = config.get(CONF_PATH)
     uri_scheme = "https" if use_ssl else "http"
     base_url = BASE_URL_FORMAT.format(uri_scheme, host, port)
     if api_key is None:

--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_API_KEY,
     CONF_NAME,
+    CONF_PATH,
     CONF_PORT,
     CONF_SENSORS,
     CONF_SSL,
@@ -69,6 +70,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_API_KEY): cv.string,
                 vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+                vol.Optional(CONF_PATH): cv.string,
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                 vol.Optional(CONF_SENSORS): vol.All(
@@ -102,17 +104,20 @@ async def async_configure_sabnzbd(
 
     host = config[CONF_HOST]
     port = config[CONF_PORT]
+    web_root = config[CONF_PATH]
     uri_scheme = "https" if use_ssl else "http"
     base_url = BASE_URL_FORMAT.format(uri_scheme, host, port)
     if api_key is None:
         conf = await hass.async_add_job(load_json, hass.config.path(CONFIG_FILE))
         api_key = conf.get(base_url, {}).get(CONF_API_KEY, "")
 
-    sab_api = SabnzbdApi(base_url, api_key, session=async_get_clientsession(hass))
+    sab_api = SabnzbdApi(
+        base_url, api_key, web_root=web_root, session=async_get_clientsession(hass)
+    )
     if await async_check_sabnzbd(sab_api):
         async_setup_sabnzbd(hass, sab_api, config, name)
     else:
-        async_request_configuration(hass, config, base_url)
+        async_request_configuration(hass, config, base_url, web_root)
 
 
 async def async_setup(hass, config):
@@ -181,7 +186,7 @@ def async_setup_sabnzbd(hass, sab_api, config, name):
 
 
 @callback
-def async_request_configuration(hass, config, host):
+def async_request_configuration(hass, config, host, web_root):
     """Request configuration steps from the user."""
     from pysabnzbd import SabnzbdApi
 
@@ -197,7 +202,9 @@ def async_request_configuration(hass, config, host):
     async def async_configuration_callback(data):
         """Handle configuration changes."""
         api_key = data.get(CONF_API_KEY)
-        sab_api = SabnzbdApi(host, api_key, session=async_get_clientsession(hass))
+        sab_api = SabnzbdApi(
+            host, api_key, web_root=web_root, session=async_get_clientsession(hass)
+        )
         if not await async_check_sabnzbd(sab_api):
             return
 


### PR DESCRIPTION
## Description:

Adds an optional `path` setting to the SABnzbd component. This allows support for SABnzbd installs that use a different `url_base` (typically a reverse proxied configuration; see https://sabnzbd.org/wiki/configuration/2.3/special).

This change passes the `path` along to pysabnzbd as its `web_root`, which in turn uses the path to build up it's api URLs.

Rebased on top of `dev` now after #23846

**Related issue (if applicable):** #23846 which was approved/reviewed by @MartinHjelmare 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10124

## Example entry for `configuration.yaml` (if applicable):
```yaml
sabnzbd:
  path: /sabnzbd
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
