### PR TITLE
Move config and connections to Plex component

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -36,6 +36,7 @@ SERVICE_KONNECTED = "konnected"
 SERVICE_MOBILE_APP = "hass_mobile_app"
 SERVICE_NETGEAR = "netgear_router"
 SERVICE_OCTOPRINT = "octoprint"
+SERVICE_PLEX = "plex_mediaserver"
 SERVICE_ROKU = "roku"
 SERVICE_SABNZBD = "sabnzbd"
 SERVICE_SAMSUNG_PRINTER = "samsung_printer"
@@ -68,7 +69,7 @@ SERVICE_HANDLERS = {
     SERVICE_FREEBOX: ("freebox", None),
     SERVICE_YEELIGHT: ("yeelight", None),
     "panasonic_viera": ("media_player", "panasonic_viera"),
-    "plex_mediaserver": ("media_player", "plex"),
+    SERVICE_PLEX: ("plex", None),
     "yamaha": ("media_player", "yamaha"),
     "logitech_mediaserver": ("media_player", "squeezebox"),
     "directv": ("media_player", "directv"),

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -137,12 +137,7 @@ def setup(hass, config):
                 )
 
             if not hass.data.get(PLEX_MEDIA_PLAYER_OPTIONS):
-                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = {
-                    CONF_USE_EPISODE_ART: False,
-                    CONF_SHOW_ALL_CONTROLS: False,
-                    CONF_REMOVE_UNAVAILABLE_CLIENTS: True,
-                    CONF_CLIENT_REMOVE_INTERVAL: 600,
-                }
+                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = MEDIA_PLAYER_SCHEMA({})
 
             for platform in PLATFORMS:
                 hass.helpers.discovery.load_platform(

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -148,6 +148,8 @@ def setup(hass, config):
                     platform, PLEX_DOMAIN, {}, original_config
                 )
 
+            return True
+
     def request_configuration(host_and_port):
         """Request configuration steps from the user."""
         configurator = hass.components.configurator
@@ -193,6 +195,4 @@ def setup(hass, config):
     discovery.listen(hass, SERVICE_PLEX, server_discovered)
 
     plex_config = config.get(PLEX_DOMAIN, {})
