### PR TITLE
Mqtt binary sensor expire after

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -271,6 +271,7 @@ class MqttBinarySensor(
     def available(self) -> bool:
         """Return true if the device is available and value has not expired."""
         expire_after = self._config.get(CONF_EXPIRE_AFTER)
+        # pylint: disable=no-member
         return MqttAvailability.available.fget(self) and (
             expire_after is None or not self._expired
         )

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -17,9 +17,6 @@ from homeassistant.const import (
     CONF_PAYLOAD_OFF,
     CONF_PAYLOAD_ON,
     CONF_VALUE_TEMPLATE,
-    STATE_UNAVAILABLE,
-    STATE_ON,
-    STATE_OFF,
 )
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -176,6 +173,10 @@ class MqttBinarySensor(
             expire_after = self._config.get(CONF_EXPIRE_AFTER)
 
             if expire_after is not None and expire_after > 0:
+
+                # When expire_after is set, and we receive a message, assume device is available since it has to be to receive the message
+                self._available = True
+
                 # Reset old trigger
                 if self._expiration_trigger:
                     self._expiration_trigger()
@@ -274,11 +275,3 @@ class MqttBinarySensor(
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    @property
-    def state(self):
-        """Return the state of the binary sensor."""
-        if self._available:
-            return STATE_ON if self.is_on else STATE_OFF
-
-        return STATE_UNAVAILABLE

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -31,6 +31,7 @@ from homeassistant.util import dt as dt_util
 
 from . import (
     ATTR_DISCOVERY_HASH,
+    CONF_AVAILABILITY_TOPIC,
     CONF_QOS,
     CONF_STATE_TOPIC,
     CONF_UNIQUE_ID,
@@ -49,7 +50,6 @@ CONF_OFF_DELAY = "off_delay"
 DEFAULT_PAYLOAD_OFF = "OFF"
 DEFAULT_PAYLOAD_ON = "ON"
 DEFAULT_FORCE_UPDATE = False
-CONF_AVAILABILITY_TOPIC = "availability_topic"
 CONF_EXPIRE_AFTER = "expire_after"
 
 PLATFORM_SCHEMA = (
@@ -174,14 +174,6 @@ class MqttBinarySensor(
             payload = msg.payload
             # auto-expire enabled?
             expire_after = self._config.get(CONF_EXPIRE_AFTER)
-            self._available = True
-
-            _LOGGER.debug(
-                "Expire after set to %s for entity: %s with state_topic: %s",
-                expire_after,
-                self._config[CONF_NAME],
-                self._config[CONF_STATE_TOPIC],
-            )
 
             if expire_after is not None and expire_after > 0:
                 # Reset old trigger

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -37,12 +37,13 @@ async def test_setting_sensor_value_expires(hass, mqtt_mock, caplog):
                 "state_topic": "test-topic",
                 "expire_after": 4,
                 "force_update": True,
+                "availability_topic": "availability-topic",
             }
         },
     )
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNAVAILABLE
 
     now = datetime(2017, 1, 1, 1, tzinfo=dt_util.UTC)
     with patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -1,7 +1,9 @@
 """The tests for the  MQTT binary sensor platform."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
-from unittest.mock import ANY
+
+from unittest.mock import ANY, patch
+import logging
 
 from homeassistant.components import binary_sensor, mqtt
 from homeassistant.components.mqtt.discovery import async_start
@@ -24,6 +26,78 @@ from tests.common import (
 )
 
 
+logging.basicConfig(level=logging.DEBUG)
+LOG = logging.getLogger()
+
+
+async def test_not_specifying_expire_at_setting(hass, mqtt_mock):
+    """Test when not setting an expire_after value."""
+    assert await async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            binary_sensor.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "test-topic",
+                "force_update": True,
+            }
+        },
+    )
+
+    # We still run through the time jumps to make sure the sensor doesn't expire.
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    now = datetime(2017, 1, 1, 1, tzinfo=dt_util.UTC)
+    with patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(hass, "test-topic", "ON")
+        await hass.async_block_till_done()
+
+    # Value was set correctly.
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    # Time jump +3s
+    now = now + timedelta(seconds=3)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    # Value is not yet expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    # Next message resets timer
+    with patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(hass, "test-topic", "OFF")
+        await hass.async_block_till_done()
+
+    # Value was updated correctly.
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    # Time jump +3s
+    now = now + timedelta(seconds=3)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    # Value is not yet expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    # Time jump +2s
+    now = now + timedelta(seconds=2)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    # Value is still off, because it shouldn't expire
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+
 async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
     """Test the setting of the value via MQTT."""
     assert await async_setup_component(
@@ -41,6 +115,10 @@ async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
     )
 
     state = hass.states.get("binary_sensor.test")
+
+    LOG.debug("This is my logger!")
+    LOG.debug(state)
+
     assert state.state == STATE_OFF
 
     async_fire_mqtt_message(hass, "test-topic", "ON")
@@ -50,6 +128,73 @@ async def test_setting_sensor_value_via_mqtt_message(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "test-topic", "OFF")
     state = hass.states.get("binary_sensor.test")
     assert state.state == STATE_OFF
+
+
+async def test_setting_sensor_value_expires(hass, mqtt_mock, caplog):
+    """Test the expiration of the value."""
+    assert await async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            binary_sensor.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "state_topic": "test-topic",
+                "expire_after": 4,
+                "force_update": True,
+            }
+        },
+    )
+
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    now = datetime(2017, 1, 1, 1, tzinfo=dt_util.UTC)
+    with patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(hass, "test-topic", "ON")
+        await hass.async_block_till_done()
+
+    # Value was set correctly.
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    # Time jump +3s
+    now = now + timedelta(seconds=3)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    # Value is not yet expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+
+    # Next message resets timer
+    with patch(("homeassistant.helpers.event." "dt_util.utcnow"), return_value=now):
+        async_fire_time_changed(hass, now)
+        async_fire_mqtt_message(hass, "test-topic", "OFF")
+        await hass.async_block_till_done()
+
+    # Value was updated correctly.
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    # Time jump +3s
+    now = now + timedelta(seconds=3)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    # Value is not yet expired
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_OFF
+
+    # Time jump +2s
+    now = now + timedelta(seconds=2)
+    async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+
+    # Value is expired now
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_setting_sensor_value_via_mqtt_message_and_template(hass, mqtt_mock):


### PR DESCRIPTION
First PR, so go easy on me.  Not quite sure about the tasks in the below template that I haven't checked/ticked yet.  Can someone please have a look and let me know what else I need to do?

Cheers,


## Description:

Added expire_after functionality to mqtt binary_sensor.  Basically copied the functionality from the standard mqtt sensor, except that we se availability, instead of just clearing out the state.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10203

## Example entry for **Zigbee2MQTT**  `configuration.yaml`:
```yaml
homeassistant: true
permit_join: true
mqtt:
  base_topic: zigbee2mqtt
  server: 'mqtt://192.168.111.249'
  user: dev
  password: devdev
serial:
  port: \\.\COM4
devices:
  '0x00158d0003973656':
    friendly_name: '0x00158d0003973656'
    retain: false
    homeassistant:
      unique_id: 'binary_sensor.front_door_contact'
      expire_after: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
