### PR TITLE
USGS Earthquakes icon for geolocation entities

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -288,6 +288,7 @@ homeassistant/components/upcloud/* @scop
 homeassistant/components/updater/* @home-assistant/core
 homeassistant/components/upnp/* @robbiet480
 homeassistant/components/uptimerobot/* @ludeeus
+homeassistant/components/usgs_earthquakes_feed/* @exxamalte
 homeassistant/components/utility_meter/* @dgomes
 homeassistant/components/velbus/* @cereal2nd
 homeassistant/components/velux/* @Julius2342

--- a/homeassistant/components/usgs_earthquakes_feed/geo_location.py
+++ b/homeassistant/components/usgs_earthquakes_feed/geo_location.py
@@ -244,6 +244,11 @@ class UsgsEarthquakesEvent(GeolocationEvent):
         self._alert = feed_entry.alert
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return "mdi:pulse"
+
+    @property
     def source(self) -> str:
         """Return source value of this external event."""
         return SOURCE

--- a/homeassistant/components/usgs_earthquakes_feed/manifest.json
+++ b/homeassistant/components/usgs_earthquakes_feed/manifest.json
@@ -6,5 +6,7 @@
     "geojson_client==0.4"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@exxamalte"
+  ]
 }

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    ATTR_ICON,
 )
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed
@@ -148,6 +149,7 @@ async def test_setup(hass):
                 ATTR_MAGNITUDE: 5.7,
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "usgs_earthquakes_feed",
+                ATTR_ICON: "mdi:pulse",
             }
             assert round(abs(float(state.state) - 15.5), 7) == 0
 
@@ -161,6 +163,7 @@ async def test_setup(hass):
                 ATTR_FRIENDLY_NAME: "Title 2",
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "usgs_earthquakes_feed",
+                ATTR_ICON: "mdi:pulse",
             }
             assert round(abs(float(state.state) - 20.5), 7) == 0
 
@@ -174,6 +177,7 @@ async def test_setup(hass):
                 ATTR_FRIENDLY_NAME: "Title 3",
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "usgs_earthquakes_feed",
+                ATTR_ICON: "mdi:pulse",
             }
             assert round(abs(float(state.state) - 25.5), 7) == 0
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This adds a suitable icon to the geolocation entities created by the USGS Earthquakes integration.
The screenshot in the documentation happens to already show this icon.

**Related issue (if applicable):** fixes #26227

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
