### PR TITLE
Add zwave application version

### DIFF
--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -17,6 +17,7 @@ from .const import (
     EVENT_NODE_EVENT,
     EVENT_SCENE_ACTIVATED,
     COMMAND_CLASS_CENTRAL_SCENE,
+    COMMAND_CLASS_VERSION,
     DOMAIN,
 )
 from .util import node_name, is_node_parsed, node_device_id_and_name
@@ -30,6 +31,7 @@ ATTR_FAILED = "is_failed"
 ATTR_PRODUCT_NAME = "product_name"
 ATTR_MANUFACTURER_NAME = "manufacturer_name"
 ATTR_NODE_NAME = "node_name"
+ATTR_APPLICATION_VERSION = "application_version"
 
 STAGE_COMPLETE = "Complete"
 
@@ -130,10 +132,14 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         self._product_name = node.product_name
         self._manufacturer_name = node.manufacturer_name
         self._unique_id = self._compute_unique_id()
+        self._application_version = None
         self._attributes = {}
         self.wakeup_interval = None
         self.location = None
         self.battery_level = None
+        dispatcher.connect(
+            self.network_node_value_added, ZWaveNetwork.SIGNAL_VALUE_ADDED
+        )
         dispatcher.connect(self.network_node_changed, ZWaveNetwork.SIGNAL_VALUE_CHANGED)
         dispatcher.connect(self.network_node_changed, ZWaveNetwork.SIGNAL_NODE)
         dispatcher.connect(self.network_node_changed, ZWaveNetwork.SIGNAL_NOTIFICATION)
@@ -160,6 +166,20 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         if self.node_id > 1:
             info["via_device"] = (DOMAIN, 1)
         return info
+
+    def network_node_value_added(self, node=None, value=None, args=None):
+        """Handle a added value to a none on the network."""
+        if node and node.node_id != self.node_id:
+            return
+        if args is not None and "nodeId" in args and args["nodeId"] != self.node_id:
+            return
+
+        # Handle COMMAND_CLASS_VERSION "application_version"
+        if (
+            value.command_class == COMMAND_CLASS_VERSION
+            and value.label == "Application Version"
+        ):
+            self._application_version = value.data
 
     def network_node_changed(self, node=None, value=None, args=None):
         """Handle a changed node on the network."""
@@ -343,6 +363,8 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             attrs[ATTR_BATTERY_LEVEL] = self.battery_level
         if self.wakeup_interval is not None:
             attrs[ATTR_WAKEUP] = self.wakeup_interval
+        if self._application_version is not None:
+            attrs[ATTR_APPLICATION_VERSION] = self._application_version
 
         return attrs
 

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -170,7 +170,8 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
     def maybe_update_application_version(self, value):
         """Update application version if value is a Command Class Version, Application Value."""
         if (
-            value.command_class == COMMAND_CLASS_VERSION
+            value
+            and value.command_class == COMMAND_CLASS_VERSION
             and value.label == "Application Version"
         ):
             self._application_version = value.data

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -164,6 +164,51 @@ async def test_central_scene_activated(hass, mock_openzwave):
     assert events[0].data[const.ATTR_SCENE_DATA] == scene_data
 
 
+async def test_application_version_in_device_state_attributes_after_change(
+    hass, mock_openzwave
+):
+    """Test central scene activated event."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == mock_zwave.MockNetwork.SIGNAL_VALUE_ADDED:
+            mock_receivers.append(receiver)
+
+    node = mock_zwave.MockNode(node_id=11)
+
+    with patch("pydispatch.dispatcher.connect", new=mock_connect):
+        entity = node_entity.ZWaveNodeEntity(node, mock_openzwave)
+
+    assert len(mock_receivers) == 1
+
+    events = []
+
+    def listener(event):
+        events.append(event)
+
+    # Make sure application version isn't set before
+    assert (
+        node_entity.ATTR_APPLICATION_VERSION
+        not in entity.device_state_attributes.keys()
+    )
+
+    # Add entity to hass
+    entity.hass = hass
+    entity.entity_id = "zwave.mock_node"
+
+    value = mock_zwave.MockValue(
+        command_class=const.COMMAND_CLASS_VERSION,
+        label="Application Version",
+        data="5.10",
+    )
+    hass.async_add_job(mock_receivers[0], node, value)
+    await hass.async_block_till_done()
+
+    assert (
+        entity.device_state_attributes[node_entity.ATTR_APPLICATION_VERSION] == "5.10"
+    )
+
+
 @pytest.mark.usefixtures("mock_openzwave")
 class TestZWaveNodeEntity(unittest.TestCase):
     """Class to test ZWaveNodeEntity."""

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -164,22 +164,26 @@ async def test_central_scene_activated(hass, mock_openzwave):
     assert events[0].data[const.ATTR_SCENE_DATA] == scene_data
 
 
-async def test_application_version_in_device_state_attributes_after_change(
-    hass, mock_openzwave
-):
-    """Test central scene activated event."""
-    mock_receivers = []
+async def test_application_version(hass, mock_openzwave):
+    """Test application version."""
+    mock_receivers = {}
+
+    signal_mocks = [
+        mock_zwave.MockNetwork.SIGNAL_VALUE_CHANGED,
+        mock_zwave.MockNetwork.SIGNAL_VALUE_ADDED,
+    ]
 
     def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == mock_zwave.MockNetwork.SIGNAL_VALUE_ADDED:
-            mock_receivers.append(receiver)
+        if signal in signal_mocks:
+            mock_receivers[signal] = receiver
 
     node = mock_zwave.MockNode(node_id=11)
 
     with patch("pydispatch.dispatcher.connect", new=mock_connect):
         entity = node_entity.ZWaveNodeEntity(node, mock_openzwave)
 
-    assert len(mock_receivers) == 1
+    for signal_mock in signal_mocks:
+        assert signal_mock in mock_receivers.keys()
 
     events = []
 
@@ -196,16 +200,34 @@ async def test_application_version_in_device_state_attributes_after_change(
     entity.hass = hass
     entity.entity_id = "zwave.mock_node"
 
+    # Fire off an added value
     value = mock_zwave.MockValue(
         command_class=const.COMMAND_CLASS_VERSION,
         label="Application Version",
         data="5.10",
     )
-    hass.async_add_job(mock_receivers[0], node, value)
+    hass.async_add_job(
+        mock_receivers[mock_zwave.MockNetwork.SIGNAL_VALUE_ADDED], node, value
+    )
     await hass.async_block_till_done()
 
     assert (
         entity.device_state_attributes[node_entity.ATTR_APPLICATION_VERSION] == "5.10"
+    )
+
+    # Fire off a changed
+    value = mock_zwave.MockValue(
+        command_class=const.COMMAND_CLASS_VERSION,
+        label="Application Version",
+        data="4.14",
+    )
+    hass.async_add_job(
+        mock_receivers[mock_zwave.MockNetwork.SIGNAL_VALUE_CHANGED], node, value
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        entity.device_state_attributes[node_entity.ATTR_APPLICATION_VERSION] == "4.14"
     )
 
 


### PR DESCRIPTION
## Description:
This PR adds the application version as reported by COMMAND_CLASS_VERSION to the attributes of ZWAVE node entities.

**Related issue (if applicable):** 
This doesn't have an issue, but is a feature request in the forums here:
https://community.home-assistant.io/t/zwave-nodes-firmware-version/66408

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [N/A] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [N/A] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
