### PR TITLE
Add device_info to Linky integration

### DIFF
--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -30,17 +30,6 @@ INDEX_CURRENT = -1
 INDEX_LAST = -2
 ATTRIBUTION = "Data provided by Enedis"
 
-SENSORS = {
-    "yesterday": ("Linky yesterday", DAILY, INDEX_LAST),
-    "current_month": ("Linky current month", MONTHLY, INDEX_CURRENT),
-    "last_month": ("Linky last month", MONTHLY, INDEX_LAST),
-    "current_year": ("Linky current year", YEARLY, INDEX_CURRENT),
-    "last_year": ("Linky last year", YEARLY, INDEX_LAST),
-}
-SENSORS_INDEX_LABEL = 0
-SENSORS_INDEX_SCALE = 1
-SENSORS_INDEX_WHEN = 2
-
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up the Linky platform."""

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -18,6 +18,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
 
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(hours=4)
@@ -114,6 +116,12 @@ class LinkySensor(Entity):
         self._username = account.username
         self._time = None
         self._consumption = None
+        self._unique_id = f"{DOMAIN}_{self._username}_{scale}_{when}"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def name(self):
@@ -142,6 +150,15 @@ class LinkySensor(Entity):
             ATTR_ATTRIBUTION: ATTRIBUTION,
             "time": self._time,
             CONF_USERNAME: self._username,
+        }
+
+    @property
+    def device_info(self):
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "manufacturer": "Enedis",
         }
 
     async def async_update(self) -> None:

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -105,7 +105,7 @@ class LinkySensor(Entity):
         self._username = account.username
         self._time = None
         self._consumption = None
-        self._unique_id = f"{DOMAIN}_{self._username}_{scale}_{when}"
+        self._unique_id = f"{self._username}_{scale}_{when}"
 
     @property
     def unique_id(self):


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Add device_info to display linky sensors in the _configuration_ -> _integrations_ tab.

<img width="667" alt="Capture d’écran 2019-09-06 à 14 13 10" src="https://user-images.githubusercontent.com/14821482/64427135-bc17ab00-d0b0-11e9-9c66-56686d5d73c7.png">

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html