### PR TITLE
Queensland Bushfire Alert icon for geolocation entities

### DIFF
--- a/homeassistant/components/qld_bushfire/geo_location.py
+++ b/homeassistant/components/qld_bushfire/geo_location.py
@@ -199,6 +199,11 @@ class QldBushfireLocationEvent(GeolocationEvent):
         self._status = feed_entry.status
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return "mdi:fire"
+
+    @property
     def source(self) -> str:
         """Return source value of this external event."""
         return SOURCE

--- a/tests/components/qld_bushfire/test_geo_location.py
+++ b/tests/components/qld_bushfire/test_geo_location.py
@@ -5,24 +5,24 @@ from unittest.mock import patch, MagicMock, call
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.components.qld_bushfire.geo_location import (
-    ATTR_EXTERNAL_ID,
-    SCAN_INTERVAL,
     ATTR_CATEGORY,
-    ATTR_STATUS,
+    ATTR_EXTERNAL_ID,
     ATTR_PUBLICATION_DATE,
+    ATTR_STATUS,
     ATTR_UPDATED_DATE,
+    SCAN_INTERVAL,
 )
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START,
-    CONF_RADIUS,
+    ATTR_ATTRIBUTION,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
-    ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    ATTR_ICON,
+    CONF_RADIUS,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed

--- a/tests/components/qld_bushfire/test_geo_location.py
+++ b/tests/components/qld_bushfire/test_geo_location.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    ATTR_ICON,
 )
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed
@@ -122,6 +123,7 @@ async def test_setup(hass):
                 ATTR_STATUS: "Status 1",
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "qld_bushfire",
+                ATTR_ICON: "mdi:fire",
             }
             assert float(state.state) == 15.5
 
@@ -135,6 +137,7 @@ async def test_setup(hass):
                 ATTR_FRIENDLY_NAME: "Title 2",
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "qld_bushfire",
+                ATTR_ICON: "mdi:fire",
             }
             assert float(state.state) == 20.5
 
@@ -148,6 +151,7 @@ async def test_setup(hass):
                 ATTR_FRIENDLY_NAME: "Title 3",
                 ATTR_UNIT_OF_MEASUREMENT: "km",
                 ATTR_SOURCE: "qld_bushfire",
+                ATTR_ICON: "mdi:fire",
             }
             assert float(state.state) == 25.5
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This adds a suitable icon to the geolocation entities created by the Queensland Bushfire Alert integration.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
