### PR TITLE
Fix background crash in sisyphus integration

### DIFF
--- a/homeassistant/components/sisyphus/__init__.py
+++ b/homeassistant/components/sisyphus/__init__.py
@@ -35,7 +35,7 @@ async def async_setup(hass, config):
         """Filters out excessively verbose logs from SocketIO."""
 
         def filter(self, record):
-            if record.msg.contains("waiting for connection"):
+            if "waiting for connection" in record.msg:
                 return False
             return True
 


### PR DESCRIPTION
## Description:
I think I was thinking in another language, since this was not valid Python. Result was that the thread that maintained the SocketIO connection to the table would die early on, so no status updates were actually flowing from the table.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
