### PR TITLE
Use literal string interpolation in integrations X-Z (f-strings)

### DIFF
--- a/homeassistant/components/xiaomi/device_tracker.py
+++ b/homeassistant/components/xiaomi/device_tracker.py
@@ -143,7 +143,7 @@ def _retrieve_list(host, token, **kwargs):
 
 def _get_token(host, username, password):
     """Get authentication token for the given host+username+password."""
-    url = "http://{}/cgi-bin/luci/api/xqsystem/login".format(host)
+    url = f"http://{host}/cgi-bin/luci/api/xqsystem/login"
     data = {"username": username, "password": password}
     try:
         res = requests.post(url, data=data, timeout=5)

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -232,7 +232,7 @@ class XiaomiDevice(Entity):
         self._state = None
         self._is_available = True
         self._sid = device["sid"]
-        self._name = "{}_{}".format(device_type, self._sid)
+        self._name = f"{device_type}_{self._sid}"
         self._type = device_type
         self._write_to_hub = xiaomi_hub.write_to_hub
         self._get_from_hub = xiaomi_hub.get_from_hub
@@ -247,7 +247,7 @@ class XiaomiDevice(Entity):
                 self._data_key, self._sid  # pylint: disable=no-member
             )
         else:
-            self._unique_id = "{}{}".format(self._type, self._sid)
+            self._unique_id = f"{self._type}{self._sid}"
 
     def _add_push_data_job(self, *args):
         self.hass.add_job(self.push_data, *args)
@@ -345,7 +345,7 @@ def _add_gateway_to_schema(xiaomi, schema):
             if gateway.sid == sid:
                 return gateway
 
-        raise vol.Invalid("Unknown gateway sid {}".format(sid))
+        raise vol.Invalid(f"Unknown gateway sid {sid}")
 
     gateways = list(xiaomi.gateways.values())
     kwargs = {}

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -440,7 +440,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             miio_device = Device(host, token)
             device_info = miio_device.info()
             model = device_info.model
