### PR TITLE
Add missing bluepy dependency for miflora

### DIFF
--- a/homeassistant/components/miflora/manifest.json
+++ b/homeassistant/components/miflora/manifest.json
@@ -3,6 +3,7 @@
   "name": "Miflora",
   "documentation": "https://www.home-assistant.io/components/miflora",
   "requirements": [
+    "bluepy==1.1.4",
     "miflora==0.4.0"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -284,6 +284,7 @@ blinkstick==1.1.8
 blockchain==1.4.4
 
 # homeassistant.components.decora
+# homeassistant.components.miflora
 # bluepy==1.1.4
 
 # homeassistant.components.bme680


### PR DESCRIPTION
## Breaking Change:

N/A

## Description:

Adds missing dependency on bluepy. Seems that bluepy has been removed some time ago from the default hassio installation...

**Related issue (if applicable):** fixes #24453

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
