### PR TITLE
Tone down huawei_lte logging

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -101,8 +101,8 @@ class RouterData:
             if debugging or path in self._subscriptions:
                 try:
                     setattr(self, path, func())
-                except ResponseErrorNotSupportedException as ex:
-                    _LOGGER.warning("%s not supported by device", path, exc_info=ex)
+                except ResponseErrorNotSupportedException:
+                    _LOGGER.warning("%s not supported by device", path)
                     self._subscriptions.discard(path)
                 finally:
                     _LOGGER.debug("%s=%s", path, getattr(self, path))

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -2,6 +2,7 @@
 from typing import Any, Dict, List, Optional
 
 import attr
+import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -9,9 +10,12 @@ from homeassistant.components.device_tracker import PLATFORM_SCHEMA, DeviceScann
 from homeassistant.const import CONF_URL
 from . import DATA_KEY, RouterData
 
+
+_LOGGER = logging.getLogger(__name__)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_URL): cv.url})
 
-HOSTS_PATH = "wlan_host_list.Hosts"
+HOSTS_PATH = "wlan_host_list.Hosts.Host"
 
 
 def get_scanner(hass, config):
@@ -32,11 +36,12 @@ class HuaweiLteScanner(DeviceScanner):
     def scan_devices(self) -> List[str]:
         """Scan for devices."""
         self.data.update()
-        self._hosts = {
-            x["MacAddress"]: x
-            for x in self.data[HOSTS_PATH + ".Host"]
-            if x.get("MacAddress")
-        }
+        try:
+            self._hosts = {
+                x["MacAddress"]: x for x in self.data[HOSTS_PATH] if x.get("MacAddress")
+            }
+        except KeyError:
+            _LOGGER.debug("%s not in data", HOSTS_PATH)
         return list(self._hosts)
 
     def get_device_name(self, device: str) -> Optional[str]:

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -1,8 +1,8 @@
 """Support for device tracking of Huawei LTE routers."""
+import logging
 from typing import Any, Dict, List, Optional
 
 import attr
-import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -203,7 +203,7 @@ class HuaweiLteSensor(Entity):
         try:
             value = self.data[self.path]
         except KeyError:
-            _LOGGER.warning("%s not in data", self.path)
+            _LOGGER.debug("%s not in data", self.path)
             value = None
 
         formatter = self.meta.get("formatter")


### PR DESCRIPTION
## Description:

Do not output tracebacks for expected "not supported" exceptions, handle missing wlan_host_list data more gracefully, log  missing data values on debug level.

Makes the experience smoother especially with USB modem sticks, quite probably other devices with no requested data.

**Related issue (if applicable):** #23809

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
