### PR TITLE
Use literal string interpolation in integrations H-J (f-strings)

### DIFF
--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -66,7 +66,7 @@ class HabitipySensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{0}_{1}_{2}".format(habitica.DOMAIN, self._name, self._sensor_name)
+        return f"{habitica.DOMAIN}_{self._name}_{self._sensor_name}"
 
     @property
     def state(self):

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -323,7 +323,7 @@ class HangoutsBot:
             }
 
         self.hass.states.async_set(
-            "{}.conversations".format(DOMAIN),
+            f"{DOMAIN}.conversations",
             len(self._conversation_list.get_all()),
             attributes=conversations,
         )

--- a/homeassistant/components/hangouts/intents.py
+++ b/homeassistant/components/hangouts/intents.py
@@ -25,7 +25,7 @@ class HelpIntent(intent.IntentHandler):
         help_text = "I understand the following sentences:"
         for intent_data in intents.values():
             for sentence in intent_data["sentences"]:
-                help_text += "\n'{}'".format(sentence)
+                help_text += f"\n'{sentence}'"
         response.async_set_speech(help_text)
 
         return response

--- a/homeassistant/components/haveibeenpwned/sensor.py
+++ b/homeassistant/components/haveibeenpwned/sensor.py
@@ -61,7 +61,7 @@ class HaveIBeenPwnedSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Breaches {}".format(self._email)
+        return f"Breaches {self._email}"
 
     @property
     def unit_of_measurement(self):
@@ -151,7 +151,7 @@ class HaveIBeenPwnedData:
     def update(self, **kwargs):
         """Get the latest data for current email from REST service."""
         try:
-            url = "{}{}?truncateResponse=false".format(URL, self._email)
+            url = f"{URL}{self._email}?truncateResponse=false"
             header = {USER_AGENT: HA_USER_AGENT, "hibp-api-key": self._api_key}
             _LOGGER.debug("Checking for breaches for email: %s", self._email)
             req = requests.get(url, headers=header, allow_redirects=True, timeout=5)

--- a/homeassistant/components/hddtemp/sensor.py
+++ b/homeassistant/components/hddtemp/sensor.py
@@ -67,7 +67,7 @@ class HddTempSensor(Entity):
         """Initialize a HDDTemp sensor."""
         self.hddtemp = hddtemp
         self.disk = disk
-        self._name = "{} {}".format(name, disk)
+        self._name = f"{name} {disk}"
         self._state = None
         self._details = None
         self._unit = None

--- a/homeassistant/components/hdmi_cec/__init__.py
+++ b/homeassistant/components/hdmi_cec/__init__.py
@@ -264,7 +264,7 @@ def setup(hass: HomeAssistant, base_config):
                 if isinstance(data[ATTR_ATT], (list,)):
                     att = data[ATTR_ATT]
                 else:
-                    att = reduce(lambda x, y: "%s:%x" % (x, y), data[ATTR_ATT])
+                    att = reduce(lambda x, y: f"{x}:{y:x}", data[ATTR_ATT])
             else:
                 att = ""
             command = CecCommand(cmd, dst, src, att)
@@ -312,7 +312,7 @@ def setup(hass: HomeAssistant, base_config):
 
     def _new_device(device):
         """Handle new devices which are detected by HDMI network."""
