### PR TITLE
Use literal string interpolation in honeywell

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -161,8 +161,8 @@ class HoneywellUSThermostat(ClimateDevice):
         self._password = password
 
         _LOGGER.debug(
-            "latestData = %s ", device._data
-        )  # pylint: disable=protected-access
+            "latestData = %s ", device._data  # pylint: disable=protected-access
+        )
 
         # not all honeywell HVACs support all modes
         mappings = [v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]]
@@ -457,5 +457,5 @@ class HoneywellUSThermostat(ClimateDevice):
                 _LOGGER.error("SomeComfort update failed, Retrying - Error: %s", exp)
 
         _LOGGER.debug(
-            "latestData = %s ", self._device._data
-        )  # pylint: disable=protected-access
+            "latestData = %s ", self._device._data  # pylint: disable=protected-access
+        )

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -161,10 +161,8 @@ class HoneywellUSThermostat(ClimateDevice):
         self._password = password
 
         _LOGGER.debug(
-            # noqa; pylint: disable=protected-access
-            "latestData = %s ",
-            device._data,
-        )
+            "latestData = %s ", device._data
+        )  # pylint: disable=protected-access
 
         # not all honeywell HVACs support all modes
         mappings = [v for k, v in HVAC_MODE_TO_HW_MODE.items() if device.raw_ui_data[k]]
@@ -176,8 +174,7 @@ class HoneywellUSThermostat(ClimateDevice):
             | SUPPORT_TARGET_TEMPERATURE_RANGE
         )
 
-        # noqa; pylint: disable=protected-access
-        if device._data["canControlHumidification"]:
+        if device._data["canControlHumidification"]:  # pylint: disable=protected-access
             self._supported_features |= SUPPORT_TARGET_HUMIDITY
 
         if device.raw_ui_data["SwitchEmergencyHeatAllowed"]:
@@ -320,7 +317,7 @@ class HoneywellUSThermostat(ClimateDevice):
             # Set hold if this is not the case
             if getattr(self._device, f"hold_{mode}") is False:
                 # Get next period key
-                next_period_key = "{}NextPeriod".format(mode.capitalize())
+                next_period_key = f"{mode.capitalize()}NextPeriod"
                 # Get next period raw value
                 next_period = self._device.raw_ui_data.get(next_period_key)
                 # Get next period time
@@ -460,7 +457,5 @@ class HoneywellUSThermostat(ClimateDevice):
                 _LOGGER.error("SomeComfort update failed, Retrying - Error: %s", exp)
 
         _LOGGER.debug(
-            # noqa; pylint: disable=protected-access
-            "latestData = %s ",
-            self._device._data,
-        )
+            "latestData = %s ", self._device._data
+        )  # pylint: disable=protected-access


### PR DESCRIPTION
## Description:
As per #26380, "Upgrades code to use string formatting using literal string interpolation format defined in PEP 498. Easier to read, generally smaller, and finally possible now 3.6 is the min version."

This PR adds a f-string that was missed in the above PR.

It also tweaks some lint-hints.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
