### PR TITLE
Add descriptive fields to script config

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
+from homeassistant.helpers.service import SERVICE_DESCRIPTION_CACHE
 
 from homeassistant.helpers.script import Script
 
@@ -139,7 +140,7 @@ async def _async_process_config(hass, config, component):
 
     scripts = []
 
-    hass.data.setdefault("service_description_cache", {})
+    hass.data.setdefault(SERVICE_DESCRIPTION_CACHE, {})
     for object_id, cfg in config.get(DOMAIN, {}).items():
         alias = cfg.get(CONF_ALIAS, object_id)
         script = ScriptEntity(hass, object_id, alias, cfg[CONF_SEQUENCE])
@@ -152,7 +153,7 @@ async def _async_process_config(hass, config, component):
             CONF_DESCRIPTION: cfg[CONF_DESCRIPTION],
             CONF_FIELDS: cfg[CONF_FIELDS],
         }
-        hass.data["service_description_cache"][
+        hass.data[SERVICE_DESCRIPTION_CACHE][
             ENTITY_ID_FORMAT.format(object_id)
         ] = service_desc
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
-from homeassistant.helpers.service import SERVICE_DESCRIPTION_CACHE
+from homeassistant.helpers.service import async_set_service_schema
 
 from homeassistant.helpers.script import Script
 
@@ -140,7 +140,6 @@ async def _async_process_config(hass, config, component):
 
     scripts = []
 
-    hass.data.setdefault(SERVICE_DESCRIPTION_CACHE, {})
     for object_id, cfg in config.get(DOMAIN, {}).items():
         alias = cfg.get(CONF_ALIAS, object_id)
         script = ScriptEntity(hass, object_id, alias, cfg[CONF_SEQUENCE])
@@ -149,13 +148,12 @@ async def _async_process_config(hass, config, component):
             DOMAIN, object_id, service_handler, schema=SCRIPT_SERVICE_SCHEMA
         )
 
+        # Register the service description
         service_desc = {
             CONF_DESCRIPTION: cfg[CONF_DESCRIPTION],
             CONF_FIELDS: cfg[CONF_FIELDS],
         }
-        hass.data[SERVICE_DESCRIPTION_CACHE][
-            ENTITY_ID_FORMAT.format(object_id)
-        ] = service_desc
+        async_set_service_schema(hass, DOMAIN, object_id, service_desc)
 
     await component.async_add_entities(scripts)
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -47,7 +47,10 @@ SCRIPT_ENTRY_SCHEMA = vol.Schema(
         vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_DESCRIPTION, default=""): cv.string,
         vol.Optional(CONF_FIELDS, default={}): {
-            cv.string: {vol.In([CONF_DESCRIPTION, CONF_EXAMPLE]): cv.string}
+            cv.string: {
+                vol.Optional(CONF_DESCRIPTION): cv.string,
+                vol.Optional(CONF_EXAMPLE): cv.string,
+            }
         },
     }
 )

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -31,6 +31,9 @@ ATTR_LAST_ACTION = "last_action"
 ATTR_LAST_TRIGGERED = "last_triggered"
 ATTR_VARIABLES = "variables"
 
+CONF_DESCRIPTION = "description"
+CONF_EXAMPLE = "example"
+CONF_FIELDS = "fields"
 CONF_SEQUENCE = "sequence"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
@@ -38,7 +41,14 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 GROUP_NAME_ALL_SCRIPTS = "all scripts"
 
 SCRIPT_ENTRY_SCHEMA = vol.Schema(
-    {CONF_ALIAS: cv.string, vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA}
+    {
+        CONF_ALIAS: cv.string,
+        vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_DESCRIPTION): cv.string,
+        vol.Optional(CONF_FIELDS, default={}): {
+            cv.string: {vol.In([CONF_DESCRIPTION, CONF_EXAMPLE]): cv.string}
+        },
+    }
 )
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -231,6 +231,19 @@ async def async_get_all_descriptions(hass):
     return descriptions
 
 
+@ha.callback
+def async_set_service_schema(hass, domain, service, schema):
+    """Register a description for a service."""
+    hass.data.setdefault(SERVICE_DESCRIPTION_CACHE, {})
+
+    description = {
+        "description": schema.get("description", ""),
+        "fields": schema.get("fields", {}),
+    }
+
+    hass.data[SERVICE_DESCRIPTION_CACHE]["{}.{}".format(domain, service)] = description
+
+
 @bind_hass
 async def entity_service_call(
     hass, platforms, func, call, service_name="", required_features=None

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -232,13 +232,14 @@ async def async_get_all_descriptions(hass):
 
 
 @ha.callback
+@bind_hass
 def async_set_service_schema(hass, domain, service, schema):
     """Register a description for a service."""
     hass.data.setdefault(SERVICE_DESCRIPTION_CACHE, {})
 
     description = {
-        "description": schema.get("description", ""),
-        "fields": schema.get("fields", {}),
+        "description": schema.get("description") or "",
+        "fields": schema.get("fields") or {},
     }
 
     hass.data[SERVICE_DESCRIPTION_CACHE]["{}.{}".format(domain, service)] = description

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -362,3 +362,39 @@ async def test_turning_no_scripts_off(hass):
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {"entity_id": []}, blocking=True
     )
