### PR TITLE
Fix race during initial Sonos group construction

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -345,7 +345,7 @@ class SonosEntity(MediaPlayerDevice):
             for entity in self.hass.data[DATA_SONOS].entities:
                 entity.update_groups()
 
-        self.hass.async_add_job(_rebuild_groups)
+        self.hass.async_add_executor_job(_rebuild_groups)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -337,7 +337,15 @@ class SonosEntity(MediaPlayerDevice):
     async def async_added_to_hass(self):
         """Subscribe sonos events."""
         await self.async_seen()
+
         self.hass.data[DATA_SONOS].entities.append(self)
+
+        def _rebuild_groups():
+            """Build the current group topology."""
+            for entity in self.hass.data[DATA_SONOS].entities:
+                entity.update_groups()
+
+        self.hass.async_add_job(_rebuild_groups)
 
     @property
     def unique_id(self):
@@ -468,10 +476,6 @@ class SonosEntity(MediaPlayerDevice):
             self._shuffle = self.soco.shuffle
             self.update_volume()
             self._set_favorites()
-
-            # New player available, build the current group topology
-            for entity in self.hass.data[DATA_SONOS].entities:
-                entity.update_groups()
 
             player = self.soco
 


### PR DESCRIPTION
## Description:

When adding a player we must rebuild all groups because the new player could be part of an existing group. This change moves the rebuilding of groups to _after_ an entity has been appended to our local inventory.

This avoids 2+ players rebuilding groups with each not yet knowing about the other.

**Related issue (if applicable):** fixes #26326

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
