### PR TITLE
Bump geniushub-client to 0.6.13

### DIFF
--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.6.11"
+    "geniushub-client==0.6.12"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/homeassistant/components/geniushub/manifest.json
+++ b/homeassistant/components/geniushub/manifest.json
@@ -3,7 +3,7 @@
   "name": "Genius Hub",
   "documentation": "https://www.home-assistant.io/components/geniushub",
   "requirements": [
-    "geniushub-client==0.6.12"
+    "geniushub-client==0.6.13"
   ],
   "dependencies": [],
   "codeowners": ["@zxdavb"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -525,7 +525,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.6.11
+geniushub-client==0.6.12
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -525,7 +525,7 @@ gearbest_parser==1.0.7
 geizhals==0.0.9
 
 # homeassistant.components.geniushub
-geniushub-client==0.6.12
+geniushub-client==0.6.13
 
 # homeassistant.components.geo_json_events
 # homeassistant.components.nsw_rural_fire_service_feed


### PR DESCRIPTION
## Breaking Change:

None known.

## Description:

There was a bug introduced to the **geniushubclient** during one of its recent refactors where it no longer refreshed entities' `data` attribute. Since _initial_ values were correct, the library passed it's [QC/CI tests](https://circleci.com/gh/zxdavb/geniushub-client), despite _subsequent_ values remaining static.  

This PR addresses that issue: https://github.com/zxdavb/geniushub-client/compare/v0.6.11...v0.6.13

**Related issue (if applicable):** fixes #26539 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

**Example entry for `configuration.yaml` (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
