### PR TITLE
Venstar: define success for all branches of set_temperature()

### DIFF
--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -268,7 +268,8 @@ class VenstarThermostat(ClimateDevice):
                 success = False
                 _LOGGER.error(
                     "The thermostat is currently not in a mode "
-                    "that supports target temperature: %s", operation_mode
+                    "that supports target temperature: %s", 
+                    operation_mode,
                 )
 
             if not success:

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -269,7 +269,6 @@ class VenstarThermostat(ClimateDevice):
                 _LOGGER.error(
                     "The thermostat is currently not in a mode "
                     "that supports target temperature: %s",
-                    "that supports target temperature: %s",
                     operation_mode,
                 )
 

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -268,7 +268,8 @@ class VenstarThermostat(ClimateDevice):
                 success = False
                 _LOGGER.error(
                     "The thermostat is currently not in a mode "
-                    "that supports target temperature: %s", operation_mode
+                    "that supports target temperature: %s",
+                    operation_mode,
                 )
 
             if not success:

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -265,6 +265,7 @@ class VenstarThermostat(ClimateDevice):
             elif operation_mode == self._client.MODE_AUTO:
                 success = self._client.set_setpoints(temp_low, temp_high)
             else:
+                success = False
                 _LOGGER.error(
                     "The thermostat is currently not in a mode "
                     "that supports target temperature"

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -268,7 +268,7 @@ class VenstarThermostat(ClimateDevice):
                 success = False
                 _LOGGER.error(
                     "The thermostat is currently not in a mode "
-                    "that supports target temperature"
+                    "that supports target temperature: %s", operation_mode
                 )
 
             if not success:


### PR DESCRIPTION
## Breaking Change: N/A

## Description: 
```
        if set_temp:
            if operation_mode == self._client.MODE_HEAT:
                success = self._client.set_setpoints(temperature, self._client.cooltemp)
            elif operation_mode == self._client.MODE_COOL:
                success = self._client.set_setpoints(self._client.heattemp, temperature)
            elif operation_mode == self._client.MODE_AUTO:
                success = self._client.set_setpoints(temp_low, temp_high)
            else:
                _LOGGER.error(
                    "The thermostat is currently not in a mode "
                    "that supports target temperature"
                )

            if not success:
                _LOGGER.error("Failed to change the temperature")
```
This block of code does not address `success` if `operation_mode` is not one of the expected values, which means the next if statement leads to an unbound variable being checked

**Related issue (if applicable):** fixes #26147 


## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: venstar
    host: !secret venstar_host
    humidifier: true
    timeout: 30
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
