### PR TITLE
Add upc_connect passwort authentication

### DIFF
--- a/tests/components/upc_connect/test_device_tracker.py
+++ b/tests/components/upc_connect/test_device_tracker.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components.device_tracker import DOMAIN
 import homeassistant.components.upc_connect.device_tracker as platform
-from homeassistant.const import CONF_HOST, CONF_PLATFORM
+from homeassistant.const import CONF_HOST, CONF_PLATFORM, CONF_PASSWORD
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, load_fixture, mock_component
@@ -32,10 +32,19 @@ async def test_setup_platform_timeout_loginpage(hass, caplog, aioclient_mock):
     aioclient_mock.get(
         "http://{}/common_page/login.html".format(HOST), exc=asyncio.TimeoutError()
     )
+    aioclient_mock.post("http://{}/xml/setter.xml".format(HOST), content=b"successful")
     aioclient_mock.post("http://{}/xml/getter.xml".format(HOST), content=b"successful")
 
     assert await async_setup_component(
-        hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "upc_connect", CONF_HOST: HOST}}
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_PLATFORM: "upc_connect",
+                CONF_HOST: HOST,
+                CONF_PASSWORD: "password",
+            }
+        },
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -53,7 +62,15 @@ async def test_setup_platform_timeout_webservice(hass, caplog, aioclient_mock):
     )
 
     assert await async_setup_component(
-        hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "upc_connect", CONF_HOST: HOST}}
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_PLATFORM: "upc_connect",
+                CONF_HOST: HOST,
+                CONF_PASSWORD: "password",
+            }
+        },
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -72,11 +89,20 @@ async def test_setup_platform(scan_mock, hass, aioclient_mock):
         "http://{}/common_page/login.html".format(HOST),
         cookies={"sessionToken": "654321"},
     )
+    aioclient_mock.psot("http://{}/xml/setter.xml".format(HOST), content=b"successful")
     aioclient_mock.post("http://{}/xml/getter.xml".format(HOST), content=b"successful")
 
     with assert_setup_component(1, DOMAIN):
         assert await async_setup_component(
-            hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "upc_connect", CONF_HOST: HOST}}
+            hass,
+            DOMAIN,
+            {
+                DOMAIN: {
+                    CONF_PLATFORM: "upc_connect",
+                    CONF_HOST: HOST,
+                    CONF_PASSWORD: "password",
+                }
+            },
         )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -89,13 +115,25 @@ async def test_scan_devices(hass, aioclient_mock):
         cookies={"sessionToken": "654321"},
     )
     aioclient_mock.post(
+        "http://{}/xml/setter.xml".format(HOST),
+        content=b"successful",
+        cookies={"sessionToken": "654321"},
+    )
+    aioclient_mock.post(
         "http://{}/xml/getter.xml".format(HOST),
         content=b"successful",
         cookies={"sessionToken": "654321"},
     )
 
     scanner = await platform.async_get_scanner(
-        hass, {DOMAIN: {CONF_PLATFORM: "upc_connect", CONF_HOST: HOST}}
+        hass,
+        {
+            DOMAIN: {
+                CONF_PLATFORM: "upc_connect",
+                CONF_HOST: HOST,
+                CONF_PASSWORD: "password",
+            }
+        },
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -121,13 +159,25 @@ async def test_scan_devices_without_session(hass, aioclient_mock):
         cookies={"sessionToken": "654321"},
     )
     aioclient_mock.post(
+        "http://{}/xml/setter.xml".format(HOST),
+        content=b"successful",
+        cookies={"sessionToken": "654321"},
+    )
+    aioclient_mock.post(
         "http://{}/xml/getter.xml".format(HOST),
         content=b"successful",
         cookies={"sessionToken": "654321"},
     )
 
     scanner = await platform.async_get_scanner(
-        hass, {DOMAIN: {CONF_PLATFORM: "upc_connect", CONF_HOST: HOST}}
+        hass,
+        {
+            DOMAIN: {
+                CONF_PLATFORM: "upc_connect",
+                CONF_HOST: HOST,
+                CONF_PASSWORD: "password",
+            }
+        },
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -136,6 +186,9 @@ async def test_scan_devices_without_session(hass, aioclient_mock):
     aioclient_mock.get(
         "http://{}/common_page/login.html".format(HOST),
         cookies={"sessionToken": "654321"},
+    )
+    aioclient_mock.post(
+        "http://{}/xml/setter.xml".format(HOST), cookies={"sessionToken": "1235678"}
     )
     aioclient_mock.post(
         "http://{}/xml/getter.xml".format(HOST),
@@ -158,13 +211,25 @@ async def test_scan_devices_without_session_wrong_re(hass, aioclient_mock):
         cookies={"sessionToken": "654321"},
     )
     aioclient_mock.post(
+        "http://{}/xml/setter.xml".format(HOST),
+        content=b"successful",
+        cookies={"sessionToken": "654321"},
+    )
+    aioclient_mock.post(
         "http://{}/xml/getter.xml".format(HOST),
         content=b"successful",
         cookies={"sessionToken": "654321"},
     )
 
     scanner = await platform.async_get_scanner(
-        hass, {DOMAIN: {CONF_PLATFORM: "upc_connect", CONF_HOST: HOST}}
+        hass,
+        {
+            DOMAIN: {
+                CONF_PLATFORM: "upc_connect",
+                CONF_HOST: HOST,
+                CONF_PASSWORD: "password",
+            }
+        },
     )
 
     assert len(aioclient_mock.mock_calls) == 1
@@ -173,6 +238,11 @@ async def test_scan_devices_without_session_wrong_re(hass, aioclient_mock):
     aioclient_mock.get(
         "http://{}/common_page/login.html".format(HOST),
         cookies={"sessionToken": "654321"},
+    )
+    aioclient_mock.post(
+        "http://{}/xml/getter.xml".format(HOST),
+        status=200,
+        cookies={"sessionToken": "1235678"},
     )
     aioclient_mock.post(
         "http://{}/xml/getter.xml".format(HOST),
@@ -195,13 +265,25 @@ async def test_scan_devices_parse_error(hass, aioclient_mock):
         cookies={"sessionToken": "654321"},
     )
     aioclient_mock.post(
+        "http://{}/xml/setter.xml".format(HOST),
+        content=b"successful",
+        cookies={"sessionToken": "654321"},
+    )
+    aioclient_mock.post(
         "http://{}/xml/getter.xml".format(HOST),
         content=b"successful",
         cookies={"sessionToken": "654321"},
     )
 
     scanner = await platform.async_get_scanner(
-        hass, {DOMAIN: {CONF_PLATFORM: "upc_connect", CONF_HOST: HOST}}
+        hass,
+        {
+            DOMAIN: {
+                CONF_PLATFORM: "upc_connect",
+                CONF_HOST: HOST,
+                CONF_PASSWORD: "password",
+            }
+        },
     )
 
     assert len(aioclient_mock.mock_calls) == 1


### PR DESCRIPTION

## Description:

UPC connect component seems to have upgraded and required a password authentication retrieve the connected devices. This was not necessary before the upgrade of the UPC connect box.

**Related issue (if applicable):** fixes #26490

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10317

## Example entry for `configuration.yaml` (if applicable):
```
device_tracker:
  - platform: upc_connect
    password: YOUR_ADMIN_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
