### PR TITLE
Handle more Life360 errors in config flow & bump package to 4.1.1

### DIFF
--- a/homeassistant/components/life360/.translations/en.json
+++ b/homeassistant/components/life360/.translations/en.json
@@ -10,7 +10,8 @@
         "error": {
             "invalid_credentials": "Invalid credentials",
             "invalid_username": "Invalid username",
-            "user_already_configured": "Account has already been configured"
+            "user_already_configured": "Account has already been configured",
+            "unexpected": "Unexpected error communicating with Life360 server"
         },
         "step": {
             "user": {

--- a/homeassistant/components/life360/config_flow.py
+++ b/homeassistant/components/life360/config_flow.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict
 import logging
 
-from life360 import LoginError
+from life360 import Life360Error, LoginError
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -54,6 +54,11 @@ class Life360ConfigFlow(config_entries.ConfigFlow):
                 errors[CONF_USERNAME] = "invalid_username"
             except LoginError:
                 errors["base"] = "invalid_credentials"
+            except Life360Error as error:
+                _LOGGER.error(
+                    "Unexpected error communicating with Life360 server: %s", error
+                )
+                errors["base"] = "unexpected"
             else:
                 if self._username in self.configured_usernames:
                     errors["base"] = "user_already_configured"
@@ -88,6 +93,11 @@ class Life360ConfigFlow(config_entries.ConfigFlow):
         except LoginError:
             _LOGGER.error("Invalid credentials for %s", username)
             return self.async_abort(reason="invalid_credentials")
+        except Life360Error as error:
+            _LOGGER.error(
+                "Unexpected error communicating with Life360 server: %s", error
+            )
+            return self.async_abort(reason="unexpected")
         return self.async_create_entry(
             title="{} (from configuration)".format(username),
             data={

--- a/homeassistant/components/life360/manifest.json
+++ b/homeassistant/components/life360/manifest.json
@@ -8,6 +8,6 @@
     "@pnbruckner"
   ],
   "requirements": [
-    "life360==4.0.1"
+    "life360==4.1.1"
   ]
 }

--- a/homeassistant/components/life360/strings.json
+++ b/homeassistant/components/life360/strings.json
@@ -14,7 +14,8 @@
     "error": {
       "invalid_username": "Invalid username",
       "invalid_credentials": "Invalid credentials",
-      "user_already_configured": "Account has already been configured"
+      "user_already_configured": "Account has already been configured",
+      "unexpected": "Unexpected error communicating with Life360 server"
     },
     "create_entry": {
       "default": "To set advanced options, see [Life360 documentation]({docs_url})."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -723,7 +723,7 @@ librouteros==2.3.0
 libsoundtouch==0.7.2
 
 # homeassistant.components.life360
-life360==4.0.1
+life360==4.1.1
 
 # homeassistant.components.lifx_legacy
 liffylights==0.9.4


### PR DESCRIPTION
## Description:
Life360's config flow did not handle some exceptions. Add code to handle these exceptions. Also bump the life360 package to 4.1.1 which filters urllib3 warnings from the log.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
