### PR TITLE
Remove zwave.update_config service call

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -564,11 +564,6 @@ async def async_setup_entry(hass, config_entry):
         _LOGGER.info("Z-Wave soft_reset have been initialized")
         network.controller.soft_reset()
 
-    def update_config(service):
-        """Update the config from git."""
-        _LOGGER.info("Configuration update has been initialized")
-        network.controller.update_ozw_config()
-
     def test_network(service):
         """Test the network by sending commands to all the nodes."""
         _LOGGER.info("Z-Wave test_network have been initialized")
@@ -891,7 +886,6 @@ async def async_setup_entry(hass, config_entry):
         hass.services.register(DOMAIN, const.SERVICE_CANCEL_COMMAND, cancel_command)
         hass.services.register(DOMAIN, const.SERVICE_HEAL_NETWORK, heal_network)
         hass.services.register(DOMAIN, const.SERVICE_SOFT_RESET, soft_reset)
-        hass.services.register(DOMAIN, const.SERVICE_UPDATE_CONFIG, update_config)
         hass.services.register(DOMAIN, const.SERVICE_TEST_NETWORK, test_network)
         hass.services.register(DOMAIN, const.SERVICE_STOP_NETWORK, stop_network)
         hass.services.register(

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -68,7 +68,6 @@ SERVICE_RENAME_VALUE = "rename_value"
 SERVICE_REFRESH_ENTITY = "refresh_entity"
 SERVICE_REFRESH_NODE = "refresh_node"
 SERVICE_RESET_NODE_METERS = "reset_node_meters"
-SERVICE_UPDATE_CONFIG = "update_config"
 
 EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 EVENT_NODE_EVENT = "zwave.node_event"

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -137,9 +137,6 @@ set_wakeup:
     value:
       description: Value of the interval to set. (integer)
 
-update_config:
-  description: Attempt to update ozw configuration files from git to support newer devices.
-
 start_network:
   description: Start the Z-Wave network. This might take a while, depending on how big your Z-Wave network is.
 


### PR DESCRIPTION
## Description:

The `zwave.update_config` service call uses a python-openzwave API to perform the update of the config files. The implementation of the config file update is broken in the home assistant fork. It should be removed to avoid confusion.

Due to a [bug in python-openzwave](https://github.com/OpenZWave/python-openzwave/issues/156), the service call never actually worked properly. I submitted an issue to the project and it was fixed, but the home assistant fork never pulled in the fix. The related issue referenced below was open for months with no action, so I ended up closing it. That worked out anyways, since then OZW 1.6 has been released and the config files have changed format. To pull in the upstream fix now would be a disaster since it downloads incompatible 1.6 config files (it simply downloads from the master branch of openzwave).

The main motivation to remove the service call is that occasionally I see mentions about it in Discord or the Community forums. Either users think it works when it doesn't, or they are confused as to why it doesn't work, so better to avoid the confusion. Other reasons:

1. OZW has stopped accepting device config updates for 1.4, therefore any recent install of ha-pyozw 1.4 (after April) has the latest config files, so there's nothing to update. 
2. OZW 1.6 introduced its own new API for updating config files, so an eventual update to python-openzwave would likely see this update mechanism change anyways.
3. The files that actually are downloaded (to the `config` subdir) are the incompatible 1.6 files, so attempting to use them would not work.



**Related issue (if applicable):** fixes #19893

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10139

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
