### PR TITLE
Remove support of UniFi device tracker configuration import

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Unifi."""
+"""Config flow for UniFi."""
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -163,20 +163,6 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required(CONF_SITE_ID): vol.In(sites)}),
             errors=errors,
         )
-
-    async def async_step_import(self, import_config):
-        """Import from UniFi device tracker config."""
-        config = {
-            CONF_HOST: import_config[CONF_HOST],
-            CONF_USERNAME: import_config[CONF_USERNAME],
-            CONF_PASSWORD: import_config[CONF_PASSWORD],
-            CONF_PORT: import_config.get(CONF_PORT),
-            CONF_VERIFY_SSL: import_config.get(CONF_VERIFY_SSL),
-        }
-
-        self.desc = import_config[CONF_SITE_ID]
-
-        return await self.async_step_user(user_input=config)
 
 
 class UnifiOptionsFlowHandler(config_entries.OptionsFlow):

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -1,4 +1,4 @@
-"""The tests for the Unifi WAP device tracker platform."""
+"""The tests for the UniFi device tracker platform."""
 from collections import deque
 from copy import copy
 from unittest.mock import Mock
@@ -32,7 +32,6 @@ from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 
 import homeassistant.components.device_tracker as device_tracker
-import homeassistant.components.unifi.device_tracker as unifi_dt
 import homeassistant.util.dt as dt_util
 
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
@@ -275,14 +274,14 @@ async def test_restoring_client(hass, mock_controller):
     registry = await entity_registry.async_get_registry(hass)
     registry.async_get_or_create(
         device_tracker.DOMAIN,
-        unifi_dt.UNIFI_DOMAIN,
+        unifi.DOMAIN,
         "{}-mock-site".format(CLIENT_1["mac"]),
         suggested_object_id=CLIENT_1["hostname"],
         config_entry=config_entry,
     )
     registry.async_get_or_create(
         device_tracker.DOMAIN,
-        unifi_dt.UNIFI_DOMAIN,
+        unifi.DOMAIN,
         "{}-mock-site".format(CLIENT_2["mac"]),
         suggested_object_id=CLIENT_2["hostname"],
         config_entry=config_entry,


### PR DESCRIPTION
## Breaking Change:

With Home Assistant releases 0.99 and 0.100 `unifi` `device_tracker` platform configuration section will be removed

- In 0.99, UniFi integration will ignore what is in `unifi` `device_tracker`
- In 0.100, UniFi integration will fail on config validation and not allow the `unifi` `device_tracker`  section to exist in configuration.yaml. 

TL;DR This will no longer work:
```yaml
device_tracker:
  - platform: unifi
```
Extra configuration through config entry options from the GUI (see [release notes 0.98](https://www.home-assistant.io/blog/2019/08/28/release-98/#config-entry-options) for example) and through [unifi configuration](https://www.home-assistant.io/components/unifi/#extra-configuration-for-device-tracker) in configuration.yaml will continue to work.

## Description:
Remove legacy support to import configuration for UniFi device tracker from device tracker platform.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html