### PR TITLE
Deprecate Python 3.6.0

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -97,6 +97,15 @@ async def async_from_config_dict(
     stop = time()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop - start)
 
+    if sys.version_info[:3] < (3, 6, 1):
+        hass.components.persistent_notification.async_create(
+            "Python 3.6.0 support is deprecated and will "
+            "be removed in the first release after October 2. Please "
+            "upgrade Python to 3.6.1 or higher.",
+            "Python version",
+            "python_version",
+        )
+
     return hass
 
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -98,12 +98,14 @@ async def async_from_config_dict(
     _LOGGER.info("Home Assistant initialized in %.2fs", stop - start)
 
     if sys.version_info[:3] < (3, 6, 1):
-        hass.components.persistent_notification.async_create(
+        msg = (
             "Python 3.6.0 support is deprecated and will "
             "be removed in the first release after October 2. Please "
-            "upgrade Python to 3.6.1 or higher.",
-            "Python version",
-            "python_version",
+            "upgrade Python to 3.6.1 or higher."
+        )
+        _LOGGER.warning(msg)
+        hass.components.persistent_notification.async_create(
+            msg, "Python version", "python_version"
         )
 
     return hass


### PR DESCRIPTION
## Breaking Change:

Python 3.6.0 is going to be deprecated in Home Assistant 0.99 in favor of Python 3.6.1. Reason is that an important upstream Python dependency has required a minimum version of Python 3.6.1.

## Description:

Fix: #26567