### PR TITLE
Use init_subclass for Config Entries

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -44,8 +44,7 @@ def _find_username_from_config(hass, filename):
             return None
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class HueFlowHandler(config_entries.ConfigFlow):
+class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Hue config flow."""
 
     VERSION = 1

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -17,8 +17,7 @@ def configured_instances(hass):
     )
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class MetFlowHandler(config_entries.ConfigFlow):
+class MetFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Met component."""
 
     VERSION = 1

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -668,7 +668,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     def __init_subclass__(cls, domain=None, **kwargs):
         """Initialize a subclass, register if possible."""
-        super().__init_subclass__(**kwargs)
+        super().__init_subclass__(**kwargs)  # type: ignore
         if domain is not None:
             HANDLERS.register(domain)(cls)
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -666,6 +666,12 @@ async def _old_conf_migrator(old_config):
 class ConfigFlow(data_entry_flow.FlowHandler):
     """Base class for config flows with some helpers."""
 
+    def __init_subclass__(cls, domain=None, **kwargs):
+        """Initialize a subclass, register if possible."""
+        super().__init_subclass__(**kwargs)
+        if domain is not None:
+            HANDLERS.register(domain)(cls)
+
     CONNECTION_CLASS = CONN_CLASS_UNKNOWN
 
     @staticmethod


### PR DESCRIPTION
## Description:
I learned something new today and it looks like it can make our code slightly more readable.

I learned about `init_subclass`, a callback called when a class is inherited: https://docs.python.org/3/reference/datamodel.html#customizing-class-creation

This callback can receive keyword arguments by passing them to the inheritance part. This allows us to register config flows without decorating them! 

```python
class MetFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
```

For this PR I updated Hue and Met to use this new approach.

Docs: https://github.com/home-assistant/developers.home-assistant/pull/305

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
