### PR TITLE
Update opentherm_gw.climate to match Climate 1.0

### DIFF
--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -8,7 +8,8 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
-    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT,
     SUPPORT_TARGET_TEMPERATURE,
     PRESET_AWAY,
     PRESET_NONE,
@@ -51,6 +52,7 @@ class OpenThermClimate(ClimateDevice):
         self.temp_precision = gw_dev.climate_config.get(CONF_PRECISION)
         self._current_operation = None
         self._current_temperature = None
+        self._hvac_mode = HVAC_MODE_HEAT
         self._new_target_temperature = None
         self._target_temperature = None
         self._away_mode_a = None
@@ -73,8 +75,10 @@ class OpenThermClimate(ClimateDevice):
         cooling_active = status.get(gw_vars.DATA_SLAVE_COOLING_ACTIVE)
         if ch_active and flame_on:
             self._current_operation = CURRENT_HVAC_HEAT
+            self._hvac_mode = HVAC_MODE_HEAT
         elif cooling_active:
             self._current_operation = CURRENT_HVAC_COOL
+            self._hvac_mode = HVAC_MODE_COOL
         else:
             self._current_operation = CURRENT_HVAC_IDLE
 
@@ -148,7 +152,7 @@ class OpenThermClimate(ClimateDevice):
     @property
     def hvac_mode(self):
         """Return current HVAC mode."""
-        return HVAC_MODE_AUTO
+        return self._hvac_mode
 
     @property
     def hvac_modes(self):

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -5,11 +5,13 @@ from pyotgw import vars as gw_vars
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    HVAC_MODE_AUTO,
     SUPPORT_TARGET_TEMPERATURE,
     PRESET_AWAY,
+    PRESET_NONE,
     SUPPORT_PRESET_MODE,
 )
 from homeassistant.const import (
@@ -47,7 +49,7 @@ class OpenThermClimate(ClimateDevice):
         self.friendly_name = gw_dev.name
         self.floor_temp = gw_dev.climate_config[CONF_FLOOR_TEMP]
         self.temp_precision = gw_dev.climate_config.get(CONF_PRECISION)
-        self._current_operation = HVAC_MODE_OFF
+        self._current_operation = None
         self._current_temperature = None
         self._new_target_temperature = None
         self._target_temperature = None
@@ -70,11 +72,11 @@ class OpenThermClimate(ClimateDevice):
         flame_on = status.get(gw_vars.DATA_SLAVE_FLAME_ON)
         cooling_active = status.get(gw_vars.DATA_SLAVE_COOLING_ACTIVE)
         if ch_active and flame_on:
-            self._current_operation = HVAC_MODE_HEAT
+            self._current_operation = CURRENT_HVAC_HEAT
         elif cooling_active:
-            self._current_operation = HVAC_MODE_COOL
+            self._current_operation = CURRENT_HVAC_COOL
         else:
-            self._current_operation = HVAC_MODE_OFF
+            self._current_operation = CURRENT_HVAC_IDLE
 
         self._current_temperature = status.get(gw_vars.DATA_ROOM_TEMP)
         temp_upd = status.get(gw_vars.DATA_ROOM_SETPOINT)
@@ -139,14 +141,23 @@ class OpenThermClimate(ClimateDevice):
         return TEMP_CELSIUS
 
     @property
+    def hvac_action(self):
+        """Return current HVAC operation."""
+        return self._current_operation
+
+    @property
     def hvac_mode(self):
         """Return current HVAC mode."""
-        return self._current_operation
+        return HVAC_MODE_AUTO
 
     @property
     def hvac_modes(self):
         """Return available HVAC modes."""
         return []
+
+    def set_hvac_mode(self, hvac_mode):
+        """Set the HVAC mode."""
+        _LOGGER.warning("Changing HVAC mode is not supported")
 
     @property
     def current_temperature(self):
@@ -176,6 +187,7 @@ class OpenThermClimate(ClimateDevice):
         """Return current preset mode."""
         if self._away_state_a or self._away_state_b:
             return PRESET_AWAY
+        return PRESET_NONE
 
     @property
     def preset_modes(self):


### PR DESCRIPTION
## Breaking Change:
Move climate entity state to hvac_action attribute to comply with climate 1.0. May break e.g. automations.

## Description:
Update opentherm_gw.climate to match climate 1.0 as closely as possible.
Introduce hvac_action attribute for the current action of the boiler.
Entity state is read-only and reflects the last active hvac_action as we have no way to determine or change the actual thermostat mode setting (or even if the thermostat supports such a concept).
Preset is read-only, only `PRESET_AWAY` and `PRESET_NONE` are supported.
`hvac_modes` and `preset_modes` return empty lists to prevent attempts to change their related mode through the GUI.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - N/A

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
