### PR TITLE
Device automations: Rename name to entity_name in translations

### DIFF
--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -1,17 +1,17 @@
 {
   "device_automation": {
     "action_type": {
-      "toggle": "Toggle {name}",
-      "turn_on": "Turn on {name}",
-      "turn_off": "Turn off {name}"
+      "toggle": "Toggle {entity_name}",
+      "turn_on": "Turn on {entity_name}",
+      "turn_off": "Turn off {entity_name}"
     },
     "condition_type": {
-      "is_on": "{name} is on",
-      "is_off": "{name} is off"
+      "is_on": "{entity_name} is on",
+      "is_off": "{entity_name} is off"
     },
     "trigger_type": {
-      "turn_on": "{name} turned on",
-      "turn_off": "{name} turned off"
+      "turn_on": "{entity_name} turned on",
+      "turn_off": "{entity_name} turned off"
     }
   }
 }


### PR DESCRIPTION
## Description:
Rename name to entity_name in translations to support home-assistant/home-assistant-polymer#3644

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
