### PR TITLE
NSW Rural Fire Service icon for geolocation entities

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -191,6 +191,7 @@ homeassistant/components/no_ip/* @fabaff
 homeassistant/components/notify/* @home-assistant/core
 homeassistant/components/notion/* @bachya
 homeassistant/components/nsw_fuel_station/* @nickw444
+homeassistant/components/nsw_rural_fire_service_feed/* @exxamalte
 homeassistant/components/nuki/* @pschmitt
 homeassistant/components/nws/* @MatthewFlamm
 homeassistant/components/ohmconnect/* @robbiet480

--- a/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
@@ -211,6 +211,13 @@ class NswRuralFireServiceLocationEvent(GeolocationEvent):
         self._responsible_agency = feed_entry.responsible_agency
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        if self._fire:
+            return "mdi:fire"
+        return "mdi:alarm-light"
+
+    @property
     def source(self) -> str:
         """Return source value of this external event."""
         return SOURCE

--- a/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
+++ b/homeassistant/components/nsw_rural_fire_service_feed/manifest.json
@@ -6,5 +6,7 @@
     "geojson_client==0.4"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@exxamalte"
+  ]
 }

--- a/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
+++ b/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_RADIUS,
     EVENT_HOMEASSISTANT_START,
+    ATTR_ICON,
 )
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed
@@ -150,6 +151,7 @@ async def test_setup(hass):
                 ATTR_RESPONSIBLE_AGENCY: "Agency 1",
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "nsw_rural_fire_service_feed",
+                ATTR_ICON: "mdi:fire",
             }
             assert round(abs(float(state.state) - 15.5), 7) == 0
 
@@ -164,6 +166,7 @@ async def test_setup(hass):
                 ATTR_FIRE: False,
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "nsw_rural_fire_service_feed",
+                ATTR_ICON: "mdi:alarm-light",
             }
             assert round(abs(float(state.state) - 20.5), 7) == 0
 
@@ -178,6 +181,7 @@ async def test_setup(hass):
                 ATTR_FIRE: True,
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "nsw_rural_fire_service_feed",
+                ATTR_ICON: "mdi:fire",
             }
             assert round(abs(float(state.state) - 25.5), 7) == 0
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This adds a suitable icons to the geolocation entities created by the NSW Rural Fire Service Feed integration.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
