### PR TITLE
Sonos playlists play media

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -15,6 +15,7 @@ from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_ENQUEUE,
     MEDIA_TYPE_MUSIC,
+    MEDIA_TYPE_PLAYLIST,
     SUPPORT_CLEAR_PLAYLIST,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
@@ -943,7 +944,7 @@ class SonosEntity(MediaPlayerDevice):
 
         If ATTR_MEDIA_ENQUEUE is True, add `media_id` to the queue.
         """
-        if media_type == "playlist":
+        if media_type == MEDIA_TYPE_PLAYLIST:
             try:
                 playlists = self.soco.get_sonos_playlists()
                 playlist = next(p for p in playlists if p.title == media_id)

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -950,9 +950,12 @@ class SonosEntity(MediaPlayerDevice):
                 self.soco.clear_queue()
                 self.soco.add_to_queue(playlist)
                 self.soco.play_from_queue(0)
+                return
             except StopIteration:
                 _LOGGER.error('Could not find a Sonos playlist named "%s".', media_id)
-        elif kwargs.get(ATTR_MEDIA_ENQUEUE):
+                # Fall through to the previous behavior, in case someone is relying on
+                # passing a URI with a media_type of "playlist"
+        if kwargs.get(ATTR_MEDIA_ENQUEUE):
             try:
                 self.soco.add_uri_to_queue(media_id)
             except SoCoUPnPException:

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -944,30 +944,30 @@ class SonosEntity(MediaPlayerDevice):
 
         If ATTR_MEDIA_ENQUEUE is True, add `media_id` to the queue.
         """
-        if media_type == MEDIA_TYPE_PLAYLIST:
+        if media_type == MEDIA_TYPE_MUSIC:
+            if kwargs.get(ATTR_MEDIA_ENQUEUE):
+                try:
+                    self.soco.add_uri_to_queue(media_id)
+                except SoCoUPnPException:
+                    _LOGGER.error(
+                        'Error parsing media uri "%s", '
+                        "please check it's a valid media resource "
+                        "supported by Sonos",
+                        media_id,
+                    )
+            else:
+                self.soco.play_uri(media_id)
+        elif media_type == MEDIA_TYPE_PLAYLIST:
             try:
                 playlists = self.soco.get_sonos_playlists()
                 playlist = next(p for p in playlists if p.title == media_id)
                 self.soco.clear_queue()
                 self.soco.add_to_queue(playlist)
                 self.soco.play_from_queue(0)
-                return
             except StopIteration:
-                _LOGGER.error('Could not find a Sonos playlist named "%s".', media_id)
-                # Fall through to the previous behavior, in case someone is relying on
-                # passing a URI with a media_type of "playlist"
-        if kwargs.get(ATTR_MEDIA_ENQUEUE):
-            try:
-                self.soco.add_uri_to_queue(media_id)
-            except SoCoUPnPException:
-                _LOGGER.error(
-                    'Error parsing media uri "%s", '
-                    "please check it's a valid media resource "
-                    "supported by Sonos",
-                    media_id,
-                )
+                _LOGGER.error('Could not find a Sonos playlist named "%s"', media_id)
         else:
-            self.soco.play_uri(media_id)
+            _LOGGER.error('Sonos does not support a media type of "%s"', media_type)
 
     @soco_error()
     def join(self, slaves):

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -938,9 +938,21 @@ class SonosEntity(MediaPlayerDevice):
         """
         Send the play_media command to the media player.
 
+        If media_type is "playlist", media_id should be a Sonos
+        Playlist name.  Otherwise, media_id should be a URI.
+
         If ATTR_MEDIA_ENQUEUE is True, add `media_id` to the queue.
         """
-        if kwargs.get(ATTR_MEDIA_ENQUEUE):
+        if media_type == "playlist":
+            try:
+                playlists = self.soco.get_sonos_playlists()
+                playlist = next(p for p in playlists if p.title == media_id)
+                self.soco.clear_queue()
+                self.soco.add_to_queue(playlist)
+                self.soco.play_from_queue(0)
+            except StopIteration:
+                _LOGGER.error('Could not find a Sonos playlist named "%s".', media_id)
+        elif kwargs.get(ATTR_MEDIA_ENQUEUE):
             try:
                 self.soco.add_uri_to_queue(media_id)
             except SoCoUPnPException:


### PR DESCRIPTION
## Breaking Change:

Currently, the Sonos integration's `media_player.play_media` implementation ignores the `media_content_type` parameter.  This doesn't make sense, since Sonos doesn't support most of the options (image, tvshow, video, episode or channel).  This change rejects previously accepted calls using those content_types, and changes the behavior of a content_type of "playlist" to play a Sonos playlist, rather than a URL.  

## Description:

Currently, there is no way to play a Sonos playlist from Home Assistant.  Added the ability to call `media_player.play_media` with a media_type of "playlist" and a media_id of the name of the playlist.

My previous pull request (to add Sonos playlists as sources) was rejected for not wanting to expand the abuse of sources any more, which I understand.  This is architecturally cleaner, but slightly less user friendly (since it doesn't offer a nice UI for picking a playlist).

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