-    setup_plex(config=plex_config)
-
-    return True
+    return setup_plex(config=plex_config)

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -1,1 +1,201 @@
-"""The plex component."""
+"""Support to embed Plex."""
+import logging
+import plexapi.exceptions
+import voluptuous as vol
+
+from homeassistant.components.discovery import SERVICE_PLEX
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_TOKEN,
+    CONF_URL,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import discovery
+from homeassistant.util.json import load_json, save_json
+
+from .const import (
+    CONF_USE_EPISODE_ART,
+    CONF_SHOW_ALL_CONTROLS,
+    CONF_REMOVE_UNAVAILABLE_CLIENTS,
+    CONF_CLIENT_REMOVE_INTERVAL,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN as PLEX_DOMAIN,
+    PLEX_CONFIG_FILE,
+    PLEX_MEDIA_PLAYER_OPTIONS,
+    SHARED_SERVER,
+)
+from .server import PlexServer
+
+MEDIA_PLAYER_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
+        vol.Optional(CONF_SHOW_ALL_CONTROLS, default=False): cv.boolean,
+        vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True): cv.boolean,
+        vol.Optional(CONF_CLIENT_REMOVE_INTERVAL, default=600): cv.positive_int,
+    }
+)
+
+SERVER_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+        vol.Optional(CONF_TOKEN): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+        vol.Optional(MP_DOMAIN, default={}): MEDIA_PLAYER_SCHEMA,
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema({PLEX_DOMAIN: SERVER_CONFIG_SCHEMA}, extra=vol.ALLOW_EXTRA)
+
+_CONFIGURING = {}
+_LOGGER = logging.getLogger(__package__)
+
+
+def setup(hass, config):
+    """Set up the Plex component."""
+
+    def server_discovered(service, info):
+        """Pass back discovered Plex server details."""
+        _LOGGER.info("Discovered Plex server: %s:%s", info["host"], info["port"])
+        info["discovered_plex"] = True
+        setup(hass, info)
+
+    def connect_plex_server(plex_server):
+        """Create shared PlexServer instance."""
+        try:
+            plex_server.connect()
+        except (
+            plexapi.exceptions.BadRequest,
+            plexapi.exceptions.Unauthorized,
+            plexapi.exceptions.NotFound,
+        ) as error:
+            _LOGGER.info(error)
+            return False
+        else:
+            server_id = plex_server.machine_identifier
+            hass.data[PLEX_DOMAIN][server_id] = plex_server
+            hass.data[PLEX_DOMAIN][SHARED_SERVER] = server_id
+
+            host_and_port = plex_server.url_in_use.split("/")[-1]
+            if host_and_port in _CONFIGURING:
+                request_id = _CONFIGURING.pop(host_and_port)
+                configurator = hass.components.configurator
+                configurator.request_done(request_id)
+                _LOGGER.info("Discovery configuration done")
+
+            return True
+
+    if PLEX_DOMAIN not in hass.data:
+        hass.data[PLEX_DOMAIN] = {}
+
+    if SHARED_SERVER in hass.data[PLEX_DOMAIN]:
+        _LOGGER.debug("Plex server already configured")
+        return
+
+    # Prefer configuration
+    plex_config = config.get(PLEX_DOMAIN, {})
+    # Otherwise use plex.conf
+    file_config = load_json(hass.config.path(PLEX_CONFIG_FILE))
+    # Fallback to discovery/configurator
+    discovered = config.pop("discovered_plex", False)
+    if not plex_config and discovered:
+        plex_config = config
+
+    if plex_config:
+        hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = plex_config.get(MP_DOMAIN)
+        host = plex_config[CONF_HOST]
+        port = plex_config[CONF_PORT]
+        token = plex_config.get(CONF_TOKEN)
+        has_ssl = plex_config.get(CONF_SSL)
+        verify_ssl = plex_config.get(CONF_VERIFY_SSL)
+    elif file_config:
+        host_and_port, host_config = file_config.popitem()
+        host, port = host_and_port.split(":")
+        token = host_config[CONF_TOKEN]
+        has_ssl = host_config[CONF_SSL]
+        verify_ssl = host_config["verify"]
+    else:
+        discovery.listen(hass, SERVICE_PLEX, server_discovered)
+        return True
+
+    http_prefix = "https" if has_ssl else "http"
+    url = f"{http_prefix}://{host}:{port}"
+
+    server_config = {CONF_URL: url, CONF_TOKEN: token, CONF_VERIFY_SSL: verify_ssl}
+
+    if not hass.data.get(PLEX_MEDIA_PLAYER_OPTIONS):
+        hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = {
+            CONF_USE_EPISODE_ART: False,
+            CONF_SHOW_ALL_CONTROLS: False,
+            CONF_REMOVE_UNAVAILABLE_CLIENTS: True,
+            CONF_CLIENT_REMOVE_INTERVAL: 600,
+        }
+
+    plex_server = PlexServer(server_config)
+    if connect_plex_server(plex_server):
+        if discovered:
+            # Write plex.conf if created via discovery/configurator
+            save_json(
+                hass.config.path(PLEX_CONFIG_FILE),
+                {
+                    f"{host}:{port}": {
+                        "token": token,
+                        "ssl": has_ssl,
+                        "verify": verify_ssl,
+                    }
+                },
+            )
+
+        platforms = [MP_DOMAIN, SENSOR_DOMAIN]
+        for platform in platforms:
+            hass.helpers.discovery.load_platform(platform, PLEX_DOMAIN, {}, config)
+    else:
+        request_configuration(hass, f"{host}:{port}")
+
+    return True
+
+
+def request_configuration(hass, host_and_port):
+    """Request configuration steps from the user."""
+    configurator = hass.components.configurator
+    if host_and_port in _CONFIGURING:
+        configurator.notify_errors(
+            _CONFIGURING[host_and_port], "Failed to register, please try again."
+        )
+
+        return
+
+    def plex_configuration_callback(data):
+        """Handle configuration changes."""
+        host, port = host_and_port.split(":")
+        callback_config = {
+            CONF_HOST: host,
+            CONF_PORT: port,
+            CONF_TOKEN: data.get("token"),
+            CONF_SSL: cv.boolean(data.get("has_ssl")),
+            CONF_VERIFY_SSL: cv.boolean(data.get("verify_ssl")),
+            "discovered_plex": True,
+        }
+        setup(hass, callback_config)
+
+    _CONFIGURING[host_and_port] = configurator.request_config(
+        "Plex Media Server",
+        plex_configuration_callback,
+        description="Enter the X-Plex-Token",
+        entity_picture="/static/images/logo_plex_mediaserver.png",
+        submit_caption="Confirm",
+        fields=[
+            {"id": "token", "name": "X-Plex-Token", "type": ""},
+            {"id": "has_ssl", "name": "Use SSL", "type": ""},
+            {"id": "verify_ssl", "name": "Verify SSL", "type": ""},
+        ],
+    )

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -31,7 +31,7 @@ from .const import (
     PLATFORMS,
     PLEX_CONFIG_FILE,
     PLEX_MEDIA_PLAYER_OPTIONS,
-    SHARED_SERVER,
+    SERVERS,
 )
 from .server import PlexServer
 
