### PR TITLE
Fix possible KeyError in SimpliSafe

### DIFF
--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -170,7 +170,7 @@ class SimpliSafeAlarm(AlarmControlPanel):
         """Update alarm status."""
         event_data = self._simplisafe.last_event_data[self._system.system_id]
 
-        if event_data["pinName"]:
+        if event_data.get("pinName"):
             self._changed_by = event_data["pinName"]
 
         if self._system.state == SystemStates.error:


### PR DESCRIPTION
## Description:

This PR fixes a possible KeyError when retrieving events.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/26160

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
