### PR TITLE
Update google_maps dependency and improve error message

### DIFF
--- a/homeassistant/components/google_maps/device_tracker.py
+++ b/homeassistant/components/google_maps/device_tracker.py
@@ -67,10 +67,7 @@ class GoogleMapsScanner:
 
         except InvalidCookies:
             _LOGGER.error(
-                "You have specified invalid login credentials. "
-                "Please make sure you have saved your credentials"
-                " in the following file: %s",
-                credfile,
+                "The cookie file provided does not provide a valid session. Please create another one and try again."
             )
             self.success_init = False
 

--- a/homeassistant/components/google_maps/manifest.json
+++ b/homeassistant/components/google_maps/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google maps",
   "documentation": "https://www.home-assistant.io/components/google_maps",
   "requirements": [
-    "locationsharinglib==4.0.2"
+    "locationsharinglib==4.1.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -748,7 +748,7 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.google_maps
-locationsharinglib==4.0.2
+locationsharinglib==4.1.0
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.2


### PR DESCRIPTION
## Description:
bumping dependency of locationsharinglib library that now supports text based cookies that can be exported with addons from the browser.

**Related issue (if applicable):

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10277

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
