### PR TITLE
Add Alarm Device Class for Binary Sensors

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -18,6 +18,9 @@ SCAN_INTERVAL = timedelta(seconds=30)
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
+# On means armed, Off means disarmed
+DEVICE_CLASS_ALARM = "alarm"
+
 # On means low, Off means normal
 DEVICE_CLASS_BATTERY = "battery"
 
@@ -88,6 +91,7 @@ DEVICE_CLASS_VIBRATION = "vibration"
 DEVICE_CLASS_WINDOW = "window"
 
 DEVICE_CLASSES = [
+    DEVICE_CLASS_ALARM,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_COLD,
     DEVICE_CLASS_CONNECTIVITY,


### PR DESCRIPTION
## Description:
Adding a new Device Class to binary_sensor to cater for an alarm that would be either Armed or Disarmed


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10306


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
