### PR TITLE
Use literal string interpolation in geniushub

### DIFF
--- a/homeassistant/components/geniushub/sensor.py
+++ b/homeassistant/components/geniushub/sensor.py
@@ -59,7 +59,7 @@ class GeniusBattery(GeniusEntity):
 
         icon = "mdi:battery"
         if battery_level <= 95:
-            icon += "-{}".format(int(round(battery_level / 10 - 0.01)) * 10)
+            icon += f"-{int(round(battery_level / 10 - 0.01)) * 10}"
 
         return icon
 


### PR DESCRIPTION
## Description:
As per #26379, "Upgrades code to use string formatting using literal string interpolation format defined in PEP 498. Easier to read, generally smaller, and finally possible now 3.6 is the min version."

This PR adds a f-string that was missed in the above PR.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
