### PR TITLE
Bump ZHA dependencies.

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -6,8 +6,8 @@
   "requirements": [
     "bellows-homeassistant==0.9.1",
     "zha-quirks==0.0.22",
-    "zigpy-deconz==0.2.2",
-    "zigpy-homeassistant==0.7.1",
+    "zigpy-deconz==0.3.0",
+    "zigpy-homeassistant==0.7.2",
     "zigpy-xbee-homeassistant==0.4.0",
     "zigpy-zigate==0.2.0"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2005,10 +2005,10 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.2.2
+zigpy-deconz==0.3.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.7.1
+zigpy-homeassistant==0.7.2
 
 # homeassistant.components.zha
 zigpy-xbee-homeassistant==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -423,4 +423,4 @@ wakeonlan==1.1.6
 zeroconf==0.23.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.7.1
+zigpy-homeassistant==0.7.2


### PR DESCRIPTION
## Description:
Bump ZHA dependencies
- zigpy-homeassistant==0.7.2
- zigpy-deconz==0.3.0

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
