### PR TITLE
Add support for temperature and pressure readings from onewire sensor…

### DIFF
--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -30,6 +30,7 @@ DEVICE_SENSORS = {
     "28": {"temperature": "temperature"},
     "3B": {"temperature": "temperature"},
     "42": {"temperature": "temperature"},
+    "7E": {"temperature": "EDS0068/temperature", "pressure": "EDS0068/pressure"},
 }
 
 SENSOR_TYPES = {


### PR DESCRIPTION
Adds support for temperature and pressure readings from onewire (1wire) sensor EDS0068 from Embedded Data Systems (https://www.embeddeddatasystems.com/OW-ENV-TP--Temperature-Barometric-Pressure-Sensor_p_171.html).