### PR TITLE
Fix ecobee preset and add climate mode back

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -304,7 +304,7 @@ class Thermostat(ClimateDevice):
                 self.vacation = event["name"]
                 return PRESET_VACATION
 
-        return None
+        return self._preset_modes[self.thermostat["program"]["currentClimateRef"]]
 
     @property
     def hvac_mode(self):
@@ -357,6 +357,9 @@ class Thermostat(ClimateDevice):
         status = self.thermostat["equipmentStatus"]
         return {
             "fan": self.fan,
+            "climate_mode": self._preset_modes[
+                self.thermostat["program"]["currentClimateRef"]
+            ],
             "equipment_running": status,
             "fan_min_on_time": self.thermostat["settings"]["fanMinOnTime"],
         }

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -131,6 +131,7 @@ class TestEcobee(unittest.TestCase):
         self.ecobee["equipmentStatus"] = "heatPump2"
         assert {
             "fan": "off",
+            "climate_mode": "Climate1",
             "fan_min_on_time": 10,
             "equipment_running": "heatPump2",
         } == self.thermostat.device_state_attributes
@@ -138,18 +139,21 @@ class TestEcobee(unittest.TestCase):
         self.ecobee["equipmentStatus"] = "auxHeat2"
         assert {
             "fan": "off",
+            "climate_mode": "Climate1",
             "fan_min_on_time": 10,
             "equipment_running": "auxHeat2",
         } == self.thermostat.device_state_attributes
         self.ecobee["equipmentStatus"] = "compCool1"
         assert {
             "fan": "off",
+            "climate_mode": "Climate1",
             "fan_min_on_time": 10,
             "equipment_running": "compCool1",
         } == self.thermostat.device_state_attributes
         self.ecobee["equipmentStatus"] = ""
         assert {
             "fan": "off",
+            "climate_mode": "Climate1",
             "fan_min_on_time": 10,
             "equipment_running": "",
         } == self.thermostat.device_state_attributes
@@ -157,6 +161,15 @@ class TestEcobee(unittest.TestCase):
         self.ecobee["equipmentStatus"] = "Unknown"
         assert {
             "fan": "off",
+            "climate_mode": "Climate1",
+            "fan_min_on_time": 10,
+            "equipment_running": "Unknown",
+        } == self.thermostat.device_state_attributes
+
+        self.ecobee["program"]["currentClimateRef"] = "c2"
+        assert {
+            "fan": "off",
+            "climate_mode": "Climate2",
             "fan_min_on_time": 10,
             "equipment_running": "Unknown",
         } == self.thermostat.device_state_attributes


### PR DESCRIPTION
## Description:
If no override is active, set current Ecobee preset to the activate climate program.

Add back the `climate_mode` attribute. This attribute represents the climate mode that is active or would be active if no override is active.

**Related issue (if applicable):** fixes #25833


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
