### PR TITLE
Hue tweak registered device type + discovery exception

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -458,7 +458,7 @@ class AuthManager:
             result["data"]
         )
 
-        if flow.context is not None and flow.context.get("credential_only"):
+        if flow.context.get("credential_only"):
             result["result"] = credentials
             return result
 

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -166,7 +166,7 @@ async def get_bridge(hass, host, username=None):
         with async_timeout.timeout(10):
             # Create username if we don't have one
             if not username:
-                await bridge.create_user("home-assistant")
+                await bridge.create_user(f"home-assistant#{hass.config.location_name}")
             # Initialize bridge (and validate our username)
             await bridge.initialize()
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -62,7 +62,7 @@ class HueFlowHandler(config_entries.ConfigFlow):
     async def async_step_init(self, user_input=None):
         """Handle a flow start."""
         if user_input is not None:
-            self.host = user_input["host"]
+            self.host = self.context["host"] = user_input["host"]
             return await self.async_step_link()
 
         websession = aiohttp_client.async_get_clientsession(self.hass)
@@ -141,10 +141,11 @@ class HueFlowHandler(config_entries.ConfigFlow):
         if "HASS Bridge" in discovery_info.get("name", ""):
             return self.async_abort(reason="already_configured")
 
-        # pylint: disable=unsupported-assignment-operation
         host = self.context["host"] = discovery_info.get("host")
 
-        if any(host == flow["context"]["host"] for flow in self._async_in_progress()):
+        if any(
+            host == flow["context"].get("host") for flow in self._async_in_progress()
+        ):
             return self.async_abort(reason="already_in_progress")
 
         if host in configured_hosts(self.hass):
@@ -166,10 +167,11 @@ class HueFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_homekit(self, homekit_info):
         """Handle HomeKit discovery."""
-        # pylint: disable=unsupported-assignment-operation
         host = self.context["host"] = homekit_info.get("host")
 
-        if any(host == flow["context"]["host"] for flow in self._async_in_progress()):
+        if any(
+            host == flow["context"].get("host") for flow in self._async_in_progress()
+        ):
             return self.async_abort(reason="already_in_progress")
 
         if host in configured_hosts(self.hass):
@@ -192,7 +194,7 @@ class HueFlowHandler(config_entries.ConfigFlow):
         and create an entry. Otherwise we will delegate to `link` step which
         will ask user to link the bridge.
         """
-        host = import_info["host"]
+        host = self.context["host"] = import_info["host"]
         path = import_info.get("path")
 
         if path is not None:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -179,7 +179,7 @@ class FlowHandler:
     hass: Optional[HomeAssistant] = None
     handler = None
     cur_step: Optional[Dict[str, str]] = None
-    context: Optional[Dict] = None
+    context: Dict
 
     # Set by _async_create_flow callback
     init_step = "init"

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -255,6 +255,7 @@ async def test_import_with_existing_config(hass):
     """Test importing a host with an existing config file."""
     flow = config_flow.HueFlowHandler()
     flow.hass = hass
+    flow.context = {}
 
     bridge = Mock()
     bridge.username = "username-abc"
@@ -280,6 +281,7 @@ async def test_import_with_no_config(hass):
     """Test importing a host without an existing config file."""
     flow = config_flow.HueFlowHandler()
     flow.hass = hass
+    flow.context = {}
 
     with patch.object(
         config_flow, "get_bridge", side_effect=errors.AuthenticationRequired
@@ -294,6 +296,7 @@ async def test_import_with_existing_but_invalid_config(hass):
     """Test importing a host with a config file with invalid username."""
     flow = config_flow.HueFlowHandler()
     flow.hass = hass
+    flow.context = {}
 
     with patch.object(
         config_flow, "_find_username_from_config", return_value="mock-user"
@@ -310,6 +313,7 @@ async def test_import_cannot_connect(hass):
     """Test importing a host that we cannot conncet to."""
     flow = config_flow.HueFlowHandler()
     flow.hass = hass
+    flow.context = {}
 
     with patch.object(config_flow, "get_bridge", side_effect=errors.CannotConnect):
         result = await flow.async_step_import({"host": "0.0.0.0"})
@@ -337,6 +341,7 @@ async def test_creating_entry_removes_entries_for_same_host_or_bridge(hass):
 
     flow = config_flow.HueFlowHandler()
     flow.hass = hass
+    flow.context = {}
 
     bridge = Mock()
     bridge.username = "username-abc"

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -80,6 +80,7 @@ async def test_discovery_single_instance(hass, discovery_flow_conf, source):
     """Test we not allow duplicates."""
     flow = config_entries.HANDLERS["test"]()
     flow.hass = hass
+    flow.context = {}
 
     MockConfigEntry(domain="test").add_to_hass(hass)
     result = await getattr(flow, "async_step_{}".format(source))({})
@@ -93,6 +94,7 @@ async def test_discovery_confirmation(hass, discovery_flow_conf, source):
     """Test we ask for confirmation via discovery."""
     flow = config_entries.HANDLERS["test"]()
     flow.hass = hass
+    flow.context = {}
 
     result = await getattr(flow, "async_step_{}".format(source))({})
 


### PR DESCRIPTION
## Description:
- Fix registered device type to be according to the Hue API requirements
- Fix where discovery of Hue could cause looking up a host key in context that didn't exist.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
