### PR TITLE
Fix config entry has options check

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -59,7 +59,8 @@ class ConfigManagerEntryIndexView(HomeAssistantView):
         for entry in hass.config_entries.async_entries():
             handler = config_entries.HANDLERS.get(entry.domain)
             supports_options = (
-                hasattr(handler, "async_get_options_flow")
+                # Guard in case handler is no longer registered (custom compnoent etc)
+                handler is not None
                 # pylint: disable=comparison-with-callable
                 and handler.async_get_options_flow
                 != config_entries.ConfigFlow.async_get_options_flow

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -19,7 +19,7 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
         title: str,
         discovery_function: DiscoveryFunctionType,
         connection_class: str,
-    ):
+    ) -> None:
         """Initialize the discovery config flow."""
         self._domain = domain
         self._title = title
@@ -90,7 +90,7 @@ def register_discovery_flow(
     class DiscoveryFlow(DiscoveryFlowHandler):
         """Discovery flow handler."""
 
-        def __init__(self):
+        def __init__(self) -> None:
             super().__init__(domain, title, discovery_function, connection_class)
 
     config_entries.HANDLERS.register(domain)(DiscoveryFlow)
@@ -107,7 +107,7 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
         title: str,
         description_placeholder: dict,
         allow_multiple: bool,
-    ):
+    ) -> None:
         """Initialize the discovery config flow."""
         self._domain = domain
         self._title = title
@@ -150,7 +150,7 @@ def register_webhook_flow(
     class WebhookFlow(WebhookFlowHandler):
         """Webhook flow handler."""
 
-        def __init__(self):
+        def __init__(self) -> None:
             super().__init__(domain, title, description_placeholder, allow_multiple)
 
     config_entries.HANDLERS.register(domain)(WebhookFlow)

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -1,29 +1,8 @@
 """Helpers for data entry flows for config entries."""
-from functools import partial
-
 from homeassistant import config_entries
 from .typing import HomeAssistantType
 
-
 # mypy: allow-untyped-defs
-
-
-def register_discovery_flow(domain, title, discovery_function, connection_class):
-    """Register flow for discovered integrations that not require auth."""
-    config_entries.HANDLERS.register(domain)(
-        partial(
-            DiscoveryFlowHandler, domain, title, discovery_function, connection_class
-        )
-    )
-
-
-def register_webhook_flow(domain, title, description_placeholder, allow_multiple=False):
-    """Register flow for webhook integrations."""
-    config_entries.HANDLERS.register(domain)(
-        partial(
-            WebhookFlowHandler, domain, title, description_placeholder, allow_multiple
-        )
-    )
 
 
 class DiscoveryFlowHandler(config_entries.ConfigFlow):
@@ -91,6 +70,18 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
         return self.async_create_entry(title=self._title, data={})
 
 
+def register_discovery_flow(domain, title, discovery_function, connection_class):
+    """Register flow for discovered integrations that not require auth."""
+
+    class DiscoveryFlow(DiscoveryFlowHandler):
+        """Discovery flow handler."""
+
+        def __init__(self):
+            super().__init__(domain, title, discovery_function, connection_class)
+
+    config_entries.HANDLERS.register(domain)(DiscoveryFlow)
+
+
 class WebhookFlowHandler(config_entries.ConfigFlow):
     """Handle a webhook config flow."""
 
@@ -129,6 +120,18 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
             data={"webhook_id": webhook_id, "cloudhook": cloudhook},
             description_placeholders=self._description_placeholder,
         )
+
+
+def register_webhook_flow(domain, title, description_placeholder, allow_multiple=False):
+    """Register flow for webhook integrations."""
+
+    class WebhookFlow(WebhookFlowHandler):
+        """Webhook flow handler."""
+
+        def __init__(self):
+            super().__init__(domain, title, description_placeholder, allow_multiple)
+
+    config_entries.HANDLERS.register(domain)(WebhookFlow)
 
 
 async def webhook_async_remove_entry(

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -1,8 +1,11 @@
 """Helpers for data entry flows for config entries."""
+from typing import Callable, Awaitable, Union
 from homeassistant import config_entries
 from .typing import HomeAssistantType
 
 # mypy: allow-untyped-defs
+
+DiscoveryFunctionType = Callable[[], Union[Awaitable[bool], bool]]
 
 
 class DiscoveryFlowHandler(config_entries.ConfigFlow):
@@ -10,7 +13,13 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
     VERSION = 1
 
-    def __init__(self, domain, title, discovery_function, connection_class):
+    def __init__(
+        self,
+        domain: str,
+        title: str,
+        discovery_function: DiscoveryFunctionType,
+        connection_class: str,
+    ):
         """Initialize the discovery config flow."""
         self._domain = domain
         self._title = title
@@ -70,7 +79,12 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
         return self.async_create_entry(title=self._title, data={})
 
 
-def register_discovery_flow(domain, title, discovery_function, connection_class):
+def register_discovery_flow(
+    domain: str,
+    title: str,
+    discovery_function: DiscoveryFunctionType,
+    connection_class: str,
+) -> None:
     """Register flow for discovered integrations that not require auth."""
 
     class DiscoveryFlow(DiscoveryFlowHandler):
@@ -87,7 +101,13 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
 
     VERSION = 1
 
-    def __init__(self, domain, title, description_placeholder, allow_multiple):
+    def __init__(
+        self,
+        domain: str,
+        title: str,
+        description_placeholder: dict,
+        allow_multiple: bool,
+    ):
         """Initialize the discovery config flow."""
         self._domain = domain
         self._title = title
@@ -122,7 +142,9 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
         )
 
 
-def register_webhook_flow(domain, title, description_placeholder, allow_multiple=False):
+def register_webhook_flow(
+    domain: str, title: str, description_placeholder: dict, allow_multiple: bool = False
+) -> None:
     """Register flow for webhook integrations."""
 
     class WebhookFlow(WebhookFlowHandler):


### PR DESCRIPTION
## Description:
When I tweaked the flow options, I added a fallback method that raised a method. However, that caused our `supports_options` check to be updated, and that ended up not working with partials, which is what webhook flow handlers generate.

This fixes the check.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