+
+
+async def test_async_get_descriptions_script(hass):
+    """Test async_set_service_schema for the script integration."""
+    script = hass.components.script
+    script_config = {
+        script.DOMAIN: {
+            "test1": {"sequence": [{"service": "homeassistant.restart"}]},
+            "test2": {
+                "description": "test2",
+                "fields": {
+                    "param": {
+                        "description": "param_description",
+                        "example": "param_example",
+                    }
+                },
+                "sequence": [{"service": "homeassistant.restart"}],
+            },
+        }
+    }
+
+    await async_setup_component(hass, script.DOMAIN, script_config)
+    descriptions = await hass.helpers.service.async_get_all_descriptions()
+
+    assert descriptions[script.DOMAIN]["test1"]["description"] == ""
+    assert not descriptions[script.DOMAIN]["test1"]["fields"]
+
+    assert descriptions[script.DOMAIN]["test2"]["description"] == "test2"
+    assert (
+        descriptions[script.DOMAIN]["test2"]["fields"]["param"]["description"]
+        == "param_description"
+    )
+    assert (
+        descriptions[script.DOMAIN]["test2"]["fields"]["param"]["example"]
+        == "param_example"
+    )

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -285,6 +285,43 @@ def test_async_get_all_descriptions(hass):
     assert "fields" in descriptions[logger.DOMAIN]["set_level"]
 
 
+@asyncio.coroutine
+def test_async_get_descriptions_script(hass):
+    """Test async_set_service_schema for the script integration."""
+    script = hass.components.script
+    script_config = {
+        script.DOMAIN: {
+            "test1": {"sequence": [{"service": "homeassistant.restart"}]},
+            "test2": {
+                "description": "test2",
+                "fields": {
+                    "param": {
+                        "description": "param_description",
+                        "example": "param_example",
+                    }
+                },
+                "sequence": [{"service": "homeassistant.restart"}],
+            },
+        }
+    }
+
+    yield from async_setup_component(hass, script.DOMAIN, script_config)
+    descriptions = yield from service.async_get_all_descriptions(hass)
+
+    assert descriptions[script.DOMAIN]["test1"]["description"] == ""
+    assert not descriptions[script.DOMAIN]["test1"]["fields"]
+
+    assert descriptions[script.DOMAIN]["test2"]["description"] == "test2"
+    assert (
+        descriptions[script.DOMAIN]["test2"]["fields"]["param"]["description"]
+        == "param_description"
+    )
+    assert (
+        descriptions[script.DOMAIN]["test2"]["fields"]["param"]["example"]
+        == "param_example"
+    )
+
+
 async def test_call_with_required_features(hass, mock_entities):
     """Test service calls invoked only if entity has required feautres."""
     test_service_mock = Mock(return_value=mock_coro())

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -285,43 +285,6 @@ def test_async_get_all_descriptions(hass):
     assert "fields" in descriptions[logger.DOMAIN]["set_level"]
 
 
-@asyncio.coroutine
-def test_async_get_descriptions_script(hass):
-    """Test async_set_service_schema for the script integration."""
-    script = hass.components.script
-    script_config = {
-        script.DOMAIN: {
-            "test1": {"sequence": [{"service": "homeassistant.restart"}]},
-            "test2": {
-                "description": "test2",
-                "fields": {
-                    "param": {
-                        "description": "param_description",
-                        "example": "param_example",
-                    }
-                },
-                "sequence": [{"service": "homeassistant.restart"}],
-            },
-        }
-    }
-
-    yield from async_setup_component(hass, script.DOMAIN, script_config)
-    descriptions = yield from service.async_get_all_descriptions(hass)
-
-    assert descriptions[script.DOMAIN]["test1"]["description"] == ""
-    assert not descriptions[script.DOMAIN]["test1"]["fields"]
-
-    assert descriptions[script.DOMAIN]["test2"]["description"] == "test2"
-    assert (
-        descriptions[script.DOMAIN]["test2"]["fields"]["param"]["description"]
-        == "param_description"
-    )
-    assert (
-        descriptions[script.DOMAIN]["test2"]["fields"]["param"]["example"]
-        == "param_example"
-    )
-
-
 async def test_call_with_required_features(hass, mock_entities):
     """Test service calls invoked only if entity has required feautres."""
     test_service_mock = Mock(return_value=mock_coro())


### PR DESCRIPTION
## Description:

Allow users to provide info about scripts that will be displayed in the "call services" tab, the same way that information is displayed for standard services.  

**Related issue (if applicable):** fixes the `script` portion of https://github.com/home-assistant/architecture/issues/275

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10180

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  home_assistant_restart_with_delay:
    alias: 'Home Assistant: restart with delay'
    description: Restart Home Assistant after a delay.
    fields:
      seconds:
        description: The amount of time to wait (in seconds).
        example: 5
    sequence:
    - delay: '00:00:{{ seconds | int }}'
    - service: homeassistant.restart
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
