### PR TITLE
Don't run turn on script if tv already on

### DIFF
--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -192,7 +192,7 @@ class PhilipsTV(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn on the device."""
-        if self._on_script:
+        if self._on_script and not self._tv.on:
             self._on_script.run()
             self._update_soon(DELAY_ACTION_ON)
 


### PR DESCRIPTION
## Description:
Don't issue turn on action if tv is already considered on. An IR remote command for a philips tv can be just a toggle feature. So turn_on ends up being turn off.

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: philips_js
    host: 192.168.16.21
    name: Living Room TV
    turn_on_action:
      service: broadlink.send
      data:
        host: 192.168.0.107
        packet: 'JgBGAJKVETkRORA6ERQRFBEUERQRFBE5ETkQOhAVEBUQFREUEBUQOhEUERQRORE5EBURFBA6EBUQOhE5EBUQFRA6EDoRFBEADQUAAA=='
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
