### PR TITLE
CoolMaster: Change auto to heat_cool

### DIFF
--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
-    HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
     HVAC_MODE_FAN_ONLY,
@@ -33,14 +33,14 @@ AVAILABLE_MODES = [
     HVAC_MODE_HEAT,
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
-    HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_FAN_ONLY,
 ]
 
 CM_TO_HA_STATE = {
     "heat": HVAC_MODE_HEAT,
     "cool": HVAC_MODE_COOL,
-    "auto": HVAC_MODE_AUTO,
+    "auto": HVAC_MODE_HEAT_COOL,
     "dry": HVAC_MODE_DRY,
     "fan": HVAC_MODE_FAN_ONLY,
 }


### PR DESCRIPTION
## Breaking Change:

The `supported_modes` configuration will now reject `auto` and accept `heat_cool` instead. If you're not using CoolMaster, or are using the default supported modes, or did not have `auto` in your supported modes, this does not affect you.

## Description:

Changing the `auto` mode to a `heat_cool` mode in CoolMaster to better reflect what it does.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10209

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
