### PR TITLE
Bump androidtv to 0.0.27

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "androidtv==0.0.26"
+    "androidtv==0.0.27"
   ],
   "dependencies": [],
   "codeowners": ["@JeffLIrion"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -197,7 +197,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.26
+androidtv==0.0.27
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -79,7 +79,7 @@ aiowwlln==2.0.1
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.26
+androidtv==0.0.27
 
 # homeassistant.components.apns
 apns2==0.3.0


### PR DESCRIPTION
## Description:

Bump `androidtv` to 0.0.27.

**Related issue (if applicable):** This fixes the following issue ([source](https://community.home-assistant.io/t/native-support-for-android-tv-android-devices/82792/279))

```
2019-09-04 17:13:48 ERROR (MainThread) [homeassistant.helpers.entity] Update for media_player.android_tv fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 261, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 441, in async_device_update
    await self.hass.async_add_executor_job(self.update)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/androidtv/media_player.py", line 247, in _adb_exception_catcher
    return func(self, *args, **kwargs)
  File "/usr/src/homeassistant/homeassistant/components/androidtv/media_player.py", line 443, in update
    self.aftv.update()
  File "/usr/local/lib/python3.7/site-packages/androidtv/androidtv.py", line 77, in update
    screen_on, awake, wake_lock_size, current_app, media_session_state, audio_state, device, is_volume_muted, volume = self.get_properties(lazy=True)
  File "/usr/local/lib/python3.7/site-packages/androidtv/androidtv.py", line 234, in get_properties
    wake_lock_size = self._wake_lock_size(lines[0])
  File "/usr/local/lib/python3.7/site-packages/androidtv/basetv.py", line 914, in _wake_lock_size
    return int(wake_lock_size_response.split("=")[1].strip())
IndexError: list index out of range
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
