### PR TITLE
[bugfix] Exception if vendor's servers are currently unavailable

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -270,6 +270,7 @@ class EvoBroker:
             evohomeclient2.AuthenticationError,
         ) as err:
             _handle_exception(err)
+            status = str(err)
         else:
             self.timers["statusUpdated"] = utcnow()
 

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -270,14 +270,13 @@ class EvoBroker:
             evohomeclient2.AuthenticationError,
         ) as err:
             _handle_exception(err)
-            status = str(err)
         else:
             self.timers["statusUpdated"] = utcnow()
 
-        _LOGGER.debug("Status = %s", status)
+            _LOGGER.debug("Status = %s", status)
 
-        # inform the evohome devices that state data has been updated
-        async_dispatcher_send(self.hass, DOMAIN, {"signal": "refresh"})
+            # inform the evohome devices that state data has been updated
+            async_dispatcher_send(self.hass, DOMAIN, {"signal": "refresh"})
 
 
 class EvoDevice(Entity):


### PR DESCRIPTION
## Description:

Whenever the evohome servers are down we get this error in the logs:

```
2019-08-20 21:02:02 WARNING (SyncWorker_0) [homeassistant.components.evohome] Vendor says their server is currently unavailable. Check the vendor's status page.
2019-08-20 21:02:02 ERROR (MainThread) [homeassistant.core] Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "homeassistant/components/evohome/__init__.py", line 276, in update
    _LOGGER.debug("Status = %s", status)
UnboundLocalError: local variable 'status' referenced before assignment
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
