### PR TITLE
Allow core config updated

### DIFF
--- a/homeassistant/components/websocket_api/permissions.py
+++ b/homeassistant/components/websocket_api/permissions.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     EVENT_SERVICE_REMOVED,
     EVENT_STATE_CHANGED,
     EVENT_THEMES_UPDATED,
+    EVENT_CORE_CONFIG_UPDATE,
 )
 from homeassistant.components.persistent_notification import (
     EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
@@ -22,6 +23,7 @@ from homeassistant.components.frontend import EVENT_PANELS_UPDATED
 # Except for state_changed, which is handled accordingly.
 SUBSCRIBE_WHITELIST = {
     EVENT_COMPONENT_LOADED,
+    EVENT_CORE_CONFIG_UPDATE,
     EVENT_PANELS_UPDATED,
     EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
     EVENT_SERVICE_REGISTERED,


### PR DESCRIPTION
## Description:
Whitelist another event for non-admin users.

**Related issue (if applicable):** fixes #22759

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
