### PR TITLE
Add sensor platform to iaqualink component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -289,6 +289,7 @@ omit =
     homeassistant/components/ialarm/alarm_control_panel.py
     homeassistant/components/iaqualink/climate.py
     homeassistant/components/iaqualink/light.py
+    homeassistant/components/iaqualink/sensor.py
     homeassistant/components/icloud/device_tracker.py
     homeassistant/components/idteck_prox/*
     homeassistant/components/ifttt/*

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -49,18 +49,11 @@ class HassAqualinkSensor(AqualinkEntity):
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
-        return int(self.dev.state) if self.dev.state else None
+        return int(self.dev.state) if self.dev.state != "" else None
 
     @property
     def device_class(self) -> Optional[str]:
         """Return the class of the sensor."""
         if self.dev.name.endswith("_temp"):
             return DEVICE_CLASS_TEMPERATURE
-        return None
-
-    @property
-    def icon(self) -> Optional[str]:
-        """Return an icon based on the type sensor."""
-        if self.dev.name.endswith("_temp"):
-            return "mdi:thermometer"
         return None

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -1,0 +1,66 @@
+"""Support for Aqualink temperature sensors."""
+import logging
+from typing import Optional
+
+from iaqualink import AqualinkSensor
+
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import AqualinkEntity
+from .const import DOMAIN as AQUALINK_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up discovered sensors."""
+    devs = []
+    for dev in hass.data[AQUALINK_DOMAIN][DOMAIN]:
+        devs.append(HassAqualinkSensor(dev))
+    async_add_entities(devs, True)
+
+
+class HassAqualinkSensor(AqualinkEntity):
+    """Representation of a sensor."""
+
+    def __init__(self, dev: AqualinkSensor):
+        """Initialize the sensor."""
+        self.dev = dev
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return self.dev.label
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Return the measurement unit for the sensor."""
+        if self.dev.system.temp_unit == "F":
+            return TEMP_FAHRENHEIT
+        return TEMP_CELSIUS
+
+    @property
+    def state(self) -> str:
+        """Return the state of the sensor."""
+        return int(self.dev.state) if self.dev.state else None
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of the sensor."""
+        if self.dev.name.endswith("_temp"):
+            return DEVICE_CLASS_TEMPERATURE
+        return None
+
+    @property
+    def icon(self) -> Optional[str]:
+        """Return an icon based on the type sensor."""
+        if self.dev.name.endswith("_temp"):
+            return "mdi:thermometer"
+        return None


### PR DESCRIPTION
## Description:

Add sensor platform support to iaqualink integration.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10334

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
