### PR TITLE
UniFi config entry options

### DIFF
--- a/homeassistant/components/unifi/.translations/en.json
+++ b/homeassistant/components/unifi/.translations/en.json
@@ -1,26 +1,43 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Controller site is already configured",
-            "user_privilege": "User needs to be administrator"
+        "title": "UniFi Controller",
+        "step": {
+            "user": {
+                "title": "Set up UniFi Controller",
+                "data": {
+                    "host": "Host",
+                    "username": "User name",
+                    "password": "Password",
+                    "port": "Port",
+                    "site": "Site ID",
+                    "verify_ssl": "Controller using proper certificate"
+                }
+            }
         },
         "error": {
             "faulty_credentials": "Bad user credentials",
             "service_unavailable": "No service available"
         },
+        "abort": {
+            "already_configured": "Controller site is already configured",
+            "user_privilege": "User needs to be administrator"
+        }
+    },
+    "options": {
         "step": {
-            "user": {
+            "init": {
                 "data": {
-                    "host": "Host",
-                    "password": "Password",
-                    "port": "Port",
-                    "site": "Site ID",
-                    "username": "User name",
-                    "verify_ssl": "Controller using proper certificate"
-                },
-                "title": "Set up UniFi Controller"
+                    "show_things": "Show Things"
+                }
+            },
+            "device_tracker": {
+                "description": "Configure UniFi device tracker",
+                "data": {
+                    "ap_mac": "Enable attribute showing which access point client is connected to",
+                    "last_seen": "Enable attribute showing the time client was last seen",
+                    "rx_tx": "Enable attribute showing client bandwidth usage"
+                }
             }
-        },
-        "title": "UniFi Controller"
+        }
     }
 }

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -2,6 +2,7 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.core import callback
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -25,6 +26,12 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return UnifiOptionsFlowHandler(config_entry)
 
     def __init__(self):
         """Initialize the UniFi flow."""
@@ -142,3 +149,38 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
         self.desc = import_config[CONF_SITE_ID]
 
         return await self.async_step_user(user_input=config)
+
+
+class UnifiOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Unifi options."""
+
+    def __init__(self, config_entry):
+        """Initialize UniFi options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the UniFi options."""
+        return await self.async_step_device_tracker()
+
+    async def async_step_device_tracker(self, user_input=None):
+        """Manage the device tracker options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="device_tracker",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "ap_mac", default=self.config_entry.options.get("ap_mac", False)
+                    ): bool,
+                    vol.Optional(
+                        "last_seen",
+                        default=self.config_entry.options.get("last_seen", False),
+                    ): bool,
+                    vol.Optional(
+                        "rx_tx", default=self.config_entry.options.get("rx_tx", False)
+                    ): bool,
+                }
+            ),
+        )

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -22,5 +22,23 @@
             "already_configured": "Controller site is already configured",
             "user_privilege": "User needs to be administrator"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Configure UniFi device tracker",
+                "data": {
+                    "show_things": "Show Things"
+                }
+            },
+            "device_tracker": {
+                "title": "Configure UniFi device tracker",
+                "data": {
+                    "ap_mac": "Enable attribute showing which access point client is connected to",
+                    "last_seen": "Enable attribute showing the time client was last seen",
+                    "rx_tx": "Enable attribute showing client bandwidth usage"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
