### PR TITLE
Disable special docker treatment unless root

### DIFF
--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -25,7 +25,7 @@ def is_virtual_env() -> bool:
 
 def is_docker_env() -> bool:
     """Return True if we run in a docker env."""
-    return Path("/.dockerenv").exists()
+    return Path("/.dockerenv").exists() and os.geteuid() == 0
 
 
 def is_installed(package: str) -> bool:


### PR DESCRIPTION
## Description:

**Related issue:** fixes https://github.com/home-assistant/home-assistant/issues/24397

Version 0.94 broke running the official docker image as non-root user by installing python packages system-wide instead of in `config/deps` (see https://github.com/home-assistant/home-assistant/pull/24175). This PR restores the previous behavior in this special case.
It is a no-op when the docker image is run [as suggested in the docs](https://www.home-assistant.io/docs/installation/docker/), but also allows running the image as non-root (using `docker run --user ...`) which some users prefer over securing the installation with AppArmor.

I believe this should be included in the official build, because
 1. running services inside docker as non-root is considered a security best-practice
 1. the change is trivial, chances that this breaks anything in the official build are very small
 1. it allows users to use the official image, making it less likely users are running outdated versions or poorly built / malicious images
 1. using AppArmor as suggested [here](https://github.com/home-assistant/home-assistant/issues/24397#issuecomment-527446679) is never even mentioned in the official docs and is complicated if done right
 1. there is user demand for running as non-root, for example https://github.com/home-assistant/home-assistant/issues/7872, https://github.com/home-assistant/home-assistant/pull/23262, https://github.com/home-assistant/home-assistant/issues/24397, [discourse](https://community.home-assistant.io/t/running-home-assistant-with-docker-as-non-root-user/18773), [discourse](https://community.home-assistant.io/t/installing-ha-in-docker-on-ubuntu-as-non-root-user/48424), [discourse](https://community.home-assistant.io/t/docker-installation-non-root-cant-reach-z-wave-usb/125961), [reddit](https://www.reddit.com/r/homeassistant/comments/87cmo5/how_to_run_ha_docker_on_ubuntu_as_nonroot/), [reddit](https://www.reddit.com/r/homeassistant/comments/bxx0zm/docker_container_permissions_and_running_ha_as_a/)

Thanks!

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
