### PR TITLE
Allow bumping version for nightly builds

### DIFF
--- a/script/version_bump.py
+++ b/script/version_bump.py
@@ -3,6 +3,7 @@
 import argparse
 import re
 import subprocess
+from datetime import datetime
 
 from packaging.version import Version
 
@@ -80,6 +81,16 @@ def bump_version(version, bump_type):
             to_change["release"] = _bump_release(version.release, "patch")
             to_change["pre"] = ("b", 0)
 
+    elif bump_type == "nightly":
+        # Convert 0.70.0d0 to 0.70.0d20190424, fails when run on non dev release
+        if not version.is_devrelease:
+            raise ValueError("Can only be run on dev release")
+
+        to_change["dev"] = (
+            "dev",
+            datetime.utcnow().date().isoformat().replace("-", ""),
+        )
+
     else:
         assert False, "Unsupported type: {}".format(bump_type)
 
@@ -115,7 +126,7 @@ def main():
     parser.add_argument(
         "type",
         help="The type of the bump the version to.",
-        choices=["beta", "dev", "patch", "minor"],
+        choices=["beta", "dev", "patch", "minor", "nightly"],
     )
     parser.add_argument(
         "--commit", action="store_true", help="Create a version bump commit."
@@ -134,6 +145,8 @@ def main():
 
 def test_bump_version():
     """Make sure it all works."""
+    import pytest
+
     assert bump_version(Version("0.56.0"), "beta") == Version("0.56.1b0")
     assert bump_version(Version("0.56.0b3"), "beta") == Version("0.56.0b4")
     assert bump_version(Version("0.56.0.dev0"), "beta") == Version("0.56.0b0")
@@ -152,6 +165,13 @@ def test_bump_version():
     assert bump_version(Version("0.56.3.b3"), "minor") == Version("0.57.0")
     assert bump_version(Version("0.56.0.dev0"), "minor") == Version("0.56.0")
     assert bump_version(Version("0.56.2.dev0"), "minor") == Version("0.57.0")
+
+    today = datetime.utcnow().date().isoformat().replace("-", "")
+    assert bump_version(Version("0.56.0.dev0"), "nightly") == Version(
+        f"0.56.0.dev{today}"
+    )
+    with pytest.raises(ValueError):
+        assert bump_version(Version("0.56.0"), "nightly")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description:
Add support for creating nightly build version numbers with version bump script.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
