### PR TITLE
Adds db and lx sensors to Awair

### DIFF
--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONF_DEVICES,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_ILLUMINANCE,
     TEMP_CELSIUS,
 )
 from homeassistant.exceptions import PlatformNotReady
@@ -34,6 +35,7 @@ DEVICE_CLASS_PM2_5 = "PM2.5"
 DEVICE_CLASS_PM10 = "PM10"
 DEVICE_CLASS_CARBON_DIOXIDE = "CO2"
 DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS = "VOC"
+DEVICE_CLASS_DECIBELS = "decibels"
 DEVICE_CLASS_SCORE = "score"
 
 SENSOR_TYPES = {
@@ -73,6 +75,16 @@ SENSOR_TYPES = {
         "device_class": DEVICE_CLASS_PM10,
         "unit_of_measurement": "µg/m3",
         "icon": "mdi:cloud",
+    },
+    "LUX": {
+        "device_class": DEVICE_CLASS_ILLUMINANCE,
+        "unit_of_measurement": "lx",
+        "icon": "mdi:weather-sunny",
+    },
+    "SPL_A": {
+        "device_class": DEVICE_CLASS_DECIBELS,
+        "unit_of_measurement": "dB",
+        "icon": "mdi:ear-hearing",
     },
     "score": {
         "device_class": DEVICE_CLASS_SCORE,


### PR DESCRIPTION
## Description:
Adds sound (db) and light level (lx) sensors to Awair. Note that not all Awair devices have these sensors, and I therefore didn't add any specific test, taking the lead from PM10 which is not tested as not all Awair devices have that sensor either. ping @danielsjf for comment

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io/pull/10198) (if applicable):** home-assistant/home-assistant.io#10198

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
