### PR TITLE
0.98.5

### DIFF
--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/components/frontend",
   "requirements": [
-    "home-assistant-frontend==20190828.0"
+    "home-assistant-frontend==20190828.1"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 98
-PATCH_VERSION = "4"
+PATCH_VERSION = "5"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 6, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,7 +11,7 @@ contextvars==2.4;python_version<"3.7"
 cryptography==2.7
 distro==1.4.0
 hass-nabucasa==0.17
-home-assistant-frontend==20190828.0
+home-assistant-frontend==20190828.1
 importlib-metadata==0.19
 jinja2>=2.10.1
 netdisco==2.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -624,7 +624,7 @@ hole==0.5.0
 holidays==0.9.11
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190828.0
+home-assistant-frontend==20190828.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -176,7 +176,7 @@ hdate==0.9.0
 holidays==0.9.11
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190828.0
+home-assistant-frontend==20190828.1
 
 # homeassistant.components.homekit_controller
 homekit[IP]==0.15.0


### PR DESCRIPTION
We have been notified by Gregor Godbersen that our markdown renderer was vulnerable for an XSS attack if exposed to specially crafted markdown. This was introduced in the Home Assistant 0.98 release. We have verified that Home Assistant 0.98.0 does not render unsafe markdown, yet still wanted to make sure to issue an update as soon as possible.

More information in this [frontend pull request](https://github.com/home-assistant/home-assistant-polymer/pull/3640). 