### PR TITLE
Fix velux set_cover_position command

### DIFF
--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -165,6 +165,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
         """Move the cover to a specific position."""
         if self.tahoma_device.type == HORIZONTAL_AWNING:
             self.apply_action("setPosition", kwargs.get(ATTR_POSITION, 0))
+        elif self.tahoma_device.type == "io:WindowOpenerVeluxIOComponent":
+            self.apply_action("setClosure", 100 - kwargs.get(ATTR_POSITION))
         else:
             self.apply_action("setPosition", 100 - kwargs.get(ATTR_POSITION, 0))
 


### PR DESCRIPTION
## Breaking Change:

## Description:

Fixes the cover.set_cover_position service for velux windows.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
