### PR TITLE
Remove reference to typing.Deque (added in Python 3.6.1)

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -314,7 +314,8 @@ class Camera(Entity):
         """Initialize a camera."""
         self.is_streaming = False
         self.content_type = DEFAULT_CONTENT_TYPE
-        self.access_tokens = collections.deque([], 2)
+        # Cannot properly type the following line until Python 3.6.1
+        self.access_tokens = collections.deque([], 2)  # type: ignore
         self.async_update_token()
 
     @property

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -314,8 +314,7 @@ class Camera(Entity):
         """Initialize a camera."""
         self.is_streaming = False
         self.content_type = DEFAULT_CONTENT_TYPE
-        # Cannot properly type the following line until Python 3.6.1
-        self.access_tokens = collections.deque([], 2)  # type: ignore
+        self.access_tokens: collections.deque = collections.deque([], 2)
         self.async_update_token()
 
     @property

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 import logging
 import hashlib
 from random import SystemRandom
-from typing import Deque
 
 import attr
 from aiohttp import web
@@ -315,7 +314,7 @@ class Camera(Entity):
         """Initialize a camera."""
         self.is_streaming = False
         self.content_type = DEFAULT_CONTENT_TYPE
-        self.access_tokens: Deque[str] = collections.deque([], 2)
+        self.access_tokens = collections.deque([], 2)
         self.async_update_token()
 
     @property


### PR DESCRIPTION
## Description:
The setup script claims a minimum Python version of 3.6.0, but when I run with Python 3.6.0 it chokes on an import of `Deque` from the `typing` module, since that was added in 3.6.1. This PR removes the import.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