@@ -82,9 +82,9 @@ def setup(hass, config):
             _LOGGER.info(error)
             return False
         else:
-            server_id = plex_server.machine_identifier
-            hass.data[PLEX_DOMAIN][server_id] = plex_server
-            hass.data[PLEX_DOMAIN][SHARED_SERVER] = server_id
+            hass.data[PLEX_DOMAIN][SERVERS][
+                plex_server.machine_identifier
+            ] = plex_server
 
             host_and_port = plex_server.url_in_use.split("/")[-1]
             if host_and_port in _CONFIGURING:
@@ -95,10 +95,9 @@ def setup(hass, config):
 
             return True
 
-    if PLEX_DOMAIN not in hass.data:
-        hass.data[PLEX_DOMAIN] = {}
+    hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}})
 
-    if SHARED_SERVER in hass.data[PLEX_DOMAIN]:
+    if hass.data[PLEX_DOMAIN][SERVERS]:
         _LOGGER.debug("Plex server already configured")
         return
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -2,6 +2,7 @@
 import logging
 
 import plexapi.exceptions
+import requests.exceptions
 import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_PLEX
@@ -101,12 +102,21 @@ def setup(hass, config):
         plex_server = PlexServer(server_config)
         try:
             plex_server.connect()
+        except requests.exceptions.ConnectionError as error:
+            _LOGGER.error(
+                "Plex server could not be reached, please verify host and port: [%s]",
+                error,
+            )
+            return False
         except (
             plexapi.exceptions.BadRequest,
             plexapi.exceptions.Unauthorized,
             plexapi.exceptions.NotFound,
         ) as error:
-            _LOGGER.error(error)
+            _LOGGER.error(
+                "Connection to Plex server failed, please verify token and SSL settings: [%s]",
+                error,
+            )
             request_configuration(host_and_port)
             return False
         else:

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -1,5 +1,6 @@
 """Support to embed Plex."""
 import logging
+
 import plexapi.exceptions
 import voluptuous as vol
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -95,7 +95,8 @@ def setup(hass, config):
             server_config = configurator_info
             host_and_port = server_config["host_and_port"]
         else:
-            return False
+            discovery.listen(hass, SERVICE_PLEX, server_discovered)
+            return True
 
         use_ssl = server_config.get(CONF_SSL, DEFAULT_SSL)
         http_prefix = "https" if use_ssl else "http"
@@ -194,8 +195,6 @@ def setup(hass, config):
     if hass.data[PLEX_DOMAIN][SERVERS]:
         _LOGGER.debug("Plex server already configured")
         return False
