### PR TITLE
Save config entry after updating system options

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -272,7 +272,11 @@ async def system_options_update(hass, connection, msg):
     entry_id = changes.pop("entry_id")
     entry = hass.config_entries.async_get_entry(entry_id)
 
-    if entry and changes:
-        entry.system_options.update(**changes)
+    if entry is None:
+        connection.send_error(
+            msg["id"], websocket_api.const.ERR_NOT_FOUND, "Config entry not found"
+        )
+        return
 
-        connection.send_result(msg["id"], entry.system_options.as_dict())
+    hass.config_entries.async_update_entry(entry, system_options=changes)
+    connection.send_result(msg["id"], entry.system_options.as_dict())

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -522,7 +522,9 @@ class ConfigEntries:
         return await self.async_setup(entry_id)
 
     @callback
-    def async_update_entry(self, entry, *, data=_UNDEF, options=_UNDEF):
+    def async_update_entry(
+        self, entry, *, data=_UNDEF, options=_UNDEF, system_options=_UNDEF
+    ):
         """Update a config entry."""
         if data is not _UNDEF:
             entry.data = data
@@ -530,10 +532,12 @@ class ConfigEntries:
         if options is not _UNDEF:
             entry.options = options
 
-        if data is not _UNDEF or options is not _UNDEF:
-            for listener_ref in entry.update_listeners:
-                listener = listener_ref()
-                self.hass.async_create_task(listener(self.hass, entry))
+        if system_options is not _UNDEF:
+            entry.system_options.update(**system_options)
+
+        for listener_ref in entry.update_listeners:
+            listener = listener_ref()
+            self.hass.async_create_task(listener(self.hass, entry))
 
         self._async_schedule_save()
 


### PR DESCRIPTION
## Description:
Small oversight when we added system options, we didn't save them! This routes the updating of system options through the `async_update_entry` call which correctly triggers a save.

CC @Kane610 
