### PR TITLE
Add netgear_lte.disconnect_lte service

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -43,6 +43,7 @@ EVENT_SMS = "netgear_lte_sms"
 SERVICE_DELETE_SMS = "delete_sms"
 SERVICE_SET_OPTION = "set_option"
 SERVICE_CONNECT_LTE = "connect_lte"
+SERVICE_DISCONNECT_LTE = "disconnect_lte"
 
 ATTR_HOST = "host"
 ATTR_SMS_ID = "sms_id"
@@ -122,6 +123,8 @@ SET_OPTION_SCHEMA = vol.Schema(
 
 CONNECT_LTE_SCHEMA = vol.Schema({vol.Optional(ATTR_HOST): cv.string})
 
+DISCONNECT_LTE_SCHEMA = vol.Schema({vol.Optional(ATTR_HOST): cv.string})
+
 
 @attr.s
 class ModemData:
@@ -199,18 +202,20 @@ async def async_setup(hass, config):
                     await modem_data.modem.set_autoconnect_mode(autoconnect)
             elif service.service == SERVICE_CONNECT_LTE:
                 await modem_data.modem.connect_lte()
+            elif service.service == SERVICE_DISCONNECT_LTE:
+                await modem_data.modem.disconnect_lte()
 
-        hass.services.async_register(
-            DOMAIN, SERVICE_DELETE_SMS, service_handler, schema=DELETE_SMS_SCHEMA
-        )
+        service_schemas = {
+            SERVICE_DELETE_SMS: DELETE_SMS_SCHEMA,
+            SERVICE_SET_OPTION: SET_OPTION_SCHEMA,
+            SERVICE_CONNECT_LTE: CONNECT_LTE_SCHEMA,
+            SERVICE_DISCONNECT_LTE: DISCONNECT_LTE_SCHEMA,
+        }
 
-        hass.services.async_register(
-            DOMAIN, SERVICE_SET_OPTION, service_handler, schema=SET_OPTION_SCHEMA
-        )
-
-        hass.services.async_register(
-            DOMAIN, SERVICE_CONNECT_LTE, service_handler, schema=CONNECT_LTE_SCHEMA
-        )
+        for service, schema in service_schemas.items():
+            hass.services.async_register(
+                DOMAIN, service, service_handler, schema=schema
+            )
 
     netgear_lte_config = config[DOMAIN]
 

--- a/homeassistant/components/netgear_lte/manifest.json
+++ b/homeassistant/components/netgear_lte/manifest.json
@@ -3,7 +3,7 @@
   "name": "Netgear lte",
   "documentation": "https://www.home-assistant.io/components/netgear_lte",
   "requirements": [
-    "eternalegypt==0.0.8"
+    "eternalegypt==0.0.9"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/netgear_lte/services.yaml
+++ b/homeassistant/components/netgear_lte/services.yaml
@@ -27,3 +27,10 @@ connect_lte:
     host:
       description: The modem that should connect.
       example: 192.168.5.1
+
+disconnect_lte:
+  description: Ask the modem to close the LTE connection.
+  fields:
+    host:
+      description: The modem that should disconnect.
+      example: 192.168.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -458,7 +458,7 @@ epson-projector==0.1.3
 epsonprinter==0.0.9
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.8
+eternalegypt==0.0.9
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1


### PR DESCRIPTION
## Description:

This adds `netgear_lte.disconnect_lte` as requested [in the forum](https://community.home-assistant.io/t/netgear-lte-could-be-extended-to-allow-lte-connection-management/108520/13).

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10144

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html