-        key = "{}.{}".format(DOMAIN, device.name)
+        key = f"{DOMAIN}.{device.name}"
         hass.data[key] = device
         ent_platform = base_config[DOMAIN][CONF_TYPES].get(key, platform)
         discovery.load_platform(
@@ -399,7 +399,7 @@ class CecDevice(Entity):
     def name(self):
         """Return the name of the device."""
         return (
-            "%s %s" % (self.vendor_name, self._device.osd_name)
+            f"{self.vendor_name} {self._device.osd_name}"
             if (
                 self._device.osd_name is not None
                 and self.vendor_name is not None

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -10,7 +10,7 @@ from .const import DATA_DISCOVERED_HOSTS, DOMAIN
 
 def format_title(host: str) -> str:
     """Format the title for config entries."""
-    return "Controller ({})".format(host)
+    return f"Controller ({host})"
 
 
 @config_entries.HANDLERS.register(DOMAIN)

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -183,7 +183,7 @@ class HeosMediaPlayer(MediaPlayerDevice):
                     None,
                 )
             if index is None:
-                raise ValueError("Invalid quick select '{}'".format(media_id))
+                raise ValueError(f"Invalid quick select '{media_id}'")
             await self._player.play_quick_select(index)
             return
 
@@ -191,7 +191,7 @@ class HeosMediaPlayer(MediaPlayerDevice):
             playlists = await self._player.heos.get_playlists()
             playlist = next((p for p in playlists if p.name == media_id), None)
             if not playlist:
-                raise ValueError("Invalid playlist '{}'".format(media_id))
+                raise ValueError(f"Invalid playlist '{media_id}'")
             add_queue_option = (
                 heos_const.ADD_QUEUE_ADD_TO_END
                 if kwargs.get(ATTR_MEDIA_ENQUEUE)
@@ -215,11 +215,11 @@ class HeosMediaPlayer(MediaPlayerDevice):
                     None,
                 )
             if index is None:
-                raise ValueError("Invalid favorite '{}'".format(media_id))
+                raise ValueError(f"Invalid favorite '{media_id}'")
             await self._player.play_favorite(index)
             return
 
-        raise ValueError("Unsupported media type '{}'".format(media_type))
+        raise ValueError(f"Unsupported media type '{media_type}'")
 
     @log_command_error("select source")
     async def async_select_source(self, source):

--- a/homeassistant/components/hikvision/binary_sensor.py
+++ b/homeassistant/components/hikvision/binary_sensor.py
@@ -93,7 +93,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     else:
         protocol = "http"
 
-    url = "{}://{}".format(protocol, host)
+    url = f"{protocol}://{host}"
 
     data = HikvisionData(hass, url, port, name, username, password)
 
@@ -196,11 +196,11 @@ class HikvisionBinarySensor(BinarySensorDevice):
         self._channel = channel
 
         if self._cam.type == "NVR":
-            self._name = "{} {} {}".format(self._cam.name, sensor, channel)
+            self._name = f"{self._cam.name} {sensor} {channel}"
         else:
-            self._name = "{} {}".format(self._cam.name, sensor)
+            self._name = f"{self._cam.name} {sensor}"
 
-        self._id = "{}.{}.{}".format(self._cam.cam_id, sensor, channel)
+        self._id = f"{self._cam.cam_id}.{sensor}.{channel}"
 
         if delay is None:
             self._delay = 0

--- a/homeassistant/components/hitron_coda/device_tracker.py
+++ b/homeassistant/components/hitron_coda/device_tracker.py
@@ -44,8 +44,8 @@ class HitronCODADeviceScanner(DeviceScanner):
         """Initialize the scanner."""
         self.last_results = []
         host = config[CONF_HOST]
-        self._url = "http://{}/data/getConnectInfo.asp".format(host)
-        self._loginurl = "http://{}/goform/login".format(host)
+        self._url = f"http://{host}/data/getConnectInfo.asp"
+        self._loginurl = f"http://{host}/goform/login"
 
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)

--- a/homeassistant/components/hive/binary_sensor.py
+++ b/homeassistant/components/hive/binary_sensor.py
@@ -26,8 +26,8 @@ class HiveBinarySensorEntity(BinarySensorDevice):
         self.node_device_type = hivedevice["Hive_DeviceType"]
         self.session = hivesession
         self.attributes = {}
-        self.data_updatesource = "{}.{}".format(self.device_type, self.node_id)
-        self._unique_id = "{}-{}".format(self.node_id, self.device_type)
+        self.data_updatesource = f"{self.device_type}.{self.node_id}"
+        self._unique_id = f"{self.node_id}-{self.device_type}"
         self.session.entities.append(self)
 
     @property
@@ -42,7 +42,7 @@ class HiveBinarySensorEntity(BinarySensorDevice):
 
     def handle_update(self, updatesource):
         """Handle the new update request."""
-        if "{}.{}".format(self.device_type, self.node_id) not in updatesource:
+        if f"{self.device_type}.{self.node_id}" not in updatesource:
             self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/hive/climate.py
+++ b/homeassistant/components/hive/climate.py
@@ -54,8 +54,8 @@ class HiveClimateEntity(ClimateDevice):
         self.thermostat_node_id = hivedevice["Thermostat_NodeID"]
         self.session = hivesession
         self.attributes = {}
-        self.data_updatesource = "{}.{}".format(self.device_type, self.node_id)
-        self._unique_id = "{}-{}".format(self.node_id, self.device_type)
+        self.data_updatesource = f"{self.device_type}.{self.node_id}"
+        self._unique_id = f"{self.node_id}-{self.device_type}"
 
     @property
     def unique_id(self):
@@ -74,7 +74,7 @@ class HiveClimateEntity(ClimateDevice):
 
     def handle_update(self, updatesource):
         """Handle the new update request."""
-        if "{}.{}".format(self.device_type, self.node_id) not in updatesource:
+        if f"{self.device_type}.{self.node_id}" not in updatesource:
             self.schedule_update_ha_state()
 
     @property
@@ -82,7 +82,7 @@ class HiveClimateEntity(ClimateDevice):
         """Return the name of the Climate device."""
         friendly_name = "Heating"
         if self.node_name is not None:
-            friendly_name = "{} {}".format(self.node_name, friendly_name)
+            friendly_name = f"{self.node_name} {friendly_name}"
         return friendly_name
 
     @property

--- a/homeassistant/components/hive/light.py
+++ b/homeassistant/components/hive/light.py
@@ -33,8 +33,8 @@ class HiveDeviceLight(Light):
         self.light_device_type = hivedevice["Hive_Light_DeviceType"]
         self.session = hivesession
         self.attributes = {}
-        self.data_updatesource = "{}.{}".format(self.device_type, self.node_id)
-        self._unique_id = "{}-{}".format(self.node_id, self.device_type)
+        self.data_updatesource = f"{self.device_type}.{self.node_id}"
+        self._unique_id = f"{self.node_id}-{self.device_type}"
         self.session.entities.append(self)
 
     @property
@@ -49,7 +49,7 @@ class HiveDeviceLight(Light):
 
     def handle_update(self, updatesource):
         """Handle the new update request."""
-        if "{}.{}".format(self.device_type, self.node_id) not in updatesource:
+        if f"{self.device_type}.{self.node_id}" not in updatesource:
             self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/hive/sensor.py
+++ b/homeassistant/components/hive/sensor.py
@@ -37,8 +37,8 @@ class HiveSensorEntity(Entity):
         self.device_type = hivedevice["HA_DeviceType"]
         self.node_device_type = hivedevice["Hive_DeviceType"]
         self.session = hivesession
-        self.data_updatesource = "{}.{}".format(self.device_type, self.node_id)
-        self._unique_id = "{}-{}".format(self.node_id, self.device_type)
+        self.data_updatesource = f"{self.device_type}.{self.node_id}"
+        self._unique_id = f"{self.node_id}-{self.device_type}"
         self.session.entities.append(self)
 
     @property
@@ -53,7 +53,7 @@ class HiveSensorEntity(Entity):
 
     def handle_update(self, updatesource):
         """Handle the new update request."""
-        if "{}.{}".format(self.device_type, self.node_id) not in updatesource:
+        if f"{self.device_type}.{self.node_id}" not in updatesource:
             self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/hive/switch.py
+++ b/homeassistant/components/hive/switch.py
@@ -23,8 +23,8 @@ class HiveDevicePlug(SwitchDevice):
         self.device_type = hivedevice["HA_DeviceType"]
         self.session = hivesession
         self.attributes = {}
-        self.data_updatesource = "{}.{}".format(self.device_type, self.node_id)
-        self._unique_id = "{}-{}".format(self.node_id, self.device_type)
+        self.data_updatesource = f"{self.device_type}.{self.node_id}"
+        self._unique_id = f"{self.node_id}-{self.device_type}"
         self.session.entities.append(self)
 
     @property
@@ -39,7 +39,7 @@ class HiveDevicePlug(SwitchDevice):
 
     def handle_update(self, updatesource):
         """Handle the new update request."""
-        if "{}.{}".format(self.device_type, self.node_id) not in updatesource:
+        if f"{self.device_type}.{self.node_id}" not in updatesource:
             self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/hive/water_heater.py
+++ b/homeassistant/components/hive/water_heater.py
@@ -42,8 +42,8 @@ class HiveWaterHeater(WaterHeaterDevice):
         self.node_name = hivedevice["Hive_NodeName"]
         self.device_type = hivedevice["HA_DeviceType"]
         self.session = hivesession
-        self.data_updatesource = "{}.{}".format(self.device_type, self.node_id)
-        self._unique_id = "{}-{}".format(self.node_id, self.device_type)
+        self.data_updatesource = f"{self.device_type}.{self.node_id}"
+        self._unique_id = f"{self.node_id}-{self.device_type}"
         self._unit_of_measurement = TEMP_CELSIUS
 
     @property
@@ -63,7 +63,7 @@ class HiveWaterHeater(WaterHeaterDevice):
 
     def handle_update(self, updatesource):
         """Handle the new update request."""
-        if "{}.{}".format(self.device_type, self.node_id) not in updatesource:
+        if f"{self.device_type}.{self.node_id}" not in updatesource:
             self.schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -110,7 +110,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
             hass.components.persistent_notification.async_create(
                 "Config error. See dev-info panel for details.",
                 "Config validating",
-                "{0}.check_config".format(ha.DOMAIN),
+                f"{ha.DOMAIN}.check_config",
             )
             return
 

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -127,9 +127,7 @@ class Light(HomeAccessory):
             self.set_state(0)  # Turn off light
             return
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_BRIGHTNESS_PCT: value}
-        self.call_service(
-            DOMAIN, SERVICE_TURN_ON, params, "brightness at {}%".format(value)
-        )
+        self.call_service(DOMAIN, SERVICE_TURN_ON, params, f"brightness at {value}%")
 
     def set_color_temperature(self, value):
         """Set color temperature if call came from HomeKit."""
