### PR TITLE
Update syncthru library to fix issue #25795

### DIFF
--- a/homeassistant/components/syncthru/manifest.json
+++ b/homeassistant/components/syncthru/manifest.json
@@ -3,7 +3,7 @@
   "name": "Syncthru",
   "documentation": "https://www.home-assistant.io/components/syncthru",
   "requirements": [
-    "pysyncthru==0.4.2"
+    "pysyncthru==0.4.3"
   ],
   "dependencies": [],
   "codeowners": ["@nielstron"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1422,7 +1422,7 @@ pysuez==0.1.17
 pysupla==0.0.3
 
 # homeassistant.components.syncthru
-pysyncthru==0.4.2
+pysyncthru==0.4.3
 
 # homeassistant.components.tautulli
 pytautulli==0.5.0


### PR DESCRIPTION
## Breaking Change:

None

## Description:
Fixes the issue of not updating when unable to determine the state of the printer. Should now update the sensor regardless of non-offline state.

**Related issue (if applicable):** fixes #25795

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
