### PR TITLE
The livebox integration allows you to observe Orange Livebox Router

### DIFF
--- a/homeassistant/components/livebox/.translations/en.json
+++ b/homeassistant/components/livebox/.translations/en.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "title": "Orange Livebox",
+    "step": {
+      "init": {
+        "title": "Check your livebox",
+        "data": {
+          "host": "IP Address",
+          "port": "Port",
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "link": {
+          "title": "Orange Livebox detection",
+          "description": "Search and check you livebox, please click to Finish button"
+      }
+    },
+    "error": {
+      "register_failed": "Failed to register, please try again",
+      "linking": "Unknown linking error occurred."
+    },
+    "abort": {
+      "unknown": "Unknown error occurred",
+      "cannot_connect": "Unable to connect to the livebox"
+    }
+  }
+}

--- a/homeassistant/components/livebox/__init__.py
+++ b/homeassistant/components/livebox/__init__.py
@@ -1,0 +1,85 @@
+import ipaddress
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, 
+    CONF_USERNAME, CONF_PASSWORD)
+from homeassistant.helpers import (
+    config_validation as cv, device_registry as dr)
+from homeassistant.helpers.discovery import async_load_platform
+
+from .const import DOMAIN, DEFAULT_USERNAME, DEFAULT_HOST, DEFAULT_PORT
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema(
+  {
+    DOMAIN: vol.Schema(
+      {
+        # Validate as IP address and then convert back to a string.
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): 
+            vol.All(ipaddress.ip_address, cv.string),
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+      }
+    )
+  },
+  extra=vol.ALLOW_EXTRA,
+)
+
+async def async_setup(hass, config):
+    """Set up configured Livebox."""
+    return True
+
+async def async_setup_entry(hass, entry):
+    """Set up Livebox as config entry."""
+    from aiosysbus import Sysbus
+    from aiosysbus.exceptions import HttpRequestError
+    box = Sysbus()
+    try:
+        await box.open(
+            host=entry.data['host'],
+            port=entry.data['port'],
+            username=entry.data['username'], 
+            password=entry.data['password'])
+    except HttpRequestError:
+        _LOGGER.exception('Http Request error to Livebox')
+    except CannotConnect:
+        _LOGGER.exception('Failed to connect to Livebox')
+    except AuthenticationRequired:
+        _LOGGER.exception('User or password incorrect')
+
+    hass.data[DOMAIN] = box
+    config = (await box.system.get_deviceinfo())['status']
+
+    device_registry = await dr.async_get_registry(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={
+            (DOMAIN, config['SerialNumber'])
+        },
+        manufacturer = config['Manufacturer'],
+        name = config['ProductClass'],
+        model = config['ModelName'],
+        sw_version = config['SoftwareVersion'],
+    )
+        
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    )
+    hass.async_create_task(
+        async_load_platform(hass, "device_tracker", DOMAIN, {}, entry)
+    )
+        
+    return True
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    box = hass.data[DOMAIN]
+    await box.close()
+    
+    return True

