### PR TITLE
Add sensor support for the gogogate2 temperature

### DIFF
--- a/homeassistant/components/gogogate2/sensor.py
+++ b/homeassistant/components/gogogate2/sensor.py
@@ -4,17 +4,15 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-
 from homeassistant.const import (
-    CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_IP_ADDRESS,
     CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
     TEMP_CELSIUS,
 )
-from homeassistant.helpers.entity import Entity
-
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +36,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     from pygogogate2 import Gogogate2API as pygogogate2
 
     temp_unit = hass.config.units.temperature_unit
-    
+
     ip_address = config.get(CONF_IP_ADDRESS)
     name = config.get(CONF_NAME)
     password = config.get(CONF_PASSWORD)
@@ -51,7 +49,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if devices is False:
             raise ValueError("Username or Password is incorrect or no devices found")
 
-        add_entities(MyGogogate2Thermostat(mygogogate2, door, temp_unit) for door in devices)
+        add_entities(
+            MyGogogate2Thermostat(mygogogate2, door, temp_unit) for door in devices
+        )
 
     except (TypeError, KeyError, NameError, ValueError) as ex:
         _LOGGER.error("%s", ex)
@@ -63,7 +63,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             notification_id=NOTIFICATION_ID,
         )
 
-    
+
 class MyGogogate2Sensor(Entity):
     """Representation of a Gogogate2 temperature sensor."""
 
@@ -73,7 +73,7 @@ class MyGogogate2Sensor(Entity):
         self.device_id = device["door"]
         self._name = device["name"]
         self._temperature = device["temperature"]
-        self._temp_unit=temp_unit
+        self._temp_unit = temp_unit
 
     @property
     def name(self):
@@ -93,11 +93,11 @@ class MyGogogate2Sensor(Entity):
     def update(self):
         """Cache value from pygogogate2"""
         try:
-            # mygogogate2 always returns the temperature in fahrenheit
-            self._temperature=float(self.mygogogate2.get_temperature(self.device_id))
+            # mygogogate2 always returns the temperature in fahrenheit.
+            self._temperature = float(self.mygogogate2.get_temperature(self.device_id))
             if self._temp_unit == TEMP_CELSIUS:
-                # Convert output to celcius
-                self._temperature=(self._temperature-32.0)*5.0/9.0
+                # Convert the output to celcius.
+                self._temperature = (self._temperature - 32.0) * 5.0 / 9.0
         except (TypeError, KeyError, NameError, ValueError) as ex:
             _LOGGER.error("%s", ex)
             self._temperature = None

--- a/homeassistant/components/gogogate2/sensor.py
+++ b/homeassistant/components/gogogate2/sensor.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = "gogogate2_temp"
+DEFAULT_NAME = "gogogate2"
 
 NOTIFICATION_ID = "gogogate2_temperature"
 NOTIFICATION_TITLE = "Gogogate2 Temperature"

--- a/homeassistant/components/gogogate2/sensor.py
+++ b/homeassistant/components/gogogate2/sensor.py
@@ -1,0 +1,103 @@
+"""Support for Gogogate2 temperature."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+
+from homeassistant.const import (
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_IP_ADDRESS,
+    CONF_NAME,
+    TEMP_CELSIUS,
+)
+from homeassistant.helpers.entity import Entity
+
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "gogogate2_temp"
+
+NOTIFICATION_ID = "gogogate2_temperature"
+NOTIFICATION_TITLE = "Gogogate2 Temperature"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_IP_ADDRESS): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Gogogate2 component."""
+    from pygogogate2 import Gogogate2API as pygogogate2
+
+    temp_unit = hass.config.units.temperature_unit
+    
+    ip_address = config.get(CONF_IP_ADDRESS)
+    name = config.get(CONF_NAME)
+    password = config.get(CONF_PASSWORD)
+    username = config.get(CONF_USERNAME)
+
+    mygogogate2 = pygogogate2(username, password, ip_address)
+
+    try:
+        devices = mygogogate2.get_devices()
+        if devices is False:
+            raise ValueError("Username or Password is incorrect or no devices found")
+
+        add_entities(MyGogogate2Thermostat(mygogogate2, door, temp_unit) for door in devices)
+
+    except (TypeError, KeyError, NameError, ValueError) as ex:
+        _LOGGER.error("%s", ex)
+        hass.components.persistent_notification.create(
+            "Error: {}<br />"
+            "You will need to restart hass after fixing."
+            "".format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID,
+        )
+
+    
+class MyGogogate2Sensor(Entity):
+    """Representation of a Gogogate2 temperature sensor."""
+
+    def __init__(self, mygogogate2, device, temp_unit):
+        """Initialize with API object, device id."""
+        self.mygogogate2 = mygogogate2
+        self.device_id = device["door"]
+        self._name = device["name"]
+        self._temperature = device["temperature"]
+        self._temp_unit=temp_unit
+
+    @property
+    def name(self):
+        """Return the name of the temperature sensor"""
+        return self._name if self._name else DEFAULT_NAME
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._temperature
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._temp_unit
+
+    def update(self):
+        """Cache value from pygogogate2"""
+        try:
+            # mygogogate2 always returns the temperature in fahrenheit
+            self._temperature=float(self.mygogogate2.get_temperature(self.device_id))
+            if self._temp_unit == TEMP_CELSIUS:
+                # Convert output to celcius
+                self._temperature=(self._temperature-32.0)*5.0/9.0
+        except (TypeError, KeyError, NameError, ValueError) as ex:
+            _LOGGER.error("%s", ex)
+            self._temperature = None


### PR DESCRIPTION
## Description:
As a user of the gogogate2 interface I want to retrieve the temperature data that is available from gogogate2 api.


**Related issue (if applicable):** fixes #NA

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#NA

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: gogogate2
    username: email@email.com
    password: password
    ip_address: 192.168.1.200
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
