### PR TITLE
Make uk_transport sensor timezone/DST aware

### DIFF
--- a/homeassistant/components/uk_transport/sensor.py
+++ b/homeassistant/components/uk_transport/sensor.py
@@ -281,9 +281,8 @@ def _delta_mins(hhmm_time_str):
     now = dt_util.now()
     hhmm_time = datetime.strptime(hhmm_time_str, "%H:%M")
 
-    hhmm_datetime = datetime(
-        now.year, now.month, now.day, hour=hhmm_time.hour, minute=hhmm_time.minute
-    )
+    hhmm_datetime = now.replace(hour=hhmm_time.hour, minute=hhmm_time.minute)
+
     if hhmm_datetime < now:
         hhmm_datetime += timedelta(days=1)
 

--- a/homeassistant/components/uk_transport/sensor.py
+++ b/homeassistant/components/uk_transport/sensor.py
@@ -11,6 +11,7 @@ import requests
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_MODE
 from homeassistant.helpers.entity import Entity
@@ -277,7 +278,7 @@ class UkTransportLiveTrainTimeSensor(UkTransportSensor):
 
 def _delta_mins(hhmm_time_str):
     """Calculate time delta in minutes to a time in hh:mm format."""
-    now = datetime.now()
+    now = dt_util.now()
     hhmm_time = datetime.strptime(hhmm_time_str, "%H:%M")
 
     hhmm_datetime = datetime(


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
When getting now, we should use dt_util.now so it is timezone aware

**Related issue (if applicable):** fixes #26237 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
