### PR TITLE
Tweaks to options flow

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -187,8 +187,8 @@ class ConfigManagerAvailableFlowView(HomeAssistantView):
 class OptionManagerFlowIndexView(FlowManagerIndexView):
     """View to create option flows."""
 
-    url = "/api/config/config_entries/entry/option/flow"
-    name = "api:config:config_entries:entry:resource:option:flow"
+    url = "/api/config/config_entries/options/flow"
+    name = "api:config:config_entries:option:flow"
 
     # pylint: disable=arguments-differ
     async def post(self, request):

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -658,6 +658,12 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     CONNECTION_CLASS = CONN_CLASS_UNKNOWN
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        raise data_entry_flow.UnknownHandler
+
     @callback
     def _async_current_entries(self):
         """Return current entries."""
@@ -691,7 +697,11 @@ class OptionsFlowManager:
         entry = self.hass.config_entries.async_get_entry(entry_id)
         if entry is None:
             return
-        flow = HANDLERS[entry.domain].async_get_options_flow(entry.data, entry.options)
+
+        if entry.domain not in HANDLERS:
+            raise data_entry_flow.UnknownHandler
+
+        flow = HANDLERS[entry.domain].async_get_options_flow(entry)
         return flow
 
     async def _async_finish_flow(self, flow, result):
@@ -706,3 +716,9 @@ class OptionsFlowManager:
 
         result["result"] = True
         return result
+
+
+class OptionsFlow(data_entry_flow.FlowHandler):
+    """Base class for config option flows."""
+
+    pass

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -488,12 +488,8 @@ async def test_options_flow(hass, client):
     class TestFlow(core_ce.ConfigFlow):
         @staticmethod
         @callback
-        def async_get_options_flow(config, options):
+        def async_get_options_flow(config_entry):
             class OptionsFlowHandler(data_entry_flow.FlowHandler):
-                def __init__(self, config, options):
-                    self.config = config
-                    self.options = options
-
                 async def async_step_init(self, user_input=None):
                     schema = OrderedDict()
                     schema[vol.Required("enabled")] = bool
@@ -503,7 +499,7 @@ async def test_options_flow(hass, client):
                         description_placeholders={"enabled": "Set to true to be true"},
                     )
 
-            return OptionsFlowHandler(config, options)
+            return OptionsFlowHandler()
 
     MockConfigEntry(
         domain="test",
@@ -514,7 +510,7 @@ async def test_options_flow(hass, client):
     entry = hass.config_entries._entries[0]
 
     with patch.dict(HANDLERS, {"test": TestFlow}):
-        url = "/api/config/config_entries/entry/option/flow"
+        url = "/api/config/config_entries/options/flow"
         resp = await client.post(url, json={"handler": entry.entry_id})
 
     assert resp.status == 200
@@ -538,12 +534,8 @@ async def test_two_step_options_flow(hass, client):
     class TestFlow(core_ce.ConfigFlow):
         @staticmethod
         @callback
-        def async_get_options_flow(config, options):
+        def async_get_options_flow(config_entry):
             class OptionsFlowHandler(data_entry_flow.FlowHandler):
-                def __init__(self, config, options):
-                    self.config = config
-                    self.options = options
-
                 async def async_step_init(self, user_input=None):
                     return self.async_show_form(
                         step_id="finish", data_schema=vol.Schema({"enabled": bool})
@@ -554,7 +546,7 @@ async def test_two_step_options_flow(hass, client):
                         title="Enable disable", data=user_input
                     )
 
-            return OptionsFlowHandler(config, options)
+            return OptionsFlowHandler()
 
     MockConfigEntry(
         domain="test",
@@ -565,7 +557,7 @@ async def test_two_step_options_flow(hass, client):
     entry = hass.config_entries._entries[0]
 
     with patch.dict(HANDLERS, {"test": TestFlow}):
-        url = "/api/config/config_entries/entry/option/flow"
+        url = "/api/config/config_entries/options/flow"
         resp = await client.post(url, json={"handler": entry.entry_id})
 
         assert resp.status == 200

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -666,12 +666,11 @@ async def test_entry_options(hass, manager):
     class TestFlow:
         @staticmethod
         @callback
-        def async_get_options_flow(config, options):
+        def async_get_options_flow(config_entry):
             class OptionsFlowHandler(data_entry_flow.FlowHandler):
-                def __init__(self, config, options):
-                    pass
+                pass
 
-            return OptionsFlowHandler(config, options)
+            return OptionsFlowHandler()
 
     config_entries.HANDLERS["test"] = TestFlow()
     flow = await manager.options._async_create_flow(


### PR DESCRIPTION
## Description:
Adding UI to options flow showed some small tweaks we should do to the options flow initialization.

 - [Gist with example options flow](https://gist.github.com/balloob/f0c433d10d4f0f003cb2cccb08d9901f)
 - [Frontend PR](https://github.com/home-assistant/home-assistant-polymer/pull/3491)
 - [Dev Docs PR](https://github.com/home-assistant/developers.home-assistant/pull/303)

CC @Kane610 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