-
-    discovery.listen(hass, SERVICE_PLEX, server_discovered)
 
     plex_config = config.get(PLEX_DOMAIN, {})
     return setup_plex(config=plex_config)

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -91,7 +91,7 @@ def setup(hass, config):
                 request_id = _CONFIGURING.pop(host_and_port)
                 configurator = hass.components.configurator
                 configurator.request_done(request_id)
-                _LOGGER.info("Discovery configuration done")
+                _LOGGER.debug("Discovery configuration done")
 
             return True
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -99,7 +99,7 @@ def setup(hass, config):
 
     if hass.data[PLEX_DOMAIN][SERVERS]:
         _LOGGER.debug("Plex server already configured")
-        return
+        return False
 
     # Prefer configuration
     plex_config = config.get(PLEX_DOMAIN, {})

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -85,7 +85,7 @@ def setup(hass, config):
             if MP_DOMAIN in server_config:
                 hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = server_config.pop(MP_DOMAIN)
         elif file_config:
-            _LOGGER.info("Loading config from %s", json_file)
+            _LOGGER.debug("Loading config from %s", json_file)
             host_and_port, server_config = file_config.popitem()
             server_config[CONF_VERIFY_SSL] = server_config.pop("verify")
         elif discovery_info:
@@ -109,7 +109,7 @@ def setup(hass, config):
             plexapi.exceptions.Unauthorized,
             plexapi.exceptions.NotFound,
         ) as error:
-            _LOGGER.info(error)
+            _LOGGER.error(error)
             request_configuration(host_and_port)
             return False
         else:

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_PLEX
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -29,6 +28,7 @@ from .const import (
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN as PLEX_DOMAIN,
+    PLATFORMS,
     PLEX_CONFIG_FILE,
     PLEX_MEDIA_PLAYER_OPTIONS,
     SHARED_SERVER,
@@ -156,8 +156,7 @@ def setup(hass, config):
                 },
             )
 
-        platforms = [MP_DOMAIN, SENSOR_DOMAIN]
-        for platform in platforms:
+        for platform in PLATFORMS:
             hass.helpers.discovery.load_platform(platform, PLEX_DOMAIN, {}, config)
     else:
         request_configuration(hass, f"{host}:{port}")

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -21,8 +21,6 @@ from homeassistant.util.json import load_json, save_json
 from .const import (
     CONF_USE_EPISODE_ART,
     CONF_SHOW_ALL_CONTROLS,
-    CONF_REMOVE_UNAVAILABLE_CLIENTS,
-    CONF_CLIENT_REMOVE_INTERVAL,
     DEFAULT_HOST,
     DEFAULT_PORT,
     DEFAULT_SSL,
@@ -39,8 +37,6 @@ MEDIA_PLAYER_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
         vol.Optional(CONF_SHOW_ALL_CONTROLS, default=False): cv.boolean,
-        vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True): cv.boolean,
-        vol.Optional(CONF_CLIENT_REMOVE_INTERVAL, default=600): cv.positive_int,
     }
 )
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -66,7 +66,7 @@ def setup(hass, config):
 
     def server_discovered(service, info):
         """Pass back discovered Plex server details."""
-        _LOGGER.info("Discovered Plex server: %s:%s", info["host"], info["port"])
+        _LOGGER.debug("Discovered Plex server: %s:%s", info["host"], info["port"])
         info["discovered_plex"] = True
         setup(hass, info)
 

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -8,7 +8,10 @@ DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
 PLEX_CONFIG_FILE = "plex.conf"
+PLEX_MEDIA_PLAYER_OPTIONS = "plex_mp_options"
 PLEX_SERVER_CONFIG = "server_config"
+
+SHARED_SERVER = "shared_plex_server"
 
 CONF_USE_EPISODE_ART = "use_episode_art"
 CONF_SHOW_ALL_CONTROLS = "show_all_controls"

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -7,6 +7,8 @@ DEFAULT_PORT = 32400
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
+PLATFORMS = ["media_player", "sensor"]
+
 PLEX_CONFIG_FILE = "plex.conf"
 PLEX_MEDIA_PLAYER_OPTIONS = "plex_mp_options"
 PLEX_SERVER_CONFIG = "server_config"

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -8,12 +8,11 @@ DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
 PLATFORMS = ["media_player", "sensor"]
