### PR TITLE
Add light platform to iaqualink integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -288,6 +288,7 @@ omit =
     homeassistant/components/hyperion/light.py
     homeassistant/components/ialarm/alarm_control_panel.py
     homeassistant/components/iaqualink/climate.py
+    homeassistant/components/iaqualink/light.py
     homeassistant/components/icloud/device_tracker.py
     homeassistant/components/idteck_prox/*
     homeassistant/components/ifttt/*

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -24,7 +24,7 @@ PARALLEL_UPDATES = 0
 async def async_setup_entry(
     hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
-    """Set up discovered switches."""
+    """Set up discovered lights."""
     devs = []
     for dev in hass.data[AQUALINK_DOMAIN][DOMAIN]:
         devs.append(HassAqualinkLight(dev))
@@ -36,7 +36,6 @@ class HassAqualinkLight(Light):
 
     def __init__(self, dev: AqualinkLight):
         """Initialize the light."""
-        Light.__init__(self)
         self.dev = dev
 
     @property
@@ -55,8 +54,8 @@ class HassAqualinkLight(Light):
         This handles brightness and light effects for lights that do support
         them.
         """
-        brightness = kwargs.get(ATTR_BRIGHTNESS, None)
-        effect = kwargs.get(ATTR_EFFECT, None)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        effect = kwargs.get(ATTR_EFFECT)
 
         # For now I'm assuming lights support either effects or brightness.
         if effect:
@@ -89,7 +88,7 @@ class HassAqualinkLight(Light):
     @property
     def effect_list(self) -> list:
         """Return supported light effects."""
-        return list(AqualinkLightEffect.__members__.keys())
+        return list(AqualinkLightEffect.__members__)
 
     async def async_update(self) -> None:
         """Update the internal state of the light.

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -1,0 +1,111 @@
+"""Support for Aqualink pool lights."""
+import logging
+
+from iaqualink import AqualinkLight, AqualinkLightEffect
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_EFFECT,
+    DOMAIN,
+    SUPPORT_BRIGHTNESS,
+    SUPPORT_EFFECT,
+    Light,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN as AQUALINK_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up discovered switches."""
+    devs = []
+    for dev in hass.data[AQUALINK_DOMAIN][DOMAIN]:
+        devs.append(HassAqualinkLight(dev))
+    async_add_entities(devs, True)
+
+
+class HassAqualinkLight(Light):
+    """Representation of a light."""
+
+    def __init__(self, dev: AqualinkLight):
+        """Initialize the light."""
+        Light.__init__(self)
+        self.dev = dev
+
+    @property
+    def name(self) -> str:
+        """Return the name of the light."""
+        return self.dev.label
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the light is on or off."""
+        return self.dev.is_on
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn on the light.
+
+        This handles brightness and light effects for lights that do support
+        them.
+        """
+        brightness = kwargs.get(ATTR_BRIGHTNESS, None)
+        effect = kwargs.get(ATTR_EFFECT, None)
+
+        # For now I'm assuming lights support either effects or brightness.
+        if effect:
+            effect = AqualinkLightEffect[effect].value
+            await self.dev.set_effect(effect)
+        elif brightness:
+            # Aqualink supports percentages in 25% increments.
+            pct = int(round(brightness * 4.0 / 255)) * 25
+            await self.dev.set_brightness(pct)
+        else:
+            await self.dev.turn_on()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off the light."""
+        await self.dev.turn_off()
+
+    @property
+    def brightness(self) -> int:
+        """Return current brightness of the light.
+
+        The scale needs converting between 0-100 and 0-255.
+        """
+        return self.dev.brightness * 255 / 100
+
+    @property
+    def effect(self) -> str:
+        """Return the current light effect if supported."""
+        return AqualinkLightEffect(self.dev.effect).name
+
+    @property
+    def effect_list(self) -> list:
+        """Return supported light effects."""
+        return list(AqualinkLightEffect.__members__.keys())
+
+    async def async_update(self) -> None:
+        """Update the internal state of the light.
+
+        This is currently a no-op since all devices get refreshed during the
+        main thermostat update.
+        """
+        return None
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of features supported by the light."""
+        if self.dev.is_dimmer:
+            return SUPPORT_BRIGHTNESS
+
+        if self.dev.is_color:
+            return SUPPORT_EFFECT
+
+        return 0

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -14,6 +14,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
+from . import AqualinkEntity, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkLight(Light):
+class HassAqualinkLight(Light, AqualinkEntity):
     """Representation of a light."""
 
     def __init__(self, dev: AqualinkLight):
@@ -48,6 +49,7 @@ class HassAqualinkLight(Light):
         """Return whether the light is on or off."""
         return self.dev.is_on
 
+    @refresh_system
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on the light.
 
@@ -68,6 +70,7 @@ class HassAqualinkLight(Light):
         else:
             await self.dev.turn_on()
 
+    @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the light."""
         await self.dev.turn_off()
@@ -89,14 +92,6 @@ class HassAqualinkLight(Light):
     def effect_list(self) -> list:
         """Return supported light effects."""
         return list(AqualinkLightEffect.__members__)
-
-    async def async_update(self) -> None:
-        """Update the internal state of the light.
-
-        This is currently a no-op since all devices get refreshed during the
-        main thermostat update.
-        """
-        return None
 
     @property
     def supported_features(self) -> int:


### PR DESCRIPTION
## Description:

Add light platform to iaqualink integration. Supports brightness and effects when available.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10165 (documentation is for complete integration, only climate platform has landed yet).

## Example entry for `configuration.yaml` (if applicable):
```yaml
iaqualink:
    username: USERNAME
    password: PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io): home-assistant/home-assistant.io#10165 (complete integration documentation)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
