### PR TITLE
Fix radiotherm local time

### DIFF
--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -1,5 +1,4 @@
 """Support for Radio Thermostat wifi-enabled home thermostats."""
-import datetime
 import logging
 
 import voluptuous as vol
@@ -26,6 +25,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
     STATE_ON,
 )
+from homeassistant.util import dt as dt_util
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -310,7 +310,7 @@ class RadioThermostat(ClimateDevice):
         """Set device time."""
         # Calling this clears any local temperature override and
         # reverts to the scheduled temperature.
-        now = datetime.datetime.now()
+        now = dt_util.now()
         self.device.time = {
             "day": now.weekday(),
             "hour": now.hour,


### PR DESCRIPTION
We want to use our own dt_util.now() which takes into consideration the globally set DEFAULT_TIME_ZONE

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #19082

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
