### PR TITLE
Fix issue with face api

### DIFF
--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -27,7 +27,7 @@ DATA_MICROSOFT_FACE = "microsoft_face"
 DEFAULT_TIMEOUT = 10
 DOMAIN = "microsoft_face"
 
-FACE_API_URL = "api.cognitive.microsoft.com/face/v1.0/{0}"
+FACE_API_URL = "cognitiveservices.azure.com/face/v1.0/{0}"
 
 SERVICE_CREATE_GROUP = "create_group"
 SERVICE_CREATE_PERSON = "create_person"
@@ -299,7 +299,8 @@ class MicrosoftFace:
                 response = await getattr(self.websession, method)(
                     url, data=payload, headers=headers, params=params
                 )
-
+                if response.status == 202:
+                    return None
                 answer = await response.json()
 
             _LOGGER.debug("Read from microsoft face api: %s", answer)


### PR DESCRIPTION
the `api.cognitive.microsoft.com` url only works for the trial account which lasts 7 days. After that, you need to create a real account which has different url format.

when api response with 202, there is no json body so that api will crashed with error. but 202 is a valid response from azure face api. you can see an example response where `Content-Length` is 0.
```
ClientResponse(https://{{REMOVED}}.cognitiveservices.azure.com/face/v1.0/persongroups/family/train) [202 Accepted]>
<CIMultiDictProxy('Cache-Control': 'no-cache', 'Pragma': 'no-cache', 'Content-Length': '0', 'Expires': '-1', 'Operation-Location': 'http://eastus.prod.facev1.api.cognitive.trafficmanager.net:8080/persongroups/family/training', 'X-AspNet-Version': '4.0.30319', 'X-Powered-By': 'ASP.NET', 'apim-request-id': '{{REQUEST-ID}}', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'x-content-type-options': 'nosniff', 'Access-Control-Expose-Headers': 'Operation-Location', 'Date': 'Fri, 06 Sep 2019 12:25:48 GMT')
```


## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
