### PR TITLE
Fix open-ui cli arg

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -10,12 +10,7 @@ import threading
 from typing import List, Dict, Any, TYPE_CHECKING  # noqa pylint: disable=unused-import
 
 from homeassistant import monkey_patch
-from homeassistant.const import (
-    __version__,
-    EVENT_HOMEASSISTANT_START,
-    REQUIRED_PYTHON_VER,
-    RESTART_EXIT_CODE,
-)
+from homeassistant.const import __version__, REQUIRED_PYTHON_VER, RESTART_EXIT_CODE
 
 if TYPE_CHECKING:
     from homeassistant import core
@@ -309,23 +304,10 @@ async def setup_and_run_hass(config_dir: str, args: argparse.Namespace) -> int:
             log_no_color=args.log_no_color,
         )
 
-    if args.open_ui:
-        # Imported here to avoid importing asyncio before monkey patch
-        from homeassistant.util.async_ import run_callback_threadsafe
+    if args.open_ui and hass.config.api is not None:
+        import webbrowser
 
-        def open_browser(_: Any) -> None:
-            """Open the web interface in a browser."""
-            if hass.config.api is not None:
-                import webbrowser
-
-                webbrowser.open(hass.config.api.base_url)
-
-        run_callback_threadsafe(
-            hass.loop,
-            hass.bus.async_listen_once,
-            EVENT_HOMEASSISTANT_START,
-            open_browser,
-        )
+        hass.add_job(webbrowser.open, hass.config.api.base_url)
 
     return await hass.async_run()
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -276,7 +276,7 @@ class HomeAssistant:
         self.state = CoreState.running
         _async_create_timer(self)
 
-    def add_job(self, target: Callable[..., None], *args: Any) -> None:
+    def add_job(self, target: Callable[..., Any], *args: Any) -> None:
         """Add job to the executor pool.
 
         target: target to call.


### PR DESCRIPTION
## Description:
The open UI cli arg didn't work because it would attach the listener for START event after the event got fired. This fixes it. When we refactored this code, all set up was done before we get to the check so we can just add_job it.