@@ -137,7 +135,7 @@ class Light(HomeAccessory):
         self._flag[CHAR_COLOR_TEMPERATURE] = True
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_COLOR_TEMP: value}
         self.call_service(
-            DOMAIN, SERVICE_TURN_ON, params, "color temperature at {}".format(value)
+            DOMAIN, SERVICE_TURN_ON, params, f"color temperature at {value}"
         )
 
     def set_saturation(self, value):
@@ -167,9 +165,7 @@ class Light(HomeAccessory):
                 {CHAR_HUE: False, CHAR_SATURATION: False, RGB_COLOR: True}
             )
             params = {ATTR_ENTITY_ID: self.entity_id, ATTR_HS_COLOR: color}
-            self.call_service(
-                DOMAIN, SERVICE_TURN_ON, params, "set color at {}".format(color)
-            )
+            self.call_service(DOMAIN, SERVICE_TURN_ON, params, f"set color at {color}")
 
     def update_state(self, new_state):
         """Update light after state change."""

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -209,7 +209,7 @@ class Thermostat(HomeAccessory):
             DOMAIN_CLIMATE,
             SERVICE_SET_TEMPERATURE_THERMOSTAT,
             params,
-            "cooling threshold {}{}".format(temperature, self._unit),
+            f"cooling threshold {temperature}{self._unit}",
         )
 
     @debounce
@@ -230,7 +230,7 @@ class Thermostat(HomeAccessory):
             DOMAIN_CLIMATE,
             SERVICE_SET_TEMPERATURE_THERMOSTAT,
             params,
-            "heating threshold {}{}".format(temperature, self._unit),
+            f"heating threshold {temperature}{self._unit}",
         )
 
     @debounce
@@ -244,7 +244,7 @@ class Thermostat(HomeAccessory):
             DOMAIN_CLIMATE,
             SERVICE_SET_TEMPERATURE_THERMOSTAT,
             params,
-            "{}{}".format(temperature, self._unit),
+            f"{temperature}{self._unit}",
         )
 
     def update_state(self, new_state):
@@ -378,7 +378,7 @@ class WaterHeater(HomeAccessory):
             DOMAIN_WATER_HEATER,
             SERVICE_SET_TEMPERATURE_WATER_HEATER,
             params,
