### PR TITLE
Update telegram-bot version from 11.1.0 to 12.0.0

### DIFF
--- a/homeassistant/components/telegram_bot/manifest.json
+++ b/homeassistant/components/telegram_bot/manifest.json
@@ -3,7 +3,7 @@
   "name": "Telegram bot",
   "documentation": "https://www.home-assistant.io/components/telegram_bot",
   "requirements": [
-    "python-telegram-bot==11.1.0"
+    "python-telegram-bot==12.0.0"
   ],
   "dependencies": ["http"],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1528,7 +1528,7 @@ python-synology==0.2.0
 python-tado==0.2.9
 
 # homeassistant.components.telegram_bot
-python-telegram-bot==11.1.0
+python-telegram-bot==12.0.0
 
 # homeassistant.components.vlc_telnet
 python-telnet-vlc==1.0.4


### PR DESCRIPTION
## Description:
Fixes Telegram Bot import error with version 11.1.0

**Related issue (if applicable):** fixes #26415 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
telegram_bot:
  - platform: polling
    api_key: XXXXXX
    allowed_chat_ids:
      - XXXXXX
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
