### PR TITLE
Fix events for angle reports from the SmartThings acceleration cluster in ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -6,9 +6,17 @@ https://home-assistant.io/components/zha/
 """
 import logging
 
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
 from . import AttributeListeningChannel
 from .. import registries
-from ..const import REPORT_CONFIG_ASAP, REPORT_CONFIG_MAX_INT, REPORT_CONFIG_MIN_INT
+from ..const import (
+    REPORT_CONFIG_ASAP,
+    REPORT_CONFIG_MAX_INT,
+    REPORT_CONFIG_MIN_INT,
+    SIGNAL_ATTR_UPDATED,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,3 +46,23 @@ class SmartThingsAcceleration(AttributeListeningChannel):
         {"attr": "y_axis", "config": REPORT_CONFIG_ASAP},
         {"attr": "z_axis", "config": REPORT_CONFIG_ASAP},
     ]
+
+    @callback
+    def attribute_updated(self, attrid, value):
+        """Handle attribute updates on this cluster."""
+        if attrid == self.value_attribute:
+            async_dispatcher_send(
+                self._zha_device.hass, f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", value
+            )
+        else:
+            self.zha_send_event(
+                self._cluster,
+                SIGNAL_ATTR_UPDATED,
+                {
+                    "attribute_id": attrid,
+                    "attribute_name": self._cluster.attributes.get(attrid, ["Unknown"])[
+                        0
+                    ],
+                    "value": value,
+                },
+            )


### PR DESCRIPTION
##Description:
This PR fixes the acceleration cluster handling for the SmartThings acceleration manufacturer cluster.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]