+SERVERS = "servers"
 
 PLEX_CONFIG_FILE = "plex.conf"
 PLEX_MEDIA_PLAYER_OPTIONS = "plex_mp_options"
 PLEX_SERVER_CONFIG = "server_config"
-
-SHARED_SERVER = "shared_plex_server"
 
 CONF_USE_EPISODE_ART = "use_episode_art"
 CONF_SHOW_ALL_CONTROLS = "show_all_controls"

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import json
 import logging
+
 import plexapi.exceptions
 import requests.exceptions
 

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -54,7 +54,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     if discovery_info is None:
         return
 
-    plexserver = hass.data[PLEX_DOMAIN][SERVERS].values()[0]
+    plexserver = list(hass.data[PLEX_DOMAIN][SERVERS].values())[0]
     config = hass.data[PLEX_MEDIA_PLAYER_OPTIONS]
 
     plex_clients = {}

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -38,7 +38,7 @@ from .const import (
     DOMAIN as PLEX_DOMAIN,
     NAME_FORMAT,
     PLEX_MEDIA_PLAYER_OPTIONS,
-    SHARED_SERVER,
+    SERVERS,
 )
 
 SERVER_SETUP = "server_setup"
@@ -49,8 +49,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the Plex platform."""
-    server_id = hass.data[PLEX_DOMAIN][SHARED_SERVER]
-    plexserver = hass.data[PLEX_DOMAIN][server_id]
+    plexserver = hass.data[PLEX_DOMAIN][SERVERS].values()[0]
     config = hass.data[PLEX_MEDIA_PLAYER_OPTIONS]
 
     plex_clients = {}

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -51,6 +51,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the Plex platform."""
+    if discovery_info is None:
+        return
+
     plexserver = hass.data[PLEX_DOMAIN][SERVERS].values()[0]
     config = hass.data[PLEX_MEDIA_PLAYER_OPTIONS]
 

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -2,10 +2,10 @@
 from datetime import timedelta
 import json
 import logging
+import plexapi.exceptions
 import requests.exceptions
-import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
@@ -20,150 +20,37 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
 )
 from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_URL,
-    CONF_TOKEN,
-    CONF_VERIFY_SSL,
     DEVICE_DEFAULT_NAME,
     STATE_IDLE,
     STATE_OFF,
     STATE_PAUSED,
     STATE_PLAYING,
 )
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.util import dt as dt_util
-from homeassistant.util.json import load_json, save_json
 
 from .const import (
     CONF_USE_EPISODE_ART,
     CONF_SHOW_ALL_CONTROLS,
     CONF_REMOVE_UNAVAILABLE_CLIENTS,
     CONF_CLIENT_REMOVE_INTERVAL,
-    DEFAULT_HOST,
-    DEFAULT_PORT,
-    DEFAULT_SSL,
-    DEFAULT_VERIFY_SSL,
     DOMAIN as PLEX_DOMAIN,
     NAME_FORMAT,
-    PLEX_CONFIG_FILE,
+    PLEX_MEDIA_PLAYER_OPTIONS,
+    SHARED_SERVER,
 )
