### PR TITLE
Update eternalegypt to 0.0.10

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -180,6 +180,7 @@ homeassistant/components/nello/* @pschmitt
 homeassistant/components/ness_alarm/* @nickw444
 homeassistant/components/nest/* @awarecan
 homeassistant/components/netdata/* @fabaff
+homeassistant/components/netgear_lte/* @amelchio
 homeassistant/components/nextbus/* @vividboarder
 homeassistant/components/nissan_leaf/* @filcole
 homeassistant/components/nmbs/* @thibmaek

--- a/homeassistant/components/netgear_lte/manifest.json
+++ b/homeassistant/components/netgear_lte/manifest.json
@@ -3,8 +3,10 @@
   "name": "Netgear lte",
   "documentation": "https://www.home-assistant.io/components/netgear_lte",
   "requirements": [
-    "eternalegypt==0.0.9"
+    "eternalegypt==0.0.10"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@amelchio"
+  ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -455,7 +455,7 @@ epson-projector==0.1.3
 epsonprinter==0.0.9
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.9
+eternalegypt==0.0.10
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1


### PR DESCRIPTION
## Description:

This should avoid the exception mentioned here: https://github.com/amelchio/eternalegypt/pull/16 though I have been unable to reproduce this error myself.

Also add myself as codeowner.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html