### PR TITLE
Remove device from device action schema

### DIFF
--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -12,7 +12,6 @@ from homeassistant.components.device_automation.const import (
 from homeassistant.core import split_entity_id
 from homeassistant.const import (
     CONF_CONDITION,
-    CONF_DEVICE,
     CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_ENTITY_ID,
@@ -25,18 +24,15 @@ from homeassistant.helpers import condition, config_validation as cv, service
 ENTITY_ACTIONS = [
     {
         # Turn entity off
-        CONF_DEVICE: None,
-        CONF_TYPE: CONF_TURN_OFF,
+        CONF_TYPE: CONF_TURN_OFF
     },
     {
         # Turn entity on
-        CONF_DEVICE: None,
-        CONF_TYPE: CONF_TURN_ON,
+        CONF_TYPE: CONF_TURN_ON
     },
     {
         # Toggle entity
-        CONF_DEVICE: None,
-        CONF_TYPE: CONF_TOGGLE,
+        CONF_TYPE: CONF_TOGGLE
     },
 ]
 
@@ -68,8 +64,7 @@ ENTITY_TRIGGERS = [
 
 ACTION_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_DEVICE): None,
-        vol.Optional(CONF_DEVICE_ID): str,
+        vol.Required(CONF_DEVICE_ID): str,
         vol.Required(CONF_DOMAIN): str,
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In([CONF_TOGGLE, CONF_TURN_OFF, CONF_TURN_ON]),
@@ -79,7 +74,7 @@ ACTION_SCHEMA = vol.Schema(
 CONDITION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_CONDITION): "device",
-        vol.Optional(CONF_DEVICE_ID): str,
+        vol.Required(CONF_DEVICE_ID): str,
         vol.Required(CONF_DOMAIN): str,
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In([CONF_IS_OFF, CONF_IS_ON]),
@@ -89,7 +84,7 @@ CONDITION_SCHEMA = vol.Schema(
 TRIGGER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_PLATFORM): "device",
-        vol.Optional(CONF_DEVICE_ID): str,
+        vol.Required(CONF_DEVICE_ID): str,
         vol.Required(CONF_DOMAIN): str,
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In([CONF_TURN_OFF, CONF_TURN_ON]),

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     CONF_ALIAS,
     CONF_BELOW,
     CONF_CONDITION,
-    CONF_DEVICE,
+    CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_ENTITY_ID,
     CONF_ENTITY_NAMESPACE,
@@ -863,7 +863,7 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
 )
 
 DEVICE_ACTION_SCHEMA = vol.Schema(
-    {vol.Required(CONF_DEVICE): None, vol.Required(CONF_DOMAIN): str},
+    {vol.Required(CONF_DEVICE_ID): string, vol.Required(CONF_DOMAIN): str},
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -9,7 +9,12 @@ from typing import Optional, Sequence, Callable, Dict, List, Set, Tuple
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, Context, callback, CALLBACK_TYPE
-from homeassistant.const import CONF_CONDITION, CONF_DEVICE, CONF_DOMAIN, CONF_TIMEOUT
+from homeassistant.const import (
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_TIMEOUT,
+)
 from homeassistant import exceptions
 from homeassistant.helpers import (
     service,
@@ -66,7 +71,7 @@ def _determine_action(action):
     if CONF_EVENT in action:
         return ACTION_FIRE_EVENT
 
-    if CONF_DEVICE in action:
+    if CONF_DEVICE_ID in action:
         return ACTION_DEVICE_AUTOMATION
 
     return ACTION_CALL_SERVICE

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -43,21 +43,18 @@ async def test_websocket_get_actions(hass, hass_ws_client, device_reg, entity_re
     entity_reg.async_get_or_create("light", "test", "5678", device_id=device_entry.id)
     expected_actions = [
         {
-            "device": None,
             "domain": "light",
             "type": "turn_off",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
         },
         {
-            "device": None,
             "domain": "light",
             "type": "turn_on",
             "device_id": device_entry.id,
             "entity_id": "light.test_5678",
         },
         {
-            "device": None,
             "domain": "light",
             "type": "toggle",
             "device_id": device_entry.id,

--- a/tests/components/light/test_device_automation.py
+++ b/tests/components/light/test_device_automation.py
@@ -57,21 +57,18 @@ async def test_get_actions(hass, device_reg, entity_reg):
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     expected_actions = [
         {
-            "device": None,
             "domain": DOMAIN,
             "type": "turn_off",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
         },
         {
-            "device": None,
             "domain": DOMAIN,
             "type": "turn_on",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
         },
         {
-            "device": None,
             "domain": DOMAIN,
             "type": "toggle",
             "device_id": device_entry.id,
@@ -164,6 +161,7 @@ async def test_if_fires_on_state_change(hass, calls):
                     "trigger": {
                         "platform": "device",
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_on",
                     },
@@ -187,6 +185,7 @@ async def test_if_fires_on_state_change(hass, calls):
                     "trigger": {
                         "platform": "device",
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_off",
                     },
@@ -248,6 +247,7 @@ async def test_if_state(hass, calls):
                         {
                             "condition": "device",
                             "domain": DOMAIN,
+                            "device_id": "",
                             "entity_id": dev1.entity_id,
                             "type": "is_on",
                         }
@@ -266,6 +266,7 @@ async def test_if_state(hass, calls):
                         {
                             "condition": "device",
                             "domain": DOMAIN,
+                            "device_id": "",
                             "entity_id": dev1.entity_id,
                             "type": "is_off",
                         }
@@ -316,8 +317,8 @@ async def test_action(hass, calls):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event1"},
                     "action": {
-                        "device": None,
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_off",
                     },
@@ -325,8 +326,8 @@ async def test_action(hass, calls):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event2"},
                     "action": {
-                        "device": None,
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_on",
                     },
@@ -334,8 +335,8 @@ async def test_action(hass, calls):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event3"},
                     "action": {
-                        "device": None,
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "toggle",
                     },

--- a/tests/components/switch/test_device_automation.py
+++ b/tests/components/switch/test_device_automation.py
@@ -57,21 +57,18 @@ async def test_get_actions(hass, device_reg, entity_reg):
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     expected_actions = [
         {
-            "device": None,
             "domain": DOMAIN,
             "type": "turn_off",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
         },
         {
-            "device": None,
             "domain": DOMAIN,
             "type": "turn_on",
             "device_id": device_entry.id,
             "entity_id": f"{DOMAIN}.test_5678",
         },
         {
-            "device": None,
             "domain": DOMAIN,
             "type": "toggle",
             "device_id": device_entry.id,
@@ -164,6 +161,7 @@ async def test_if_fires_on_state_change(hass, calls):
                     "trigger": {
                         "platform": "device",
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_on",
                     },
@@ -187,6 +185,7 @@ async def test_if_fires_on_state_change(hass, calls):
                     "trigger": {
                         "platform": "device",
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_off",
                     },
@@ -248,6 +247,7 @@ async def test_if_state(hass, calls):
                         {
                             "condition": "device",
                             "domain": DOMAIN,
+                            "device_id": "",
                             "entity_id": dev1.entity_id,
                             "type": "is_on",
                         }
@@ -266,6 +266,7 @@ async def test_if_state(hass, calls):
                         {
                             "condition": "device",
                             "domain": DOMAIN,
+                            "device_id": "",
                             "entity_id": dev1.entity_id,
                             "type": "is_off",
                         }
@@ -316,8 +317,8 @@ async def test_action(hass, calls):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event1"},
                     "action": {
-                        "device": None,
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_off",
                     },
@@ -325,8 +326,8 @@ async def test_action(hass, calls):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event2"},
                     "action": {
-                        "device": None,
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "turn_on",
                     },
@@ -334,8 +335,8 @@ async def test_action(hass, calls):
                 {
                     "trigger": {"platform": "event", "event_type": "test_event3"},
                     "action": {
-                        "device": None,
                         "domain": DOMAIN,
+                        "device_id": "",
                         "entity_id": dev1.entity_id,
                         "type": "toggle",
                     },


### PR DESCRIPTION
## Description:
As discussed in frontend PR home-assistant/home-assistant-polymer#3637, simplify device action schema by removing `device` so an action looks like this:
```
{
device_id: "1ff6a018e8a84e69807063ca84d566d3"
domain: "light"
entity_id: "light.led_trappan_nere"
type: "turn_off"
}
```

instead of this:
```
{
device: null
device_id: "1ff6a018e8a84e69807063ca84d566d3"
domain: "light"
entity_id: "light.led_trappan_nere"
type: "turn_off"
}
```

Also made `device_id` mandatory for device conditions and triggers.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
