### PR TITLE
Update sensor.py

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -207,6 +207,8 @@ class GlancesSensor(Entity):
                         "soc_thermal 1",
                         "soc-thermal 1",
                         "aml_thermal",
+                        "Core 0",
+                        "Core 1",
                     ]:
                         self._state = sensor["value"]
             elif self.type == "docker_active":


### PR DESCRIPTION
Added more options for CPU temp. 
Ubuntu 18.04.x Old Dell 755 lmsensors (see bottom left) 

nuc1 (Ubuntu 18.04 64bit / Linux 4.15.0-58-generic) - IP 192.168.10.90/24 Pub 213.113.35.192                                                                                                                                                      Uptime: 1:54:05

CPU  [|||||||||||                                                               14.7%]   CPU \    14.7%  nice:     0.0%  ctx_sw:    5K                     MEM -   36.3%  active:    1.13G                     SWAP -    0.2%                     LOAD    2-core
MEM  [||||||||||||||||||||||||||                                                36.2%]   user:    10.9%  irq:      0.0%  inter:   1667                     total:  2.90G  inactive:  1.32G                     total:   2.90G                     1 min:    0.68
SWAP [                                                                           0.2%]   system:   3.8%  iowait:   0.2%  sw_int:   685                     used:   1.05G  buffers:    348M                     used:    5.75M                     5 min:    0.58
                                                                                         idle:    85.1%  steal:    0.0%                                    free:   1.85G  cached:    1.48G                     free:    2.89G                     15 min:   0.51

NETWORK     Rx/s   Tx/s   TASKS 203 (575 thr), 1 run, 157 slp, 45 oth sorted automatically by cpu_percent, flat view
docker0       0b     0b
enp0s25    126Kb   31Kb   Systemd          8    Services loaded: 213 active: 213
hassio       3Kb    9Kb
lo          696b   696b     CPU%  MEM%  VIRT   RES   PID USER        NI S     TIME+   R/s   W/s Command
_h19c46f5     0b     0b      4.1   1.5  488M 44.1M 23927 newbee       0 R   0:31.53     0     0 /usr/bin/python3 /usr/bin/glances
_h3d26c0d     0b     0b      3.5   4.4  203M  131M 16723 root         0 R   0:24.16     0     0 /usr/local/bin/python3 -m homeassistant --config /config
_h657be9a     0b     0b      1.6   1.6 1.27G 47.0M  4852 root         0 S   3:57.00     0     0 /usr/bin/containerd
_hd902fda   752b    6Kb      1.0   4.6 1.29G  135M  5915 root         0 S   4:19.89     0     0 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
_he1e4727     0b     0b      0.3   0.3  220M 9.39M     1 root         0 S   1:18.19     0     0 /lib/systemd/systemd --system --deserialize 33
_hea1057e   960b    2Kb      0.3   1.5 1.18G 45.6M  3087 root         0 S   0:08.42     0     0 /usr/bin/python3 /usr/bin/glances -w
_hf5b81d1    1Kb    2Kb      0.3   0.2  106M 6.41M  6524 root         0 S   0:27.79     0     0 containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/0208592a1fd4cc10e958f4e2f887ec2d87d36621417a34cbb4d0dec894d6169c
_hf879e40     0b     0b      0.3   0.2  106M 6.67M  7078 root         0 S   0:26.91     0     0 containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/c32afa5a73b3ece8db475c6699f544f70fd0e98b58586ffb12dd03df47c3fbd4
                             0.3   0.2  106M 6.59M 11026 root         0 S   0:25.62     0     0 containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/03a36b173a6293bedc651dedcd2b4f3743a2b36e82ba2ec96b418007f3c49635
DefaultGateway      6ms      0.3   0.2  106M 6.55M 16663 root         0 S   0:19.14     0     0 containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/7a302fb30c2a043d39abb575574fa2c6e85c78477427073a82ea30ba3c9ec238
                             0.0   0.0     0     0     2 root         0 S   0:00.00     0     0 kthreadd
DISK I/O     R/s    W/s      0.0   0.0     0     0     4 root       -20 ?   0:00.00     0     0 kworker/0:0H
sda1           0      0      0.0   0.0     0     0     6 root       -20 ?   0:00.00     0     0 mm_percpu_wq
sda2           0    71K      0.0   0.0     0     0     7 root         0 S   0:00.56     0     0 ksoftirqd/0
sr0            0      0      0.0   0.0     0     0     8 root         0 ?   0:01.21     0     0 rcu_sched
                             0.0   0.0     0     0     9 root         0 ?   0:00.00     0     0 rcu_bh
FILE SYS    Used  Total      0.0   0.0     0     0    10 root         0 S   0:00.20     0     0 migration/0
/ (sda2)   10.9G   117G      0.0   0.0     0     0    11 root         0 S   0:00.10     0     0 watchdog/0
_ore/7270  88.5M  88.5M      0.0   0.0     0     0    12 root         0 S   0:00.00     0     0 cpuhp/0
                             0.0   0.0     0     0    13 root         0 S   0:00.00     0     0 cpuhp/1
SENSORS                      0.0   0.0     0     0    14 root         0 S   0:00.00     0     0 watchdog/1
Core 0              38C      0.0   0.0     0     0    15 root         0 S   0:00.10     0     0 migration/1
Core 1              40C      0.0   0.0     0     0    16 root         0 S   0:00.48     0     0 ksoftirqd/1

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
