### PR TITLE
Fix state report

### DIFF
--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -97,12 +97,15 @@ async def async_send_changereport_message(
     _LOGGER.debug("Sent: %s", json.dumps(message_serialized))
     _LOGGER.debug("Received (%s): %s", response.status, response_text)
 
-    if response.status == 202 and not invalidate_access_token:
+    if response.status == 202:
         return
 
     response_json = json.loads(response_text)
 
-    if response_json["payload"]["code"] == "INVALID_ACCESS_TOKEN_EXCEPTION":
+    if (
+        response_json["payload"]["code"] == "INVALID_ACCESS_TOKEN_EXCEPTION"
+        and not invalidate_access_token
+    ):
         config.async_invalidate_access_token()
         return await async_send_changereport_message(
             hass, config, alexa_entity, invalidate_access_token=False

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -5,7 +5,7 @@ from . import TEST_URL, DEFAULT_CONFIG
 
 async def test_report_state(hass, aioclient_mock):
     """Test proactive state reports."""
-    aioclient_mock.post(TEST_URL, json={"data": "is irrelevant"}, status=202)
+    aioclient_mock.post(TEST_URL, text="", status=202)
 
     hass.states.async_set(
         "binary_sensor.test_contact",
@@ -39,7 +39,7 @@ async def test_report_state(hass, aioclient_mock):
 
 async def test_send_add_or_update_message(hass, aioclient_mock):
     """Test sending an AddOrUpdateReport message."""
-    aioclient_mock.post(TEST_URL, json={"data": "is irrelevant"})
+    aioclient_mock.post(TEST_URL, text="")
 
     hass.states.async_set(
         "binary_sensor.test_contact",


### PR DESCRIPTION
## Description:
The `and` check was on the wrong if-condition.

**Related issue (if applicable):** fixes #26355


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
