### PR TITLE
Load user-provided descriptions for python_scripts

### DIFF
--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.service import SERVICE_DESCRIPTION_CACHE
 from homeassistant.loader import bind_hass
 from homeassistant.util import sanitize_filename
 from homeassistant.util.yaml.loader import load_yaml
@@ -98,13 +99,13 @@ def discover_scripts(hass):
     else:
         services_dict = {}
 
-    hass.data.setdefault("service_description_cache", {})
+    hass.data.setdefault(SERVICE_DESCRIPTION_CACHE, {})
     for fil in glob.iglob(os.path.join(path, "*.py")):
         name = os.path.splitext(os.path.basename(fil))[0]
         hass.services.register(DOMAIN, name, python_script_service_handler)
 
         if name in services_dict:
-            hass.data["service_description_cache"]["{}.{}".format(DOMAIN, name)] = {
+            hass.data[SERVICE_DESCRIPTION_CACHE]["{}.{}".format(DOMAIN, name)] = {
                 "description": services_dict[name].get("description", ""),
                 "fields": services_dict[name].get("fields", {}),
             }

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.service import SERVICE_DESCRIPTION_CACHE
+from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.loader import bind_hass
 from homeassistant.util import sanitize_filename
 from homeassistant.util.yaml.loader import load_yaml
@@ -99,16 +99,15 @@ def discover_scripts(hass):
     else:
         services_dict = {}
 
-    hass.data.setdefault(SERVICE_DESCRIPTION_CACHE, {})
     for fil in glob.iglob(os.path.join(path, "*.py")):
         name = os.path.splitext(os.path.basename(fil))[0]
         hass.services.register(DOMAIN, name, python_script_service_handler)
 
-        if name in services_dict:
-            hass.data[SERVICE_DESCRIPTION_CACHE]["{}.{}".format(DOMAIN, name)] = {
-                "description": services_dict[name].get("description", ""),
-                "fields": services_dict[name].get("fields", {}),
-            }
+        service_desc = {
+            "description": services_dict.get(name, {}).get("description", ""),
+            "fields": services_dict.get(name, {}).get("fields", {}),
+        }
+        async_set_service_schema(hass, DOMAIN, name, service_desc)
 
 
 @bind_hass

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -3,8 +3,11 @@ import asyncio
 import logging
 from unittest.mock import patch, mock_open
 
+from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.setup import async_setup_component
-from homeassistant.components.python_script import execute
+from homeassistant.components.python_script import DOMAIN, execute, FOLDER
+
+from tests.common import patch_yaml_files
 
 
 @asyncio.coroutine
@@ -287,6 +290,102 @@ def test_reload(hass):
     assert hass.services.has_service("python_script", "hello2")
     assert hass.services.has_service("python_script", "world_beer")
     assert hass.services.has_service("python_script", "reload")
+
+
+@asyncio.coroutine
+def test_service_descriptions(hass):
+    """Test that service descriptions are loaded and reloaded correctly."""
+    # Test 1: no user-provided services.yaml file
+    scripts1 = [
+        "/some/config/dir/python_scripts/hello.py",
+        "/some/config/dir/python_scripts/world_beer.py",
+    ]
+
+    service_descriptions1 = (
+        "hello:\n"
+        "  description: Description of hello.py.\n"
+        "  fields:\n"
+        "    fake_param:\n"
+        "      description: Parameter used by hello.py.\n"
+        "      example: 'This is a test of python_script.hello'"
+    )
+    services_yaml1 = {
+        "{}/{}/services.yaml".format(
+            hass.config.config_dir, FOLDER
+        ): service_descriptions1
+    }
+
+    with patch(
+        "homeassistant.components.python_script.os.path.isdir", return_value=True
+    ), patch(
+        "homeassistant.components.python_script.glob.iglob", return_value=scripts1
+    ), patch(
+        "homeassistant.components.python_script.os.path.exists", return_value=True
+    ), patch_yaml_files(
+        services_yaml1
+    ):
+        yield from async_setup_component(hass, DOMAIN, {})
+
+        descriptions = yield from async_get_all_descriptions(hass)
+
+    assert len(descriptions) == 1
+
+    assert descriptions[DOMAIN]["hello"]["description"] == "Description of hello.py."
+    assert (
+        descriptions[DOMAIN]["hello"]["fields"]["fake_param"]["description"]
+        == "Parameter used by hello.py."
+    )
+    assert (
+        descriptions[DOMAIN]["hello"]["fields"]["fake_param"]["example"]
+        == "This is a test of python_script.hello"
+    )
+
+    assert descriptions[DOMAIN]["world_beer"]["description"] == ""
+    assert bool(descriptions[DOMAIN]["world_beer"]["fields"]) is False
+
+    # Test 2: user-provided services.yaml file
+    scripts2 = [
+        "/some/config/dir/python_scripts/hello2.py",
+        "/some/config/dir/python_scripts/world_beer.py",
+    ]
+
+    service_descriptions2 = (
+        "hello2:\n"
+        "  description: Description of hello2.py.\n"
+        "  fields:\n"
+        "    fake_param:\n"
+        "      description: Parameter used by hello2.py.\n"
+        "      example: 'This is a test of python_script.hello2'"
+    )
+    services_yaml2 = {
+        "{}/{}/services.yaml".format(
+            hass.config.config_dir, FOLDER
+        ): service_descriptions2
+    }
+
+    with patch(
+        "homeassistant.components.python_script.os.path.isdir", return_value=True
+    ), patch(
+        "homeassistant.components.python_script.glob.iglob", return_value=scripts2
+    ), patch(
+        "homeassistant.components.python_script.os.path.exists", return_value=True
+    ), patch_yaml_files(
+        services_yaml2
+    ):
+        yield from hass.services.async_call(DOMAIN, "reload", {}, blocking=True)
+        descriptions = yield from async_get_all_descriptions(hass)
+
+    assert len(descriptions) == 1
+
+    assert descriptions[DOMAIN]["hello2"]["description"] == "Description of hello2.py."
+    assert (
+        descriptions[DOMAIN]["hello2"]["fields"]["fake_param"]["description"]
+        == "Parameter used by hello2.py."
+    )
+    assert (
+        descriptions[DOMAIN]["hello2"]["fields"]["fake_param"]["example"]
+        == "This is a test of python_script.hello2"
+    )
 
 
 @asyncio.coroutine

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -292,8 +292,7 @@ def test_reload(hass):
     assert hass.services.has_service("python_script", "reload")
 
 
-@asyncio.coroutine
-def test_service_descriptions(hass):
+async def test_service_descriptions(hass):
     """Test that service descriptions are loaded and reloaded correctly."""
     # Test 1: no user-provided services.yaml file
     scripts1 = [
@@ -324,9 +323,9 @@ def test_service_descriptions(hass):
     ), patch_yaml_files(
         services_yaml1
     ):
-        yield from async_setup_component(hass, DOMAIN, {})
+        await async_setup_component(hass, DOMAIN, {})
 
-        descriptions = yield from async_get_all_descriptions(hass)
+        descriptions = await async_get_all_descriptions(hass)
 
     assert len(descriptions) == 1
 
@@ -372,8 +371,8 @@ def test_service_descriptions(hass):
     ), patch_yaml_files(
         services_yaml2
     ):
-        yield from hass.services.async_call(DOMAIN, "reload", {}, blocking=True)
-        descriptions = yield from async_get_all_descriptions(hass)
+        await hass.services.async_call(DOMAIN, "reload", {}, blocking=True)
+        descriptions = await async_get_all_descriptions(hass)
 
     assert len(descriptions) == 1
 


### PR DESCRIPTION
## Description:

For the `python_script` integration, load user-provided service descriptions from `<config>/python_scripts/services.yaml`.  This is a a different implementation of https://github.com/home-assistant/home-assistant/pull/26050.  

**Related issue (if applicable):** fixes the `python_script` portion of https://github.com/home-assistant/architecture/issues/275

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10186

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