-from .server import PlexServer
 
 SERVER_SETUP = "server_setup"
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-        vol.Optional(CONF_TOKEN): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-        vol.Optional(CONF_USE_EPISODE_ART, default=False): cv.boolean,
-        vol.Optional(CONF_SHOW_ALL_CONTROLS, default=False): cv.boolean,
-        vol.Optional(CONF_REMOVE_UNAVAILABLE_CLIENTS, default=True): cv.boolean,
-        vol.Optional(
-            CONF_CLIENT_REMOVE_INTERVAL, default=timedelta(seconds=600)
-        ): vol.All(cv.time_period, cv.positive_timedelta),
-    }
-)
-
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the Plex platform."""
-    plex_data = hass.data.setdefault(PLEX_DOMAIN, {})
-    server_setup = plex_data.setdefault(SERVER_SETUP, False)
-    if server_setup:
-        return
-
-    # get config from plex.conf
-    file_config = load_json(hass.config.path(PLEX_CONFIG_FILE))
-
-    if file_config:
-        # Setup a configured PlexServer
-        host, host_config = file_config.popitem()
-        token = host_config["token"]
-        try:
-            has_ssl = host_config["ssl"]
-        except KeyError:
-            has_ssl = False
-        try:
-            verify_ssl = host_config["verify"]
-        except KeyError:
-            verify_ssl = True
-
-    # Via discovery
-    elif discovery_info is not None:
-        # Parse discovery data
-        host = discovery_info.get("host")
-        port = discovery_info.get("port")
-        host = f"{host}:{port}"
-        _LOGGER.info("Discovered PLEX server: %s", host)
-
-        if host in _CONFIGURING:
-            return
-        token = None
-        has_ssl = False
-        verify_ssl = True
-    else:
-        host = config[CONF_HOST]
-        port = config[CONF_PORT]
-        host = f"{host}:{port}"
-        token = config.get(CONF_TOKEN)
-        has_ssl = config[CONF_SSL]
-        verify_ssl = config[CONF_VERIFY_SSL]
-
-    setup_plexserver(
-        host, token, has_ssl, verify_ssl, hass, config, add_entities_callback
-    )
-
-
-def setup_plexserver(
-    host, token, has_ssl, verify_ssl, hass, config, add_entities_callback
-):
-    """Set up a plexserver based on host parameter."""
-    import plexapi.exceptions
-
-    http_prefix = "https" if has_ssl else "http"
-
-    server_config = {
-        CONF_URL: f"{http_prefix}://{host}",
-        CONF_TOKEN: token,
-        CONF_VERIFY_SSL: verify_ssl,
-    }
-
-    try:
-        plexserver = PlexServer(server_config)
-        plexserver.connect()
-    except (
-        plexapi.exceptions.BadRequest,
-        plexapi.exceptions.Unauthorized,
-        plexapi.exceptions.NotFound,
-    ) as error:
-        _LOGGER.info(error)
-        # No token or wrong token
-        request_configuration(host, hass, config, add_entities_callback)
-        return
-    else:
-        hass.data[PLEX_DOMAIN][SERVER_SETUP] = True
-
-    # If we came here and configuring this host, mark as done
-    if host in _CONFIGURING:
-        request_id = _CONFIGURING.pop(host)
-        configurator = hass.components.configurator
-        configurator.request_done(request_id)
-        _LOGGER.info("Discovery configuration done")
-
-    # Save config
-    save_json(
-        hass.config.path(PLEX_CONFIG_FILE),
-        {host: {"token": token, "ssl": has_ssl, "verify": verify_ssl}},
-    )
+    server_id = hass.data[PLEX_DOMAIN][SHARED_SERVER]
+    plexserver = hass.data[PLEX_DOMAIN][server_id]
+    config = hass.data[PLEX_MEDIA_PLAYER_OPTIONS]
 
     plex_clients = {}
     plex_sessions = {}
@@ -178,7 +65,9 @@ def setup_plexserver(
             return
         except requests.exceptions.RequestException as ex:
             _LOGGER.warning(
-                "Could not connect to plex server at http://%s (%s)", host, ex
+                "Could not connect to Plex server: %s (%s)",
+                plexserver.friendly_name,
+                ex,
             )
             return
 
@@ -210,7 +99,9 @@ def setup_plexserver(
             return
         except requests.exceptions.RequestException as ex:
             _LOGGER.warning(
-                "Could not connect to plex server at http://%s (%s)", host, ex
+                "Could not connect to Plex server: %s (%s)",
+                plexserver.friendly_name,
+                ex,
             )
             return
 
@@ -257,7 +148,7 @@ def setup_plexserver(
                 continue
 
             if (dt_util.utcnow() - client.marked_unavailable) >= (
-                config.get(CONF_CLIENT_REMOVE_INTERVAL)
+                timedelta(seconds=config[CONF_CLIENT_REMOVE_INTERVAL])
             ):
                 hass.add_job(client.async_remove())
                 clients_to_remove.append(client.machine_identifier)
@@ -267,43 +158,6 @@ def setup_plexserver(
 
         if new_plex_clients:
             add_entities_callback(new_plex_clients)
-
-
-def request_configuration(host, hass, config, add_entities_callback):
-    """Request configuration steps from the user."""
-    configurator = hass.components.configurator
-    # We got an error if this method is called while we are configuring
-    if host in _CONFIGURING:
-        configurator.notify_errors(
-            _CONFIGURING[host], "Failed to register, please try again."
-        )
-
-        return
-
-    def plex_configuration_callback(data):
-        """Handle configuration changes."""
-        setup_plexserver(
-            host,
-            data.get("token"),
-            cv.boolean(data.get("has_ssl")),
-            cv.boolean(data.get("do_not_verify_ssl")),
-            hass,
-            config,
-            add_entities_callback,
-        )
-
-    _CONFIGURING[host] = configurator.request_config(
-        "Plex Media Server",
-        plex_configuration_callback,
-        description="Enter the X-Plex-Token",
-        entity_picture="/static/images/logo_plex_mediaserver.png",
-        submit_caption="Confirm",
-        fields=[
-            {"id": "token", "name": "X-Plex-Token", "type": ""},
-            {"id": "has_ssl", "name": "Use SSL", "type": ""},
-            {"id": "do_not_verify_ssl", "name": "Do not verify SSL", "type": ""},
-        ],
-    )
 
 
 class PlexClient(MediaPlayerDevice):
@@ -378,9 +232,6 @@ class PlexClient(MediaPlayerDevice):
 
     def refresh(self, device, session):
         """Refresh key device data."""
-        import plexapi.exceptions
-
-        # new data refresh
         self._clear_media_details()
 
         if session:  # Not being triggered by Chrome or FireTablet Plex App

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -4,6 +4,8 @@ import json
 import logging
 
 import plexapi.exceptions
+import plexapi.playlist
+import plexapi.playqueue
 import requests.exceptions
 
 from homeassistant.components.media_player import MediaPlayerDevice
@@ -702,8 +704,6 @@ class PlexClient(MediaPlayerDevice):
                 src["video_name"]
             )
 
-        import plexapi.playlist
-
         if (
             media
             and media_type == "EPISODE"
@@ -768,8 +768,6 @@ class PlexClient(MediaPlayerDevice):
         if not (self.device and "playback" in self._device_protocol_capabilities):
             _LOGGER.error("Client cannot play media: %s", self.entity_id)
             return
-
-        import plexapi.playqueue
 
         playqueue = plexapi.playqueue.PlayQueue.create(
             self.device.server, media, **params

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -21,7 +21,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if discovery_info is None:
         return
 
-    plexserver = hass.data[PLEX_DOMAIN][SERVERS].values()[0]
+    plexserver = list(hass.data[PLEX_DOMAIN][SERVERS].values())[0]
     add_entities([PlexSensor(plexserver)], True)
 
 

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -32,11 +32,17 @@ class PlexSensor(Entity):
         self._state = None
         self._now_playing = []
         self._server = plex_server
+        self._unique_id = f"sensor-{plex_server.machine_identifier}"
 
     @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return the id of this plex client."""