--- a/homeassistant/components/livebox/config_flow.py
+++ b/homeassistant/components/livebox/config_flow.py
@@ -1,0 +1,129 @@
+"""Config flow to configure Livebox."""
+import asyncio
+import json
+import os
+
+import async_timeout
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client
+
+from .const import (
+    DOMAIN, LOGGER, 
+    DEFAULT_USERNAME, DEFAULT_HOST, DEFAULT_PORT,
+    TEMPLATE_SENSOR)
+from .errors import AuthenticationRequired, CannotConnect
+
+@callback
+def configured_hosts(hass):
+    """Return a set of the configured hosts."""
+    return set(entry.data['host'] for entry
+               in hass.config_entries.async_entries(DOMAIN))
+
+@config_entries.HANDLERS.register(DOMAIN)
+class LiveboxFlowHandler(config_entries.ConfigFlow):
+    """Handle a Livebox config flow."""
+
+    VERSION = 1
+    # CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self):
+        """Initialize the Livebox flow."""
+        self.host = None
+        self.port = None
+        self.username = None 
+        self.password = None
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        # Use OrderedDict to guarantee order of the form shown to the user
+        from collections import OrderedDict 
+        
+        data_schema = OrderedDict()
+        data_schema[vol.Optional('host',default=DEFAULT_HOST)] = str
+        data_schema[vol.Optional('port', default=DEFAULT_PORT)] = str
+        data_schema[vol.Optional('username', default=DEFAULT_USERNAME)] = str
+        data_schema[vol.Required('password')] = str
+
+        return self.async_show_form(
+            step_id='init',
+            data_schema=vol.Schema(data_schema)
+        )
+
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow start."""
+        if user_input is not None:
+            self.host = user_input['host']
+            self.port = user_input['port']
+            self.username = user_input['username']
+            self.password = user_input['password']
+            return await self.async_step_link()
+
+        return self.async_show_form(
+            step_id='init',
+            data_schema=vol.Schema(data_schema),
+        )
+
+    async def async_step_link(self, user_input=None):
+        errors = {}
+
+        from aiosysbus import Sysbus
+        
+        try:
+            box = Sysbus()
+            await box.open(
+                host=self.host,
+                port=self.port,
+                username=self.username,
+                password=self.password)
+            return await self._entry_from_box(box)
+
+        except AuthenticationRequired:
+            errors['base'] = 'register_failed'
+
+        except CannotConnect:
+            LOGGER.error("Error connecting to the Livebox at %s", self.host)
+            errors['base'] = 'linking'
+
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception(
+                'Unknown error connecting with Livebox at %s',
+                self.host)
+            errors['base'] = 'linking'
+
+        # If there was no user input, do not show the errors.
+        if user_input is None:
+            errors = {}
+
+        return self.async_show_form(
+            step_id='link',
+            errors=errors,
+        )    
+
+    async def _entry_from_box(self, box):
+        """Return a config entry from an initialized box."""
+        config = await box.system.get_deviceinfo()
+        box_id = config['status']['SerialNumber']
+
+        # Remove all other entries of hubs with same ID or host
+        same_hub_entries = [entry.entry_id for entry
+                            in self.hass.config_entries.async_entries(DOMAIN)
+                            if entry.data['box_id'] == box_id]
+
+        if same_hub_entries:
+            await asyncio.wait([self.hass.config_entries.async_remove(entry_id)
+                                for entry_id in same_hub_entries])
+
+        return self.async_create_entry(
+            title=TEMPLATE_SENSOR.format(''),
+            data={
+                'box_id': box_id,
+                'host': self.host,
+                'port': self.port,
+                'username': self.username,
+                'password': self.password
+            }
+        )

--- a/homeassistant/components/livebox/const.py
+++ b/homeassistant/components/livebox/const.py
@@ -1,0 +1,12 @@
+"""Constants for the Hue component."""
+import logging
+
+LOGGER = logging.getLogger(__package__)
+DOMAIN = "livebox"
+
+API_NUPNP = 'http://livebox.home/ws'
+TEMPLATE_SENSOR = 'Orange Livebox {}'
+
+DEFAULT_USERNAME='admin'
+DEFAULT_HOST='192.168.1.1'
+DEFAULT_PORT=80

--- a/homeassistant/components/livebox/device_tracker.py
+++ b/homeassistant/components/livebox/device_tracker.py
@@ -1,0 +1,64 @@
+"""Support for Livebox devices."""
+from collections import namedtuple
+from datetime import timedelta
+import logging
+
+from homeassistant.components.device_tracker import DeviceScanner
+import homeassistant.util.dt as dt_util
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Livebox scanner."""
+    scanner = LiveboxDeviceScanner(hass.data[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+Device = namedtuple("Device", ["mac", "name", "ip","last_update"])
+
+class LiveboxDeviceScanner(DeviceScanner):
+    """Queries the Livebox device."""
+
+    def __init__(self, box):
+        """Initialize the scanner."""
+        
+        self._box = box
+        self.last_results = []  # type: List[Device]
+
+        self.success_init = self.async_update_info()
+
+    async def async_scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        _LOGGER.debug('Scan new devices')
+        await self.async_update_info()
+        return [device.mac for device in self.last_results]
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        
+        filter_named = [
+            result.name for result in self.last_results if result.mac == device
+        ]
+        if filter_named:
+            return filter_named[0]
+        return None
+
+    async def async_update_info(self):
+        """Ensure the information from the Livebox router is up to date."""
+        
+        result = (await self._box.system.get_devices())['status']
+        now = dt_util.now()
+        last_results = []
+        for device in result:
+            if device["Active"] and 'IPAddress' in device:
+                last_results.append(
+                    Device(
+                        device["PhysAddress"],
+                        device["Name"],
+                        device["IPAddress"],
+                        now)
+                )
+        self.last_results = last_results
+        return True

--- a/homeassistant/components/livebox/errors.py
+++ b/homeassistant/components/livebox/errors.py
@@ -1,0 +1,14 @@
+"""Errors for the Livebox component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class LiveboxException(HomeAssistantError):
+    """Base class for Livebox exceptions."""
+
+
+class CannotConnect(LiveboxException):
+    """Unable to connect to the bridge."""
+
+
+class AuthenticationRequired(LiveboxException):
+    """Unknown error occurred."""

--- a/homeassistant/components/livebox/manifest.json
+++ b/homeassistant/components/livebox/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "livebox",
+  "name": "Orange Livebox",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/components/livebox",
+  "requirements": [
+    "aiosysbus==0.1.2"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@cyr-ius"
+  ]
+}

--- a/homeassistant/components/livebox/sensor.py
+++ b/homeassistant/components/livebox/sensor.py
@@ -1,0 +1,186 @@
+import logging
+from datetime import timedelta
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, DEVICE_CLASS_CONNECTIVITY)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+from . import DOMAIN
+from .const import TEMPLATE_SENSOR
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(minutes=5)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the sensors."""
+    box = hass.data[DOMAIN]
+    async_add_entities(
+        [
+            RXSensor(box, config_entry),
+            TXSensor(box,config_entry),
+            InfoSensor(box, config_entry)
+            ],
+        True)
+
+class LiveboxSensor(Entity):
+    """Representation of a livebox sensor."""
+
+    _name = "generic"
+
+    def __init__(self, box, config_entry):
+        """Initialize the sensor."""
+        self._box = box
+        self._box_id = config_entry.data['box_id']
+        self._state = None
+        self._datas = None
+        self._dsl = None
+
+class InfoSensor(LiveboxSensor, BinarySensorDevice):
+    """ Update Wan Status sensor """
+    
+    device_class = DEVICE_CLASS_CONNECTIVITY
+    
+    @property
+    def name(self):
+        return TEMPLATE_SENSOR.format('Wan status')
+    
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        if self._dsl['WanState'] == 'up':
+            return True
+        return False
+    
+    @property
+    def unique_id(self):
+        return '{}_connectivity'.format(self._box_id)
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {'name': self.name,
+            "identifiers": {
+                (DOMAIN, self.unique_id)
+            },
+            'manufacturer': 'Orange',
+            'via_device':(DOMAIN,self._box_id)
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {
+            "link_type": self._dsl['LinkType'],
+            "link_state": self._dsl['LinkState'],
+            "last_connection_error":self._dsl['LastConnectionError'],
+            "wan_ipaddress":self._dsl['IPAddress'],
+            "wan_ipv6address":self._dsl['IPv6Address']
+        }
+
+    @Throttle(SCAN_INTERVAL)
+    async def async_update(self):
+        """Fetch status from livebox."""
+        self._datas = await self._box.system.get_WANStatus()
+        self._dsl = self._datas["data"]
+
+class RXSensor(LiveboxSensor):
+    """Update the Livebox RxSensor."""
+
+    unit_of_measurement = "Mb/s"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return TEMPLATE_SENSOR.format('download speed')
+    
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self._dsl['DownstreamCurrRate'] is None:
+            return None
+        return round(self._dsl['DownstreamCurrRate'] / 1000, 2)
+
+    @property
+    def unique_id(self):
+        return '{}_downstream'.format(self._box_id)
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {'name': self.name,
+            "identifiers": {
+                (DOMAIN, self.unique_id)
+            },
+            'manufacturer': 'Orange',
+            'via_device':(DOMAIN,self._box_id)
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {
+            "downstream_maxrate": self._dsl['DownstreamMaxRate'],
+            "downstream_lineattenuation": self._dsl['DownstreamLineAttenuation'],
+            "downstream_noisemargin":self._dsl['DownstreamNoiseMargin'],
+            "downstream_power":self._dsl['DownstreamPower']
+        }
+
+    @Throttle(SCAN_INTERVAL)
+    async def async_update(self):
+        """Get the value from fetched datas."""
+        parameters = {"parameters":{"mibs":"dsl","flag":"","traverse":"down"}}
+        self._datas = await self._box.connection.get_data_MIBS(parameters)
+        self._dsl = self._datas["status"]["dsl"]["dsl0"]
+        
+
+class TXSensor(LiveboxSensor):
+    """Update the Livebox TxSensor."""
+
+    unit_of_measurement = "Mb/s"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return TEMPLATE_SENSOR.format('upload speed')
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self._dsl['UpstreamCurrRate'] is None:
+            return None
+        return round(self._dsl['UpstreamCurrRate'] / 1000, 2)
+    
+    @property
+    def unique_id(self):
+        return '{}_upstream'.format(self._box_id)
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return {
+            'name':self.name,
+            "identifiers": {
+                (DOMAIN, self.unique_id)
+            },
+            'manufacturer': 'Orange',
+            'via_device':(DOMAIN,self._box_id)
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {
+            "upstream_maxrate": self._dsl['UpstreamMaxRate'],
+            "upstream_lineattenuation": self._dsl['UpstreamLineAttenuation'],
+            "upstream_noisemargin":self._dsl['UpstreamNoiseMargin'],
+            "upstream_power":self._dsl['UpstreamPower']
+        }
+
+    @Throttle(SCAN_INTERVAL)
+    async def async_update(self):
+        """Get the value from fetched datas."""
+        parameters = {"parameters":{"mibs":"dsl","flag":"","traverse":"down"}}
+        self._datas = await self._box.connection.get_data_MIBS(parameters)
+        self._dsl = self._datas["status"]["dsl"]["dsl0"]
+

--- a/homeassistant/components/livebox/strings.json
+++ b/homeassistant/components/livebox/strings.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "title": "Orange Livebox",
+    "step": {
+      "init": {
+        "title": "Check your livebox",
+        "data": {
+          "host": "IP Address",
+          "port": "Port",
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "link": {
+          "title": "Orange Livebox detection",
+          "description": "Search and check you livebox, please click to Finish button"
+      }
+    },
+    "error": {
+      "register_failed": "Failed to register, please try again",
+      "linking": "Unknown linking error occurred."
+    },
+    "abort": {
+      "unknown": "Unknown error occurred",
+      "cannot_connect": "Unable to connect to the livebox"
+    }
+  }
+}


### PR DESCRIPTION
## Description:

The livebox integration allows you to observe Orange Livebox Router
 Add Wan Status  , Up bandwidth & Download bandwidth
 Add device tracker

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [»] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
