### PR TITLE
Add support for Homekit accessory battery sensors

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -25,4 +25,5 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     "humidity": "sensor",
     "light": "sensor",
     "temperature": "sensor",
+    "battery": "sensor",
 }

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -198,14 +198,14 @@ class HomeKitBatterySensor(HomeKitEntity):
         icon = "mdi:battery"
         if self._charging and self.state > 10:
             percentage = int(round(self.state / 20 - 0.01)) * 20
-            icon += "-charging-{}".format(percentage)
+            icon += f"-charging-{percentage}"
         elif self._charging:
             icon += "-outline"
         elif self._low_battery:
             icon += "-alert"
         elif self.state < 95:
             percentage = max(int(round(self.state / 10 - 0.01)) * 10, 10)
-            icon += "-{}".format(percentage)
+            icon += f"-{percentage}"
 
         return icon
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -2,6 +2,7 @@
 from homekit.model.characteristics import CharacteristicsTypes
 
 from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import KNOWN_DEVICES, HomeKitEntity
 
@@ -9,7 +10,6 @@ HUMIDITY_ICON = "mdi:water-percent"
 TEMP_C_ICON = "mdi:thermometer"
 BRIGHTNESS_ICON = "mdi:brightness-6"
 CO2_ICON = "mdi:periodic-table-co2"
-BATTERY_ICON = "mdi:battery"
 
 UNIT_PERCENT = "%"
 UNIT_LUX = "lux"
@@ -180,7 +180,7 @@ class HomeKitBatterySensor(HomeKitEntity):
     @property
     def icon(self):
         """Return the sensor icon."""
-        return BATTERY_ICON
+        return icon_for_battery_level(self._state, False)
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -9,6 +9,7 @@ HUMIDITY_ICON = "mdi:water-percent"
 TEMP_C_ICON = "mdi:thermometer"
 BRIGHTNESS_ICON = "mdi:brightness-6"
 CO2_ICON = "mdi:periodic-table-co2"
+BATTERY_ICON = "mdi:battery"
 
 UNIT_PERCENT = "%"
 UNIT_LUX = "lux"
@@ -159,11 +160,48 @@ class HomeKitCarbonDioxideSensor(HomeKitEntity):
         return self._state
 
 
+class HomeKitBatterySensor(HomeKitEntity):
+    """Representation of a Homekit battery sensor."""
+
+    def __init__(self, *args):
+        """Initialise the entity."""
+        super().__init__(*args)
+        self._state = None
+
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity is tracking."""
+        return [CharacteristicsTypes.BATTERY_LEVEL]
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return "{} {}".format(super().name, "Battery")
+
+    @property
+    def icon(self):
+        """Return the sensor icon."""
+        return BATTERY_ICON
+
+    @property
+    def unit_of_measurement(self):
+        """Return units for the sensor."""
+        return UNIT_PERCENT
+
+    def _update_battery_level(self, value):
+        self._state = value
+
+    @property
+    def state(self):
+        """Return the current battery level percentage."""
+        return self._state
+
+
 ENTITY_TYPES = {
     "humidity": HomeKitHumiditySensor,
     "temperature": HomeKitTemperatureSensor,
     "light": HomeKitLightSensor,
     "carbon-dioxide": HomeKitCarbonDioxideSensor,
+    "battery": HomeKitBatterySensor,
 }
 
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -167,10 +167,16 @@ class HomeKitBatterySensor(HomeKitEntity):
         """Initialise the entity."""
         super().__init__(*args)
         self._state = None
+        self._low_battery = False
+        self._charging = False
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity is tracking."""
-        return [CharacteristicsTypes.BATTERY_LEVEL]
+        return [
+            CharacteristicsTypes.BATTERY_LEVEL,
+            CharacteristicsTypes.STATUS_LO_BATT,
+            CharacteristicsTypes.CHARGING_STATE,
+        ]
 
     @property
     def name(self):
@@ -180,7 +186,7 @@ class HomeKitBatterySensor(HomeKitEntity):
     @property
     def icon(self):
         """Return the sensor icon."""
