### PR TITLE
Remove ID from groups for Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -38,7 +38,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
-from .device import ATTR_GROUP_MEMBER_UNREACHABLE
+from .device import ATTR_GROUP_MEMBER_UNREACHABLE, ATTR_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -310,6 +310,10 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice, BinarySensorD
     def device_state_attributes(self):
         """Return the state attributes of the security zone group."""
         attr = super().device_state_attributes
+
+        # Remove ATTR_ID from dict, because security groups don't have
+        # device id/sgtin, just an ugly uuid that is referenced no where else.
+        del attr[ATTR_ID]
 
         if self._device.motionDetected:
             attr[ATTR_MOTIONDETECTED] = True


### PR DESCRIPTION
## Description:

This PR remove the id attribute for groups, because groups don't have device id/sgtin, just an ugly uuid that is referenced no where else.
![image](https://user-images.githubusercontent.com/5650106/63449864-2e498800-c441-11e9-9791-3dedb1d9ee4c.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
