### PR TITLE
Fix wrong exposed light for emulated hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -562,17 +562,27 @@ def get_entity_state(config, entity):
 
 def entity_to_json(config, entity, state):
     """Convert an entity to its Hue bridge JSON representation."""
+    entity_features = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+    if (entity_features & SUPPORT_BRIGHTNESS) or entity.domain != light.DOMAIN:
+        return {
+            "state": {
+                HUE_API_STATE_ON: state[STATE_ON],
+                HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],
+                HUE_API_STATE_HUE: state[STATE_HUE],
+                HUE_API_STATE_SAT: state[STATE_SATURATION],
+                "reachable": True,
+            },
+            "type": "Dimmable light",
+            "name": config.get_entity_name(entity),
+            "modelid": "HASS123",
+            "uniqueid": entity.entity_id,
+            "swversion": "123",
+        }
     return {
-        "state": {
-            HUE_API_STATE_ON: state[STATE_ON],
-            HUE_API_STATE_BRI: state[STATE_BRIGHTNESS],
-            HUE_API_STATE_HUE: state[STATE_HUE],
-            HUE_API_STATE_SAT: state[STATE_SATURATION],
-            "reachable": True,
-        },
-        "type": "Dimmable light",
+        "state": {HUE_API_STATE_ON: state[STATE_ON], "reachable": True},
+        "type": "On/off light",
         "name": config.get_entity_name(entity),
-        "modelid": "HASS123",
+        "modelid": "HASS321",
         "uniqueid": entity.entity_id,
         "swversion": "123",
     }

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -128,6 +128,9 @@ def hass_hue(loop, hass):
         kitchen_light_entity.entity_id, kitchen_light_entity.state, attributes=attrs
     )
 
+    # create a lamp without brightness support
+    hass.states.async_set("light.no_brightness", "on", {})
+
     # Ceiling Fan is explicitly excluded from being exposed
     ceiling_fan_entity = hass.states.get("fan.ceiling_fan")
     attrs = dict(ceiling_fan_entity.attributes)
@@ -216,6 +219,17 @@ def test_discover_lights(hue_client):
     assert "climate.hvac" in devices
     assert "climate.heatpump" in devices
     assert "climate.ecobee" not in devices
+
+
+@asyncio.coroutine
+def test_light_without_brightness_supported(hass_hue, hue_client):
+    """Test that light without brightness is supported."""
+    light_without_brightness_json = yield from perform_get_light_state(
+        hue_client, "light.no_brightness", 200
+    )
+
+    assert light_without_brightness_json["state"][HUE_API_STATE_ON] is True
+    assert light_without_brightness_json["type"] == "On/off light"
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Breaking Change:
A light without brightness support which was discovered before this PR will not be recognized more.
The old light has to be deleted over the web interface or the app from Alexa.
After this Tell Alexa: `Alexa, discover my devices` and the light without brightness support should be found.
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
All lights without brightness support, generate errors in the Alexa app.
When a lamp is switched on via voice control Alexa responds `Light isn’t responding` but the light turns on and the app shows `Device doesn't support requested value`.




## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]



If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html