### PR TITLE
GeoNet NZ Quakes Sensor

### DIFF
--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import voluptuous as vol
 from aio_geojson_geonetnz_quakes import GeonetnzQuakesFeedManager
 
-from homeassistant.components.geonetnz_quakes.geo_location import GeonetnzQuakesEvent
 from homeassistant.core import callback
 from homeassistant.setup import ATTR_COMPONENT
 from homeassistant.util.unit_system import METRIC_SYSTEM
@@ -221,10 +220,13 @@ class GeonetnzQuakesFeedEntityManager:
 
     async def _generate_entity(self, external_id):
         """Generate new entity."""
-        new_entity = GeonetnzQuakesEvent(self, external_id, self._unit_system)
-        # Add new entities to HA.
-        _LOGGER.debug("Creating new entity %s", new_entity)
-        async_dispatcher_send(self._hass, self.async_event_new_entity(), new_entity)
+        async_dispatcher_send(
+            self._hass,
+            self.async_event_new_entity(),
+            self,
+            external_id,
+            self._unit_system,
+        )
 
     async def _update_entity(self, external_id):
         """Update entity."""

--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -9,14 +9,6 @@ from homeassistant.components.geonetnz_quakes.geo_location import GeonetnzQuakes
 from homeassistant.core import callback
 from homeassistant.setup import ATTR_COMPONENT
 from homeassistant.util.unit_system import METRIC_SYSTEM
-from .const import (
-    SIGNAL_DELETE_ENTITY,
-    SIGNAL_UPDATE_ENTITY,
-    SIGNAL_STATUS,
-    DEFAULT_FILTER_TIME_INTERVAL,
-    SIGNAL_NEW_GEOLOCATION,
-)
-
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_LATITUDE,
@@ -34,15 +26,20 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .config_flow import configured_instances
 from .const import (
+    COMPONENTS,
     CONF_MINIMUM_MAGNITUDE,
     CONF_MMI,
+    DEFAULT_FILTER_TIME_INTERVAL,
     DEFAULT_MINIMUM_MAGNITUDE,
     DEFAULT_MMI,
     DEFAULT_RADIUS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    COMPONENTS,
     FEED,
+    SIGNAL_DELETE_ENTITY,
+    SIGNAL_NEW_GEOLOCATION,
+    SIGNAL_STATUS,
+    SIGNAL_UPDATE_ENTITY,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 from aio_geojson_geonetnz_quakes import GeonetnzQuakesFeedManager
 
 from homeassistant.core import callback
-from homeassistant.setup import ATTR_COMPONENT
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
@@ -17,7 +16,6 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM,
     LENGTH_MILES,
-    EVENT_COMPONENT_LOADED,
 )
 from homeassistant.helpers import config_validation as cv, aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -177,17 +175,10 @@ class GeonetnzQuakesFeedEntityManager:
             """Update."""
             await self.async_update()
 
+        # Trigger updates at regular intervals.
         self._track_time_remove_callback = async_track_time_interval(
             self._hass, update, self._scan_interval
         )
-
-        async def component_loaded(event):
-            """Handle a new component loaded."""
-            component = event.data.get(ATTR_COMPONENT)
-            if component == DOMAIN:
-                await self.async_update()
-
-        self._hass.bus.async_listen(EVENT_COMPONENT_LOADED, component_loaded)
 
         _LOGGER.debug("Feed entity manager initialized")
 

--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     DEFAULT_RADIUS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    COMPONENTS,
     FEED,
 )
 
@@ -84,9 +85,10 @@ async def async_setup_entry(hass, config_entry):
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][FEED] = {}
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config_entry, "geo_location")
-    )
+    for domain in COMPONENTS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, domain)
+        )
 
     return True
 
@@ -96,6 +98,7 @@ async def async_unload_entry(hass, config_entry):
     manager = hass.data[DOMAIN][FEED].pop(config_entry.entry_id)
     await manager.async_stop()
 
-    await hass.config_entries.async_forward_entry_unload(config_entry, "geo_location")
+    for domain in COMPONENTS:
+        await hass.config_entries.async_forward_entry_unload(config_entry, domain)
 
     return True

