### PR TITLE
Load service descriptions from <config>/python_scripts/services.yaml

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -181,9 +181,8 @@ async def _load_services_file(hass: HomeAssistantType, domain: str) -> JSON_TYPE
             # 2. A user-provided services.yaml file
             user_services = await hass.async_add_executor_job(
                 load_yaml,
-                str(
-                    hass.config.config_dir
-                    + "/{}/services.yaml".format(PYTHON_SCRIPT_FOLDER)
+                "{}/{}/services.yaml".format(
+                    hass.config.config_dir, PYTHON_SCRIPT_FOLDER
                 ),
             )
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -337,8 +337,9 @@ def test_async_get_all_descriptions_python_script_with_services_yaml(hass):
         "      example: 'This is a test of python_script.has_description'"
     )
     services_yaml = {
-        hass.config.config_dir
-        + "/{}/services.yaml".format(python_script.FOLDER): service_descriptions
+        "{}/{}/services.yaml".format(
+            hass.config.config_dir, python_script.FOLDER
+        ): service_descriptions
     }
 
     with patch(
@@ -385,8 +386,9 @@ def test_async_get_all_descriptions_python_script_with_invalid_services_yaml(has
     # Invalid user-provided services.yaml file
     service_descriptions = "invalid:\n - item 1\n  - item 2"
     services_yaml = {
-        hass.config.config_dir
-        + "/{}/services.yaml".format(python_script.FOLDER): service_descriptions
+        "{}/{}/services.yaml".format(
+            hass.config.config_dir, python_script.FOLDER
+        ): service_descriptions
     }
 
     with patch(


### PR DESCRIPTION
## Description:

For the `python_script` integration, load user-provided service descriptions from `<config>/python_scripts/services.yaml`.

**Related issue (if applicable):** fixes the `python_script` portion of https://github.com/home-assistant/architecture/issues/275

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
