### PR TITLE
Disconnect velux on hass stop

### DIFF
--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -6,7 +6,7 @@ from pyvlx import PyVLXException
 
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (CONF_HOST, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP
 
 DOMAIN = "velux"
 DATA_VELUX = "data_velux"
@@ -50,7 +50,6 @@ class VeluxModule:
         self._hass = hass
         self._domain_config = domain_config
 
-
     def setup(self):
         async def on_hass_stop(event):
             """Close connection when hass stops."""
@@ -62,10 +61,8 @@ class VeluxModule:
         password = self._domain_config.get(CONF_PASSWORD)
         self.pyvlx = PyVLX(host=host, password=password)
 
-
     async def async_start(self):
         """Start velux component."""
         _LOGGER.debug("Velux interface started")
         await self.pyvlx.load_scenes()
         await self.pyvlx.load_nodes()
-

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass, config):
-    """Set up the velux component."""    
+    """Set up the velux component."""
     try:
         hass.data[DATA_VELUX] = VeluxModule(hass, config[DOMAIN])
         hass.data[DATA_VELUX].setup()
@@ -47,17 +47,17 @@ class VeluxModule:
     def __init__(self, hass, domain_config):
         """Initialize for velux component."""
         self.pyvlx = None
-        self._hass = hass        
+        self._hass = hass
         self._domain_config = domain_config
-        
+
 
     def setup(self):
         async def on_hass_stop(event):
             """Close connection when hass stops."""
             _LOGGER.debug("Velux interface terminated")
             await self.pyvlx.disconnect()
-            
-        self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)             
+
+        self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
         host = self._domain_config.get(CONF_HOST)
         password = self._domain_config.get(CONF_PASSWORD)
         self.pyvlx = PyVLX(host=host, password=password)
@@ -65,7 +65,7 @@ class VeluxModule:
 
     async def async_start(self):
         """Start velux component."""
-        _LOGGER.debug("Velux interface started")        
+        _LOGGER.debug("Velux interface started")
         await self.pyvlx.load_scenes()
         await self.pyvlx.load_nodes()
-        
+

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -52,6 +52,7 @@ class VeluxModule:
 
     def setup(self):
         """Velux component setup."""
+
         async def on_hass_stop(event):
             """Close connection when hass stops."""
             _LOGGER.debug("Velux interface terminated")

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -51,6 +51,7 @@ class VeluxModule:
         self._domain_config = domain_config
 
     def setup(self):
+        """Velux component setup"""
         async def on_hass_stop(event):
             """Close connection when hass stops."""
             _LOGGER.debug("Velux interface terminated")

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -28,6 +28,7 @@ async def async_setup(hass, config):
 
     try:
         hass.data[DATA_VELUX] = VeluxModule(hass, config)
+        hass.data[DATA_VELUX].setup()
         await hass.data[DATA_VELUX].async_start()
 
     except PyVLXException as ex:
@@ -40,24 +41,35 @@ async def async_setup(hass, config):
         )
     return True
 
+
 class VeluxModule:
     """Abstraction for velux component."""
 
     def __init__(self, hass, config):
         """Initialize for velux component."""
+        self._hass = hass
+        self._config = config
         
+
+    def setup(self):
         async def on_hass_stop(event):
             """Close connection when hass stops."""
-            _LOGGER.info("velux interface terminated")
-            await self.pyvlx.disconnect()                    
-        
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)                   
+            _LOGGER.info("Velux interface terminated")
+            await self.pyvlx.disconnect()
+            
+        self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)     
         from pyvlx import PyVLX
-        host = config[DOMAIN].get(CONF_HOST)
-        password = config[DOMAIN].get(CONF_PASSWORD)
+        host = self._config[DOMAIN].get(CONF_HOST)
+        password = self._config[DOMAIN].get(CONF_PASSWORD)
         self.pyvlx = PyVLX(host=host, password=password)
+
 
     async def async_start(self):
         """Start velux component."""
+        _LOGGER.info("Velux interface started")        
         await self.pyvlx.load_scenes()
         await self.pyvlx.load_nodes()
+                        
+        for node in self.pyvlx.nodes:
+          _LOGGER.info("Stopping node: " + str(node))
+          await node.stop(wait_for_completion=False)

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass, config):
     """Set up the velux component."""    
     try:
-        hass.data[DATA_VELUX] = VeluxModule(hass, config)
+        hass.data[DATA_VELUX] = VeluxModule(hass, config[DOMAIN])
         hass.data[DATA_VELUX].setup()
         await hass.data[DATA_VELUX].async_start()
 
@@ -44,11 +44,11 @@ async def async_setup(hass, config):
 class VeluxModule:
     """Abstraction for velux component."""
 
-    def __init__(self, hass, config):
+    def __init__(self, hass, domain_config):
         """Initialize for velux component."""
         self.pyvlx = None
         self._hass = hass        
-        self._domain_config = config[DOMAIN]
+        self._domain_config = domain_config
         
 
     def setup(self):

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -51,7 +51,7 @@ class VeluxModule:
         self._domain_config = domain_config
 
     def setup(self):
-        """Velux component setup"""
+        """Velux component setup."""
         async def on_hass_stop(event):
             """Close connection when hass stops."""
             _LOGGER.debug("Velux interface terminated")

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -51,14 +51,11 @@ class VeluxModule:
             _LOGGER.info("velux interface terminated")
             await self.pyvlx.disconnect()                    
         
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
-        #from custom_components.pyvlx import PyVLX                
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)                   
         from pyvlx import PyVLX
         host = config[DOMAIN].get(CONF_HOST)
         password = config[DOMAIN].get(CONF_PASSWORD)
-        self.pyvlx = PyVLX(
-            host=host,
-            password=password)
+        self.pyvlx = PyVLX(host=host, password=password)
 
     async def async_start(self):
         """Start velux component."""

--- a/homeassistant/components/velux/__init__.py
+++ b/homeassistant/components/velux/__init__.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.const import (CONF_HOST, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP)
 
 DOMAIN = "velux"
 DATA_VELUX = "data_velux"
@@ -40,17 +40,25 @@ async def async_setup(hass, config):
         )
     return True
 
-
 class VeluxModule:
     """Abstraction for velux component."""
 
     def __init__(self, hass, config):
         """Initialize for velux component."""
+        
+        async def on_hass_stop(event):
+            """Close connection when hass stops."""
+            _LOGGER.info("velux interface terminated")
+            await self.pyvlx.disconnect()                    
+        
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
+        #from custom_components.pyvlx import PyVLX                
         from pyvlx import PyVLX
-
         host = config[DOMAIN].get(CONF_HOST)
         password = config[DOMAIN].get(CONF_PASSWORD)
-        self.pyvlx = PyVLX(host=host, password=password)
+        self.pyvlx = PyVLX(
+            host=host,
+            password=password)
 
     async def async_start(self):
         """Start velux component."""


### PR DESCRIPTION
## Description:

Often when rebooting hass the KLF 200 device would not disconnect the previous connection which in turns locks out the use from connecting again.
In these situations one would have to powercycle the klf200 velux device, which could be a problem if not being at home.

Ive set up af listener for EVENT_HOMEASSISTANT_STOP, which would jsutm ake sure to call disconnect on the device.

more info here:
https://community.home-assistant.io/t/velux-component-for-klf-200-doesnt-support-the-new-api-with-firmware-2-0-0-71/75641/67

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
