### PR TITLE
Add support for turn on/off the display

### DIFF
--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -14,6 +14,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_STOP,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
+    SUPPORT_DISPLAY,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
@@ -47,6 +48,7 @@ SUPPORT_VIERATV = (
     | SUPPORT_PLAY
     | SUPPORT_PLAY_MEDIA
     | SUPPORT_STOP
+    | SUPPORT_DISPLAY
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -109,6 +111,7 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
         self._host = host
         self._volume = 0
         self._app_power = app_power
+        self._display = True
 
     @property
     def unique_id(self) -> str:
@@ -153,6 +156,11 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._muted
+    
+    @property
+    def is_display_on(self):
+        """Boolean if screen is currently on."""
+        return self._display   
 
     @property
     def supported_features(self):
@@ -183,11 +191,15 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
     def volume_down(self):
         """Volume down media player."""
         self._remote.volume_down()
-
+        
     def mute_volume(self, mute):
         """Send mute command."""
         self._remote.set_mute(mute)
-
+    
+    def display(self, display):
+        """Send screen on or off command."""
+        self._remote.set_display(display)
+        
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         volume = int(volume * 100)


### PR DESCRIPTION
## Description:

This feature is supported on "Screen Display" configuration in the TV menus, using the remote control. Is also supported on the python library panasonic-viera with the remote control code 'NRC_DISP_MODE-ONOFF'.

It's particular useful when used to play music of other content through apps or HDMI (from a AVR or media player), with the Viera control turned On (CEC control), allowing to reduce the power consumption and to increase the LCD panel life span.

I'm not that familiar with Python code and Home assistant integrations, so I may need some code review and suggestions from you.

Thanks.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<N/A>


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
