### PR TITLE
Fix torque degree char

### DIFF
--- a/homeassistant/components/torque/sensor.py
+++ b/homeassistant/components/torque/sensor.py
@@ -90,8 +90,8 @@ class TorqueReceiveDataView(HomeAssistantView):
                 pid = convert_pid(is_unit.group(1))
 
                 temp_unit = data[key]
-                if '\\xC2\\xB0' in temp_unit:
-                    temp_unit = temp_unit.replace('\\xC2\\xB0', '°')
+                if "\\xC2\\xB0" in temp_unit:
+                    temp_unit = temp_unit.replace("\\xC2\\xB0", "°")
 
                 units[pid] = temp_unit
             elif is_value:

--- a/homeassistant/components/torque/sensor.py
+++ b/homeassistant/components/torque/sensor.py
@@ -88,7 +88,13 @@ class TorqueReceiveDataView(HomeAssistantView):
                 names[pid] = data[key]
             elif is_unit:
                 pid = convert_pid(is_unit.group(1))
-                units[pid] = data[key]
+
+                # Fix for degree symbol
+                temp_unit = data[key]
+                if '\\xC2\\xB0' in temp_unit:
+                    temp_unit = temp_unit.replace('\\xC2\\xB0', '°')
+
+                units[pid] = temp_unit
             elif is_value:
                 pid = convert_pid(is_value.group(1))
                 if pid in self.sensors:

--- a/homeassistant/components/torque/sensor.py
+++ b/homeassistant/components/torque/sensor.py
@@ -89,7 +89,6 @@ class TorqueReceiveDataView(HomeAssistantView):
             elif is_unit:
                 pid = convert_pid(is_unit.group(1))
 
-                # Fix for degree symbol
                 temp_unit = data[key]
                 if '\\xC2\\xB0' in temp_unit:
                     temp_unit = temp_unit.replace('\\xC2\\xB0', '°')


### PR DESCRIPTION
## Breaking Change:

None

## Description:
When sensors are added to home-assistant, those with degree symbols are shown as ```\\xC2\\xB0``` instead of ```°```. This PR corrects the symbol.

**Related issue (if applicable):** 
None. Created a PR instead of issue. :-)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
None

## Example entry for `configuration.yaml` (if applicable):
Nothing changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
