### PR TITLE
Replaces IOError by OSError

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -216,7 +216,7 @@ def check_pid(pid_file: str) -> None:
     try:
         with open(pid_file, "r") as file:
             pid = int(file.readline())
-    except IOError:
+    except OSError:
         # PID File does not exist
         return
 
@@ -239,7 +239,7 @@ def write_pid(pid_file: str) -> None:
     try:
         with open(pid_file, "w") as file:
             file.write(str(pid))
-    except IOError:
+    except OSError:
         print(f"Fatal Error: Unable to write pid file {pid_file}")
         sys.exit(1)
 
@@ -258,7 +258,7 @@ def closefds_osx(min_fd: int, max_fd: int) -> None:
             val = fcntl(_fd, F_GETFD)
             if not val & FD_CLOEXEC:
                 fcntl(_fd, F_SETFD, val | FD_CLOEXEC)
-        except IOError:
+        except OSError:
             pass
 
 

--- a/homeassistant/components/bme680/sensor.py
+++ b/homeassistant/components/bme680/sensor.py
@@ -171,7 +171,7 @@ def _setup_bme680(config):
             sensor.select_gas_heater_profile(0)
         else:
             sensor.set_gas_status(bme680.DISABLE_GAS_MEAS)
-    except (RuntimeError, IOError):
+    except (RuntimeError, OSError):
         _LOGGER.error("BME680 sensor not detected at 0x%02x", i2c_address)
         return None
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -142,7 +142,7 @@ class BMWConnectedDriveAccount:
             self.account.update_vehicle_states()
             for listener in self._update_listeners:
                 listener()