--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -98,8 +98,10 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up the GeoNet NZ Quakes component as config entry."""
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][FEED] = {}
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    if FEED not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][FEED] = {}
 
     for domain in COMPONENTS:
         hass.async_create_task(

--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -1,5 +1,17 @@
 """The GeoNet NZ Quakes integration."""
+import logging
+from datetime import timedelta
+
 import voluptuous as vol
+from aio_geojson_geonetnz_quakes import GeonetnzQuakesFeedManager
+
+from homeassistant.components.geonetnz_quakes.geo_location import GeonetnzQuakesEvent
+from .const import (
+    SIGNAL_DELETE_ENTITY,
+    SIGNAL_UPDATE_ENTITY,
+    SIGNAL_STATUS,
+    DEFAULT_FILTER_TIME_INTERVAL,
+)
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
@@ -8,7 +20,9 @@ from homeassistant.const import (
     CONF_RADIUS,
     CONF_SCAN_INTERVAL,
 )
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, aiohttp_client
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
 
 from .config_flow import configured_instances
 from .const import (
@@ -22,6 +36,8 @@ from .const import (
     COMPONENTS,
     FEED,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -102,3 +118,95 @@ async def async_unload_entry(hass, config_entry):
         await hass.config_entries.async_forward_entry_unload(config_entry, domain)
 
     return True
+
+
+class GeonetnzQuakesFeedEntityManager:
+    """Feed Entity Manager for GeoNet NZ Quakes feed."""
+
+    def __init__(
+        self,
+        hass,
+        async_add_entities,
+        config_entry_id,
+        scan_interval,
+        latitude,
+        longitude,
+        mmi,
+        radius_in_km,
+        unit_system,
+        minimum_magnitude,
+    ):
+        """Initialize the Feed Entity Manager."""
+        self._hass = hass
+        coordinates = (latitude, longitude)
+        websession = aiohttp_client.async_get_clientsession(hass)
+        self._feed_manager = GeonetnzQuakesFeedManager(
+            websession,
+            self._generate_entity,
+            self._update_entity,
+            self._remove_entity,
+            coordinates,
+            mmi=mmi,
+            filter_radius=radius_in_km,
+            filter_minimum_magnitude=minimum_magnitude,
+            filter_time=DEFAULT_FILTER_TIME_INTERVAL,
+            status_callback=self._status_update,
+        )
+        self._async_add_entities = async_add_entities
+        self._config_entry_id = config_entry_id
+        self._scan_interval = timedelta(seconds=scan_interval)
+        self._unit_system = unit_system
+        self._track_time_remove_callback = None
+        self._status_info = None
+
+    async def async_init(self):
+        """Schedule regular updates based on configured time interval."""
+
+        async def update(event_time):
+            """Update."""
+            await self.async_update()
+
+        await self.async_update()
+        self._track_time_remove_callback = async_track_time_interval(
+            self._hass, update, self._scan_interval
+        )
+        _LOGGER.debug("Feed entity manager initialized")
+
+    async def async_update(self):
+        """Refresh data."""
+        await self._feed_manager.update()
+        _LOGGER.debug("Feed entity manager updated")
+
+    async def async_stop(self):
+        """Stop this feed entity manager from refreshing."""
+        if self._track_time_remove_callback:
+            self._track_time_remove_callback()
+        _LOGGER.debug("Feed entity manager stopped")
+
+    def get_entry(self, external_id):
+        """Get feed entry by external id."""
+        return self._feed_manager.feed_entries.get(external_id)
+
+    def status_info(self):
+        """Return latest status update info received."""
+        return self._status_info
+
+    async def _generate_entity(self, external_id):
+        """Generate new entity."""
+        new_entity = GeonetnzQuakesEvent(self, external_id, self._unit_system)
+        # Add new entities to HA.
+        self._async_add_entities([new_entity], True)
+
+    async def _update_entity(self, external_id):
+        """Update entity."""
+        async_dispatcher_send(self._hass, SIGNAL_UPDATE_ENTITY.format(external_id))
+
+    async def _remove_entity(self, external_id):
+        """Remove entity."""
+        async_dispatcher_send(self._hass, SIGNAL_DELETE_ENTITY.format(external_id))
+
+    async def _status_update(self, status_info):
+        """Propagate status update."""
+        _LOGGER.debug("Status update received: %s", status_info)
+        self._status_info = status_info
+        async_dispatcher_send(self._hass, SIGNAL_STATUS.format(self._config_entry_id))

--- a/homeassistant/components/geonetnz_quakes/__init__.py
+++ b/homeassistant/components/geonetnz_quakes/__init__.py
@@ -117,7 +117,9 @@ async def async_unload_entry(hass, config_entry):
     await manager.async_stop()
 
     for domain in COMPONENTS:
-        await hass.config_entries.async_forward_entry_unload(config_entry, domain)
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_unload(config_entry, domain)
+        )
 
     return True
 

--- a/homeassistant/components/geonetnz_quakes/const.py
+++ b/homeassistant/components/geonetnz_quakes/const.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 DOMAIN = "geonetnz_quakes"
 
-COMPONENTS = ("sensor", "geo_location")
+PLATFORMS = ("sensor", "geo_location")
 
 CONF_MINIMUM_MAGNITUDE = "minimum_magnitude"
 CONF_MMI = "mmi"

--- a/homeassistant/components/geonetnz_quakes/const.py
+++ b/homeassistant/components/geonetnz_quakes/const.py
@@ -19,3 +19,5 @@ DEFAULT_SCAN_INTERVAL = timedelta(minutes=5)
 SIGNAL_DELETE_ENTITY = "geonetnz_quakes_delete_{}"
 SIGNAL_UPDATE_ENTITY = "geonetnz_quakes_update_{}"
 SIGNAL_STATUS = "geonetnz_quakes_status_{}"
+
+SIGNAL_NEW_GEOLOCATION = "geonetnz_quakes_new_geolocation_{}"

--- a/homeassistant/components/geonetnz_quakes/const.py
+++ b/homeassistant/components/geonetnz_quakes/const.py
@@ -10,7 +10,12 @@ CONF_MMI = "mmi"
 
 FEED = "feed"
 
+DEFAULT_FILTER_TIME_INTERVAL = timedelta(days=7)
 DEFAULT_MINIMUM_MAGNITUDE = 0.0
 DEFAULT_MMI = 3
 DEFAULT_RADIUS = 50.0
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=5)
+
+SIGNAL_DELETE_ENTITY = "geonetnz_quakes_delete_{}"
+SIGNAL_UPDATE_ENTITY = "geonetnz_quakes_update_{}"
+SIGNAL_STATUS = "geonetnz_quakes_status_{}"

--- a/homeassistant/components/geonetnz_quakes/const.py
+++ b/homeassistant/components/geonetnz_quakes/const.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 
 DOMAIN = "geonetnz_quakes"
 
+COMPONENTS = ("sensor", "geo_location")
+
 CONF_MINIMUM_MAGNITUDE = "minimum_magnitude"
 CONF_MMI = "mmi"
 

--- a/homeassistant/components/geonetnz_quakes/geo_location.py
+++ b/homeassistant/components/geonetnz_quakes/geo_location.py
@@ -45,6 +45,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             hass, manager.async_event_new_entity(), async_add_geolocation
         )
     )
+    hass.async_create_task(manager.async_update())
     _LOGGER.debug("Geolocation setup done")
 
 

--- a/homeassistant/components/geonetnz_quakes/geo_location.py
+++ b/homeassistant/components/geonetnz_quakes/geo_location.py
@@ -34,10 +34,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     manager = hass.data[DOMAIN][FEED][entry.entry_id]
 
     @callback
-    def async_add_geolocation(entity):
+    def async_add_geolocation(feed_manager, external_id, unit_system):
         """Add gelocation entity from feed."""
-        _LOGGER.debug("Adding geolocation %s", entity)
-        async_add_entities([entity], True)
+        new_entity = GeonetnzQuakesEvent(feed_manager, external_id, unit_system)
+        _LOGGER.debug("Adding geolocation %s", new_entity)
+        async_add_entities([new_entity], True)
 
     manager.listeners.append(
         async_dispatcher_connect(

--- a/homeassistant/components/geonetnz_quakes/geo_location.py
+++ b/homeassistant/components/geonetnz_quakes/geo_location.py
@@ -107,6 +107,7 @@ class GeonetnzQuakesFeedEntityManager:
         self._scan_interval = timedelta(seconds=scan_interval)
         self._unit_system = unit_system
         self._track_time_remove_callback = None
+        self._status_info = None
 
     async def async_init(self):
         """Schedule regular updates based on configured time interval."""

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -5,6 +5,7 @@ from typing import Optional
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import dt
 
 from .const import DOMAIN, FEED, SIGNAL_STATUS
 
@@ -86,8 +87,14 @@ class GeonetnzQuakesSensor(Entity):
     def _update_from_status_info(self, status_info):
         """Update the internal state from the provided information."""
         self._status = status_info.status
-        self._last_update = status_info.last_update
-        self._last_update_successful = status_info.last_update_successful
+        self._last_update = (
+            dt.as_utc(status_info.last_update) if status_info.last_update else None
+        )
+        self._last_update_successful = (
+            dt.as_utc(status_info.last_update_successful)
+            if status_info.last_update_successful
+            else None
+        )
         self._last_timestamp = status_info.last_timestamp
         self._total = status_info.total
         self._created = status_info.created

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -30,6 +30,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
 
 class GeonetnzQuakesSensor(Entity):
+    """This is a status sensor for the GeoNet NZ Quakes integration."""
+
     def __init__(self, config_entry_id, config_title):
         """Initialize entity."""
         self._config_entry_id = config_entry_id

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -1,0 +1,126 @@
+"""Feed Entity Manager Sensor support for GeoNet NZ Quakes Feeds."""
+import logging
+from typing import Optional
+
+from homeassistant.components.geonetnz_quakes import DOMAIN, FEED
+from homeassistant.components.geonetnz_quakes.geo_location import SIGNAL_STATUS
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_ENTRY_ID = "entry_id"
+ATTR_STATUS = "status"
+ATTR_LAST_UPDATE = "last_update"
+ATTR_LAST_UPDATE_SUCCESSFUL = "last_update_successful"
+ATTR_LAST_TIMESTAMP = "last_timestamp"
+ATTR_CREATED = "created"
+ATTR_UPDATED = "updated"
+ATTR_REMOVED = "removed"
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the GeoNet NZ Quakes Feed platform."""
+    sensor = GeonetnzQuakesSensor(entry.entry_id, entry.title)
+    async_add_entities([sensor])
+
+
+class GeonetnzQuakesSensor(Entity):
+    def __init__(self, config_entry_id, config_title):
+        """Initialize entity."""
+        self._config_entry_id = config_entry_id
+        self._config_title = config_title
+        self._status = None
+        self._last_update = None
+        self._last_update_successful = None
+        self._last_timestamp = None
+        self._total = None
+        self._created = None
+        self._updated = None
+        self._removed = None
+        self._remove_signal_status = None
+
+    async def async_added_to_hass(self):
+        """Call when entity is added to hass."""
+        self._remove_signal_status = async_dispatcher_connect(
+            self.hass,
+            SIGNAL_STATUS.format(self._config_entry_id),
+            self._update_status_callback,
+        )
+        _LOGGER.debug("Waiting for updates %s", self._config_entry_id)
+        # First update is manual because of how the feed entity manager is updated.
+        await self.async_update()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Call when entity will be removed from hass."""
+        self._remove_signal_status()
+
+    @callback
+    def _update_status_callback(self):
+        """Call status update method."""
+        _LOGGER.debug("Received status update for %s", self._config_entry_id)
+        self.async_schedule_update_ha_state(True)
+
+    @property
+    def should_poll(self):
+        """No polling needed for GeoNet NZ Quakes status sensor."""
+        return False
+
+    async def async_update(self):
+        """Update this entity from the data held in the feed manager."""
+        _LOGGER.debug("Updating %s", self._config_entry_id)
+        manager = self.hass.data[DOMAIN][FEED][self._config_entry_id]
+        if manager:
+            status_info = manager.status_info()
+            if status_info:
+                self._update_from_status_info(status_info)
+
+    def _update_from_status_info(self, status_info):
+        """Update the internal state from the provided information."""
+        self._status = status_info.status
+        self._last_update = status_info.last_update
+        self._last_update_successful = status_info.last_update_successful
+        self._last_timestamp = status_info.last_timestamp
+        self._total = status_info.total
+        self._created = status_info.created
+        self._updated = status_info.updated
+        self._removed = status_info.removed
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._total
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the entity."""
+        return f"GeoNet NZ Quakes Status {self._config_title}"
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:pulse"
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return "entities"
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        for key, value in (
+            (ATTR_STATUS, self._status),
+            (ATTR_LAST_UPDATE, self._last_update),
+            (ATTR_LAST_UPDATE_SUCCESSFUL, self._last_update_successful),
+            (ATTR_LAST_TIMESTAMP, self._last_timestamp),
+            (ATTR_CREATED, self._created),
+            (ATTR_UPDATED, self._updated),
+            (ATTR_REMOVED, self._removed),
+            (ATTR_ENTRY_ID, self._config_entry_id),
+        ):
+            if value or isinstance(value, bool):
+                attributes[key] = value
+        return attributes

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_ENTRY_ID = "entry_id"
 ATTR_STATUS = "status"
 ATTR_LAST_UPDATE = "last_update"
 ATTR_LAST_UPDATE_SUCCESSFUL = "last_update_successful"