-            unique_id = "{}-{}".format(model, device_info.mac_address)
+            unique_id = f"{model}-{device_info.mac_address}"
             _LOGGER.info(
                 "%s %s %s detected",
                 model,

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -136,7 +136,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             miio_device = Device(host, token)
             device_info = miio_device.info()
             model = device_info.model
-            unique_id = "{}-{}".format(model, device_info.mac_address)
+            unique_id = f"{model}-{device_info.mac_address}"
             _LOGGER.info(
                 "%s %s %s detected",
                 model,
@@ -731,7 +731,7 @@ class XiaomiPhilipsEyecareLampAmbientLight(XiaomiPhilipsAbstractLight):
 
     def __init__(self, name, light, model, unique_id):
         """Initialize the light device."""
-        name = "{} Ambient Light".format(name)
+        name = f"{name} Ambient Light"
         if unique_id is not None:
             unique_id = "{}-{}".format(unique_id, "ambient")
         super().__init__(name, light, model, unique_id)

--- a/homeassistant/components/xiaomi_miio/remote.py
+++ b/homeassistant/components/xiaomi_miio/remote.py
@@ -90,7 +90,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     try:
         device_info = device.info()
         model = device_info.model
-        unique_id = "{}-{}".format(model, device_info.mac_address)
+        unique_id = f"{model}-{device_info.mac_address}"
         _LOGGER.info(
             "%s %s %s detected",
             model,

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -52,7 +52,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         air_quality_monitor = AirQualityMonitor(host, token)
         device_info = air_quality_monitor.info()
         model = device_info.model
-        unique_id = "{}-{}".format(model, device_info.mac_address)
+        unique_id = f"{model}-{device_info.mac_address}"
         _LOGGER.info(
             "%s %s %s detected",
             model,

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -117,7 +117,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             miio_device = Device(host, token)
             device_info = miio_device.info()
             model = device_info.model
-            unique_id = "{}-{}".format(model, device_info.mac_address)
+            unique_id = f"{model}-{device_info.mac_address}"
             _LOGGER.info(
                 "%s %s %s detected",
                 model,
@@ -426,7 +426,7 @@ class ChuangMiPlugSwitch(XiaomiPlugGenericSwitch):
 
     def __init__(self, name, plug, model, unique_id, channel_usb):
         """Initialize the plug switch."""
-        name = "{} USB".format(name) if channel_usb else name
+        name = f"{name} USB" if channel_usb else name
 
         if unique_id is not None and channel_usb:
             unique_id = "{}-{}".format(unique_id, "usb")

--- a/homeassistant/components/xmpp/notify.py
+++ b/homeassistant/components/xmpp/notify.py
@@ -87,12 +87,12 @@ class XmppNotificationService(BaseNotificationService):
     async def async_send_message(self, message="", **kwargs):
         """Send a message to a user."""
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-        text = "{}: {}".format(title, message) if title else message
+        text = f"{title}: {message}" if title else message
         data = kwargs.get(ATTR_DATA)
         timeout = data.get(ATTR_TIMEOUT, XEP_0363_TIMEOUT) if data else None
 
         await async_send_message(
-            "{}/{}".format(self._sender, self._resource),
+            f"{self._sender}/{self._resource}",
             self._password,
             self._recipient,
             self._tls,

--- a/homeassistant/components/yamaha/media_player.py
+++ b/homeassistant/components/yamaha/media_player.py
@@ -114,7 +114,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for recv in rxv.find():
             receivers.extend(recv.zone_controllers())
     else:
-        ctrl_url = "http://{}:80/YamahaRemoteControl/ctrl".format(host)
+        ctrl_url = f"http://{host}:80/YamahaRemoteControl/ctrl"
         receivers = rxv.RXV(ctrl_url, name).zone_controllers()
 
     devices = []
@@ -276,7 +276,7 @@ class YamahaDevice(MediaPlayerDevice):
     @property
     def zone_id(self):
         """Return a zone_id to ensure 1 media player per zone."""
-        return "{0}:{1}".format(self.receiver.ctrl_url, self._zone)
+        return f"{self.receiver.ctrl_url}:{self._zone}"
 
     @property
     def supported_features(self):
@@ -410,6 +410,6 @@ class YamahaDevice(MediaPlayerDevice):
             # If both song and station is available, print both, otherwise
             # just the one we have.
             if song and station:
-                return "{}: {}".format(station, song)
+                return f"{station}: {song}"
 
             return song or station

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -128,7 +128,7 @@ class YamahaDevice(MediaPlayerDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return "{} ({})".format(self._name, self._zone.zone_id)
+        return f"{self._name} ({self._zone.zone_id})"
 
     @property
     def state(self):

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "yeelight"
 DATA_YEELIGHT = DOMAIN
 DATA_UPDATED = "yeelight_{}_data_updated"
-DEVICE_INITIALIZED = "{}_device_initialized".format(DOMAIN)
+DEVICE_INITIALIZED = f"{DOMAIN}_device_initialized"
 
 DEFAULT_NAME = "Yeelight"
 DEFAULT_TRANSITION = 350

--- a/homeassistant/components/yeelight/binary_sensor.py
+++ b/homeassistant/components/yeelight/binary_sensor.py
@@ -48,7 +48,7 @@ class YeelightNightlightModeSensor(BinarySensorDevice):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} nightlight".format(self._device.name)
+        return f"{self._device.name} nightlight"
 
     @property
     def is_on(self):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -165,7 +165,7 @@ def _cmd(func):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Yeelight bulbs."""
-    data_key = "{}_lights".format(DATA_YEELIGHT)
+    data_key = f"{DATA_YEELIGHT}_lights"
 
     if not discovery_info:
         return
@@ -673,7 +673,7 @@ class YeelightAmbientLight(YeelightColorLight):
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
-        return "{} ambilight".format(self.device.name)
+        return f"{self.device.name} ambilight"
 
     def _get_property(self, prop, default=None):
         bg_prop = self.PROPERTIES_MAPPING.get(prop)

--- a/homeassistant/components/yeelightsunflower/light.py
+++ b/homeassistant/components/yeelightsunflower/light.py
@@ -50,7 +50,7 @@ class SunflowerBulb(Light):
     @property
     def name(self):
         """Return the display name of this light."""
-        return "sunflower_{}".format(self._light.zid)
+        return f"sunflower_{self._light.zid}"
 
     @property
     def available(self):

--- a/homeassistant/components/yr/sensor.py
+++ b/homeassistant/components/yr/sensor.py
@@ -106,7 +106,7 @@ class YrSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self.client_name, self._name)
+        return f"{self.client_name} {self._name}"
 
     @property
     def state(self):
@@ -168,7 +168,7 @@ class YrData:
             with async_timeout.timeout(10):
                 resp = await websession.get(self._url, params=self._urlparams)
             if resp.status != 200:
-                try_again("{} returned {}".format(resp.url, resp.status))
+                try_again(f"{resp.url} returned {resp.status}")
                 return
             text = await resp.text()
 

--- a/homeassistant/components/yweather/sensor.py
+++ b/homeassistant/components/yweather/sensor.py
@@ -108,7 +108,7 @@ class YahooWeatherSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self._client, self._name)
+        return f"{self._client} {self._name}"
 
     @property
     def state(self):

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -124,7 +124,7 @@ class ZamgSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self.client_name, self.variable)
+        return f"{self.client_name} {self.variable}"
 
     @property
     def state(self):
@@ -212,7 +212,7 @@ class ZamgData:
                 }
                 break
         else:
-            raise ValueError("No weather data for station {}".format(self._station_id))
+            raise ValueError(f"No weather data for station {self._station_id}")
 
     def get_data(self, variable):
         """Get the data."""

--- a/homeassistant/components/zestimate/sensor.py
+++ b/homeassistant/components/zestimate/sensor.py
@@ -19,7 +19,7 @@ CONF_ZPID = "zpid"
 
 DEFAULT_NAME = "Zestimate"
 NAME = "zestimate"
-ZESTIMATE = "{}:{}".format(DEFAULT_NAME, NAME)
+ZESTIMATE = f"{DEFAULT_NAME}:{NAME}"
 
 ICON = "mdi:home-variant"
 
@@ -74,7 +74,7 @@ class ZestimateDataSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self._name, self.address)
+        return f"{self._name} {self.address}"
 
     @property
     def state(self):

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -283,10 +283,10 @@ async def websocket_device_cluster_attributes(hass, connection, msg):
                 )
     _LOGGER.debug(
         "Requested attributes for: %s %s %s %s",
-        "{}: [{}]".format(ATTR_CLUSTER_ID, cluster_id),
-        "{}: [{}]".format(ATTR_CLUSTER_TYPE, cluster_type),
-        "{}: [{}]".format(ATTR_ENDPOINT_ID, endpoint_id),
-        "{}: [{}]".format(RESPONSE, cluster_attributes),
+        f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
+        f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
+        f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
+        f"{RESPONSE}: [{cluster_attributes}]",
     )
 
     connection.send_result(msg[ID], cluster_attributes)
@@ -337,10 +337,10 @@ async def websocket_device_cluster_commands(hass, connection, msg):
                 )
     _LOGGER.debug(
         "Requested commands for: %s %s %s %s",
-        "{}: [{}]".format(ATTR_CLUSTER_ID, cluster_id),
-        "{}: [{}]".format(ATTR_CLUSTER_TYPE, cluster_type),
-        "{}: [{}]".format(ATTR_ENDPOINT_ID, endpoint_id),
-        "{}: [{}]".format(RESPONSE, cluster_commands),
+        f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
+        f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
+        f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
+        f"{RESPONSE}: [{cluster_commands}]",
     )
 
     connection.send_result(msg[ID], cluster_commands)
@@ -381,11 +381,11 @@ async def websocket_read_zigbee_cluster_attributes(hass, connection, msg):
         )
     _LOGGER.debug(
         "Read attribute for: %s %s %s %s %s %s %s",
-        "{}: [{}]".format(ATTR_CLUSTER_ID, cluster_id),
-        "{}: [{}]".format(ATTR_CLUSTER_TYPE, cluster_type),
-        "{}: [{}]".format(ATTR_ENDPOINT_ID, endpoint_id),
-        "{}: [{}]".format(ATTR_ATTRIBUTE, attribute),
-        "{}: [{}]".format(ATTR_MANUFACTURER, manufacturer),
+        f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
+        f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
+        f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
+        f"{ATTR_ATTRIBUTE}: [{attribute}]",
+        f"{ATTR_MANUFACTURER}: [{manufacturer}]",
         "{}: [{}]".format(RESPONSE, str(success.get(attribute))),
         "{}: [{}]".format("failure", failure),
     )
@@ -411,7 +411,7 @@ async def websocket_get_bindable_devices(hass, connection, msg):
 
     _LOGGER.debug(
         "Get bindable devices: %s %s",
-        "{}: [{}]".format(ATTR_SOURCE_IEEE, source_ieee),
+        f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
         "{}: [{}]".format("bindable devices:", devices),
     )
 
@@ -435,8 +435,8 @@ async def websocket_bind_devices(hass, connection, msg):
     await async_binding_operation(zha_gateway, source_ieee, target_ieee, BIND_REQUEST)
     _LOGGER.info(
         "Issue bind devices: %s %s",
-        "{}: [{}]".format(ATTR_SOURCE_IEEE, source_ieee),
-        "{}: [{}]".format(ATTR_TARGET_IEEE, target_ieee),
+        f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
+        f"{ATTR_TARGET_IEEE}: [{target_ieee}]",
     )
 
 
@@ -457,8 +457,8 @@ async def websocket_unbind_devices(hass, connection, msg):
     await async_binding_operation(zha_gateway, source_ieee, target_ieee, UNBIND_REQUEST)
     _LOGGER.info(
         "Issue unbind devices: %s %s",
-        "{}: [{}]".format(ATTR_SOURCE_IEEE, source_ieee),
-        "{}: [{}]".format(ATTR_TARGET_IEEE, target_ieee),
+        f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
+        f"{ATTR_TARGET_IEEE}: [{target_ieee}]",
     )
 
 
@@ -482,8 +482,8 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
 
         _LOGGER.debug(
             "processing binding operation for: %s %s %s",
-            "{}: [{}]".format(ATTR_SOURCE_IEEE, source_ieee),
-            "{}: [{}]".format(ATTR_TARGET_IEEE, target_ieee),
+            f"{ATTR_SOURCE_IEEE}: [{source_ieee}]",
+            f"{ATTR_TARGET_IEEE}: [{target_ieee}]",
             "{}: {}".format("cluster", cluster_pair.source_cluster.cluster_id),
         )
         bind_tasks.append(
@@ -551,13 +551,13 @@ def async_load_api(hass):
             )
         _LOGGER.debug(
             "Set attribute for: %s %s %s %s %s %s %s",
-            "{}: [{}]".format(ATTR_CLUSTER_ID, cluster_id),
-            "{}: [{}]".format(ATTR_CLUSTER_TYPE, cluster_type),
-            "{}: [{}]".format(ATTR_ENDPOINT_ID, endpoint_id),
-            "{}: [{}]".format(ATTR_ATTRIBUTE, attribute),
-            "{}: [{}]".format(ATTR_VALUE, value),
-            "{}: [{}]".format(ATTR_MANUFACTURER, manufacturer),
-            "{}: [{}]".format(RESPONSE, response),
+            f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
+            f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
+            f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
+            f"{ATTR_ATTRIBUTE}: [{attribute}]",
+            f"{ATTR_VALUE}: [{value}]",
+            f"{ATTR_MANUFACTURER}: [{manufacturer}]",
+            f"{RESPONSE}: [{response}]",
         )
 
     hass.helpers.service.async_register_admin_service(
@@ -593,14 +593,14 @@ def async_load_api(hass):
             )
         _LOGGER.debug(
             "Issue command for: %s %s %s %s %s %s %s %s",
-            "{}: [{}]".format(ATTR_CLUSTER_ID, cluster_id),
-            "{}: [{}]".format(ATTR_CLUSTER_TYPE, cluster_type),
-            "{}: [{}]".format(ATTR_ENDPOINT_ID, endpoint_id),
-            "{}: [{}]".format(ATTR_COMMAND, command),
-            "{}: [{}]".format(ATTR_COMMAND_TYPE, command_type),
-            "{}: [{}]".format(ATTR_ARGS, args),
-            "{}: [{}]".format(ATTR_MANUFACTURER, manufacturer),
-            "{}: [{}]".format(RESPONSE, response),
+            f"{ATTR_CLUSTER_ID}: [{cluster_id}]",
+            f"{ATTR_CLUSTER_TYPE}: [{cluster_type}]",
+            f"{ATTR_ENDPOINT_ID}: [{endpoint_id}]",
+            f"{ATTR_COMMAND}: [{command}]",
+            f"{ATTR_COMMAND_TYPE}: [{command_type}]",
+            f"{ATTR_ARGS}: [{args}]",
+            f"{ATTR_MANUFACTURER}: [{manufacturer}]",
+            f"{RESPONSE}: [{response}]",
         )
 
     hass.helpers.service.async_register_admin_service(

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -87,7 +87,7 @@ class ZigbeeChannel(LogMixin):
         self._channel_name = cluster.ep_attribute
         if self.CHANNEL_NAME:
             self._channel_name = self.CHANNEL_NAME
-        self._generic_id = "channel_0x{:04x}".format(cluster.cluster_id)
+        self._generic_id = f"channel_0x{cluster.cluster_id:04x}"
         self._cluster = cluster
         self._zha_device = device
         self._unique_id = "{}:{}:0x{:04x}".format(
@@ -299,9 +299,7 @@ class AttributeListeningChannel(ZigbeeChannel):
         """Handle attribute updates on this cluster."""
         if attrid == self.value_attribute:
             async_dispatcher_send(
-                self._zha_device.hass,
-                "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-                value,
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
             )
 
     async def async_initialize(self, from_cache):

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -30,9 +30,7 @@ class DoorLockChannel(ZigbeeChannel):
         result = await self.get_attribute_value("lock_state", from_cache=True)
 
         async_dispatcher_send(
-            self._zha_device.hass,
-            "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-            result,
+            self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", result
         )
 
     @callback
@@ -44,9 +42,7 @@ class DoorLockChannel(ZigbeeChannel):
         )
         if attrid == self._value_attribute:
             async_dispatcher_send(
-                self._zha_device.hass,
-                "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-                value,
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
             )
 
     async def async_initialize(self, from_cache):

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -198,7 +198,7 @@ class LevelControlChannel(ZigbeeChannel):
     def dispatch_level_change(self, command, level):
         """Dispatch level change."""
         async_dispatcher_send(
-            self._zha_device.hass, "{}_{}".format(self.unique_id, command), level
+            self._zha_device.hass, f"{self.unique_id}_{command}", level
         )
 
     async def async_initialize(self, from_cache):
@@ -284,9 +284,7 @@ class OnOffChannel(ZigbeeChannel):
         """Handle attribute updates on this cluster."""
         if attrid == self.ON_OFF:
             async_dispatcher_send(
-                self._zha_device.hass,
-                "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-                value,
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
             )
             self._state = bool(value)
 
@@ -355,9 +353,7 @@ class PowerConfigurationChannel(ZigbeeChannel):
             attr_id = attr
         if attrid == attr_id:
             async_dispatcher_send(
-                self._zha_device.hass,
-                "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-                value,
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
             )
 
     async def async_initialize(self, from_cache):

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -72,9 +72,7 @@ class ElectricalMeasurementChannel(AttributeListeningChannel):
         # This is a polling channel. Don't allow cache.
         result = await self.get_attribute_value("active_power", from_cache=False)
         async_dispatcher_send(
-            self._zha_device.hass,
-            "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-            result,
+            self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", result
         )
 
     async def async_initialize(self, from_cache):

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -48,9 +48,7 @@ class FanChannel(ZigbeeChannel):
         result = await self.get_attribute_value("fan_mode", from_cache=True)
 
         async_dispatcher_send(
-            self._zha_device.hass,
-            "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-            result,
+            self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", result
         )
 
     @callback
@@ -62,9 +60,7 @@ class FanChannel(ZigbeeChannel):
         )
         if attrid == self._value_attribute:
             async_dispatcher_send(
-                self._zha_device.hass,
-                "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-                value,
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
             )
 
     async def async_initialize(self, from_cache):

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -43,9 +43,7 @@ class IASZoneChannel(ZigbeeChannel):
         if command_id == 0:
             state = args[0] & 3
             async_dispatcher_send(
-                self._zha_device.hass,
-                "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-                state,
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", state
             )
             self.debug("Updated alarm state: %s", state)
         elif command_id == 1:
@@ -91,9 +89,7 @@ class IASZoneChannel(ZigbeeChannel):
         if attrid == 2:
             value = value & 3
             async_dispatcher_send(
-                self._zha_device.hass,
-                "{}_{}".format(self.unique_id, SIGNAL_ATTR_UPDATED),
-                value,
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
             )
 
     async def async_initialize(self, from_cache):

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -102,7 +102,7 @@ class ZHADevice(LogMixin):
     @property
     def name(self):
         """Return device name."""
-        return "{} {}".format(self.manufacturer, self.model)
+        return f"{self.manufacturer} {self.model}"
 
     @property
     def ieee(self):
@@ -461,10 +461,10 @@ class ZHADevice(LogMixin):
         except DeliveryError as exc:
             self.debug(
                 "failed to set attribute: %s %s %s %s %s",
-                "{}: {}".format(ATTR_VALUE, value),
-                "{}: {}".format(ATTR_ATTRIBUTE, attribute),
-                "{}: {}".format(ATTR_CLUSTER_ID, cluster_id),
-                "{}: {}".format(ATTR_ENDPOINT_ID, endpoint_id),
+                f"{ATTR_VALUE}: {value}",
+                f"{ATTR_ATTRIBUTE}: {attribute}",
+                f"{ATTR_CLUSTER_ID}: {cluster_id}",
+                f"{ATTR_ENDPOINT_ID}: {endpoint_id}",
                 exc,
             )
             return None
@@ -493,13 +493,13 @@ class ZHADevice(LogMixin):
 
         self.debug(
             "Issued cluster command: %s %s %s %s %s %s %s",
-            "{}: {}".format(ATTR_CLUSTER_ID, cluster_id),
-            "{}: {}".format(ATTR_COMMAND, command),
-            "{}: {}".format(ATTR_COMMAND_TYPE, command_type),
-            "{}: {}".format(ATTR_ARGS, args),
-            "{}: {}".format(ATTR_CLUSTER_ID, cluster_type),
-            "{}: {}".format(ATTR_MANUFACTURER, manufacturer),
-            "{}: {}".format(ATTR_ENDPOINT_ID, endpoint_id),
+            f"{ATTR_CLUSTER_ID}: {cluster_id}",
+            f"{ATTR_COMMAND}: {command}",
+            f"{ATTR_COMMAND_TYPE}: {command_type}",
+            f"{ATTR_ARGS}: {args}",
+            f"{ATTR_CLUSTER_ID}: {cluster_type}",
+            f"{ATTR_MANUFACTURER}: {manufacturer}",
+            f"{ATTR_ENDPOINT_ID}: {endpoint_id}",
         )
         return response
 

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -62,7 +62,7 @@ def async_process_endpoint(
 
     component = None
     profile_clusters = []
-    device_key = "{}-{}".format(device.ieee, endpoint_id)
+    device_key = f"{device.ieee}-{endpoint_id}"
     node_config = {}
     if CONF_DEVICE_CONFIG in config:
         node_config = config[CONF_DEVICE_CONFIG].get(device_key, {})
@@ -281,12 +281,12 @@ def _async_handle_single_cluster_match(
     channels = []
     _async_create_cluster_channel(cluster, zha_device, is_new_join, channels=channels)
 
-    cluster_key = "{}-{}".format(device_key, cluster.cluster_id)
+    cluster_key = f"{device_key}-{cluster.cluster_id}"
     discovery_info = {
         "unique_id": cluster_key,
         "zha_device": zha_device,
         "channels": channels,
-        "entity_suffix": "_{}".format(cluster.cluster_id),
+        "entity_suffix": f"_{cluster.cluster_id}",
         "component": component,
     }
 

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -339,7 +339,7 @@ class ZHAGateway:
 
         _LOGGER.debug(
             "device - %s entering async_device_initialized - is_new_join: %s",
-            "0x{:04x}:{}".format(device.nwk, device.ieee),
+            f"0x{device.nwk:04x}:{device.ieee}",
             zha_device.status is not DeviceStatus.INITIALIZED,
         )
 
@@ -348,13 +348,13 @@ class ZHAGateway:
             # new nwk or device was physically reset and added again without being removed
             _LOGGER.debug(
                 "device - %s has been reset and readded or its nwk address changed",
-                "0x{:04x}:{}".format(device.nwk, device.ieee),
+                f"0x{device.nwk:04x}:{device.ieee}",
             )
             await self._async_device_rejoined(zha_device)
         else:
             _LOGGER.debug(
                 "device - %s has joined the ZHA zigbee network",
-                "0x{:04x}:{}".format(device.nwk, device.ieee),
+                f"0x{device.nwk:04x}:{device.ieee}",
             )
             await self._async_device_joined(device, zha_device)
 
@@ -413,9 +413,9 @@ class ZHAGateway:
             # to update it now
             _LOGGER.debug(
                 "attempting to request fresh state for device - %s %s %s",
-                "0x{:04x}:{}".format(zha_device.nwk, zha_device.ieee),
+                f"0x{zha_device.nwk:04x}:{zha_device.ieee}",
                 zha_device.name,
-                "with power source: {}".format(zha_device.power_source),
+                f"with power source: {zha_device.power_source}",
             )
             await zha_device.async_initialize(from_cache=False)
         else:
@@ -427,7 +427,7 @@ class ZHAGateway:
     async def _async_device_rejoined(self, zha_device):
         _LOGGER.debug(
             "skipping discovery for previously discovered device - %s",
-            "0x{:04x}:{}".format(zha_device.nwk, zha_device.ieee),
+            f"0x{zha_device.nwk:04x}:{zha_device.ieee}",
         )
         # we don't have to do this on a nwk swap but we don't have a way to tell currently
         await zha_device.async_configure()

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -189,7 +189,7 @@ class ZhaEntity(RestoreEntity, LogMixin, entity.Entity):
             unsub = async_dispatcher_connect(self.hass, signal, func)
         else:
             unsub = async_dispatcher_connect(
-                self.hass, "{}_{}".format(channel.unique_id, signal), func
+                self.hass, f"{channel.unique_id}_{signal}", func
             )
         self._unsubs.append(unsub)
 

--- a/homeassistant/components/ziggo_mediabox_xl/media_player.py
+++ b/homeassistant/components/ziggo_mediabox_xl/media_player.py
@@ -206,5 +206,5 @@ class ZiggoMediaboxXLDevice(MediaPlayerDevice):
         if digits is None:
             return
 
-        self.send_keys(["NUM_{}".format(digit) for digit in str(digits)])
+        self.send_keys([f"NUM_{digit}" for digit in str(digits)])
         self._state = STATE_PLAYING

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -64,7 +64,7 @@ def setup(hass, config):
             schema = "http"
 
         host_name = conf[CONF_HOST]
-        server_origin = "{}://{}".format(schema, host_name)
+        server_origin = f"{schema}://{host_name}"
         zm_client = ZoneMinder(
             server_origin,
             conf.get(CONF_USERNAME),

--- a/homeassistant/components/zoneminder/sensor.py
+++ b/homeassistant/components/zoneminder/sensor.py
@@ -68,7 +68,7 @@ class ZMSensorMonitors(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} Status".format(self._monitor.name)
+        return f"{self._monitor.name} Status"
 
     @property
     def state(self):
@@ -105,7 +105,7 @@ class ZMSensorEvents(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "{} {}".format(self._monitor.name, self.time_period.title)
+        return f"{self._monitor.name} {self.time_period.title}"
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/zoneminder/switch.py
+++ b/homeassistant/components/zoneminder/switch.py
@@ -53,7 +53,7 @@ class ZMSwitchMonitors(SwitchDevice):
     @property
     def name(self):
         """Return the name of the switch."""
-        return "{} State".format(self._monitor.name)
+        return f"{self._monitor.name} State"
 
     def update(self):
         """Update the switch value."""

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -478,10 +478,10 @@ async def async_setup_entry(hass, config_entry):
 
     def node_removed(node):
         node_id = node.node_id
-        node_key = "node-{}".format(node_id)
+        node_key = f"node-{node_id}"
         _LOGGER.info("Node Removed: %s", hass.data[DATA_DEVICES][node_key])
         for key in list(hass.data[DATA_DEVICES]):
-            if not key.startswith("{}-".format(node_id)):
+            if not key.startswith(f"{node_id}-"):
                 continue
 
             entity = hass.data[DATA_DEVICES][key]
@@ -586,11 +586,11 @@ async def async_setup_entry(hass, config_entry):
         update_ids = service.data.get(const.ATTR_UPDATE_IDS)
         # We want to rename the device, the node entity,
         # and all the contained entities
-        node_key = "node-{}".format(node_id)
+        node_key = f"node-{node_id}"
         entity = hass.data[DATA_DEVICES][node_key]
         await entity.node_renamed(update_ids)
         for key in list(hass.data[DATA_DEVICES]):
-            if not key.startswith("{}-".format(node_id)):
+            if not key.startswith(f"{node_id}-"):
                 continue
             entity = hass.data[DATA_DEVICES][key]
             await entity.value_renamed(update_ids)
@@ -607,7 +607,7 @@ async def async_setup_entry(hass, config_entry):
             "Renamed Z-Wave value (Node %d Value %d) to %s", node_id, value_id, name
         )
         update_ids = service.data.get(const.ATTR_UPDATE_IDS)
-        value_key = "{}-{}".format(node_id, value_id)
+        value_key = f"{node_id}-{value_id}"
         entity = hass.data[DATA_DEVICES][value_key]
         await entity.value_renamed(update_ids)
 
@@ -1109,7 +1109,7 @@ class ZWaveDeviceEntityValues:
         if polling_intensity:
             self.primary.enable_poll(polling_intensity)
 
-        platform = import_module(".{}".format(component), __name__)
+        platform = import_module(f".{component}", __name__)
 
         device = platform.get_device(
             node=self._node, values=self, node_config=node_config, hass=self._hass
@@ -1149,9 +1149,7 @@ class ZWaveDeviceEntityValues:
 
             self._hass.data[DATA_DEVICES][device.unique_id] = device
             if component in SUPPORTED_PLATFORMS:
-                async_dispatcher_send(
-                    self._hass, "zwave_new_{}".format(component), device
-                )
+                async_dispatcher_send(self._hass, f"zwave_new_{component}", device)
             else:
                 await discovery.async_load_platform(
                     self._hass,
@@ -1316,4 +1314,4 @@ class ZWaveDeviceEntity(ZWaveBaseEntity):
 
 def compute_value_unique_id(node, value):
     """Compute unique_id a value would get if it were to get one."""
-    return "{}-{}".format(node.node_id, value.object_id)
+    return f"{node.node_id}-{value.object_id}"

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -348,5 +348,5 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
 
     def _compute_unique_id(self):
         if is_node_parsed(self.node) or self.node.is_ready:
-            return "node-{}".format(self.node_id)
+            return f"node-{self.node_id}"
         return None

--- a/homeassistant/components/zwave/util.py
+++ b/homeassistant/components/zwave/util.py
@@ -91,8 +91,8 @@ def check_value_schema(value, schema):
 def node_name(node):
     """Return the name of the node."""
     if is_node_parsed(node):
-        return node.name or "{} {}".format(node.manufacturer_name, node.product_name)
-    return "Unknown Node {}".format(node.node_id)
+        return node.name or f"{node.manufacturer_name} {node.product_name}"
+    return f"Unknown Node {node.node_id}"
 
 
 def node_device_id_and_name(node, instance=1):
@@ -100,7 +100,7 @@ def node_device_id_and_name(node, instance=1):
     name = node_name(node)
     if instance == 1:
         return ((const.DOMAIN, node.node_id), name)
-    name = "{} ({})".format(name, instance)
+    name = f"{name} ({instance})"
     return ((const.DOMAIN, node.node_id, instance), name)
 
 


### PR DESCRIPTION
## Description:

Upgrades code to use string formatting using literal string interpolation format defined in PEP 498. Easier to read, generally smaller, and finally possible now 3.6 is the min version.

PEP 498: https://www.python.org/dev/peps/pep-0498

This PR converts code in integrations starting with the letter `X`, `Y` and `Z`. 🎉 

⚠️ I expect codecov to fail on this one 🤷‍♂ 

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
