### PR TITLE
Add "particulate matter 1.0" to air_quality platform

### DIFF
--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -20,6 +20,7 @@ ATTR_NO = "nitrogen_monoxide"
 ATTR_NO2 = "nitrogen_dioxide"
 ATTR_OZONE = "ozone"
 ATTR_PM_0_1 = "particulate_matter_0_1"
+ATTR_PM_1_0 = "particulate_matter_1_0"
 ATTR_PM_10 = "particulate_matter_10"
 ATTR_PM_2_5 = "particulate_matter_2_5"
 ATTR_SO2 = "sulphur_dioxide"
@@ -40,6 +41,7 @@ PROP_TO_ATTR = {
     "nitrogen_dioxide": ATTR_NO2,
     "ozone": ATTR_OZONE,
     "particulate_matter_0_1": ATTR_PM_0_1,
+    "particulate_matter_1_0": ATTR_PM_1_0,
     "particulate_matter_10": ATTR_PM_10,
     "particulate_matter_2_5": ATTR_PM_2_5,
     "sulphur_dioxide": ATTR_SO2,
@@ -76,6 +78,11 @@ class AirQualityEntity(Entity):
     @property
     def particulate_matter_10(self):
         """Return the particulate matter 10 level."""
+        return None
+    
+    @property
+    def particulate_matter_1_0(self):
+        """Return the particulate matter 1.0 level."""
         return None
 
     @property


### PR DESCRIPTION
## Description:
A lot air quality services and sensors measure particulate matter 1.0 µm. Home assistant air_quality platform doesn't support this.

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/281

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
