### PR TITLE
Bump simplisafe-python to 4.3.0

### DIFF
--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/simplisafe",
   "requirements": [
-    "simplisafe-python==4.2.0"
+    "simplisafe-python==4.3.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1699,7 +1699,7 @@ shodan==1.13.0
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==4.2.0
+simplisafe-python==4.3.0
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -358,7 +358,7 @@ ring_doorbell==0.2.3
 rxv==0.6.0
 
 # homeassistant.components.simplisafe
-simplisafe-python==4.2.0
+simplisafe-python==4.3.0
 
 # homeassistant.components.sleepiq
 sleepyq==0.7


### PR DESCRIPTION
## Description:

This PR bumps `simplisafe-python` to 4.3.0. Changelog: https://github.com/bachya/simplisafe-python/releases/tag/4.3.0

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/25872

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
