### PR TITLE
Upgrade ruamel.yaml to 0.16.5 and add ruamel.yaml.clib

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,7 @@ python-slugify==3.0.3
 pytz>=2019.02
 pyyaml==5.1.2
 requests==2.22.0
-ruamel.yaml==0.15.100
+ruamel.yaml==0.16.5
 sqlalchemy==1.3.7
 voluptuous-serialize==2.2.0
 voluptuous==0.11.7

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,6 +20,7 @@ python-slugify==3.0.3
 pytz>=2019.02
 pyyaml==5.1.2
 requests==2.22.0
+ruamel.yaml.clib==0.1.2
 ruamel.yaml==0.16.5
 sqlalchemy==1.3.7
 voluptuous-serialize==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,7 +15,7 @@ python-slugify==3.0.3
 pytz>=2019.02
 pyyaml==5.1.2
 requests==2.22.0
-ruamel.yaml==0.15.100
+ruamel.yaml==0.16.5
 voluptuous==0.11.7
 voluptuous-serialize==2.2.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -16,6 +16,7 @@ pytz>=2019.02
 pyyaml==5.1.2
 requests==2.22.0
 ruamel.yaml==0.16.5
+ruamel.yaml.clib==0.1.2
 voluptuous==0.11.7
 voluptuous-serialize==2.2.0
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ REQUIRES = [
     "pytz>=2019.02",
     "pyyaml==5.1.2",
     "requests==2.22.0",
-    "ruamel.yaml==0.15.100",
+    "ruamel.yaml==0.16.5",
     "voluptuous==0.11.7",
     "voluptuous-serialize==2.2.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ REQUIRES = [
     "pyyaml==5.1.2",
     "requests==2.22.0",
     "ruamel.yaml==0.16.5",
+    "ruamel.yaml.clib==0.1.2",
     "voluptuous==0.11.7",
     "voluptuous-serialize==2.2.0",
 ]


### PR DESCRIPTION
## Breaking Change:
Not a breaking change.

## Description:
- When I wanted to run homeassistant, it said:
`pkg_resources.DistributionNotFound: The 'ruamel.yaml.clib>=0.1.2' distribution was not found and is required by ruamel.yaml`, so that's why added ruamel.yaml.clib, which is the C based reader/scanner and emitter for ruamel.yaml

Changelog of ruamel.yaml: https://pypi.org/project/ruamel.yaml/
Repository of ruamel.yaml.clib: https://bitbucket.org/ruamel/yaml.clib/

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
However, it passed without ruamel.yaml.clip. No new warnings. And then I run it with added ruamel.yaml.clib. Also, it passed. 
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html