### PR TITLE
Move elv integration to component and bump pypca

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -164,7 +164,7 @@ omit =
     homeassistant/components/eight_sleep/*
     homeassistant/components/eliqonline/sensor.py
     homeassistant/components/elkm1/*
-    homeassistant/components/elv/switch.py
+    homeassistant/components/elv/*
     homeassistant/components/emby/media_player.py
     homeassistant/components/emoncms/sensor.py
     homeassistant/components/emoncms_history/*

--- a/homeassistant/components/elv/__init__.py
+++ b/homeassistant/components/elv/__init__.py
@@ -19,11 +19,7 @@ ELV_PLATFORMS = ["switch"]
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {
-                vol.Optional(
-                    CONF_DEVICE, default=DEFAULT_DEVICE
-                ): cv.string
-            }
+            {vol.Optional(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string}
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -35,11 +31,7 @@ def setup(hass, config):
 
     for platform in ELV_PLATFORMS:
         discovery.load_platform(
-            hass,
-            platform,
-            DOMAIN,
-            {"device": config[DOMAIN][CONF_DEVICE]},
-            config,
+            hass, platform, DOMAIN, {"device": config[DOMAIN][CONF_DEVICE]}, config
         )
 
     return True

--- a/homeassistant/components/elv/__init__.py
+++ b/homeassistant/components/elv/__init__.py
@@ -1,1 +1,45 @@
 """The Elv integration."""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.helpers import discovery
+from homeassistant.const import CONF_DEVICE
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "elv"
+
+DEFAULT_DEVICE = "/dev/ttyUSB0"
+
+ELV_PLATFORMS = ["switch"]
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(
+                    CONF_DEVICE, default=DEFAULT_DEVICE
+                ): cv.string
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def setup(hass, config):
+    """Set up the PCA switch platform."""
+
+    for platform in ELV_PLATFORMS:
+        discovery.load_platform(
+            hass,
+            platform,
+            DOMAIN,
+            {"device": config[DOMAIN][CONF_DEVICE]},
+            config,
+        )
+
+    return True

--- a/homeassistant/components/elv/manifest.json
+++ b/homeassistant/components/elv/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://www.home-assistant.io/components/pca",
     "dependencies": [],
     "codeowners": ["@majuss"],
-    "requirements": ["pypca==0.0.4"]
+    "requirements": ["pypca==0.0.5"]
   }

--- a/homeassistant/components/elv/switch.py
+++ b/homeassistant/components/elv/switch.py
@@ -18,7 +18,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the PCA switch platform."""
 
     if discovery_info is None:
-        _LOGGER.warning("Please update your config for elv")
         return
 
     serial_device = discovery_info["device"]

--- a/homeassistant/components/elv/switch.py
+++ b/homeassistant/components/elv/switch.py
@@ -1,11 +1,11 @@
 """Support for PCA 301 smart switch."""
 import logging
 
-from homeassistant.components.switch import SwitchDevice, ATTR_CURRENT_POWER_W
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-
 import pypca
 from serial import SerialException
+
+from homeassistant.components.switch import SwitchDevice, ATTR_CURRENT_POWER_W
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/elv/switch.py
+++ b/homeassistant/components/elv/switch.py
@@ -1,10 +1,7 @@
 """Support for PCA 301 smart switch."""
 import logging
 
-from homeassistant.components.switch import (
-    SwitchDevice,
-    ATTR_CURRENT_POWER_W,
-)
+from homeassistant.components.switch import SwitchDevice, ATTR_CURRENT_POWER_W
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 import pypca
@@ -17,9 +14,7 @@ ATTR_TOTAL_ENERGY_KWH = "total_energy_kwh"
 DEFAULT_NAME = "PCA 301"
 
 
-def setup_platform(
-    hass, config, add_entities, discovery_info=None
-):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the PCA switch platform."""
 
     if discovery_info is None:
@@ -32,21 +27,14 @@ def setup_platform(
         pca = pypca.PCA(serial_device)
         pca.open()
 
-        entities = [
-            SmartPlugSwitch(pca, device)
-            for device in pca.get_devices()
-        ]
+        entities = [SmartPlugSwitch(pca, device) for device in pca.get_devices()]
         add_entities(entities, True)
 
     except SerialException as exc:
-        _LOGGER.warning(
-            "Unable to open serial port: %s", exc
-        )
+        _LOGGER.warning("Unable to open serial port: %s", exc)
         return
 
-    hass.bus.listen_once(
-        EVENT_HOMEASSISTANT_STOP, pca.close
-    )
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, pca.close)
 
     pca.start_scan()
 
@@ -94,29 +82,17 @@ class SmartPlugSwitch(SwitchDevice):
     def update(self):
         """Update the PCA switch's state."""
         try:
-            self._emeter_params[
-                ATTR_CURRENT_POWER_W
-            ] = "{:.1f}".format(
+            self._emeter_params[ATTR_CURRENT_POWER_W] = "{:.1f}".format(
                 self._pca.get_current_power(self._device_id)
             )
-            self._emeter_params[
-                ATTR_TOTAL_ENERGY_KWH
-            ] = "{:.2f}".format(
-                self._pca.get_total_consumption(
-                    self._device_id
-                )
+            self._emeter_params[ATTR_TOTAL_ENERGY_KWH] = "{:.2f}".format(
+                self._pca.get_total_consumption(self._device_id)
             )
 
             self._available = True
-            self._state = self._pca.get_state(
-                self._device_id
-            )
+            self._state = self._pca.get_state(self._device_id)
 
         except (OSError) as ex:
             if self._available:
-                _LOGGER.warning(
-                    "Could not read state for %s: %s",
-                    self.name,
-                    ex,
-                )
+                _LOGGER.warning("Could not read state for %s: %s", self.name, ex)
                 self._available = False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1366,7 +1366,7 @@ pyowlet==1.0.2
 pyowm==2.10.0
 
 # homeassistant.components.elv
-pypca==0.0.4
+pypca==0.0.5
 
 # homeassistant.components.lcn
 pypck==0.6.3


### PR DESCRIPTION
## Breaking Change:

All config for the ELV/PCA component/integration should be removed and replaced with:
```yaml
elv:
```
Optionally the exact port for the serial interface can be specified (default is: /dev/ttyUSB0).

## Description:

Corrected the setup of the elv integration and it's switch platform. Bumped pypca to version 0.0.5.

Documentation PR: home-assistant/home-assistant.io#9995

## Example entry for `configuration.yaml` (if applicable):
```yaml
elv:
  device: '/dev/ttyUSB0'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.