### PR TITLE
Add config entry options support to deCONZ

### DIFF
--- a/homeassistant/components/deconz/.translations/en.json
+++ b/homeassistant/components/deconz/.translations/en.json
@@ -40,5 +40,16 @@
             }
         },
         "title": "deCONZ Zigbee gateway"
+    },
+    "options": {
+        "step": {
+            "deconz_devices": {
+                "description": "Configure visibility of deCONZ device types",
+                "data": {
+                    "allow_clip_sensor": "Allow deCONZ CLIP sensors",
+                    "allow_deconz_groups": "Allow deCONZ light groups"
+                }
+            }
+        }
     }
 }

--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -40,5 +40,16 @@
             "one_instance_only": "Component only supports one deCONZ instance",
             "updated_instance": "Updated deCONZ instance with new host address"
         }
+    },
+    "options": {
+        "step": {
+            "async_step_deconz_devices": {
+                "description": "Configure visibility of deCONZ device types",
+                "data": {
+                    "allow_clip_sensor": "Allow deCONZ CLIP sensors",
+                    "allow_deconz_groups": "Allow deCONZ light groups"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
