### PR TITLE
Make sure config flows extend ConfigFlow base class

### DIFF
--- a/homeassistant/components/ipma/config_flow.py
+++ b/homeassistant/components/ipma/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure IPMA component."""
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
@@ -9,7 +9,7 @@ from .const import DOMAIN, HOME_LOCATION_NAME
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class IpmaFlowHandler(data_entry_flow.FlowHandler):
+class IpmaFlowHandler(config_entries.ConfigFlow):
     """Config flow for IPMA component."""
 
     VERSION = 1

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure Met component."""
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -18,7 +18,7 @@ def configured_instances(hass):
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class MetFlowHandler(data_entry_flow.FlowHandler):
+class MetFlowHandler(config_entries.ConfigFlow):
     """Config flow for Met component."""
 
     VERSION = 1

--- a/homeassistant/components/smhi/config_flow.py
+++ b/homeassistant/components/smhi/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure SMHI component."""
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import aiohttp_client
@@ -21,7 +21,7 @@ def smhi_locations(hass: HomeAssistant):
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class SmhiFlowHandler(data_entry_flow.FlowHandler):
+class SmhiFlowHandler(config_entries.ConfigFlow):
     """Config flow for SMHI component."""
 
     VERSION = 1


### PR DESCRIPTION
## Description:
With the introduction of config options we assumed all config flow handlers extend ConfigFlow, as per the docs. This was not the case for 3 config flows. This fixes it. 

Thinking about writing a hassfest validator later.

