### PR TITLE
Use is_server for cluster reporting in ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -202,7 +202,7 @@ class ZigbeeChannel(LogMixin):
         # Xiaomi devices don't need this and it disrupts pairing
         if self._zha_device.manufacturer != "LUMI":
             await self.bind()
-            if self.cluster.cluster_id in self.cluster.endpoint.in_clusters:
+            if self.cluster.is_server:
                 for report_config in self._report_config:
                     await self.configure_reporting(
                         report_config["attr"], report_config["config"]

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -50,7 +50,7 @@ class FakeEndpoint:
         """Add an input cluster."""
         from zigpy.zcl import Cluster
 
-        cluster = Cluster.from_id(self, cluster_id)
+        cluster = Cluster.from_id(self, cluster_id, is_server=True)
         patch_cluster(cluster)
         self.in_clusters[cluster_id] = cluster
         if hasattr(cluster, "ep_attribute"):
@@ -60,7 +60,7 @@ class FakeEndpoint:
         """Add an output cluster."""
         from zigpy.zcl import Cluster
 
-        cluster = Cluster.from_id(self, cluster_id)
+        cluster = Cluster.from_id(self, cluster_id, is_server=False)
         patch_cluster(cluster)
         self.out_clusters[cluster_id] = cluster
 


### PR DESCRIPTION
## Description:
[zigpy_homeassistant](https://github.com/zigpy/zigpy/commit/b82dab7d126ad2ac1119fddb8926d8892b7dfbaf) added properties: is_server and is_client to aid in differentiating client and server clusters. This PR leverages is_server for cluster reporting configuration so that we only configure reporting on server clusters. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]