### PR TITLE
Skip homekit_controller polls when system is overloaded and still trying to process the previous one

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -259,7 +259,9 @@ class HKDevice:
                 self._polling_lock_warned = True
             return
 
-        self._polling_lock_warned = False
+        if self._polling_lock_warned:
+            _LOGGER.info("HomeKit controller no longer detecting back pressure - not skipping poll")
+            self._polling_lock_warned = False
 
         async with self._polling_lock:
             _LOGGER.debug("Starting HomeKit controller update")

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -251,7 +251,9 @@ class HKDevice:
             return
 
         if self._polling_lock.locked():
-            _LOGGER.warning("HomeKit controller update skipped as previous poll still in flight")
+            _LOGGER.warning(
+                "HomeKit controller update skipped as previous poll still in flight"
+            )
             return
 
         async with self._polling_lock:

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -260,7 +260,9 @@ class HKDevice:
             return
 
         if self._polling_lock_warned:
-            _LOGGER.info("HomeKit controller no longer detecting back pressure - not skipping poll")
+            _LOGGER.info(
+                "HomeKit controller no longer detecting back pressure - not skipping poll"
+            )
             self._polling_lock_warned = False
 
         async with self._polling_lock:

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -105,6 +105,7 @@ class HKDevice:
 
         # Never allow concurrent polling of the same accessory or bridge
         self._polling_lock = asyncio.Lock()
+        self._polling_lock_warned = False
 
     def add_pollable_characteristics(self, characteristics):
         """Add (aid, iid) pairs that we need to poll."""
@@ -251,10 +252,14 @@ class HKDevice:
             return
 
         if self._polling_lock.locked():
-            _LOGGER.warning(
-                "HomeKit controller update skipped as previous poll still in flight"
-            )
+            if not self._polling_lock_warned:
+                _LOGGER.warning(
+                    "HomeKit controller update skipped as previous poll still in flight"
+                )
+                self._polling_lock_warned = True
             return
+
+        self._polling_lock_warned = False
 
         async with self._polling_lock:
             _LOGGER.debug("Starting HomeKit controller update")


### PR DESCRIPTION
## Description:

In #25178 we have a system with 75 HomeKit entities. A couple of pull requests ago I landed a change to massively reduce the thread pool usage for such a setup (a 15x5 setup like this now requires a poll for each pairing (15 pairings) rather than for each entity (75 entities). But we can still do more.

While we have connection timeouts in HomeKit with this many pairings a poor wifi connection to a device or a heavily loaded system with back pressure could find itself in a situation where more pollings are being queued than satisfied. In the worst cases a HA instance might not be able to recover.

This change places a lock around the update code, but rather than waiting for the lock we instead skip (and warn) polls if the lock is already held. On a normal system this will be a no-op. On a HA instance that is struggling it should avoid placing any more pressure on the thread pool.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]