-        return icon_for_battery_level(self._state, False)
+        return icon_for_battery_level(self._state, self._charging)
 
     @property
     def unit_of_measurement(self):
@@ -189,6 +195,15 @@ class HomeKitBatterySensor(HomeKitEntity):
 
     def _update_battery_level(self, value):
         self._state = value
+
+    def _update_status_lo_batt(self, value):
+        self._low_battery = value == 1
+
+    def _update_charging_state(self, value):
+        # 0 = not charging
+        # 1 = charging
+        # 2 = not chargeable
+        self._charging = value == 1
 
     @property
     def state(self):

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -193,21 +193,19 @@ class HomeKitBatterySensor(HomeKitEntity):
         if not self.available or self.state is None:
             return "mdi:battery-unknown"
 
-        battery_level = self._state
-        charging = self._charging
-
         # This is similar to the logic in helpers.icon, but we have delegated the
         # decision about what mdi:battery-alert is to the device.
         icon = "mdi:battery"
-        if charging and self._state > 10:
-            icon += "-charging-{}".format(int(round(battery_level / 20 - 0.01)) * 20)
-        elif charging:
+        if self._charging and self.state > 10:
+            percentage = int(round(self.state / 20 - 0.01)) * 20
+            icon += "-charging-{}".format(percentage)
+        elif self._charging:
             icon += "-outline"
         elif self._low_battery:
             icon += "-alert"
