### PR TITLE
Add google_assistant alarm_control_panel

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -15,6 +15,7 @@ from homeassistant.components import (
     sensor,
     switch,
     vacuum,
+    alarm_control_panel,
 )
 
 DOMAIN = "google_assistant"
@@ -48,6 +49,7 @@ DEFAULT_EXPOSED_DOMAINS = [
     "lock",
     "binary_sensor",
     "sensor",
+    "alarm_control_panel",
 ]
 
 PREFIX_TYPES = "action.devices.types."
@@ -66,6 +68,7 @@ TYPE_SENSOR = PREFIX_TYPES + "SENSOR"
 TYPE_DOOR = PREFIX_TYPES + "DOOR"
 TYPE_TV = PREFIX_TYPES + "TV"
 TYPE_SPEAKER = PREFIX_TYPES + "SPEAKER"
+TYPE_ALARM = PREFIX_TYPES + "SECURITYSYSTEM"
 
 SERVICE_REQUEST_SYNC = "request_sync"
 HOMEGRAPH_URL = "https://homegraph.googleapis.com/"
@@ -106,6 +109,7 @@ DOMAIN_TO_GOOGLE_TYPES = {
     script.DOMAIN: TYPE_SCENE,
     switch.DOMAIN: TYPE_SWITCH,
     vacuum.DOMAIN: TYPE_VACUUM,
+    alarm_control_panel.DOMAIN: TYPE_ALARM,
 }
 
 DEVICE_CLASS_TO_GOOGLE_TYPES = {

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -84,6 +84,9 @@ ERR_PROTOCOL_ERROR = "protocolError"
 ERR_UNKNOWN_ERROR = "unknownError"
 ERR_FUNCTION_NOT_SUPPORTED = "functionNotSupported"
 
+ERR_ALREADY_DISARMED = "alreadyDisarmed"
+ERR_ALREADY_ARMED = "alreadyArmed"
+
 ERR_CHALLENGE_NEEDED = "challengeNeeded"
 ERR_CHALLENGE_NOT_SETUP = "challengeFailedNotSetup"
 ERR_TOO_MANY_FAILED_ATTEMPTS = "tooManyFailedAttempts"

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -920,13 +920,16 @@ class ArmDisArmTrait(_Trait):
         """Return ArmDisarm attributes for a sync request."""
         response = {}
         levels = []
-        for key in self.state_to_service:
+        for state in self.state_to_service:
             level = {
-                "level_name": key,
+                "level_name": state,
                 "level_values": [
                     {
                         "level_synonym": [
-                            key.split("_")[1 if key != STATE_ALARM_TRIGGERED else 0]
+                            state.replace("_", " "),
+                            state.split("_")[
+                                1 if state != STATE_ALARM_TRIGGERED else 0
+                            ],
                         ],
                         "lang": "en",
                     }
@@ -952,7 +955,7 @@ class ArmDisArmTrait(_Trait):
         """Execute an ArmDisarm command."""
         if params["arm"] and self.state.attributes["code_arm_required"]:
             _verify_pin_challenge(data, self.state, challenge)
-        elif params["arm"]:
+        elif params["arm"] and not params.get("cancel"):
             service = self.state_to_service[params["armLevel"]]
         else:
             _verify_pin_challenge(data, self.state, challenge)

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -230,4 +230,11 @@ DEMO_DEVICES = [
         "type": "action.devices.types.LOCK",
         "willReportState": False,
     },
+    {
+        "id": "alarm_control_panel.home_alarm",
+        "name": {"name": "Home Alarm"},
+        "traits": ["action.devices.traits.ArmDisarm"],
+        "type": "action.devices.types.SECURITYSYSTEM",
+        "willReportState": False,
+    },
 ]

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -231,8 +231,8 @@ DEMO_DEVICES = [
         "willReportState": False,
     },
     {
-        "id": "alarm_control_panel.home_alarm",
-        "name": {"name": "Home Alarm"},
+        "id": "alarm_control_panel.alarm",
+        "name": {"name": "Alarm"},
         "traits": ["action.devices.traits.ArmDisarm"],
         "type": "action.devices.types.SECURITYSYSTEM",
         "willReportState": False,

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -7,7 +7,15 @@ from aiohttp.hdrs import CONTENT_TYPE, AUTHORIZATION
 import pytest
 
 from homeassistant import core, const, setup
-from homeassistant.components import fan, cover, light, switch, lock, media_player
+from homeassistant.components import (
+    fan,
+    cover,
+    light,
+    switch,
+    lock,
+    media_player,
+    alarm_control_panel,
+)
 from homeassistant.components.climate import const as climate
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
 from homeassistant.components import google_assistant as ga
@@ -96,6 +104,14 @@ def hass_fixture(loop, hass):
 
     loop.run_until_complete(
         setup.async_setup_component(hass, lock.DOMAIN, {"lock": [{"platform": "demo"}]})
+    )
+
+    loop.run_until_complete(
+        setup.async_setup_component(
+            hass,
+            alarm_control_panel.DOMAIN,
+            {"alarm_control_panel": [{"platform": "demo"}]},
+        )
     )
 
     return hass

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1,6 +1,6 @@
 """Tests for the Google Assistant traits."""
 from unittest.mock import patch, Mock
-
+import logging
 import pytest
 
 from homeassistant.components import (
@@ -18,12 +18,16 @@ from homeassistant.components import (
     switch,
     vacuum,
     group,
+    alarm_control_panel,
 )
 from homeassistant.components.climate import const as climate
 from homeassistant.components.google_assistant import trait, helpers, const, error
 from homeassistant.const import (
     STATE_ON,
     STATE_OFF,
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_DISARMED,
+    STATE_ALARM_PENDING,
     ATTR_ENTITY_ID,
     SERVICE_TURN_ON,
     SERVICE_TURN_OFF,
@@ -40,6 +44,7 @@ from homeassistant.util import color
 from tests.common import async_mock_service, mock_coro
 from . import BASIC_CONFIG, MockConfig
 
+_LOGGER = logging.getLogger(__name__)
 
 REQ_ID = "ff36a3cc-ec34-11e6-b1a0-64510650abcf"
 
@@ -814,6 +819,344 @@ async def test_lock_unlock_unlock(hass):
     ):
         await trt.execute(trait.COMMAND_LOCKUNLOCK, BASIC_DATA, {"lock": False}, {})
     assert len(calls) == 2
+
+
+async def test_arm_disarm_arm_away(hass):
+    """Test ArmDisarm trait Arming support for alarm_control_panel domain."""
+    assert helpers.get_google_type(alarm_control_panel.DOMAIN, None) is not None
+    assert trait.ArmDisArmTrait.supported(alarm_control_panel.DOMAIN, 0, None)
+    assert trait.ArmDisArmTrait.might_2fa(alarm_control_panel.DOMAIN, 0, None)
+
+    trt = trait.ArmDisArmTrait(
+        hass,
+        State(
+            "alarm_control_panel.home_alarm",
+            STATE_ALARM_ARMED_AWAY,
+            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+        ),
+        PIN_CONFIG,
+    )
+    assert trt.sync_attributes() == {
+        "availableArmLevels": {
+            "levels": [
+                {
+                    "level_name": "armed_home",
+                    "level_values": [
+                        {"level_synonym": ["armed home", "home"], "lang": "en"}
+                    ],
+                },
+                {
+                    "level_name": "armed_away",
+                    "level_values": [
+                        {"level_synonym": ["armed away", "away"], "lang": "en"}
+                    ],
+                },
+                {
+                    "level_name": "armed_night",
+                    "level_values": [
+                        {"level_synonym": ["armed night", "night"], "lang": "en"}
+                    ],
+                },
+                {
+                    "level_name": "armed_custom_bypass",
+                    "level_values": [
+                        {
+                            "level_synonym": ["armed custom bypass", "custom"],
+                            "lang": "en",
+                        }
+                    ],
+                },
+                {
+                    "level_name": "triggered",
+                    "level_values": [
+                        {"level_synonym": ["triggered", "triggered"], "lang": "en"}
+                    ],
+                },
+            ],
+            "ordered": False,
+        }
+    }
+
+    assert trt.query_attributes() == {
+        "isArmed": True,
+        "currentArmLevel": STATE_ALARM_ARMED_AWAY,
+    }
+
+    assert trt.can_execute(
+        trait.COMMAND_ARMDISARM, {"arm": True, "armLevel": STATE_ALARM_ARMED_AWAY}
+    )
+
+    calls = async_mock_service(
+        hass, alarm_control_panel.DOMAIN, alarm_control_panel.SERVICE_ALARM_ARM_AWAY
+    )
+
+    # Test with no secure_pin configured
+
+    with pytest.raises(error.SmartHomeError) as err:
+        trt = trait.ArmDisArmTrait(
+            hass,
+            State(
+                "alarm_control_panel.home_alarm",
+                STATE_ALARM_DISARMED,
+                {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+            ),
+            BASIC_CONFIG,
+        )
+        await trt.execute(
+            trait.COMMAND_ARMDISARM,
+            BASIC_DATA,
+            {"arm": True, "armLevel": STATE_ALARM_ARMED_AWAY},
+            {},
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NOT_SETUP
+
+    trt = trait.ArmDisArmTrait(
+        hass,
+        State(
+            "alarm_control_panel.home_alarm",
+            STATE_ALARM_DISARMED,
+            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+        ),
+        PIN_CONFIG,
+    )
+    # No challenge data
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_ARMDISARM,
+            PIN_DATA,
+            {"arm": True, "armLevel": STATE_ALARM_ARMED_AWAY},
+            {},
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_PIN_NEEDED
+
+    # invalid pin
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_ARMDISARM,
+            PIN_DATA,
+            {"arm": True, "armLevel": STATE_ALARM_ARMED_AWAY},
+            {"pin": 9999},
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_FAILED_PIN_NEEDED
+
+    # correct pin
+    await trt.execute(
+        trait.COMMAND_ARMDISARM,
+        PIN_DATA,
+        {"arm": True, "armLevel": STATE_ALARM_ARMED_AWAY},
+        {"pin": "1234"},
+    )
+
+    assert len(calls) == 1
+    # assert calls[0].data == {
+    #     "entity_id": "alarm.control_panel.home_alarm",
+    #     "code": "1234",
+    # }
+
+    # Cancel arming while already armed
+    with pytest.raises(error.SmartHomeError) as err:
+        trt = trait.ArmDisArmTrait(
+            hass,
+            State(
+                "alarm_control_panel.home_alarm",
+                STATE_ALARM_ARMED_AWAY,
+                {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
+            ),
+            PIN_CONFIG,
+        )
+        await trt.execute(
+            trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": True, "cancel": True}, {}
+        )
+    assert len(calls) == 1
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_PIN_NEEDED
+
+    # Cancel arming while pending doesn't require pin
+    trt = trait.ArmDisArmTrait(
+        hass,
+        State(
+            "alarm_control_panel.home_alarm",
+            STATE_ALARM_PENDING,
+            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
+        ),
+        PIN_CONFIG,
+    )
+    await trt.execute(
+        trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": True, "cancel": True}, {}
+    )
+    assert len(calls) == 1
+
+    # Test already armed
+    with pytest.raises(error.SmartHomeError) as err:
+        trt = trait.ArmDisArmTrait(
+            hass,
+            State(
+                "alarm_control_panel.home_alarm",
+                STATE_ALARM_ARMED_AWAY,
+                {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+            ),
+            PIN_CONFIG,
+        )
+        await trt.execute(
+            trait.COMMAND_ARMDISARM,
+            PIN_DATA,
+            {"arm": True, "armLevel": STATE_ALARM_ARMED_AWAY},
+            {},
+        )
+    assert len(calls) == 1
+    assert err.value.code == const.ERR_ALREADY_ARMED
+
+    # Test with code_arm_required False
+    trt = trait.ArmDisArmTrait(
+        hass,
+        State(
+            "alarm_control_panel.home_alarm",
+            STATE_ALARM_DISARMED,
+            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
+        ),
+        PIN_CONFIG,
+    )
+    await trt.execute(
+        trait.COMMAND_ARMDISARM,
+        PIN_DATA,
+        {"arm": True, "armLevel": STATE_ALARM_ARMED_AWAY},
+        {},
+    )
+    assert len(calls) == 2
+
+
+async def test_arm_disarm_disarm(hass):
+    """Test ArmDisarm trait Disarming support for alarm_control_panel domain."""
+    assert helpers.get_google_type(alarm_control_panel.DOMAIN, None) is not None
+    assert trait.ArmDisArmTrait.supported(alarm_control_panel.DOMAIN, 0, None)
+    assert trait.ArmDisArmTrait.might_2fa(alarm_control_panel.DOMAIN, 0, None)
+
+    trt = trait.ArmDisArmTrait(
+        hass,
+        State(
+            "alarm_control_panel.home_alarm",
+            STATE_ALARM_DISARMED,
+            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+        ),
+        PIN_CONFIG,
+    )
+    assert trt.sync_attributes() == {
+        "availableArmLevels": {
+            "levels": [
+                {
+                    "level_name": "armed_home",
+                    "level_values": [
+                        {"level_synonym": ["armed home", "home"], "lang": "en"}
+                    ],
+                },
+                {
+                    "level_name": "armed_away",
+                    "level_values": [
+                        {"level_synonym": ["armed away", "away"], "lang": "en"}
+                    ],
+                },
+                {
+                    "level_name": "armed_night",
+                    "level_values": [
+                        {"level_synonym": ["armed night", "night"], "lang": "en"}
+                    ],
+                },
+                {
+                    "level_name": "armed_custom_bypass",
+                    "level_values": [
+                        {
+                            "level_synonym": ["armed custom bypass", "custom"],
+                            "lang": "en",
+                        }
+                    ],
+                },
+                {
+                    "level_name": "triggered",
+                    "level_values": [
+                        {"level_synonym": ["triggered", "triggered"], "lang": "en"}
+                    ],
+                },
+            ],
+            "ordered": False,
+        }
+    }
+
+    assert trt.query_attributes() == {"isArmed": False}
+
+    assert trt.can_execute(trait.COMMAND_ARMDISARM, {"arm": False})
+
+    calls = async_mock_service(
+        hass, alarm_control_panel.DOMAIN, alarm_control_panel.SERVICE_ALARM_DISARM
+    )
+
+    # Test without secure_pin configured
+    with pytest.raises(error.SmartHomeError) as err:
+        trt = trait.ArmDisArmTrait(
+            hass,
+            State(
+                "alarm_control_panel.home_alarm",
+                STATE_ALARM_ARMED_AWAY,
+                {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+            ),
+            BASIC_CONFIG,
+        )
+        await trt.execute(trait.COMMAND_ARMDISARM, BASIC_DATA, {"arm": False}, {})
+
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NOT_SETUP
+
+    trt = trait.ArmDisArmTrait(
+        hass,
+        State(
+            "alarm_control_panel.home_alarm",
+            STATE_ALARM_ARMED_AWAY,
+            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+        ),
+        PIN_CONFIG,
+    )
+
+    # No challenge data
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": False}, {})
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_PIN_NEEDED
+
+    # invalid pin
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": False}, {"pin": 9999}
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_FAILED_PIN_NEEDED
+
+    # correct pin
+    await trt.execute(
+        trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": False}, {"pin": "1234"}
+    )
+
+    assert len(calls) == 1
+
+    # Test already disarmed
+    with pytest.raises(error.SmartHomeError) as err:
+        trt = trait.ArmDisArmTrait(
+            hass,
+            State(
+                "alarm_control_panel.home_alarm",
+                STATE_ALARM_DISARMED,
+                {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
+            ),
+            PIN_CONFIG,
+        )
+        await trt.execute(trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": False}, {})
+    assert len(calls) == 1
+    assert err.value.code == const.ERR_ALREADY_DISARMED
 
 
 async def test_fan_speed(hass):

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -830,7 +830,7 @@ async def test_arm_disarm_arm_away(hass):
     trt = trait.ArmDisArmTrait(
         hass,
         State(
-            "alarm_control_panel.home_alarm",
+            "alarm_control_panel.alarm",
             STATE_ALARM_ARMED_AWAY,
             {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
         ),
@@ -896,7 +896,7 @@ async def test_arm_disarm_arm_away(hass):
         trt = trait.ArmDisArmTrait(
             hass,
             State(
-                "alarm_control_panel.home_alarm",
+                "alarm_control_panel.alarm",
                 STATE_ALARM_DISARMED,
                 {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
             ),
@@ -914,7 +914,7 @@ async def test_arm_disarm_arm_away(hass):
     trt = trait.ArmDisArmTrait(
         hass,
         State(
-            "alarm_control_panel.home_alarm",
+            "alarm_control_panel.alarm",
             STATE_ALARM_DISARMED,
             {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
         ),
@@ -953,50 +953,13 @@ async def test_arm_disarm_arm_away(hass):
     )
 
     assert len(calls) == 1
-    # assert calls[0].data == {
-    #     "entity_id": "alarm.control_panel.home_alarm",
-    #     "code": "1234",
-    # }
-
-    # Cancel arming while already armed
-    with pytest.raises(error.SmartHomeError) as err:
-        trt = trait.ArmDisArmTrait(
-            hass,
-            State(
-                "alarm_control_panel.home_alarm",
-                STATE_ALARM_ARMED_AWAY,
-                {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
-            ),
-            PIN_CONFIG,
-        )
-        await trt.execute(
-            trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": True, "cancel": True}, {}
-        )
-    assert len(calls) == 1
-    assert err.value.code == const.ERR_CHALLENGE_NEEDED
-    assert err.value.challenge_type == const.CHALLENGE_PIN_NEEDED
-
-    # Cancel arming while pending doesn't require pin
-    trt = trait.ArmDisArmTrait(
-        hass,
-        State(
-            "alarm_control_panel.home_alarm",
-            STATE_ALARM_PENDING,
-            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
-        ),
-        PIN_CONFIG,
-    )
-    await trt.execute(
-        trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": True, "cancel": True}, {}
-    )
-    assert len(calls) == 1
 
     # Test already armed
     with pytest.raises(error.SmartHomeError) as err:
         trt = trait.ArmDisArmTrait(
             hass,
             State(
-                "alarm_control_panel.home_alarm",
+                "alarm_control_panel.alarm",
                 STATE_ALARM_ARMED_AWAY,
                 {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
             ),
@@ -1015,7 +978,7 @@ async def test_arm_disarm_arm_away(hass):
     trt = trait.ArmDisArmTrait(
         hass,
         State(
-            "alarm_control_panel.home_alarm",
+            "alarm_control_panel.alarm",
             STATE_ALARM_DISARMED,
             {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
         ),
@@ -1039,7 +1002,7 @@ async def test_arm_disarm_disarm(hass):
     trt = trait.ArmDisArmTrait(
         hass,
         State(
-            "alarm_control_panel.home_alarm",
+            "alarm_control_panel.alarm",
             STATE_ALARM_DISARMED,
             {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
         ),
@@ -1099,7 +1062,7 @@ async def test_arm_disarm_disarm(hass):
         trt = trait.ArmDisArmTrait(
             hass,
             State(
-                "alarm_control_panel.home_alarm",
+                "alarm_control_panel.alarm",
                 STATE_ALARM_ARMED_AWAY,
                 {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
             ),
@@ -1113,7 +1076,7 @@ async def test_arm_disarm_disarm(hass):
     trt = trait.ArmDisArmTrait(
         hass,
         State(
-            "alarm_control_panel.home_alarm",
+            "alarm_control_panel.alarm",
             STATE_ALARM_ARMED_AWAY,
             {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
         ),
@@ -1148,7 +1111,7 @@ async def test_arm_disarm_disarm(hass):
         trt = trait.ArmDisArmTrait(
             hass,
             State(
-                "alarm_control_panel.home_alarm",
+                "alarm_control_panel.alarm",
                 STATE_ALARM_DISARMED,
                 {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True},
             ),
@@ -1157,6 +1120,39 @@ async def test_arm_disarm_disarm(hass):
         await trt.execute(trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": False}, {})
     assert len(calls) == 1
     assert err.value.code == const.ERR_ALREADY_DISARMED
+
+    # Cancel arming after already armed will require pin
+    with pytest.raises(error.SmartHomeError) as err:
+        trt = trait.ArmDisArmTrait(
+            hass,
+            State(
+                "alarm_control_panel.alarm",
+                STATE_ALARM_ARMED_AWAY,
+                {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
+            ),
+            PIN_CONFIG,
+        )
+        await trt.execute(
+            trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": True, "cancel": True}, {}
+        )
+    assert len(calls) == 1
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.challenge_type == const.CHALLENGE_PIN_NEEDED
+
+    # Cancel arming while pending to arm doesn't require pin
+    trt = trait.ArmDisArmTrait(
+        hass,
+        State(
+            "alarm_control_panel.alarm",
+            STATE_ALARM_PENDING,
+            {alarm_control_panel.ATTR_CODE_ARM_REQUIRED: False},
+        ),
+        PIN_CONFIG,
+    )
+    await trt.execute(
+        trait.COMMAND_ARMDISARM, PIN_DATA, {"arm": True, "cancel": True}, {}
+    )
+    assert len(calls) == 2
 
 
 async def test_fan_speed(hass):

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -868,9 +868,7 @@ async def test_arm_disarm_arm_away(hass):
                 },
                 {
                     "level_name": "triggered",
-                    "level_values": [
-                        {"level_synonym": ["triggered", "triggered"], "lang": "en"}
-                    ],
+                    "level_values": [{"level_synonym": ["triggered"], "lang": "en"}],
                 },
             ],
             "ordered": False,
@@ -1040,9 +1038,7 @@ async def test_arm_disarm_disarm(hass):
                 },
                 {
                     "level_name": "triggered",
-                    "level_values": [
-                        {"level_synonym": ["triggered", "triggered"], "lang": "en"}
-                    ],
+                    "level_values": [{"level_synonym": ["triggered"], "lang": "en"}],
                 },
             ],
             "ordered": False,


### PR DESCRIPTION
## Description:
This PR adds the Alarm Control Panel devices to Google Assistant so that we can Arm and Disarm using google voice commands.
The Alarm Panel code needs to be the same as the `secure_devices_pin` assigned for security devices. If the `code_arm_required` is False then the system will arm without asking for the PIN otherwise it will ask for the PIN (which is the security CODE).
I have tested this using the manual alarm control panel. This should work for the other alarm system integrations.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10250

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
