### PR TITLE
Add switch platform to iaqualink integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -291,6 +291,7 @@ omit =
     homeassistant/components/iaqualink/climate.py
     homeassistant/components/iaqualink/light.py
     homeassistant/components/iaqualink/sensor.py
+    homeassistant/components/iaqualink/switch.py
     homeassistant/components/icloud/device_tracker.py
     homeassistant/components/idteck_prox/*
     homeassistant/components/ifttt/*

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -12,12 +12,14 @@ from iaqualink import (
     AqualinkLoginException,
     AqualinkSensor,
     AqualinkThermostat,
+    AqualinkToggle,
 )
 
 from homeassistant import config_entries
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
@@ -77,6 +79,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
     climates = hass.data[DOMAIN][CLIMATE_DOMAIN] = []
     lights = hass.data[DOMAIN][LIGHT_DOMAIN] = []
     sensors = hass.data[DOMAIN][SENSOR_DOMAIN] = []
+    switches = hass.data[DOMAIN][SWITCH_DOMAIN] = []
 
     session = async_create_clientsession(hass, cookie_jar=CookieJar(unsafe=True))
     aqualink = AqualinkClient(username, password, session)
@@ -102,6 +105,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
             lights += [dev]
         elif isinstance(dev, AqualinkSensor):
             sensors += [dev]
+        elif isinstance(dev, AqualinkToggle):
+            switches += [dev]
 
     forward_setup = hass.config_entries.async_forward_entry_setup
     if climates:
@@ -113,6 +118,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> None
     if sensors:
         _LOGGER.debug("Got %s sensors: %s", len(sensors), sensors)
         hass.async_create_task(forward_setup(entry, SENSOR_DOMAIN))
+    if switches:
+        _LOGGER.debug("Got %s switches: %s", len(switches), switches)
+        hass.async_create_task(forward_setup(entry, SWITCH_DOMAIN))
 
     async def _async_systems_update(now):
         """Refresh internal state for all systems."""
@@ -136,6 +144,8 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> boo
         tasks += [forward_unload(entry, LIGHT_DOMAIN)]
     if hass.data[DOMAIN][SENSOR_DOMAIN]:
         tasks += [forward_unload(entry, SENSOR_DOMAIN)]
+    if hass.data[DOMAIN][SWITCH_DOMAIN]:
+        tasks += [forward_unload(entry, SWITCH_DOMAIN)]
 
     hass.data[DOMAIN].clear()
 

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -1,0 +1,66 @@
+"""Support for Aqualink pool feature switches."""
+import logging
+
+from iaqualink import AqualinkToggle
+
+from homeassistant.components.switch import DOMAIN, SwitchDevice
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import AqualinkEntity, refresh_system
+from .const import DOMAIN as AQUALINK_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up discovered switches."""
+    devs = []
+    for dev in hass.data[AQUALINK_DOMAIN][DOMAIN]:
+        devs.append(HassAqualinkSwitch(dev))
+    async_add_entities(devs, True)
+
+
+class HassAqualinkSwitch(SwitchDevice, AqualinkEntity):
+    """Representation of a switch."""
+
+    def __init__(self, dev: AqualinkToggle):
+        """Initialize the switch."""
+        SwitchDevice.__init__(self)
+        self.dev = dev
+
+    @property
+    def name(self) -> str:
+        """Return the name of the switch."""
+        return self.dev.label
+
+    @property
+    def icon(self) -> str:
+        """Return an icon based on the switch type."""
+        if self.name == "Cleaner":
+            return "mdi:robot-vacuum"
+        if self.name == "Waterfall" or self.name.endswith("Dscnt"):
+            return "mdi:fountain"
+        if self.name.endswith("Pump") or self.name.endswith("Blower"):
+            return "mdi:fan"
+        if self.name.endswith("Heater"):
+            return "mdi:radiator"
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the switch is on or not."""
+        return self.dev.is_on
+
+    @refresh_system
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn on the switch."""
+        await self.dev.turn_on()
+
+    @refresh_system
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off the switch."""
+        await self.dev.turn_off()

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -30,7 +30,6 @@ class HassAqualinkSwitch(SwitchDevice, AqualinkEntity):
 
     def __init__(self, dev: AqualinkToggle):
         """Initialize the switch."""
-        SwitchDevice.__init__(self)
         self.dev = dev
 
     @property


### PR DESCRIPTION
## Description:

Add switch platform to iaqualink integration.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10335

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