-            "{}{}".format(temperature, self._unit),
+            f"{temperature}{self._unit}",
         )
 
     def update_state(self, new_state):

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -116,9 +116,7 @@ def validate_entity_config(values):
                 params = MEDIA_PLAYER_SCHEMA(feature)
                 key = params.pop(CONF_FEATURE)
                 if key in feature_list:
-                    raise vol.Invalid(
-                        "A feature can be added only once for {}".format(entity)
-                    )
+                    raise vol.Invalid(f"A feature can be added only once for {entity}")
                 feature_list[key] = params
             config[CONF_FEATURE_LIST] = feature_list
 

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -106,7 +106,7 @@ class HomeKitEntity(Entity):
         # Callback to allow entity to configure itself based on this
         # characteristics metadata (valid values, value ranges, features, etc)
         setup_fn_name = escape_characteristic_name(short_name)
-        setup_fn = getattr(self, "_setup_{}".format(setup_fn_name), None)
+        setup_fn = getattr(self, f"_setup_{setup_fn_name}", None)
         if not setup_fn:
             return
         # pylint: disable=not-callable
@@ -128,7 +128,7 @@ class HomeKitEntity(Entity):
 
             # Callback to update the entity with this characteristic value
             char_name = escape_characteristic_name(self._char_names[iid])
-            update_fn = getattr(self, "_update_{}".format(char_name), None)
+            update_fn = getattr(self, f"_update_{char_name}", None)
             if not update_fn:
                 continue
 
@@ -141,7 +141,7 @@ class HomeKitEntity(Entity):
     def unique_id(self):
         """Return the ID of this device."""
         serial = self._accessory_info["serial-number"]
-        return "homekit-{}-{}".format(serial, self._iid)
+        return f"homekit-{serial}-{self._iid}"
 
     @property
     def name(self):

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -1,9 +1,9 @@
 """Constants for the homekit_controller component."""
 DOMAIN = "homekit_controller"
 
-KNOWN_DEVICES = "{}-devices".format(DOMAIN)
-CONTROLLER = "{}-controller".format(DOMAIN)
-ENTITY_MAP = "{}-entity-map".format(DOMAIN)
+KNOWN_DEVICES = f"{DOMAIN}-devices"
+CONTROLLER = f"{DOMAIN}-controller"
+ENTITY_MAP = f"{DOMAIN}-entity-map"
 
 HOMEKIT_DIR = ".homekit"
 PAIRING_FILE = "pairing.json"

--- a/homeassistant/components/homekit_controller/storage.py
+++ b/homeassistant/components/homekit_controller/storage.py
@@ -5,7 +5,7 @@ from homeassistant.core import callback
 
 from .const import DOMAIN
 
-ENTITY_MAP_STORAGE_KEY = "{}-entity-map".format(DOMAIN)
+ENTITY_MAP_STORAGE_KEY = f"{DOMAIN}-entity-map"
 ENTITY_MAP_STORAGE_VERSION = 1
 ENTITY_MAP_SAVE_DELAY = 10
 

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -711,15 +711,15 @@ def _create_ha_id(name, channel, param, count):
 
     # Has multiple elements/channels
     if count > 1 and param is None:
-        return "{} {}".format(name, channel)
+        return f"{name} {channel}"
 
     # With multiple parameters on first channel
     if count == 1 and param is not None:
-        return "{} {}".format(name, param)
+        return f"{name} {param}"
 
     # Multiple parameters with multiple channels
     if count > 1 and param is not None:
-        return "{} {} {}".format(name, channel, param)
+        return f"{name} {channel} {param}"
 
 
 def _hm_event_handler(hass, interface, device, caller, attribute, value):

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -234,7 +234,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_registry = await dr.async_get_registry(hass)
     home = hap.home
     # Add the HAP name from configuration if set.
