### PR TITLE
Fix Emulated Hue AttributeError: 'NoneType' object has no attribute '…

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -197,16 +197,16 @@ class HueOneLightStateView(HomeAssistantView):
             return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
 
         hass = request.app["hass"]
-        entity_id = self.config.number_to_entity_id(entity_id)
+        hass_entity_id = self.config.number_to_entity_id(entity_id)
 
-        if entity_id is None:
+        if hass_entity_id is None:
             _LOGGER.error("Entity not found: %s", entity_id)
             return web.Response(text="Entity not found", status=404)
 
-        entity = hass.states.get(entity_id)
+        entity = hass.states.get(hass_entity_id)
 
         if entity is None:
-            _LOGGER.error("Entity not found: %s", entity_id)
+            _LOGGER.error("Entity not found: %s", hass_entity_id)
             return web.Response(text="Entity not found", status=404)
 
         if not self.config.is_entity_exposed(entity):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -200,7 +200,10 @@ class HueOneLightStateView(HomeAssistantView):
         hass_entity_id = self.config.number_to_entity_id(entity_id)
 
         if hass_entity_id is None:
-            _LOGGER.error("Entity not found: %s", entity_id)
+            _LOGGER.error(
+                "Unknown entity number: %s not found in emulated_hue_ids.json",
+                entity_id,
+            )
             return web.Response(text="Entity not found", status=404)
 
         entity = hass.states.get(hass_entity_id)

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -198,6 +198,11 @@ class HueOneLightStateView(HomeAssistantView):
 
         hass = request.app["hass"]
         entity_id = self.config.number_to_entity_id(entity_id)
+
+        if entity_id is None:
+            _LOGGER.error("Entity not found: %s", entity_id)
+            return web.Response(text="Entity not found", status=404)
+
         entity = hass.states.get(entity_id)
 
         if entity is None:


### PR DESCRIPTION
# Description:
Fix crash if a device tries to check the state of a non-existing entry

**Related issue (if applicable):** fixes #24728


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
