### PR TITLE
Remove unnecessary force_refresh=True, clarify system behavior

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -151,7 +151,8 @@ class AqualinkEntity(Entity):
     Any entity state change via the iaqualink library triggers an internal
     state refresh which is then propagated to all the entities in the system
     via the refresh_system decorator above to the _update_callback in this
-    class."""
+    class.
+    """
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -145,7 +145,13 @@ def refresh_system(func):
 
 
 class AqualinkEntity(Entity):
-    """Abstract class for all Aqualink platforms."""
+    """Abstract class for all Aqualink platforms.
+
+    Entity state is updated via the interval timer within the integration.
+    Any entity state change via the iaqualink library triggers an internal
+    state refresh which is then propagated to all the entities in the system
+    via the refresh_system decorator above to the _update_callback in this
+    class."""
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
@@ -153,7 +159,7 @@ class AqualinkEntity(Entity):
 
     @callback
     def _update_callback(self) -> None:
-        self.async_schedule_update_ha_state(force_refresh=True)
+        self.async_schedule_update_ha_state()
 
     @property
     def should_poll(self) -> bool:


### PR DESCRIPTION
## Description:

Remove unnecessary force_refresh parameter and document the behavior of the iaqualink library (and the underlying system).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
