### PR TITLE
Add arbitrary netgear_lte sensors

### DIFF
--- a/homeassistant/components/netgear_lte/__init__.py
+++ b/homeassistant/components/netgear_lte/__init__.py
@@ -67,7 +67,15 @@ SENSOR_SCHEMA = vol.Schema(
     {
         vol.Optional(
             CONF_MONITORED_CONDITIONS, default=sensor_types.DEFAULT_SENSORS
-        ): vol.All(cv.ensure_list, [vol.In(sensor_types.ALL_SENSORS)])
+        ): vol.All(
+            cv.ensure_list,
+            [
+                vol.Any(
+                    vol.In(sensor_types.ALL_SENSORS),
+                    cv.matches_regex(r"^([a-z0-9]+\.)+[a-z0-9]+$"),
+                )
+            ],
+        )
     }
 )
 


### PR DESCRIPTION
## Description:

I keep getting requests for new netgear_lte sensors. Since a modem provides 100+ values that someone might find interesting, this adds a generic way to select any value. These are flattened JSON keys with dot as path separator.

The hardcoded list is still around. This is both to avoid a breaking change and because it is nice to have well-known and easy names for some common values.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10151

## Example entry for `configuration.yaml` (if applicable):
```yaml
netgear_lte:
  - host: !secret lb2120_hostname
    password: !secret lb2120_password
    sensor:
      monitored_conditions:
        - sms
        - usage
        - wwan.signalstrength.bars
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
