### PR TITLE
Fix forwarded-for ip extraction

### DIFF
--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -32,7 +32,7 @@ def setup_real_ip(app, use_x_forwarded_for, trusted_proxies):
                 )
             ):
                 request[KEY_REAL_IP] = ip_address(
-                    request.headers.get(X_FORWARDED_FOR).split(", ")[-1]
+                    request.headers.get(X_FORWARDED_FOR).split(", ")[0]
                 )
         except ValueError:
             pass

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -81,7 +81,7 @@ async def test_use_x_forwarded_for_with_spoofed_header(aiohttp_client):
     )
     assert resp.status == 200
     text = await resp.text()
-    assert text == "255.255.255.255"
+    assert text == "222.222.222.222"
 
 
 async def test_use_x_forwarded_for_with_nonsense_header(aiohttp_client):


### PR DESCRIPTION
## Description:
We were using the last proxy IP instead of the IP of the client.

[MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#Syntax)

**Related issue (if applicable):** fixes #25963

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