-        except IOError as exception:
+        except OSError as exception:
             _LOGGER.error(
                 "Could not connect to the BMW Connected Drive portal. "
                 "The vehicle state could not be updated."

--- a/homeassistant/components/egardia/__init__.py
+++ b/homeassistant/components/egardia/__init__.py
@@ -110,7 +110,7 @@ def setup(hass, config):
                 server = egardiaserver.EgardiaServer("", rs_port)
                 bound = server.bind()
                 if not bound:
-                    raise IOError(
+                    raise OSError(
                         "Binding error occurred while " + "starting EgardiaServer."
                     )
                 hass.data[EGARDIA_SERVER] = server
@@ -123,7 +123,7 @@ def setup(hass, config):
             # listen to home assistant stop event
             hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, handle_stop_event)
 
-        except IOError:
+        except OSError:
             _LOGGER.error("Binding error occurred while starting EgardiaServer")
             return False
 

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -293,7 +293,7 @@ class HangoutsBot:
                 if self.hass.config.is_allowed_path(uri):
                     try:
                         image_file = open(uri, "rb")
-                    except IOError as error:
+                    except OSError as error:
                         _LOGGER.error(
                             "Image file I/O error(%s): %s", error.errno, error.strerror
                         )

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -157,7 +157,7 @@ class KeyboardRemoteThread(threading.Thread):
 
             try:
                 event = self.dev.read_one()
-            except IOError:  # Keyboard Disconnected
+            except OSError:  # Keyboard Disconnected
                 self.dev = None
                 self.hass.bus.fire(
                     KEYBOARD_REMOTE_DISCONNECTED,

--- a/homeassistant/components/liveboxplaytv/media_player.py
+++ b/homeassistant/components/liveboxplaytv/media_player.py
@@ -70,7 +70,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     try:
         device = LiveboxPlayTvDevice(host, port, name)
         livebox_devices.append(device)
-    except IOError:
+    except OSError:
         _LOGGER.error(
             "Failed to connect to Livebox Play TV at %s:%s. "
             "Please check your configuration",

--- a/homeassistant/components/miflora/sensor.py
+++ b/homeassistant/components/miflora/sensor.py
@@ -157,7 +157,7 @@ class MiFloraSensor(Entity):
         try:
             _LOGGER.debug("Polling data for %s", self.name)
             data = self.poller.parameter_value(self.parameter)
-        except IOError as ioerr:
+        except OSError as ioerr:
             _LOGGER.info("Polling error %s", ioerr)
             return
         except BluetoothBackendException as bterror:

--- a/homeassistant/components/mitemp_bt/sensor.py
+++ b/homeassistant/components/mitemp_bt/sensor.py
@@ -157,7 +157,7 @@ class MiTempBtSensor(Entity):
         try:
             _LOGGER.debug("Polling data for %s", self.name)
             data = self.poller.parameter_value(self.parameter)
-        except IOError as ioerr:
+        except OSError as ioerr:
             _LOGGER.warning("Polling error %s", ioerr)
             return
         except BluetoothBackendException as bterror:

--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -92,7 +92,7 @@ def setup(hass, config):
 
         try:
             pilight_client.send_code(message_data)
-        except IOError:
+        except OSError:
             _LOGGER.error("Pilight send failed for %s", str(message_data))
 
     hass.services.register(DOMAIN, SERVICE_NAME, send_code, schema=RF_CODE_SCHEMA)

--- a/homeassistant/components/proxy/camera.py
+++ b/homeassistant/components/proxy/camera.py
@@ -66,7 +66,7 @@ def _precheck_image(image, opts):
         raise ValueError()
     try:
         img = Image.open(io.BytesIO(image))
-    except IOError:
+    except OSError:
         _LOGGER.warning("Failed to open image")
         raise ValueError()
     imgfmt = str(img.format)

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -47,7 +47,7 @@ def setup_input(address, port, pull_mode, bouncetime):
             bounce_time=bouncetime,
             pin_factory=PiGPIOFactory(address),
         )
-    except (ValueError, IndexError, KeyError, IOError):
+    except (ValueError, IndexError, KeyError, OSError):
         return None
 
 

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             button = remote_rpi_gpio.setup_input(
                 address, port_num, pull_mode, bouncetime
             )
-        except (ValueError, IndexError, KeyError, IOError):
+        except (ValueError, IndexError, KeyError, OSError):
             return
         new_sensor = RemoteRPiGPIOBinarySensor(port_name, button, invert_logic)
         devices.append(new_sensor)

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -36,7 +36,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for port, name in ports.items():
         try:
             led = remote_rpi_gpio.setup_output(address, port, invert_logic)
-        except (ValueError, IndexError, KeyError, IOError):
+        except (ValueError, IndexError, KeyError, OSError):
             return
         new_switch = RemoteRPiGPIOSwitch(name, led, invert_logic)
         devices.append(new_switch)

--- a/homeassistant/components/sky_hub/device_tracker.py
+++ b/homeassistant/components/sky_hub/device_tracker.py
@@ -94,7 +94,7 @@ def _parse_skyhub_response(data_str):
     """Parse the Sky Hub data format."""
     pattmatch = re.search("attach_dev = '(.*)'", data_str)
     if pattmatch is None:
-        raise IOError(
+        raise OSError(
             "Error: Impossible to fetch data from"
             + " Sky Hub. Try to reboot the router."
         )

--- a/homeassistant/components/supla/__init__.py
+++ b/homeassistant/components/supla/__init__.py
@@ -65,7 +65,7 @@ def setup(hass, base_config):
                     srv_info,
                 )
                 return False
-        except IOError:
+        except OSError:
             _LOGGER.exception(
                 "Server: %s not configured. Error on Supla API access: ", server_address
             )

--- a/homeassistant/components/telnet/switch.py
+++ b/homeassistant/components/telnet/switch.py
@@ -117,7 +117,7 @@ class TelnetSwitch(SwitchDevice):
             response = telnet.read_until(b"\r", timeout=self._timeout)
             _LOGGER.debug("telnet response: %s", response.decode("ASCII").strip())
             return response.decode("ASCII").strip()
-        except IOError as error:
+        except OSError as error:
             _LOGGER.error(
                 'Command "%s" failed with exception: %s', command, repr(error)
             )

--- a/homeassistant/components/temper/sensor.py
+++ b/homeassistant/components/temper/sensor.py
@@ -96,7 +96,7 @@ class TemperSensor(Entity):
             )
             sensor_value = self.temper_device.get_temperature(format_str)
             self.current_value = round(sensor_value, 1)
-        except IOError:
+        except OSError:
             _LOGGER.error(
                 "Failed to get temperature. The device address may"
                 "have changed. Attempting to reset device"

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -289,7 +289,7 @@ def _write_default_config(config_dir: str) -> Optional[str]:
 
         return config_path
 
-    except IOError:
+    except OSError:
         print("Unable to create default configuration file", config_path)
         return None
 
@@ -393,7 +393,7 @@ def process_ha_config_upgrade(hass: HomeAssistant) -> None:
             try:
                 with open(config_path, "wt", encoding="utf-8") as config_file:
                     config_file.write(config_raw)
-            except IOError:
+            except OSError:
                 _LOGGER.exception("Migrating to google_translate tts failed")
                 pass
 

--- a/homeassistant/scripts/macos/__init__.py
+++ b/homeassistant/scripts/macos/__init__.py
@@ -27,7 +27,7 @@ def install_osx():
     try:
         with open(path, "w", encoding="utf-8") as outp:
             outp.write(plist)
-    except IOError as err:
+    except OSError as err:
         print("Unable to write to " + path, err)
         return
 


### PR DESCRIPTION
## Description:

Replaces the use of `IOError` by `OSError` in our codebase since `IOError` is an alias.

See [PEP 3151](https://www.python.org/dev/peps/pep-3151/). A more compact explanation is in the Python 3.3 release notes:
["PEP 3151: Reworking the OS and IO exception hierarchy"](https://docs.python.org/3/whatsnew/3.3.html#pep-3151-reworking-the-os-and-io-exception-hierarchy)

Basically Python makes no difference between the two, the original source is `OSError`, the others are still there for compatibility reasons.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
