### PR TITLE
Add device automation action

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -107,7 +107,7 @@ async def websocket_device_automation_list_actions(hass, connection, msg):
     """Handle request for device actions."""
     device_id = msg["device_id"]
     actions = await _async_get_device_automations(hass, "async_get_actions", device_id)
-    connection.send_result(msg["id"], {"actions": actions})
+    connection.send_result(msg["id"], actions)
 
 
 @websocket_api.async_response

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -21,6 +21,9 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup(hass, config):
     """Set up device automation."""
     hass.components.websocket_api.async_register_command(
+        websocket_device_automation_list_actions
+    )
+    hass.components.websocket_api.async_register_command(
         websocket_device_automation_list_conditions
     )
     hass.components.websocket_api.async_register_command(
@@ -91,6 +94,20 @@ async def _async_get_device_automations(hass, fname, device_id):
             automations.extend(device_automation)
 
     return automations
+
+
+@websocket_api.async_response
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "device_automation/action/list",
+        vol.Required("device_id"): str,
+    }
+)
+async def websocket_device_automation_list_actions(hass, connection, msg):
+    """Handle request for device actions."""
+    device_id = msg["device_id"]
+    actions = await _async_get_device_automations(hass, "async_get_actions", device_id)
+    connection.send_result(msg["id"], {"actions": actions})
 
 
 @websocket_api.async_response

--- a/homeassistant/components/device_automation/const.py
+++ b/homeassistant/components/device_automation/const.py
@@ -1,5 +1,6 @@
 """Constants for device automations."""
 CONF_IS_OFF = "is_off"
 CONF_IS_ON = "is_on"
+CONF_TOGGLE = "toggle"
 CONF_TURN_OFF = "turn_off"
 CONF_TURN_ON = "turn_on"

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -1,5 +1,10 @@
 {
   "device_automation": {
+    "action_type": {
+      "toggle": "Toggle {name}",
+      "turn_on": "Turn on {name}",
+      "turn_off": "Turn off {name}"
+    },
     "condition_type": {
       "is_on": "{name} is on",
       "is_off": "{name} is off"

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     CONF_ALIAS,
     CONF_BELOW,
     CONF_CONDITION,
+    CONF_DEVICE,
     CONF_DOMAIN,
     CONF_ENTITY_ID,
     CONF_ENTITY_NAMESPACE,
@@ -861,6 +862,11 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
     }
 )
 
+DEVICE_ACTION_SCHEMA = vol.Schema(
+    {vol.Required(CONF_DEVICE): None, vol.Required(CONF_DOMAIN): str},
+    extra=vol.ALLOW_EXTRA,
+)
+
 SCRIPT_SCHEMA = vol.All(
     ensure_list,
     [
@@ -870,6 +876,7 @@ SCRIPT_SCHEMA = vol.All(
             _SCRIPT_WAIT_TEMPLATE_SCHEMA,
             EVENT_SCHEMA,
             CONDITION_SCHEMA,
+            DEVICE_ACTION_SCHEMA,
         )
     ],
 )

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -74,7 +74,7 @@ async def test_websocket_get_actions(hass, hass_ws_client, device_reg, entity_re
     assert msg["id"] == 1
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
-    actions = msg["result"]["actions"]
+    actions = msg["result"]
     assert _same_lists(actions, expected_actions)
 
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -31,6 +31,53 @@ def _same_lists(a, b):
     return True
 
 
+async def test_websocket_get_actions(hass, hass_ws_client, device_reg, entity_reg):
+    """Test we get the expected conditions from a light through websocket."""
+    await async_setup_component(hass, "device_automation", {})
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create("light", "test", "5678", device_id=device_entry.id)
+    expected_actions = [
+        {
+            "device": None,
+            "domain": "light",
+            "type": "turn_off",
+            "device_id": device_entry.id,
+            "entity_id": "light.test_5678",
+        },
+        {
+            "device": None,
+            "domain": "light",
+            "type": "turn_on",
+            "device_id": device_entry.id,
+            "entity_id": "light.test_5678",
+        },
+        {
+            "device": None,
+            "domain": "light",
+            "type": "toggle",
+            "device_id": device_entry.id,
+            "entity_id": "light.test_5678",
+        },
+    ]
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {"id": 1, "type": "device_automation/action/list", "device_id": device_entry.id}
+    )
+    msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    actions = msg["result"]["actions"]
+    assert _same_lists(actions, expected_actions)
+
+
 async def test_websocket_get_conditions(hass, hass_ws_client, device_reg, entity_reg):
     """Test we get the expected conditions from a light through websocket."""
     await async_setup_component(hass, "device_automation", {})

--- a/tests/components/light/test_device_automation.py
+++ b/tests/components/light/test_device_automation.py
@@ -46,6 +46,44 @@ def _same_lists(a, b):
     return True
 
 
+async def test_get_actions(hass, device_reg, entity_reg):
+    """Test we get the expected actions from a light."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create("light", "test", "5678", device_id=device_entry.id)
+    expected_actions = [
+        {
+            "device": None,
+            "domain": "light",
+            "type": "turn_off",
+            "device_id": device_entry.id,
+            "entity_id": "light.test_5678",
+        },
+        {
+            "device": None,
+            "domain": "light",
+            "type": "turn_on",
+            "device_id": device_entry.id,
+            "entity_id": "light.test_5678",
+        },
+        {
+            "device": None,
+            "domain": "light",
+            "type": "toggle",
+            "device_id": device_entry.id,
+            "entity_id": "light.test_5678",
+        },
+    ]
+    actions = await async_get_device_automations(
+        hass, "async_get_actions", device_entry.id
+    )
+    assert _same_lists(actions, expected_actions)
+
+
 async def test_get_conditions(hass, device_reg, entity_reg):
     """Test we get the expected conditions from a light."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -263,3 +301,78 @@ async def test_if_state(hass, calls):
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert calls[1].data["some"] == "is_off event - test_event2"
+
+
+async def test_action(hass, calls):
+    """Test for turn_on and turn_off actions."""
+    platform = getattr(hass.components, "test.light")
+
+    platform.init()
+    assert await async_setup_component(
+        hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
+    )
+
+    dev1, dev2, dev3 = platform.DEVICES
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "action": {
+                        "device": None,
+                        "domain": "light",
+                        "entity_id": dev1.entity_id,
+                        "type": "turn_off",
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event2"},
+                    "action": {
+                        "device": None,
+                        "domain": "light",
+                        "entity_id": dev1.entity_id,
+                        "type": "turn_on",
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event3"},
+                    "action": {
+                        "device": None,
+                        "domain": "light",
+                        "entity_id": dev1.entity_id,
+                        "type": "toggle",
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(dev1.entity_id).state == STATE_ON
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert hass.states.get(dev1.entity_id).state == STATE_OFF
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert hass.states.get(dev1.entity_id).state == STATE_OFF
+
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert hass.states.get(dev1.entity_id).state == STATE_ON
+
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert hass.states.get(dev1.entity_id).state == STATE_ON
+
+    hass.bus.async_fire("test_event3")
+    await hass.async_block_till_done()
+    assert hass.states.get(dev1.entity_id).state == STATE_OFF
+
+    hass.bus.async_fire("test_event3")
+    await hass.async_block_till_done()
+    assert hass.states.get(dev1.entity_id).state == STATE_ON


### PR DESCRIPTION
## Description:

Add websock command to query device for actions.

Conditions can be provided by the integration that provided the device or the entity integrations that the device has entities with.

As an example of the latter, this PR also adds `turn_on` and `turn_off` conditions to `light` entities.

This PR is intended as a step towards home-assistant/architecture#178

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
