### PR TITLE
Add pcal9535a integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -463,6 +463,7 @@ omit =
     homeassistant/components/panasonic_bluray/media_player.py
     homeassistant/components/panasonic_viera/media_player.py
     homeassistant/components/pandora/media_player.py
+    homeassistant/components/pcal9535a/*
     homeassistant/components/pencom/switch.py
     homeassistant/components/philips_js/media_player.py
     homeassistant/components/pi_hole/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -206,6 +206,7 @@ homeassistant/components/orangepi_gpio/* @pascallj
 homeassistant/components/owlet/* @oblogic7
 homeassistant/components/panel_custom/* @home-assistant/frontend
 homeassistant/components/panel_iframe/* @home-assistant/frontend
+homeassistant/components/pcal9535a/* @Shulyaka
 homeassistant/components/persistent_notification/* @home-assistant/core
 homeassistant/components/philips_js/* @elupus
 homeassistant/components/pi_hole/* @fabaff

--- a/homeassistant/components/pcal9535a/__init__.py
+++ b/homeassistant/components/pcal9535a/__init__.py
@@ -1,0 +1,3 @@
+"""Support for I2C PCAL9535A chip."""
+
+DOMAIN = "pcal9535a"

--- a/homeassistant/components/pcal9535a/binary_sensor.py
+++ b/homeassistant/components/pcal9535a/binary_sensor.py
@@ -7,6 +7,8 @@ from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 
+from pcal9535a import PCAL9535A
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_INVERT_LOGIC = "invert_logic"
@@ -39,10 +41,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the PCAL9535A binary sensors."""
-    from pcal9535a import PCAL9535A
-
     pull_mode = config[CONF_PULL_MODE]
     invert_logic = config[CONF_INVERT_LOGIC]
     i2c_address = config[CONF_I2C_ADDRESS]
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             PCAL9535ABinarySensor(pin_name, pin, pull_mode, invert_logic)
         )
 
-    add_devices(binary_sensors, True)
+    add_entities(binary_sensors, True)
 
 
 class PCAL9535ABinarySensor(BinarySensorDevice):

--- a/homeassistant/components/pcal9535a/binary_sensor.py
+++ b/homeassistant/components/pcal9535a/binary_sensor.py
@@ -2,7 +2,6 @@
 import logging
 
 import voluptuous as vol
-
 from pcal9535a import PCAL9535A
 
 from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA

--- a/homeassistant/components/pcal9535a/binary_sensor.py
+++ b/homeassistant/components/pcal9535a/binary_sensor.py
@@ -3,11 +3,11 @@ import logging
 
 import voluptuous as vol
 
+from pcal9535a import PCAL9535A
+
 from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
-
-from pcal9535a import PCAL9535A
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pcal9535a/binary_sensor.py
+++ b/homeassistant/components/pcal9535a/binary_sensor.py
@@ -1,0 +1,94 @@
+"""Support for binary sensor using I2C PCAL9535A chip."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.const import DEVICE_DEFAULT_NAME
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_INVERT_LOGIC = "invert_logic"
+CONF_I2C_ADDRESS = "i2c_address"
+CONF_I2C_BUS = "i2c_bus"
+CONF_PINS = "pins"
+CONF_PULL_MODE = "pull_mode"
+
+MODE_UP = "UP"
+MODE_DOWN = "DOWN"
+MODE_DISABLED = "DISABLED"
+
+DEFAULT_INVERT_LOGIC = False
+DEFAULT_I2C_ADDRESS = 0x20
+DEFAULT_I2C_BUS = 1
+DEFAULT_PULL_MODE = MODE_DISABLED
+
+_SENSORS_SCHEMA = vol.Schema({cv.positive_int: cv.string})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_PINS): _SENSORS_SCHEMA,
+        vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+        vol.Optional(CONF_PULL_MODE, default=DEFAULT_PULL_MODE): vol.All(
+            vol.Upper, vol.In([MODE_UP, MODE_DOWN, MODE_DISABLED])
+        ),
+        vol.Optional(CONF_I2C_ADDRESS, default=DEFAULT_I2C_ADDRESS): vol.Coerce(int),
+        vol.Optional(CONF_I2C_BUS, default=DEFAULT_I2C_BUS): cv.positive_int,
+    }
+)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the PCAL9535A binary sensors."""
+    from pcal9535a import PCAL9535A
+
+    pull_mode = config[CONF_PULL_MODE]
+    invert_logic = config[CONF_INVERT_LOGIC]
+    i2c_address = config[CONF_I2C_ADDRESS]
+    bus = config[CONF_I2C_BUS]
+
+    pcal = PCAL9535A(bus, i2c_address)
+
+    binary_sensors = []
+    pins = config[CONF_PINS]
+
+    for pin_num, pin_name in pins.items():
+        pin = pcal.get_pin(pin_num // 8, pin_num % 8)
+        binary_sensors.append(
+            PCAL9535ABinarySensor(pin_name, pin, pull_mode, invert_logic)
+        )
+
+    add_devices(binary_sensors, True)
+
+
+class PCAL9535ABinarySensor(BinarySensorDevice):
+    """Represent a binary sensor that uses PCAL9535A."""
+
+    def __init__(self, name, pin, pull_mode, invert_logic):
+        """Initialize the PCAL9535A binary sensor."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._pin = pin
+        self._pin.input = True
+        self._pin.inverted = invert_logic
+        if pull_mode == "DISABLED":
+            self._pin.pullup = 0
+        elif pull_mode == "DOWN":
+            self._pin.pullup = -1
+        else:
+            self._pin.pullup = 1
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return the cached state of the entity."""
+        return self._state
+
+    def update(self):
+        """Update the GPIO state."""
+        self._state = self._pin.level

--- a/homeassistant/components/pcal9535a/manifest.json
+++ b/homeassistant/components/pcal9535a/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "pcal9535a",
+  "name": "PCAL9535A I/O Expander",
+  "documentation": "https://www.home-assistant.io/components/pcal9535a",
+  "requirements": [
+    "pcal9535a==0.7"
+    ],
+  "dependencies": [],
+  "codeowners": ["@Shulyaka"]
+}

--- a/homeassistant/components/pcal9535a/switch.py
+++ b/homeassistant/components/pcal9535a/switch.py
@@ -3,11 +3,11 @@ import logging
 
 import voluptuous as vol
 
+from pcal9535a import PCAL9535A
+
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
-
-from pcal9535a import PCAL9535A
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/pcal9535a/switch.py
+++ b/homeassistant/components/pcal9535a/switch.py
@@ -2,7 +2,6 @@
 import logging
 
 import voluptuous as vol
-
 from pcal9535a import PCAL9535A
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice

--- a/homeassistant/components/pcal9535a/switch.py
+++ b/homeassistant/components/pcal9535a/switch.py
@@ -3,10 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
-from homeassistant.helpers.entity import ToggleEntity
 import homeassistant.helpers.config_validation as cv
+
+from pcal9535a import PCAL9535A
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,23 +44,22 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the PCAL9535A devices."""
-    from pcal9535a import PCAL9535A
-
-    invert_logic = config.get(CONF_INVERT_LOGIC)
-    i2c_address = config.get(CONF_I2C_ADDRESS)
-    bus = config.get(CONF_I2C_BUS)
+    invert_logic = config[CONF_INVERT_LOGIC]
+    i2c_address = config[CONF_I2C_ADDRESS]
+    bus = config[CONF_I2C_BUS]
 
     pcal = PCAL9535A(bus, i2c_address)
 
     switches = []
-    pins = config.get(CONF_PINS)
+    pins = config[CONF_PINS]
     for pin_num, pin_name in pins.items():
         pin = pcal.get_pin(pin_num // 8, pin_num % 8)
         switches.append(PCAL9535ASwitch(pin_name, pin, invert_logic))
+
     add_entities(switches)
 
 
-class PCAL9535ASwitch(ToggleEntity):
+class PCAL9535ASwitch(SwitchDevice):
     """Representation of a PCAL9535A output pin."""
 
     def __init__(self, name, pin, invert_logic):

--- a/homeassistant/components/pcal9535a/switch.py
+++ b/homeassistant/components/pcal9535a/switch.py
@@ -1,0 +1,103 @@
+"""Support for switch sensor using I2C PCAL9535A chip."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_INVERT_LOGIC = "invert_logic"
+CONF_I2C_ADDRESS = "i2c_address"
+CONF_I2C_BUS = "i2c_bus"
+CONF_PINS = "pins"
+CONF_STRENGTH = "strength"
+
+STRENGTH_025 = "0.25"
+STRENGTH_050 = "0.5"
+STRENGTH_075 = "0.75"
+STRENGTH_100 = "1.0"
+
+DEFAULT_INVERT_LOGIC = False
+DEFAULT_I2C_ADDRESS = 0x20
+DEFAULT_I2C_BUS = 1
+DEFAULT_STRENGTH = STRENGTH_100
+
+_SWITCHES_SCHEMA = vol.Schema({cv.positive_int: cv.string})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_PINS): _SWITCHES_SCHEMA,
+        vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
+        vol.Optional(CONF_STRENGTH, default=DEFAULT_STRENGTH): vol.In(
+            [STRENGTH_025, STRENGTH_050, STRENGTH_075, STRENGTH_100]
+        ),
+        vol.Optional(CONF_I2C_ADDRESS, default=DEFAULT_I2C_ADDRESS): vol.Coerce(int),
+        vol.Optional(CONF_I2C_BUS, default=DEFAULT_I2C_BUS): cv.positive_int,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the PCAL9535A devices."""
+    from pcal9535a import PCAL9535A
+
+    invert_logic = config.get(CONF_INVERT_LOGIC)
+    i2c_address = config.get(CONF_I2C_ADDRESS)
+    bus = config.get(CONF_I2C_BUS)
+
+    pcal = PCAL9535A(bus, i2c_address)
+
+    switches = []
+    pins = config.get(CONF_PINS)
+    for pin_num, pin_name in pins.items():
+        pin = pcal.get_pin(pin_num // 8, pin_num % 8)
+        switches.append(PCAL9535ASwitch(pin_name, pin, invert_logic))
+    add_entities(switches)
+
+
+class PCAL9535ASwitch(ToggleEntity):
+    """Representation of a PCAL9535A output pin."""
+
+    def __init__(self, name, pin, invert_logic):
+        """Initialize the pin."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._pin = pin
+        self._pin.inverted = invert_logic
+        self._pin.input = False
+        self._state = self._pin.level
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def assumed_state(self):
+        """Return true if optimistic updates are used."""
+        return True
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self._pin.level = True
+        self._state = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        self._pin.level = False
+        self._state = False
+        self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -929,6 +929,9 @@ panacotta==0.1
 # homeassistant.components.panasonic_viera
 panasonic_viera==0.3.2
 
+# homeassistant.components.pcal9535a
+pcal9535a==0.7
+
 # homeassistant.components.dunehd
 pdunehd==1.3
 


### PR DESCRIPTION
Signed-off-by: Denis Shulyaka <Shulyaka@gmail.com>

## Breaking Change:

N/A

## Description:


**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10336

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: pcal9535a
    i2c_address: 0x20
    invert_logic: False
    strength: 1.0
    pins:
      0: P0_0
      1: P0_1
      2: P0_2
      3: P0_3

binary_sensor:
  - platform: pcal9535a
    i2c_address: 0x20
    invert_logic: True
    pull_mode: DOWN
    pins:
      4: P0_4
      6: P0_6
      8: P1_0
      9: P1_1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
