### PR TITLE
Statistics sensors respect given name

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -82,10 +82,7 @@ class StatisticsSensor(Entity):
         """Initialize the Statistics sensor."""
         self._entity_id = entity_id
         self.is_binary = self._entity_id.split(".")[0] == "binary_sensor"
-        if not self.is_binary:
-            self._name = "{} {}".format(name, ATTR_MEAN)
-        else:
-            self._name = "{} {}".format(name, ATTR_COUNT)
+        self._name = name
         self._sampling_size = sampling_size
         self._max_age = max_age
         self._precision = precision

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -60,7 +60,7 @@ class TestStatisticsSensor(unittest.TestCase):
             self.hass.states.set("binary_sensor.test_monitored", value)
             self.hass.block_till_done()
 
-        state = self.hass.states.get("sensor.test_count")
+        state = self.hass.states.get("sensor.test")
 
         assert str(len(values)) == state.state
 
@@ -87,7 +87,7 @@ class TestStatisticsSensor(unittest.TestCase):
             )
             self.hass.block_till_done()
 
-        state = self.hass.states.get("sensor.test_mean")
+        state = self.hass.states.get("sensor.test")
 
         assert str(self.mean) == state.state
         assert self.min == state.attributes.get("min_value")
@@ -126,7 +126,7 @@ class TestStatisticsSensor(unittest.TestCase):
             )
             self.hass.block_till_done()
 
-        state = self.hass.states.get("sensor.test_mean")
+        state = self.hass.states.get("sensor.test")
 
         assert 3.8 == state.attributes.get("min_value")
         assert 14 == state.attributes.get("max_value")
@@ -155,7 +155,7 @@ class TestStatisticsSensor(unittest.TestCase):
             )
             self.hass.block_till_done()
 
-        state = self.hass.states.get("sensor.test_mean")
+        state = self.hass.states.get("sensor.test")
 
         # require only one data point
         assert self.values[-1] == state.attributes.get("min_value")
@@ -206,7 +206,7 @@ class TestStatisticsSensor(unittest.TestCase):
                 # insert the next value one minute later
                 mock_data["return_time"] += timedelta(minutes=1)
 
-            state = self.hass.states.get("sensor.test_mean")
+            state = self.hass.states.get("sensor.test")
 
         assert 6 == state.attributes.get("min_value")
         assert 14 == state.attributes.get("max_value")
@@ -248,7 +248,7 @@ class TestStatisticsSensor(unittest.TestCase):
                 # insert the next value one minute later
                 mock_data["return_time"] += timedelta(minutes=1)
 
-            state = self.hass.states.get("sensor.test_mean")
+            state = self.hass.states.get("sensor.test")
 
         assert datetime(
             2017, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC
@@ -290,7 +290,7 @@ class TestStatisticsSensor(unittest.TestCase):
         self.hass.block_till_done()
 
         # check if the result is as in test_sensor_source()
-        state = self.hass.states.get("sensor.test_mean")
+        state = self.hass.states.get("sensor.test")
         assert str(self.mean) == state.state
 
     @pytest.mark.skip("Flaky in CI")
@@ -355,7 +355,7 @@ class TestStatisticsSensor(unittest.TestCase):
             self.hass.block_till_done()
 
             # check if the result is as in test_sensor_source()
-            state = self.hass.states.get("sensor.test_mean")
+            state = self.hass.states.get("sensor.test")
 
         assert expected_min_age == state.attributes.get("min_age")
         # The max_age timestamp should be 1 hour before what we have right


### PR DESCRIPTION
## Breaking Change:

The names of statistics sensor no longer get `mean` or `count` appended automatically, respecting the name configured by the user. If you use this integration, this name change will affect the name of the entity.

## Description:

The statistics sensor, appends `mean` or `count` to the name, while it should respect the name given by the user.

**Related issue (if applicable):** fixes #26116

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** Not needed

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: statistics
  name: 'MiAP2 PSI Stat'
  entity_id: sensor.mi_ap2_aqi
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
