### PR TITLE
Fix ZHA cluster configuration

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -202,7 +202,7 @@ class ZigbeeChannel(LogMixin):
         # Xiaomi devices don't need this and it disrupts pairing
         if self._zha_device.manufacturer != "LUMI":
             await self.bind()
-            if self.cluster.cluster_id not in self.cluster.endpoint.out_clusters:
+            if self.cluster.cluster_id in self.cluster.endpoint.in_clusters:
                 for report_config in self._report_config:
                     await self.configure_reporting(
                         report_config["attr"], report_config["config"]


### PR DESCRIPTION
## Description:
Some devices have the same. cluster in both input and output (client and server) collections on the same endpoint. We weren't handling this case correctly and as a result devices are not getting configured correctly.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]