### PR TITLE
Allow adding of data to body for status get of REST switch

### DIFF
--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -30,6 +30,7 @@ CONF_IS_ON_TEMPLATE = "is_on_template"
 DEFAULT_METHOD = "post"
 DEFAULT_BODY_OFF = "OFF"
 DEFAULT_BODY_ON = "ON"
+DEFAULT_BODY_STATE = ""
 DEFAULT_NAME = "REST Switch"
 DEFAULT_TIMEOUT = 10
 DEFAULT_VERIFY_SSL = True
@@ -42,7 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_HEADERS): {cv.string: cv.string},
         vol.Optional(CONF_BODY_OFF, default=DEFAULT_BODY_OFF): cv.template,
         vol.Optional(CONF_BODY_ON, default=DEFAULT_BODY_ON): cv.template,
-        vol.Optional(CONF_BODY_STATE): cv.template,
+        vol.Optional(CONF_BODY_STATE, default=DEFAULT_BODY_STATE): cv.template,
         vol.Optional(CONF_IS_ON_TEMPLATE): cv.template,
         vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.All(
             vol.Lower, vol.In(SUPPORT_REST_METHODS)

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -217,8 +217,10 @@ class RestSwitch(SwitchDevice):
 
         with async_timeout.timeout(self._timeout):
             req = await websession.get(
-                self._resource, auth=self._auth, data=bytes(body_state_t, 'utf-8'),
-                headers=self._headers
+                self._resource,
+                auth=self._auth,
+                data=bytes(body_state_t, "utf-8"),
+                headers=self._headers,
             )
             text = await req.text()
 

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -102,6 +102,7 @@ class TestRestSwitch:
         self.auth = None
         self.body_on = Template("on", self.hass)
         self.body_off = Template("off", self.hass)
+        self.body_state = Template("", self.hass)
         self.switch = rest.RestSwitch(
             self.name,
             self.resource,
@@ -110,6 +111,7 @@ class TestRestSwitch:
             self.auth,
             self.body_on,
             self.body_off,
+            self.body_state,
             None,
             10,
             True,


### PR DESCRIPTION
## Description:
Allow for the sending of data in the body on the get_device_state call.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10193

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: rest
    resource: 'http://192.168.10.249/mf'
    name: Kids room light
    body_on: '{"lightOn":true}'
    body_off: '{"lightOn":false}'
    body_state: '{"queryDynamicShadowData":1}'
    is_on_template: '{{value_json.lightOn}}'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
