### PR TITLE
Add Plex config flow support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -476,7 +476,10 @@ omit =
     homeassistant/components/pioneer/media_player.py
     homeassistant/components/pjlink/media_player.py
     homeassistant/components/plaato/*
-    homeassistant/components/plex/*
+    homeassistant/components/plex/__init__.py
+    homeassistant/components/plex/media_player.py
+    homeassistant/components/plex/sensor.py
+    homeassistant/components/plex/server.py
     homeassistant/components/plugwise/*
     homeassistant/components/plum_lightpad/*
     homeassistant/components/pocketcasts/sensor.py

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -50,6 +50,7 @@ CONFIG_ENTRY_HANDLERS = {
     SERVICE_DAIKIN: "daikin",
     SERVICE_TELLDUSLIVE: "tellduslive",
     SERVICE_IGD: "upnp",
+    SERVICE_PLEX: "plex",
 }
 
 SERVICE_HANDLERS = {
@@ -69,7 +70,6 @@ SERVICE_HANDLERS = {
     SERVICE_FREEBOX: ("freebox", None),
     SERVICE_YEELIGHT: ("yeelight", None),
     "panasonic_viera": ("media_player", "panasonic_viera"),
-    SERVICE_PLEX: ("plex", None),
     "yamaha": ("media_player", "yamaha"),
     "logitech_mediaserver": ("media_player", "squeezebox"),
     "directv": ("media_player", "directv"),

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -145,6 +145,9 @@ async def async_setup_entry(hass, entry):
         )
         return False
 
+    _LOGGER.debug(
+        "Connected to: %s (%s)", plex_server.friendly_name, plex_server.url_in_use
+    )
     hass.data[PLEX_DOMAIN][SERVERS][plex_server.machine_identifier] = plex_server
 
     if not hass.data.get(PLEX_MEDIA_PLAYER_OPTIONS):

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -126,7 +126,7 @@ async def async_setup_entry(hass, entry):
     server_id = entry.data[CONF_SERVER_IDENTIFIER]
 
     if server_id not in hass.data[PLEX_DOMAIN][SERVERS]:
-        plex_server = await hass.async_add_executor_job(PlexServer, server_config)
+        plex_server = PlexServer(server_config)
         try:
             await hass.async_add_executor_job(plex_server.connect)
         except requests.exceptions.ConnectionError as error:
@@ -147,8 +147,8 @@ async def async_setup_entry(hass, entry):
                 error,
             )
             return False
-        else:
-            hass.data[PLEX_DOMAIN][SERVERS][server_id] = plex_server
+
+        hass.data[PLEX_DOMAIN][SERVERS][server_id] = plex_server
 
     if not hass.data.get(PLEX_MEDIA_PLAYER_OPTIONS):
         hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = MEDIA_PLAYER_SCHEMA({})

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -84,30 +84,40 @@ def setup(hass, config):
         """Pass configuration to a config flow."""
         json_file = hass.config.path(PLEX_CONFIG_FILE)
         file_config = load_json(json_file)
+        server_config = None
 
         if config:
-            if MP_DOMAIN in config:
-                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = config.pop(MP_DOMAIN)
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    PLEX_DOMAIN,
-                    context={"source": config_entries.SOURCE_IMPORT},
-                    data=config,
-                )
-            )
+            server_config = dict(config)
+            if MP_DOMAIN in server_config:
+                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = server_config.pop(MP_DOMAIN)
+            if CONF_HOST in server_config:
+                prefix = "https" if server_config.pop(CONF_SSL) else "http"
+                server_config[
+                    CONF_URL
+                ] = f"{prefix}://{server_config.pop(CONF_HOST)}:{server_config.pop(CONF_PORT)}"
         elif file_config:
             if not hass.config_entries.async_entries(PLEX_DOMAIN):
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        PLEX_DOMAIN,
-                        context={"source": "import_plex_conf"},
-                        data=file_config,
-                    )
-                )
+                host_and_port, host_config = file_config.popitem()
+                prefix = "https" if host_config[CONF_SSL] else "http"
+
+                server_config = {
+                    CONF_URL: f"{prefix}://{host_and_port}",
+                    CONF_TOKEN: host_config[CONF_TOKEN],
+                    CONF_VERIFY_SSL: host_config["verify"],
+                }
             else:
                 _LOGGER.info("Legacy config file can be removed: %s", json_file)
         else:
             discovery.listen(hass, SERVICE_PLEX, server_discovered)
+
+        if server_config:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    PLEX_DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT},
+                    data=server_config,
+                )
+            )
 
     hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}})
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -6,7 +6,6 @@ import requests.exceptions
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.discovery import SERVICE_PLEX
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
@@ -17,7 +16,6 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import discovery
 from homeassistant.util.json import load_json
 
 from .const import (
@@ -66,20 +64,6 @@ _LOGGER = logging.getLogger(__package__)
 def setup(hass, config):
     """Set up the Plex component."""
 
-    def server_discovered(service, info):
-        """Pass discovered Plex server details to a config flow."""
-        if hass.config_entries.async_entries(PLEX_DOMAIN):
-            _LOGGER.debug("Plex server already configured, ignoring discovery.")
-            return
-        _LOGGER.debug("Discovered Plex server: %s:%s", info["host"], info["port"])
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                PLEX_DOMAIN,
-                context={"source": config_entries.SOURCE_DISCOVERY},
-                data=info,
-            )
-        )
-
     def setup_plex(config):
         """Pass configuration to a config flow."""
         json_file = hass.config.path(PLEX_CONFIG_FILE)
@@ -107,8 +91,6 @@ def setup(hass, config):
                 }
             else:
                 _LOGGER.info("Legacy config file can be removed: %s", json_file)
-        else:
-            discovery.listen(hass, SERVICE_PLEX, server_discovered)
 
         if server_config:
             hass.async_create_task(

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -63,50 +63,50 @@ _LOGGER = logging.getLogger(__package__)
 
 def setup(hass, config):
     """Set up the Plex component."""
-
-    def setup_plex(config):
-        """Pass configuration to a config flow."""
-        json_file = hass.config.path(PLEX_CONFIG_FILE)
-        file_config = load_json(json_file)
-        server_config = None
-
-        if config:
-            server_config = dict(config)
-            if MP_DOMAIN in server_config:
-                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = server_config.pop(MP_DOMAIN)
-            if CONF_HOST in server_config:
-                prefix = "https" if server_config.pop(CONF_SSL) else "http"
-                server_config[
-                    CONF_URL
-                ] = f"{prefix}://{server_config.pop(CONF_HOST)}:{server_config.pop(CONF_PORT)}"
-        elif file_config:
-            if not hass.config_entries.async_entries(PLEX_DOMAIN):
-                host_and_port, host_config = file_config.popitem()
-                prefix = "https" if host_config[CONF_SSL] else "http"
-
-                server_config = {
-                    CONF_URL: f"{prefix}://{host_and_port}",
-                    CONF_TOKEN: host_config[CONF_TOKEN],
-                    CONF_VERIFY_SSL: host_config["verify"],
-                }
-            else:
-                _LOGGER.info("Legacy config file can be removed: %s", json_file)
-
-        if server_config:
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    PLEX_DOMAIN,
-                    context={"source": config_entries.SOURCE_IMPORT},
-                    data=server_config,
-                )
-            )
-
     hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}})
 
     plex_config = config.get(PLEX_DOMAIN, {})
-    setup_plex(config=plex_config)
+    _setup_plex(hass, plex_config)
 
     return True
+
+
+def _setup_plex(hass, config):
+    """Pass configuration to a config flow."""
+    json_file = hass.config.path(PLEX_CONFIG_FILE)
+    file_config = load_json(json_file)
+    server_config = None
+
+    if config:
+        server_config = dict(config)
+        if MP_DOMAIN in server_config:
+            hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = server_config.pop(MP_DOMAIN)
+        if CONF_HOST in server_config:
+            prefix = "https" if server_config.pop(CONF_SSL) else "http"
+            server_config[
+                CONF_URL
+            ] = f"{prefix}://{server_config.pop(CONF_HOST)}:{server_config.pop(CONF_PORT)}"
+    elif file_config:
+        if not hass.config_entries.async_entries(PLEX_DOMAIN):
+            host_and_port, host_config = file_config.popitem()
+            prefix = "https" if host_config[CONF_SSL] else "http"
+
+            server_config = {
+                CONF_URL: f"{prefix}://{host_and_port}",
+                CONF_TOKEN: host_config[CONF_TOKEN],
+                CONF_VERIFY_SSL: host_config["verify"],
+            }
+        else:
+            _LOGGER.info("Legacy config file can be removed: %s", json_file)
+
+    if server_config:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                PLEX_DOMAIN,
+                context={"source": config_entries.SOURCE_IMPORT},
+                data=server_config,
+            )
+        )
 
 
 async def async_setup_entry(hass, entry):

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -5,6 +5,7 @@ import plexapi.exceptions
 import requests.exceptions
 import voluptuous as vol
 
+from homeassistant import config_entries
 from homeassistant.components.discovery import SERVICE_PLEX
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.const import (
@@ -17,12 +18,13 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
-from homeassistant.util.json import load_json, save_json
+from homeassistant.util.json import load_json
 
 from .const import (
-    CONF_SERVER,
     CONF_USE_EPISODE_ART,
     CONF_SHOW_ALL_CONTROLS,
+    CONF_SERVER,
+    CONF_SERVER_IDENTIFIER,
     DEFAULT_PORT,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
@@ -30,6 +32,7 @@ from .const import (
     PLATFORMS,
     PLEX_CONFIG_FILE,
     PLEX_MEDIA_PLAYER_OPTIONS,
+    PLEX_SERVER_CONFIG,
     SERVERS,
 )
 from .server import PlexServer
@@ -58,7 +61,6 @@ SERVER_CONFIG_SCHEMA = vol.Schema(
 
 CONFIG_SCHEMA = vol.Schema({PLEX_DOMAIN: SERVER_CONFIG_SCHEMA}, extra=vol.ALLOW_EXTRA)
 
-CONFIGURING = "configuring"
 _LOGGER = logging.getLogger(__package__)
 
 
@@ -66,52 +68,71 @@ def setup(hass, config):
     """Set up the Plex component."""
 
     def server_discovered(service, info):
-        """Pass back discovered Plex server details."""
-        if hass.data[PLEX_DOMAIN][SERVERS]:
+        """Pass discovered Plex server details to a config flow."""
+        if hass.config_entries.async_entries(PLEX_DOMAIN):
             _LOGGER.debug("Plex server already configured, ignoring discovery.")
             return
         _LOGGER.debug("Discovered Plex server: %s:%s", info["host"], info["port"])
-        setup_plex(discovery_info=info)
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                PLEX_DOMAIN,
+                context={"source": config_entries.SOURCE_DISCOVERY},
+                data=info,
+            )
+        )
 
-    def setup_plex(config=None, discovery_info=None, configurator_info=None):
-        """Return assembled server_config dict."""
+    def setup_plex(config):
+        """Pass configuration to a config flow."""
         json_file = hass.config.path(PLEX_CONFIG_FILE)
         file_config = load_json(json_file)
-        host_and_port = None
 
         if config:
-            server_config = config
-            if CONF_HOST in server_config:
-                host_and_port = (
-                    f"{server_config.pop(CONF_HOST)}:{server_config.pop(CONF_PORT)}"
+            if MP_DOMAIN in config:
+                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = config.pop(MP_DOMAIN)
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    PLEX_DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT},
+                    data=config,
                 )
-            if MP_DOMAIN in server_config:
-                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = server_config.pop(MP_DOMAIN)
+            )
         elif file_config:
-            _LOGGER.debug("Loading config from %s", json_file)
-            host_and_port, server_config = file_config.popitem()
-            server_config[CONF_VERIFY_SSL] = server_config.pop("verify")
-        elif discovery_info:
-            server_config = {}
-            host_and_port = f"{discovery_info[CONF_HOST]}:{discovery_info[CONF_PORT]}"
-        elif configurator_info:
-            server_config = configurator_info
-            host_and_port = server_config["host_and_port"]
+            if not hass.config_entries.async_entries(PLEX_DOMAIN):
+                hass.async_create_task(
+                    hass.config_entries.flow.async_init(
+                        PLEX_DOMAIN,
+                        context={"source": "import_plex_conf"},
+                        data=file_config,
+                    )
+                )
+            else:
+                _LOGGER.info("Legacy config file can be removed: %s", json_file)
         else:
             discovery.listen(hass, SERVICE_PLEX, server_discovered)
-            return True
 
-        if host_and_port:
-            use_ssl = server_config.get(CONF_SSL, DEFAULT_SSL)
-            http_prefix = "https" if use_ssl else "http"
-            server_config[CONF_URL] = f"{http_prefix}://{host_and_port}"
+    hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}})
 
-        plex_server = PlexServer(server_config)
+    plex_config = config.get(PLEX_DOMAIN, {})
+    setup_plex(config=plex_config)
+
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up Plex from a config entry."""
+    hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}})
+
+    server_config = entry.data[PLEX_SERVER_CONFIG]
+    server_id = entry.data[CONF_SERVER_IDENTIFIER]
+
+    if server_id not in hass.data[PLEX_DOMAIN][SERVERS]:
+        plex_server = await hass.async_add_executor_job(PlexServer, server_config)
         try:
-            plex_server.connect()
+            await hass.async_add_executor_job(plex_server.connect)
         except requests.exceptions.ConnectionError as error:
             _LOGGER.error(
-                "Plex server could not be reached, please verify host and port: [%s]",
+                "Plex server (%s) could not be reached: [%s]",
+                server_config[CONF_URL],
                 error,
             )
             return False
@@ -121,88 +142,20 @@ def setup(hass, config):
             plexapi.exceptions.NotFound,
         ) as error:
             _LOGGER.error(
-                "Connection to Plex server failed, please verify token and SSL settings: [%s]",
+                "Login to %s failed, verify token and SSL settings: [%s]",
+                server_config[CONF_SERVER],
                 error,
             )
-            request_configuration(host_and_port)
             return False
         else:
-            hass.data[PLEX_DOMAIN][SERVERS][
-                plex_server.machine_identifier
-            ] = plex_server
+            hass.data[PLEX_DOMAIN][SERVERS][server_id] = plex_server
 
-            if host_and_port in hass.data[PLEX_DOMAIN][CONFIGURING]:
-                request_id = hass.data[PLEX_DOMAIN][CONFIGURING].pop(host_and_port)
-                configurator = hass.components.configurator
-                configurator.request_done(request_id)
-                _LOGGER.debug("Discovery configuration done")
-            if configurator_info:
-                # Write plex.conf if created via discovery/configurator
-                save_json(
-                    hass.config.path(PLEX_CONFIG_FILE),
-                    {
-                        host_and_port: {
-                            CONF_TOKEN: server_config[CONF_TOKEN],
-                            CONF_SSL: use_ssl,
-                            "verify": server_config[CONF_VERIFY_SSL],
-                        }
-                    },
-                )
+    if not hass.data.get(PLEX_MEDIA_PLAYER_OPTIONS):
+        hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = MEDIA_PLAYER_SCHEMA({})
 
-            if not hass.data.get(PLEX_MEDIA_PLAYER_OPTIONS):
-                hass.data[PLEX_MEDIA_PLAYER_OPTIONS] = MEDIA_PLAYER_SCHEMA({})
-
-            for platform in PLATFORMS:
-                hass.helpers.discovery.load_platform(
-                    platform, PLEX_DOMAIN, {}, original_config
-                )
-
-            return True
-
-    def request_configuration(host_and_port):
-        """Request configuration steps from the user."""
-        configurator = hass.components.configurator
-        if host_and_port in hass.data[PLEX_DOMAIN][CONFIGURING]:
-            configurator.notify_errors(
-                hass.data[PLEX_DOMAIN][CONFIGURING][host_and_port],
-                "Failed to register, please try again.",
-            )
-            return
-
-        def plex_configuration_callback(data):
-            """Handle configuration changes."""
-            config = {
-                "host_and_port": host_and_port,
-                CONF_TOKEN: data.get("token"),
-                CONF_SSL: cv.boolean(data.get("ssl")),
-                CONF_VERIFY_SSL: cv.boolean(data.get("verify_ssl")),
-            }
-            setup_plex(configurator_info=config)
-
-        hass.data[PLEX_DOMAIN][CONFIGURING][
-            host_and_port
-        ] = configurator.request_config(
-            "Plex Media Server",
-            plex_configuration_callback,
-            description="Enter the X-Plex-Token",
-            entity_picture="/static/images/logo_plex_mediaserver.png",
-            submit_caption="Confirm",
-            fields=[
-                {"id": "token", "name": "X-Plex-Token", "type": ""},
-                {"id": "ssl", "name": "Use SSL", "type": ""},
-                {"id": "verify_ssl", "name": "Verify SSL", "type": ""},
-            ],
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
-    # End of inner functions.
-
-    original_config = config
-
-    hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}, CONFIGURING: {}})
-
-    if hass.data[PLEX_DOMAIN][SERVERS]:
-        _LOGGER.debug("Plex server already configured")
-        return False
-
-    plex_config = config.get(PLEX_DOMAIN, {})
-    return setup_plex(config=plex_config)
+    return True

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -119,8 +119,6 @@ def setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up Plex from a config entry."""
-    hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}})
-
     server_config = entry.data[PLEX_SERVER_CONFIG]
 
     plex_server = PlexServer(server_config)

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -34,7 +34,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Initialize the Plex flow."""
         self.current_login = {}
-        self.discovery_info = {}
         self.available_servers = None
 
     async def async_step_user(self, user_input=None):
@@ -151,7 +150,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.info("Imported legacy config, file can be removed: %s", json_file)
             return await self.async_step_server_validate(server_config)
 
-        self.discovery_info = discovery_info
         return await self.async_step_user()
 
     async def async_step_import(self, import_config):

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -38,12 +38,10 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=USER_SCHEMA, errors={}
-            )
+        if user_input is not None:
+            return await self.async_step_server_validate(user_input)
 
-        return await self.async_step_server_validate(user_input)
+        return self.async_show_form(step_id="user", data_schema=USER_SCHEMA, errors={})
 
     async def async_step_server_validate(self, server_config):
         """Validate a provided configuration."""
@@ -106,7 +104,9 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_select_server(self, user_input=None):
         """Use selected Plex server."""
         config = dict(self.current_login)
-        if user_input is None:
+        if user_input is not None:
+            config[CONF_SERVER] = user_input[CONF_SERVER]
+        else:
             configured_servers = [
                 x.data[CONF_SERVER_IDENTIFIER] for x in self._async_current_entries()
             ]
@@ -124,8 +124,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     errors={},
                 )
             config[CONF_SERVER] = available_servers[0]
-        else:
-            config[CONF_SERVER] = user_input[CONF_SERVER]
 
         return await self.async_step_server_validate(config)
 

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -71,11 +71,11 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception as error:  # pylint: disable=broad-except
             _LOGGER.error("Unknown error connecting to Plex server: %s", error)
             return self.async_abort(reason="unknown")
-        else:
-            if errors:
-                return self.async_show_form(
-                    step_id="user", data_schema=data_schema, errors=errors
-                )
+
+        if errors:
+            return self.async_show_form(
+                step_id="user", data_schema=self.USER_SCHEMA, errors=errors
+            )
 
         server_id = plex_server.machine_identifier
 

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -134,8 +134,9 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_discovery(self, discovery_info):
         """Set default host and port from discovery."""
-        if self._async_in_progress():
-            return self.async_abort(reason="already_in_progress")
+        if self._async_current_entries():
+            # Skip discovery if any config already exists.
+            return self.async_abort(reason="already_configured")
 
         self.discovery_info = discovery_info
         return await self.async_step_user()

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -31,8 +31,7 @@ from .server import PlexServer
 _LOGGER = logging.getLogger(__package__)
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class PlexFlowHandler(config_entries.ConfigFlow):
+class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Plex config flow."""
 
     VERSION = 1
@@ -54,7 +53,7 @@ class PlexFlowHandler(config_entries.ConfigFlow):
 
             self.current_login = user_input
 
-            plex_server = await self.hass.async_add_executor_job(PlexServer, user_input)
+            plex_server = PlexServer(user_input)
             try:
                 await self.hass.async_add_executor_job(plex_server.connect)
             except NoServersFound:

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -172,9 +172,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         Legacy.
         """
-        if self._async_in_progress():
-            return self.async_abort(reason="already_in_progress")
-
         host_and_port, host_config = import_config.popitem()
         prefix = "https" if host_config[CONF_SSL] else "http"
         url = f"{prefix}://{host_and_port}"
@@ -190,9 +187,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config):
         """Import from Plex configuration."""
-        if self._async_in_progress():
-            return self.async_abort(reason="already_in_progress")
-
         host = import_config.get(CONF_HOST)
         port = import_config[CONF_PORT]
         token = import_config.get(CONF_TOKEN)

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -167,35 +167,13 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.discovery_info = discovery_info
         return await self.async_step_user()
 
-    async def async_step_import_plex_conf(self, import_config):
-        """Import from Plex media_player file config.
-
-        Legacy.
-        """
-        host_and_port, host_config = import_config.popitem()
-        prefix = "https" if host_config[CONF_SSL] else "http"
-        url = f"{prefix}://{host_and_port}"
-
-        config = {
-            CONF_URL: url,
-            CONF_TOKEN: host_config[CONF_TOKEN],
-            CONF_VERIFY_SSL: host_config["verify"],
-        }
-
-        _LOGGER.info("Imported configuration from legacy config file")
-        return await self.async_step_user(user_input=config)
-
     async def async_step_import(self, import_config):
         """Import from Plex configuration."""
-        host = import_config.get(CONF_HOST)
-        port = import_config[CONF_PORT]
+        url = import_config.get(CONF_URL)
         token = import_config.get(CONF_TOKEN)
         server = import_config.get(CONF_SERVER)
 
-        if host and port:
-            prefix = "https" if import_config[CONF_SSL] else "http"
-            url = f"{prefix}://{host}:{port}"
-
+        if url:
             config = {
                 CONF_URL: url,
                 CONF_TOKEN: token,

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 
-from .const import (
+from .const import (  # pylint: disable=unused-import
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
     DEFAULT_PORT,

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -136,7 +136,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="already_configured")
 
         json_file = self.hass.config.path(PLEX_CONFIG_FILE)
-        file_config = load_json(json_file)
+        file_config = await self.hass.async_add_executor_job(load_json, json_file)
 
         if file_config:
             host_and_port, host_config = file_config.popitem()

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -104,6 +104,8 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL
                 )
 
+            _LOGGER.debug("Valid config created for %s", plex_server.friendly_name)
+
             return self.async_create_entry(
                 title=plex_server.friendly_name,
                 data={

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -59,13 +59,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except NoServersFound:
                 errors["base"] = "no_servers"
             except ServerNotSpecified as available_servers:
-                return self.async_show_form(
-                    step_id="select_server",
-                    data_schema=vol.Schema(
-                        {vol.Required(CONF_SERVER): vol.In(available_servers.args[0])}
-                    ),
-                    errors={},
-                )
+                return await self.async_step_select_server(available_servers.args[0])
             except (plexapi.exceptions.BadRequest, plexapi.exceptions.Unauthorized):
                 _LOGGER.error("Invalid credentials provided, config not created")
                 errors["base"] = "faulty_credentials"
@@ -152,6 +146,13 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Use selected Plex server."""
         if user_input is None:
             return await self.async_step_user()
+
+        if isinstance(user_input, list):
+            return self.async_show_form(
+                step_id="select_server",
+                data_schema=vol.Schema({vol.Required(CONF_SERVER): vol.In(user_input)}),
+                errors={},
+            )
 
         config = self.current_login
         config[CONF_SERVER] = user_input.get(CONF_SERVER)

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -71,6 +71,9 @@ class PlexFlowHandler(config_entries.ConfigFlow):
                 _LOGGER.error("Invalid credentials provided, config not created")
                 errors["base"] = "faulty_credentials"
             except (plexapi.exceptions.NotFound, requests.exceptions.ConnectionError):
+                _LOGGER.error(
+                    "Plex server could not be reached: %s", user_input[CONF_URL]
+                )
                 errors["base"] = "not_found"
             except Exception as error:  # pylint: disable=broad-except
                 _LOGGER.error("Unknown error connecting to Plex server: %s", error)

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -23,7 +23,6 @@ from .const import (
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     PLEX_SERVER_CONFIG,
-    SERVERS,
 )
 from .errors import NoServersFound, ServerNotSpecified
 from .server import PlexServer
@@ -75,11 +74,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="unknown")
             else:
                 server_id = plex_server.machine_identifier
-
-                # Allow shared server creation from imports...
-                self.hass.data[DOMAIN][SERVERS][server_id] = plex_server
-
-                # ...but do not create a new config entry if it already exists.
                 for entry in self._async_current_entries():
                     if entry.data[CONF_SERVER_IDENTIFIER] == server_id:
                         return self.async_abort(  # pylint: disable=lost-exception

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -132,8 +132,8 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_discovery(self, discovery_info):
         """Set default host and port from discovery."""
-        if self._async_current_entries():
-            # Skip discovery if any config already exists.
+        if self._async_current_entries() or self._async_in_progress():
+            # Skip discovery if a config already exists or is in progress.
             return self.async_abort(reason="already_configured")
 
         self.discovery_info = discovery_info

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -6,20 +6,11 @@ import requests.exceptions
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_URL,
-    CONF_HOST,
-    CONF_PORT,
-    CONF_TOKEN,
-    CONF_SSL,
-    CONF_VERIFY_SSL,
-)
+from homeassistant.const import CONF_URL, CONF_TOKEN, CONF_VERIFY_SSL
 
 from .const import (  # pylint: disable=unused-import
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
-    DEFAULT_PORT,
-    DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     PLEX_SERVER_CONFIG,
@@ -50,16 +41,11 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Optional(
                     CONF_TOKEN, default=self.current_login.get(CONF_TOKEN, "")
-                ): str,
-                vol.Optional("manual_setup"): bool,
+                ): str
             }
         )
 
         if user_input is not None:
-            manual_setup = user_input.get("manual_setup")
-            if manual_setup is True:
-                return await self.async_step_manual_setup()
-
             self.current_login = user_input
 
             plex_server = PlexServer(user_input)
@@ -118,31 +104,6 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
         )
-
-    async def async_step_manual_setup(self, user_input=None):
-        """Begin manual configuration."""
-        if user_input is None:
-            data_schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST, default=self.discovery_info.get(CONF_HOST)
-                    ): str,
-                    vol.Required(
-                        CONF_PORT,
-                        default=int(self.discovery_info.get(CONF_PORT, DEFAULT_PORT)),
-                    ): int,
-                    vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
-                    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
-                    vol.Optional(CONF_TOKEN): str,
-                }
-            )
-            return self.async_show_form(step_id="manual_setup", data_schema=data_schema)
-
-        host = user_input.pop(CONF_HOST)
-        port = user_input.pop(CONF_PORT)
-        prefix = "https" if user_input.get(CONF_SSL) else "http"
-        user_input[CONF_URL] = f"{prefix}://{host}:{port}"
-        return await self.async_step_user(user_input=user_input)
 
     async def async_step_select_server(self, user_input=None):
         """Use selected Plex server."""

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -1,0 +1,212 @@
+"""Config flow for Plex."""
+import logging
+
+import plexapi.exceptions
+import requests.exceptions
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_URL,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TOKEN,
+    CONF_SSL,
+    CONF_VERIFY_SSL,
+)
+
+from .const import (
+    CONF_SERVER,
+    CONF_SERVER_IDENTIFIER,
+    DEFAULT_PORT,
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    PLEX_SERVER_CONFIG,
+    SERVERS,
+)
+from .errors import NoServersFound, ServerNotSpecified
+from .server import PlexServer
+
+_LOGGER = logging.getLogger(__package__)
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class PlexFlowHandler(config_entries.ConfigFlow):
+    """Handle a Plex config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self):
+        """Initialize the Plex flow."""
+        self.current_login = {}
+        self.discovery_info = {}
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        if user_input is not None:
+            manual_setup = user_input.get("manual_setup")
+            if manual_setup is True:
+                return await self.async_step_manual_setup()
+
+            self.current_login = user_input
+
+            plex_server = await self.hass.async_add_executor_job(PlexServer, user_input)
+            try:
+                await self.hass.async_add_executor_job(plex_server.connect)
+            except NoServersFound:
+                errors["base"] = "no_servers"
+            except ServerNotSpecified as available_servers:
+                return self.async_show_form(
+                    step_id="select_server",
+                    data_schema=vol.Schema(
+                        {vol.Required(CONF_SERVER): vol.In(available_servers.args[0])}
+                    ),
+                    errors={},
+                )
+            except (plexapi.exceptions.BadRequest, plexapi.exceptions.Unauthorized):
+                _LOGGER.error("Invalid credentials provided, config not created")
+                errors["base"] = "faulty_credentials"
+            except (plexapi.exceptions.NotFound, requests.exceptions.ConnectionError):
+                errors["base"] = "not_found"
+            except Exception as error:  # pylint: disable=broad-except
+                _LOGGER.error("Unknown error connecting to Plex server: %s", error)
+                return self.async_abort(reason="unknown")
+            else:
+                server_id = plex_server.machine_identifier
+
+                # Allow shared server creation from imports...
+                self.hass.data[DOMAIN][SERVERS][server_id] = plex_server
+
+                # ...but do not create a new config entry if it already exists.
+                for entry in self._async_current_entries():
+                    if entry.data[CONF_SERVER_IDENTIFIER] == server_id:
+                        return self.async_abort(  # pylint: disable=lost-exception
+                            reason="already_configured"
+                        )
+
+                url = plex_server.url_in_use
+                token = user_input.get(CONF_TOKEN)
+
+                server_config = {CONF_URL: url}
+                if token:
+                    server_config[CONF_TOKEN] = token
+                if url.startswith("https"):
+                    server_config[CONF_VERIFY_SSL] = user_input.get(
+                        CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL
+                    )
+
+                return self.async_create_entry(  # pylint: disable=lost-exception
+                    title=plex_server.friendly_name,
+                    data={
+                        CONF_SERVER: plex_server.friendly_name,
+                        CONF_SERVER_IDENTIFIER: server_id,
+                        PLEX_SERVER_CONFIG: server_config,
+                    },
+                )
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_TOKEN, default=self.current_login.get(CONF_TOKEN, "")
+                ): str,
+                vol.Optional("manual_setup"): bool,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_manual_setup(self, user_input=None):
+        """Begin manual configuration."""
+        if user_input is None:
+            data_schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST, default=self.discovery_info.get(CONF_HOST)
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=int(self.discovery_info.get(CONF_PORT, DEFAULT_PORT)),
+                    ): int,
+                    vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
+                    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
+                    vol.Optional(CONF_TOKEN): str,
+                }
+            )
+            return self.async_show_form(step_id="manual_setup", data_schema=data_schema)
+
+        host = user_input.pop(CONF_HOST)
+        port = user_input.pop(CONF_PORT)
+        prefix = "https" if user_input.get(CONF_SSL) else "http"
+        user_input[CONF_URL] = f"{prefix}://{host}:{port}"
+        return await self.async_step_user(user_input=user_input)
+
+    async def async_step_select_server(self, user_input=None):
+        """Use selected Plex server."""
+        if user_input is None:
+            return await self.async_step_user()
+
+        config = self.current_login
+        config[CONF_SERVER] = user_input.get(CONF_SERVER)
+        return await self.async_step_user(user_input=config)
+
+    async def async_step_discovery(self, discovery_info):
+        """Set default host and port from discovery."""
+        if self._async_in_progress():
+            return self.async_abort(reason="already_in_progress")
+
+        self.discovery_info = discovery_info
+        return await self.async_step_user()
+
+    async def async_step_import_plex_conf(self, import_config):
+        """Import from Plex media_player file config.
+
+        Legacy.
+        """
+        if self._async_in_progress():
+            return self.async_abort(reason="already_in_progress")
+
+        host_and_port, host_config = import_config.popitem()
+        prefix = "https" if host_config[CONF_SSL] else "http"
+        url = f"{prefix}://{host_and_port}"
+
+        config = {
+            CONF_URL: url,
+            CONF_TOKEN: host_config[CONF_TOKEN],
+            CONF_VERIFY_SSL: host_config["verify"],
+        }
+
+        _LOGGER.info("Imported configuration from legacy config file")
+        return await self.async_step_user(user_input=config)
+
+    async def async_step_import(self, import_config):
+        """Import from Plex configuration."""
+        if self._async_in_progress():
+            return self.async_abort(reason="already_in_progress")
+
+        host = import_config.get(CONF_HOST)
+        port = import_config[CONF_PORT]
+        token = import_config.get(CONF_TOKEN)
+        server = import_config.get(CONF_SERVER)
+
+        if host and port:
+            prefix = "https" if import_config[CONF_SSL] else "http"
+            url = f"{prefix}://{host}:{port}"
+
+            config = {
+                CONF_URL: url,
+                CONF_TOKEN: token,
+                CONF_VERIFY_SSL: import_config[CONF_VERIFY_SSL],
+            }
+        elif token:
+            config = {CONF_TOKEN: token, CONF_SERVER: server}
+        else:
+            return self.async_abort(reason="invalid_import")
+
+        _LOGGER.debug("Imported Plex configuration")
+        return await self.async_step_user(user_input=config)

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -14,5 +14,6 @@ PLEX_MEDIA_PLAYER_OPTIONS = "plex_mp_options"
 PLEX_SERVER_CONFIG = "server_config"
 
 CONF_SERVER = "server"
+CONF_SERVER_IDENTIFIER = "server_id"
 CONF_USE_EPISODE_ART = "use_episode_art"
 CONF_SHOW_ALL_CONTROLS = "show_all_controls"

--- a/homeassistant/components/plex/errors.py
+++ b/homeassistant/components/plex/errors.py
@@ -1,0 +1,14 @@
+"""Errors for the Plex component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class PlexException(HomeAssistantError):
+    """Base class for Plex exceptions."""
+
+
+class NoServersFound(PlexException):
+    """No servers found on Plex account."""
+
+
+class ServerNotSpecified(PlexException):
+    """Multiple servers linked to account without choice provided."""

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -1,11 +1,12 @@
 {
   "domain": "plex",
   "name": "Plex",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/plex",
   "requirements": [
     "plexapi==3.0.6"
   ],
-  "dependencies": ["configurator"],
+  "dependencies": [],
   "codeowners": [
     "@jjlawren"
   ]

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -45,20 +45,20 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities_callback, discovery_info=None):
+def async_setup_platform(hass, config, add_entities_callback, discovery_info=None):
     """Set up the Plex media_player platform.
 
     Deprecated.
     """
-    return
+    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Plex media_player from a config entry."""
 
-    def add_entities(devices, update_before_add=False):
-        """Sync version of async add devices."""
-        hass.add_job(async_add_entities, devices, update_before_add)
+    def add_entities(entities, update_before_add=False):
+        """Sync version of async add entities."""
+        hass.add_job(async_add_entities, entities, update_before_add)
 
     hass.async_add_executor_job(_setup_platform, hass, config_entry, add_entities)
 

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -35,26 +35,40 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_USE_EPISODE_ART,
     CONF_SHOW_ALL_CONTROLS,
+    CONF_SERVER_IDENTIFIER,
     DOMAIN as PLEX_DOMAIN,
     NAME_FORMAT,
     PLEX_MEDIA_PLAYER_OPTIONS,
     SERVERS,
 )
 
-SERVER_SETUP = "server_setup"
-
-_CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_entities_callback, discovery_info=None):
-    """Set up the Plex platform."""
-    if discovery_info is None:
-        return
+    """Set up the Plex media_player platform.
 
-    plexserver = list(hass.data[PLEX_DOMAIN][SERVERS].values())[0]
+    Deprecated.
+    """
+    return
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Plex media_player from a config entry."""
+
+    def add_entities(devices, update_before_add=False):
+        """Sync version of async add devices."""
+        hass.add_job(async_add_entities, devices, update_before_add)
+
+    hass.async_add_executor_job(_setup_platform, hass, config_entry, add_entities)
+
+
+def _setup_platform(hass, config_entry, add_entities_callback):
+    """Set up the Plex media_player platform."""
+    server_id = config_entry.data[CONF_SERVER_IDENTIFIER]
     config = hass.data[PLEX_MEDIA_PLAYER_OPTIONS]
 
+    plexserver = hass.data[PLEX_DOMAIN][SERVERS][server_id]
     plex_clients = {}
     plex_sessions = {}
     track_time_interval(hass, lambda now: update_devices(), timedelta(seconds=10))

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -45,7 +45,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def async_setup_platform(hass, config, add_entities_callback, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Plex media_player platform.
 
     Deprecated.

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -8,21 +8,36 @@ import requests.exceptions
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-from .const import DOMAIN as PLEX_DOMAIN, SERVERS
+from .const import CONF_SERVER_IDENTIFIER, DOMAIN as PLEX_DOMAIN, SERVERS
 
-DEFAULT_NAME = "Plex"
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Plex sensor."""
-    if discovery_info is None:
-        return
+    """Set up the Plex sensor platform.
 
-    plexserver = list(hass.data[PLEX_DOMAIN][SERVERS].values())[0]
-    add_entities([PlexSensor(plexserver)], True)
+    Deprecated.
+    """
+    return
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Plex sensor from a config entry."""
+
+    def add_entities(devices, update_before_add=False):
+        """Sync version of async add devices."""
+        hass.add_job(async_add_entities, devices, update_before_add)
+
+    hass.async_add_executor_job(_setup_platform, hass, config_entry, add_entities)
+
+
+def _setup_platform(hass, config_entry, add_entities):
+    """Set up the Plex sensor platform."""
+    server_id = config_entry.data[CONF_SERVER_IDENTIFIER]
+    sensor = PlexSensor(hass.data[PLEX_DOMAIN][SERVERS][server_id])
+    add_entities([sensor], True)
 
 
 class PlexSensor(Entity):
@@ -30,10 +45,10 @@ class PlexSensor(Entity):
 
     def __init__(self, plex_server):
         """Initialize the sensor."""
-        self._name = DEFAULT_NAME
         self._state = None
         self._now_playing = []
         self._server = plex_server
+        self._name = f"Plex ({plex_server.friendly_name})"
         self._unique_id = f"sensor-{plex_server.machine_identifier}"
 
     @property

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -15,29 +15,19 @@ _LOGGER = logging.getLogger(__name__)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def async_setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Plex sensor platform.
 
     Deprecated.
     """
-    return
+    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Plex sensor from a config entry."""
-
-    def add_entities(devices, update_before_add=False):
-        """Sync version of async add devices."""
-        hass.add_job(async_add_entities, devices, update_before_add)
-
-    hass.async_add_executor_job(_setup_platform, hass, config_entry, add_entities)
-
-
-def _setup_platform(hass, config_entry, add_entities):
-    """Set up the Plex sensor platform."""
     server_id = config_entry.data[CONF_SERVER_IDENTIFIER]
     sensor = PlexSensor(hass.data[PLEX_DOMAIN][SERVERS][server_id])
-    add_entities([sensor], True)
+    async_add_entities([sensor], True)
 
 
 class PlexSensor(Entity):

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 
-def async_setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Plex sensor platform.
 
     Deprecated.

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -1,6 +1,4 @@
 """Shared class to maintain Plex server instances."""
-import logging
-
 import plexapi.myplex
 import plexapi.server
 from requests import Session
@@ -9,8 +7,6 @@ from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
 from .const import CONF_SERVER, DEFAULT_VERIFY_SSL
 from .errors import NoServersFound, ServerNotSpecified
-
-_LOGGER = logging.getLogger(__package__)
 
 
 class PlexServer:
@@ -54,7 +50,6 @@ class PlexServer:
             self._plex_server = plexapi.server.PlexServer(
                 self._url, self._token, session
             )
-            _LOGGER.debug("Connected to: %s (%s)", self.friendly_name, self.url_in_use)
 
         if self._token and not self._url:
             _set_missing_url()

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -8,6 +8,7 @@ from requests import Session
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
 from .const import CONF_SERVER, DEFAULT_VERIFY_SSL
+from .errors import NoServersFound, ServerNotSpecified
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -31,6 +32,12 @@ class PlexServer:
             available_servers = [
                 x.name for x in account.resources() if "server" in x.provides
             ]
+
+            if not available_servers:
+                raise NoServersFound
+            if not self._server_name and len(available_servers) > 1:
+                raise ServerNotSpecified(available_servers)
+
             server_choice = (
                 self._server_name if self._server_name else available_servers[0]
             )

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -26,7 +26,9 @@ class PlexServer:
         def _set_missing_url():
             account = plexapi.myplex.MyPlexAccount(token=self._token)
             available_servers = [
-                x.name for x in account.resources() if "server" in x.provides
+                (x.name, x.clientIdentifier)
+                for x in account.resources()
+                if "server" in x.provides
             ]
 
             if not available_servers:

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -23,6 +23,7 @@
             "not_found": "Plex server not found"
         },
         "abort": {
+            "all_configured": "All linked servers already configured",
             "already_configured": "This Plex server is already configured",
             "already_in_progress": "Plex is being configured",
             "invalid_import": "Imported configuration is invalid",

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -2,16 +2,6 @@
     "config": {
         "title": "Plex",
         "step": {
-            "manual_setup": {
-                "title": "Plex server",
-                "data": {
-                    "host": "Host",
-                    "port": "Port",
-                    "ssl": "Use SSL",
-                    "verify_ssl": "Verify SSL certificate",
-                    "token": "Token (if required)"
-                }
-            },
             "select_server": {
                 "title": "Select Plex server",
                 "description": "Multiple servers available, select one:",
@@ -21,10 +11,9 @@
             },
             "user": {
                 "title": "Connect Plex server",
-                "description": "Enter a Plex token for automatic setup or manually configure a server.",
+                "description": "Enter a Plex token for automatic setup.",
                 "data": {
-                    "token": "Plex token",
-                    "manual_setup": "Manual setup"
+                    "token": "Plex token"
                 }
             }
         },

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -29,11 +29,9 @@
             }
         },
         "error": {
-            "config_not_ready": "Configuration provided is incomplete",
             "faulty_credentials": "Authorization failed",
             "no_servers": "No servers linked to account",
-            "not_found": "Plex server not found",
-            "server_not_specified": "Multiple servers available, select one"
+            "not_found": "Plex server not found"
         },
         "abort": {
             "already_configured": "This Plex server is already configured",

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -1,0 +1,45 @@
+{
+    "config": {
+        "title": "Plex",
+        "step": {
+            "manual_setup": {
+                "title": "Plex server",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "ssl": "Use SSL",
+                    "verify_ssl": "Verify SSL certificate",
+                    "token": "Token (if required)"
+                }
+            },
+            "select_server": {
+                "title": "Select Plex server",
+                "description": "Multiple servers available, select one:",
+                "data": {
+                    "server": "Server"
+                }
+            },
+            "user": {
+                "title": "Connect Plex server",
+                "description": "Enter a Plex token for automatic setup or manually configure a server.",
+                "data": {
+                    "token": "Plex token",
+                    "manual_setup": "Manual setup"
+                }
+            }
+        },
+        "error": {
+            "config_not_ready": "Configuration provided is incomplete",
+            "faulty_credentials": "Authorization failed",
+            "no_servers": "No servers linked to account",
+            "not_found": "Plex server not found",
+            "server_not_specified": "Multiple servers available, select one"
+        },
+        "abort": {
+            "already_configured": "This Plex server is already configured",
+            "already_in_progress": "Plex is being configured",
+            "invalid_import": "Imported configuration is invalid",
+            "unknown": "Failed for unknown reason"
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -45,6 +45,7 @@ FLOWS = [
     "openuv",
     "owntracks",
     "plaato",
+    "plex",
     "point",
     "ps4",
     "rainmachine",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -249,6 +249,9 @@ pexpect==4.6.0
 # homeassistant.components.pilight
 pilight==0.1.1
 
+# homeassistant.components.plex
+plexapi==3.0.6
+
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm
 pmsensor==0.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -110,6 +110,7 @@ TEST_REQUIREMENTS = (
     "paho-mqtt",
     "pexpect",
     "pilight",
+    "plexapi",
     "pmsensor",
     "prometheus_client",
     "ptvsd",

--- a/tests/components/plex/__init__.py
+++ b/tests/components/plex/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Plex component."""

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -1,0 +1,35 @@
+"""Mock classes used in tests."""
+
+MOCK_HOST_1 = "1.2.3.4"
+MOCK_PORT_1 = "32400"
+MOCK_HOST_2 = "4.3.2.1"
+MOCK_PORT_2 = "32400"
+
+
+class MockAvailableServer:  # pylint: disable=too-few-public-methods
+    """Mock avilable server objects."""
+
+    def __init__(self, name, client_id):
+        """Initialize the object."""
+        self.name = name
+        self.clientIdentifier = client_id  # pylint: disable=invalid-name
+        self.provides = ["server"]
+
+
+class MockConnection:  # pylint: disable=too-few-public-methods
+    """Mock a single account resource connection object."""
+
+    def __init__(self, ssl):
+        """Initialize the object."""
+        prefix = "https" if ssl else "http"
+        self.httpuri = f"{prefix}://{MOCK_HOST_1}:{MOCK_PORT_1}"
+        self.uri = "{prefix}://{MOCK_HOST_2}:{MOCK_PORT_2}"
+        self.local = True
+
+
+class MockConnections:  # pylint: disable=too-few-public-methods
+    """Mock a list of resource connections."""
+
+    def __init__(self, ssl=False):
+        """Initialize the object."""
+        self.connections = [MockConnection(ssl)]

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -159,6 +159,7 @@ async def test_import_success(hass):
         result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_URL]
         == mock_connections.connections[0].httpuri
     )
+    assert result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
 
 async def test_import_bad_hostname(hass):
@@ -266,6 +267,11 @@ async def test_single_available_server(hass):
             result["data"][config_flow.CONF_SERVER_IDENTIFIER]
             == MOCK_SERVER_1.clientIdentifier
         )
+        assert (
+            result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_URL]
+            == mock_connections.connections[0].httpuri
+        )
+        assert result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
 
 async def test_multiple_servers_with_selection(hass):
@@ -314,6 +320,11 @@ async def test_multiple_servers_with_selection(hass):
             result["data"][config_flow.CONF_SERVER_IDENTIFIER]
             == MOCK_SERVER_1.clientIdentifier
         )
+        assert (
+            result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_URL]
+            == mock_connections.connections[0].httpuri
+        )
+        assert result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
 
 async def test_adding_last_unconfigured_server(hass):
@@ -363,6 +374,11 @@ async def test_adding_last_unconfigured_server(hass):
             result["data"][config_flow.CONF_SERVER_IDENTIFIER]
             == MOCK_SERVER_1.clientIdentifier
         )
+        assert (
+            result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_URL]
+            == mock_connections.connections[0].httpuri
+        )
+        assert result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_TOKEN] == MOCK_TOKEN
 
 
 async def test_already_configured(hass):

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -1,0 +1,265 @@
+"""Tests for Plex config flow."""
+from unittest.mock import MagicMock, Mock, patch, PropertyMock
+import plexapi.exceptions
+import requests.exceptions
+
+from homeassistant.components.plex import config_flow
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_URL
+
+from tests.common import mock_coro
+
+
+class MockAvailableServer:
+    """Mock avilable server objects."""
+
+    def __init__(self, name, client_id):
+        """Initialize the object."""
+        self.name = name
+        self.clientIdentifier = client_id
+        self.provides = ["server"]
+
+
+class MockConnection:
+    """Mock a single account resource connection object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.httpuri = "http://1.2.3.4:32400"
+        self.uri = "http://4.3.2.1:32400"
+        self.local = True
+
+
+class MockConnections:
+    """Mock a list of resource connections."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.connections = [MockConnection()]
+
+
+async def test_bad_credentials(hass, aioclient_mock):
+    """Test when provided credentials are rejected."""
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    with patch(
+        "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
+    ):
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+        )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "faulty_credentials"
+
+
+async def test_import_file_from_discovery(hass, aioclient_mock):
+    """Test importing a legacy file during discovery."""
+
+    mock_file_contents = {
+        "1.2.3.4:32400": {"ssl": False, "token": "12345", "verify": True}
+    }
+    file_host_and_port, file_config = list(mock_file_contents.items())[0]
+    used_url = f"http://{file_host_and_port}"
+
+    with patch("plexapi.server.PlexServer") as mock_plex_server, patch(
+        "homeassistant.components.plex.config_flow.load_json",
+        return_value=mock_coro(mock_file_contents),
+    ):
+        type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
+            return_value="unique_id_123"
+        )
+        type(mock_plex_server.return_value).friendlyName = PropertyMock(
+            return_value="Mock Server"
+        )
+        type(mock_plex_server.return_value)._baseurl = PropertyMock(
+            return_value=used_url
+        )
+
+        result = await hass.config_entries.flow.async_init(
+            config_flow.DOMAIN,
+            context={"source": "discovery"},
+            data={CONF_HOST: "1.2.3.4", CONF_PORT: "32400"},
+        )
+        print(result)
+
+        assert result["type"] == "create_entry"
+        assert result["title"] == "Mock Server"
+        assert result["data"][config_flow.CONF_SERVER] == "Mock Server"
+        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
+        assert result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_URL] == used_url
+        assert (
+            result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_TOKEN]
+            == file_config[CONF_TOKEN]
+        )
+
+
+async def test_discovery(hass, aioclient_mock):
+    """Test starting a flow from discovery."""
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN,
+        context={"source": "discovery"},
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: "32400"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+
+async def test_import_bad_hostname(hass, aioclient_mock):
+    """Test when an invalid address is provided."""
+
+    with patch(
+        "plexapi.server.PlexServer", side_effect=requests.exceptions.ConnectionError
+    ):
+        result = await hass.config_entries.flow.async_init(
+            config_flow.DOMAIN,
+            context={"source": "import"},
+            data={CONF_TOKEN: "12345", CONF_URL: "http://1.2.3.4:32400"},
+        )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "not_found"
+
+
+async def test_unknown_exception(hass, aioclient_mock):
+    """Test when an unknown exception is encountered."""
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    with patch("plexapi.myplex.MyPlexAccount", side_effect=Exception):
+        result = await hass.config_entries.flow.async_init(
+            config_flow.DOMAIN, context={"source": "user"}, data={CONF_TOKEN: "12345"}
+        )
+        print(result)
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "unknown"
+
+
+async def test_no_servers_found(hass, aioclient_mock):
+    """Test when no servers are on an account."""
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    mm_plex_account = MagicMock()
+    mm_plex_account.resources = Mock(return_value=[])
+
+    with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account):
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+        )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "no_servers"
+
+
+async def test_single_available_server(hass, aioclient_mock):
+    """Test creating an entry with one server available."""
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    mock_connections = MockConnections()
+    mock_servers = ["Server1"]
+    server1 = MockAvailableServer("Server1", "1")
+
+    mm_plex_account = MagicMock()
+    mm_plex_account.resources = Mock(return_value=[server1])
+    mm_plex_account.resource = Mock(return_value=mock_connections)
+
+    with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
+        "plexapi.server.PlexServer"
+    ) as mock_plex_server:
+        type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
+            return_value="unique_id_123"
+        )
+        type(mock_plex_server.return_value).friendlyName = PropertyMock(
+            return_value=mock_servers[0]
+        )
+        type(mock_plex_server.return_value)._baseurl = PropertyMock(
+            return_value=mock_connections.connections[0].httpuri
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+        )
+
+        assert result["type"] == "create_entry"
+        assert result["title"] == mock_servers[0]
+        assert result["data"][config_flow.CONF_SERVER] == mock_servers[0]
+        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
+
+
+async def test_multiple_servers_with_selection(hass, aioclient_mock):
+    """Test creating an entry with multiple servers available."""
+
+    result = await hass.config_entries.flow.async_init(
+        config_flow.DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    mock_connections = MockConnections()
+    mock_servers = ["Server1", "Server2"]
+    server1 = MockAvailableServer("Server1", "1")
+    server2 = MockAvailableServer("Server2", "2")
+
+    mm_plex_account = MagicMock()
+    mm_plex_account.resources = Mock(return_value=[server1, server2])
+    mm_plex_account.resource = Mock(return_value=mock_connections)
+
+    with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
+        "plexapi.server.PlexServer"
+    ) as mock_plex_server:
+        type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
+            return_value="unique_id_123"
+        )
+        type(mock_plex_server.return_value).friendlyName = PropertyMock(
+            return_value=mock_servers[0]
+        )
+        type(mock_plex_server.return_value)._baseurl = PropertyMock(
+            return_value=mock_connections.connections[0].httpuri
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+        )
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "select_server"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={config_flow.CONF_SERVER: mock_servers[0]}
+        )
+
+        assert result["type"] == "create_entry"
+        assert result["title"] == mock_servers[0]
+        assert result["data"][config_flow.CONF_SERVER] == mock_servers[0]
+        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -6,8 +6,6 @@ import requests.exceptions
 from homeassistant.components.plex import config_flow
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_URL
 
-from tests.common import mock_coro
-
 
 class MockAvailableServer:
     """Mock avilable server objects."""
@@ -37,7 +35,7 @@ class MockConnections:
         self.connections = [MockConnection()]
 
 
-async def test_bad_credentials(hass, aioclient_mock):
+async def test_bad_credentials(hass):
     """Test when provided credentials are rejected."""
 
     result = await hass.config_entries.flow.async_init(
@@ -60,7 +58,7 @@ async def test_bad_credentials(hass, aioclient_mock):
         assert result["errors"]["base"] == "faulty_credentials"
 
 
-async def test_import_file_from_discovery(hass, aioclient_mock):
+async def test_import_file_from_discovery(hass):
     """Test importing a legacy file during discovery."""
 
     mock_file_contents = {
@@ -71,7 +69,7 @@ async def test_import_file_from_discovery(hass, aioclient_mock):
 
     with patch("plexapi.server.PlexServer") as mock_plex_server, patch(
         "homeassistant.components.plex.config_flow.load_json",
-        return_value=mock_coro(mock_file_contents),
+        return_value=mock_file_contents,
     ):
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -88,7 +86,6 @@ async def test_import_file_from_discovery(hass, aioclient_mock):
             context={"source": "discovery"},
             data={CONF_HOST: "1.2.3.4", CONF_PORT: "32400"},
         )
-        print(result)
 
         assert result["type"] == "create_entry"
         assert result["title"] == "Mock Server"
@@ -101,7 +98,7 @@ async def test_import_file_from_discovery(hass, aioclient_mock):
         )
 
 
-async def test_discovery(hass, aioclient_mock):
+async def test_discovery(hass):
     """Test starting a flow from discovery."""
 
     result = await hass.config_entries.flow.async_init(
@@ -114,7 +111,7 @@ async def test_discovery(hass, aioclient_mock):
     assert result["step_id"] == "user"
 
 
-async def test_import_bad_hostname(hass, aioclient_mock):
+async def test_import_bad_hostname(hass):
     """Test when an invalid address is provided."""
 
     with patch(
@@ -131,7 +128,7 @@ async def test_import_bad_hostname(hass, aioclient_mock):
         assert result["errors"]["base"] == "not_found"
 
 
-async def test_unknown_exception(hass, aioclient_mock):
+async def test_unknown_exception(hass):
     """Test when an unknown exception is encountered."""
 
     result = await hass.config_entries.flow.async_init(
@@ -145,13 +142,12 @@ async def test_unknown_exception(hass, aioclient_mock):
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN, context={"source": "user"}, data={CONF_TOKEN: "12345"}
         )
-        print(result)
 
         assert result["type"] == "abort"
         assert result["reason"] == "unknown"
 
 
-async def test_no_servers_found(hass, aioclient_mock):
+async def test_no_servers_found(hass):
     """Test when no servers are on an account."""
 
     result = await hass.config_entries.flow.async_init(
@@ -175,7 +171,7 @@ async def test_no_servers_found(hass, aioclient_mock):
         assert result["errors"]["base"] == "no_servers"
 
 
-async def test_single_available_server(hass, aioclient_mock):
+async def test_single_available_server(hass):
     """Test creating an entry with one server available."""
 
     result = await hass.config_entries.flow.async_init(
@@ -216,7 +212,7 @@ async def test_single_available_server(hass, aioclient_mock):
         assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
 
 
-async def test_multiple_servers_with_selection(hass, aioclient_mock):
+async def test_multiple_servers_with_selection(hass):
     """Test creating an entry with multiple servers available."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -16,17 +16,17 @@ def init_config_flow(hass):
     return flow
 
 
-class MockAvailableServer:
+class MockAvailableServer:  # pylint: disable=too-few-public-methods
     """Mock avilable server objects."""
 
     def __init__(self, name, client_id):
         """Initialize the object."""
         self.name = name
-        self.clientIdentifier = client_id
+        self.clientIdentifier = client_id  # pylint: disable=invalid-name
         self.provides = ["server"]
 
 
-class MockConnection:
+class MockConnection:  # pylint: disable=too-few-public-methods
     """Mock a single account resource connection object."""
 
     def __init__(self, ssl):
@@ -37,7 +37,7 @@ class MockConnection:
         self.local = True
 
 
-class MockConnections:
+class MockConnections:  # pylint: disable=too-few-public-methods
     """Mock a list of resource connections."""
 
     def __init__(self, ssl=False):
@@ -56,7 +56,7 @@ async def test_bad_credentials(hass):
     assert result["step_id"] == "user"
 
     with patch(
-        "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
+            "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
     ):
 
         result = await hass.config_entries.flow.async_configure(
@@ -78,8 +78,8 @@ async def test_import_file_from_discovery(hass):
     used_url = f"http://{file_host_and_port}"
 
     with patch("plexapi.server.PlexServer") as mock_plex_server, patch(
-        "homeassistant.components.plex.config_flow.load_json",
-        return_value=mock_file_contents,
+            "homeassistant.components.plex.config_flow.load_json",
+            return_value=mock_file_contents,
     ):
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -87,9 +87,9 @@ async def test_import_file_from_discovery(hass):
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
             return_value="Mock Server"
         )
-        type(mock_plex_server.return_value)._baseurl = PropertyMock(
-            return_value=used_url
-        )
+        type(  # pylint: disable=protected-access
+            mock_plex_server.return_value
+        )._baseurl = PropertyMock(return_value=used_url)
 
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
@@ -156,9 +156,9 @@ async def test_import_success(hass):
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
             return_value=mock_servers[0]
         )
-        type(mock_plex_server.return_value)._baseurl = PropertyMock(
-            return_value=mock_connections.connections[0].httpuri
-        )
+        type(  # pylint: disable=protected-access
+            mock_plex_server.return_value
+        )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
 
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
@@ -180,7 +180,7 @@ async def test_import_bad_hostname(hass):
     """Test when an invalid address is provided."""
 
     with patch(
-        "plexapi.server.PlexServer", side_effect=requests.exceptions.ConnectionError
+            "plexapi.server.PlexServer", side_effect=requests.exceptions.ConnectionError
     ):
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
@@ -255,7 +255,7 @@ async def test_single_available_server(hass):
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
-        "plexapi.server.PlexServer"
+            "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -263,9 +263,9 @@ async def test_single_available_server(hass):
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
             return_value=mock_servers[0]
         )
-        type(mock_plex_server.return_value)._baseurl = PropertyMock(
-            return_value=mock_connections.connections[0].httpuri
-        )
+        type(  # pylint: disable=protected-access
+            mock_plex_server.return_value
+        )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_TOKEN: "12345"}
@@ -297,7 +297,7 @@ async def test_multiple_servers_with_selection(hass):
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
-        "plexapi.server.PlexServer"
+            "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -305,9 +305,9 @@ async def test_multiple_servers_with_selection(hass):
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
             return_value=mock_servers[0]
         )
-        type(mock_plex_server.return_value)._baseurl = PropertyMock(
-            return_value=mock_connections.connections[0].httpuri
-        )
+        type(  # pylint: disable=protected-access
+            mock_plex_server.return_value
+        )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_TOKEN: "12345"}
@@ -354,7 +354,7 @@ async def test_adding_last_unconfigured_server(hass):
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
-        "plexapi.server.PlexServer"
+            "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -362,9 +362,9 @@ async def test_adding_last_unconfigured_server(hass):
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
             return_value=mock_servers[0]
         )
-        type(mock_plex_server.return_value)._baseurl = PropertyMock(
-            return_value=mock_connections.connections[0].httpuri
-        )
+        type(  # pylint: disable=protected-access
+            mock_plex_server.return_value
+        )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_TOKEN: "12345"}
@@ -400,9 +400,9 @@ async def test_already_configured(hass):
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
             return_value=mock_servers[0]
         )
-        type(mock_plex_server.return_value)._baseurl = PropertyMock(
-            return_value=mock_connections.connections[0].httpuri
-        )
+        type(  # pylint: disable=protected-access
+            mock_plex_server.return_value
+        )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
         result = await flow.async_step_import(
             {CONF_TOKEN: "12345", CONF_URL: "http://1.2.3.4:32400"}
         )

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -56,7 +56,7 @@ async def test_bad_credentials(hass):
     assert result["step_id"] == "user"
 
     with patch(
-            "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
+        "plexapi.myplex.MyPlexAccount", side_effect=plexapi.exceptions.Unauthorized
     ):
 
         result = await hass.config_entries.flow.async_configure(
@@ -78,8 +78,8 @@ async def test_import_file_from_discovery(hass):
     used_url = f"http://{file_host_and_port}"
 
     with patch("plexapi.server.PlexServer") as mock_plex_server, patch(
-            "homeassistant.components.plex.config_flow.load_json",
-            return_value=mock_file_contents,
+        "homeassistant.components.plex.config_flow.load_json",
+        return_value=mock_file_contents,
     ):
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -180,7 +180,7 @@ async def test_import_bad_hostname(hass):
     """Test when an invalid address is provided."""
 
     with patch(
-            "plexapi.server.PlexServer", side_effect=requests.exceptions.ConnectionError
+        "plexapi.server.PlexServer", side_effect=requests.exceptions.ConnectionError
     ):
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
@@ -255,7 +255,7 @@ async def test_single_available_server(hass):
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
-            "plexapi.server.PlexServer"
+        "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -297,7 +297,7 @@ async def test_multiple_servers_with_selection(hass):
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
-            "plexapi.server.PlexServer"
+        "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"
@@ -354,7 +354,7 @@ async def test_adding_last_unconfigured_server(hass):
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
-            "plexapi.server.PlexServer"
+        "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
             return_value="unique_id_123"

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -8,41 +8,25 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_URL
 
 from tests.common import MockConfigEntry
 
+from .mock_classes import MOCK_HOST_1, MOCK_PORT_1, MockAvailableServer, MockConnections
+
+MOCK_NAME_1 = "Plex Server 1"
+MOCK_ID_1 = "unique_id_123"
+MOCK_NAME_2 = "Plex Server 2"
+MOCK_ID_2 = "unique_id_456"
+MOCK_TOKEN = "secret_token"
+MOCK_FILE_CONTENTS = {
+    f"{MOCK_HOST_1}:{MOCK_PORT_1}": {"ssl": False, "token": MOCK_TOKEN, "verify": True}
+}
+MOCK_SERVER_1 = MockAvailableServer(MOCK_NAME_1, MOCK_ID_1)
+MOCK_SERVER_2 = MockAvailableServer(MOCK_NAME_2, MOCK_ID_2)
+
 
 def init_config_flow(hass):
     """Init a configuration flow."""
     flow = config_flow.PlexFlowHandler()
     flow.hass = hass
     return flow
-
-
-class MockAvailableServer:  # pylint: disable=too-few-public-methods
-    """Mock avilable server objects."""
-
-    def __init__(self, name, client_id):
-        """Initialize the object."""
-        self.name = name
-        self.clientIdentifier = client_id  # pylint: disable=invalid-name
-        self.provides = ["server"]
-
-
-class MockConnection:  # pylint: disable=too-few-public-methods
-    """Mock a single account resource connection object."""
-
-    def __init__(self, ssl):
-        """Initialize the object."""
-        prefix = "https" if ssl else "http"
-        self.httpuri = f"{prefix}://1.2.3.4:32400"
-        self.uri = "http://4.3.2.1:32400"
-        self.local = True
-
-
-class MockConnections:  # pylint: disable=too-few-public-methods
-    """Mock a list of resource connections."""
-
-    def __init__(self, ssl=False):
-        """Initialize the object."""
-        self.connections = [MockConnection(ssl)]
 
 
 async def test_bad_credentials(hass):
@@ -60,7 +44,7 @@ async def test_bad_credentials(hass):
     ):
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+            result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )
 
         assert result["type"] == "form"
@@ -71,21 +55,18 @@ async def test_bad_credentials(hass):
 async def test_import_file_from_discovery(hass):
     """Test importing a legacy file during discovery."""
 
-    mock_file_contents = {
-        "1.2.3.4:32400": {"ssl": False, "token": "12345", "verify": True}
-    }
-    file_host_and_port, file_config = list(mock_file_contents.items())[0]
+    file_host_and_port, file_config = list(MOCK_FILE_CONTENTS.items())[0]
     used_url = f"http://{file_host_and_port}"
 
     with patch("plexapi.server.PlexServer") as mock_plex_server, patch(
         "homeassistant.components.plex.config_flow.load_json",
-        return_value=mock_file_contents,
+        return_value=MOCK_FILE_CONTENTS,
     ):
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
-            return_value="unique_id_123"
+            return_value=MOCK_ID_1
         )
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
-            return_value="Mock Server"
+            return_value=MOCK_NAME_1
         )
         type(  # pylint: disable=protected-access
             mock_plex_server.return_value
@@ -94,13 +75,13 @@ async def test_import_file_from_discovery(hass):
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
             context={"source": "discovery"},
-            data={CONF_HOST: "1.2.3.4", CONF_PORT: "32400"},
+            data={CONF_HOST: MOCK_HOST_1, CONF_PORT: MOCK_PORT_1},
         )
 
         assert result["type"] == "create_entry"
-        assert result["title"] == "Mock Server"
-        assert result["data"][config_flow.CONF_SERVER] == "Mock Server"
-        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
+        assert result["title"] == MOCK_NAME_1
+        assert result["data"][config_flow.CONF_SERVER] == MOCK_NAME_1
+        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == MOCK_ID_1
         assert result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_URL] == used_url
         assert (
             result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_TOKEN]
@@ -114,7 +95,7 @@ async def test_discovery(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": "discovery"},
-        data={CONF_HOST: "1.2.3.4", CONF_PORT: "32400"},
+        data={CONF_HOST: MOCK_HOST_1, CONF_PORT: MOCK_PORT_1},
     )
 
     assert result["type"] == "form"
@@ -131,7 +112,7 @@ async def test_discovery_while_in_progress(hass):
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": "discovery"},
-        data={CONF_HOST: "1.2.3.4", CONF_PORT: "32400"},
+        data={CONF_HOST: MOCK_HOST_1, CONF_PORT: MOCK_PORT_1},
     )
 
     assert result["type"] == "abort"
@@ -142,19 +123,17 @@ async def test_import_success(hass):
     """Test a successful configuration import."""
 
     mock_connections = MockConnections(ssl=True)
-    mock_servers = ["Server1"]
-    server1 = MockAvailableServer("Server1", "1")
 
     mm_plex_account = MagicMock()
-    mm_plex_account.resources = Mock(return_value=[server1])
+    mm_plex_account.resources = Mock(return_value=[MOCK_SERVER_1])
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.server.PlexServer") as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
-            return_value="unique_id_123"
+            return_value=MOCK_SERVER_1.clientIdentifier
         )
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
-            return_value=mock_servers[0]
+            return_value=MOCK_SERVER_1.name
         )
         type(  # pylint: disable=protected-access
             mock_plex_server.return_value
@@ -163,13 +142,19 @@ async def test_import_success(hass):
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
             context={"source": "import"},
-            data={CONF_TOKEN: "12345", CONF_URL: "https://1.2.3.4:32400"},
+            data={
+                CONF_TOKEN: MOCK_TOKEN,
+                CONF_URL: f"https://{MOCK_HOST_1}:{MOCK_PORT_1}",
+            },
         )
 
     assert result["type"] == "create_entry"
-    assert result["title"] == mock_servers[0]
-    assert result["data"][config_flow.CONF_SERVER] == mock_servers[0]
-    assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
+    assert result["title"] == MOCK_SERVER_1.name
+    assert result["data"][config_flow.CONF_SERVER] == MOCK_SERVER_1.name
+    assert (
+        result["data"][config_flow.CONF_SERVER_IDENTIFIER]
+        == MOCK_SERVER_1.clientIdentifier
+    )
     assert (
         result["data"][config_flow.PLEX_SERVER_CONFIG][CONF_URL]
         == mock_connections.connections[0].httpuri
@@ -185,7 +170,10 @@ async def test_import_bad_hostname(hass):
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
             context={"source": "import"},
-            data={CONF_TOKEN: "12345", CONF_URL: "http://1.2.3.4:32400"},
+            data={
+                CONF_TOKEN: MOCK_TOKEN,
+                CONF_URL: f"http://{MOCK_HOST_1}:{MOCK_PORT_1}",
+            },
         )
 
         assert result["type"] == "form"
@@ -205,7 +193,9 @@ async def test_unknown_exception(hass):
 
     with patch("plexapi.myplex.MyPlexAccount", side_effect=Exception):
         result = await hass.config_entries.flow.async_init(
-            config_flow.DOMAIN, context={"source": "user"}, data={CONF_TOKEN: "12345"}
+            config_flow.DOMAIN,
+            context={"source": "user"},
+            data={CONF_TOKEN: MOCK_TOKEN},
         )
 
         assert result["type"] == "abort"
@@ -228,7 +218,7 @@ async def test_no_servers_found(hass):
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account):
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+            result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )
 
         assert result["type"] == "form"
@@ -247,34 +237,35 @@ async def test_single_available_server(hass):
     assert result["step_id"] == "user"
 
     mock_connections = MockConnections()
-    mock_servers = ["Server1"]
-    server1 = MockAvailableServer("Server1", "1")
 
     mm_plex_account = MagicMock()
-    mm_plex_account.resources = Mock(return_value=[server1])
+    mm_plex_account.resources = Mock(return_value=[MOCK_SERVER_1])
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
         "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
-            return_value="unique_id_123"
+            return_value=MOCK_SERVER_1.clientIdentifier
         )
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
-            return_value=mock_servers[0]
+            return_value=MOCK_SERVER_1.name
         )
         type(  # pylint: disable=protected-access
             mock_plex_server.return_value
         )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+            result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )
 
         assert result["type"] == "create_entry"
-        assert result["title"] == mock_servers[0]
-        assert result["data"][config_flow.CONF_SERVER] == mock_servers[0]
-        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
+        assert result["title"] == MOCK_SERVER_1.name
+        assert result["data"][config_flow.CONF_SERVER] == MOCK_SERVER_1.name
+        assert (
+            result["data"][config_flow.CONF_SERVER_IDENTIFIER]
+            == MOCK_SERVER_1.clientIdentifier
+        )
 
 
 async def test_multiple_servers_with_selection(hass):
@@ -288,42 +279,41 @@ async def test_multiple_servers_with_selection(hass):
     assert result["step_id"] == "user"
 
     mock_connections = MockConnections()
-    mock_servers = ["Server1", "Server2"]
-    server1 = MockAvailableServer("Server1", "1")
-    server2 = MockAvailableServer("Server2", "2")
-
     mm_plex_account = MagicMock()
-    mm_plex_account.resources = Mock(return_value=[server1, server2])
+    mm_plex_account.resources = Mock(return_value=[MOCK_SERVER_1, MOCK_SERVER_2])
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
         "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
-            return_value="unique_id_123"
+            return_value=MOCK_SERVER_1.clientIdentifier
         )
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
-            return_value=mock_servers[0]
+            return_value=MOCK_SERVER_1.name
         )
         type(  # pylint: disable=protected-access
             mock_plex_server.return_value
         )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+            result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )
 
         assert result["type"] == "form"
         assert result["step_id"] == "select_server"
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={config_flow.CONF_SERVER: mock_servers[0]}
+            result["flow_id"], user_input={config_flow.CONF_SERVER: MOCK_SERVER_1.name}
         )
 
         assert result["type"] == "create_entry"
-        assert result["title"] == mock_servers[0]
-        assert result["data"][config_flow.CONF_SERVER] == mock_servers[0]
-        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
+        assert result["title"] == MOCK_SERVER_1.name
+        assert result["data"][config_flow.CONF_SERVER] == MOCK_SERVER_1.name
+        assert (
+            result["data"][config_flow.CONF_SERVER_IDENTIFIER]
+            == MOCK_SERVER_1.clientIdentifier
+        )
 
 
 async def test_adding_last_unconfigured_server(hass):
@@ -332,8 +322,8 @@ async def test_adding_last_unconfigured_server(hass):
     MockConfigEntry(
         domain=config_flow.DOMAIN,
         data={
-            config_flow.CONF_SERVER_IDENTIFIER: "unique_id_456",
-            config_flow.CONF_SERVER: "Server2",
+            config_flow.CONF_SERVER_IDENTIFIER: MOCK_ID_2,
+            config_flow.CONF_SERVER: MOCK_NAME_2,
         },
     ).add_to_hass(hass)
 
@@ -345,35 +335,34 @@ async def test_adding_last_unconfigured_server(hass):
     assert result["step_id"] == "user"
 
     mock_connections = MockConnections()
-    mock_servers = ["Server1", "Server2"]
-    server1 = MockAvailableServer("Server1", "unique_id_123")
-    server2 = MockAvailableServer("Server2", "unique_id_456")
-
     mm_plex_account = MagicMock()
-    mm_plex_account.resources = Mock(return_value=[server1, server2])
+    mm_plex_account.resources = Mock(return_value=[MOCK_SERVER_1, MOCK_SERVER_2])
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account), patch(
         "plexapi.server.PlexServer"
     ) as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
-            return_value="unique_id_123"
+            return_value=MOCK_SERVER_1.clientIdentifier
         )
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
-            return_value=mock_servers[0]
+            return_value=MOCK_SERVER_1.name
         )
         type(  # pylint: disable=protected-access
             mock_plex_server.return_value
         )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+            result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )
 
         assert result["type"] == "create_entry"
-        assert result["title"] == mock_servers[0]
-        assert result["data"][config_flow.CONF_SERVER] == mock_servers[0]
-        assert result["data"][config_flow.CONF_SERVER_IDENTIFIER] == "unique_id_123"
+        assert result["title"] == MOCK_SERVER_1.name
+        assert result["data"][config_flow.CONF_SERVER] == MOCK_SERVER_1.name
+        assert (
+            result["data"][config_flow.CONF_SERVER_IDENTIFIER]
+            == MOCK_SERVER_1.clientIdentifier
+        )
 
 
 async def test_already_configured(hass):
@@ -381,30 +370,27 @@ async def test_already_configured(hass):
 
     flow = init_config_flow(hass)
     MockConfigEntry(
-        domain=config_flow.DOMAIN,
-        data={config_flow.CONF_SERVER_IDENTIFIER: "unique_id_123"},
+        domain=config_flow.DOMAIN, data={config_flow.CONF_SERVER_IDENTIFIER: MOCK_ID_1}
     ).add_to_hass(hass)
 
     mock_connections = MockConnections()
-    mock_servers = ["Server1"]
-    server1 = MockAvailableServer("Server1", "1")
 
     mm_plex_account = MagicMock()
-    mm_plex_account.resources = Mock(return_value=[server1])
+    mm_plex_account.resources = Mock(return_value=[MOCK_SERVER_1])
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.server.PlexServer") as mock_plex_server:
         type(mock_plex_server.return_value).machineIdentifier = PropertyMock(
-            return_value="unique_id_123"
+            return_value=MOCK_SERVER_1.clientIdentifier
         )
         type(mock_plex_server.return_value).friendlyName = PropertyMock(
-            return_value=mock_servers[0]
+            return_value=MOCK_SERVER_1.name
         )
         type(  # pylint: disable=protected-access
             mock_plex_server.return_value
         )._baseurl = PropertyMock(return_value=mock_connections.connections[0].httpuri)
         result = await flow.async_step_import(
-            {CONF_TOKEN: "12345", CONF_URL: "http://1.2.3.4:32400"}
+            {CONF_TOKEN: MOCK_TOKEN, CONF_URL: f"http://{MOCK_HOST_1}:{MOCK_PORT_1}"}
         )
 
         assert result["type"] == "abort"
@@ -417,16 +403,16 @@ async def test_all_available_servers_configured(hass):
     MockConfigEntry(
         domain=config_flow.DOMAIN,
         data={
-            config_flow.CONF_SERVER_IDENTIFIER: "unique_id_123",
-            config_flow.CONF_SERVER: "Server1",
+            config_flow.CONF_SERVER_IDENTIFIER: MOCK_ID_1,
+            config_flow.CONF_SERVER: MOCK_NAME_1,
         },
     ).add_to_hass(hass)
 
     MockConfigEntry(
         domain=config_flow.DOMAIN,
         data={
-            config_flow.CONF_SERVER_IDENTIFIER: "unique_id_456",
-            config_flow.CONF_SERVER: "Server2",
+            config_flow.CONF_SERVER_IDENTIFIER: MOCK_ID_2,
+            config_flow.CONF_SERVER: MOCK_NAME_2,
         },
     ).add_to_hass(hass)
 
@@ -438,17 +424,14 @@ async def test_all_available_servers_configured(hass):
     assert result["step_id"] == "user"
 
     mock_connections = MockConnections()
-    server1 = MockAvailableServer("Server1", "unique_id_123")
-    server2 = MockAvailableServer("Server2", "unique_id_456")
-
     mm_plex_account = MagicMock()
-    mm_plex_account.resources = Mock(return_value=[server1, server2])
+    mm_plex_account.resources = Mock(return_value=[MOCK_SERVER_1, MOCK_SERVER_2])
     mm_plex_account.resource = Mock(return_value=mock_connections)
 
     with patch("plexapi.myplex.MyPlexAccount", return_value=mm_plex_account):
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_TOKEN: "12345"}
+            result["flow_id"], user_input={CONF_TOKEN: MOCK_TOKEN}
         )
 
         assert result["type"] == "abort"


### PR DESCRIPTION
## Description:
Add support for config flow setup for Plex. Major changes:
* Uses config flow
* Allows to configure multiple Plex servers
* Validates configs during setup
* Removes legacy `configurator` setup
* Imports existing configurations from component and legacy plex.conf file
* Uses discovery to set defaults for manual setup
* Allows interactive selection of server if multiple servers associated with an account

A continuation from #26157 and #26488, #26583

**Related issue (if applicable):** fixes #18113 #22973

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10389

## Example entry for `configuration.yaml` (if applicable):
Legacy configurations are accepted and imported to a config entry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html