-    hapname = home.label if not home.name else "{} {}".format(home.label, home.name)
+    hapname = home.label if not home.name else f"{home.label} {home.name}"
     device_registry.async_get_or_create(
         config_entry_id=home.id,
         identifiers={(DOMAIN, home.id)},

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -112,7 +112,7 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
         """Return the name of the generic device."""
         name = CONST_ALARM_CONTROL_PANEL_NAME
         if self._home.name:
-            name = "{} {}".format(self._home.name, name)
+            name = f"{self._home.name} {name}"
         return name
 
     @property
@@ -131,7 +131,7 @@ class HomematicipAlarmControlPanel(AlarmControlPanel):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return "{}_{}".format(self.__class__.__name__, self._home.id)
+        return f"{self.__class__.__name__}_{self._home.id}"
 
 
 def _get_zone_alarm_state(security_zone) -> bool:

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -291,7 +291,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice, BinarySensorD
 
     def __init__(self, home: AsyncHome, device, post: str = "SecurityZone") -> None:
         """Initialize security zone group."""
-        device.modelType = "HmIP-{}".format(post)
+        device.modelType = f"HmIP-{post}"
         super().__init__(home, device, post)
 
     @property

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -92,9 +92,9 @@ class HomematicipGenericDevice(Entity):
         """Return the name of the generic device."""
         name = self._device.label
         if self._home.name is not None and self._home.name != "":
-            name = "{} {}".format(self._home.name, name)
+            name = f"{self._home.name} {name}"
         if self.post is not None and self.post != "":
-            name = "{} {}".format(name, self.post)
+            name = f"{name} {self.post}"
         return name
 
     @property
@@ -110,7 +110,7 @@ class HomematicipGenericDevice(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return "{}_{}".format(self.__class__.__name__, self._device.id)
+        return f"{self.__class__.__name__}_{self._device.id}"
 
     @property
     def icon(self) -> Optional[str]:

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -205,7 +205,7 @@ class HomematicipNotificationLight(HomematicipGenericDevice, Light):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return "{}_{}_{}".format(self.__class__.__name__, self.post, self._device.id)
+        return f"{self.__class__.__name__}_{self.post}_{self._device.id}"
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -93,7 +93,7 @@ class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
 
     def __init__(self, home: AsyncHome, device, post: str = "Group") -> None:
         """Initialize switching group."""
-        device.modelType = "HmIP-{}".format(post)
+        device.modelType = f"HmIP-{post}"
         super().__init__(home, device, post)
 
     @property
@@ -149,12 +149,12 @@ class HomematicipMultiSwitch(HomematicipGenericDevice, SwitchDevice):
     def __init__(self, home: AsyncHome, device, channel: int):
         """Initialize the multi switch device."""
         self.channel = channel
-        super().__init__(home, device, "Channel{}".format(channel))
+        super().__init__(home, device, f"Channel{channel}")
 
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return "{}_{}_{}".format(self.__class__.__name__, self.post, self._device.id)
+        return f"{self.__class__.__name__}_{self.post}_{self._device.id}"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/homeworks/__init__.py
+++ b/homeassistant/components/homeworks/__init__.py
@@ -106,7 +106,7 @@ class HomeworksDevice:
     @property
     def unique_id(self):
         """Return a unique identifier."""
-        return "homeworks.{}".format(self._addr)
+        return f"homeworks.{self._addr}"
 
     @property
     def name(self):

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -318,7 +318,7 @@ class HoneywellUSThermostat(ClimateDevice):
             # Get current mode
             mode = self._device.system_mode
             # Set hold if this is not the case
-            if getattr(self._device, "hold_{}".format(mode)) is False:
+            if getattr(self._device, f"hold_{mode}") is False:
                 # Get next period key
                 next_period_key = "{}NextPeriod".format(mode.capitalize())
                 # Get next period raw value
@@ -326,11 +326,9 @@ class HoneywellUSThermostat(ClimateDevice):
                 # Get next period time
                 hour, minute = divmod(next_period * 15, 60)
                 # Set hold time
-                setattr(
-                    self._device, "hold_{}".format(mode), datetime.time(hour, minute)
-                )
+                setattr(self._device, f"hold_{mode}", datetime.time(hour, minute))
             # Set temperature
-            setattr(self._device, "setpoint_{}".format(mode), temperature)
+            setattr(self._device, f"setpoint_{mode}", temperature)
         except somecomfort.SomeComfortError:
             _LOGGER.error("Temperature %.1f out of range", temperature)
 
@@ -375,17 +373,14 @@ class HoneywellUSThermostat(ClimateDevice):
         try:
 
             # Set permanent hold
-            setattr(self._device, "hold_{}".format(mode), True)
+            setattr(self._device, f"hold_{mode}", True)
             # Set temperature
             setattr(
-                self._device,
-                "setpoint_{}".format(mode),
-                getattr(self, "_{}_away_temp".format(mode)),
+                self._device, f"setpoint_{mode}", getattr(self, f"_{mode}_away_temp")
             )
         except somecomfort.SomeComfortError:
             _LOGGER.error(
-                "Temperature %.1f out of range",
-                getattr(self, "_{}_away_temp".format(mode)),
+                "Temperature %.1f out of range", getattr(self, f"_{mode}_away_temp")
             )
 
     def _turn_away_mode_off(self) -> None:

--- a/homeassistant/components/hp_ilo/sensor.py
+++ b/homeassistant/components/hp_ilo/sensor.py
@@ -194,4 +194,4 @@ class HpIloData:
             hpilo.IloCommunicationError,
             hpilo.IloLoginFailed,
         ) as error:
-            raise ValueError("Unable to init HP ILO, {}".format(error))
+            raise ValueError(f"Unable to init HP ILO, {error}")

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -570,8 +570,8 @@ def create_vapid_headers(vapid_email, subscription_info, vapid_private_key):
     if vapid_email and vapid_private_key and ATTR_ENDPOINT in subscription_info:
         url = urlparse(subscription_info.get(ATTR_ENDPOINT))
         vapid_claims = {
-            "sub": "mailto:{}".format(vapid_email),
-            "aud": "{}://{}".format(url.scheme, url.netloc),
+            "sub": f"mailto:{vapid_email}",
+            "aud": f"{url.scheme}://{url.netloc}",
         }
         vapid = Vapid.from_string(private_key=vapid_private_key)
         return vapid.sign(vapid_claims)

--- a/homeassistant/components/htu21d/sensor.py
+++ b/homeassistant/components/htu21d/sensor.py
@@ -76,7 +76,7 @@ class HTU21DSensor(Entity):
 
     def __init__(self, htu21d_client, name, variable, unit):
         """Initialize the sensor."""
-        self._name = "{}_{}".format(name, variable)
+        self._name = f"{name}_{variable}"
         self._variable = variable
         self._unit_of_measurement = unit
         self._client = htu21d_client

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -175,7 +175,7 @@ class HuaweiLteSensor(Entity):
     @property
     def unique_id(self) -> str:
         """Return unique ID for sensor."""
-        return "{}-{}".format(self.data.mac, self.path)
+        return f"{self.data.mac}-{self.path}"
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/huawei_router/device_tracker.py
+++ b/homeassistant/components/huawei_router/device_tracker.py
@@ -119,12 +119,12 @@ class HuaweiDeviceScanner(DeviceScanner):
 
     def _get_devices_response(self):
         """Get the raw string with the devices from the router."""
-        cnt = requests.post("http://{}/asp/GetRandCount.asp".format(self.host))
+        cnt = requests.post(f"http://{self.host}/asp/GetRandCount.asp")
         cnt_str = str(cnt.content, cnt.apparent_encoding, errors="replace")
 
         _LOGGER.debug("Logging in")
         cookie = requests.post(
-            "http://{}/login.cgi".format(self.host),
+            f"http://{self.host}/login.cgi",
             data=[
                 ("UserName", self.username),
                 ("PassWord", self.password),
@@ -136,13 +136,13 @@ class HuaweiDeviceScanner(DeviceScanner):
         _LOGGER.debug("Requesting lan user info update")
         # this request is needed or else some devices' state won't be updated
         requests.get(
-            "http://{}/html/bbsp/common/lanuserinfo.asp".format(self.host),
+            f"http://{self.host}/html/bbsp/common/lanuserinfo.asp",
             cookies=cookie.cookies,
         )
 
         _LOGGER.debug("Requesting lan user info data")
         devices = requests.get(
-            "http://{}/html/bbsp/common/GetLanUserDevInfo.asp".format(self.host),
+            f"http://{self.host}/html/bbsp/common/GetLanUserDevInfo.asp",
             cookies=cookie.cookies,
         )
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -160,7 +160,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 "host": host,
                 # This format is the legacy format that Hue used for discovery
-                "path": "phue-{}.conf".format(serial),
+                "path": f"phue-{serial}.conf",
             }
         )
 

--- a/homeassistant/components/hydroquebec/sensor.py
+++ b/homeassistant/components/hydroquebec/sensor.py
@@ -104,7 +104,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 HOST = "https://www.hydroquebec.com"
-HOME_URL = "{}/portail/web/clientele/authentification".format(HOST)
+HOME_URL = f"{HOST}/portail/web/clientele/authentification"
 PROFILE_URL = "{}/portail/fr/group/clientele/" "portrait-de-consommation".format(HOST)
 MONTHLY_MAP = (
     ("period_total_bill", "montantFacturePeriode"),
@@ -164,7 +164,7 @@ class HydroQuebecSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self.client_name, self._name)
+        return f"{self.client_name} {self._name}"
 
     @property
     def state(self):

--- a/homeassistant/components/ialarm/alarm_control_panel.py
+++ b/homeassistant/components/ialarm/alarm_control_panel.py
@@ -28,7 +28,7 @@ def no_application_protocol(value):
     """Validate that value is without the application protocol."""
     protocol_separator = "://"
     if not value or protocol_separator in value:
-        raise vol.Invalid("Invalid host, {} is not allowed".format(protocol_separator))
+        raise vol.Invalid(f"Invalid host, {protocol_separator} is not allowed")
 
     return value
 
@@ -52,7 +52,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     password = config.get(CONF_PASSWORD)
     host = config.get(CONF_HOST)
 
-    url = "http://{}".format(host)
+    url = f"http://{host}"
     ialarm = IAlarmPanel(name, code, username, password, url)
     add_entities([ialarm], True)
 

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -281,10 +281,10 @@ class Icloud(DeviceScanner):
             devicename = device.get(
                 "deviceName", "SMS to %s" % device.get("phoneNumber")
             )
-            devicesstring += "{}: {};".format(i, devicename)
+            devicesstring += f"{i}: {devicename};"
 
         _CONFIGURING[self.accountname] = configurator.request_config(
-            "iCloud {}".format(self.accountname),
+            f"iCloud {self.accountname}",
             self.icloud_trusted_device_callback,
             description=(
                 "Please choose your trusted device by entering"
@@ -327,7 +327,7 @@ class Icloud(DeviceScanner):
             return
 
         _CONFIGURING[self.accountname] = configurator.request_config(
-            "iCloud {}".format(self.accountname),
+            f"iCloud {self.accountname}",
             self.icloud_verification_callback,
             description=("Please enter the validation code:"),
             entity_picture="/static/images/config_icloud.png",
@@ -528,7 +528,7 @@ class Icloud(DeviceScanner):
         """Set the interval of the given devices."""
         devs = [devicename] if devicename else self.devices
         for device in devs:
-            devid = "{}.{}".format(DOMAIN, device)
+            devid = f"{DOMAIN}.{device}"
             devicestate = self.hass.states.get(devid)
             if interval is not None:
                 if devicestate is not None:

--- a/homeassistant/components/ign_sismologia/geo_location.py
+++ b/homeassistant/components/ign_sismologia/geo_location.py
@@ -210,9 +210,9 @@ class IgnSismologiaLocationEvent(GeolocationEvent):
     def name(self) -> Optional[str]:
         """Return the name of the entity."""
         if self._magnitude and self._region:
-            return "M {:.1f} - {}".format(self._magnitude, self._region)
+            return f"M {self._magnitude:.1f} - {self._region}"
         if self._magnitude:
-            return "M {:.1f}".format(self._magnitude)
+            return f"M {self._magnitude:.1f}"
         if self._region:
             return self._region
         return self._title

--- a/homeassistant/components/ihc/__init__.py
+++ b/homeassistant/components/ihc/__init__.py
@@ -61,7 +61,7 @@ def validate_name(config):
     if CONF_NAME in config:
         return config
     ihcid = config[CONF_ID]
-    name = "ihc_{}".format(ihcid)
+    name = f"ihc_{ihcid}"
     config[CONF_NAME] = name
     return config
 
@@ -312,7 +312,7 @@ def get_discovery_info(component_setup, groups, controller_id):
                     if "setting" in node.attrib and node.attrib["setting"] == "yes":
                         continue
                     ihc_id = int(node.attrib["id"].strip("_"), 0)
-                    name = "{}_{}".format(groupname, ihc_id)
+                    name = f"{groupname}_{ihc_id}"
                     device = {
                         "ihc_id": ihc_id,
                         "ctrl_id": controller_id,

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -118,7 +118,7 @@ class EmailReader:
             if not self._unread_ids:
                 search = "SINCE {0:%d-%b-%Y}".format(datetime.date.today())
                 if self._last_id is not None:
-                    search = "UID {}:*".format(self._last_id)
+                    search = f"UID {self._last_id}:*"
 
                 _, data = self.connection.uid("search", None, search)
                 self._unread_ids = deque(data[0].split())

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -30,7 +30,7 @@ class InComfortClimate(ClimateDevice):
         """Initialize the climate device."""
         self._client = client
         self._room = room
-        self._name = "Room {}".format(room.room_no)
+        self._name = f"Room {room.room_no}"
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -96,7 +96,7 @@ class IncomfortWaterHeater(WaterHeaterDevice):
     def current_operation(self):
         """Return the current operation mode."""
         if self._heater.is_failed:
-            return "Fault code: {}".format(self._heater.fault_code)
+            return f"Fault code: {self._heater.fault_code}"
 
         return self._heater.display_text
 

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -247,7 +247,7 @@ def setup(hass, config):
                 try:
                     json["fields"][key] = float(value)
                 except (ValueError, TypeError):
-                    new_key = "{}_str".format(key)
+                    new_key = f"{key}_str"
                     new_value = str(value)
                     json["fields"][new_key] = new_value
 

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -314,7 +314,7 @@ async def async_setup(hass, config):
 
     def _send_load_aldb_signal(entity_id, reload):
         """Send the load All-Link database signal to INSTEON entity."""
-        signal = "{}_{}".format(entity_id, SIGNAL_LOAD_ALDB)
+        signal = f"{entity_id}_{SIGNAL_LOAD_ALDB}"
         dispatcher_send(hass, signal, reload)
 
     def print_aldb(service):
@@ -322,7 +322,7 @@ async def async_setup(hass, config):
         # For now this sends logs to the log file.
         # Furture direction is to create an INSTEON control panel.
         entity_id = service.data[CONF_ENTITY_ID]
-        signal = "{}_{}".format(entity_id, SIGNAL_PRINT_ALDB)
+        signal = f"{entity_id}_{SIGNAL_PRINT_ALDB}"
         dispatcher_send(hass, signal)
 
     def print_im_aldb(service):
@@ -652,9 +652,9 @@ class InsteonEntity(Entity):
         )
         self._insteon_device_state.register_updates(self.async_entity_update)
         self.hass.data[DOMAIN][INSTEON_ENTITIES][self.entity_id] = self
-        load_signal = "{}_{}".format(self.entity_id, SIGNAL_LOAD_ALDB)
+        load_signal = f"{self.entity_id}_{SIGNAL_LOAD_ALDB}"
         async_dispatcher_connect(self.hass, load_signal, self._load_aldb)
-        print_signal = "{}_{}".format(self.entity_id, SIGNAL_PRINT_ALDB)
+        print_signal = f"{self.entity_id}_{SIGNAL_PRINT_ALDB}"
         async_dispatcher_connect(self.hass, print_signal, self._print_aldb)
 
     def _load_aldb(self, reload=False):
@@ -679,7 +679,7 @@ class InsteonEntity(Entity):
             if self._insteon_device_state.name in STATE_NAME_LABEL_MAP:
                 label = STATE_NAME_LABEL_MAP[self._insteon_device_state.name]
             else:
-                label = "Group {:d}".format(self.group)
+                label = f"Group {self.group:d}"
         return label
 
 

--- a/homeassistant/components/ios/sensor.py
+++ b/homeassistant/components/ios/sensor.py
@@ -67,7 +67,7 @@ class IOSSensor(Entity):
     def unique_id(self):
         """Return the unique ID of this sensor."""
         device_id = self._device[ios.ATTR_DEVICE_ID]
-        return "{}_{}".format(self.type, device_id)
+        return f"{self.type}_{device_id}"
 
     @property
     def unit_of_measurement(self):
@@ -100,11 +100,11 @@ class IOSSensor(Entity):
             ios.ATTR_BATTERY_STATE_UNPLUGGED,
         ):
             charging = False
-            icon_state = "{}-off".format(DEFAULT_ICON_STATE)
+            icon_state = f"{DEFAULT_ICON_STATE}-off"
         elif battery_state == ios.ATTR_BATTERY_STATE_UNKNOWN:
             battery_level = None
             charging = False
-            icon_state = "{}-unknown".format(DEFAULT_ICON_LEVEL)
+            icon_state = f"{DEFAULT_ICON_LEVEL}-unknown"
 
         if self.type == "state":
             return icon_state

--- a/homeassistant/components/iota/sensor.py
+++ b/homeassistant/components/iota/sensor.py
@@ -46,7 +46,7 @@ class IotaBalanceSensor(IotaDevice):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} Balance".format(self._name)
+        return f"{self._name} Balance"
 
     @property
     def state(self):

--- a/homeassistant/components/iperf3/__init__.py
+++ b/homeassistant/components/iperf3/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
 DOMAIN = "iperf3"
-DATA_UPDATED = "{}_data_updated".format(DOMAIN)
+DATA_UPDATED = f"{DOMAIN}_data_updated"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -132,7 +132,7 @@ class IPMAWeather(WeatherEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique id."""
-        return "{}, {}".format(self._station.latitude, self._station.longitude)
+        return f"{self._station.latitude}, {self._station.longitude}"
 
     @property
     def attribution(self):

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -234,7 +234,7 @@ class IQVIAEntity(Entity):
     @property
     def unique_id(self):
         """Return a unique, HASS-friendly identifier for this entity."""
-        return "{0}_{1}".format(self._zip_code, self._type)
+        return f"{self._zip_code}_{self._type}"
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -174,9 +174,9 @@ class IndexSensor(IQVIAEntity):
                 index = idx + 1
                 self._attrs.update(
                     {
-                        "{0}_{1}".format(ATTR_ALLERGEN_GENUS, index): attrs["Genus"],
-                        "{0}_{1}".format(ATTR_ALLERGEN_NAME, index): attrs["Name"],
-                        "{0}_{1}".format(ATTR_ALLERGEN_TYPE, index): attrs["PlantType"],
+                        f"{ATTR_ALLERGEN_GENUS}_{index}": attrs["Genus"],
+                        f"{ATTR_ALLERGEN_NAME}_{index}": attrs["Name"],
+                        f"{ATTR_ALLERGEN_TYPE}_{index}": attrs["PlantType"],
                     }
                 )
         elif self._type in (TYPE_ASTHMA_TODAY, TYPE_ASTHMA_TOMORROW):
@@ -184,8 +184,8 @@ class IndexSensor(IQVIAEntity):
                 index = idx + 1
                 self._attrs.update(
                     {
-                        "{0}_{1}".format(ATTR_ALLERGEN_NAME, index): attrs["Name"],
-                        "{0}_{1}".format(ATTR_ALLERGEN_AMOUNT, index): attrs["PPM"],
+                        f"{ATTR_ALLERGEN_NAME}_{index}": attrs["Name"],
+                        f"{ATTR_ALLERGEN_AMOUNT}_{index}": attrs["PPM"],
                     }
                 )
         elif self._type == TYPE_DISEASE_TODAY:

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -343,7 +343,7 @@ def _categorize_programs(hass: HomeAssistant, programs: dict) -> None:
     """Categorize the ISY994 programs."""
     for domain in SUPPORTED_PROGRAM_DOMAINS:
         try:
-            folder = programs[KEY_MY_PROGRAMS]["HA.{}".format(domain)]
+            folder = programs[KEY_MY_PROGRAMS][f"HA.{domain}"]
         except KeyError:
             pass
         else:
@@ -378,10 +378,10 @@ def _categorize_weather(hass: HomeAssistant, climate) -> None:
         WeatherNode(
             getattr(climate, attr),
             attr.replace("_", " "),
-            getattr(climate, "{}_units".format(attr)),
+            getattr(climate, f"{attr}_units"),
         )
         for attr in climate_attrs
-        if "{}_units".format(attr) in climate_attrs
+        if f"{attr}_units" in climate_attrs
     ]
     hass.data[ISY994_WEATHER].extend(weather_nodes)
 

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -272,7 +272,7 @@ class ISYSensorDevice(ISYDevice):
                 int_prec = int(self._node.prec)
                 decimal_part = str_val[-int_prec:]
                 whole_part = str_val[: len(str_val) - int_prec]
-                val = float("{}.{}".format(whole_part, decimal_part))
+                val = float(f"{whole_part}.{decimal_part}")
                 raw_units = self.raw_unit_of_measurement
                 if raw_units in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
                     val = self.hass.config.units.temperature(val, raw_units)

--- a/homeassistant/components/itach/remote.py
+++ b/homeassistant/components/itach/remote.py
@@ -78,7 +78,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             cmddata = cmd[CONF_DATA].strip()
             if not cmddata:
                 cmddata = '""'
-            cmddatas += "{}\n{}\n".format(cmdname, cmddata)
+            cmddatas += f"{cmdname}\n{cmddata}\n"
         itachip2ir.addDevice(name, modaddr, connaddr, cmddatas)
         devices.append(ITachIP2IRRemote(itachip2ir, name))
     add_entities(devices, True)

--- a/homeassistant/components/itunes/media_player.py
+++ b/homeassistant/components/itunes/media_player.py
@@ -84,13 +84,13 @@ class Itunes:
             uri_scheme = "http://"
 
         if self.port:
-            return "{}{}:{}".format(uri_scheme, self.host, self.port)
+            return f"{uri_scheme}{self.host}:{self.port}"
 
-        return "{}{}".format(uri_scheme, self.host)
+        return f"{uri_scheme}{self.host}"
 
     def _request(self, method, path, params=None):
         """Make the actual request and return the parsed response."""
-        url = "{}{}".format(self._base_url, path)
+        url = f"{self._base_url}{path}"
 
         try:
             if method == "GET":

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -129,7 +129,7 @@ class JewishCalSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self.client_name, self._name)
+        return f"{self.client_name} {self._name}"
 
     @property
     def icon(self):


### PR DESCRIPTION
## Description:

Upgrades code to use string formatting using literal string interpolation format defined in PEP 498. Easier to read, generally smaller, and finally possible now 3.6 is the min version.

PEP 498: https://www.python.org/dev/peps/pep-0498

This PR converts code in integrations starting with the letter `H`, `I` and `J`.

⚠️ I expect codecov to fail on this one 🤷‍♂ 

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
