### PR TITLE
deCONZ - Dont update entry if data is equal

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -157,8 +157,12 @@ class DeconzFlowHandler(config_entries.ConfigFlow):
 
     async def _update_entry(self, entry, host):
         """Update existing entry."""
+        if entry.data[CONF_HOST] == host:
+            return self.async_abort(reason="already_configured")
+
         entry.data[CONF_HOST] = host
         self.hass.config_entries.async_update_entry(entry)
+        return self.async_abort(reason="updated_instance")
 
     async def async_step_ssdp(self, discovery_info):
         """Handle a discovered deCONZ bridge."""
@@ -175,8 +179,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow):
 
         if uuid in gateways:
             entry = gateways[uuid].config_entry
-            await self._update_entry(entry, discovery_info[CONF_HOST])
-            return self.async_abort(reason="updated_instance")
+            return await self._update_entry(entry, discovery_info[CONF_HOST])
 
         bridgeid = discovery_info[ATTR_SERIAL]
         if any(
@@ -224,8 +227,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow):
 
         if bridgeid in gateway_entries:
             entry = gateway_entries[bridgeid]
-            await self._update_entry(entry, user_input[CONF_HOST])
-            return self.async_abort(reason="updated_instance")
+            return await self._update_entry(entry, user_input[CONF_HOST])
 
         self._hassio_discovery = user_input
 

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -336,6 +336,24 @@ async def test_hassio_update_instance(hass):
     assert entry.data[config_flow.CONF_HOST] == "mock-deconz"
 
 
+async def test_hassio_dont_update_instance(hass):
+    """Test we can update an existing config entry."""
+    entry = MockConfigEntry(
+        domain=config_flow.DOMAIN,
+        data={config_flow.CONF_BRIDGEID: "id", config_flow.CONF_HOST: "1.2.3.4"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        data={config_flow.CONF_HOST: "1.2.3.4", config_flow.CONF_SERIAL: "id"},
+        context={"source": "hassio"},
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
 async def test_hassio_confirm(hass):
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
**Related issue (if applicable):** fixes #26301

## Description:
On discovery of already configured entry make sure to not update entry data if new data is equal to old data

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
