### PR TITLE
Bump androidtv to 0.0.26 and update tests

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.25"
+    "androidtv==0.0.26"
   ],
   "dependencies": [],
   "codeowners": ["@JeffLIrion"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -194,7 +194,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.25
+androidtv==0.0.26
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -79,7 +79,7 @@ aiowwlln==1.0.0
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.25
+androidtv==0.0.26
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -120,10 +120,10 @@ def patch_shell(response=None, error=False):
 
     if not error:
         return {
-            "python": patch("{}.AdbCommandsFake.Shell".format(__name__), shell_success),
-            "server": patch("{}.DeviceFake.shell".format(__name__), shell_success),
+            "python": patch(f"{__name__}.AdbCommandsFake.Shell", shell_success),
+            "server": patch(f"{__name__}.DeviceFake.shell", shell_success),
         }
     return {
-        "python": patch("{}.AdbCommandsFake.Shell".format(__name__), shell_fail_python),
-        "server": patch("{}.DeviceFake.shell".format(__name__), shell_fail_server),
+        "python": patch(f"{__name__}.AdbCommandsFake.Shell", shell_fail_python),
+        "server": patch(f"{__name__}.DeviceFake.shell", shell_fail_server),
     }

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -1,0 +1,77 @@
+"""Define patches used for androidtv tests."""
+
+from socket import error as socket_error
+from unittest.mock import patch
+
+
+def connect_device_success(self, *args, **kwargs):
+    """Return `self`, which will result in the ADB connection being interpreted as available."""
+    return self
+
+
+def connect_device_fail(self, *args, **kwargs):
+    """Raise a socket error."""
+    raise socket_error
+
+
+def adb_shell_python_adb_error(self, cmd):
+    """Raise an error that is among those caught for the Python ADB implementation."""
+    raise AttributeError
+
+
+def adb_shell_adb_server_error(self, cmd):
+    """Raise an error that is among those caught for the ADB server implementation."""
+    raise ConnectionResetError
+
+
+class AdbAvailable:
+    """A class that indicates the ADB connection is available."""
+
+    def shell(self, cmd):
+        """Send an ADB shell command (ADB server implementation)."""
+        return ""
+
+
+class AdbUnavailable:
+    """A class with ADB shell methods that raise errors."""
+
+    def __bool__(self):
+        """Return `False` to indicate that the ADB connection is unavailable."""
+        return False
+
+    def shell(self, cmd):
+        """Raise an error that pertains to the Python ADB implementation."""
+        raise ConnectionResetError
+
+
+PATCH_PYTHON_ADB_CONNECT_SUCCESS = patch(
+    "adb.adb_commands.AdbCommands.ConnectDevice", connect_device_success
+)
+PATCH_PYTHON_ADB_COMMAND_SUCCESS = patch(
+    "adb.adb_commands.AdbCommands.Shell", return_value=""
+)
+PATCH_PYTHON_ADB_CONNECT_FAIL = patch(
+    "adb.adb_commands.AdbCommands.ConnectDevice", connect_device_fail
+)
+PATCH_PYTHON_ADB_COMMAND_FAIL = patch(
+    "adb.adb_commands.AdbCommands.Shell", adb_shell_python_adb_error
+)
+PATCH_PYTHON_ADB_COMMAND_NONE = patch(
+    "adb.adb_commands.AdbCommands.Shell", return_value=None
+)
+
+PATCH_ADB_SERVER_CONNECT_SUCCESS = patch(
+    "adb_messenger.client.Client.device", return_value=AdbAvailable()
+)
+PATCH_ADB_SERVER_AVAILABLE = patch(
+    "androidtv.basetv.BaseTV.available", return_value=True
+)
+PATCH_ADB_SERVER_CONNECT_FAIL = patch(
+    "adb_messenger.client.Client.device", return_value=AdbUnavailable()
+)
+PATCH_ADB_SERVER_COMMAND_FAIL = patch(
+    "{}.AdbAvailable.shell".format(__name__), adb_shell_adb_server_error
+)
+PATCH_ADB_SERVER_COMMAND_NONE = patch(
+    "{}.AdbAvailable.shell".format(__name__), return_value=None
+)

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -92,8 +92,7 @@ async def _test_reconnect(hass, caplog, config):
     ]:
         for _ in range(5):
             await hass.helpers.entity_component.async_update_entity(entity_id)
