### PR TITLE
Add support for the temperature and pressure sensors of the EDS0068 (1wire)

### DIFF
--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -33,7 +33,6 @@ DEVICE_SENSORS = {
     "7E": {"temperature": "EDS0068/temperature", "pressure": "EDS0068/pressure"},
 }
 
-
 SENSOR_TYPES = {
     "temperature": ["temperature", TEMP_CELSIUS],
     "humidity": ["humidity", "%"],

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -30,10 +30,7 @@ DEVICE_SENSORS = {
     "28": {"temperature": "temperature"},
     "3B": {"temperature": "temperature"},
     "42": {"temperature": "temperature"},
-    "7E": {
-        "temperature": "EDS0068/temperature",
-        "pressure": "EDS0068/pressure",
-    },
+    "7E": {"temperature": "EDS0068/temperature", "pressure": "EDS0068/pressure"},
 }
 
 SENSOR_TYPES = {

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -33,6 +33,7 @@ DEVICE_SENSORS = {
     "7E": {"temperature": "EDS0068/temperature", "pressure": "EDS0068/pressure"},
 }
 
+
 SENSOR_TYPES = {
     "temperature": ["temperature", TEMP_CELSIUS],
     "humidity": ["humidity", "%"],

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -30,6 +30,9 @@ DEVICE_SENSORS = {
     "28": {"temperature": "temperature"},
     "3B": {"temperature": "temperature"},
     "42": {"temperature": "temperature"},
+    "7E": {"temperature": "EDS0068/temperature",
+           "pressure": "EDS0068/pressure",
+    },
 }
 
 SENSOR_TYPES = {

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -30,8 +30,9 @@ DEVICE_SENSORS = {
     "28": {"temperature": "temperature"},
     "3B": {"temperature": "temperature"},
     "42": {"temperature": "temperature"},
-    "7E": {"temperature": "EDS0068/temperature",
-           "pressure": "EDS0068/pressure",
+    "7E": {
+        "temperature": "EDS0068/temperature",
+        "pressure": "EDS0068/pressure",
     },
 }
 


### PR DESCRIPTION
Here is a small patch that add support for the temperature and pressure sensors of the onewire (1wire) device EDS0068 (https://www.embeddeddatasystems.com/OW-ENV-TP--Temperature-Barometric-Pressure-Sensor_p_171.html) 


