### PR TITLE
Upgrade ruamel_yaml to 0.15.100

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,7 @@ python-slugify==3.0.3
 pytz>=2019.02
 pyyaml==5.1.2
 requests==2.22.0
-ruamel.yaml==0.15.99
+ruamel.yaml==0.15.100
 sqlalchemy==1.3.7
 voluptuous-serialize==2.2.0
 voluptuous==0.11.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,7 +15,7 @@ python-slugify==3.0.3
 pytz>=2019.02
 pyyaml==5.1.2
 requests==2.22.0
-ruamel.yaml==0.15.99
+ruamel.yaml==0.15.100
 voluptuous==0.11.7
 voluptuous-serialize==2.2.0
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ REQUIRES = [
     "pytz>=2019.02",
     "pyyaml==5.1.2",
     "requests==2.22.0",
-    "ruamel.yaml==0.15.99",
+    "ruamel.yaml==0.15.100",
     "voluptuous==0.11.7",
     "voluptuous-serialize==2.2.0",
 ]


### PR DESCRIPTION
## Description:

From https://pypi.org/project/ruamel.yaml/
> 0.15.100 (2019-07-17):
> fixing issue with dumping deep-copied data from commented YAML, by providing both the memo parameter to __deepcopy__, and by allowing startmarks to be compared on their content (reported by Theofilos Petsios)

Maybe it will be useful to update it to 0.16.x?

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