+        return self._unique_id
 
     @property
     def state(self):

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -8,7 +8,7 @@ import requests.exceptions
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-from .const import DOMAIN as PLEX_DOMAIN, SHARED_SERVER
+from .const import DOMAIN as PLEX_DOMAIN, SERVERS
 
 DEFAULT_NAME = "Plex"
 _LOGGER = logging.getLogger(__name__)
@@ -18,8 +18,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Plex sensor."""
-    server_id = hass.data[PLEX_DOMAIN][SHARED_SERVER]
-    plexserver = hass.data[PLEX_DOMAIN][server_id]
+    plexserver = hass.data[PLEX_DOMAIN][SERVERS].values()[0]
     add_entities([PlexSensor(plexserver)], True)
 
 

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -3,76 +3,31 @@ from datetime import timedelta
 import logging
 import plexapi.exceptions
 import requests.exceptions
-import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_HOST,
-    CONF_PORT,
-    CONF_TOKEN,
-    CONF_SSL,
-    CONF_URL,
-    CONF_VERIFY_SSL,
-)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
 
-from .const import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_SSL, DEFAULT_VERIFY_SSL
-from .server import PlexServer
+from .const import DOMAIN as PLEX_DOMAIN, SHARED_SERVER
 
 DEFAULT_NAME = "Plex"
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_TOKEN): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    }
-)
-
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Plex sensor."""
-    name = config.get(CONF_NAME)
-    plex_host = config.get(CONF_HOST)
-    plex_port = config.get(CONF_PORT)
-    plex_token = config.get(CONF_TOKEN)
-    verify_ssl = config.get(CONF_VERIFY_SSL)
-
-    plex_url = "{}://{}:{}".format(
-        "https" if config.get(CONF_SSL) else "http", plex_host, plex_port
-    )
-
-    try:
-        plex_server = PlexServer(
-            {CONF_URL: plex_url, CONF_TOKEN: plex_token, CONF_VERIFY_SSL: verify_ssl}
-        )
-        plex_server.connect()
-    except (
-        plexapi.exceptions.BadRequest,
-        plexapi.exceptions.Unauthorized,
-        plexapi.exceptions.NotFound,
-    ) as error:
-        _LOGGER.error(error)
-        return
-
-    add_entities([PlexSensor(name, plex_server)], True)
+    server_id = hass.data[PLEX_DOMAIN][SHARED_SERVER]
+    plexserver = hass.data[PLEX_DOMAIN][server_id]
+    add_entities([PlexSensor(plexserver)], True)
 
 
 class PlexSensor(Entity):
     """Representation of a Plex now playing sensor."""
 
