### PR TITLE
Don't force a query to the main lutron repeater on update

### DIFF
--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -34,7 +34,6 @@ class LutronLight(LutronDevice, Light):
     def __init__(self, area_name, lutron_device, controller):
         """Initialize the light."""
         self._prev_brightness = None
-        self._is_on = False
         super().__init__(area_name, lutron_device, controller)
 
     @property
@@ -78,6 +77,5 @@ class LutronLight(LutronDevice, Light):
 
     def update(self):
         """Call when forcing a refresh of the device."""
-        self._is_on = self._lutron_device.level > 0
         if self._prev_brightness is None:
             self._prev_brightness = to_hass_level(self._lutron_device.level)

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -23,7 +23,7 @@ class LutronSwitch(LutronDevice, SwitchDevice):
 
     def __init__(self, area_name, lutron_device, controller):
         """Initialize the switch."""
-        self._is_on = False
+        self._prev_state = None
         super().__init__(area_name, lutron_device, controller)
 
     def turn_on(self, **kwargs):
@@ -48,4 +48,5 @@ class LutronSwitch(LutronDevice, SwitchDevice):
 
     def update(self):
         """Call when forcing a refresh of the device."""
-        self._is_on = self._lutron_device.level > 0
+        if self._prev_state is None:
+            self._prev_state = self._lutron_device.level > 0


### PR DESCRIPTION
## Description:

We only want to force a query if we don't have any previous state.
Otherwise, we should be tracking the state via continuous status
updates.

For lights (not switches) the extra query was also superfluous since
it was already querying on startup.

We should probably have a timeout on that so at some point we'll
requery in case remote end disconnected/rebooted, etc. Leaving for
another PR.

**Related PR (if applicable):** fixes small issues in #25592

## Checklist:
  - [ ] The code change is tested and works locally. **NOT RETESTED YET**
  - [ x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.
  - [ x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
