### PR TITLE
Guard against unavailable climate entities

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -264,7 +264,9 @@ class ClimateCapabilities(AlexaEntity):
     def interfaces(self):
         """Yield the supported interfaces."""
         # If we support two modes, one being off, we allow turning on too.
-        if climate.HVAC_MODE_OFF in self.entity.attributes[climate.ATTR_HVAC_MODES]:
+        if climate.HVAC_MODE_OFF in self.entity.attributes.get(
+            climate.ATTR_HVAC_MODES, []
+        ):
             yield AlexaPowerController(self.entity)
 
         yield AlexaThermostatController(self.hass, self.entity)


### PR DESCRIPTION
## Description:
Alexa would crash when a climate entity would have the unavailable status.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

