### PR TITLE
Upgrade pydocstyle to 4.0.1

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,7 +12,7 @@ flake8==3.7.8
 mock-open==1.3.1
 mypy==0.720
 pre-commit==1.18.2
-pydocstyle==4.0.0
+pydocstyle==4.0.1
 pylint==2.3.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -13,7 +13,7 @@ flake8==3.7.8
 mock-open==1.3.1
 mypy==0.720
 pre-commit==1.18.2
-pydocstyle==4.0.0
+pydocstyle==4.0.1
 pylint==2.3.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.7.1


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

https://github.com/PyCQA/pydocstyle/blob/4.0.1/docs/release_notes.rst#401---august-14th-2019

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