-    def __init__(self, name, plex_server):
+    def __init__(self, plex_server):
         """Initialize the sensor."""
-        self._name = name
+        self._name = DEFAULT_NAME
         self._state = None
         self._now_playing = []
         self._server = plex_server

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -18,6 +18,9 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Plex sensor."""
+    if discovery_info is None:
+        return
+
     plexserver = hass.data[PLEX_DOMAIN][SERVERS].values()[0]
     add_entities([PlexSensor(plexserver)], True)
 

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -1,6 +1,7 @@
 """Support for Plex media server monitoring."""
 from datetime import timedelta
 import logging
+
 import plexapi.exceptions
 import requests.exceptions
 

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -1,5 +1,6 @@
 """Shared class to maintain Plex server instances."""
 import logging
+
 import plexapi.server
 from requests import Session
 


### PR DESCRIPTION
## Breaking Change:
Configuration is moved from the `media_player` and `sensor` platforms to the `plex` component. Existing configurations will need to be updated. The `remove_unavailable_clients` and `client_remove_interval` options for `media_player` entities have been removed as the functionality has limited value now that the entity registry exists.

The `plex` component will now enable both `sensor` and `media_player` platforms by default, sharing the same credentials.

Old example:
```yaml
media_player:
  - platform: plex
    host: 192.168.1.5
    token: mysecrettoken
    use_episode_art: False

sensor:
  - platform: plex
    host: 192.168.1.5
    token: myothersecrettoken
```
New example:
```yaml
plex:
  host: 192.168.1.5
  token: mysecrettoken
  media_player:
    use_episode_art: False
```


## Description:
A continuation from #26157 and #26458.

Configuration for the `media_player` and `sensor` `plex` platforms have been merged into a shared configuration. Connection logic has been centralized and both platforms now share the same connection object. The legacy `configurator` configuration method has been preserved and now works for both platforms instead of just `media_player`. Discovery has also been modified to load the `plex` component instead of the Plex `media_player` component.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
https://github.com/home-assistant/home-assistant.io/pull/10328

## Example entry for `configuration.yaml` (if applicable):
See **Breaking Change** above.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html