### PR TITLE
Add two new methods to the OpenUV component that consume only a singl…

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -23,6 +23,8 @@ from homeassistant.helpers.service import verify_domain_control
 from .config_flow import configured_instances
 from .const import DOMAIN
 
+import asyncio
+
 _LOGGER = logging.getLogger(__name__)
 
 DATA_OPENUV_CLIENT = "data_client"
@@ -200,44 +202,30 @@ async def async_setup_entry(hass, config_entry):
     async def update_data(service):
         """Refresh all OpenUV data."""
         _LOGGER.debug("Refreshing all OpenUV data")
-
-        try:
-            await openuv.async_update()
-        except OpenUvError as err:
-            _LOGGER.error("Error during data update: %s", err)
-            return
-
+        await openuv.async_update()
         async_dispatcher_send(hass, TOPIC_UPDATE)
 
     hass.services.async_register(DOMAIN, "update_data", update_data)
 
+    @_verify_domain_control
     async def update_uv_index_data(service):
         """Refresh OpenUV UV index data."""
         _LOGGER.debug("Refreshing OpenUV UV index data")
-
-        try:
-            await openuv.async_update_uv_index_data()
-        except OpenUvError as err:
-            _LOGGER.error("Error during data update: %s", err)
-            return
-
+        await openuv.async_update_uv_index_data()
         async_dispatcher_send(hass, TOPIC_UPDATE)
 
     hass.services.async_register(DOMAIN, "update_uv_index_data", update_uv_index_data)
 
+    @_verify_domain_control
     async def update_protection_data(service):
         """Refresh OpenUV protection window data."""
         _LOGGER.debug("Refreshing OpenUV protection window data")
-
-        try:
-            await openuv.async_update_protection_data()
-        except OpenUvError as err:
-            _LOGGER.error("Error during data update: %s", err)
-            return
-
+        await openuv.async_update_protection_data()
         async_dispatcher_send(hass, TOPIC_UPDATE)
 
-    hass.services.async_register(DOMAIN, "update_protection_data", update_protection_data)
+    hass.services.async_register(
+        DOMAIN, "update_protection_data", update_protection_data
+    )
 
     return True
 
@@ -264,26 +252,35 @@ class OpenUV:
 
     async def async_update_protection_data(self):
         """Update binary sensor (protection window) data."""
-        if TYPE_PROTECTION_WINDOW in self.binary_sensor_conditions:
-            resp = await self.client.uv_protection_window()
-            data = resp["result"]
+        from pyopenuv.errors import OpenUvError
 
-            if data.get("from_time") and data.get("to_time"):
-                self.data[DATA_PROTECTION_WINDOW] = data
-            else:
-                _LOGGER.debug("No valid protection window data for this location")
+        if TYPE_PROTECTION_WINDOW in self.binary_sensor_conditions:
+            try:
+                resp = await self.client.uv_protection_window()
+                self.data[DATA_PROTECTION_WINDOW] = resp["result"]
+            except OpenUvError as err:
+                _LOGGER.error("Error during data update: %s", err)
                 self.data[DATA_PROTECTION_WINDOW] = {}
+                return
 
     async def async_update_uv_index_data(self):
         """Update sensor (uv index, etc) data."""
+        from pyopenuv.errors import OpenUvError
+
         if any(c in self.sensor_conditions for c in SENSORS):
-            data = await self.client.uv_index()
-            self.data[DATA_UV] = data
+            try:
+                data = await self.client.uv_index()
+                self.data[DATA_UV] = data
+            except OpenUvError as err:
+                _LOGGER.error("Error during data update: %s", err)
+                self.data[DATA_UV] = {}
+                return
 
     async def async_update(self):
         """Update sensor/binary sensor data."""
-        await self.async_update_protection_data()
-        await self.async_update_uv_index_data()
+
+        tasks = [self.async_update_protection_data(), self.async_update_uv_index_data()]
+        await asyncio.gather(*tasks)
 
 
 class OpenUvEntity(Entity):

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -1,5 +1,6 @@
 """Support for UV data from openuv.io."""
 import logging
+import asyncio
 
 import voluptuous as vol
 
@@ -22,8 +23,6 @@ from homeassistant.helpers.service import verify_domain_control
 
 from .config_flow import configured_instances
 from .const import DOMAIN
-
-import asyncio
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -296,6 +296,7 @@ class OpenUV:
             data = await self.client.uv_index()
             self.data[DATA_UV] = data
 
+
 class OpenUvEntity(Entity):
     """Define a generic OpenUV entity."""
 

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -258,7 +258,7 @@ class OpenUV:
                 resp = await self.client.uv_protection_window()
                 self.data[DATA_PROTECTION_WINDOW] = resp["result"]
             except OpenUvError as err:
-                _LOGGER.error("Error during data update: %s", err)
+                _LOGGER.error("Error during protection data update: %s", err)
                 self.data[DATA_PROTECTION_WINDOW] = {}
                 return
 
@@ -271,13 +271,12 @@ class OpenUV:
                 data = await self.client.uv_index()
                 self.data[DATA_UV] = data
             except OpenUvError as err:
-                _LOGGER.error("Error during data update: %s", err)
+                _LOGGER.error("Error during uv index data update: %s", err)
                 self.data[DATA_UV] = {}
                 return
 
     async def async_update(self):
         """Update sensor/binary sensor data."""
-
         tasks = [self.async_update_protection_data(), self.async_update_uv_index_data()]
         await asyncio.gather(*tasks)
 

--- a/homeassistant/components/openuv/services.yaml
+++ b/homeassistant/components/openuv/services.yaml
@@ -2,4 +2,10 @@
 
 ---
 update_data:
-  description: Request new data from OpenUV.
+  description: Request new data from OpenUV. Consumes two API calls.
+
+update_uv_index_data:
+  description: Request new UV index data from OpenUV.
+
+update_protection_data:
+  description: Request new protection window data from OpenUV.


### PR DESCRIPTION
…e API call

## Description:

The OpenUV component makes calls to http://openuv.io/ the current method `openuv.update_data` makes 2 calls from the daily limit of 50.  The one endpoint only needs to be called once a day.  There should be separate methods for the separate api calls.

I didn't change the existing method at all, to prevent breaking changes.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10235


## Checklist:
  - [✓ ] The code change is tested and works locally.
  - [✓ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [✓ ] There is no commented out code in this PR.
  - [✓ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [✓ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
