### PR TITLE
Fix bmw_connected_drive and eq3btsmart components by updating their dependencies  

### DIFF
--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bmw connected drive",
   "documentation": "https://www.home-assistant.io/components/bmw_connected_drive",
   "requirements": [
-    "bimmer_connected==0.5.3"
+    "bimmer_connected==0.5.6"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/eq3btsmart/manifest.json
+++ b/homeassistant/components/eq3btsmart/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://www.home-assistant.io/components/eq3btsmart",
   "requirements": [
     "construct==2.9.45",
-    "python-eq3bt==0.1.9"
+    "python-eq3bt==0.1.11"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -266,7 +266,7 @@ beautifulsoup4==4.7.1
 bellows-homeassistant==0.9.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.5.3
+bimmer_connected==0.5.6
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1
@@ -1446,7 +1446,7 @@ python-digitalocean==1.13.2
 python-ecobee-api==0.0.21
 
 # homeassistant.components.eq3btsmart
-# python-eq3bt==0.1.9
+# python-eq3bt==0.1.11
 
 # homeassistant.components.etherscan
 python-etherscan-api==0.0.3


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Fix bmw_connected_drive and eq3btsmart components by updating their dependencies  

**Related issue (if applicable):

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):

## Example entry for `configuration.yaml` (if applicable):
None changed

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.
  - [ x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html