### PR TITLE
Fix WWLLN entity management

### DIFF
--- a/homeassistant/components/wwlln/geo_location.py
+++ b/homeassistant/components/wwlln/geo_location.py
@@ -88,6 +88,7 @@ class WWLLNEventManager:
     @callback
     def _create_events(self, ids_to_create):
         """Create new geo location events."""
+        _LOGGER.debug("Going to create %s", ids_to_create)
         events = []
         for strike_id in ids_to_create:
             strike = self._strikes[strike_id]
@@ -106,6 +107,7 @@ class WWLLNEventManager:
     @callback
     def _remove_events(self, ids_to_remove):
         """Remove old geo location events."""
+        _LOGGER.debug("Going to remove %s", ids_to_remove)
         for strike_id in ids_to_remove:
             async_dispatcher_send(self._hass, SIGNAL_DELETE_ENTITY.format(strike_id))
 

--- a/homeassistant/components/wwlln/geo_location.py
+++ b/homeassistant/components/wwlln/geo_location.py
@@ -138,11 +138,16 @@ class WWLLNEventManager:
             return
 
         new_strike_ids = set(self._strikes)
+        # Remove all managed entities that are not in the latest update anymore.
         ids_to_remove = self._managed_strike_ids.difference(new_strike_ids)
         self._remove_events(ids_to_remove)
 
+        # Create new entities for all strikes that are not managed entities yet.
         ids_to_create = new_strike_ids.difference(self._managed_strike_ids)
         self._create_events(ids_to_create)
+
+        # Store all external IDs of all managed strikes.
+        self._managed_strike_ids = new_strike_ids
 
 
 class WWLLNEvent(GeolocationEvent):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This fixes the integration to correctly remove outdated entities which is currently not happening. The `WWLLNEventManager` is now correctly keeping track of the external IDs of entities that it manages.

Also, added some debug log statements showing how entities are going to be created and removed based on the external IDs managed by the integration.

**Related issue (if applicable):** fixes #26248

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
