### PR TITLE
Fix KNX light tunable white rounding error

### DIFF
--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -305,7 +305,7 @@ class KNXLight(Light):
             await self.device.set_color_temperature(kelvin)
         elif self.device.supports_tunable_white and update_color_temp:
             # calculate relative_ct from Kelvin to fit typical KNX devices
-            kelvin = min(self._min_kelvin,
+            kelvin = min(self._max_kelvin,
                          int(color_util.color_temperature_mired_to_kelvin(mireds)))
             relative_ct = int(
                 255

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -305,8 +305,10 @@ class KNXLight(Light):
             await self.device.set_color_temperature(kelvin)
         elif self.device.supports_tunable_white and update_color_temp:
             # calculate relative_ct from Kelvin to fit typical KNX devices
-            kelvin = min(self._max_kelvin,
-                         int(color_util.color_temperature_mired_to_kelvin(mireds)))
+            kelvin = min(
+                self._max_kelvin,
+                int(color_util.color_temperature_mired_to_kelvin(mireds)),
+            )
             relative_ct = int(
                 255
                 * (kelvin - self._min_kelvin)

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -305,7 +305,8 @@ class KNXLight(Light):
             await self.device.set_color_temperature(kelvin)
         elif self.device.supports_tunable_white and update_color_temp:
             # calculate relative_ct from Kelvin to fit typical KNX devices
-            kelvin = int(color_util.color_temperature_mired_to_kelvin(mireds))
+            kelvin = min(self._min_kelvin,
+                         int(color_util.color_temperature_mired_to_kelvin(mireds)))
             relative_ct = int(
                 255
                 * (kelvin - self._min_kelvin)


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

mitigate rounding errors in kelvin - mired conversion for lights with relative color temperature

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/26357

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** not applicable
