### PR TITLE
Fix unnecessary db entries for metro_france

### DIFF
--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -121,7 +121,7 @@ def setup(hass, config):
             weather_alert_client.update_data()
         except VigilanceMeteoError as exp:
             _LOGGER.error(
-                "Unexpected error when creating the" "vigilance_meteoFrance proxy: %s ",
+                "Unexpected error when creating the vigilance_meteoFrance proxy: %s ",
                 exp,
             )
     else:

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -1,5 +1,5 @@
 """Support for Meteo-France weather service."""
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
 
 from homeassistant.components.weather import (
@@ -9,6 +9,7 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TIME,
     WeatherEntity,
 )
+import homeassistant.util.dt as dt_util
 from homeassistant.const import TEMP_CELSIUS
 
 from . import ATTRIBUTION, CONDITION_CLASSES, CONF_CITY, DATA_METEO_FRANCE
@@ -83,7 +84,9 @@ class MeteoFranceWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast."""
-        reftime = datetime.now().replace(hour=12, minute=00)
+        reftime = dt_util.now(dt_util.get_time_zone("Europe/Paris")).replace(
+            hour=12, minute=00, second=00, microsecond=00
+        )
         reftime += timedelta(hours=24)
         forecast_data = []
         for key in self._data["forecast"]:

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -84,10 +84,13 @@ class MeteoFranceWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast."""
-        reftime = dt_util.now(dt_util.get_time_zone("Europe/Paris")).replace(
-            hour=12, minute=00, second=00, microsecond=00
+        reftime = dt_util.as_utc(
+            dt_util.now(dt_util.get_time_zone("Europe/Paris")).replace(
+                hour=12, minute=00, second=00, microsecond=00
+            )
         )
         reftime += timedelta(hours=24)
+        _LOGGER.debug("reftime used for %s forecast: %s", self._data["name"], reftime)
         forecast_data = []
         for key in self._data["forecast"]:
             value = self._data["forecast"][key]

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -84,11 +84,7 @@ class MeteoFranceWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast."""
-        reftime = dt_util.as_utc(
-            dt_util.now(dt_util.get_time_zone("Europe/Paris")).replace(
-                hour=12, minute=00, second=00, microsecond=00
-            )
-        )
+        reftime = dt_util.utcnow().replace(hour=12, minute=0, second=0, microsecond=0)
         reftime += timedelta(hours=24)
         _LOGGER.debug("reftime used for %s forecast: %s", self._data["name"], reftime)
         forecast_data = []


### PR DESCRIPTION
##  Description:
 - Fix #25911 : unnecessary entries in db from weather platform in Météo-France component.
 - Correct typo in log messages.

**Related issue (if applicable):** fixes #25911 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable): N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed: N/A

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html