### PR TITLE
Upgrade luftdaten to 0.6.3

### DIFF
--- a/homeassistant/components/luftdaten/manifest.json
+++ b/homeassistant/components/luftdaten/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/luftdaten",
   "requirements": [
-    "luftdaten==0.6.2"
+    "luftdaten==0.6.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -753,7 +753,7 @@ logi_circle==0.2.2
 london-tube-status==0.2
 
 # homeassistant.components.luftdaten
-luftdaten==0.6.2
+luftdaten==0.6.3
 
 # homeassistant.components.lupusec
 lupupy==0.0.17

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -205,7 +205,7 @@ libpurecool==0.5.0
 libsoundtouch==0.7.2
 
 # homeassistant.components.luftdaten
-luftdaten==0.6.2
+luftdaten==0.6.3
 
 # homeassistant.components.mythicbeastsdns
 mbddns==0.1.2


### PR DESCRIPTION
## Description:
Changelog: https://github.com/fabaff/python-luftdaten/releases/tag/0.6.3

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
