### PR TITLE
IGN Sismologia icon for geolocation entities

### DIFF
--- a/homeassistant/components/ign_sismologia/geo_location.py
+++ b/homeassistant/components/ign_sismologia/geo_location.py
@@ -202,6 +202,11 @@ class IgnSismologiaLocationEvent(GeolocationEvent):
         self._image_url = feed_entry.image_url
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return "mdi:pulse"
+
+    @property
     def source(self) -> str:
         """Return source value of this external event."""
         return SOURCE

--- a/tests/components/ign_sismologia/test_geo_location.py
+++ b/tests/components/ign_sismologia/test_geo_location.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    ATTR_ICON,
 )
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed
@@ -126,6 +127,7 @@ async def test_setup(hass):
                 ATTR_MAGNITUDE: 5.7,
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "ign_sismologia",
+                ATTR_ICON: "mdi:pulse",
             }
             assert float(state.state) == 15.5
 
@@ -141,6 +143,7 @@ async def test_setup(hass):
                 ATTR_MAGNITUDE: 4.6,
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "ign_sismologia",
+                ATTR_ICON: "mdi:pulse",
             }
             assert float(state.state) == 20.5
 
@@ -156,6 +159,7 @@ async def test_setup(hass):
                 ATTR_REGION: "Region 3",
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "ign_sismologia",
+                ATTR_ICON: "mdi:pulse",
             }
             assert float(state.state) == 25.5
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This adds a suitable icon to the geolocation entities created by the IGN Sismologia integration.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
