### PR TITLE
Remove monitored_conditions from netgear_lte

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -182,6 +182,7 @@ homeassistant/components/nello/* @pschmitt
 homeassistant/components/ness_alarm/* @nickw444
 homeassistant/components/nest/* @awarecan
 homeassistant/components/netdata/* @fabaff
+homeassistant/components/netgear_lte/* @amelchio
 homeassistant/components/nextbus/* @vividboarder
 homeassistant/components/nissan_leaf/* @filcole
 homeassistant/components/nmbs/* @thibmaek

--- a/homeassistant/components/netgear_lte/binary_sensor.py
+++ b/homeassistant/components/netgear_lte/binary_sensor.py
@@ -1,11 +1,11 @@
 """Support for Netgear LTE binary sensors."""
 import logging
 
-from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDevice
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.exceptions import PlatformNotReady
 
-from . import CONF_MONITORED_CONDITIONS, DATA_KEY, LTEEntity
-from .sensor_types import BINARY_SENSOR_CLASSES
+from . import DATA_KEY, LTEEntity
+from . import sensor_types
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,11 +20,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info)
     if not modem_data or not modem_data.data:
         raise PlatformNotReady
 
-    binary_sensor_conf = discovery_info[DOMAIN]
-    monitored_conditions = binary_sensor_conf[CONF_MONITORED_CONDITIONS]
-
     binary_sensors = []
-    for sensor_type in monitored_conditions:
+    for sensor_type in sensor_types.ALL_BINARY_SENSORS:
         binary_sensors.append(LTEBinarySensor(modem_data, sensor_type))
 
     async_add_entities(binary_sensors)
@@ -41,4 +38,4 @@ class LTEBinarySensor(LTEEntity, BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of binary sensor."""
-        return BINARY_SENSOR_CLASSES[self.sensor_type]
+        return sensor_types.BINARY_SENSOR_CLASSES[self.sensor_type]

--- a/homeassistant/components/netgear_lte/manifest.json
+++ b/homeassistant/components/netgear_lte/manifest.json
@@ -3,8 +3,10 @@
   "name": "Netgear lte",
   "documentation": "https://www.home-assistant.io/components/netgear_lte",
   "requirements": [
-    "eternalegypt==0.0.9"
+    "eternalegypt==0.0.10"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@amelchio"
+  ]
 }

--- a/homeassistant/components/netgear_lte/sensor_types.py
+++ b/homeassistant/components/netgear_lte/sensor_types.py
@@ -10,28 +10,17 @@ SENSOR_UNITS = {
     SENSOR_SMS: "unread",
     SENSOR_SMS_TOTAL: "messages",
     SENSOR_USAGE: "MiB",
-    "radio_quality": "%",
-    "rx_level": "dBm",
-    "tx_level": "dBm",
-    "upstream": None,
-    "connection_text": None,
-    "connection_type": None,
-    "current_ps_service_type": None,
-    "register_network_display": None,
-    "current_band": None,
-    "cell_id": None,
+    "wwanadv.radioquality": "%",
+    "wwanadv.rxlevel": "dBm",
+    "wwanadv.txlevel": "dBm",
 }
-
-BINARY_SENSOR_MOBILE_CONNECTED = "mobile_connected"
 
 BINARY_SENSOR_CLASSES = {
     "roaming": None,
     "wire_connected": DEVICE_CLASS_CONNECTIVITY,
-    BINARY_SENSOR_MOBILE_CONNECTED: DEVICE_CLASS_CONNECTIVITY,
+    "mobile_connected": DEVICE_CLASS_CONNECTIVITY,
 }
 
-ALL_SENSORS = list(SENSOR_UNITS)
-DEFAULT_SENSORS = [SENSOR_USAGE]
+ALL_SENSORS = [x for x in SENSOR_UNITS if "." not in x]
 
 ALL_BINARY_SENSORS = list(BINARY_SENSOR_CLASSES)
-DEFAULT_BINARY_SENSORS = [BINARY_SENSOR_MOBILE_CONNECTED]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -455,7 +455,7 @@ epson-projector==0.1.3
 epsonprinter==0.0.9
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.9
+eternalegypt==0.0.10
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1


### PR DESCRIPTION
## Breaking Change:

The `netgear_lte` integration has removed `monitored_conditions`and now always adds all possible sensors and binary sensors, though most are disabled by default. Configuration subsections `sensor:` and `binary_sensor:` must be removed from `netgear_lte:`. See the PR link for more information.

## Breaking Change, more information:

A (big) number of sensors are now automatically created from information provided by the Netgear modem. For convenience, here is a mapping of former `monitored_conditions` names to the new default `entity_id` names:
```
upstream                 => sensor.netgear_lte_failover_backhaul
connection_text          => sensor.netgear_lte_wwan_connectiontext
connection_type          => sensor.netgear_lte_wwan_connectiontype
current_nw_service_type  => sensor.netgear_lte_wwan_currentnwservicetype
current_ps_service_type  => sensor.netgear_lte_wwan_currentpsservicetype
register_network_display => sensor.netgear_lte_wwan_registernetworkdisplay
radio_quality            => sensor.netgear_lte_wwanadv_radioquality
rx_level                 => sensor.netgear_lte_wwanadv_rxlevel 
tx_level                 => sensor.netgear_lte_wwanadv_txlevel
current_band             => sensor.netgear_lte_wwanadv_curband
cell_id                  => sensor.netgear_lte_wwanadv_cellid
```

That is just a list of those that have changed, you will get many new ones as well. The new names are a bit odd since they are built automatically from information provided by the modem.

The new sensors are disabled by default. If you want to enable one, go to the Configuration page, locate the entity in the Entity Registry and click it to be able to modify it.

## Description:

This is my rework of #25979, now removing `monitored_conditions` and using the new `entity_registry_enabled_default` to add all sensors. Only the data usage sensor is enabled by default.

I have removed the explicit naming of most sensors since they are now available as generic sensors. This is a breaking change where `entity_id` changes.

The supporting library is updated to reveal not quite as many values (excluding, for example, the SMS inbox).

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
netgear_lte:
  - host: !secret lb2120_hostname
    password: !secret lb2120_password
    notify:
      - name: sms
        recipient:
          - !secret lb2120_phone
    # No longer any sensor: section
    # No longer any binary_sensor: section
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html