@@ -125,7 +124,6 @@ class GeonetnzQuakesSensor(Entity):
             (ATTR_CREATED, self._created),
             (ATTR_UPDATED, self._updated),
             (ATTR_REMOVED, self._removed),
-            (ATTR_ENTRY_ID, self._config_entry_id),
         ):
             if value or isinstance(value, bool):
                 attributes[key] = value

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -24,17 +24,20 @@ DEFAULT_UNIT_OF_MEASUREMENT = "quakes"
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the GeoNet NZ Quakes Feed platform."""
-    sensor = GeonetnzQuakesSensor(entry.entry_id, entry.title)
+    manager = hass.data[DOMAIN][FEED][entry.entry_id]
+    sensor = GeonetnzQuakesSensor(entry.entry_id, entry.title, manager)
     async_add_entities([sensor])
+    _LOGGER.debug("Sensor setup done")
 
 
 class GeonetnzQuakesSensor(Entity):
     """This is a status sensor for the GeoNet NZ Quakes integration."""
 
-    def __init__(self, config_entry_id, config_title):
+    def __init__(self, config_entry_id, config_title, manager):
         """Initialize entity."""
         self._config_entry_id = config_entry_id
         self._config_title = config_title
+        self._manager = manager
         self._status = None
         self._last_update = None
         self._last_update_successful = None
@@ -75,9 +78,8 @@ class GeonetnzQuakesSensor(Entity):
     async def async_update(self):
         """Update this entity from the data held in the feed manager."""
         _LOGGER.debug("Updating %s", self._config_entry_id)
-        manager = self.hass.data[DOMAIN][FEED][self._config_entry_id]
-        if manager:
-            status_info = manager.status_info()
+        if self._manager:
+            status_info = self._manager.status_info()
             if status_info:
                 self._update_from_status_info(status_info)
 

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -97,7 +97,7 @@ class GeonetnzQuakesSensor(Entity):
     @property
     def name(self) -> Optional[str]:
         """Return the name of the entity."""
-        return f"GeoNet NZ Quakes Status {self._config_title}"
+        return f"GeoNet NZ Quakes ({self._config_title})"
 
     @property
     def icon(self):

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -2,11 +2,11 @@
 import logging
 from typing import Optional
 
-from homeassistant.components.geonetnz_quakes import DOMAIN, FEED
-from homeassistant.components.geonetnz_quakes.geo_location import SIGNAL_STATUS
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN, FEED, SIGNAL_STATUS
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -56,7 +56,8 @@ class GeonetnzQuakesSensor(Entity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
-        self._remove_signal_status()
+        if self._remove_signal_status:
+            self._remove_signal_status()
 
     @callback
     def _update_status_callback(self):

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -19,6 +19,8 @@ ATTR_CREATED = "created"
 ATTR_UPDATED = "updated"
 ATTR_REMOVED = "removed"
 
+DEFAULT_UNIT_OF_MEASUREMENT = "earthquakes"
+
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the GeoNet NZ Quakes Feed platform."""
@@ -105,7 +107,7 @@ class GeonetnzQuakesSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return "entities"
+        return DEFAULT_UNIT_OF_MEASUREMENT
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -19,6 +19,7 @@ ATTR_CREATED = "created"
 ATTR_UPDATED = "updated"
 ATTR_REMOVED = "removed"
 
