### PR TITLE
UniFi - Temporary config option to utilize system options disable new entities

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -34,7 +34,7 @@ CONTROLLER_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_DONT_TRACK_CLIENTS): cv.boolean,
         vol.Optional(CONF_DONT_TRACK_DEVICES): cv.boolean,
-        vol.Optional(CONF_DONT_TRACK_NEW_CLIENTS, default=True): cv.boolean,
+        vol.Optional(CONF_DONT_TRACK_NEW_CLIENTS, default=False): cv.boolean,
         vol.Optional(CONF_DONT_TRACK_WIRED_CLIENTS): cv.boolean,
         vol.Optional(CONF_DETECTION_TIME): vol.All(
             cv.time_period, cv.positive_timedelta

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -13,6 +13,7 @@ from .const import (
     CONF_DETECTION_TIME,
     CONF_DONT_TRACK_CLIENTS,
     CONF_DONT_TRACK_DEVICES,
+    CONF_DONT_TRACK_NEW_CLIENTS,
     CONF_DONT_TRACK_WIRED_CLIENTS,
     CONF_SITE_ID,
     CONF_SSID_FILTER,
@@ -33,6 +34,7 @@ CONTROLLER_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_DONT_TRACK_CLIENTS): cv.boolean,
         vol.Optional(CONF_DONT_TRACK_DEVICES): cv.boolean,
+        vol.Optional(CONF_DONT_TRACK_NEW_CLIENTS, default=True): cv.boolean,
         vol.Optional(CONF_DONT_TRACK_WIRED_CLIENTS): cv.boolean,
         vol.Optional(CONF_DETECTION_TIME): vol.All(
             cv.time_period, cv.positive_timedelta

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -15,6 +15,7 @@ CONF_BLOCK_CLIENT = "block_client"
 CONF_DETECTION_TIME = "detection_time"
 CONF_DONT_TRACK_CLIENTS = "dont_track_clients"
 CONF_DONT_TRACK_DEVICES = "dont_track_devices"
+CONF_DONT_TRACK_NEW_CLIENTS = "dont_track_new_clients"
 CONF_DONT_TRACK_WIRED_CLIENTS = "dont_track_wired_clients"
 CONF_SSID_FILTER = "ssid_filter"
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -157,10 +157,11 @@ class UniFiController:
                 break
 
         if (
-            self.config_entry.system_options.disable_new_entities
-            != unifi_config[CONF_DONT_TRACK_NEW_CLIENTS]
+            CONF_DONT_TRACK_NEW_CLIENTS in self.unifi_config
+            and self.config_entry.system_options.disable_new_entities
+            != self.unifi_config[CONF_DONT_TRACK_NEW_CLIENTS]
         ):
-            self.config_entry.system_options.disable_new_entities = unifi_config[
+            self.config_entry.system_options.disable_new_entities = self.unifi_config[
                 CONF_DONT_TRACK_NEW_CLIENTS
             ]
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .const import (
     CONF_BLOCK_CLIENT,
     CONF_CONTROLLER,
+    CONF_DONT_TRACK_NEW_CLIENTS,
     CONF_SITE_ID,
     CONTROLLER_ID,
     LOGGER,
@@ -154,6 +155,14 @@ class UniFiController:
             ):
                 self.unifi_config = unifi_config
                 break
+
+        if (
+            self.config_entry.system_options.disable_new_entities
+            != unifi_config[CONF_DONT_TRACK_NEW_CLIENTS]
+        ):
+            self.config_entry.system_options.disable_new_entities = unifi_config[
+                CONF_DONT_TRACK_NEW_CLIENTS
+            ]
 
         for platform in ["device_tracker", "switch"]:
             hass.async_create_task(

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -46,6 +46,7 @@ async def test_setup_with_config(hass):
             unifi.CONF_BLOCK_CLIENT: ["12:34:56:78:90:AB"],
             unifi.CONF_DETECTION_TIME: timedelta(seconds=3),
             unifi.CONF_SSID_FILTER: ["ssid"],
+            unifi.CONF_DONT_TRACK_NEW_CLIENTS: False,
         }
     ]
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #25764

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