-        elif battery_level < 95:
-            modifier = max(int(round(battery_level / 10 - 0.01)) * 10, 10)
-            icon += "-{}".format(modifier)
+        elif self.state < 95:
+            percentage = max(int(round(self.state / 10 - 0.01)) * 10, 10)
+            icon += "-{}".format(percentage)
 
         return icon
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -30,7 +30,7 @@ class HomeKitHumiditySensor(HomeKitEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        return "{} {}".format(super().name, "Humidity")
+        return f"{super().name} Humidity"
 
     @property
     def icon(self):
@@ -66,7 +66,7 @@ class HomeKitTemperatureSensor(HomeKitEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        return "{} {}".format(super().name, "Temperature")
+        return f"{super().name} Temperature"
 
     @property
     def icon(self):
@@ -102,7 +102,7 @@ class HomeKitLightSensor(HomeKitEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        return "{} {}".format(super().name, "Light Level")
+        return f"{super().name} Light Level"
 
     @property
     def icon(self):
@@ -138,7 +138,7 @@ class HomeKitCarbonDioxideSensor(HomeKitEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        return "{} {}".format(super().name, "CO2")
+        return f"{super().name} CO2"
 
     @property
     def icon(self):
@@ -185,7 +185,7 @@ class HomeKitBatterySensor(HomeKitEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        return "{} {}".format(super().name, "Battery")
+        return f"{super().name} Battery"
 
     @property
     def icon(self):

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -1,7 +1,7 @@
 """Support for Homekit sensors."""
 from homekit.model.characteristics import CharacteristicsTypes
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import DEVICE_CLASS_BATTERY, TEMP_CELSIUS
 from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import KNOWN_DEVICES, HomeKitEntity
@@ -177,6 +177,11 @@ class HomeKitBatterySensor(HomeKitEntity):
             CharacteristicsTypes.STATUS_LO_BATT,
             CharacteristicsTypes.CHARGING_STATE,
         ]
+
+    @property
+    def device_class(self) -> str:
+        """Return the device class of the sensor."""
+        return DEVICE_CLASS_BATTERY
 
     @property
     def name(self):

--- a/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
@@ -1,0 +1,36 @@
+"""Tests for handling accessories on a Hue bridge via HomeKit."""
+
+from tests.components.homekit_controller.common import (
+    setup_accessories_from_file,
+    setup_test_accessories,
+    Helper,
+)
+
+
+async def test_hue_bridge_setup(hass):
+    """Test that a Hue hub can be correctly setup in HA via HomeKit."""
+    accessories = await setup_accessories_from_file(hass, "hue_bridge.json")
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    # Check that the battery is correctly found and set up
+    battery_id = "sensor.hue_dimmer_switch_battery"
+    battery = entity_registry.async_get(battery_id)
+    assert battery.unique_id == "homekit-6623462389072572-644245094400"
+
+    battery_helper = Helper(
+        hass, "sensor.hue_dimmer_switch_battery", pairing, accessories[0], config_entry
+    )
+    battery_state = await battery_helper.poll_and_get_state()
+    assert battery_state.attributes["friendly_name"] == "Hue dimmer switch Battery"
+    assert battery_state.attributes["icon"] == "mdi:battery"
+    assert battery_state.state == "100"
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+
+    device = device_registry.async_get(battery.device_id)
+    assert device.manufacturer == "Philips"
+    assert device.name == "Hue dimmer switch"
+    assert device.model == "RWL021"
+    assert device.sw_version == "45.1.17846"

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -6,6 +6,8 @@ HUMIDITY = ("humidity", "relative-humidity.current")
 LIGHT_LEVEL = ("light", "light-level.current")
 CARBON_DIOXIDE_LEVEL = ("carbon-dioxide", "carbon-dioxide.level")
 BATTERY_LEVEL = ("battery", "battery-level")
+CHARGING_STATE = ("battery", "charging-state")
+LO_BATT = ("battery", "status-lo-batt")
 
 
 def create_temperature_sensor_service():
@@ -53,7 +55,13 @@ def create_battery_level_sensor():
     service = FakeService("public.hap.service.battery")
 
     cur_state = service.add_characteristic("battery-level")
-    cur_state.value = 0
+    cur_state.value = 100
+
+    low_battery = service.add_characteristic("status-lo-batt")
+    low_battery.value = 0
+
+    charging_state = service.add_characteristic("charging-state")
+    charging_state.value = 0
 
     return service
 
@@ -128,3 +136,33 @@ async def test_battery_level_sensor(hass, utcnow):
     state = await helper.poll_and_get_state()
     assert state.state == "20"
     assert state.attributes["icon"] == "mdi:battery-20"
+
+
+async def test_battery_charging(hass, utcnow):
+    """Test reading the state of a HomeKit battery's charging state."""
+    sensor = create_battery_level_sensor()
+    helper = await setup_test_component(hass, [sensor], suffix="battery")
+
+    helper.characteristics[BATTERY_LEVEL].value = 0
+    helper.characteristics[CHARGING_STATE].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.attributes["icon"] == "mdi:battery-outline"
+
+    helper.characteristics[BATTERY_LEVEL].value = 20
+    state = await helper.poll_and_get_state()
+    assert state.attributes["icon"] == "mdi:battery-charging-20"
+
+
+async def test_battery_low(hass, utcnow):
+    """Test reading the state of a HomeKit battery's low state."""
+    sensor = create_battery_level_sensor()
+    helper = await setup_test_component(hass, [sensor], suffix="battery")
+
+    helper.characteristics[LO_BATT].value = 0
+    helper.characteristics[BATTERY_LEVEL].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.attributes["icon"] == "mdi:battery-10"
+
+    helper.characteristics[LO_BATT].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.attributes["icon"] == "mdi:battery-alert"

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -5,6 +5,7 @@ TEMPERATURE = ("temperature", "temperature.current")
 HUMIDITY = ("humidity", "relative-humidity.current")
 LIGHT_LEVEL = ("light", "light-level.current")
 CARBON_DIOXIDE_LEVEL = ("carbon-dioxide", "carbon-dioxide.level")
+BATTERY_LEVEL = ("battery", "battery-level")
 
 
 def create_temperature_sensor_service():
@@ -42,6 +43,16 @@ def create_carbon_dioxide_level_sensor_service():
     service = FakeService("public.hap.service.sensor.carbon-dioxide")
 
     cur_state = service.add_characteristic("carbon-dioxide.level")
+    cur_state.value = 0
+
+    return service
+
+
+def create_battery_level_sensor():
+    """Define battery level characteristics."""
+    service = FakeService("public.hap.service.battery")
+
+    cur_state = service.add_characteristic("battery-level")
     cur_state.value = 0
 
     return service
@@ -101,3 +112,19 @@ async def test_carbon_dioxide_level_sensor_read_state(hass, utcnow):
     helper.characteristics[CARBON_DIOXIDE_LEVEL].value = 20
     state = await helper.poll_and_get_state()
     assert state.state == "20"
+
+
+async def test_battery_level_sensor(hass, utcnow):
+    """Test reading the state of a HomeKit battery level sensor."""
+    sensor = create_battery_level_sensor()
+    helper = await setup_test_component(hass, [sensor], suffix="battery")
+
+    helper.characteristics[BATTERY_LEVEL].value = 100
+    state = await helper.poll_and_get_state()
+    assert state.state == "100"
+    assert state.attributes["icon"] == "mdi:battery"
+
+    helper.characteristics[BATTERY_LEVEL].value = 20
+    state = await helper.poll_and_get_state()
+    assert state.state == "20"
+    assert state.attributes["icon"] == "mdi:battery-20"

--- a/tests/fixtures/homekit_controller/hue_bridge.json
+++ b/tests/fixtures/homekit_controller/hue_bridge.json
@@ -1,0 +1,2249 @@
+[
+    {
+        "aid": 6623462389072572,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 37,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue dimmer switch"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 35,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "RWL021"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 34,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 84,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "45.1.17846"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 50,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462389072572"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 22,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 644245094436,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue dimmer switch battery"
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 644245094505,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "00000068-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 644245094522,
+                        "maxValue": 1,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "00000079-0000-1000-8000-0026BB765291",
+                        "value": 0
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 644245094544,
+                        "maxValue": 2,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "0000008F-0000-1000-8000-0026BB765291",
+                        "value": 2
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 644245149880,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462389072572"
+                    }
+                ],
+                "iid": 644245094400,
+                "type": "00000096-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 588410585124,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue dimmer switch button 1"
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410585204,
+                        "maxValue": 0,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "00000073-0000-1000-8000-0026BB765291",
+                        "value": null
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410585292,
+                        "minStep": 1,
+                        "minValue": 1,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "000000CB-0000-1000-8000-0026BB765291",
+                        "value": 1
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 588410640568,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462389072572"
+                    }
+                ],
+                "iid": 588410585088,
+                "linked": [
+                    256
+                ],
+                "type": "00000089-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "uint8",
+                        "iid": 462,
+                        "maxValue": 1,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "000000CD-0000-1000-8000-0026BB765291",
+                        "value": 1
+                    }
+                ],
+                "iid": 256,
+                "type": "000000CC-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 588410650660,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue dimmer switch button 2"
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410650740,
+                        "maxValue": 0,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "00000073-0000-1000-8000-0026BB765291",
+                        "value": null
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410650828,
+                        "minStep": 1,
+                        "minValue": 1,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "000000CB-0000-1000-8000-0026BB765291",
+                        "value": 2
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 588410706104,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462389072572"
+                    }
+                ],
+                "iid": 588410650624,
+                "linked": [
+                    256
+                ],
+                "type": "00000089-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 588410716196,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue dimmer switch button 3"
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410716276,
+                        "maxValue": 0,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "00000073-0000-1000-8000-0026BB765291",
+                        "value": null
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410716364,
+                        "minStep": 1,
+                        "minValue": 1,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "000000CB-0000-1000-8000-0026BB765291",
+                        "value": 3
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 588410771640,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462389072572"
+                    }
+                ],
+                "iid": 588410716160,
+                "linked": [
+                    256
+                ],
+                "type": "00000089-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 588410781732,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue dimmer switch button 4"
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410781812,
+                        "maxValue": 0,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "00000073-0000-1000-8000-0026BB765291",
+                        "value": null
+                    },
+                    {
+                        "format": "uint8",
+                        "iid": 588410781900,
+                        "minStep": 1,
+                        "minValue": 1,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "000000CB-0000-1000-8000-0026BB765291",
+                        "value": 4
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 588410837176,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462389072572"
+                    }
+                ],
+                "iid": 588410781696,
+                "linked": [
+                    256
+                ],
+                "type": "00000089-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 1,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Philips hue - 482544"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "BSB002"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips Lighting"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 8,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.32.1932126170"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 6,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "1"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 7,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462378982941,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LWB010"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462378982941"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462378982941"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462378983942,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LWB010"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462378983942"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462378983942"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462379123707,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LWB010"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462379123707"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462379123707"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462379122122,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LWB010"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462379122122"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 70
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462379122122"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462385996792,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LWB010"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462385996792"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462385996792"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462383114193,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LWB010"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462383114193"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 20
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462383114193"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462383114163,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LWB010"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462383114163"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue white lamp"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462383114163"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462412413293,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance spot"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LTW013"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462412413293"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance spot"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": true
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "Color Temperature",
+                        "format": "uint32",
+                        "iid": 3017,
+                        "maxValue": 454,
+                        "minStep": 1,
+                        "minValue": 153,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "000000CE-0000-1000-8000-0026BB765291",
+                        "value": 366
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462412413293"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462412411853,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance spot"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LTW013"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462412411853"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance spot"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": true
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "Color Temperature",
+                        "format": "uint32",
+                        "iid": 3017,
+                        "maxValue": 454,
+                        "minStep": 1,
+                        "minValue": 153,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "000000CE-0000-1000-8000-0026BB765291",
+                        "value": 366
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462412411853"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462403233419,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LTW012"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462403233419"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "Color Temperature",
+                        "format": "uint32",
+                        "iid": 3017,
+                        "maxValue": 454,
+                        "minStep": 1,
+                        "minValue": 153,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "000000CE-0000-1000-8000-0026BB765291",
+                        "value": 366
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462403233419"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462403113447,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LTW012"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462403113447"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 35
+                    },
+                    {
+                        "description": "Color Temperature",
+                        "format": "uint32",
+                        "iid": 3017,
+                        "maxValue": 454,
+                        "minStep": 1,
+                        "minValue": 153,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "000000CE-0000-1000-8000-0026BB765291",
+                        "value": 366
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462403113447"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462395276939,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LTW012"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462395276939"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "Color Temperature",
+                        "format": "uint32",
+                        "iid": 3017,
+                        "maxValue": 454,
+                        "minStep": 1,
+                        "minValue": 153,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "000000CE-0000-1000-8000-0026BB765291",
+                        "value": 366
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462395276939"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    },
+    {
+        "aid": 6623462395276914,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "LTW012"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Philips"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 112,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.46.13"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 11,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "6623462395276914"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    }
+                ],
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 65591,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "value": "1.1.0"
+                    }
+                ],
+                "iid": 65535,
+                "type": "000000A2-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2817,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Hue ambiance candle"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 2822,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "int",
+                        "iid": 2823,
+                        "maxValue": 100,
+                        "minStep": 1,
+                        "minValue": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "unit": "percentage",
+                        "value": 100
+                    },
+                    {
+                        "description": "Color Temperature",
+                        "format": "uint32",
+                        "iid": 3017,
+                        "maxValue": 454,
+                        "minStep": 1,
+                        "minValue": 153,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "000000CE-0000-1000-8000-0026BB765291",
+                        "value": 366
+                    },
+                    {
+                        "description": "ID to uniquely identify service within a single accessory",
+                        "format": "string",
+                        "iid": 2827,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "D8B76298-42E7-5FFD-B1D6-1782D9A1F936",
+                        "value": "6623462395276914"
+                    }
+                ],
+                "iid": 2816,
+                "type": "00000043-0000-1000-8000-0026BB765291"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Description:

This adds support for the HomeKit battery service - so battery powered HomeKit accessories can now report their battery percentage, if they are currently charging and if their battery percentage is low.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.