+DEFAULT_ICON = "mdi:pulse"
 DEFAULT_UNIT_OF_MEASUREMENT = "quakes"
 
 
@@ -103,7 +104,7 @@ class GeonetnzQuakesSensor(Entity):
     @property
     def icon(self):
         """Return the icon to use in the frontend, if any."""
-        return "mdi:pulse"
+        return DEFAULT_ICON
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -19,7 +19,7 @@ ATTR_CREATED = "created"
 ATTR_UPDATED = "updated"
 ATTR_REMOVED = "removed"
 
-DEFAULT_UNIT_OF_MEASUREMENT = "earthquakes"
+DEFAULT_UNIT_OF_MEASUREMENT = "quakes"
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/tests/components/geonetnz_quakes/__init__.py
+++ b/tests/components/geonetnz_quakes/__init__.py
@@ -1,1 +1,31 @@
 """Tests for the geonetnz_quakes component."""
+from unittest.mock import MagicMock
+
+
+def _generate_mock_feed_entry(
+    external_id,
+    title,
+    distance_to_home,
+    coordinates,
+    attribution=None,
+    depth=None,
+    magnitude=None,
+    mmi=None,
+    locality=None,
+    quality=None,
+    time=None,
+):
+    """Construct a mock feed entry for testing purposes."""
+    feed_entry = MagicMock()
+    feed_entry.external_id = external_id
+    feed_entry.title = title
+    feed_entry.distance_to_home = distance_to_home
+    feed_entry.coordinates = coordinates
+    feed_entry.attribution = attribution
+    feed_entry.depth = depth
+    feed_entry.magnitude = magnitude
+    feed_entry.mmi = mmi
+    feed_entry.locality = locality
+    feed_entry.quality = quality
+    feed_entry.time = time
+    return feed_entry

