### PR TITLE
Reworked PJLink component to handle more states

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -217,6 +217,8 @@ STATE_UNLOCKED = "unlocked"
 STATE_UNAVAILABLE = "unavailable"
 STATE_OK = "ok"
 STATE_PROBLEM = "problem"
+STATE_COOLING = "cooling_down"
+STATE_WARMING = "warming_up"
 
 # #### STATE AND EVENT ATTRIBUTES ####
 # Attribution


### PR DESCRIPTION
## Breaking Change:

PJLink projectors support more states and the projector state is handled better. It is possible that in some setups this leads to breaking automations.

## Description:

The current PJLink component assumes that the projector is turned off if no source is selected. This is not desirable since a projector can be on, in an idle state waiting for (the selection of) an input. 

This change adds three states to the PJLink component:
 - Idle
 - Cooling Down
 - Warming Up

 |   HASS state | Projector state | Projector input    |
 |:------------:|-----------------|--------------------|
 | Off          | Off             | n/a                |
 | Warming up   | warming         | n/a                |
 | Idle         | on              | None               |
 | On           | on              | Any Input Selected |
 | Cooling Down | cooling         | n/a                |

Frontend change needed as well, that is included in [this PR](https://github.com/home-assistant/home-assistant-polymer/pull/3516)




## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
