### PR TITLE
Add strings for traccar config flow

### DIFF
--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -3,8 +3,8 @@
     "title": "Traccar",
     "step": {
       "user": {
-        "title": "Set up the Traccar",
-        "description": "Are you sure you want to set up the Traccar?"
+        "title": "Set up Traccar",
+        "description": "Are you sure you want to set up Traccar?"
       }
     },
     "abort": {

--- a/homeassistant/components/traccar/strings.json
+++ b/homeassistant/components/traccar/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "title": "Traccar",
+    "step": {
+      "user": {
+        "title": "Set up the Traccar",
+        "description": "Are you sure you want to set up the Traccar?"
+      }
+    },
+    "abort": {
+      "one_instance_allowed": "Only a single instance is necessary.",
+      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Traccar."
+    },
+    "create_entry": {
+      "default": "To send events to Home Assistant, you will need to setup the webhook feature in Traccar.\n\nUse the following url: `{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."
+    }
+  }
+}


### PR DESCRIPTION
## Description:
In #24762 a config flow was added for Traccar but it forgot to add translation strings. This adds them in.