--- a/tests/components/geonetnz_quakes/test_config_flow.py
+++ b/tests/components/geonetnz_quakes/test_config_flow.py
@@ -130,6 +130,6 @@ async def test_component_unload_config_entry(hass, config_entry):
         assert mock_feed_manager_update.call_count == 1
         assert hass.data[DOMAIN][FEED][config_entry.entry_id] is not None
         # Unload config entry.
-        assert await async_unload_entry(hass, config_entry) is True
+        assert await async_unload_entry(hass, config_entry)
         await hass.async_block_till_done()
         assert hass.data[DOMAIN][FEED].get(config_entry.entry_id) is None

--- a/tests/components/geonetnz_quakes/test_config_flow.py
+++ b/tests/components/geonetnz_quakes/test_config_flow.py
@@ -1,10 +1,12 @@
 """Define tests for the GeoNet NZ Quakes config flow."""
 from datetime import timedelta
+from unittest.mock import Mock
 
 import pytest
 from asynctest import patch, CoroutineMock
 
 from homeassistant import data_entry_flow
+from homeassistant.components import geonetnz_quakes
 from homeassistant.components.geonetnz_quakes import (
     async_setup_entry,
     config_flow,
@@ -20,7 +22,9 @@ from homeassistant.const import (
     CONF_RADIUS,
     CONF_UNIT_SYSTEM,
     CONF_SCAN_INTERVAL,
+    EVENT_COMPONENT_LOADED,
 )
+from homeassistant.setup import ATTR_COMPONENT
 from tests.common import MockConfigEntry
 
 
@@ -117,19 +121,32 @@ async def test_step_user(hass):
     }
 
 
