### PR TITLE
Expose current direction properly on state machine

### DIFF
--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -34,13 +34,13 @@ class DemoFan(FanEntity):
         self._supported_features = supported_features
         self._speed = STATE_OFF
         self.oscillating = None
-        self.direction = None
+        self._direction = None
         self._name = name
 
         if supported_features & SUPPORT_OSCILLATE:
             self.oscillating = False
         if supported_features & SUPPORT_DIRECTION:
-            self.direction = "forward"
+            self._direction = "forward"
 
     @property
     def name(self) -> str:
@@ -80,7 +80,7 @@ class DemoFan(FanEntity):
 
     def set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
-        self.direction = direction
+        self._direction = direction
         self.schedule_update_ha_state()
 
     def oscillate(self, oscillating: bool) -> None:
@@ -91,7 +91,7 @@ class DemoFan(FanEntity):
     @property
     def current_direction(self) -> str:
         """Fan direction."""
-        return self.direction
+        return self._direction
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -54,7 +54,7 @@ PROP_TO_ATTR = {
     "speed": ATTR_SPEED,
     "speed_list": ATTR_SPEED_LIST,
     "oscillating": ATTR_OSCILLATING,
-    "direction": ATTR_DIRECTION,
+    "current_direction": ATTR_DIRECTION,
 }  # type: dict
 
 FAN_SET_SPEED_SCHEMA = ENTITY_SERVICE_SCHEMA.extend(

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -243,7 +243,7 @@ class TemplateFan(FanEntity):
         return self._oscillating
 
     @property
-    def direction(self):
+    def current_direction(self):
         """Return the oscillation state."""
         return self._direction
 


### PR DESCRIPTION
## Description:
There was a bug in prop_to_attr mapping, causing fan entity to expose `self.direction` instead of `self.current_direction` to the state machine. This was also incorrectly implemented in the demo.

I thought about just changing it all to `self.direction`, but that would be a breaking change, and now it is like documented 👍 

This fixes it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
