### PR TITLE
Upgrade voluptuous-serialize to 2.2.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ pyyaml==5.1.2
 requests==2.22.0
 ruamel.yaml==0.15.99
 sqlalchemy==1.3.7
-voluptuous-serialize==2.1.0
+voluptuous-serialize==2.2.0
 voluptuous==0.11.7
 zeroconf==0.23.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -17,7 +17,7 @@ pyyaml==5.1.2
 requests==2.22.0
 ruamel.yaml==0.15.99
 voluptuous==0.11.7
-voluptuous-serialize==2.1.0
+voluptuous-serialize==2.2.0
 
 # homeassistant.components.nuimo_controller
 --only-binary=all nuimo==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ REQUIRES = [
     "requests==2.22.0",
     "ruamel.yaml==0.15.99",
     "voluptuous==0.11.7",
-    "voluptuous-serialize==2.1.0",
+    "voluptuous-serialize==2.2.0",
 ]
 
 MIN_PY_VERSION = ".".join(map(str, hass_const.REQUIRED_PYTHON_VER))


### PR DESCRIPTION
## Description:
Changelog: https://github.com/balloob/voluptuous-serialize/releases/tag/2.2.0

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