-async def test_component_unload_config_entry(hass, config_entry):
+async def test_component_unload_config_entry(hass):
     """Test that loading and unloading of a config entry works."""
-    config_entry.add_to_hass(hass)
     with patch(
         "aio_geojson_geonetnz_quakes.GeonetnzQuakesFeedManager.update",
         new_callable=CoroutineMock,
     ) as mock_feed_manager_update:
+        entry = Mock()
+        entry.data = {
+            CONF_LATITUDE: -41.2,
+            CONF_LONGITUDE: 174.7,
+            CONF_RADIUS: 25,
+            CONF_UNIT_SYSTEM: "metric",
+            CONF_SCAN_INTERVAL: 300.0,
+            CONF_MMI: 4,
+            CONF_MINIMUM_MAGNITUDE: 0.0,
+        }
         # Load config entry.
-        assert await async_setup_entry(hass, config_entry)
+        assert await async_setup_entry(hass, entry)
+        await hass.async_block_till_done()
+        hass.bus.async_fire(
+            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: geonetnz_quakes.DOMAIN}
+        )
         await hass.async_block_till_done()
         assert mock_feed_manager_update.call_count == 1
-        assert hass.data[DOMAIN][FEED][config_entry.entry_id] is not None
+        assert len(hass.data[DOMAIN][FEED]) == 1
         # Unload config entry.
-        assert await async_unload_entry(hass, config_entry)
+        assert await async_unload_entry(hass, entry) is True
         await hass.async_block_till_done()
-        assert hass.data[DOMAIN][FEED].get(config_entry.entry_id) is None
+        assert len(hass.data[DOMAIN][FEED]) == 0

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -24,9 +24,8 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_TIME,
     ATTR_ICON,
-    EVENT_COMPONENT_LOADED,
 )
-from homeassistant.setup import async_setup_component, ATTR_COMPONENT
+from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 from tests.common import async_fire_time_changed
 import homeassistant.util.dt as dt_util
@@ -68,10 +67,6 @@ async def test_setup(hass):
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
         # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        await hass.async_block_till_done()
-        hass.bus.async_fire(
-            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: geonetnz_quakes.DOMAIN}
-        )
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()
@@ -171,15 +166,15 @@ async def test_setup_imperial(hass):
         "aio_geojson_client.feed.GeoJsonFeed.__init__",
         new_callable=CoroutineMock,
         create=True,
-    ) as mock_feed_init:
+    ) as mock_feed_init, patch(
+        "aio_geojson_client.feed.GeoJsonFeed.last_timestamp",
+        new_callable=CoroutineMock,
+        create=True,
+    ):
         mock_feed_update.return_value = "OK", [mock_entry_1]
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
         # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        await hass.async_block_till_done()
-        hass.bus.async_fire(
-            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: geonetnz_quakes.DOMAIN}
-        )
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -24,8 +24,9 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_TIME,
     ATTR_ICON,
+    EVENT_COMPONENT_LOADED,
 )
-from homeassistant.setup import async_setup_component
+from homeassistant.setup import async_setup_component, ATTR_COMPONENT
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 from tests.common import async_fire_time_changed
 import homeassistant.util.dt as dt_util
@@ -65,9 +66,12 @@ async def test_setup(hass):
     ) as mock_feed_update:
         mock_feed_update.return_value = "OK", [mock_entry_1, mock_entry_2, mock_entry_3]
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
-        # Artificially trigger update.
+        # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        # Collect events.
+        await hass.async_block_till_done()
+        hass.bus.async_fire(
+            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: geonetnz_quakes.DOMAIN}
+        )
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()
@@ -170,9 +174,12 @@ async def test_setup_imperial(hass):
     ) as mock_feed_init:
         mock_feed_update.return_value = "OK", [mock_entry_1]
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
-        # Artificially trigger update.
+        # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        # Collect events.
+        await hass.async_block_till_done()
+        hass.bus.async_fire(
+            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: geonetnz_quakes.DOMAIN}
+        )
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -164,7 +164,9 @@ async def test_setup_imperial(hass):
     with patch("homeassistant.util.dt.utcnow", return_value=utcnow), patch(
         "aio_geojson_client.feed.GeoJsonFeed.update", new_callable=CoroutineMock
     ) as mock_feed_update, patch(
-        "aio_geojson_client.feed.GeoJsonFeed.__init__", new_callable=CoroutineMock
+        "aio_geojson_client.feed.GeoJsonFeed.__init__",
+        new_callable=CoroutineMock,
+        create=True,
     ) as mock_feed_init:
         mock_feed_update.return_value = "OK", [mock_entry_1]
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
@@ -174,7 +176,7 @@ async def test_setup_imperial(hass):
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()
-        assert len(all_states) == 1
+        assert len(all_states) == 2
 
         # Test conversion of 200 miles to kilometers.
         assert mock_feed_init.call_args[1].get("filter_radius") == 321.8688

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -100,7 +100,8 @@ async def test_setup(hass):
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()
-        assert len(all_states) == 3
+        # 3 geolocation and 1 sensor entities
+        assert len(all_states) == 4
 
         state = hass.states.get("geo_location.title_1")
         assert state is not None
