### PR TITLE
Fix BMW Check Control Messages

### DIFF
--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -9,7 +9,7 @@ from . import DOMAIN as BMW_DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {
-    "lids": ["Doors", "opening", "mdi:car-door"],
+    "lids": ["Doors", "opening", "mdi:car-door-lock"],
     "windows": ["Windows", "opening", "mdi:car-door"],
     "door_lock_state": ["Door lock state", "safety", "mdi:car-key"],
     "lights_parking": ["Parking lights", "light", "mdi:car-parking-lights"],
@@ -122,8 +122,9 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
             for report in vehicle_state.condition_based_services:
                 result.update(self._format_cbs_report(report))
         elif self._attribute == "check_control_messages":
-            check_control_messages = vehicle_state.has_check_control_messages
-            if check_control_messages:
+            check_control_messages = vehicle_state.check_control_messages
+            has_check_control_messages = vehicle_state.has_check_control_messages
+            if has_check_control_messages:
                 cbs_list = []
                 for message in check_control_messages:
                     cbs_list.append(message["ccmDescriptionShort"])
@@ -184,9 +185,9 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
             distance = round(
                 self.hass.config.units.length(report.due_distance, LENGTH_KILOMETERS)
             )
-            result[f"{service_type} distance"] = "{} {}".format(
-                distance, self.hass.config.units.length_unit
-            )
+            result[
+                f"{service_type} distance"
+            ] = f"{distance} {self.hass.config.units.length_unit}"
         return result
 
     def update_callback(self):

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -17,10 +17,10 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_TO_HA_METRIC = {
     "mileage": ["mdi:speedometer", LENGTH_KILOMETERS],
-    "remaining_range_total": ["mdi:ruler", LENGTH_KILOMETERS],
-    "remaining_range_electric": ["mdi:ruler", LENGTH_KILOMETERS],
-    "remaining_range_fuel": ["mdi:ruler", LENGTH_KILOMETERS],
-    "max_range_electric": ["mdi:ruler", LENGTH_KILOMETERS],
+    "remaining_range_total": ["mdi:map-marker-distance", LENGTH_KILOMETERS],
+    "remaining_range_electric": ["mdi:map-marker-distance", LENGTH_KILOMETERS],
+    "remaining_range_fuel": ["mdi:map-marker-distance", LENGTH_KILOMETERS],
+    "max_range_electric": ["mdi:map-marker-distance", LENGTH_KILOMETERS],
     "remaining_fuel": ["mdi:gas-station", VOLUME_LITERS],
     "charging_time_remaining": ["mdi:update", "h"],
     "charging_status": ["mdi:battery-charging", None],
@@ -28,10 +28,10 @@ ATTR_TO_HA_METRIC = {
 
 ATTR_TO_HA_IMPERIAL = {
     "mileage": ["mdi:speedometer", LENGTH_MILES],
-    "remaining_range_total": ["mdi:ruler", LENGTH_MILES],
-    "remaining_range_electric": ["mdi:ruler", LENGTH_MILES],
-    "remaining_range_fuel": ["mdi:ruler", LENGTH_MILES],
-    "max_range_electric": ["mdi:ruler", LENGTH_MILES],
+    "remaining_range_total": ["mdi:map-marker-distance", LENGTH_MILES],
+    "remaining_range_electric": ["mdi:map-marker-distance", LENGTH_MILES],
+    "remaining_range_fuel": ["mdi:map-marker-distance", LENGTH_MILES],
+    "max_range_electric": ["mdi:map-marker-distance", LENGTH_MILES],
     "remaining_fuel": ["mdi:gas-station", VOLUME_GALLONS],
     "charging_time_remaining": ["mdi:update", "h"],
     "charging_status": ["mdi:battery-charging", None],


### PR DESCRIPTION
## Description:
This PR fixes the Check Control Messages binary sensor were an issue was introduced during the previous PR #26098 which prevents this sensor to show correct data when there is an actual check message.

Also there was still one str.format which is now changed to f-string.

Changed some mdi icons.

**Related issue (if applicable):** fixes # n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io# n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
bmw_connected_drive:
  name_of_car:
    username: USERNAME_BMW_CONNECTED_DRIVE
    password: PASSWORD_BMW_CONNECTED_DRIVE
    region: one of "north_america", "china" , "rest_of_world"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
