### PR TITLE
Add HEAD and PUT support to webhooks

### DIFF
--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -99,10 +99,14 @@ class WebhookView(HomeAssistantView):
     name = "api:webhook"
     requires_auth = False
 
-    async def post(self, request, webhook_id):
+    async def _handle(self, request, webhook_id):
         """Handle webhook call."""
         hass = request.app["hass"]
         return await async_handle_webhook(hass, webhook_id, request)
+
+    head = _handle
+    post = _handle
+    put = _handle
 
 
 @callback

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -99,7 +99,46 @@ async def test_posting_webhook_no_data(hass, mock_client):
     assert len(hooks) == 1
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
+    assert hooks[0][2].method == "POST"
     assert await hooks[0][2].text() == ""
+
+
+async def test_webhook_put(hass, mock_client):
+    """Test sending a put request to a webhook."""
+    hooks = []
+    webhook_id = hass.components.webhook.async_generate_id()
+
+    async def handle(*args):
+        """Handle webhook."""
+        hooks.append(args)
+
+    hass.components.webhook.async_register("test", "Test hook", webhook_id, handle)
+
+    resp = await mock_client.put("/api/webhook/{}".format(webhook_id))
+    assert resp.status == 200
+    assert len(hooks) == 1
+    assert hooks[0][0] is hass
+    assert hooks[0][1] == webhook_id
+    assert hooks[0][2].method == "PUT"
+
+
+async def test_webhook_head(hass, mock_client):
+    """Test sending a head request to a webhook."""
+    hooks = []
+    webhook_id = hass.components.webhook.async_generate_id()
+
+    async def handle(*args):
+        """Handle webhook."""
+        hooks.append(args)
+
+    hass.components.webhook.async_register("test", "Test hook", webhook_id, handle)
+
+    resp = await mock_client.head("/api/webhook/{}".format(webhook_id))
+    assert resp.status == 200
+    assert len(hooks) == 1
+    assert hooks[0][0] is hass
+    assert hooks[0][1] == webhook_id
+    assert hooks[0][2].method == "HEAD"
 
 
 async def test_listing_webhook(hass, hass_ws_client, hass_access_token):


### PR DESCRIPTION
## Description:
This adds HEAD and PUT support to webhooks.

HEAD support is needed to allow working with the Trello API, as they do that to verify if an endpoint exists ([docs](https://developers.trello.com/page/webhooks)).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
