### PR TITLE
Bump aioambient to 0.3.2

### DIFF
--- a/homeassistant/components/ambient_station/manifest.json
+++ b/homeassistant/components/ambient_station/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/ambient_station",
   "requirements": [
-    "aioambient==0.3.1"
+    "aioambient==0.3.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -118,7 +118,7 @@ afsapi==0.0.4
 aio_geojson_geonetnz_quakes==0.9
 
 # homeassistant.components.ambient_station
-aioambient==0.3.1
+aioambient==0.3.2
 
 # homeassistant.components.asuswrt
 aioasuswrt==1.1.21

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -46,7 +46,7 @@ adguardhome==0.2.1
 aio_geojson_geonetnz_quakes==0.9
 
 # homeassistant.components.ambient_station
-aioambient==0.3.1
+aioambient==0.3.2
 
 # homeassistant.components.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
##  Description:

This PR bumps `aioambient` to 0.3.2. Changelog: https://github.com/bachya/aioambient/releases/tag/0.3.2

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/24509

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
