### PR TITLE
Add Obihai integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -434,6 +434,7 @@ omit =
     homeassistant/components/nut/sensor.py
     homeassistant/components/nx584/alarm_control_panel.py
     homeassistant/components/nzbget/sensor.py
+    homeassistant/components/obihai/*
     homeassistant/components/octoprint/*
     homeassistant/components/oem/climate.py
     homeassistant/components/oasa_telematics/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -197,6 +197,7 @@ homeassistant/components/nsw_fuel_station/* @nickw444
 homeassistant/components/nsw_rural_fire_service_feed/* @exxamalte
 homeassistant/components/nuki/* @pschmitt
 homeassistant/components/nws/* @MatthewFlamm
+homeassistant/components/obihai/* @dshokouhi
 homeassistant/components/ohmconnect/* @robbiet480
 homeassistant/components/onboarding/* @home-assistant/core
 homeassistant/components/opentherm_gw/* @mvn23

--- a/homeassistant/components/obihai/__init__.py
+++ b/homeassistant/components/obihai/__init__.py
@@ -1,0 +1,1 @@
+"""The Obihai integration."""

--- a/homeassistant/components/obihai/manifest.json
+++ b/homeassistant/components/obihai/manifest.json
@@ -3,7 +3,7 @@
     "name": "Obihai",
     "documentation": "https://www.home-assistant.io/components/obihai",
     "requirements": [
-      "pyobihai==1.0"
+      "pyobihai==1.0.1"
     ],
     "dependencies": [],
     "codeowners": ["@dshokouhi"]

--- a/homeassistant/components/obihai/manifest.json
+++ b/homeassistant/components/obihai/manifest.json
@@ -3,7 +3,7 @@
     "name": "Obihai",
     "documentation": "https://www.home-assistant.io/components/obihai",
     "requirements": [
-      "pyobihai==1.0.1"
+      "pyobihai==1.0.2"
     ],
     "dependencies": [],
     "codeowners": ["@dshokouhi"]

--- a/homeassistant/components/obihai/manifest.json
+++ b/homeassistant/components/obihai/manifest.json
@@ -1,0 +1,11 @@
+{
+    "domain": "obihai",
+    "name": "Obihai",
+    "documentation": "https://www.home-assistant.io/components/obihai",
+    "requirements": [
+      "pyobihai==1.0"
+    ],
+    "dependencies": [],
+    "codeowners": ["@dshokouhi"]
+  }
+  

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -1,41 +1,46 @@
-"""Support for Obihai Sensors."""
+"""
+Support for Obihai Sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/obihai/
+"""
 import logging
 
-from datetime import timedelta
 import voluptuous as vol
-
-from pyobihai import PyObihai
+from datetime import timedelta
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
+from .pyobihai import PyObihai
 
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
-OBIHAI = "Obihai"
+DOMAIN = "Obihai"
 DEFAULT_USERNAME = "admin"
 DEFAULT_PASSWORD = "admin"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     }
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Obihai sensor platform."""
 
-    username = config[CONF_USERNAME]
-    password = config[CONF_PASSWORD]
-    host = config[CONF_HOST]
+    username = config.get(CONF_USERNAME, None)
+    password = config.get(CONF_PASSWORD, None)
+    host = config.get(CONF_HOST, None)
 
     sensors = []
 
@@ -46,26 +51,26 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     line_services = pyobihai.get_line_state(host, username, password)
 
     for key in services:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        sensors.append(ObihaiServiceSensors(host, username, password, key))
 
     for key in line_services:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        sensors.append(ObihaiServiceSensors(host, username, password, key))
 
-    add_entities(sensors)
+    add_devices(sensors)
 
 
 class ObihaiServiceSensors(Entity):
     """Get the status of each Obihai Lines."""
 
-    def __init__(self, pyobihai, host, username, password, service_name):
+    def __init__(self, host, username, password, service_name):
         """Initialize monitor sensor."""
         self._host = host
         self._username = username
         self._password = password
         self._service_name = service_name
         self._state = None
-        self._name = f"{OBIHAI} {self._service_name}"
-        self._pyobihai = pyobihai
+        self._name = "{} {}".format(DOMAIN, self._service_name)
+        self._pyobihai = PyObihai()
 
     @property
     def name(self):
@@ -77,13 +82,19 @@ class ObihaiServiceSensors(Entity):
         """Return the state of the sensor."""
         return self._state
 
+    @property
+    def device_class(self):
+        """Return the device class for uptime sensor."""
+        if self._service_name == "Last Reboot":
+            return "timestamp"
+
     def update(self):
         """Update the sensor."""
         services = self._pyobihai.get_state(self._host, self._username, self._password)
 
         if self._service_name in services:
             if services[self._service_name] is None:
-                self._state = None
+                self._state = STATE_UNKNOWN
             else:
                 self._state = services[self._service_name]
 
@@ -93,6 +104,6 @@ class ObihaiServiceSensors(Entity):
 
         if self._service_name in services:
             if services[self._service_name] is None:
-                self._state = None
+                self._state = STATE_UNKNOWN
             else:
                 self._state = services[self._service_name]

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -1,8 +1,10 @@
 """Support for Obihai Sensors."""
 import logging
 
-import voluptuous as vol
 from datetime import timedelta
+import voluptuous as vol
+
+from pyobihai import PyObihai
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import STATE_UNKNOWN
@@ -11,7 +13,6 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-from pyobihai import PyObihai
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -82,23 +82,18 @@ class ObihaiServiceSensors(Entity):
         """Return the device class for uptime sensor."""
         if self._service_name == "Last Reboot":
             return "timestamp"
+        return None
 
     def update(self):
         """Update the sensor."""
         services = self._pyobihai.get_state(self._host, self._username, self._password)
 
         if self._service_name in services:
-            if services[self._service_name] is None:
-                self._state = None
-            else:
-                self._state = services[self._service_name]
+            self._state = services.get(self._service_name)
 
         services = self._pyobihai.get_line_state(
             self._host, self._username, self._password
         )
 
         if self._service_name in services:
-            if services[self._service_name] is None:
-                self._state = None
-            else:
-                self._state = services[self._service_name]
+            self._state = services.get(self._service_name)

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -1,0 +1,98 @@
+"""Support for Obihai Sensors."""
+import logging
+
+import voluptuous as vol
+from datetime import timedelta
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+from pyobihai import PyObihai
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=5)
+
+DOMAIN = "Obihai"
+DEFAULT_USERNAME = "admin"
+DEFAULT_PASSWORD = "admin"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Obihai sensor platform."""
+
+    username = config.get(CONF_USERNAME, None)
+    password = config.get(CONF_PASSWORD, None)
+    host = config.get(CONF_HOST, None)
+
+    sensors = []
+
+    pyobihai = PyObihai()
+
+    services = pyobihai.get_state(host, username, password)
+
+    line_services = pyobihai.get_line_state(host, username, password)
+
+    for key, value in services.items():
+        sensors.append(ObihaiServiceSensors(host, username, password, key))
+
+    for key, value in line_services.items():
+        sensors.append(ObihaiServiceSensors(host, username, password, key))
+
+    add_devices(sensors)
+
+
+class ObihaiServiceSensors(Entity):
+    """Get the status of each Obihai Lines."""
+
+    def __init__(self, host, username, password, service_name):
+        """Initialize monitor sensor."""
+        self._host = host
+        self._username = username
+        self._password = password
+        self._service_name = service_name
+        self._state = None
+        self._name = "{} {}".format(DOMAIN, self._service_name)
+        self._pyobihai = PyObihai()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Update the sensor."""
+        services = self._pyobihai.get_state(self._host, self._username, self._password)
+
+        if self._service_name in services:
+            if services[self._service_name] is None:
+                self._state = STATE_UNKNOWN
+            else:
+                self._state = services[self._service_name]
+
+        services = self._pyobihai.get_line_state(
+            self._host, self._username, self._password
+        )
+
+        if self._service_name in services:
+            if services[self._service_name] is None:
+                self._state = STATE_UNKNOWN
+            else:
+                self._state = services[self._service_name]

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -7,7 +7,12 @@ import voluptuous as vol
 from pyobihai import PyObihai
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    DEVICE_CLASS_TIMESTAMP,
+)
 
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
@@ -81,7 +86,7 @@ class ObihaiServiceSensors(Entity):
     def device_class(self):
         """Return the device class for uptime sensor."""
         if self._service_name == "Last Reboot":
-            return "timestamp"
+            return DEVICE_CLASS_TIMESTAMP
         return None
 
     def update(self):

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -46,10 +46,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     line_services = pyobihai.get_line_state(host, username, password)
 
-    for key, value in services.items():
+    for key in services:
         sensors.append(ObihaiServiceSensors(host, username, password, key))
 
-    for key, value in line_services.items():
+    for key in line_services:
         sensors.append(ObihaiServiceSensors(host, username, password, key))
 
     add_devices(sensors)

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -1,46 +1,41 @@
-"""
-Support for Obihai Sensors.
-
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/obihai/
-"""
+"""Support for Obihai Sensors."""
 import logging
 
-import voluptuous as vol
 from datetime import timedelta
+import voluptuous as vol
+
+from pyobihai import PyObihai
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-from .pyobihai import PyObihai
 
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
-DOMAIN = "Obihai"
+OBIHAI = "Obihai"
 DEFAULT_USERNAME = "admin"
 DEFAULT_PASSWORD = "admin"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_HOST): cv.string,
+        vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     }
 )
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Obihai sensor platform."""
 
-    username = config.get(CONF_USERNAME, None)
-    password = config.get(CONF_PASSWORD, None)
-    host = config.get(CONF_HOST, None)
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    host = config[CONF_HOST]
 
     sensors = []
 
@@ -51,26 +46,26 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     line_services = pyobihai.get_line_state(host, username, password)
 
     for key in services:
-        sensors.append(ObihaiServiceSensors(host, username, password, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
 
     for key in line_services:
-        sensors.append(ObihaiServiceSensors(host, username, password, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
 
-    add_devices(sensors)
+    add_entities(sensors)
 
 
 class ObihaiServiceSensors(Entity):
     """Get the status of each Obihai Lines."""
 
-    def __init__(self, host, username, password, service_name):
+    def __init__(self, pyobihai, host, username, password, service_name):
         """Initialize monitor sensor."""
         self._host = host
         self._username = username
         self._password = password
         self._service_name = service_name
         self._state = None
-        self._name = "{} {}".format(DOMAIN, self._service_name)
-        self._pyobihai = PyObihai()
+        self._name = f"{OBIHAI} {self._service_name}"
+        self._pyobihai = pyobihai
 
     @property
     def name(self):
@@ -94,7 +89,7 @@ class ObihaiServiceSensors(Entity):
 
         if self._service_name in services:
             if services[self._service_name] is None:
-                self._state = STATE_UNKNOWN
+                self._state = None
             else:
                 self._state = services[self._service_name]
 
@@ -104,6 +99,6 @@ class ObihaiServiceSensors(Entity):
 
         if self._service_name in services:
             if services[self._service_name] is None:
-                self._state = STATE_UNKNOWN
+                self._state = None
             else:
                 self._state = services[self._service_name]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1345,7 +1345,7 @@ pynws==0.7.4
 pynx584==0.4
 
 # homeassistant.components.obihai
-pyobihai==1.0
+pyobihai==1.0.1
 
 # homeassistant.components.openuv
 pyopenuv==1.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1345,7 +1345,7 @@ pynws==0.7.4
 pynx584==0.4
 
 # homeassistant.components.obihai
-pyobihai==1.0.1
+pyobihai==1.0.2
 
 # homeassistant.components.openuv
 pyopenuv==1.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1344,6 +1344,9 @@ pynws==0.7.4
 # homeassistant.components.nx584
 pynx584==0.4
 
+# homeassistant.components.obihai
+pyobihai==1.0
+
 # homeassistant.components.openuv
 pyopenuv==1.0.9
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Integration for Obihai devices to pull the line status.

**Related issue (if applicable):** fixes #n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10324

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: obihai
    host: 192.168.1.10
    username: admin
    password: 12345
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