-            state = hass.states.get(entity_id)
-            assert state.state == STATE_UNAVAILABLE
+            assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     assert len(caplog.record_tuples) == 2
 

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -20,9 +20,6 @@ from homeassistant.const import (
 from . import patchers
 
 
-ENTITY_ID_ANDROIDTV = "media_player.android_tv"
-ENTITY_ID_FIRETV = "media_player.fire_tv"
-
 # Android TV device with Python ADB implementation
 CONFIG_ANDROIDTV_PYTHON_ADB = {
     DOMAIN: {

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -95,6 +95,8 @@ async def _test_reconnect(hass, caplog, config):
             assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     assert len(caplog.record_tuples) == 2
+    assert caplog.record_tuples[0][1] == logging.ERROR
+    assert caplog.record_tuples[1][1] == logging.WARNING
 
     caplog.set_level(logging.DEBUG)
     with patchers.patch_connect(True)[patch_key], patchers.patch_shell("1")[patch_key]:

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -82,7 +82,9 @@ async def _test_reconnect(hass, caplog, config):
     with patchers.patch_connect(True)[patch_key], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.helpers.entity_component.async_update_entity(entity_id)
-        assert hass.states.get(entity_id).state == STATE_OFF
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_OFF
 
     caplog.clear()
     caplog.set_level(logging.WARNING)
@@ -92,7 +94,9 @@ async def _test_reconnect(hass, caplog, config):
     ]:
         for _ in range(5):
             await hass.helpers.entity_component.async_update_entity(entity_id)
-            assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+            state = hass.states.get(entity_id)
+            assert state is not None
+            assert state.state == STATE_UNAVAILABLE
 
     assert len(caplog.record_tuples) == 2
     assert caplog.record_tuples[0][1] == logging.ERROR
@@ -105,15 +109,18 @@ async def _test_reconnect(hass, caplog, config):
 
         # If using an ADB server, the state will get updated; otherwise, the
         # state will be the last known state
+        state = hass.states.get(entity_id)
         if patch_key == "server":
-            assert hass.states.get(entity_id).state == STATE_IDLE
+            assert state.state == STATE_IDLE
         else:
-            assert hass.states.get(entity_id).state == STATE_OFF
+            assert state.state == STATE_OFF
 
         # Update 2 will update the state, regardless of which ADB connection
         # method is used
         await hass.helpers.entity_component.async_update_entity(entity_id)
-        assert hass.states.get(entity_id).state == STATE_IDLE
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_IDLE
 
     if patch_key == "python":
         assert (
@@ -147,60 +154,96 @@ async def _test_adb_shell_returns_none(hass, config):
     with patchers.patch_connect(True)[patch_key], patchers.patch_shell("")[patch_key]:
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.helpers.entity_component.async_update_entity(entity_id)
-        assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state != STATE_UNAVAILABLE
 
     with patchers.patch_shell(None)[patch_key], patchers.patch_shell(error=True)[
         patch_key
     ]:
         await hass.helpers.entity_component.async_update_entity(entity_id)
-        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_UNAVAILABLE
 
     return True
 
 
 async def test_reconnect_androidtv_python_adb(hass, caplog):
-    """Test that the error and reconnection attempts are logged correctly."""
+    """Test that the error and reconnection attempts are logged correctly.
 
+    * Device type: Android TV
+    * ADB connection method: Python ADB implementation
+
+    """
     assert await _test_reconnect(hass, caplog, CONFIG_ANDROIDTV_PYTHON_ADB)
 
 
 async def test_adb_shell_returns_none_androidtv_python_adb(hass):
-    """Test the case that the ADB shell command returns `None`."""
+    """Test the case that the ADB shell command returns `None`.
 
+    * Device type: Android TV
+    * ADB connection method: Python ADB implementation
+
+    """
     assert await _test_adb_shell_returns_none(hass, CONFIG_ANDROIDTV_PYTHON_ADB)
 
 
 async def test_reconnect_firetv_python_adb(hass, caplog):
-    """Test that the error and reconnection attempts are logged correctly."""
+    """Test that the error and reconnection attempts are logged correctly.
 
+    * Device type: Fire TV
+    * ADB connection method: Python ADB implementation
+
+    """
     assert await _test_reconnect(hass, caplog, CONFIG_FIRETV_PYTHON_ADB)
 
 
 async def test_adb_shell_returns_none_firetv_python_adb(hass):
-    """Test the case that the ADB shell command returns `None`."""
+    """Test the case that the ADB shell command returns `None`.
 
+    * Device type: Fire TV
+    * ADB connection method: Python ADB implementation
+
+    """
     assert await _test_adb_shell_returns_none(hass, CONFIG_FIRETV_PYTHON_ADB)
 
 
 async def test_reconnect_androidtv_adb_server(hass, caplog):
-    """Test that the error and reconnection attempts are logged correctly."""
+    """Test that the error and reconnection attempts are logged correctly.
 
+    * Device type: Android TV
+    * ADB connection method: ADB server
+
+    """
     assert await _test_reconnect(hass, caplog, CONFIG_ANDROIDTV_ADB_SERVER)
 
 
 async def test_adb_shell_returns_none_androidtv_adb_server(hass):
-    """Test the case that the ADB shell command returns `None`."""
+    """Test the case that the ADB shell command returns `None`.
 
+    * Device type: Android TV
+    * ADB connection method: ADB server
+
+    """
     assert await _test_adb_shell_returns_none(hass, CONFIG_ANDROIDTV_ADB_SERVER)
 
 
 async def test_reconnect_firetv_adb_server(hass, caplog):
-    """Test that the error and reconnection attempts are logged correctly."""
+    """Test that the error and reconnection attempts are logged correctly.
 
+    * Device type: Fire TV
+    * ADB connection method: ADB server
+
+    """
     assert await _test_reconnect(hass, caplog, CONFIG_FIRETV_ADB_SERVER)
 
 
 async def test_adb_shell_returns_none_firetv_adb_server(hass):
-    """Test the case that the ADB shell command returns `None`."""
+    """Test the case that the ADB shell command returns `None`.
 
+    * Device type: Fire TV
+    * ADB connection method: ADB server
+
+    """
     assert await _test_adb_shell_returns_none(hass, CONFIG_FIRETV_ADB_SERVER)


### PR DESCRIPTION
## Description:

Update the `androidtv` tests to use `pytest` instead of `unittest`.  

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
