### PR TITLE
Add plex server config options to media_player platform

### DIFF
--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -2,6 +2,7 @@
 DOMAIN = "plex"
 NAME_FORMAT = "Plex {}"
 
+DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 32400
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_SHOW_ALL_CONTROLS,
     CONF_REMOVE_UNAVAILABLE_CLIENTS,
     CONF_CLIENT_REMOVE_INTERVAL,
+    DEFAULT_HOST,
     DEFAULT_PORT,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
@@ -51,7 +52,6 @@ from .const import (
 )
 from .server import PlexServer
 
-DEFAULT_HOST = "localhost"
 SERVER_SETUP = "server_setup"
 
 _CONFIGURING = {}

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -20,6 +20,9 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
 )
 from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_SSL,
     CONF_URL,
     CONF_TOKEN,
     CONF_VERIFY_SSL,
@@ -39,6 +42,9 @@ from .const import (
     CONF_SHOW_ALL_CONTROLS,
     CONF_REMOVE_UNAVAILABLE_CLIENTS,
     CONF_CLIENT_REMOVE_INTERVAL,
+    DEFAULT_PORT,
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
     DOMAIN as PLEX_DOMAIN,
     NAME_FORMAT,
     PLEX_CONFIG_FILE,
@@ -52,6 +58,11 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_TOKEN): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
         vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
         vol.Optional(CONF_SHOW_ALL_CONTROLS, default=False): cv.boolean,
         vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True): cv.boolean,
@@ -98,6 +109,13 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         token = None
         has_ssl = False
         verify_ssl = True
+    elif config:
+        host = config.get(CONF_HOST)
+        port = config.get(CONF_PORT)
+        host = f"{host}:{port}"
+        token = config.get(CONF_TOKEN)
+        has_ssl = config.get(CONF_SSL)
+        verify_ssl = config.get(CONF_VERIFY_SSL)
     else:
         return
 

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -51,6 +51,7 @@ from .const import (
 )
 from .server import PlexServer
 
+DEFAULT_HOST = "localhost"
 SERVER_SETUP = "server_setup"
 
 _CONFIGURING = {}
@@ -58,7 +59,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
         vol.Optional(CONF_TOKEN): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -111,12 +111,12 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         has_ssl = False
         verify_ssl = True
     else:
-        host = config.get(CONF_HOST)
-        port = config.get(CONF_PORT)
+        host = config[CONF_HOST]
+        port = config[CONF_PORT]
         host = f"{host}:{port}"
         token = config.get(CONF_TOKEN)
-        has_ssl = config.get(CONF_SSL)
-        verify_ssl = config.get(CONF_VERIFY_SSL)
+        has_ssl = config[CONF_SSL]
+        verify_ssl = config[CONF_VERIFY_SSL]
 
     setup_plexserver(
         host, token, has_ssl, verify_ssl, hass, config, add_entities_callback

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -109,15 +109,13 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         token = None
         has_ssl = False
         verify_ssl = True
-    elif config:
+    else:
         host = config.get(CONF_HOST)
         port = config.get(CONF_PORT)
         host = f"{host}:{port}"
         token = config.get(CONF_TOKEN)
         has_ssl = config.get(CONF_SSL)
         verify_ssl = config.get(CONF_VERIFY_SSL)
-    else:
-        return
 
     setup_plexserver(
         host, token, has_ssl, verify_ssl, hass, config, add_entities_callback

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -19,10 +19,9 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-from .const import DEFAULT_PORT, DEFAULT_SSL, DEFAULT_VERIFY_SSL
+from .const import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_SSL, DEFAULT_VERIFY_SSL
 from .server import PlexServer
 
-DEFAULT_HOST = "localhost"
 DEFAULT_NAME = "Plex"
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description:
Adds config options to platform in addition to non-standard plex.conf file.

Continuation from https://github.com/home-assistant/home-assistant/pull/26157 & https://github.com/home-assistant/home-assistant/pull/26444

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
https://github.com/home-assistant/home-assistant.io/pull/10303

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: plex
    host: 10.0.10.5
    token: asdfasdf1234
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html