### PR TITLE
Add config flow to linky

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -339,7 +339,8 @@ omit =
     homeassistant/components/limitlessled/light.py
     homeassistant/components/linksys_ap/device_tracker.py
     homeassistant/components/linksys_smart/device_tracker.py
-    homeassistant/components/linky/*
+    homeassistant/components/linky/__init__.py
+    homeassistant/components/linky/sensor.py
     homeassistant/components/linode/*
     homeassistant/components/linux_battery/sensor.py
     homeassistant/components/lirc/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -339,7 +339,7 @@ omit =
     homeassistant/components/limitlessled/light.py
     homeassistant/components/linksys_ap/device_tracker.py
     homeassistant/components/linksys_smart/device_tracker.py
-    homeassistant/components/linky/sensor.py
+    homeassistant/components/linky/*
     homeassistant/components/linode/*
     homeassistant/components/linux_battery/sensor.py
     homeassistant/components/lirc/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -153,7 +153,7 @@ homeassistant/components/life360/* @pnbruckner
 homeassistant/components/lifx/* @amelchio
 homeassistant/components/lifx_cloud/* @amelchio
 homeassistant/components/lifx_legacy/* @amelchio
-homeassistant/components/linky/* @tiste @Quentame
+homeassistant/components/linky/* @Quentame
 homeassistant/components/linux_battery/* @fabaff
 homeassistant/components/liveboxplaytv/* @pschmitt
 homeassistant/components/logger/* @home-assistant/core

--- a/homeassistant/components/linky/.translations/en.json
+++ b/homeassistant/components/linky/.translations/en.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "abort": {
+            "username_exists": "Account already configured"
+        },
+        "error": {
+            "username_exists": "Account already configured"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "password": "Password",
+                    "timeout": "Timeout",
+                    "username": "Email"
+                },
+                "description": "Enter your credentials and preferences",
+                "title": "Linky parameters"
+            }
+        },
+        "title": "Linky"
+    }
+}

--- a/homeassistant/components/linky/.translations/en.json
+++ b/homeassistant/components/linky/.translations/en.json
@@ -10,11 +10,10 @@
             "user": {
                 "data": {
                     "password": "Password",
-                    "timeout": "Timeout",
                     "username": "Email"
                 },
-                "description": "Enter your credentials and preferences",
-                "title": "Linky parameters"
+                "description": "Enter your credentials",
+                "title": "Linky"
             }
         },
         "title": "Linky"

--- a/homeassistant/components/linky/.translations/en.json
+++ b/homeassistant/components/linky/.translations/en.json
@@ -4,7 +4,11 @@
             "username_exists": "Account already configured"
         },
         "error": {
-            "username_exists": "Account already configured"
+            "access": "Could not access to Enedis.fr, please check your internet connection",
+            "enedis": "Enedis.fr answered with an error: please retry later (usually not between 11PM and 2AM)",
+            "unknown": "Unknown error: please retry later (usually not between 11PM and 2AM)",
+            "username_exists": "Account already configured",
+            "wrong_login": "Login error: please check your email & password"
         },
         "step": {
             "user": {

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -1,7 +1,7 @@
 """The linky component."""
 import logging
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -14,12 +14,6 @@ _LOGGER.error("LINKY_INIT")
 
 async def async_setup(hass, config):
     """Set up Linky sensor from legacy config file."""
-    _LOGGER.error("LINKY_SENSOR:async_setup")
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
     return True
 
 
@@ -39,7 +33,6 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
         _LOGGER.error("LINKY_INIT:async_start")
         for eid in hass.data[DOMAIN]:
             entry = hass.data[DOMAIN][eid]
-            _LOGGER.error("LINKY_INIT:entry %s", entry.entry_id)
             hass.async_create_task(
                 hass.config_entries.async_forward_entry_setup(entry, "sensor")
             )

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -28,20 +28,20 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up Linky sensor from legacy config file."""
-    _LOGGER.error("LINKY_INIT:async_setup")
 
     conf = config[DOMAIN]
-    _LOGGER.error(conf)
     if conf is not None:
-        for sensor_conf in conf:
-            _LOGGER.error(sensor_conf)
+        for linky_account_conf in conf:
 
-            if sensor_conf is not None and not hass.config_entries.async_entries(
-                DOMAIN
+            if (
+                linky_account_conf is not None
+                and not hass.config_entries.async_entries(DOMAIN)
             ):
                 hass.async_create_task(
                     hass.config_entries.flow.async_init(
-                        DOMAIN, context={"source": SOURCE_IMPORT}, data=sensor_conf
+                        DOMAIN,
+                        context={"source": SOURCE_IMPORT},
+                        data=linky_account_conf,
                     )
                 )
 
@@ -50,7 +50,6 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Load the saved entities."""
-    _LOGGER.error("LINKY_INIT:async_setup_entry")
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "sensor")

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -12,16 +12,16 @@ from .const import DEFAULT_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
+ACCOUNT_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-            }
-        )
-    },
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [ACCOUNT_SCHEMA]))},
     extra=vol.ALLOW_EXTRA,
 )
 
@@ -30,18 +30,20 @@ async def async_setup(hass, config):
     """Set up Linky sensor from legacy config file."""
     _LOGGER.error("LINKY_INIT:async_setup")
 
-    _LOGGER.error(config["sensor"])
-    sensors_conf = config["sensor"]
-    for sensor_conf in sensors_conf:
-        _LOGGER.error(sensor_conf)
-        hass.data[DOMAIN] = sensor_conf or {}
+    conf = config[DOMAIN]
+    _LOGGER.error(conf)
+    if conf is not None:
+        for sensor_conf in conf:
+            _LOGGER.error(sensor_conf)
 
-        if sensor_conf is not None and not hass.config_entries.async_entries(DOMAIN):
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_IMPORT}, data=sensor_conf
+            if sensor_conf is not None and not hass.config_entries.async_entries(
+                DOMAIN
+            ):
+                hass.async_create_task(
+                    hass.config_entries.flow.async_init(
+                        DOMAIN, context={"source": SOURCE_IMPORT}, data=sensor_conf
+                    )
                 )
-            )
 
     return True
 

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -1,1 +1,44 @@
 """The linky component."""
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import callback
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.error("LINKY_INIT")
+
+
+async def async_setup(hass, config):
+    """Platform setup, do nothing."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Load the saved entities."""
+    _LOGGER.error("LINKY_INIT:async_setup_entry")
+    hass.data.setdefault(DOMAIN, {})
+
+    # store the info for later
+    hass.data[DOMAIN][entry.entry_id] = entry
+
+    # TODO: also add sensors directly after adding the integration, but how ?
+
+    @callback
+    def async_start(_):
+        """Load the entry after the start event."""
+        _LOGGER.error("LINKY_INIT:async_start")
+        for eid in hass.data[DOMAIN]:
+            entry = hass.data[DOMAIN][eid]
+            _LOGGER.error("LINKY_INIT:entry %s", entry.entry_id)
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(entry, "sensor")
+            )
+        hass.data[DOMAIN] = {}
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start)
+
+    return True

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -27,29 +27,27 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass, config):
-    """Set up Linky sensor from legacy config file."""
+    """Set up Linky sensors from legacy config file."""
 
-    conf = config[DOMAIN]
-    if conf is not None:
-        for linky_account_conf in conf:
+    conf = config.get(DOMAIN)
+    if conf is None:
+        return True
 
-            if (
-                linky_account_conf is not None
-                and not hass.config_entries.async_entries(DOMAIN)
-            ):
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": SOURCE_IMPORT},
-                        data=linky_account_conf,
-                    )
-                )
+    _LOGGER.error(hass.config_entries.async_entries(DOMAIN))
+    for linky_account_conf in conf:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=linky_account_conf.copy(),
+            )
+        )
 
     return True
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
-    """Load the saved entities."""
+    """Set up Linky sensors."""
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "sensor")

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -1,7 +1,7 @@
 """The linky component."""
 import logging
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import callback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -13,7 +13,13 @@ _LOGGER.error("LINKY_INIT")
 
 
 async def async_setup(hass, config):
-    """Platform setup, do nothing."""
+    """Set up Linky sensor from legacy config file."""
+    _LOGGER.error("LINKY_SENSOR:async_setup")
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
     return True
 
 

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -1,43 +1,57 @@
 """The linky component."""
 import logging
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_START
-from homeassistant.core import callback
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN
+from .const import DEFAULT_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.error("LINKY_INIT")
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+                vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 async def async_setup(hass, config):
     """Set up Linky sensor from legacy config file."""
+    _LOGGER.error("LINKY_INIT:async_setup")
+
+    _LOGGER.error(config["sensor"])
+    sensors_conf = config["sensor"]
+    for sensor_conf in sensors_conf:
+        _LOGGER.error(sensor_conf)
+        hass.data[DOMAIN] = sensor_conf or {}
+
+        if sensor_conf is not None and not hass.config_entries.async_entries(DOMAIN):
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=sensor_conf
+                )
+            )
+
     return True
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Load the saved entities."""
     _LOGGER.error("LINKY_INIT:async_setup_entry")
-    hass.data.setdefault(DOMAIN, {})
 
-    # store the info for later
-    hass.data[DOMAIN][entry.entry_id] = entry
-
-    # TODO: also add sensors directly after adding the integration, but how ?
-
-    @callback
-    def async_start(_):
-        """Load the entry after the start event."""
-        _LOGGER.error("LINKY_INIT:async_start")
-        for eid in hass.data[DOMAIN]:
-            entry = hass.data[DOMAIN][eid]
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, "sensor")
-            )
-        hass.data[DOMAIN] = {}
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, async_start)
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    )
 
     return True

--- a/homeassistant/components/linky/__init__.py
+++ b/homeassistant/components/linky/__init__.py
@@ -33,7 +33,6 @@ async def async_setup(hass, config):
     if conf is None:
         return True
 
-    _LOGGER.error(hass.config_entries.async_entries(DOMAIN))
     for linky_account_conf in conf:
         hass.async_create_task(
             hass.config_entries.flow.async_init(

--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -34,7 +34,7 @@ class LinkyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def _configuration_exists(self, username: str) -> bool:
         """Return True if username exists in configuration."""
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.title == username:
+            if entry.data[CONF_USERNAME] == username:
                 return True
         return False
 

--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -60,7 +60,7 @@ class LinkyFlowHandler(config_entries.ConfigFlow):
         """Handle a flow initiated by the user."""
 
         if user_input is None:
-            return await self._show_setup_form(user_input, None)
+            return self._show_setup_form(user_input, None)
 
         self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
@@ -69,17 +69,17 @@ class LinkyFlowHandler(config_entries.ConfigFlow):
         if self._configuration_exists(self._username):
             errors = {}
             errors[CONF_USERNAME] = "username_exists"
-            return await self._show_setup_form(user_input, errors)
+            return self._show_setup_form(user_input, errors)
 
         client = LinkyClient(self._username, self._password, None, self._timeout)
         try:
-            self.hass.async_add_executor_job(client.login)
-            client.fetch_data()
+            await self.hass.async_add_executor_job(client.login)
+            await self.hass.async_add_executor_job(client.fetch_data)
         except PyLinkyError as exp:
             _LOGGER.error(exp)
             errors = {}
             errors["PyLinkyError"] = exp
-            return await self._show_setup_form(user_input, None)
+            return self._show_setup_form(user_input, None)
         finally:
             client.close_session()
 

--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class LinkyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a Linky config flow."""
+    """Handle a config flow."""
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
@@ -112,11 +112,7 @@ class LinkyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         Only host was required in the yaml file all other fields are optional
         """
-        username = user_input[CONF_USERNAME]
-        password = user_input[CONF_PASSWORD]
-        timeout = user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        if self._configuration_exists(username):
+        if self._configuration_exists(user_input[CONF_USERNAME]):
             return self.async_abort(reason="username_exists")
-        return await self.async_step_user(
-            {CONF_USERNAME: username, CONF_PASSWORD: password, CONF_TIMEOUT: timeout}
-        )
+
+        return await self.async_step_user(user_input)

--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -1,0 +1,110 @@
+"""Config flow to configure the Linky integration."""
+import logging
+
+import voluptuous as vol
+from pylinky.client import LinkyClient, PyLinkyError
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
+
+from .const import DEFAULT_TIMEOUT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.error("LINKY_CONFIG_FLOW")
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class LinkyFlowHandler(config_entries.ConfigFlow):
+    """Handle a Linky config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize Linky config flow."""
+        self._username = None
+        self.__password = None
+        self._timeout = None
+
+    def _configuration_exists(self, username: str) -> bool:
+        """Return True if username exists in configuration."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.title == username:
+                return True
+        return False
+
+    async def _show_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user."""
+
+        if user_input is None:
+            user_input = {}
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")
+                    ): str,
+                    vol.Required(
+                        CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")
+                    ): str,
+                    vol.Required(
+                        CONF_TIMEOUT,
+                        default=user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+                    ): int,
+                }
+            ),
+            errors=errors or {},
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+
+        if user_input is None:
+            return await self._show_setup_form(user_input, None)
+
+        self._username = user_input[CONF_USERNAME]
+        self.__password = user_input[CONF_PASSWORD]
+        self._timeout = user_input[CONF_TIMEOUT]
+
+        if self._configuration_exists(self._username):
+            errors = {}
+            errors[CONF_USERNAME] = "username_exists"
+            return await self._show_setup_form(user_input, errors)
+
+        client = LinkyClient(self._username, self.__password, None, self._timeout)
+        try:
+            client.login()
+            client.fetch_data()
+        except PyLinkyError as exp:
+            _LOGGER.error(exp)
+            errors = {}
+            errors["PyLinkyError"] = exp
+            return await self._show_setup_form(user_input, None)
+        finally:
+            client.close_session()
+
+        _LOGGER.error("LINKY_CONFIG_FLOW:async_create_entry")
+        return self.async_create_entry(
+            title=self._username,
+            data={
+                CONF_USERNAME: self._username,
+                CONF_PASSWORD: self.__password,
+                CONF_TIMEOUT: self._timeout,
+            },
+        )
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry.
+
+        Only host was required in the yaml file all other fields are optional
+        """
+        username = user_input[CONF_USERNAME]
+        password = user_input[CONF_PASSWORD]
+        timeout = user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+        if self._configuration_exists(username):
+            return self.async_abort(reason="username_exists")
+        return await self.async_step_user(
+            {CONF_USERNAME: username, CONF_PASSWORD: password, CONF_TIMEOUT: timeout}
+        )

--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -98,7 +98,6 @@ class LinkyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         finally:
             client.close_session()
 
-        _LOGGER.error("LINKY_CONFIG_FLOW:async_create_entry")
         return self.async_create_entry(
             title=self._username,
             data={

--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -11,11 +11,9 @@ from homeassistant.core import callback
 from .const import DEFAULT_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.error("LINKY_CONFIG_FLOW")
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class LinkyFlowHandler(config_entries.ConfigFlow):
+class LinkyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Linky config flow."""
 
     VERSION = 1

--- a/homeassistant/components/linky/config_flow.py
+++ b/homeassistant/components/linky/config_flow.py
@@ -6,6 +6,7 @@ from pylinky.client import LinkyClient, PyLinkyError
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
+from homeassistant.core import callback
 
 from .const import DEFAULT_TIMEOUT, DOMAIN
 
@@ -23,7 +24,7 @@ class LinkyFlowHandler(config_entries.ConfigFlow):
     def __init__(self):
         """Initialize Linky config flow."""
         self._username = None
-        self.__password = None
+        self._password = None
         self._timeout = None
 
     def _configuration_exists(self, username: str) -> bool:
@@ -33,7 +34,8 @@ class LinkyFlowHandler(config_entries.ConfigFlow):
                 return True
         return False
 
-    async def _show_setup_form(self, user_input=None, errors=None):
+    @callback
+    def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
 
         if user_input is None:
@@ -49,10 +51,6 @@ class LinkyFlowHandler(config_entries.ConfigFlow):
                     vol.Required(
                         CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")
                     ): str,
-                    vol.Required(
-                        CONF_TIMEOUT,
-                        default=user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
-                    ): int,
                 }
             ),
             errors=errors or {},
@@ -65,17 +63,17 @@ class LinkyFlowHandler(config_entries.ConfigFlow):
             return await self._show_setup_form(user_input, None)
 
         self._username = user_input[CONF_USERNAME]
-        self.__password = user_input[CONF_PASSWORD]
-        self._timeout = user_input[CONF_TIMEOUT]
+        self._password = user_input[CONF_PASSWORD]
+        self._timeout = user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
 
         if self._configuration_exists(self._username):
             errors = {}
             errors[CONF_USERNAME] = "username_exists"
             return await self._show_setup_form(user_input, errors)
 
-        client = LinkyClient(self._username, self.__password, None, self._timeout)
+        client = LinkyClient(self._username, self._password, None, self._timeout)
         try:
-            client.login()
+            self.hass.async_add_executor_job(client.login)
             client.fetch_data()
         except PyLinkyError as exp:
             _LOGGER.error(exp)
@@ -90,7 +88,7 @@ class LinkyFlowHandler(config_entries.ConfigFlow):
             title=self._username,
             data={
                 CONF_USERNAME: self._username,
-                CONF_PASSWORD: self.__password,
+                CONF_PASSWORD: self._password,
                 CONF_TIMEOUT: self._timeout,
             },
         )

--- a/homeassistant/components/linky/const.py
+++ b/homeassistant/components/linky/const.py
@@ -1,5 +1,5 @@
 """Linky component constants."""
 
-DOMAIN = 'linky'
+DOMAIN = "linky"
 
 DEFAULT_TIMEOUT = 10

--- a/homeassistant/components/linky/const.py
+++ b/homeassistant/components/linky/const.py
@@ -1,0 +1,5 @@
+"""Linky component constants."""
+
+DOMAIN = 'linky'
+
+DEFAULT_TIMEOUT = 10

--- a/homeassistant/components/linky/manifest.json
+++ b/homeassistant/components/linky/manifest.json
@@ -1,13 +1,13 @@
 {
   "domain": "linky",
   "name": "Linky",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/linky",
   "requirements": [
     "pylinky==0.3.3"
   ],
   "dependencies": [],
   "codeowners": [
-    "@tiste",
     "@Quentame"
   ]
 }

--- a/homeassistant/components/linky/manifest.json
+++ b/homeassistant/components/linky/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/linky",
   "requirements": [
-    "pylinky==0.3.3"
+    "pylinky==0.4.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
 )
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import track_time_interval
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import DEFAULT_TIMEOUT, DOMAIN
@@ -104,7 +104,7 @@ class LinkyAccount:
         )
         self.sensors.append(LinkySensor("Linky last year", self, YEARLY, INDEX_LAST))
 
-        track_time_interval(hass, self.update_linky_data, SCAN_INTERVAL)
+        async_track_time_interval(hass, self.update_linky_data, SCAN_INTERVAL)
 
     def update_linky_data(self, event_time):
         """Fetch new state data for the sensor."""
@@ -175,7 +175,7 @@ class LinkySensor(Entity):
             CONF_USERNAME: self._username,
         }
 
-    def update(self):
+    async def async_update(self) -> None:
         """Retrieve the new data for the sensor."""
         _LOGGER.error("LINKY_SENSOR:sensor update : %s", self.name)
         data = self.__account.data[self._scale][self.__when]

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -3,7 +3,8 @@ import json
 import logging
 from datetime import timedelta
 
-from pylinky.client import DAILY, MONTHLY, YEARLY, LinkyClient, PyLinkyError
+from pylinky.client import DAILY, MONTHLY, YEARLY, LinkyClient
+from pylinky.client import PyLinkyException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -88,7 +89,7 @@ class LinkyAccount:
             client.fetch_data()
             self._data = client.get_data()
             _LOGGER.debug(json.dumps(self._data, indent=2))
-        except PyLinkyError as exp:
+        except PyLinkyException as exp:
             _LOGGER.error(exp)
         finally:
             client.close_session()

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -3,11 +3,8 @@ import json
 import logging
 from datetime import timedelta
 
-import voluptuous as vol
 from pylinky.client import DAILY, MONTHLY, YEARLY, LinkyClient, PyLinkyError
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -19,8 +16,6 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
-
-from .const import DEFAULT_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,16 +38,6 @@ SENSORS_INDEX_LABEL = 0
 SENSORS_INDEX_SCALE = 1
 SENSORS_INDEX_WHEN = 2
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-    }
-)
-
-_LOGGER.error("LINKY_SENSOR")
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up the Linky platform."""
@@ -68,7 +53,7 @@ async def async_setup_entry(
         entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD], entry.data[CONF_TIMEOUT]
     )
 
-    await hass.async_add_executor_job(account.update_linky_data())
+    await hass.async_add_executor_job(account.update_linky_data)
 
     sensors = [
         LinkySensor("Linky yesterday", account, DAILY, INDEX_LAST),

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -49,7 +49,6 @@ async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Add Linky entries."""
-    _LOGGER.error("LINKY_SENSOR:async_setup_entry")
     account = LinkyAccount(
         entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD], entry.data[CONF_TIMEOUT]
     )
@@ -74,8 +73,6 @@ class LinkyAccount:
 
     def __init__(self, username, password, timeout):
         """Initialise the Linky account."""
-
-        _LOGGER.error("LINKY_SENSOR:account init")
         self._username = username
         self._password = password
         self._timeout = timeout
@@ -94,8 +91,6 @@ class LinkyAccount:
         finally:
             client.close_session()
 
-        _LOGGER.error("LINKY_SENSOR:update finished")
-
     @property
     def username(self):
         """Return the username."""
@@ -112,7 +107,6 @@ class LinkySensor(Entity):
 
     def __init__(self, name, account: LinkyAccount, scale, when):
         """Initialize the sensor."""
-        _LOGGER.error("LINKY_SENSOR:sensor init : %s", name)
         self._name = name
         self._account = account
         self._scale = scale
@@ -152,7 +146,6 @@ class LinkySensor(Entity):
 
     async def async_update(self) -> None:
         """Retrieve the new data for the sensor."""
-        _LOGGER.error("LINKY_SENSOR:sensor update : %s", self.name)
         data = self._account.data[self._scale][self._when]
         self._consumption = data[CONSUMPTION]
         self._time = data[TIME]

--- a/homeassistant/components/linky/strings.json
+++ b/homeassistant/components/linky/strings.json
@@ -12,7 +12,11 @@
             }
         },
         "error":{
-            "username_exists": "Account already configured"
+            "username_exists": "Account already configured",
+            "access": "Could not access to Enedis.fr, please check your internet connection",
+            "enedis": "Enedis.fr answered with an error: please retry later (usually not between 11PM and 2AM)",
+            "wrong_login": "Login error: please check your email & password",
+            "unknown": "Unknown error: please retry later (usually not between 11PM and 2AM)"
         },
         "abort":{
             "username_exists": "Account already configured"

--- a/homeassistant/components/linky/strings.json
+++ b/homeassistant/components/linky/strings.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "title": "Linky",
+        "step": {
+            "user": {
+                "title": "Linky parameters",
+                "description": "Enter your credentials and preferences",
+                "data": {
+                    "username": "Email",
+                    "password": "Password",
+                    "timeout": "Timeout"
+                }
+            }
+        },
+        "error":{
+            "username_exists": "Account already configured"
+        },
+        "abort":{
+            "username_exists": "Account already configured"
+        }
+    }
+}

--- a/homeassistant/components/linky/strings.json
+++ b/homeassistant/components/linky/strings.json
@@ -3,12 +3,11 @@
         "title": "Linky",
         "step": {
             "user": {
-                "title": "Linky parameters",
-                "description": "Enter your credentials and preferences",
+                "title": "Linky",
+                "description": "Enter your credentials",
                 "data": {
                     "username": "Email",
-                    "password": "Password",
-                    "timeout": "Timeout"
+                    "password": "Password"
                 }
             }
         },

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -30,6 +30,7 @@ FLOWS = [
     "iqvia",
     "life360",
     "lifx",
+    "linky",
     "locative",
     "logi_circle",
     "luftdaten",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1256,7 +1256,7 @@ pylgnetcast-homeassistant==0.2.0.dev0
 pylgtv==0.1.9
 
 # homeassistant.components.linky
-pylinky==0.3.3
+pylinky==0.4.0
 
 # homeassistant.components.litejet
 pylitejet==0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,6 +288,9 @@ pyhomematic==0.1.60
 # homeassistant.components.iqvia
 pyiqvia==0.2.1
 
+# homeassistant.components.linky
+pylinky==0.4.0
+
 # homeassistant.components.litejet
 pylitejet==0.1
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -119,6 +119,7 @@ TEST_REQUIREMENTS = (
     "pyheos",
     "pyhomematic",
     "pyiqvia",
+    "pylinky",
     "pylitejet",
     "pymfy",
     "pymonoprice",

--- a/tests/components/linky/__init__.py
+++ b/tests/components/linky/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Linky component."""

--- a/tests/components/linky/test_config_flow.py
+++ b/tests/components/linky/test_config_flow.py
@@ -1,0 +1,108 @@
+"""Tests for the Linky config flow."""
+import pytest
+from unittest.mock import patch
+
+from homeassistant import data_entry_flow
+from homeassistant.components.linky import config_flow
+from homeassistant.components.linky.const import DOMAIN, DEFAULT_TIMEOUT
+from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+USERNAME = "username"
+PASSWORD = "password"
+TIMEOUT = 20
+
+
+@pytest.fixture(name="login")
+def mock_controller_login():
+    """Mock a successful login."""
+    with patch("pylinky.client.LinkyClient.login", return_value=True):
+        yield
+
+
+@pytest.fixture(name="fetch_data")
+def mock_controller_fetch_data():
+    """Mock a successful get data."""
+    with patch("pylinky.client.LinkyClient.fetch_data", return_value={}):
+        yield
+
+
+@pytest.fixture(name="close_session")
+def mock_controller_close_session():
+    """Mock a successful closing session."""
+    with patch("pylinky.client.LinkyClient.close_session", return_value=None):
+        yield
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    flow = config_flow.LinkyFlowHandler()
+    flow.hass = hass
+    return flow
+
+
+async def test_user(hass, login, fetch_data, close_session):
+    """Test user config."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # test with all provided
+    result = await flow.async_step_user(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_TIMEOUT] == DEFAULT_TIMEOUT
+
+
+async def test_import(hass, login, fetch_data, close_session):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with username and password
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_TIMEOUT] == DEFAULT_TIMEOUT
+
+    # import with all
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD, CONF_TIMEOUT: TIMEOUT}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_TIMEOUT] == TIMEOUT
+
+
+async def test_abort_if_already_setup(hass, login, fetch_data, close_session):
+    """Test we abort if Linky is already setup."""
+    flow = init_config_flow(hass)
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    ).add_to_hass(hass)
+
+    # Should fail, same USERNAME (import)
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "username_exists"
+
+    # Should fail, same USERNAME (flow)
+    result = await flow.async_step_user(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_USERNAME: "username_exists"}


### PR DESCRIPTION
## Breaking Change:

Linky platform moved to integration.

`configuration.yaml` before : 
```yaml
sensor:
  - platform: linky
    username: __email__
    password: __password__
```

After : 
```yaml
linky:
  - username: __email__
    password: __password__
```

Documentation updated : https://github.com/home-assistant/home-assistant.io/pull/10284

## Description:

Hi !

Just *adding Linky a config flow*, but I need some help for **3 things**.

I am still learning Python with you guys, while coding for HA ... everyone is pleased to make a review, go for it ! (with cool links if it's something tricky, that would be nice 👍)

I made `_LOGGER.error` to see it better, screenshots will illustrate :wink: with the actual code.

***1 : Make the component actually retrieving the data without stop HA boot***

I mean, it's the same working retrieve data code, but the async and timeout part makes it not working I think.

So I got a `RuntimeError: cannot be called from within the event loop` caused by `run_callback_threadsafe` call in a async method, then the sensors aren't created.

Actually HA is booting because the sensors try to be added after HA starts with a listener and `async_start` callback, but without it's not, and no logs are coming.

See the logs, at HA starts (the only way the retrieve the data for now)
<img width="955" alt="Capture d’écran 2019-08-19 à 13 44 14" src="https://user-images.githubusercontent.com/14821482/63296760-228a8400-c2d0-11e9-8cb4-2e1f7373cb1f.png">

This first point should be though with point 2 in mind ⬇️ 

- [x] fixed

***2 : Add the Linky sensors directly after adding the integration by the user in the config flow (not only at boot)***

I know that it should be added in `async_setup_entry` but if I do so, it is gonna block HA start and Linky's data are never gonna be retrieved. That's why there is an `async_start`.

So I get those logs right after adding my integration : 
<img width="867" alt="Capture d’écran 2019-08-19 à 13 45 46" src="https://user-images.githubusercontent.com/14821482/63296515-8f514e80-c2cf-11e9-96c3-79316dd6b046.png">

But no sensors.

- [x] fixed

***3 : Here it's more a question but it will permits much less duplicated code***

Can/Should I display "computed" errors to the user ? (one's that are not in the `strings.json` file)

I'am telling that because the `LinkyClient` can raise multiple functional errors, but they got all the same type `PyLinkyError`.

`PyLinkyError`is raised for (quoting the pylinky lib) : 

1. `raise PyLinkyError("Can not submit login form")`
2. `raise PyLinkyError("Login error: Please check your username/password.")`
3. `raise PyLinkyError("Could not access enedis.fr: " + str(e))`
4. `raise PyLinkyError("No data")`
5. `raise PyLinkyError("Site in maintenance")`
6. `raise PyLinkyError("Impossible to decode response: " + str(e) + "\nResponse was: " + str(raw_res.text))`
7. `raise PyLinkyError("Enedis.fr answered with an error: " + str(json_output))`

So how should I tell the user he has a wrong password ? or if the website is in maintenance and retry later ?

I come up this 3 ideas : 

1. Display the message as it is (but meaning no translation)
2. Parse the message (no future proof at all)
3. Change the lib to raise specific Exceptions, wait until the approval and release, update the lib and add specific translations for every exceptions (might be very long)
4. Just say the user to verify its credentials and if the website isn't in maintenance and retry (all in one but not precise and accurate for the user)

- [x] fixed


@MartinHjelmare, if you have some time I will appreciate.

Thanks a lot !

PS : config flow inspired with AdGuard Home ([Config flow file](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/adguard/config_flow.py), by @frenck) and Cert Expiry (still in PR #25624 by @Cereal2nd) code.

---

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

Not yet