### PR TITLE
Move iaqualink update from climate to component

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -1,6 +1,8 @@
 """Component to embed Aqualink devices."""
 import asyncio
+from functools import wraps
 import logging
+from typing import Awaitable
 
 from aiohttp import CookieJar
 import voluptuous as vol
@@ -11,11 +13,18 @@ from homeassistant import config_entries
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .const import DOMAIN
+from .const import DOMAIN, UPDATE_INTERVAL
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -86,6 +95,13 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
         _LOGGER.debug("Got %s climates: %s", len(climates), climates)
         hass.async_create_task(forward_setup(entry, CLIMATE_DOMAIN))
 
+    async def _async_systems_update(now):
+        """Refresh internal state for all systems."""
+        await systems[0].update()
+        async_dispatcher_send(hass, DOMAIN)
+
+    async_track_time_interval(hass, _async_systems_update, UPDATE_INTERVAL)
+
     return True
 
 
@@ -101,3 +117,36 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> boo
     hass.data[DOMAIN].clear()
 
     return all(await asyncio.gather(*tasks))
+
+
+def refresh_system(func):
+    """Force update all entities after state change."""
+
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        """Call decorated function and send update signal to all entities."""
+        await func(self, *args, **kwargs)
+        async_dispatcher_send(self.hass, DOMAIN)
+
+    return wrapper
+
+
+class AqualinkEntity(Entity):
+    """Abstract class for all Aqualink platforms."""
+
+    async def async_added_to_hass(self) -> Awaitable[None]:
+        """Set up a listener when this entity is added to HA."""
+        async_dispatcher_connect(self.hass, DOMAIN, self._update_callback)
+
+    @callback
+    def _update_callback(self) -> None:
+        self.async_schedule_update_ha_state(force_refresh=True)
+
+    @property
+    def should_poll(self) -> bool:
+        """Return False as entities shouldn't be polled.
+
+        Entities are checked periodically as the integration runs periodic
+        updates on a timer.
+        """
+        return False

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 from functools import wraps
 import logging
-from typing import Awaitable
 
 from aiohttp import CookieJar
 import voluptuous as vol
@@ -134,7 +133,7 @@ def refresh_system(func):
 class AqualinkEntity(Entity):
     """Abstract class for all Aqualink platforms."""
 
-    async def async_added_to_hass(self) -> Awaitable[None]:
+    async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
         async_dispatcher_connect(self.hass, DOMAIN, self._update_callback)
 

--- a/homeassistant/components/iaqualink/const.py
+++ b/homeassistant/components/iaqualink/const.py
@@ -1,5 +1,8 @@
 """Constants for the the iaqualink component."""
+from datetime import timedelta
+
 from homeassistant.components.climate.const import HVAC_MODE_HEAT, HVAC_MODE_OFF
 
 DOMAIN = "iaqualink"
 CLIMATE_SUPPORTED_MODES = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+UPDATE_INTERVAL = timedelta(seconds=30)


### PR DESCRIPTION
## Description:

Move the update logic from polling within one climate to being interval-based inside the component itself.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
