### PR TITLE
Add X10 devices as ISY994 switches

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -182,6 +182,7 @@ def _check_for_node_def(hass: HomeAssistant, node, single_domain: str = None) ->
             hass.data[ISY994_NODES][domain].append(node)
             return True
 
+    _LOGGER.warning("unsupported node: {node.name}, type: {node.type}")
     return False
 
 

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -114,7 +114,7 @@ NODE_FILTERS = {
         "insteon_type": ["1."],
     },
     "switch": {
-        "uom": ["2", "78"],
+        "uom": ["2", "78", "100"],
         "states": ["on", "off"],
         "node_def_id": [
             "OnOffControl",
@@ -138,7 +138,7 @@ NODE_FILTERS = {
             "Siren",
             "Siren_ADV",
         ],
-        "insteon_type": ["2.", "9.10.", "9.11."],
+        "insteon_type": ["2.", "9.10.", "9.11.", "113."],
     },
 }
 

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -114,7 +114,7 @@ NODE_FILTERS = {
         "insteon_type": ["1."],
     },
     "switch": {
-        "uom": ["2", "78", "100"],
+        "uom": ["2", "78"],
         "states": ["on", "off"],
         "node_def_id": [
             "OnOffControl",

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -182,7 +182,7 @@ def _check_for_node_def(hass: HomeAssistant, node, single_domain: str = None) ->
             hass.data[ISY994_NODES][domain].append(node)
             return True
 
-    _LOGGER.warning("unsupported node: {node.name}, type: {node.type}")
+    _LOGGER.warning("Unsupported node: %s, type: %s", node.name, node.type)
     return False
 
 


### PR DESCRIPTION
## Description:

This PR adds two things that I would like feedback on.
1. ~A new flag that adds X10 devices from the ISY994 as switches. I was not satisfied with having to write 20+ programs for all the X10 devices I have at my place. I think adding all X10 devices as switches is a decent middle ground instead of adding full support for them.~
Adds X10 devices as switches.
2. A warning message to help users debug why their ISY994 devices aren't being added as entities. I spent a lot of time trying to figure out why my X10 devices weren't being added and the current logging didn't provide enough detail. I had to dig into the component code to figure out why it wasn't being added. Having a logging message like this would have helped.

~**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10271~

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
