### PR TITLE
Support formatting and scaling with ZHA Metering cluster

### DIFF
--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -115,17 +115,17 @@ class Metering(AttributeListeningChannel):
 
     @callback
     def attribute_updated(self, attrid, value):
-        """Called when attribute has been updated."""
-        super().attribute_updated(attrid, value * self._multiplier /
-                                  self._divisor)
+        """Handle attribute update from Metering cluster."""
+        super().attribute_updated(attrid, value * self._multiplier
+                                  / self._divisor)
 
     @property
     def unit_of_measurement(self):
-        """Returns unit of measurement."""
+        """Return unit of measurement."""
         return self.unit_of_measure_map.get(self._unit_enum & 0x7f, 'unknown')
 
     async def fetch_config(self, from_cache):
-        """Fetches config from device and updates format specifier."""
+        """Fetch config from device and updates format specifier."""
         self._divisor = await self.get_attribute_value(
             "divisor", from_cache=from_cache
         )
@@ -144,9 +144,9 @@ class Metering(AttributeListeningChannel):
         if self._multiplier is None or self._multiplier == 0:
             self._multiplier = 1
         if self._unit_enum is None:
-            self._unit_enum = 0x7f # unknown
+            self._unit_enum = 0x7f  # unknown
         if fmting is None:
-            fmting = 0xf9 # 1 digit to the right, 15 digits to the left
+            fmting = 0xf9  # 1 digit to the right, 15 digits to the left
 
         r_digits = fmting & 0x07  # digits to the right of decimal point
         l_digits = (fmting >> 3) & 0x0F  # digits to the left of decimal point

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -8,6 +8,8 @@ import logging
 
 import zigpy.zcl.clusters.smartenergy as smartenergy
 
+from homeassistant.core import callback
+
 from .. import registries
 from ..channels import AttributeListeningChannel, ZigbeeChannel
 from ..const import REPORT_CONFIG_DEFAULT
@@ -76,6 +78,92 @@ class Metering(AttributeListeningChannel):
     """Metering channel."""
 
     REPORT_CONFIG = [{"attr": "instantaneous_demand", "config": REPORT_CONFIG_DEFAULT}]
+
+    unit_of_measure_map = {
+        0x00: 'kW',
+        0x01: 'm³/h',
+        0x02: 'ft³/h',
+        0x03: 'ccf/h',
+        0x04: 'US gal/h',
+        0x05: 'IMP gal/h',
+        0x06: 'BTU/h',
+        0x07: 'l/h',
+        0x08: 'kPa',
+        0x09: 'kPa',
+        0x0a: 'mcf/h',
+        0x0b: 'unitless',
+        0x0c: 'MJ/s',
+    }
+
+    def __init__(self, cluster, device):
+        """Initialize Metering."""
+        super().__init__(cluster, device)
+        self._divisor = None
+        self._multiplier = None
+        self._unit_enum = None
+        self._format_spec = None
+
+    async def async_configure(self):
+        """Configure channel."""
+        await self.fetch_config(False)
+        await super().async_configure()
+
+    async def async_initialize(self, from_cache):
+        """Initialize channel."""
+        await self.fetch_config(True)
+        await super().async_initialize(from_cache)
+
+    @callback
+    def attribute_updated(self, attrid, value):
+        """Called when attribute has been updated."""
+        super().attribute_updated(attrid, value * self._multiplier /
+                                  self._divisor)
+
+    @property
+    def unit_of_measurement(self):
+        """Returns unit of measurement."""
+        return self.unit_of_measure_map.get(self._unit_enum & 0x7f, 'unknown')
+
+    async def fetch_config(self, from_cache):
+        """Fetches config from device and updates format specifier."""
+        self._divisor = await self.get_attribute_value(
+            "divisor", from_cache=from_cache
+        )
+        self._multiplier = await self.get_attribute_value(
+            "multiplier", from_cache=from_cache
+        )
+        self._unit_enum = await self.get_attribute_value(
+            "unit_of_measure", from_cache=from_cache
+        )
+        fmting = await self.get_attribute_value(
+            "demand_formatting", from_cache=from_cache
+        )
+
+        if self._divisor is None or self._divisor == 0:
+            self._divisor = 1
+        if self._multiplier is None or self._multiplier == 0:
+            self._multiplier = 1
+        if self._unit_enum is None:
+            self._unit_enum = 0x7f # unknown
+        if fmting is None:
+            fmting = 0xf9 # 1 digit to the right, 15 digits to the left
+
+        r_digits = fmting & 0x07  # digits to the right of decimal point
+        l_digits = (fmting >> 3) & 0x0F  # digits to the left of decimal point
+        if l_digits == 0:
+            l_digits = 15
+        width = r_digits + l_digits + (1 if r_digits > 0 else 0)
+
+        if fmting & 0x80:
+            self._format_spec = '{:' + str(width) + '.' + \
+                                str(r_digits) + 'f}'
+        else:
+            self._format_spec = '{:0' + str(width) + '.' + \
+                                str(r_digits) + 'f}'
+
+    def formatter_function(self, value):
+        """Return formatted value for display."""
+        return self._format_spec.format(value).lstrip()
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(smartenergy.Prepayment.cluster_id)

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -80,19 +80,19 @@ class Metering(AttributeListeningChannel):
     REPORT_CONFIG = [{"attr": "instantaneous_demand", "config": REPORT_CONFIG_DEFAULT}]
 
     unit_of_measure_map = {
-        0x00: 'kW',
-        0x01: 'm³/h',
-        0x02: 'ft³/h',
-        0x03: 'ccf/h',
-        0x04: 'US gal/h',
-        0x05: 'IMP gal/h',
-        0x06: 'BTU/h',
-        0x07: 'l/h',
-        0x08: 'kPa',
-        0x09: 'kPa',
-        0x0a: 'mcf/h',
-        0x0b: 'unitless',
-        0x0c: 'MJ/s',
+        0x00: "kW",
+        0x01: "m³/h",
+        0x02: "ft³/h",
+        0x03: "ccf/h",
+        0x04: "US gal/h",
+        0x05: "IMP gal/h",
+        0x06: "BTU/h",
+        0x07: "l/h",
+        0x08: "kPa",
+        0x09: "kPa",
+        0x0A: "mcf/h",
+        0x0B: "unitless",
+        0x0C: "MJ/s",
     }
 
     def __init__(self, cluster, device):
