### PR TITLE
Home Assistant Cast

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -1,6 +1,7 @@
 """Component to embed Google Cast."""
 from homeassistant import config_entries
 
+from . import home_assistant_cast
 from .const import DOMAIN
 
 
@@ -20,8 +21,10 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass, entry):
+async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     """Set up Cast from a config entry."""
+    await home_assistant_cast.async_setup_ha_cast(hass, entry)
+
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "media_player")
     )

--- a/homeassistant/components/cast/const.py
+++ b/homeassistant/components/cast/const.py
@@ -21,3 +21,6 @@ SIGNAL_CAST_DISCOVERED = "cast_discovered"
 # Dispatcher signal fired with a ChromecastInfo every time a Chromecast is
 # removed
 SIGNAL_CAST_REMOVED = "cast_removed"
+
+# Dispatcher signal fired when a Chromecast should show a Home Assistant Cast view.
+SIGNAL_HASS_CAST_SHOW_VIEW = "cast_show_view"

--- a/homeassistant/components/cast/home_assistant_cast.py
+++ b/homeassistant/components/cast/home_assistant_cast.py
@@ -1,0 +1,64 @@
+"""Home Assistant Cast integration for Cast."""
+from typing import Optional
+
+import voluptuous as vol
+
+from pychromecast.controllers.homeassistant import HomeAssistantController
+
+from homeassistant import auth, config_entries, core
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers import config_validation as cv, dispatcher
+
+from .const import DOMAIN, SIGNAL_HASS_CAST_SHOW_VIEW
+
+SERVICE_SHOW_VIEW = "show_lovelace_view"
+ATTR_VIEW_PATH = "view_path"
+
+
+async def async_setup_ha_cast(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+):
+    """Set up Home Assistant Cast."""
+    user_id: Optional[str] = entry.data.get("user_id")
+    user: Optional[auth.models.User] = None
+
+    if user_id is not None:
+        user = await hass.auth.async_get_user(user_id)
+
+    if user is None:
+        user = await hass.auth.async_create_system_user(
+            "Home Assistant Cast", [auth.GROUP_ID_ADMIN]
+        )
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "user_id": user.id}
+        )
+
+    if user.refresh_tokens:
+        refresh_token: auth.models.RefreshToken = list(user.refresh_tokens.values())[0]
+    else:
+        refresh_token = await hass.auth.async_create_refresh_token(user)
+
+    async def handle_show_view(call: core.ServiceCall):
+        """Handle a Show View service call."""
+        controller = HomeAssistantController(
+            # If you are developing Home Assistant Cast, uncomment and set to your dev app id.
+            # app_id="5FE44367",
+            hass_url=hass.config.api.base_url,
+            client_id=None,
+            refresh_token=refresh_token.token,
+        )
+
+        dispatcher.async_dispatcher_send(
+            hass,
+            SIGNAL_HASS_CAST_SHOW_VIEW,
+            controller,
+            call.data[ATTR_ENTITY_ID],
+            call.data[ATTR_VIEW_PATH],
+        )
+
+    hass.helpers.service.async_register_admin_service(
+        DOMAIN,
+        SERVICE_SHOW_VIEW,
+        handle_show_view,
+        vol.Schema({ATTR_ENTITY_ID: cv.entity_id, ATTR_VIEW_PATH: str}),
+    )

--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,9 +3,7 @@
   "name": "Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/cast",
-  "requirements": [
-    "pychromecast==3.2.2"
-  ],
+  "requirements": ["pychromecast==4.0.0"],
   "dependencies": [],
   "zeroconf": ["_googlecast._tcp.local."],
   "codeowners": []

--- a/homeassistant/components/cast/services.yaml
+++ b/homeassistant/components/cast/services.yaml
@@ -1,0 +1,9 @@
+show_lovelace_view:
+  description: Show a Lovelace view on a Chromecast.
+  fields:
+    entity_id:
+      description: Media Player entity to show the Lovelace view on.
+      example: "media_player.kitchen"
+    view_path:
+      description: The path of the Lovelace view to show.
+      example: downstairs

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1108,7 +1108,7 @@ pycfdns==0.0.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==3.2.2
+pychromecast==4.0.0
 
 # homeassistant.components.cmus
 pycmus==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -280,7 +280,7 @@ pyMetno==0.4.6
 pyblackbird==0.5
 
 # homeassistant.components.cast
-pychromecast==3.2.2
+pychromecast==4.0.0
 
 # homeassistant.components.deconz
 pydeconz==62

--- a/tests/common.py
+++ b/tests/common.py
@@ -1030,3 +1030,18 @@ def async_capture_events(hass, event_name):
     hass.bus.async_listen(event_name, capture_events)
 
     return events
+
+
+@ha.callback
+def async_mock_signal(hass, signal):
+    """Catch all dispatches to a signal."""
+    calls = []
+
+    @ha.callback
+    def mock_signal_handler(*args):
+        """Mock service call."""
+        calls.append(args)
+
+    hass.helpers.dispatcher.async_dispatcher_connect(signal, mock_signal_handler)
+
+    return calls

--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -1,0 +1,28 @@
+"""Test Home Assistant Cast."""
+from unittest.mock import Mock
+from homeassistant.components.cast import home_assistant_cast
+
+from tests.common import MockConfigEntry, async_mock_signal
+
+
+async def test_service_show_view(hass):
+    """Test we don't set app id in prod."""
+    hass.config.api = Mock(base_url="http://example.com")
+    await home_assistant_cast.async_setup_ha_cast(hass, MockConfigEntry())
+    calls = async_mock_signal(hass, home_assistant_cast.SIGNAL_HASS_CAST_SHOW_VIEW)
+
+    await hass.services.async_call(
+        "cast",
+        "show_lovelace_view",
+        {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
+        blocking=True,
+    )
+
+    assert len(calls) == 1
+    controller, entity_id, view_path = calls[0]
+    assert controller.hass_url == "http://example.com"
+    assert controller.client_id is None
+    # Verify user did not accidentally submit their dev app id
+    assert controller.supporting_app_id == "B12CE3CA"
+    assert entity_id == "media_player.kitchen"
+    assert view_path == "mock_path"


### PR DESCRIPTION
## Description:
Add a new service `cast.show_lovelace_view` to allow showing Lovelace views on Chromecasts on the network.

Requires a new build of Home Assistant Cast to be published.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10339

## Example entry for `configuration.yaml` (if applicable):

Service data:

```yaml
{
  "entity_id": "media_player.office_display_4",
  "view_path":"lights"
}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
