### PR TITLE
Fix for 0.98: Don't update disabled entities (Homematic IP Cloud)

### DIFF
--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -77,7 +77,7 @@ class HomematicipGenericDevice(Entity):
     def _async_device_changed(self, *args, **kwargs):
         """Handle device state changes."""
         # Don't update disabled entities
-        if self.registry_entry is None or not self.registry_entry.disabled:
+        if self.enabled:
             _LOGGER.debug("Event %s (%s)", self.name, self._device.modelType)
             self.async_schedule_update_ha_state()
         else:

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -76,8 +76,16 @@ class HomematicipGenericDevice(Entity):
 
     def _async_device_changed(self, *args, **kwargs):
         """Handle device state changes."""
-        _LOGGER.debug("Event %s (%s)", self.name, self._device.modelType)
-        self.async_schedule_update_ha_state()
+        # Don't update disabled entities
+        if self.registry_entry is None or not self.registry_entry.disabled:
+            _LOGGER.debug("Event %s (%s)", self.name, self._device.modelType)
+            self.async_schedule_update_ha_state()
+        else:
+            _LOGGER.debug(
+                "Device Changed Event for %s (%s) not fired. Entity is disabled.",
+                self.name,
+                self._device.modelType,
+            )
 
     @property
     def name(self) -> str:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -196,11 +196,6 @@ class Entity:
         return True
 
     @property
-    def enabled(self):
-        """Return if the entity is enabled in the entity registry."""
-        return self.registry_entry is None or not self.registry_entry.disabled
-
-    @property
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
         return False
@@ -233,6 +228,11 @@ class Entity:
     # These properties and methods are either managed by Home Assistant or they
     # are used to perform a very specific function. Overwriting these may
     # produce undesirable effects in the entity's operation.
+
+    @property
+    def enabled(self):
+        """Return if the entity is enabled in the entity registry."""
+        return self.registry_entry is None or not self.registry_entry.disabled
 
     @callback
     def async_set_context(self, context):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -196,6 +196,11 @@ class Entity:
         return True
 
     @property
+    def enabled(self):
+        """Return if the entity is enabled in the entity registry."""
+        return self.registry_entry is None or not self.registry_entry.disabled
+
+    @property
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
         return False

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -552,8 +552,10 @@ async def test_disabled_in_entity_registry(hass):
     await hass.async_block_till_done()
     assert entry2 != entry
     assert ent.registry_entry == entry2
+    assert ent.enabled is True
 
     entry3 = registry.async_update_entity("hello.world", disabled_by="user")
     await hass.async_block_till_done()
     assert entry3 != entry2
     assert ent.registry_entry == entry3
+    assert ent.enabled is False


### PR DESCRIPTION
## Description:
This PR prevents that disabled entities receive updates.
This PR should be added to 0.98 Milestone
It's related to #26143

The enabled property was added to entity.py to simplify access to enabled/disabled state.
This should be in compliance with (https://github.com/home-assistant/architecture):** home-assistant/architecture/issues/276

**Pull request with documentation for [developers.home-assistant](https://github.com/home-assistant/developers.home-assistant):** home-assistant/developers.home-assistant#310

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [developers.home-assistant](https://github.com/home-assistant/developers.home-assistant)


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
