### PR TITLE
Add more attributes to vicare climate entity

### DIFF
--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -88,6 +88,7 @@ class ViCareClimate(ClimateDevice):
         self._name = name
         self._state = None
         self._api = api
+        self._attributes = {}
         self._target_temperature = None
         self._current_mode = None
         self._current_temperature = None
@@ -113,6 +114,25 @@ class ViCareClimate(ClimateDevice):
         self._target_temperature = desired_temperature
 
         self._current_mode = self._api.getActiveMode()
+
+        # Update the device attributes
+        self._attributes = {}
+        self._attributes["room_temperature"] = _room_temperature
+        self._attributes["supply_temperature"] = _supply_temperature
+        self._attributes["outside_temperature"] = self._api.getOutsideTemperature()
+        self._attributes["active_vicare_program"] = self._current_program
+        self._attributes["active_vicare_mode"] = self._current_mode
+        self._attributes["heating_curve_slope"] = self._api.getHeatingCurveSlope()
+        self._attributes["heating_curve_shift"] = self._api.getHeatingCurveShift()
+        self._attributes[
+            "month_since_last_service"
+        ] = self._api.getMonthSinceLastService()
+        self._attributes["date_last_service"] = self._api.getLastServiceDate()
+        self._attributes["error_history"] = self._api.getErrorHistory()
+        self._attributes["active_error"] = self._api.getActiveError()
+        self._attributes[
+            "circulationpump_active"
+        ] = self._api.getCirculationPumpActive()
 
     @property
     def supported_features(self):
@@ -208,3 +228,8 @@ class ViCareClimate(ClimateDevice):
         _LOGGER.debug("Setting preset to %s / %s", preset_mode, vicare_program)
         self._api.deactivateProgram(self._current_program)
         self._api.activateProgram(vicare_program)
+
+    @property
+    def device_state_attributes(self):
+        """Show Device Attributes."""
+        return self._attributes


### PR DESCRIPTION
## Description:

Add some device information as attributes to the climate device:
 - room_temperature
 - supply_temperature
 - outside_temperature
 - active_vicare_program
 - active_vicare_mode
 - heating_curve_slope
 - heating_curve_shift
 - month_since_last_service
 - date_last_service
 - error_history
 - active_error
 - circulationpump_active

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
