### PR TITLE
Refactor nzbget to support future platform changes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -435,6 +435,7 @@ omit =
     homeassistant/components/nuki/lock.py
     homeassistant/components/nut/sensor.py
     homeassistant/components/nx584/alarm_control_panel.py
+    homeassistant/components/nzbget/__init__.py
     homeassistant/components/nzbget/sensor.py
     homeassistant/components/obihai/*
     homeassistant/components/octoprint/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -197,6 +197,7 @@ homeassistant/components/nsw_fuel_station/* @nickw444
 homeassistant/components/nsw_rural_fire_service_feed/* @exxamalte
 homeassistant/components/nuki/* @pschmitt
 homeassistant/components/nws/* @MatthewFlamm
+homeassistant/components/nzbget/* @chriscla
 homeassistant/components/obihai/* @dshokouhi
 homeassistant/components/ohmconnect/* @robbiet480
 homeassistant/components/onboarding/* @home-assistant/core

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -7,15 +7,15 @@ import requests
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_SSL,
     CONF_HOST,
+    CONF_MONITORED_VARIABLES,
     CONF_NAME,
-    CONF_PORT,
     CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_SSL,
     CONF_USERNAME,
     CONTENT_TYPE_JSON,
-    CONF_MONITORED_VARIABLES,
-    CONF_SCAN_INTERVAL,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -21,7 +21,6 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import track_time_interval
 
-
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "nzbget"

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 import logging
 
-from aiohttp.hdrs import CONTENT_TYPE
+import pynzbgetapi
 import requests
 import voluptuous as vol
 

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -67,7 +67,7 @@ def setup(hass, config):
         _LOGGER.error("Error setting up NZBGet API: %s", conn_err)
         return False
 
-    _LOGGER.debug("Successfully validated NZBGet API connection.")
+    _LOGGER.debug("Successfully validated NZBGet API connection")
 
     nzbget_data = hass.data[DATA_NZBGET] = NZBGetData(hass, nzbget_api)
     nzbget_data.update()

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_SSL,
     CONF_USERNAME,
-    CONTENT_TYPE_JSON,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -70,24 +69,19 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the NZBGet sensors."""
     host = config[DOMAIN][CONF_HOST]
-    port = config[DOMAIN].get(CONF_PORT)
-    ssl = "s" if config[DOMAIN].get(CONF_SSL) else ""
+    port = config[DOMAIN][CONF_PORT]
+    ssl = "s" if config[DOMAIN][CONF_SSL] else ""
     name = config[DOMAIN][CONF_NAME]
     username = config[DOMAIN].get(CONF_USERNAME)
     password = config[DOMAIN].get(CONF_PASSWORD)
     monitored_types = config[DOMAIN].get(CONF_MONITORED_VARIABLES)
     scan_interval = config[DOMAIN].get(CONF_SCAN_INTERVAL)
 
-    url = f"http{ssl}://{host}:{port}/jsonrpc"
-
     try:
-        nzbget_api = NZBGetAPI(api_url=url, username=username, password=password)
-        nzbget_api.status()
+        nzbget_api = pynzbgetapi.NZBGetAPI(host, username, password, ssl, ssl, port)
+        nzbget_api.version()
         _LOGGER.debug("Successfully validated NZBGet API connection.")
-    except (
-        requests.exceptions.ConnectionError,
-        requests.exceptions.HTTPError,
-    ) as conn_err:
+    except pynzbgetapi.NZBGetAPIException as conn_err:
         _LOGGER.error("Error setting up NZBGet API: %s", conn_err)
         return False
 
@@ -125,45 +119,3 @@ class NZBGetData:
         except requests.exceptions.ConnectionError:
             self.available = False
             _LOGGER.error("Unable to refresh NZBGet data")
-
-
-class NZBGetAPI:
-    """Simple JSON-RPC wrapper for NZBGet's API."""
-
-    def __init__(self, api_url, username=None, password=None):
-        """Initialize NZBGet API and set headers needed later."""
-        self.api_url = api_url
-        self.headers = {CONTENT_TYPE: CONTENT_TYPE_JSON}
-
-        if username is not None and password is not None:
-            self.auth = (username, password)
-        else:
-            self.auth = None
-
-    def post(self, method, params=None):
-        """Send a POST request and return the response as a dict."""
-        payload = {"method": method}
-
-        if params:
-            payload["params"] = params
-        try:
-            response = requests.post(
-                self.api_url,
-                json=payload,
-                auth=self.auth,
-                headers=self.headers,
-                timeout=5,
-            )
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.ConnectionError as conn_exc:
-            _LOGGER.error(
-                "Failed to update NZBGet status from %s. Error: %s",
-                self.api_url,
-                conn_exc,
-            )
-            raise
-
-    def status(self):
-        """Update cached response."""
-        return self.post("status")["result"]

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -1,1 +1,170 @@
 """The nzbget component."""
+from datetime import timedelta
+import logging
+
+from aiohttp.hdrs import CONTENT_TYPE
+import requests
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_SSL,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONTENT_TYPE_JSON,
+    CONF_MONITORED_VARIABLES,
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import track_time_interval
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "nzbget"
+DATA_NZBGET = "data_nzbget"
+DATA_UPDATED = "nzbget_data_updated"
+
+DEFAULT_NAME = "NZBGet"
+DEFAULT_PORT = 6789
+
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=5)
+
+SENSOR_TYPES = {
+    "article_cache": ["ArticleCacheMB", "Article Cache", "MB"],
+    "average_download_rate": ["AverageDownloadRate", "Average Speed", "MB/s"],
+    "download_paused": ["DownloadPaused", "Download Paused", None],
+    "download_rate": ["DownloadRate", "Speed", "MB/s"],
+    "download_size": ["DownloadedSizeMB", "Size", "MB"],
+    "free_disk_space": ["FreeDiskSpaceMB", "Disk Free", "MB"],
+    "post_paused": ["PostPaused", "Post Processing Paused", None],
+    "remaining_size": ["RemainingSizeMB", "Queue Size", "MB"],
+    "uptime": ["UpTimeSec", "Uptime", "min"],
+}
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Optional(CONF_PASSWORD): cv.string,
+                vol.Optional(CONF_USERNAME): cv.string,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                ): cv.time_period,
+                vol.Optional(
+                    CONF_MONITORED_VARIABLES, default=["download_rate"]
+                ): vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+                vol.Optional(CONF_SSL, default=False): cv.boolean,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def setup(hass, config):
+    """Set up the NZBGet sensors."""
+    host = config[DOMAIN][CONF_HOST]
+    port = config[DOMAIN].get(CONF_PORT)
+    ssl = "s" if config[DOMAIN].get(CONF_SSL) else ""
+    name = config[DOMAIN][CONF_NAME]
+    username = config[DOMAIN].get(CONF_USERNAME)
+    password = config[DOMAIN].get(CONF_PASSWORD)
+    monitored_types = config[DOMAIN].get(CONF_MONITORED_VARIABLES)
+    scan_interval = config[DOMAIN].get(CONF_SCAN_INTERVAL)
+
+    url = f"http{ssl}://{host}:{port}/jsonrpc"
+
+    try:
+        nzbget_api = NZBGetAPI(api_url=url, username=username, password=password)
+        nzbget_api.status()
+        _LOGGER.debug("Successfully validated NZBGet API connection.")
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.HTTPError,
+    ) as conn_err:
+        _LOGGER.error("Error setting up NZBGet API: %s", conn_err)
+        return False
+
+    nzbget_data = hass.data[DATA_NZBGET] = NZBGetData(hass, nzbget_api)
+    nzbget_data.update()
+
+    def refresh(event_time):
+        """Get the latest data from NZBGet."""
+        nzbget_data.update()
+
+    track_time_interval(hass, refresh, scan_interval)
+
+    sensorconfig = {"sensors": monitored_types, "client_name": name}
+
+    hass.helpers.discovery.load_platform("sensor", DOMAIN, sensorconfig, config)
+
+    return True
+
+
+class NZBGetData:
+    """Get the latest data and update the states."""
+
+    def __init__(self, hass, api):
+        """Initialize the NZBGet RPC API."""
+        self.hass = hass
+        self.status = None
+        self.available = True
+        self._api = api
+
+    def update(self):
+        """Get the latest data from NZBGet instance."""
+        try:
+            self.status = self._api.status()
+            dispatcher_send(self.hass, DATA_UPDATED)
+        except requests.exceptions.ConnectionError:
+            self.available = False
+            _LOGGER.error("Unable to refresh NZBGet data")
+
+
+class NZBGetAPI:
+    """Simple JSON-RPC wrapper for NZBGet's API."""
+
+    def __init__(self, api_url, username=None, password=None):
+        """Initialize NZBGet API and set headers needed later."""
+        self.api_url = api_url
+        self.headers = {CONTENT_TYPE: CONTENT_TYPE_JSON}
+
+        if username is not None and password is not None:
+            self.auth = (username, password)
+        else:
+            self.auth = None
+
+    def post(self, method, params=None):
+        """Send a POST request and return the response as a dict."""
+        payload = {"method": method}
+
+        if params:
+            payload["params"] = params
+        try:
+            response = requests.post(
+                self.api_url,
+                json=payload,
+                auth=self.auth,
+                headers=self.headers,
+                timeout=5,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.ConnectionError as conn_exc:
+            _LOGGER.error(
+                "Failed to update NZBGet status from %s. Error: %s",
+                self.api_url,
+                conn_exc,
+            )
+            raise
+
+    def status(self):
+        """Update cached response."""
+        return self.post("status")["result"]

--- a/homeassistant/components/nzbget/manifest.json
+++ b/homeassistant/components/nzbget/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nzbget",
   "name": "Nzbget",
   "documentation": "https://www.home-assistant.io/components/nzbget",
-  "requirements": [ "pynzbgetapi>=0.1.0"],
+  "requirements": [ "pynzbgetapi==0.1.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/nzbget/manifest.json
+++ b/homeassistant/components/nzbget/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nzbget",
   "name": "Nzbget",
   "documentation": "https://www.home-assistant.io/components/nzbget",
-  "requirements": [ "pynzbgetapi==0.2.0"],
+  "requirements": ["pynzbgetapi==0.2.0"],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@chriscla"]
 }

--- a/homeassistant/components/nzbget/manifest.json
+++ b/homeassistant/components/nzbget/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nzbget",
   "name": "Nzbget",
   "documentation": "https://www.home-assistant.io/components/nzbget",
-  "requirements": [],
+  "requirements": [ "pynzbgetapi>=0.1.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/nzbget/manifest.json
+++ b/homeassistant/components/nzbget/manifest.json
@@ -2,7 +2,7 @@
   "domain": "nzbget",
   "name": "Nzbget",
   "documentation": "https://www.home-assistant.io/components/nzbget",
-  "requirements": [ "pynzbgetapi==0.1.0"],
+  "requirements": [ "pynzbgetapi==0.2.0"],
   "dependencies": [],
   "codeowners": []
 }

--- a/homeassistant/components/nzbget/sensor.py
+++ b/homeassistant/components/nzbget/sensor.py
@@ -1,7 +1,6 @@
 """Monitor the NZBGet API."""
 import logging
 
-
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/nzbget/sensor.py
+++ b/homeassistant/components/nzbget/sensor.py
@@ -1,8 +1,20 @@
 """Monitor the NZBGet API."""
 import logging
 
-from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+import pynzbgetapi
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_SSL,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_MONITORED_VARIABLES,
+)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 from . import DATA_NZBGET, DATA_UPDATED, SENSOR_TYPES
@@ -13,15 +25,21 @@ DEFAULT_NAME = "NZBGet"
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Create NZBGet sensors."""
-    _LOGGER.info("Setting up NZBGet sensor platform")
+    """Set up the NZBGet sensors."""
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    ssl = config.get(CONF_SSL)
+    name = config.get(CONF_NAME)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    monitored_types = config.get(CONF_MONITORED_VARIABLES)
 
-    if discovery_info is None:
-        return
-
-    nzbget_api = hass.data[DATA_NZBGET]
-    monitored_variables = discovery_info["sensors"]
-    name = discovery_info["client_name"]
+    try:
+        nzbgetapi = NZBGetAPICache(host, port, ssl, username, password)
+        nzbgetapi.update()
+    except pynzbgetapi.NZBGetAPIException as conn_err:
+        _LOGGER.error("Error setting up NZBGet API: %s", conn_err)
+        return False
 
     devices = []
     for ng_type in monitored_variables:
@@ -78,6 +96,11 @@ class NZBGetSensor(Entity):
 
     def update(self):
         """Update state of sensor."""
+        try:
+            self.api.update()
+        except pynzbgetapi.NZBGetAPIException:
+            # Error calling the API, already logged in api.update()
+            return
 
         if self.api.status is None:
             _LOGGER.debug(
@@ -98,3 +121,20 @@ class NZBGetSensor(Entity):
             self._state = round(value / 60, 2)
         else:
             self._state = value
+
+
+class NZBGetAPICache:
+    """Rate-limit calls to the NZBGetAPI."""
+
+    def __init__(self, host, port, ssl, username=None, password=None):
+        """Initialize NZBGet API and set headers needed later."""
+
+        self.status = None
+
+        self.ng_api = pynzbgetapi.NZBGetAPI(host, username, password, ssl, ssl, port)
+        self.update()
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update cached response."""
+        self.status = self.ng_api.status()

--- a/homeassistant/components/nzbget/sensor.py
+++ b/homeassistant/components/nzbget/sensor.py
@@ -1,103 +1,53 @@
-"""Support for monitoring NZBGet NZB client."""
-from datetime import timedelta
+"""Monitor the NZBGet API."""
 import logging
 
-from aiohttp.hdrs import CONTENT_TYPE
-import requests
-import voluptuous as vol
-
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_SSL,
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PORT,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONTENT_TYPE_JSON,
-    CONF_MONITORED_VARIABLES,
-)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+
+from . import DATA_NZBGET, DATA_UPDATED, SENSOR_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "NZBGet"
-DEFAULT_PORT = 6789
-
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
-
-SENSOR_TYPES = {
-    "article_cache": ["ArticleCacheMB", "Article Cache", "MB"],
-    "average_download_rate": ["AverageDownloadRate", "Average Speed", "MB/s"],
-    "download_paused": ["DownloadPaused", "Download Paused", None],
-    "download_rate": ["DownloadRate", "Speed", "MB/s"],
-    "download_size": ["DownloadedSizeMB", "Size", "MB"],
-    "free_disk_space": ["FreeDiskSpaceMB", "Disk Free", "MB"],
-    "post_paused": ["PostPaused", "Post Processing Paused", None],
-    "remaining_size": ["RemainingSizeMB", "Queue Size", "MB"],
-    "uptime": ["UpTimeSec", "Uptime", "min"],
-}
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_MONITORED_VARIABLES, default=["download_rate"]): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES)]
-        ),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_SSL, default=False): cv.boolean,
-        vol.Optional(CONF_USERNAME): cv.string,
-    }
-)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the NZBGet sensors."""
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    ssl = "s" if config.get(CONF_SSL) else ""
-    name = config.get(CONF_NAME)
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
-    monitored_types = config.get(CONF_MONITORED_VARIABLES)
+    """Create NZBGet sensors."""
+    _LOGGER.info("Setting up NZBGet sensor platform")
 
-    url = f"http{ssl}://{host}:{port}/jsonrpc"
+    if discovery_info is None:
+        return
 
-    try:
-        nzbgetapi = NZBGetAPI(api_url=url, username=username, password=password)
-        nzbgetapi.update()
-    except (
-        requests.exceptions.ConnectionError,
-        requests.exceptions.HTTPError,
-    ) as conn_err:
-        _LOGGER.error("Error setting up NZBGet API: %s", conn_err)
-        return False
+    nzbget_api = hass.data[DATA_NZBGET]
+    monitored_variables = discovery_info["sensors"]
+    name = discovery_info["client_name"]
 
     devices = []
-    for ng_type in monitored_types:
+    for ng_type in monitored_variables:
         new_sensor = NZBGetSensor(
-            api=nzbgetapi, sensor_type=SENSOR_TYPES.get(ng_type), client_name=name
+            nzbget_api,
+            ng_type,
+            name,
+            SENSOR_TYPES[ng_type][0],
+            SENSOR_TYPES[ng_type][1],
         )
         devices.append(new_sensor)
 
-    add_entities(devices)
+    add_entities(devices, True)
 
 
 class NZBGetSensor(Entity):
     """Representation of a NZBGet sensor."""
 
-    def __init__(self, api, sensor_type, client_name):
+    def __init__(self, api, sensor_type, client_name, sensor_name, unit_of_measurement):
         """Initialize a new NZBGet sensor."""
-        self._name = "{} {}".format(client_name, sensor_type[1])
-        self.type = sensor_type[0]
+        self._name = "{} {}".format(client_name, sensor_type)
+        self.type = sensor_name
         self.client_name = client_name
         self.api = api
         self._state = None
-        self._unit_of_measurement = sensor_type[2]
+        self._unit_of_measurement = unit_of_measurement
         self.update()
         _LOGGER.debug("Created NZBGet sensor: %s", self.type)
 
@@ -116,13 +66,18 @@ class NZBGetSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        async_dispatcher_connect(
+            self.hass, DATA_UPDATED, self._schedule_immediate_update
+        )
+
+    @callback
+    def _schedule_immediate_update(self):
+        self.async_schedule_update_ha_state(True)
+
     def update(self):
         """Update state of sensor."""
-        try:
-            self.api.update()
-        except requests.exceptions.ConnectionError:
-            # Error calling the API, already logged in api.update()
-            return
 
         if self.api.status is None:
             _LOGGER.debug(
@@ -143,48 +98,3 @@ class NZBGetSensor(Entity):
             self._state = round(value / 60, 2)
         else:
             self._state = value
-
-
-class NZBGetAPI:
-    """Simple JSON-RPC wrapper for NZBGet's API."""
-
-    def __init__(self, api_url, username=None, password=None):
-        """Initialize NZBGet API and set headers needed later."""
-        self.api_url = api_url
-        self.status = None
-        self.headers = {CONTENT_TYPE: CONTENT_TYPE_JSON}
-
-        if username is not None and password is not None:
-            self.auth = (username, password)
-        else:
-            self.auth = None
-        self.update()
-
-    def post(self, method, params=None):
-        """Send a POST request and return the response as a dict."""
-        payload = {"method": method}
-
-        if params:
-            payload["params"] = params
-        try:
-            response = requests.post(
-                self.api_url,
-                json=payload,
-                auth=self.auth,
-                headers=self.headers,
-                timeout=5,
-            )
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.ConnectionError as conn_exc:
-            _LOGGER.error(
-                "Failed to update NZBGet status from %s. Error: %s",
-                self.api_url,
-                conn_exc,
-            )
-            raise
-
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
-        """Update cached response."""
-        self.status = self.post("status")["result"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1350,6 +1350,9 @@ pynx584==0.4
 # homeassistant.components.obihai
 pyobihai==1.0.2
 
+# homeassistant.components.nzbget
+pynzbgetapi==0.2.0
+
 # homeassistant.components.openuv
 pyopenuv==1.0.9
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1347,11 +1347,11 @@ pynws==0.7.4
 # homeassistant.components.nx584
 pynx584==0.4
 
-# homeassistant.components.obihai
-pyobihai==1.0.2
-
 # homeassistant.components.nzbget
 pynzbgetapi==0.2.0
+
+# homeassistant.components.obihai
+pyobihai==1.0.2
 
 # homeassistant.components.openuv
 pyopenuv==1.0.9


### PR DESCRIPTION
## Breaking Change:

The NZBGet integration has been changed to support multiple platforms and future events, and common code has been centralized to the component. The configuration has moved from the sensor platform to the `nzbget` key in configuration.yaml, and the `monitored_variables` option has been removed. Users need to update their configuration.

## Description:
Re-factor NZBGet component to move core logic out of the sensor platform and into a common component. Update config to have a nzbget: root-level entry.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io/pull/10300

## Example entry for `configuration.yaml`:
```yaml
nzbget:
  host: 192.168.1.1
  ssl: false  
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
