### PR TITLE
Splitt device_state_attributes between device and group for Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -38,7 +38,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
-from .device import ATTR_GROUP_MEMBER_UNREACHABLE, ATTR_ID
+from .device import ATTR_GROUP_MEMBER_UNREACHABLE, ATTR_MODEL_TYPE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -309,11 +309,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice, BinarySensorD
     @property
     def device_state_attributes(self):
         """Return the state attributes of the security zone group."""
-        attr = super().device_state_attributes
-
-        # Remove ATTR_ID from dict, because security groups don't have
-        # device id/sgtin, just an ugly uuid that is referenced no where else.
-        del attr[ATTR_ID]
+        attr = {ATTR_MODEL_TYPE: self._device.modelType}
 
         if self._device.motionDetected:
             attr[ATTR_MOTIONDETECTED] = True

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -117,9 +117,10 @@ class HomematicipGenericDevice(Entity):
     def device_state_attributes(self):
         """Return the state attributes of the generic device."""
         state_attr = {}
-        for attr, attr_key in DEVICE_ATTRIBUTES.items():
-            attr_value = getattr(self._device, attr, None)
-            if attr_value:
-                state_attr[attr_key] = attr_value
+        if isinstance(self._device, AsyncDevice):
+            for attr, attr_key in DEVICE_ATTRIBUTES.items():
+                attr_value = getattr(self._device, attr, None)
+                if attr_value:
+                    state_attr[attr_key] = attr_value
 
         return state_attr

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
+from .device import ATTR_MODEL_TYPE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -141,6 +142,11 @@ class HomematicipAccesspointStatus(HomematicipGenericDevice):
     def unit_of_measurement(self) -> str:
         """Return the unit this state is expressed in."""
         return "%"
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the security zone group."""
+        return {ATTR_MODEL_TYPE: self._device.modelType}
 
 
 class HomematicipHeatingThermostat(HomematicipGenericDevice):


### PR DESCRIPTION
## Description:
Splitt device_state_attributes between device and group for Homematic IP Cloud.

#26086 added ID/SGTIN 
#26114 removes ID/SGTIN for groups
This PR removes the ID/SGTIN for the "virtual device" Access Point that also only contains a useless uuid.

device_state_attributes are now explicitly added for groups and devices.
The Access Point  has its own device_state_attributes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
