### PR TITLE
Fix qBittorrent sensor

### DIFF
--- a/homeassistant/components/qbittorrent/sensor.py
+++ b/homeassistant/components/qbittorrent/sensor.py
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the qBittorrent sensors."""
     from qbittorrent.client import Client, LoginRequired
 
@@ -62,7 +62,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         sensor = QBittorrentSensor(sensor_type, client, name, LoginRequired)
         dev.append(sensor)
 
-    async_add_entities(dev, True)
+    add_entities(dev, True)
 
 
 def format_speed(speed):
@@ -105,7 +105,7 @@ class QBittorrentSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
-    async def async_update(self):
+    def update(self):
         """Get the latest data from qBittorrent and updates the state."""
         try:
             data = self.client.sync()
@@ -113,7 +113,6 @@ class QBittorrentSensor(Entity):
         except RequestException:
             _LOGGER.error("Connection lost")
             self._available = False
-            return
         except self._exception:
             _LOGGER.error("Invalid authentication")
             return


### PR DESCRIPTION
## Description:
Switch qBittorrent sensor to sync to avoid locking the event loop.

**Related issue (if applicable):** fixes #21865 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
