### PR TITLE
Upgrade sisyphus-control to 2.2.1

### DIFF
--- a/homeassistant/components/sisyphus/manifest.json
+++ b/homeassistant/components/sisyphus/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sisyphus",
   "documentation": "https://www.home-assistant.io/components/sisyphus",
   "requirements": [
-    "sisyphus-control==2.2"
+    "sisyphus-control==2.2.1"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1699,7 +1699,7 @@ simplepush==1.1.4
 simplisafe-python==4.3.0
 
 # homeassistant.components.sisyphus
-sisyphus-control==2.2
+sisyphus-control==2.2.1
 
 # homeassistant.components.skybell
 skybellpy==0.4.0


### PR DESCRIPTION
## Description:
This picks up a bugfix for a crash on shutdown, so that the `sisyphus`
component can now shut down cleanly.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