@@ -162,7 +163,7 @@ async def test_setup(hass):
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()
-        assert len(all_states) == 3
+        assert len(all_states) == 4
 
         # Simulate an update - empty data, but successful update,
         # so no changes to entities.
@@ -171,7 +172,7 @@ async def test_setup(hass):
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()
-        assert len(all_states) == 3
+        assert len(all_states) == 4
 
         # Simulate an update - empty data, removes all entities
         mock_feed_update.return_value = "ERROR", None
@@ -179,7 +180,7 @@ async def test_setup(hass):
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()
-        assert len(all_states) == 0
+        assert len(all_states) == 1
 
 
 async def test_setup_imperial(hass):

--- a/tests/components/geonetnz_quakes/test_sensor.py
+++ b/tests/components/geonetnz_quakes/test_sensor.py
@@ -18,8 +18,9 @@ from homeassistant.const import (
     CONF_RADIUS,
     ATTR_UNIT_OF_MEASUREMENT,
     ATTR_ICON,
+    EVENT_COMPONENT_LOADED,
 )
-from homeassistant.setup import async_setup_component
+from homeassistant.setup import async_setup_component, ATTR_COMPONENT
 from tests.common import async_fire_time_changed
 import homeassistant.util.dt as dt_util
 from tests.components.geonetnz_quakes import _generate_mock_feed_entry
@@ -58,9 +59,12 @@ async def test_setup(hass):
     ) as mock_feed_update:
         mock_feed_update.return_value = "OK", [mock_entry_1, mock_entry_2, mock_entry_3]
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
-        # Artificially trigger update.
+        # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        # Collect events.
+        await hass.async_block_till_done()
+        hass.bus.async_fire(
+            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: geonetnz_quakes.DOMAIN}
+        )
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()

--- a/tests/components/geonetnz_quakes/test_sensor.py
+++ b/tests/components/geonetnz_quakes/test_sensor.py
@@ -18,9 +18,8 @@ from homeassistant.const import (
     CONF_RADIUS,
     ATTR_UNIT_OF_MEASUREMENT,
     ATTR_ICON,
-    EVENT_COMPONENT_LOADED,
 )
-from homeassistant.setup import async_setup_component, ATTR_COMPONENT
+from homeassistant.setup import async_setup_component
 from tests.common import async_fire_time_changed
 import homeassistant.util.dt as dt_util
 from tests.components.geonetnz_quakes import _generate_mock_feed_entry
@@ -61,10 +60,6 @@ async def test_setup(hass):
         assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
         # Artificially trigger update and collect events.
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-        await hass.async_block_till_done()
-        hass.bus.async_fire(
-            EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: geonetnz_quakes.DOMAIN}
-        )
         await hass.async_block_till_done()
 
         all_states = hass.states.async_all()

--- a/tests/components/geonetnz_quakes/test_sensor.py
+++ b/tests/components/geonetnz_quakes/test_sensor.py
@@ -78,6 +78,8 @@ async def test_setup(hass):
         attributes = state.attributes
         assert attributes[ATTR_STATUS] == "OK"
         assert attributes[ATTR_CREATED] == 3
+        assert attributes[ATTR_LAST_UPDATE].tzinfo == dt_util.UTC
+        assert attributes[ATTR_LAST_UPDATE_SUCCESSFUL].tzinfo == dt_util.UTC
         assert attributes[ATTR_LAST_UPDATE] == attributes[ATTR_LAST_UPDATE_SUCCESSFUL]
         assert attributes[ATTR_UNIT_OF_MEASUREMENT] == "quakes"
         assert attributes[ATTR_ICON] == "mdi:pulse"

