### PR TITLE
fix issue setting scan_interval for google_maps

### DIFF
--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -52,7 +52,7 @@ class GoogleMapsScanner:
         self.see = see
         self.username = config[CONF_USERNAME]
         self.max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
-        self.scan_interval = timedelta(seconds=config.get(CONF_SCAN_INTERVAL, 60))
+        self.scan_interval = config.get(CONF_SCAN_INTERVAL) or timedelta(60)
 
         credfile = "{}.{}".format(
             hass.config.path(CREDENTIALS_FILE), slugify(self.username)


### PR DESCRIPTION
I was getting the following error when i set the scan_interval on `google_maps`
```
self.scan_interval = timedelta(seconds=config.get(CONF_SCAN_INTERVAL, 60))
TypeError: unsupported type for timedelta seconds component: datetime.timedelta
```
it turns out `config.get(CONF_SCAN_INTERVAL)` already returns `datetime.timedelta`

```('scan_interval', datetime.timedelta(seconds=180))```

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: google_maps
    username: thisisatest@gmail.com
    scan_interval: 180
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
