### PR TITLE
Add a keypress service for AlarmDecoder

### DIFF
--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -60,16 +60,6 @@ envisalink_alarm_keypress:
       description: 'String to send to the alarm panel (1-6 characters).'
       example: '*71'
 
-alarmdecoder_alarm_keypress:
-  description: Send custom keypresses to the alarm.
-  fields:
-    entity_id:
-      description: Name of the alarm control panel to trigger.
-      example: 'alarm_control_panel.downstairs'
-    keypress:
-      description: 'String ot send to the alarm panel.'
-      example: '*71'
-
 alarmdecoder_alarm_toggle_chime:
   description: Send the alarm the toggle chime command.
   fields:

--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -60,6 +60,16 @@ envisalink_alarm_keypress:
       description: 'String to send to the alarm panel (1-6 characters).'
       example: '*71'
 
+alarmdecoder_alarm_keypress:
+  description: Send custom keypresses to the alarm.
+  fields:
+    entity_id:
+      description: Name of the alarm control panel to trigger.
+      example: 'alarm_control_panel.downstairs'
+    keypress:
+      description: 'String ot send to the alarm panel.'
+      example: '*71'
+
 alarmdecoder_alarm_toggle_chime:
   description: Send the alarm the toggle chime command.
   fields:

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.const import (
     ATTR_CODE,
-    ATTR_ENTITY_ID,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
@@ -18,17 +17,14 @@ from . import DATA_AD, SIGNAL_PANEL_MESSAGE
 
 _LOGGER = logging.getLogger(__name__)
 
+DOMAIN = "alarmdecoder"
+
 SERVICE_ALARM_TOGGLE_CHIME = "alarmdecoder_alarm_toggle_chime"
 ALARM_TOGGLE_CHIME_SCHEMA = vol.Schema({vol.Required(ATTR_CODE): cv.string})
 
-SERVICE_ALARM_KEYPRESS = "alarmdecoder_alarm_keypress"
+SERVICE_ALARM_KEYPRESS = "alarm_keypress"
 ATTR_KEYPRESS = "keypress"
-ALARM_KEYPRESS_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-        vol.Required(ATTR_KEYPRESS): cv.string,
-    }
-)
+ALARM_KEYPRESS_SCHEMA = vol.Schema({vol.Required(ATTR_KEYPRESS): cv.string})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -50,11 +46,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     def alarm_keypress_handler(service):
         """Register keypress handler."""
-        keypress = service.data.get(ATTR_KEYPRESS)
+        keypress = service.data[ATTR_KEYPRESS]
         device.alarm_keypress(keypress)
 
     hass.services.register(
-        alarm.DOMAIN,
+        DOMAIN,
         SERVICE_ALARM_KEYPRESS,
         alarm_keypress_handler,
         schema=ALARM_KEYPRESS_SCHEMA,
@@ -168,7 +164,7 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
         if code:
             self.hass.data[DATA_AD].send("{!s}9".format(code))
 
-    def alarm_keypress(self, keypress=None):
+    def alarm_keypress(self, keypress):
         """Send custom keypresses."""
         if keypress:
             self.hass.data[DATA_AD].send(keypress)

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -13,11 +13,9 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
-from . import DATA_AD, SIGNAL_PANEL_MESSAGE
+from . import DATA_AD, DOMAIN as DOMAIN_ALARMDECODER, SIGNAL_PANEL_MESSAGE
 
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "alarmdecoder"
 
 SERVICE_ALARM_TOGGLE_CHIME = "alarmdecoder_alarm_toggle_chime"
 ALARM_TOGGLE_CHIME_SCHEMA = vol.Schema({vol.Required(ATTR_CODE): cv.string})
@@ -50,7 +48,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device.alarm_keypress(keypress)
 
     hass.services.register(
-        DOMAIN,
+        DOMAIN_ALARMDECODER,
         SERVICE_ALARM_KEYPRESS,
         alarm_keypress_handler,
         schema=ALARM_KEYPRESS_SCHEMA,

--- a/homeassistant/components/alarmdecoder/services.yaml
+++ b/homeassistant/components/alarmdecoder/services.yaml
@@ -1,0 +1,9 @@
+alarm_keypress:
+  description: Send custom keypresses to the alarm.
+  fields:
+    entity_id:
+      description: Name of the alarm control panel to trigger.
+      example: 'alarm_control_panel.downstairs'
+    keypress:
+      description: 'String to send to the alarm panel.'
+      example: '*71'


### PR DESCRIPTION
## Description:
This allows automations to send arbitrary keypresses to the alarm panel, which opens up possibilities ranging from arming in modes not supported by the general component (like "instant" or "max"), to performing complex programming tasks.

The Envisalink component already had such a service. This one sticks to its naming and schema as much as possible, though to my knowledge there is no character limit on the keypresses you can send to the panel.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10195

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
