### PR TITLE
Add new integration for Jandy iAqualink pool control

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -286,6 +286,7 @@ omit =
     homeassistant/components/hydrawise/*
     homeassistant/components/hyperion/light.py
     homeassistant/components/ialarm/alarm_control_panel.py
+    homeassistant/components/iaqualink/climate.py
     homeassistant/components/icloud/device_tracker.py
     homeassistant/components/idteck_prox/*
     homeassistant/components/ifttt/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -128,6 +128,7 @@ homeassistant/components/http/* @home-assistant/core
 homeassistant/components/huawei_lte/* @scop
 homeassistant/components/huawei_router/* @abmantis
 homeassistant/components/hue/* @balloob
+homeassistant/components/iaqualink/* @flz
 homeassistant/components/ign_sismologia/* @exxamalte
 homeassistant/components/incomfort/* @zxdavb
 homeassistant/components/influxdb/* @fabaff

--- a/homeassistant/components/iaqualink/.translations/en.json
+++ b/homeassistant/components/iaqualink/.translations/en.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "title": "Jandy iAqualink",
+    "step": {
+      "user": {
+        "title": "Connect to iAqualink",
+        "description": "Please enter the username and password for your iAqualink account.",
+        "data": {
+          "username": "Username / Email Address",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "connection_failure": "Unable to connect to iAqualink. Check your username and password."
+    },
+    "abort": {
+      "already_setup": "You can only configure a single iAqualink connection."
+    }
+  }
+}

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -5,7 +5,6 @@ import logging
 from aiohttp import CookieJar
 import voluptuous as vol
 
-
 from iaqualink import AqualinkClient, AqualinkLoginException, AqualinkThermostat
 
 from homeassistant import config_entries
@@ -42,7 +41,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> None:
     conf = config.get(DOMAIN)
 
     hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][ATTR_CONFIG] = conf
 
     if conf is not None:
         hass.async_create_task(
@@ -67,9 +65,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
     try:
         await aqualink.login()
     except AqualinkLoginException as login_exception:
-        _LOGGER.error(
-            "Exception raised while attempting to login: %s", str(login_exception)
-        )
+        _LOGGER.error("Exception raised while attempting to login: %s", login_exception)
         return False
 
     systems = await aqualink.get_systems()

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -1,0 +1,107 @@
+"""Component to embed Aqualink devices."""
+import asyncio
+import logging
+
+from aiohttp import CookieJar
+import voluptuous as vol
+
+
+from iaqualink import AqualinkClient, AqualinkLoginException, AqualinkThermostat
+
+from homeassistant import config_entries
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+
+from .const import DOMAIN
+
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_CONFIG = "config"
+PARALLEL_UPDATES = 0
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> None:
+    """Set up the Aqualink component."""
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][ATTR_CONFIG] = conf
+
+    if conf is not None:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=conf
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None:
+    """Set up Aqualink from a config entry."""
+    username = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+
+    # These will contain the initialized devices
+    climates = hass.data[DOMAIN][CLIMATE_DOMAIN] = []
+
+    session = async_create_clientsession(hass, cookie_jar=CookieJar(unsafe=True))
+    aqualink = AqualinkClient(username, password, session)
+    try:
+        await aqualink.login()
+    except AqualinkLoginException as login_exception:
+        _LOGGER.error(
+            "Exception raised while attempting to login: %s", str(login_exception)
+        )
+        return False
+
+    systems = await aqualink.get_systems()
+    systems = list(systems.values())
+    if not systems:
+        _LOGGER.error("No systems detected or supported")
+        return False
+
+    # Only supporting the first system for now.
+    devices = await systems[0].get_devices()
+
+    for dev in devices.values():
+        if isinstance(dev, AqualinkThermostat):
+            climates += [dev]
+
+    forward_setup = hass.config_entries.async_forward_entry_setup
+    if climates:
+        _LOGGER.debug("Got %s climates: %s", len(climates), climates)
+        hass.async_create_task(forward_setup(entry, CLIMATE_DOMAIN))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    forward_unload = hass.config_entries.async_forward_entry_unload
+
+    tasks = []
+
+    if hass.data[DOMAIN][CLIMATE_DOMAIN]:
+        tasks += [forward_unload(entry, CLIMATE_DOMAIN)]
+
+    hass.data[DOMAIN].clear()
+
+    return all(await asyncio.gather(*tasks))

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -1,6 +1,20 @@
 """Support for Aqualink Thermostats."""
 import logging
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
+
+from iaqualink import (
+    AqualinkState,
+    AqualinkHeater,
+    AqualinkPump,
+    AqualinkSensor,
+    AqualinkThermostat,
+)
+from iaqualink.const import (
+    AQUALINK_TEMP_CELSIUS_HIGH,
+    AQUALINK_TEMP_CELSIUS_LOW,
+    AQUALINK_TEMP_FAHRENHEIT_HIGH,
+    AQUALINK_TEMP_FAHRENHEIT_LOW,
+)
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
@@ -19,14 +33,6 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
-if TYPE_CHECKING:
-    from iaqualink import (
-        AqualinkHeater,
-        AqualinkPump,
-        AqualinkSensor,
-        AqualinkThermostat,
-    )
-
 
 async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
@@ -41,7 +47,7 @@ async def async_setup_entry(
 class HassAqualinkThermostat(ClimateDevice):
     """Representation of a thermostat."""
 
-    def __init__(self, dev: "AqualinkThermostat"):
+    def __init__(self, dev: AqualinkThermostat):
         """Initialize the thermostat."""
         self.dev = dev
 
@@ -72,16 +78,14 @@ class HassAqualinkThermostat(ClimateDevice):
         return CLIMATE_SUPPORTED_MODES
 
     @property
-    def pump(self) -> "AqualinkPump":
+    def pump(self) -> AqualinkPump:
         """Return the pump device for the current thermostat."""
-        pump = self.name.lower() + "_pump"
+        pump = f"{self.name.lower()}_pump"
         return self.dev.system.devices[pump]
 
     @property
     def hvac_mode(self) -> str:
         """Return the current HVAC mode."""
-        from iaqualink import AqualinkState
-
         state = AqualinkState(self.heater.state)
         if state == AqualinkState.ON:
             return HVAC_MODE_HEAT
@@ -106,11 +110,6 @@ class HassAqualinkThermostat(ClimateDevice):
     @property
     def min_temp(self) -> int:
         """Return the minimum temperature supported by the thermostat."""
-        from iaqualink.const import (
-            AQUALINK_TEMP_CELSIUS_LOW,
-            AQUALINK_TEMP_FAHRENHEIT_LOW,
-        )
-
         if self.temperature_unit == TEMP_FAHRENHEIT:
             return AQUALINK_TEMP_FAHRENHEIT_LOW
         return AQUALINK_TEMP_CELSIUS_LOW
@@ -118,11 +117,6 @@ class HassAqualinkThermostat(ClimateDevice):
     @property
     def max_temp(self) -> int:
         """Return the minimum temperature supported by the thermostat."""
-        from iaqualink.const import (
-            AQUALINK_TEMP_CELSIUS_HIGH,
-            AQUALINK_TEMP_FAHRENHEIT_HIGH,
-        )
-
         if self.temperature_unit == TEMP_FAHRENHEIT:
             return AQUALINK_TEMP_FAHRENHEIT_HIGH
         return AQUALINK_TEMP_CELSIUS_HIGH
@@ -137,9 +131,9 @@ class HassAqualinkThermostat(ClimateDevice):
         await self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE]))
 
     @property
-    def sensor(self) -> "AqualinkSensor":
+    def sensor(self) -> AqualinkSensor:
         """Return the sensor device for the current thermostat."""
-        sensor = self.name.lower() + "_temp"
+        sensor = f"{self.name.lower()}_temp"
         return self.dev.system.devices[sensor]
 
     @property
@@ -150,7 +144,7 @@ class HassAqualinkThermostat(ClimateDevice):
         return None
 
     @property
-    def heater(self) -> "AqualinkHeater":
+    def heater(self) -> AqualinkHeater:
         """Return the heater device for the current thermostat."""
-        heater = self.name.lower() + "_heater"
+        heater = f"{self.name.lower()}_heater"
         return self.dev.system.devices[heater]

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -1,0 +1,156 @@
+"""Support for Aqualink Thermostats."""
+import logging
+from typing import TYPE_CHECKING, List, Optional
+
+from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate.const import (
+    DOMAIN,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN as AQUALINK_DOMAIN, CLIMATE_SUPPORTED_MODES
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+if TYPE_CHECKING:
+    from iaqualink import (
+        AqualinkHeater,
+        AqualinkPump,
+        AqualinkSensor,
+        AqualinkThermostat,
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up discovered switches."""
+    devs = []
+    for dev in hass.data[AQUALINK_DOMAIN][DOMAIN]:
+        devs.append(HassAqualinkThermostat(dev))
+    async_add_entities(devs, True)
+
+
+class HassAqualinkThermostat(ClimateDevice):
+    """Representation of a thermostat."""
+
+    def __init__(self, dev: "AqualinkThermostat"):
+        """Initialize the thermostat."""
+        self.dev = dev
+
+    @property
+    def name(self) -> str:
+        """Return the name of the thermostat."""
+        return self.dev.label.split(" ")[0]
+
+    async def async_update(self) -> None:
+        """Update the internal state of the thermostat.
+
+        The API update() command refreshes the state of all devices so we
+        only update if this is the main thermostat to avoid unnecessary
+        calls.
+        """
+        if self.name != "Pool":
+            return
+        await self.dev.system.update()
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+        return SUPPORT_TARGET_TEMPERATURE
+
+    @property
+    def hvac_modes(self) -> List[str]:
+        """Return the list of supported HVAC modes."""
+        return CLIMATE_SUPPORTED_MODES
+
+    @property
+    def pump(self) -> "AqualinkPump":
+        """Return the pump device for the current thermostat."""
+        pump = self.name.lower() + "_pump"
+        return self.dev.system.devices[pump]
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return the current HVAC mode."""
+        from iaqualink import AqualinkState
+
+        state = AqualinkState(self.heater.state)
+        if state == AqualinkState.ON:
+            return HVAC_MODE_HEAT
+        return HVAC_MODE_OFF
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Turn the underlying heater switch on or off."""
+        if hvac_mode == HVAC_MODE_HEAT:
+            await self.heater.turn_on()
+        elif hvac_mode == HVAC_MODE_OFF:
+            await self.heater.turn_off()
+        else:
+            _LOGGER.warning("Unknown operation mode: %s", hvac_mode)
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the unit of measurement."""
+        if self.dev.system.temp_unit == "F":
+            return TEMP_FAHRENHEIT
+        return TEMP_CELSIUS
+
+    @property
+    def min_temp(self) -> int:
+        """Return the minimum temperature supported by the thermostat."""
+        from iaqualink.const import (
+            AQUALINK_TEMP_CELSIUS_LOW,
+            AQUALINK_TEMP_FAHRENHEIT_LOW,
+        )
+
+        if self.temperature_unit == TEMP_FAHRENHEIT:
+            return AQUALINK_TEMP_FAHRENHEIT_LOW
+        return AQUALINK_TEMP_CELSIUS_LOW
+
+    @property
+    def max_temp(self) -> int:
+        """Return the minimum temperature supported by the thermostat."""
+        from iaqualink.const import (
+            AQUALINK_TEMP_CELSIUS_HIGH,
+            AQUALINK_TEMP_FAHRENHEIT_HIGH,
+        )
+
+        if self.temperature_unit == TEMP_FAHRENHEIT:
+            return AQUALINK_TEMP_FAHRENHEIT_HIGH
+        return AQUALINK_TEMP_CELSIUS_HIGH
+
+    @property
+    def target_temperature(self) -> float:
+        """Return the current target temperature."""
+        return float(self.dev.state)
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set new target temperature."""
+        await self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE]))
+
+    @property
+    def sensor(self) -> "AqualinkSensor":
+        """Return the sensor device for the current thermostat."""
+        sensor = self.name.lower() + "_temp"
+        return self.dev.system.devices[sensor]
+
+    @property
+    def current_temperature(self) -> Optional[float]:
+        """Return the current temperature."""
+        if self.sensor.state != "":
+            return float(self.sensor.state)
+        return None
+
+    @property
+    def heater(self) -> "AqualinkHeater":
+        """Return the heater device for the current thermostat."""
+        heater = self.name.lower() + "_heater"
+        return self.dev.system.devices[heater]

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -1,8 +1,9 @@
 """Config flow to configure zone component."""
-
 from typing import Optional
 
 import voluptuous as vol
+
+from iaqualink import AqualinkClient, AqualinkLoginException
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -20,8 +21,6 @@ class AqualinkFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input: Optional[ConfigType] = None):
         """Handle a flow start."""
-        from iaqualink import AqualinkClient, AqualinkLoginException
-
         # Supporting a single account.
         entries = self.hass.config_entries.async_entries(DOMAIN)
         if entries:
@@ -50,4 +49,4 @@ class AqualinkFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_import(self, user_input: Optional[ConfigType] = None):
         """Occurs when an entry is setup through config."""
-        return self.async_step_user(user_input)
+        return await self.async_step_user(user_input)

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -1,0 +1,53 @@
+"""Config flow to configure zone component."""
+
+from typing import Optional
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import ConfigType
+
+from .const import DOMAIN
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class AqualinkFlowHandler(config_entries.ConfigFlow):
+    """Aqualink config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input: Optional[ConfigType] = None):
+        """Handle a flow start."""
+        from iaqualink import AqualinkClient, AqualinkLoginException
+
+        # Supporting a single account.
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        if entries:
+            return self.async_abort(reason="already_setup")
+
+        errors = {}
+
+        if user_input is not None:
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
+
+            try:
+                aqualink = AqualinkClient(username, password)
+                await aqualink.login()
+                return self.async_create_entry(title=username, data=user_input)
+            except AqualinkLoginException:
+                errors["base"] = "connection_failure"
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+            ),
+            errors=errors,
+        )
+
+    async def async_step_import(self, user_input: Optional[ConfigType] = None):
+        """Occurs when an entry is setup through config."""
+        return self.async_step_user(user_input)

--- a/homeassistant/components/iaqualink/const.py
+++ b/homeassistant/components/iaqualink/const.py
@@ -1,0 +1,5 @@
+"""Constants for the the iaqualink component."""
+from homeassistant.components.climate.const import HVAC_MODE_HEAT, HVAC_MODE_OFF
+
+DOMAIN = "iaqualink"
+CLIMATE_SUPPORTED_MODES = [HVAC_MODE_HEAT, HVAC_MODE_OFF]

--- a/homeassistant/components/iaqualink/manifest.json
+++ b/homeassistant/components/iaqualink/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "iaqualink",
+  "name": "Jandy iAqualink",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/components/iaqualink/",
+  "dependencies": [],
+  "codeowners": [
+    "@flz"
+  ],
+  "requirements": [
+    "iaqualink==0.2.9"
+  ]
+}

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "title": "Jandy iAqualink",
+    "step": {
+      "user": {
+        "title": "Connect to iAqualink",
+        "description": "Please enter the username and password for your iAqualink account.",
+        "data": {
+          "username": "Username / Email Address",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "connection_failure": "Unable to connect to iAqualink. Check your username and password."
+    },
+    "abort": {
+      "already_setup": "You can only configure a single iAqualink connection."
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -24,6 +24,7 @@ FLOWS = [
     "homekit_controller",
     "homematicip_cloud",
     "hue",
+    "iaqualink",
     "ifttt",
     "ios",
     "ipma",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -656,6 +656,9 @@ hydrawiser==0.1.1
 # homeassistant.components.htu21d
 # i2csense==0.0.4
 
+# homeassistant.components.iaqualink
+iaqualink==0.2.9
+
 # homeassistant.components.watson_tts
 ibm-watson==3.0.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -191,6 +191,9 @@ httplib2==0.10.3
 # homeassistant.components.huawei_lte
 huawei-lte-api==1.3.0
 
+# homeassistant.components.iaqualink
+iaqualink==0.2.9
+
 # homeassistant.components.influxdb
 influxdb==5.2.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -92,6 +92,7 @@ TEST_REQUIREMENTS = (
     "homematicip",
     "httplib2",
     "huawei-lte-api",
+    "iaqualink",
     "influxdb",
     "jsonpath",
     "libpurecool",

--- a/tests/components/iaqualink/__init__.py
+++ b/tests/components/iaqualink/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the iAqualink component."""

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -1,11 +1,10 @@
 """Tests for iAqualink config flow."""
-import pytest
 from unittest.mock import patch
 
 import iaqualink
+import pytest
 
 from homeassistant.components.iaqualink import config_flow
-
 from tests.common import MockConfigEntry, mock_coro
 
 DATA = {"username": "test@example.com", "password": "pass"}

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -12,7 +12,7 @@ DATA = {"username": "test@example.com", "password": "pass"}
 
 @pytest.mark.parametrize("step", ["import", "user"])
 async def test_already_configured(hass, step):
-    """Test if a HomeKit discovered bridge has already been configured."""
+    """Test config flow when iaqualink component is already setup."""
     MockConfigEntry(domain="iaqualink", data=DATA).add_to_hass(hass)
 
     flow = config_flow.AqualinkFlowHandler()
@@ -27,8 +27,24 @@ async def test_already_configured(hass, step):
 
 
 @pytest.mark.parametrize("step", ["import", "user"])
+async def test_without_config(hass, step):
+    """Test with no configuration."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+    flow.context = {}
+
+    fname = f"async_step_{step}"
+    func = getattr(flow, fname)
+    result = await func()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+
+@pytest.mark.parametrize("step", ["import", "user"])
 async def test_with_invalid_credentials(hass, step):
-    """Test config flow ."""
+    """Test config flow with invalid username and/or password."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
 
@@ -46,7 +62,7 @@ async def test_with_invalid_credentials(hass, step):
 
 @pytest.mark.parametrize("step", ["import", "user"])
 async def test_with_existing_config(hass, step):
-    """Test importing a host with an existing config file."""
+    """Test with existing configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
     flow.context = {}

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -1,0 +1,52 @@
+"""Tests for iAqualink config flow."""
+from unittest.mock import patch
+
+import iaqualink
+
+from homeassistant.components.iaqualink import config_flow
+
+from tests.common import MockConfigEntry, mock_coro
+
+DATA = {"username": "test@example.com", "password": "pass"}
+
+
+async def test_already_configured(hass):
+    """Test if a HomeKit discovered bridge has already been configured."""
+    MockConfigEntry(domain="iaqualink", data=DATA).add_to_hass(hass)
+
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+    flow.context = {}
+
+    result = await flow.async_step_user(DATA)
+
+    assert result["type"] == "abort"
+
+
+async def test_import_with_invalid_credentials(hass):
+    """Test config flow ."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+
+    with patch(
+        "iaqualink.AqualinkClient.login", side_effect=iaqualink.AqualinkLoginException
+    ):
+        result = await flow.async_step_user(DATA)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "connection_failure"}
+
+
+async def test_import_with_existing_config(hass):
+    """Test importing a host with an existing config file."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+    flow.context = {}
+
+    with patch("iaqualink.AqualinkClient.login", return_value=mock_coro(None)):
+        result = await flow.async_step_user(DATA)
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == DATA["username"]
+    assert result["data"] == DATA


### PR DESCRIPTION
## Description:

This is a new component introducing support for Jandy iAqualink pool controls.

This PR includes support for the climate platform only.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10165

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