@@ -116,19 +116,16 @@ class Metering(AttributeListeningChannel):
     @callback
     def attribute_updated(self, attrid, value):
         """Handle attribute update from Metering cluster."""
-        super().attribute_updated(attrid, value * self._multiplier
-                                  / self._divisor)
+        super().attribute_updated(attrid, value * self._multiplier / self._divisor)
 
     @property
     def unit_of_measurement(self):
         """Return unit of measurement."""
-        return self.unit_of_measure_map.get(self._unit_enum & 0x7f, 'unknown')
+        return self.unit_of_measure_map.get(self._unit_enum & 0x7F, "unknown")
 
     async def fetch_config(self, from_cache):
         """Fetch config from device and updates format specifier."""
-        self._divisor = await self.get_attribute_value(
-            "divisor", from_cache=from_cache
-        )
+        self._divisor = await self.get_attribute_value("divisor", from_cache=from_cache)
         self._multiplier = await self.get_attribute_value(
             "multiplier", from_cache=from_cache
         )
@@ -144,9 +141,9 @@ class Metering(AttributeListeningChannel):
         if self._multiplier is None or self._multiplier == 0:
             self._multiplier = 1
         if self._unit_enum is None:
-            self._unit_enum = 0x7f  # unknown
+            self._unit_enum = 0x7F  # unknown
         if fmting is None:
-            fmting = 0xf9  # 1 digit to the right, 15 digits to the left
+            fmting = 0xF9  # 1 digit to the right, 15 digits to the left
 
         r_digits = fmting & 0x07  # digits to the right of decimal point
         l_digits = (fmting >> 3) & 0x0F  # digits to the left of decimal point
@@ -155,11 +152,9 @@ class Metering(AttributeListeningChannel):
         width = r_digits + l_digits + (1 if r_digits > 0 else 0)
 
         if fmting & 0x80:
-            self._format_spec = '{:' + str(width) + '.' + \
-                                str(r_digits) + 'f}'
+            self._format_spec = "{:" + str(width) + "." + str(r_digits) + "f}"
         else:
-            self._format_spec = '{:0' + str(width) + '.' + \
-                                str(r_digits) + 'f}'
+            self._format_spec = "{:0" + str(width) + "." + str(r_digits) + "f}"
 
     def formatter_function(self, value):
         """Return formatted value for display."""

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -160,8 +160,8 @@ async def async_test_illuminance(hass, device_info):
 
 async def async_test_metering(hass, device_info):
     """Test metering sensor."""
-    await send_attribute_report(hass, device_info["cluster"], 1024, 10)
-    assert_state(hass, device_info, "10", "W")
+    await send_attribute_report(hass, device_info["cluster"], 1024, 12345)
+    assert_state(hass, device_info, "12345.0", "unknown")
 
 
 async def async_test_electrical_measurement(hass, device_info):


### PR DESCRIPTION
## Description:
This adds support for formatting and scaling with the ZHA Metering cluster.

It is recommended to reconfigure any affected devices to update the cached configuration, otherwise they will use the default formatting and scaling and not the configuration from the device.

**Related issue (if applicable):** fixes #24452


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
