### PR TITLE
Bump androidtv to 0.0.24

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.23"
+    "androidtv==0.0.24"
   ],
   "dependencies": [],
   "codeowners": ["@JeffLIrion"]

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -270,6 +270,9 @@ class ADBDevice(MediaPlayerDevice):
         self._apps.update(apps)
         self._keys = KEYS
 
+        self._device_properties = self.aftv.device_properties
+        self._unique_id = self._device_properties.get("serialno")
+
         self.turn_on_command = turn_on_command
         self.turn_off_command = turn_off_command
 
@@ -337,6 +340,11 @@ class ADBDevice(MediaPlayerDevice):
     def state(self):
         """Return the state of the player."""
         return self._state
+
+    @property
+    def unique_id(self):
+        """Return the device unique id."""
+        return self._unique_id
 
     @adb_decorator()
     def media_play(self):
@@ -412,9 +420,7 @@ class AndroidTVDevice(ADBDevice):
         super().__init__(aftv, name, apps, turn_on_command, turn_off_command)
 
         self._device = None
-        self._device_properties = self.aftv.device_properties
         self._is_volume_muted = None
-        self._unique_id = self._device_properties.get("serialno")
         self._volume_level = None
 
     @adb_decorator(override_available=True)
@@ -453,11 +459,6 @@ class AndroidTVDevice(ADBDevice):
     def supported_features(self):
         """Flag media player features that are supported."""
         return SUPPORT_ANDROIDTV
-
-    @property
-    def unique_id(self):
-        """Return the device unique id."""
-        return self._unique_id
 
     @property
     def volume_level(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -194,7 +194,7 @@ ambiclimate==0.2.0
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.23
+androidtv==0.0.24
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:

Bump `androidtv` to 0.0.24.  

* Fixes https://github.com/home-assistant/home-assistant/issues/26125 (bad unique ID for Android TV)
* This removes `'stopped'` as a valid state for the `'state_detection_rules'` config parameter -- it would have caused an error anyways if it was used.
* This also adds the `unique_id` property for Fire TV devices, not just Android TV devices.  

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/26125

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** TODO

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
