### PR TITLE
Update pylacrosse library to version 0.4.0

### DIFF
--- a/homeassistant/components/lacrosse/manifest.json
+++ b/homeassistant/components/lacrosse/manifest.json
@@ -3,7 +3,7 @@
   "name": "Lacrosse",
   "documentation": "https://www.home-assistant.io/components/lacrosse",
   "requirements": [
-    "pylacrosse==0.3.1"
+    "pylacrosse==0.4.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1234,7 +1234,7 @@ pykira==0.1.1
 pykwb==0.0.8
 
 # homeassistant.components.lacrosse
-pylacrosse==0.3.1
+pylacrosse==0.4.0
 
 # homeassistant.components.lastfm
 pylast==3.1.0


### PR DESCRIPTION
This PR just updates the pylacrosse library to version 0.4.0.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
