### PR TITLE
Bump version of library aio_geojson_geonetnz_quakes to v0.9

### DIFF
--- a/homeassistant/components/geonetnz_quakes/manifest.json
+++ b/homeassistant/components/geonetnz_quakes/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/geonetnz_quakes",
   "requirements": [
-    "aio_geojson_geonetnz_quakes==0.5"
+    "aio_geojson_geonetnz_quakes==0.9"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -115,7 +115,7 @@ adguardhome==0.2.1
 afsapi==0.0.4
 
 # homeassistant.components.geonetnz_quakes
-aio_geojson_geonetnz_quakes==0.5
+aio_geojson_geonetnz_quakes==0.9
 
 # homeassistant.components.ambient_station
 aioambient==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -43,7 +43,7 @@ YesssSMS==0.2.3
 adguardhome==0.2.1
 
 # homeassistant.components.geonetnz_quakes
-aio_geojson_geonetnz_quakes==0.5
+aio_geojson_geonetnz_quakes==0.9
 
 # homeassistant.components.ambient_station
 aioambient==0.3.1


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Update to aio_geojson_geonetnz_quakes v0.9 which depends on aio_geojson_client >= v0.7.

This fixes #25938 and also introduces a 10 second timeout when fetching data from the external feed.

**Related issue (if applicable):** fixes #25938

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
geonetnz_quakes:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
