### PR TITLE
Use canonical pre-commit black URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/python/black
+-   repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:
     -   id: black


### PR DESCRIPTION
## Description:

Trivial, black is in the psf, not python project.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
