### PR TITLE
Log warning if disabled entities receive updates.

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -281,7 +281,7 @@ class Entity:
                 self._disabled_reported = True
                 _LOGGER.warning(
                     "Entity %s is incorrectly being triggered for updates while it is disabled. This is a bug in the %s integration.",
-                    self.registry_entry.entity_id,
+                    self.entity_id,
                     self.platform.platform_name,
                 )
             return

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -99,6 +99,9 @@ class Entity:
     # If we reported if this entity was slow
     _slow_reported = False
 
+    # If we reported this entity is updated while disabled
+    _disabled_reported = False
+
     # Protect for multiple updates
     _update_staged = False
 
@@ -273,6 +276,16 @@ class Entity:
     @callback
     def _async_write_ha_state(self):
         """Write the state to the state machine."""
+        if self.registry_entry and self.registry_entry.disabled_by:
+            if not self._disabled_reported:
+                self._disabled_reported = True
+                _LOGGER.warning(
+                    "Entity %s is incorrectly being triggered for updates while it is disabled. This is a bug in the %s integration.",
+                    self.registry_entry.entity_id,
+                    self.platform.platform_name,
+                )
+            return
+
         start = timer()
 
         attr = {}

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -349,6 +349,9 @@ class EntityPlatform:
                 disabled_by=disabled_by,
             )
 
+            entity.registry_entry = entry
+            entity.entity_id = entry.entity_id
+
             if entry.disabled:
                 self.logger.info(
                     "Not adding entity %s because it's disabled",
@@ -357,9 +360,6 @@ class EntityPlatform:
                     or '"{} {}"'.format(self.platform_name, entity.unique_id),
                 )
                 return
-
-            entity.registry_entry = entry
-            entity.entity_id = entry.entity_id
 
         # We won't generate an entity ID if the platform has already set one
         # We will however make sure that platform cannot pick a registered ID

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -127,13 +127,13 @@ async def test_update_entity(hass, client):
     assert state is not None
     assert state.name == "before update"
 
+    # UPDATE NAME
     await client.send_json(
         {
             "id": 6,
             "type": "config/entity_registry/update",
             "entity_id": "test_domain.world",
             "name": "after update",
-            "disabled_by": "user",
         }
     )
 
@@ -142,7 +142,7 @@ async def test_update_entity(hass, client):
     assert msg["result"] == {
         "config_entry_id": None,
         "device_id": None,
-        "disabled_by": "user",
+        "disabled_by": None,
         "platform": "test_platform",
         "entity_id": "test_domain.world",
         "name": "after update",
@@ -151,11 +151,24 @@ async def test_update_entity(hass, client):
     state = hass.states.get("test_domain.world")
     assert state.name == "after update"
 
-    assert registry.entities["test_domain.world"].disabled_by == "user"
-
+    # UPDATE DISABLED_BY TO USER
     await client.send_json(
         {
             "id": 7,
+            "type": "config/entity_registry/update",
+            "entity_id": "test_domain.world",
+            "disabled_by": "user",
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert registry.entities["test_domain.world"].disabled_by == "user"
+
+    # UPDATE DISABLED_BY TO NONE
+    await client.send_json(
+        {
+            "id": 8,
             "type": "config/entity_registry/update",
             "entity_id": "test_domain.world",
             "disabled_by": None,

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -491,7 +491,7 @@ async def test_registry_respect_entity_disabled(hass):
     platform = MockEntityPlatform(hass)
     entity = MockEntity(unique_id="1234")
     await platform.async_add_entities([entity])
-    assert entity.entity_id is None
+    assert entity.entity_id == "test_domain.world"
     assert hass.states.async_entity_ids() == []
 
 


### PR DESCRIPTION
## Description:
Most integrations cannot deal with entity disabling, and will probably end up incorrectly pushing updates to the entity.

This PR will ignore state updates for disabled entities and will trigger a one time warning per entity that they should not have been updated.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
