### PR TITLE
Add config flow to transmission

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -656,7 +656,11 @@ omit =
     homeassistant/components/tradfri/light.py
     homeassistant/components/trafikverket_train/sensor.py
     homeassistant/components/trafikverket_weatherstation/sensor.py
-    homeassistant/components/transmission/*
+    homeassistant/components/transmission/__init__.py
+    homeassistant/components/transmission/sensor.py
+    homeassistant/components/transmission/switch.py
+    homeassistant/components/transmission/const.py
+    homeassistant/components/transmission/errors.py
     homeassistant/components/travisci/sensor.py
     homeassistant/components/tuya/*
     homeassistant/components/twentemilieu/const.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -283,6 +283,7 @@ homeassistant/components/tplink/* @rytilahti
 homeassistant/components/traccar/* @ludeeus
 homeassistant/components/tradfri/* @ggravlingen
 homeassistant/components/trafikverket_train/* @endor-force
+homeassistant/components/transmission/* @engrbm87
 homeassistant/components/tts/* @robbiet480
 homeassistant/components/twentemilieu/* @frenck
 homeassistant/components/twilio_call/* @robbiet480

--- a/homeassistant/components/transmission/.translations/en.json
+++ b/homeassistant/components/transmission/.translations/en.json
@@ -20,7 +20,7 @@
             }
         },
         "error": {
-            "wrong_cerdentials": "Wrong username or password",
+            "wrong_credentials": "Wrong username or password",
             "cannot_connect": "Unable to Connect to host"
         },
         "abort": {

--- a/homeassistant/components/transmission/.translations/en.json
+++ b/homeassistant/components/transmission/.translations/en.json
@@ -3,7 +3,7 @@
         "title": "Transmission",
         "step": {
             "user": {
-                "title": "Set up Transmission Client",
+                "title": "Setup Transmission Client",
                 "data": {
                     "name": "Name",
                     "host": "Host",
@@ -15,21 +15,13 @@
             "options": {
                 "title": "Configure Options",
                 "data": {
-                    "active_torrents": "Active Torrents",
-                    "current_status": "Current Status",
-                    "download_speed": "Download Speed [MB/s]",
-                    "paused_torrents": "Pause Torrents",
-                    "total_torrents": "Total Torrents",
-                    "upload_speed": "Upload Speed [MB/s]",
-                    "completed_torrents": "Completed torrents (seeding)",
-                    "started_torrents": "Started torrents (downloading)",
-                    "turtle_mode": "‘Turtle mode’ switch",
                     "scan_interval": "Update frequency"
                 }
             }
         },
         "error": {
-            "cannot_connect": "Unable to Connect to Client"
+            "wrong_cerdentials": "Wrong username or password",
+            "cannot_connect": "Unable to Connect to host"
         },
         "abort": {
             "one_instance_allowed": "Only a single instance is necessary."
@@ -40,15 +32,6 @@
             "init": {
                 "description": "Configure options for Transmission",
                 "data": {
-                    "active_torrents": "Active Torrents",
-                    "current_status": "Current Status",
-                    "download_speed": "Download Speed [MB/s]",
-                    "paused_torrents": "Pause Torrents",
-                    "total_torrents": "Total Torrents",
-                    "upload_speed": "Upload Speed [MB/s]",
-                    "completed_torrents": "Completed torrents (seeding)",
-                    "started_torrents": "Started torrents (downloading)",
-                    "turtle_mode": "‘Turtle mode’ switch",
                     "scan_interval": "Update frequency"
                 }
             }

--- a/homeassistant/components/transmission/.translations/en.json
+++ b/homeassistant/components/transmission/.translations/en.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "title": "Transmission",
+        "step": {
+            "user": {
+                "title": "Set up Transmission Client",
+                "data": {
+                    "name": "Name",
+                    "host": "Host",
+                    "username": "User name",
+                    "password": "Password",
+                    "port": "Port"
+                }
+            },
+            "options": {
+                "title": "Configure Options",
+                "data": {
+                    "active_torrents": "Active Torrents",
+                    "current_status": "Current Status",
+                    "download_speed": "Download Speed [MB/s]",
+                    "paused_torrents": "Pause Torrents",
+                    "total_torrents": "Total Torrents",
+                    "upload_speed": "Upload Speed [MB/s]",
+                    "completed_torrents": "Completed torrents (seeding)",
+                    "started_torrents": "Started torrents (downloading)",
+                    "turtle_mode": "‘Turtle mode’ switch",
+                    "scan_interval": "Update frequency"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Unable to Connect to Client"
+        },
+        "abort": {
+            "one_instance_allowed": "Only a single instance is necessary."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "description": "Configure options for Transmission",
+                "data": {
+                    "active_torrents": "Active Torrents",
+                    "current_status": "Current Status",
+                    "download_speed": "Download Speed [MB/s]",
+                    "paused_torrents": "Pause Torrents",
+                    "total_torrents": "Total Torrents",
+                    "upload_speed": "Upload Speed [MB/s]",
+                    "completed_torrents": "Completed torrents (seeding)",
+                    "started_torrents": "Started torrents (downloading)",
+                    "turtle_mode": "‘Turtle mode’ switch",
+                    "scan_interval": "Update frequency"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -111,12 +111,12 @@ async def get_api(hass, host, port, username=None, password=None):
         if "401: Unauthorized" in str(error):
             _LOGGER.error("Credentials for Transmission client are not valid")
             raise AuthenticationError
-        elif "111: Connection refused" in str(error):
+        if "111: Connection refused" in str(error):
             _LOGGER.error("Connecting to the Transmission client failed")
             raise CannotConnect
-        else:
-            _LOGGER.error(error)
-            raise UnknownError
+
+        _LOGGER.error(error)
+        raise UnknownError
 
 
 async def async_populate_options(hass, config_entry):

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -2,8 +2,11 @@
 from datetime import timedelta
 import logging
 
+import transmissionrpc
+from transmissionrpc.error import TransmissionError
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_HOST,
     CONF_MONITORED_CONDITIONS,
@@ -13,36 +16,26 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
-from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
-from homeassistant.helpers.event import track_time_interval
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import (
+    ATTR_TORRENT,
+    CONF_SENSOR_TYPES,
+    CONF_TURTLE_MODE,
+    DATA_TRANSMISSION,
+    DATA_UPDATED,
+    DOMAIN,
+    SERVICE_ADD_TORRENT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "transmission"
-DATA_UPDATED = "transmission_data_updated"
-DATA_TRANSMISSION = "data_transmission"
 
 DEFAULT_NAME = "Transmission"
 DEFAULT_PORT = 9091
-TURTLE_MODE = "turtle_mode"
-
-SENSOR_TYPES = {
-    "active_torrents": ["Active Torrents", None],
-    "current_status": ["Status", None],
-    "download_speed": ["Down Speed", "MB/s"],
-    "paused_torrents": ["Paused Torrents", None],
-    "total_torrents": ["Total Torrents", None],
-    "upload_speed": ["Up Speed", "MB/s"],
-    "completed_torrents": ["Completed Torrents", None],
-    "started_torrents": ["Started Torrents", None],
-}
-
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=120)
-
-ATTR_TORRENT = "torrent"
-
-SERVICE_ADD_TORRENT = "add_torrent"
+DEFAULT_SCAN_INTERVAL = 120
 
 SERVICE_ADD_TORRENT_SCHEMA = vol.Schema({vol.Required(ATTR_TORRENT): cv.string})
 
@@ -55,13 +48,13 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_USERNAME): cv.string,
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                vol.Optional(TURTLE_MODE, default=False): cv.boolean,
+                vol.Optional(CONF_TURTLE_MODE, default=False): cv.boolean,
                 vol.Optional(
                     CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                 ): cv.time_period,
                 vol.Optional(
                     CONF_MONITORED_CONDITIONS, default=["current_status"]
-                ): vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+                ): vol.All(cv.ensure_list, [vol.In(CONF_SENSOR_TYPES)]),
             }
         )
     },
@@ -69,63 +62,121 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass, config):
-    """Set up the Transmission Component."""
-    host = config[DOMAIN][CONF_HOST]
-    username = config[DOMAIN].get(CONF_USERNAME)
-    password = config[DOMAIN].get(CONF_PASSWORD)
-    port = config[DOMAIN][CONF_PORT]
-    scan_interval = config[DOMAIN][CONF_SCAN_INTERVAL]
-
-    import transmissionrpc
-    from transmissionrpc.error import TransmissionError
-
-    try:
-        api = transmissionrpc.Client(host, port=port, user=username, password=password)
-        api.session_stats()
-    except TransmissionError as error:
-        if str(error).find("401: Unauthorized"):
-            _LOGGER.error("Credentials for" " Transmission client are not valid")
-        return False
-
-    tm_data = hass.data[DATA_TRANSMISSION] = TransmissionData(hass, config, api)
-
-    tm_data.update()
-    tm_data.init_torrent_list()
-
-    def refresh(event_time):
-        """Get the latest data from Transmission."""
-        tm_data.update()
-
-    track_time_interval(hass, refresh, scan_interval)
-
-    def add_torrent(service):
-        """Add new torrent to download."""
-        torrent = service.data[ATTR_TORRENT]
-        if torrent.startswith(
-            ("http", "ftp:", "magnet:")
-        ) or hass.config.is_allowed_path(torrent):
-            api.add_torrent(torrent)
-        else:
-            _LOGGER.warning(
-                "Could not add torrent: " "unsupported type or no permission"
+async def async_setup(hass, config):
+    """Set up the Transmission Component from config."""
+    if not hass.config_entries.async_entries(DOMAIN) and DOMAIN in config:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
             )
-
-    hass.services.register(
-        DOMAIN, SERVICE_ADD_TORRENT, add_torrent, schema=SERVICE_ADD_TORRENT_SCHEMA
-    )
-
-    sensorconfig = {
-        "sensors": config[DOMAIN][CONF_MONITORED_CONDITIONS],
-        "client_name": config[DOMAIN][CONF_NAME],
-    }
-
-    discovery.load_platform(hass, "sensor", DOMAIN, sensorconfig, config)
-
-    if config[DOMAIN][TURTLE_MODE]:
-        discovery.load_platform(hass, "switch", DOMAIN, sensorconfig, config)
+        )
 
     return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set up the Transmission Component."""
+    if not config_entry.options:
+        await async_populate_options(hass, config_entry)
+
+    client = TransmissionClient(hass, config_entry)
+    if not await client.async_setup():
+        return False
+
+    return True
+
+
+async def async_populate_options(hass, config_entry):
+    """Populate default options for Transmission Client."""
+    options = {}
+    options[CONF_MONITORED_CONDITIONS] = {}
+    for sensor in CONF_SENSOR_TYPES:
+        options[CONF_MONITORED_CONDITIONS][sensor] = config_entry.data["options"].get(
+            sensor, False
+        )
+    options[CONF_TURTLE_MODE] = config_entry.data["options"].get(
+        CONF_TURTLE_MODE, False
+    )
+    options[CONF_SCAN_INTERVAL] = config_entry.data["options"].get(
+        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+    )
+
+    hass.config_entries.async_update_entry(config_entry, options=options)
+
+
+async def async_unload_entry(hass, entry):
+    """Unload Transmission Entry from config_entry."""
+    hass.services.async_remove(DOMAIN, SERVICE_ADD_TORRENT)
+    return True
+
+
+class TransmissionClient:
+    """Transmission Client Object."""
+
+    def __init__(self, hass, config_entry):
+        """Initialize the Transmission RPC API."""
+        self.hass = hass
+        self.config_entry = config_entry
+        self.host = self.config_entry.data[CONF_HOST]
+        self.username = self.config_entry.data.get(CONF_USERNAME)
+        self.password = self.config_entry.data.get(CONF_PASSWORD)
+        self.port = self.config_entry.data[CONF_PORT]
+        self.scan_interval = self.config_entry.options.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+
+    async def async_setup(self):
+        """Set up the Transmission client."""
+        hass = self.hass
+        try:
+            api = transmissionrpc.Client(
+                self.host, port=self.port, user=self.username, password=self.password
+            )
+            api.session_stats()
+        except TransmissionError as error:
+            if str(error).find("401: Unauthorized"):
+                _LOGGER.error("Credentials for" " Transmission client are not valid")
+            return False
+        tm_data = self.hass.data[DATA_TRANSMISSION] = TransmissionData(
+            self.hass, self.config_entry, api
+        )
+
+        tm_data.update()
+        await tm_data.async_init_torrent_list()
+
+        def refresh(event_time):
+            """Get the latest data from Transmission."""
+            tm_data.update()
+
+        async_track_time_interval(
+            self.hass, refresh, timedelta(seconds=self.scan_interval)
+        )
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(self.config_entry, "sensor")
+        )
+        if self.config_entry.options.get(CONF_TURTLE_MODE):
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(
+                    self.config_entry, "switch"
+                )
+            )
+
+        def add_torrent(self, service):
+            """Add new torrent to download."""
+            torrent = service.data[ATTR_TORRENT]
+            if torrent.startswith(
+                ("http", "ftp:", "magnet:")
+            ) or self.hass.config.is_allowed_path(torrent):
+                self.api.add_torrent(torrent)
+            else:
+                _LOGGER.warning(
+                    "Could not add torrent: " "unsupported type or no permission"
+                )
+
+        hass.services.async_register(
+            DOMAIN, SERVICE_ADD_TORRENT, add_torrent, schema=SERVICE_ADD_TORRENT_SCHEMA
+        )
+        return True
 
 
 class TransmissionData:
@@ -141,11 +192,12 @@ class TransmissionData:
         self.completed_torrents = []
         self.started_torrents = []
         self.hass = hass
+        self.scan_interval = timedelta(
+            seconds=config.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        )
 
     def update(self):
         """Get the latest data from Transmission instance."""
-        from transmissionrpc.error import TransmissionError
-
         try:
             self.data = self._api.session_stats()
             self.torrents = self._api.get_torrents()
@@ -162,7 +214,7 @@ class TransmissionData:
             self.available = False
             _LOGGER.error("Unable to connect to Transmission client")
 
-    def init_torrent_list(self):
+    async def async_init_torrent_list(self):
         """Initialize torrent lists."""
         self.torrents = self._api.get_torrents()
         self.completed_torrents = [

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -43,7 +43,7 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             self.config[CONF_NAME] = user_input.pop(CONF_NAME)
             try:
-                get_api(**user_input)
+                await get_api(**user_input)
                 self.config.update(user_input)
                 if "options" not in self.config:
                     self.config["options"] = {CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL}
@@ -73,9 +73,7 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_config):
         """Import from Transmission client config."""
         self.config["options"] = {
-            CONF_SCAN_INTERVAL: import_config.pop(
-                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-            )
+            CONF_SCAN_INTERVAL: import_config.pop(CONF_SCAN_INTERVAL).seconds
         }
 
         return await self.async_step_user(user_input=import_config)

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -1,0 +1,165 @@
+"""Config flow for Transmission Bittorent Client."""
+import transmissionrpc
+from transmissionrpc.error import TransmissionError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.core import callback
+
+from .const import (
+    CONF_SENSOR_TYPES,
+    CONF_TURTLE_MODE,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+
+
+class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a UniFi config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return TransmissionOptionsFlowHandler(config_entry)
+
+    def __init__(self):
+        """Initialize the Transmission flow."""
+        self.config = None
+        self.errors = {}
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if self.hass.config_entries.async_entries(DOMAIN):
+            return self.async_abort(reason="one_instance_allowed")
+
+        if user_input is not None:
+            valid = await self.is_valid(user_input)
+            if valid:
+                self.config = user_input
+                return await self.async_step_options()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+                    vol.Required(CONF_HOST): str,
+                    vol.Optional(CONF_USERNAME): str,
+                    vol.Optional(CONF_PASSWORD): str,
+                    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                }
+            ),
+            errors=self.errors,
+        )
+
+    async def is_valid(self, user_input):
+        """Validate connection to the Transmission Client."""
+        try:
+            transmissionrpc.Client(
+                user_input[CONF_HOST],
+                port=user_input[CONF_PORT],
+                user=user_input.get(CONF_USERNAME),
+                password=user_input.get(CONF_PASSWORD),
+            )
+            return True
+
+        except TransmissionError as error:
+            if str(error).find("401: Unauthorized"):
+                self.errors["base"] = "cannot_connect"
+
+        return False
+
+    async def async_step_options(self, user_input=None):
+        """Set options for the Transmission Client."""
+        if user_input is not None:
+            self.config["options"] = user_input
+            return self.async_create_entry(
+                title=self.config[CONF_NAME], data=self.config
+            )
+
+        options = {
+            vol.Optional(CONF_TURTLE_MODE, default=False): bool,
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
+        }
+        for sensor in CONF_SENSOR_TYPES:
+            options.update(
+                {vol.Optional(sensor, default=CONF_SENSOR_TYPES[sensor][2]): bool}
+            )
+
+        return self.async_show_form(step_id="options", data_schema=vol.Schema(options))
+
+    async def async_step_import(self, import_config):
+        """Import from Transmission client config."""
+        config = {
+            CONF_NAME: import_config.get(CONF_NAME, DEFAULT_NAME),
+            CONF_HOST: import_config[CONF_HOST],
+            CONF_USERNAME: import_config.get(CONF_USERNAME),
+            CONF_PASSWORD: import_config.get(CONF_PASSWORD),
+            CONF_PORT: import_config.get(CONF_PORT, DEFAULT_PORT),
+        }
+
+        return await self.async_step_user(user_input=config)
+
+
+class TransmissionOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Transmission client options."""
+
+    def __init__(self, config_entry):
+        """Initialize Transmission options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Transmission options."""
+        if user_input is not None:
+            options = {}
+            options[CONF_MONITORED_CONDITIONS] = {}
+            for sensor in CONF_SENSOR_TYPES:
+                options[CONF_MONITORED_CONDITIONS][sensor] = user_input[sensor]
+            options[CONF_TURTLE_MODE] = user_input[CONF_TURTLE_MODE]
+            options[CONF_SCAN_INTERVAL] = user_input[CONF_SCAN_INTERVAL]
+
+            return self.async_create_entry(title="", data=options)
+
+        options = {
+            vol.Optional(
+                CONF_TURTLE_MODE,
+                default=self.config_entry.options.get(
+                    CONF_TURTLE_MODE,
+                    self.config_entry.data["options"][CONF_TURTLE_MODE],
+                ),
+            ): bool,
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=self.config_entry.options.get(
+                    CONF_SCAN_INTERVAL,
+                    self.config_entry.data["options"][CONF_SCAN_INTERVAL],
+                ),
+            ): int,
+        }
+        for sensor in CONF_SENSOR_TYPES:
+            options.update(
+                {
+                    vol.Optional(
+                        sensor,
+                        default=self.config_entry.options[
+                            CONF_MONITORED_CONDITIONS
+                        ].get(sensor, self.config_entry.data["options"][sensor]),
+                    ): bool
+                }
+            )
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.core import callback
 
 from . import get_api
 from .const import DEFAULT_NAME, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
-from .errors import AuthenticationError, CannotConnect
+from .errors import AuthenticationError, CannotConnect, UnknownError
 
 
 class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -53,8 +53,8 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except AuthenticationError:
                 self.errors[CONF_USERNAME] = "wrong_credentials"
                 self.errors[CONF_PASSWORD] = "wrong_credentials"
-            except CannotConnect:
-                self.errors[CONF_HOST] = "cannot_connect"
+            except (CannotConnect, UnknownError):
+                self.errors["base"] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -43,7 +43,7 @@ class TransmissionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             self.config[CONF_NAME] = user_input.pop(CONF_NAME)
             try:
-                await get_api(**user_input)
+                await get_api(self.hass, **user_input)
                 self.config.update(user_input)
                 if "options" not in self.config:
                     self.config["options"] = {CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL}

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -1,24 +1,23 @@
 """Constants for the Transmission Bittorent Client component."""
 DOMAIN = "transmission"
 
-CONF_TURTLE_MODE = "turtle_mode"
-CONF_SENSOR_TYPES = {
-    "active_torrents": ["Active Torrents", None, False],
-    "current_status": ["Status", None, True],
-    "download_speed": ["Down Speed", "MB/s", False],
-    "paused_torrents": ["Paused Torrents", None, False],
-    "total_torrents": ["Total Torrents", None, False],
-    "upload_speed": ["Up Speed", "MB/s", False],
-    "completed_torrents": ["Completed Torrents", None, False],
-    "started_torrents": ["Started Torrents", None, False],
+SENSOR_TYPES = {
+    "active_torrents": ["Active Torrents", None],
+    "current_status": ["Status", None],
+    "download_speed": ["Down Speed", "MB/s"],
+    "paused_torrents": ["Paused Torrents", None],
+    "total_torrents": ["Total Torrents", None],
+    "upload_speed": ["Up Speed", "MB/s"],
+    "completed_torrents": ["Completed Torrents", None],
+    "started_torrents": ["Started Torrents", None],
 }
+SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 
 DEFAULT_NAME = "Transmission"
 DEFAULT_PORT = 9091
 DEFAULT_SCAN_INTERVAL = 120
 
 ATTR_TORRENT = "torrent"
-
 SERVICE_ADD_TORRENT = "add_torrent"
 
 DATA_UPDATED = "transmission_data_updated"

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -1,0 +1,25 @@
+"""Constants for the Transmission Bittorent Client component."""
+DOMAIN = "transmission"
+
+CONF_TURTLE_MODE = "turtle_mode"
+CONF_SENSOR_TYPES = {
+    "active_torrents": ["Active Torrents", None, False],
+    "current_status": ["Status", None, True],
+    "download_speed": ["Down Speed", "MB/s", False],
+    "paused_torrents": ["Paused Torrents", None, False],
+    "total_torrents": ["Total Torrents", None, False],
+    "upload_speed": ["Up Speed", "MB/s", False],
+    "completed_torrents": ["Completed Torrents", None, False],
+    "started_torrents": ["Started Torrents", None, False],
+}
+
+DEFAULT_NAME = "Transmission"
+DEFAULT_PORT = 9091
+DEFAULT_SCAN_INTERVAL = 120
+
+ATTR_TORRENT = "torrent"
+
+SERVICE_ADD_TORRENT = "add_torrent"
+
+DATA_UPDATED = "transmission_data_updated"
+DATA_TRANSMISSION = "data_transmission"

--- a/homeassistant/components/transmission/errors.py
+++ b/homeassistant/components/transmission/errors.py
@@ -1,0 +1,10 @@
+"""Errors for the Transmission component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class AuthenticationError(HomeAssistantError):
+    """Wrong Username or Password."""
+
+
+class CannotConnect(HomeAssistantError):
+    """Unable to connect to client."""

--- a/homeassistant/components/transmission/errors.py
+++ b/homeassistant/components/transmission/errors.py
@@ -8,3 +8,7 @@ class AuthenticationError(HomeAssistantError):
 
 class CannotConnect(HomeAssistantError):
     """Unable to connect to client."""
+
+
+class UnknownError(HomeAssistantError):
+    """Unknown Error."""

--- a/homeassistant/components/transmission/manifest.json
+++ b/homeassistant/components/transmission/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "transmission",
   "name": "Transmission",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/transmission",
   "requirements": [
     "transmissionrpc==0.11"

--- a/homeassistant/components/transmission/manifest.json
+++ b/homeassistant/components/transmission/manifest.json
@@ -7,5 +7,7 @@
     "transmissionrpc==0.11"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@engrbm87"
+  ]
 }

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -1,41 +1,39 @@
 """Support for monitoring the Transmission BitTorrent client API."""
-from datetime import timedelta
 import logging
 
-from homeassistant.const import STATE_IDLE
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, STATE_IDLE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from . import DATA_TRANSMISSION, DATA_UPDATED, SENSOR_TYPES
+from .const import CONF_SENSOR_TYPES, DATA_TRANSMISSION, DATA_UPDATED
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = "Transmission"
-
-SCAN_INTERVAL = timedelta(seconds=120)
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Import config from configuration.yaml."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Transmission sensors."""
-    if discovery_info is None:
-        return
 
     transmission_api = hass.data[DATA_TRANSMISSION]
-    monitored_variables = discovery_info["sensors"]
-    name = discovery_info["client_name"]
+    name = config_entry.data[CONF_NAME]
 
     dev = []
-    for sensor_type in monitored_variables:
-        dev.append(
-            TransmissionSensor(
-                sensor_type,
-                transmission_api,
-                name,
-                SENSOR_TYPES[sensor_type][0],
-                SENSOR_TYPES[sensor_type][1],
+    for sensor_type in CONF_SENSOR_TYPES:
+        if config_entry.options[CONF_MONITORED_CONDITIONS].get(sensor_type):
+            dev.append(
+                TransmissionSensor(
+                    sensor_type,
+                    transmission_api,
+                    name,
+                    CONF_SENSOR_TYPES[sensor_type][0],
+                    CONF_SENSOR_TYPES[sensor_type][1],
+                )
             )
-        )
 
     async_add_entities(dev, True)
 

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -1,12 +1,12 @@
 """Support for monitoring the Transmission BitTorrent client API."""
 import logging
 
-from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, STATE_IDLE
+from homeassistant.const import CONF_NAME, STATE_IDLE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from .const import CONF_SENSOR_TYPES, DATA_TRANSMISSION, DATA_UPDATED
+from .const import DATA_TRANSMISSION, DATA_UPDATED, DOMAIN, SENSOR_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,21 +19,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Transmission sensors."""
 
-    transmission_api = hass.data[DATA_TRANSMISSION]
+    transmission_api = hass.data[DOMAIN][DATA_TRANSMISSION]
     name = config_entry.data[CONF_NAME]
 
     dev = []
-    for sensor_type in CONF_SENSOR_TYPES:
-        if config_entry.options[CONF_MONITORED_CONDITIONS].get(sensor_type):
-            dev.append(
-                TransmissionSensor(
-                    sensor_type,
-                    transmission_api,
-                    name,
-                    CONF_SENSOR_TYPES[sensor_type][0],
-                    CONF_SENSOR_TYPES[sensor_type][1],
-                )
+    for sensor_type in SENSOR_TYPES:
+        dev.append(
+            TransmissionSensor(
+                sensor_type,
+                transmission_api,
+                name,
+                SENSOR_TYPES[sensor_type][0],
+                SENSOR_TYPES[sensor_type][1],
             )
+        )
 
     async_add_entities(dev, True)
 

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -3,4 +3,4 @@ add_torrent:
   fields:
     torrent:
       description: URL, magnet link or Base64 encoded file.
-      example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent}
+      example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -20,7 +20,7 @@
             }
         },
         "error": {
-            "wrong_cerdentials": "Wrong username or password",
+            "wrong_credentials": "Wrong username or password",
             "cannot_connect": "Unable to Connect to host"
         },
         "abort": {

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -15,21 +15,13 @@
             "options": {
                 "title": "Configure Options",
                 "data": {
-                    "active_torrents": "Active Torrents",
-                    "current_status": "Current Status",
-                    "download_speed": "Download Speed [MB/s]",
-                    "paused_torrents": "Pause Torrents",
-                    "total_torrents": "Total Torrents",
-                    "upload_speed": "Upload Speed [MB/s]",
-                    "completed_torrents": "Completed torrents (seeding)",
-                    "started_torrents": "Started torrents (downloading)",
-                    "turtle_mode": "‘Turtle mode’ switch",
                     "scan_interval": "Update frequency"
                 }
             }
         },
         "error": {
-            "cannot_connect": "Unable to Connect to Client"
+            "wrong_cerdentials": "Wrong username or password",
+            "cannot_connect": "Unable to Connect to host"
         },
         "abort": {
             "one_instance_allowed": "Only a single instance is necessary."
@@ -40,15 +32,6 @@
             "init": {
                 "description": "Configure options for Transmission",
                 "data": {
-                    "active_torrents": "Active Torrents",
-                    "current_status": "Current Status",
-                    "download_speed": "Download Speed [MB/s]",
-                    "paused_torrents": "Pause Torrents",
-                    "total_torrents": "Total Torrents",
-                    "upload_speed": "Upload Speed [MB/s]",
-                    "completed_torrents": "Completed torrents (seeding)",
-                    "started_torrents": "Started torrents (downloading)",
-                    "turtle_mode": "‘Turtle mode’ switch",
                     "scan_interval": "Update frequency"
                 }
             }

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -1,0 +1,57 @@
+{
+    "config": {
+        "title": "Transmission",
+        "step": {
+            "user": {
+                "title": "Setup Transmission Client",
+                "data": {
+                    "name": "Name",
+                    "host": "Host",
+                    "username": "User name",
+                    "password": "Password",
+                    "port": "Port"
+                }
+            },
+            "options": {
+                "title": "Configure Options",
+                "data": {
+                    "active_torrents": "Active Torrents",
+                    "current_status": "Current Status",
+                    "download_speed": "Download Speed [MB/s]",
+                    "paused_torrents": "Pause Torrents",
+                    "total_torrents": "Total Torrents",
+                    "upload_speed": "Upload Speed [MB/s]",
+                    "completed_torrents": "Completed torrents (seeding)",
+                    "started_torrents": "Started torrents (downloading)",
+                    "turtle_mode": "‘Turtle mode’ switch",
+                    "scan_interval": "Update frequency"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Unable to Connect to Client"
+        },
+        "abort": {
+            "one_instance_allowed": "Only a single instance is necessary."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "description": "Configure options for Transmission",
+                "data": {
+                    "active_torrents": "Active Torrents",
+                    "current_status": "Current Status",
+                    "download_speed": "Download Speed [MB/s]",
+                    "paused_torrents": "Pause Torrents",
+                    "total_torrents": "Total Torrents",
+                    "upload_speed": "Upload Speed [MB/s]",
+                    "completed_torrents": "Completed torrents (seeding)",
+                    "started_torrents": "Started torrents (downloading)",
+                    "turtle_mode": "‘Turtle mode’ switch",
+                    "scan_interval": "Update frequency"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -61,6 +61,11 @@ class TransmissionSwitch(ToggleEntity):
         """Return true if device is on."""
         return self._state == STATE_ON
 
+    @property
+    def available(self):
+        """Could the device be accessed during the last update call."""
+        return self._transmission_api.available
+
     def turn_on(self, **kwargs):
         """Turn the device on."""
         if self.type == "on_off":

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -23,12 +23,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     name = config_entry.data[CONF_NAME]
 
     dev = []
-    for switch_type in SWITCH_TYPES:
-        dev.append(
-            TransmissionSwitch(
-                switch_type, SWITCH_TYPES[switch_type], transmission_api, name
-            )
-        )
+    for switch_type, switch_name in SWITCH_TYPES.items():
+        dev.append(TransmissionSwitch(switch_type, switch_name, transmission_api, name))
 
     async_add_entities(dev, True)
 
@@ -73,7 +69,7 @@ class TransmissionSwitch(ToggleEntity):
         elif self.type == "turtle_mode":
             _LOGGING.debug("Turning Turtle Mode of Transmission on")
             self._transmission_api.set_alt_speed_enabled(True)
-        self._transmission_api.request_update()
+        self._transmission_api.update()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
@@ -83,7 +79,7 @@ class TransmissionSwitch(ToggleEntity):
         if self.type == "turtle_mode":
             _LOGGING.debug("Turning Turtle Mode of Transmission off")
             self._transmission_api.set_alt_speed_enabled(False)
-        self._transmission_api.request_update()
+        self._transmission_api.update()
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -1,7 +1,7 @@
 """Support for setting the Transmission BitTorrent client Turtle Mode."""
 import logging
 
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import ToggleEntity
@@ -10,17 +10,17 @@ from . import DATA_TRANSMISSION, DATA_UPDATED
 
 _LOGGING = logging.getLogger(__name__)
 
-DEFAULT_NAME = "Transmission Turtle Mode"
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Transmission switch."""
-    if discovery_info is None:
-        return
+    """Import config from configuration.yaml."""
+    pass
 
-    component_name = DATA_TRANSMISSION
-    transmission_api = hass.data[component_name]
-    name = discovery_info["client_name"]
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Transmission switch."""
+
+    transmission_api = hass.data[DATA_TRANSMISSION]
+    name = config_entry.data[CONF_NAME]
 
     async_add_entities([TransmissionSwitch(transmission_api, name)], True)
 
@@ -74,7 +74,7 @@ class TransmissionSwitch(ToggleEntity):
     def _schedule_immediate_update(self):
         self.async_schedule_update_ha_state(True)
 
-    def update(self):
+    async def async_update(self):
         """Get the latest data from Transmission and updates the state."""
         active = self.transmission_client.get_alt_speed_enabled()
 

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -6,7 +6,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import ToggleEntity
 
-from . import DATA_TRANSMISSION, DATA_UPDATED
+from .const import DATA_TRANSMISSION, DATA_UPDATED, DOMAIN, SWITCH_TYPES
 
 _LOGGING = logging.getLogger(__name__)
 
@@ -19,25 +19,36 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Transmission switch."""
 
-    transmission_api = hass.data[DATA_TRANSMISSION]
+    transmission_api = hass.data[DOMAIN][DATA_TRANSMISSION]
     name = config_entry.data[CONF_NAME]
 
-    async_add_entities([TransmissionSwitch(transmission_api, name)], True)
+    dev = []
+    for switch_type in SWITCH_TYPES:
+        dev.append(
+            TransmissionSwitch(
+                switch_type, SWITCH_TYPES[switch_type], transmission_api, name
+            )
+        )
+
+    async_add_entities(dev, True)
 
 
 class TransmissionSwitch(ToggleEntity):
     """Representation of a Transmission switch."""
 
-    def __init__(self, transmission_client, name):
+    def __init__(self, switch_type, switch_name, transmission_api, name):
         """Initialize the Transmission switch."""
-        self._name = name
-        self.transmission_client = transmission_client
+        self._name = switch_name
+        self.client_name = name
+        self.type = switch_type
+        self._transmission_api = transmission_api
         self._state = STATE_OFF
+        self._data = None
 
     @property
     def name(self):
         """Return the name of the switch."""
-        return self._name
+        return f"{self.client_name} {self._name}"
 
     @property
     def state(self):
@@ -56,13 +67,23 @@ class TransmissionSwitch(ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        _LOGGING.debug("Turning Turtle Mode of Transmission on")
-        self.transmission_client.set_alt_speed_enabled(True)
+        if self.type == "on_off":
+            _LOGGING.debug("Starting all torrents")
+            self._transmission_api.start_torrents()
+        elif self.type == "turtle_mode":
+            _LOGGING.debug("Turning Turtle Mode of Transmission on")
+            self._transmission_api.set_alt_speed_enabled(True)
+        self._transmission_api.request_update()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        _LOGGING.debug("Turning Turtle Mode of Transmission off")
-        self.transmission_client.set_alt_speed_enabled(False)
+        if self.type == "on_off":
+            _LOGGING.debug("Stoping all torrents")
+            self._transmission_api.stop_torrents()
+        if self.type == "turtle_mode":
+            _LOGGING.debug("Turning Turtle Mode of Transmission off")
+            self._transmission_api.set_alt_speed_enabled(False)
+        self._transmission_api.request_update()
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -74,9 +95,16 @@ class TransmissionSwitch(ToggleEntity):
     def _schedule_immediate_update(self):
         self.async_schedule_update_ha_state(True)
 
-    async def async_update(self):
+    def update(self):
         """Get the latest data from Transmission and updates the state."""
-        active = self.transmission_client.get_alt_speed_enabled()
+        active = None
+        if self.type == "on_off":
+            self._data = self._transmission_api.data
+            if self._data:
+                active = self._data.activeTorrentCount > 0
+
+        elif self.type == "turtle_mode":
+            active = self._transmission_api.get_alt_speed_enabled()
 
         if active is None:
             return

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -3,6 +3,7 @@
 To update, run python3 -m script.hassfest
 """
 
+# fmt: off
 
 FLOWS = [
     "adguard",
@@ -68,5 +69,5 @@ FLOWS = [
     "wwlln",
     "zha",
     "zone",
-    "zwave",
+    "zwave"
 ]

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -56,6 +56,7 @@ FLOWS = [
     "tplink",
     "traccar",
     "tradfri",
+    "transmission",
     "twentemilieu",
     "twilio",
     "unifi",
@@ -67,5 +68,5 @@ FLOWS = [
     "wwlln",
     "zha",
     "zone",
-    "zwave"
+    "zwave",
 ]

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -399,6 +399,9 @@ statsd==3.2.1
 # homeassistant.components.toon
 toonapilib==3.2.4
 
+# homeassistant.components.transmission
+transmissionrpc==0.11
+
 # homeassistant.components.twentemilieu
 twentemilieu==0.1.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -161,6 +161,7 @@ TEST_REQUIREMENTS = (
     "srpenergy",
     "statsd",
     "toonapilib",
+    "transmissionrpc",
     "twentemilieu",
     "uvcclient",
     "vsure",

--- a/tests/components/transmission/__init__.py
+++ b/tests/components/transmission/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Transmission."""

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -1,0 +1,195 @@
+"""Tests for Met.no config flow."""
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from transmissionrpc.error import TransmissionError
+
+from homeassistant import data_entry_flow
+from homeassistant.components.transmission import config_flow
+from homeassistant.components.transmission.const import (
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+
+from tests.common import MockConfigEntry, mock_coro
+
+NAME = "Transmission"
+HOST = "192.168.1.100"
+USERNAME = "username"
+PASSWORD = "password"
+PORT = 9091
+SCAN_INTERVAL = 10
+
+
+@pytest.fixture(name="api")
+def mock_transmission_api():
+    """Mock an api."""
+    with patch("transmissionrpc.Client", return_value=mock_coro(True)):
+        yield
+
+
+@pytest.fixture(name="auth_error")
+def mock_api_authentication_error():
+    """Mock an api."""
+    with patch(
+        "transmissionrpc.Client", side_effect=TransmissionError("401: Unauthorized")
+    ):
+        yield
+
+
+@pytest.fixture(name="conn_error")
+def mock_api_connection_error():
+    """Mock an api."""
+    with patch(
+        "transmissionrpc.Client",
+        side_effect=TransmissionError("111: Connection refused"),
+    ):
+        yield
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    flow = config_flow.TransmissionFlowHandler()
+    flow.hass = hass
+    return flow
+
+
+async def test_flow_works(hass, api):
+    """Test user config."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # test with required fields only
+    result = await flow.async_step_user(
+        {CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
+    assert result["data"]["options"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
+
+    # test with all provided
+    result = await flow.async_step_user(
+        {
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_PORT: PORT,
+        }
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_PORT] == PORT
+    assert result["data"]["options"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
+
+
+async def test_import(hass, api):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with minimum fields only
+    result = await flow.async_step_import(
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_HOST: HOST,
+            CONF_PORT: DEFAULT_PORT,
+            CONF_SCAN_INTERVAL: timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+    assert result["data"][CONF_NAME] == DEFAULT_NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+    assert result["data"]["options"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
+
+    # import with all
+    result = await flow.async_step_import(
+        {
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_PORT: PORT,
+            CONF_SCAN_INTERVAL: timedelta(seconds=SCAN_INTERVAL),
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_PORT] == PORT
+    assert result["data"]["options"][CONF_SCAN_INTERVAL] == SCAN_INTERVAL
+
+
+async def test_integration_already_exists(hass, api):
+    """Test we only allow a single config flow."""
+    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "one_instance_allowed"
+
+
+async def test_error_on_wrong_credentials(hass, auth_error):
+    """Test with wrong credentials."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user(
+        {
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_PORT: PORT,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {
+        CONF_USERNAME: "wrong_credentials",
+        CONF_PASSWORD: "wrong_credentials",
+    }
+
+
+async def test_error_on_connection_failure(hass, conn_error):
+    """Test when connection to host fails."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user(
+        {
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_PORT: PORT,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_HOST: "cannot_connect"}

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for Met.no config flow."""
-import logging
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -24,8 +23,6 @@ from homeassistant.const import (
 )
 
 from tests.common import MockConfigEntry
-
-LOGGER = logging.getLogger(__name__)
 
 NAME = "Transmission"
 HOST = "192.168.1.100"
@@ -131,14 +128,13 @@ async def test_options(hass):
         },
         options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
     )
+    flow = init_config_flow(hass)
+    options_flow = flow.async_get_options_flow(entry)
 
-    flow = config_flow.TransmissionOptionsFlowHandler(entry)
-    flow.hass = hass
-
-    result = await flow.async_step_init()
+    result = await options_flow.async_step_init()
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
-    result = await flow.async_step_init({CONF_SCAN_INTERVAL: 10})
+    result = await options_flow.async_step_init({CONF_SCAN_INTERVAL: 10})
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"][CONF_SCAN_INTERVAL] == 10
 

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import MockConfigEntry
 
 NAME = "Transmission"
 HOST = "192.168.1.100"
@@ -35,7 +35,7 @@ SCAN_INTERVAL = 10
 @pytest.fixture(name="api")
 def mock_transmission_api():
     """Mock an api."""
-    with patch("transmissionrpc.Client", return_value=mock_coro(True)):
+    with patch("transmissionrpc.Client", return_value=True):
         yield
 
 


### PR DESCRIPTION
## Breaking Change:
The Transmission integration can now be configured through a config flow via `Integrations` in the GUI. Once configured all sensors and switches will be created and available for the user.
`monitored_conditions` has been removed so existing users need to update their configuration in `configuration.yaml` and remove monitored conditions. The existing configuration will be imported as an entry under Integrations.

## Description:
In addition to the previous sensors and switches that were available under `monitored_conditions` a new switch to `start` and `stop` all torrents has been added.
The update Interval is now an option that can be altered under `options`.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10293

## Example entry for `configuration.yaml` (if applicable):
```yaml
transmission:
  host: 192.168.1.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
