### PR TITLE
Update homekit_controller import style to be consistent

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -1,6 +1,9 @@
 """Support for Homekit device discovery."""
 import logging
 
+import homekit
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -63,9 +66,6 @@ class HomeKitEntity(Entity):
 
     def setup(self):
         """Configure an entity baed on its HomeKit characterstics metadata."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         accessories = self._accessory.accessories
 
         get_uuid = CharacteristicsTypes.get_uuid
@@ -95,9 +95,6 @@ class HomeKitEntity(Entity):
 
     def _setup_characteristic(self, char):
         """Configure an entity based on a HomeKit characteristics metadata."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         # Build up a list of (aid, iid) tuples to poll on update()
         self.pollable_characteristics.append((self._aid, char["iid"]))
 
@@ -211,9 +208,6 @@ async def async_setup_entry(hass, entry):
 
 async def async_setup(hass, config):
     """Set up for Homekit devices."""
-    # pylint: disable=import-error
-    import homekit
-
     map_storage = hass.data[ENTITY_MAP] = EntityMapStorage(hass)
     await map_storage.async_initialize()
 

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -1,6 +1,8 @@
 """Support for Homekit Alarm Control Panel."""
 import logging
 
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
@@ -64,9 +66,6 @@ class HomeKitAlarmControlPanel(HomeKitEntity, AlarmControlPanel):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.SECURITY_SYSTEM_STATE_CURRENT,
             CharacteristicsTypes.SECURITY_SYSTEM_STATE_TARGET,

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -1,6 +1,8 @@
 """Support for Homekit climate devices."""
 import logging
 
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.components.climate import (
     ClimateDevice,
     DEFAULT_MIN_HUMIDITY,
@@ -84,9 +86,6 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.HEATING_COOLING_CURRENT,
             CharacteristicsTypes.HEATING_COOLING_TARGET,

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -3,6 +3,7 @@ import os
 import json
 import logging
 
+import homekit
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -62,8 +63,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
     def __init__(self):
         """Initialize the homekit_controller flow."""
-        import homekit  # pylint: disable=import-error
-
         self.model = None
         self.hkid = None
         self.devices = {}
@@ -224,8 +223,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_pair(self, pair_info=None):
         """Pair with a new HomeKit accessory."""
-        import homekit  # pylint: disable=import-error
-
         # If async_step_pair is called with no pairing code then we do the M1
         # phase of pairing. If this is successful the device enters pairing
         # mode.

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -3,6 +3,14 @@ import asyncio
 import datetime
 import logging
 
+from homekit.exceptions import (
+    AccessoryDisconnectedError,
+    AccessoryNotFoundError,
+    EncryptionError,
+)
+from homekit.model.services import ServicesTypes
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import DOMAIN, HOMEKIT_ACCESSORY_DISPATCH, ENTITY_MAP
@@ -16,10 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_accessory_information(accessory):
     """Obtain the accessory information service of a HomeKit device."""
-    # pylint: disable=import-error
-    from homekit.model.services import ServicesTypes
-    from homekit.model.characteristics import CharacteristicsTypes
-
     result = {}
     for service in accessory["services"]:
         stype = service["type"].upper()
@@ -163,9 +167,6 @@ class HKDevice:
 
     async def async_refresh_entity_map(self, config_num):
         """Handle setup of a HomeKit accessory."""
-        # pylint: disable=import-error
-        from homekit.exceptions import AccessoryDisconnectedError
-
         try:
             async with self.pairing_lock:
                 self.accessories = await self.hass.async_add_executor_job(
@@ -205,8 +206,6 @@ class HKDevice:
         self._add_new_entities(self.listeners)
 
     def _add_new_entities(self, callbacks):
-        from homekit.model.services import ServicesTypes
-
         for accessory in self.accessories:
             aid = accessory["aid"]
             for service in accessory["services"]:
@@ -225,8 +224,6 @@ class HKDevice:
 
     def async_load_platforms(self):
         """Load any platforms needed by this HomeKit device."""
-        from homekit.model.services import ServicesTypes
-
         for accessory in self.accessories:
             for service in accessory["services"]:
                 stype = ServicesTypes.get_short(service["type"].upper())
@@ -246,13 +243,6 @@ class HKDevice:
 
     async def async_update(self, now=None):
         """Poll state of all entities attached to this bridge/accessory."""
-        # pylint: disable=import-error
-        from homekit.exceptions import (
-            AccessoryDisconnectedError,
-            AccessoryNotFoundError,
-            EncryptionError,
-        )
-
         if not self.pollable_characteristics:
             _LOGGER.debug("HomeKit connection not polling any characteristics.")
             return

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -1,6 +1,8 @@
 """Support for Homekit covers."""
 import logging
 
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
@@ -76,9 +78,6 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverDevice):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.DOOR_STATE_CURRENT,
             CharacteristicsTypes.DOOR_STATE_TARGET,
@@ -154,9 +153,6 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.POSITION_STATE,
             CharacteristicsTypes.POSITION_CURRENT,

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -1,6 +1,8 @@
 """Support for Homekit lights."""
 import logging
 
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
@@ -50,9 +52,6 @@ class HomeKitLight(HomeKitEntity, Light):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.ON,
             CharacteristicsTypes.BRIGHTNESS,

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -1,6 +1,8 @@
 """Support for HomeKit Controller locks."""
 import logging
 
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import ATTR_BATTERY_LEVEL, STATE_LOCKED, STATE_UNLOCKED
 
@@ -46,9 +48,6 @@ class HomeKitLock(HomeKitEntity, LockDevice):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [
             CharacteristicsTypes.LOCK_MECHANISM_CURRENT_STATE,
             CharacteristicsTypes.LOCK_MECHANISM_TARGET_STATE,

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -1,6 +1,8 @@
 """Support for Homekit switches."""
 import logging
 
+from homekit.model.characteristics import CharacteristicsTypes
+
 from homeassistant.components.switch import SwitchDevice
 
 from . import KNOWN_DEVICES, HomeKitEntity
@@ -41,9 +43,6 @@ class HomeKitSwitch(HomeKitEntity, SwitchDevice):
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity cares about."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
-
         return [CharacteristicsTypes.ON, CharacteristicsTypes.OUTLET_IN_USE]
 
     def _update_on(self, value):


### PR DESCRIPTION
## Description:

This is just a change to be consistent with binary_sensor.py and sensor.py which both recently switched their imports to be at the top now we have manifest.json.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]