### PR TITLE
Allow passing None as input_text config

### DIFF
--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -58,20 +58,23 @@ def _cv_input_text(cfg):
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: cv.schema_with_slug_keys(
-            vol.All(
-                {
-                    vol.Optional(CONF_NAME): cv.string,
-                    vol.Optional(CONF_MIN, default=0): vol.Coerce(int),
-                    vol.Optional(CONF_MAX, default=100): vol.Coerce(int),
-                    vol.Optional(CONF_INITIAL, ""): cv.string,
-                    vol.Optional(CONF_ICON): cv.icon,
-                    vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
-                    vol.Optional(ATTR_PATTERN): cv.string,
-                    vol.Optional(CONF_MODE, default=MODE_TEXT): vol.In(
-                        [MODE_TEXT, MODE_PASSWORD]
-                    ),
-                },
-                _cv_input_text,
+            vol.Any(
+                vol.All(
+                    {
+                        vol.Optional(CONF_NAME): cv.string,
+                        vol.Optional(CONF_MIN, default=0): vol.Coerce(int),
+                        vol.Optional(CONF_MAX, default=100): vol.Coerce(int),
+                        vol.Optional(CONF_INITIAL, ""): cv.string,
+                        vol.Optional(CONF_ICON): cv.icon,
+                        vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
+                        vol.Optional(ATTR_PATTERN): cv.string,
+                        vol.Optional(CONF_MODE, default=MODE_TEXT): vol.In(
+                            [MODE_TEXT, MODE_PASSWORD]
+                        ),
+                    },
+                    _cv_input_text,
+                ),
+                None,
             )
         )
     },
@@ -87,6 +90,8 @@ async def async_setup(hass, config):
     entities = []
 
     for object_id, cfg in config[DOMAIN].items():
+        if cfg is None:
+            cfg = {}
         name = cfg.get(CONF_NAME)
         minimum = cfg.get(CONF_MIN)
         maximum = cfg.get(CONF_MAX)

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -186,3 +186,12 @@ async def test_input_text_context(hass, hass_admin_user):
     assert state2 is not None
     assert state.state != state2.state
     assert state2.context.user_id == hass_admin_user.id
+
+
+async def test_config_none(hass):
+    """Set up input_text without any config."""
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"b1": None}})
+
+    state = hass.states.get("input_text.b1")
+    assert state
+    assert str(state.state) == "unknown"


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Allow setting no variables for input_text

```yaml
input_text:
  some_input:
```

**Related issue (if applicable):** fixes #26264

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
