### PR TITLE
deCONZ normalizes cover values to follow zigbee spec

### DIFF
--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -16,7 +16,7 @@ SUPPORTED_COVERS = {
         "id": "Cover 1 id",
         "name": "Cover 1 name",
         "type": "Level controllable output",
-        "state": {"bri": 255, "reachable": True},
+        "state": {"bri": 255, "on": False, "reachable": True},
         "modelid": "Not zigbee spec",
         "uniqueid": "00:00:00:00:00:00:00:00-00",
     },
@@ -24,7 +24,7 @@ SUPPORTED_COVERS = {
         "id": "Cover 2 id",
         "name": "Cover 2 name",
         "type": "Window covering device",
-        "state": {"bri": 255, "reachable": True},
+        "state": {"bri": 255, "on": True, "reachable": True},
         "modelid": "lumi.curtain",
     },
 }
@@ -107,7 +107,7 @@ async def test_cover(hass):
 
     cover_1 = hass.states.get("cover.cover_1_name")
     assert cover_1 is not None
-    assert cover_1.state == "closed"
+    assert cover_1.state == "open"
 
     gateway.api.lights["1"].async_update({})
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Apparently deCONZ normalises cover values to follow Zigbee spec

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
