### PR TITLE
Add French translation to Linky config flow

### DIFF
--- a/homeassistant/components/linky/.translations/fr.json
+++ b/homeassistant/components/linky/.translations/fr.json
@@ -1,0 +1,25 @@
+{
+    "config": {
+        "abort": {
+            "username_exists": "Compte d\u00e9j\u00e0 configur\u00e9"
+        },
+        "error": {
+            "access": "Impossible d'acc\u00e9der \u00e0 Enedis.fr, merci de v\u00e9rifier votre connexion internet",
+            "enedis": "Erreur d'Enedis.fr: merci de r\u00e9essayer plus tard (pas entre 23h et 2h)",
+            "unknown": "Erreur inconnue: merci de r\u00e9essayer plus tard (pas entre 23h et 2h)",
+            "username_exists": "Compte d\u00e9j\u00e0 configur\u00e9",
+            "wrong_login": "Impossible de vous identifier: merci de v\u00e9rifier vos identifiants"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "password": "Mot de passe",
+                    "username": "Email"
+                },
+                "description": "Entrez vos identifiants",
+                "title": "Linky"
+            }
+        },
+        "title": "Linky"
+    }
+}


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Add French translation to Linky config flow, don't know if I should go by a PR or Localise, so I also did it [there](https://lokalise.co/project/130246255a974bd3b5e8a1.51616605/?view=single&reference_lang_id=640&single_lang_id=673).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
