### PR TITLE
Add support for Supla switches

### DIFF
--- a/homeassistant/components/supla/__init__.py
+++ b/homeassistant/components/supla/__init__.py
@@ -17,7 +17,10 @@ DOMAIN = "supla"
 CONF_SERVER = "server"
 CONF_SERVERS = "servers"
 
-SUPLA_FUNCTION_HA_CMP_MAP = {"CONTROLLINGTHEROLLERSHUTTER": "cover"}
+SUPLA_FUNCTION_HA_CMP_MAP = {
+    "CONTROLLINGTHEROLLERSHUTTER": "cover",
+    "LIGHTSWITCH": "switch"
+}
 SUPLA_CHANNELS = "supla_channels"
 SUPLA_SERVERS = "supla_servers"
 

--- a/homeassistant/components/supla/__init__.py
+++ b/homeassistant/components/supla/__init__.py
@@ -19,7 +19,7 @@ CONF_SERVERS = "servers"
 
 SUPLA_FUNCTION_HA_CMP_MAP = {
     "CONTROLLINGTHEROLLERSHUTTER": "cover",
-    "LIGHTSWITCH": "switch"
+    "LIGHTSWITCH": "switch",
 }
 SUPLA_CHANNELS = "supla_channels"
 SUPLA_SERVERS = "supla_servers"

--- a/homeassistant/components/supla/cover.py
+++ b/homeassistant/components/supla/cover.py
@@ -5,8 +5,6 @@ from pprint import pformat
 from homeassistant.components.cover import ATTR_POSITION, CoverDevice
 from homeassistant.components.supla import SuplaChannel
 
-DEPENDENCIES = ["supla"]
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/supla/switch.py
+++ b/homeassistant/components/supla/switch.py
@@ -5,8 +5,6 @@ from pprint import pformat
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.components.supla import SuplaChannel
 
-DEPENDENCIES = ["supla"]
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/supla/switch.py
+++ b/homeassistant/components/supla/switch.py
@@ -1,0 +1,41 @@
+"""Support for Supla cover - curtains, rollershutters etc."""
+import logging
+from pprint import pformat
+
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.supla import SuplaChannel
+
+DEPENDENCIES = ["supla"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Supla switches."""
+    if discovery_info is None:
+        return
+
+    _LOGGER.debug("Discovery: %s", pformat(discovery_info))
+
+    add_entities([SuplaSwitch(device) for device in discovery_info])
+
+
+class SuplaSwitch(SuplaChannel, SwitchDevice):
+    """Representation of a Supla Switch."""
+
+    def turn_on(self, **kwargs):
+        """Turn on the switch."""
+        self.action("TURN_ON")
+
+    def turn_off(self, **kwargs):
+        """Turn off the switch."""
+        self.action("TURN_OFF")
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        state = self.channel_data.get("state")
+        if state:
+            return state["on"]
+        return False
+

--- a/homeassistant/components/supla/switch.py
+++ b/homeassistant/components/supla/switch.py
@@ -38,4 +38,3 @@ class SuplaSwitch(SuplaChannel, SwitchDevice):
         if state:
             return state["on"]
         return False
-


### PR DESCRIPTION
## Description:

Handle _Supla_ based devices for switching state like _Zamel ROW-01_ and _Zamel ROW-02_.

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/10265

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
