### PR TITLE
Test with 3.6.1 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,14 @@ addons:
 matrix:
   fast_finish: true
   include:
-    - python: "3.6.0"
+    - python: "3.6.1"
       env: TOXENV=lint
-      dist: trusty
-    - python: "3.6.0"
+    - python: "3.6.1"
       env: TOXENV=pylint
-      dist: trusty
-    - python: "3.6.0"
+    - python: "3.6.1"
       env: TOXENV=typing
-      dist: trusty
-    - python: "3.6.0"
+    - python: "3.6.1"
       env: TOXENV=py36
-      dist: trusty
     - python: "3.7"
       env: TOXENV=py37
 


### PR DESCRIPTION
## Description:

3.6.0 is already untestable, so no reason to wait before we bump the actual dependency to 3.6.1.

**Related issue (if applicable):** https://github.com/home-assistant/architecture/issues/278

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
