### PR TITLE
Fix ZHA state restore by always restoring last seen on devices

### DIFF
--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -296,7 +296,7 @@ class ZHAGateway:
         if zha_device is None:
             zha_device = ZHADevice(self._hass, zigpy_device, self)
             self._devices[zigpy_device.ieee] = zha_device
-            entry = self.ha_device_registry.async_get_or_create(
+            self.ha_device_registry.async_get_or_create(
                 config_entry_id=self._config_entry.entry_id,
                 connections={(CONNECTION_ZIGBEE, str(zha_device.ieee))},
                 identifiers={(DOMAIN, str(zha_device.ieee))},

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -296,7 +296,7 @@ class ZHAGateway:
         if zha_device is None:
             zha_device = ZHADevice(self._hass, zigpy_device, self)
             self._devices[zigpy_device.ieee] = zha_device
-            self.ha_device_registry.async_get_or_create(
+            entry = self.ha_device_registry.async_get_or_create(
                 config_entry_id=self._config_entry.entry_id,
                 connections={(CONNECTION_ZIGBEE, str(zha_device.ieee))},
                 identifiers={(DOMAIN, str(zha_device.ieee))},
@@ -304,6 +304,8 @@ class ZHAGateway:
                 manufacturer=zha_device.manufacturer,
                 model=zha_device.model,
             )
+        entry = self.zha_storage.async_get_or_create(zha_device)
+        zha_device.async_update_last_seen(entry.last_seen)
         return zha_device
 
     @callback
@@ -355,10 +357,6 @@ class ZHAGateway:
                 "0x{:04x}:{}".format(device.nwk, device.ieee),
             )
             await self._async_device_joined(device, zha_device)
-
-        # This is real traffic from a device so lets update last seen on the entry
-        entry = self.zha_storage.async_get_or_create(zha_device)
-        zha_device.async_update_last_seen(entry.last_seen)
 
         device_info = async_get_device_info(
             self._hass, zha_device, self.ha_device_registry


### PR DESCRIPTION
## Description:
This PR corrects an issue that I introduced in .98 that prevents state restore from functioning correctly. 

**Related issue (if applicable):** fixes #26269 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]