### PR TITLE
Fritz device tracker: change 'Scanning' log entry to debug

### DIFF
--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -85,6 +85,6 @@ class FritzBoxScanner(DeviceScanner):
         if not self.success_init:
             return False
 
-        _LOGGER.info("Scanning")
+        _LOGGER.debug("Scanning")
         self.last_results = self.fritz_box.get_hosts_info()
         return True


### PR DESCRIPTION
## Description:
I noticed that since I started using the Fritz device tracker one message made up 99% of my log. The info message 'Scanning' was logged up to 6 times per minute and bloated the log file.

Since I believe that this is not wanted behavior I changed the logging level for the polling of the fritz device tracker from info to debug.  

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
