### PR TITLE
Add 'stopped' to ANDROIDTV_STATES

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -116,6 +116,7 @@ ANDROIDTV_STATES = {
     "standby": STATE_STANDBY,
     "playing": STATE_PLAYING,
     "paused": STATE_PAUSED,
+    "stopped": STATE_STANDBY,
 }
 
 


### PR DESCRIPTION
## Description:

The `state_detection_rules` parameter allows the user to configure their device to report that its state is `"stopped"` under certain conditions. This pull request avoids a `KeyError` exception when translating that to a Home Assistant state. 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
