### PR TITLE
Avoid invalid vicare temperature values

### DIFF
--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -96,10 +96,13 @@ class ViCareClimate(ClimateDevice):
     def update(self):
         """Let HA know there has been an update from the ViCare API."""
         _room_temperature = self._api.getRoomTemperature()
-        if _room_temperature is not None and _room_temperature != "error":
+        _supply_temperature = self._api.getSupplyTemperature()
+        if _room_temperature is not None and _room_temperature != PYVICARE_ERROR:
             self._current_temperature = _room_temperature
+        elif _supply_temperature != PYVICARE_ERROR:
+            self._current_temperature = _supply_temperature
         else:
-            self._current_temperature = self._api.getSupplyTemperature()
+            self._current_temperature = None
         self._current_program = self._api.getActiveProgram()
 
         # The getCurrentDesiredTemperature call can yield 'error' (str) when the system is in standby


### PR DESCRIPTION
The PyVicare API can return the string "error" in case of connection
or authentication errors.
The current_temperature value could be set to "error" instead of a
nueric value or None which breaks the climate component.

This commit sets the current_temperature to None instead.

## Breaking Change:

## Description:

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