--- a/tests/components/geonetnz_quakes/test_sensor.py
+++ b/tests/components/geonetnz_quakes/test_sensor.py
@@ -1,0 +1,114 @@
+"""The tests for the GeoNet NZ Quakes Feed integration."""
+import datetime
+
+from asynctest import patch, CoroutineMock
+
+from homeassistant.components import geonetnz_quakes
+from homeassistant.components.geonetnz_quakes import DEFAULT_SCAN_INTERVAL
+from homeassistant.components.geonetnz_quakes.sensor import (
+    ATTR_STATUS,
+    ATTR_LAST_UPDATE,
+    ATTR_CREATED,
+    ATTR_UPDATED,
+    ATTR_REMOVED,
+    ATTR_LAST_UPDATE_SUCCESSFUL,
+)
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START,
+    CONF_RADIUS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    ATTR_ICON,
+)
+from homeassistant.setup import async_setup_component
+from tests.common import async_fire_time_changed
+import homeassistant.util.dt as dt_util
+from tests.components.geonetnz_quakes import _generate_mock_feed_entry
+
+CONFIG = {geonetnz_quakes.DOMAIN: {CONF_RADIUS: 200}}
+
+
+async def test_setup(hass):
+    """Test the general setup of the integration."""
+    # Set up some mock feed entries for this test.
+    mock_entry_1 = _generate_mock_feed_entry(
+        "1234",
+        "Title 1",
+        15.5,
+        (38.0, -3.0),
+        locality="Locality 1",
+        attribution="Attribution 1",
+        time=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc),
+        magnitude=5.7,
+        mmi=5,
+        depth=10.5,
+        quality="best",
+    )
+    mock_entry_2 = _generate_mock_feed_entry(
+        "2345", "Title 2", 20.5, (38.1, -3.1), magnitude=4.6
+    )
+    mock_entry_3 = _generate_mock_feed_entry(
+        "3456", "Title 3", 25.5, (38.2, -3.2), locality="Locality 3"
+    )
+    mock_entry_4 = _generate_mock_feed_entry("4567", "Title 4", 12.5, (38.3, -3.3))
+
+    # Patching 'utcnow' to gain more control over the timed update.
+    utcnow = dt_util.utcnow()
+    with patch("homeassistant.util.dt.utcnow", return_value=utcnow), patch(
+        "aio_geojson_client.feed.GeoJsonFeed.update", new_callable=CoroutineMock
+    ) as mock_feed_update:
+        mock_feed_update.return_value = "OK", [mock_entry_1, mock_entry_2, mock_entry_3]
+        assert await async_setup_component(hass, geonetnz_quakes.DOMAIN, CONFIG)
+        # Artificially trigger update.
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        # Collect events.
+        await hass.async_block_till_done()
+
+        all_states = hass.states.async_all()
+        # 3 geolocation and 1 sensor entities
+        assert len(all_states) == 4
+
+        state = hass.states.get("sensor.geonet_nz_quakes_32_87336_117_22743")
+        assert state is not None
+        assert int(state.state) == 3
+        assert state.name == "GeoNet NZ Quakes (32.87336, -117.22743)"
+        attributes = state.attributes
+        assert attributes[ATTR_STATUS] == "OK"
+        assert attributes[ATTR_CREATED] == 3
+        assert attributes[ATTR_LAST_UPDATE] == attributes[ATTR_LAST_UPDATE_SUCCESSFUL]
+        assert attributes[ATTR_UNIT_OF_MEASUREMENT] == "quakes"
+        assert attributes[ATTR_ICON] == "mdi:pulse"
+
+        # Simulate an update - two existing, one new entry, one outdated entry
+        mock_feed_update.return_value = "OK", [mock_entry_1, mock_entry_4, mock_entry_3]
+        async_fire_time_changed(hass, utcnow + DEFAULT_SCAN_INTERVAL)
+        await hass.async_block_till_done()
+
+        all_states = hass.states.async_all()
+        assert len(all_states) == 4
+
+        state = hass.states.get("sensor.geonet_nz_quakes_32_87336_117_22743")
+        attributes = state.attributes
+        assert attributes[ATTR_CREATED] == 1
+        assert attributes[ATTR_UPDATED] == 2
+        assert attributes[ATTR_REMOVED] == 1
+
+        # Simulate an update - empty data, but successful update,
+        # so no changes to entities.
+        mock_feed_update.return_value = "OK_NO_DATA", None
+        async_fire_time_changed(hass, utcnow + 2 * DEFAULT_SCAN_INTERVAL)
+        await hass.async_block_till_done()
+
+        all_states = hass.states.async_all()
+        assert len(all_states) == 4
+
+        # Simulate an update - empty data, removes all entities
+        mock_feed_update.return_value = "ERROR", None
+        async_fire_time_changed(hass, utcnow + 3 * DEFAULT_SCAN_INTERVAL)
+        await hass.async_block_till_done()
+
+        all_states = hass.states.async_all()
+        assert len(all_states) == 1
+
+        state = hass.states.get("sensor.geonet_nz_quakes_32_87336_117_22743")
+        attributes = state.attributes
+        assert attributes[ATTR_REMOVED] == 3


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This is an add-on to the new GeoNet NZ geolocation integration. The sensor's state shows the number of geolocation entities currently managed by this integration, and in addition shows some details about the last update from the feed - successful or error, time of last update, time of last successful update, number of entities created/updated/removed.

This sensor will always be available (as opposed to geolocation entities that come and go) and give the user the ability to see if the integration is working as expected.

Background: I have seen plenty of comments in the forum about the wwlln integration recently where users were not sure if it was working as expected. Geolocation entities were showing up unexpectedly or were not showing up even though expected, etc. I think this type of sensor would be useful for all geolocation integrations, and I propose to trial it with the GeoNet NZ Quakes integration and then roll it out to the other geolocation integrations later.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10229

## Example entry for `configuration.yaml` (if applicable):
```yaml
geonetnz_quakes:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
