### PR TITLE
Add config flow to iCloud

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -314,6 +314,7 @@ omit =
     homeassistant/components/iaqualink/light.py
     homeassistant/components/iaqualink/sensor.py
     homeassistant/components/iaqualink/switch.py
+    homeassistant/components/icloud/__init__.py
     homeassistant/components/icloud/device_tracker.py
     homeassistant/components/izone/climate.py
     homeassistant/components/izone/discovery.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -144,6 +144,7 @@ homeassistant/components/huawei_lte/* @scop
 homeassistant/components/huawei_router/* @abmantis
 homeassistant/components/hue/* @balloob
 homeassistant/components/iaqualink/* @flz
+homeassistant/components/icloud/* @Quentame
 homeassistant/components/ign_sismologia/* @exxamalte
 homeassistant/components/incomfort/* @zxdavb
 homeassistant/components/influxdb/* @fabaff

--- a/homeassistant/components/icloud/.translations/en.json
+++ b/homeassistant/components/icloud/.translations/en.json
@@ -4,10 +4,8 @@
             "username_exists": "Account already configured"
         },
         "error": {
-            "2fa": "Error setting up 2FA: please check that your iCloud account has a trusted phone number",
             "login": "Login error: please check your email & password",
             "send_verification_code": "Failed to send verification code",
-            "unknown": "Unknown error: please check your credentials and/or retry later",
             "username_exists": "Account already configured",
             "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again"
         },

--- a/homeassistant/components/icloud/.translations/en.json
+++ b/homeassistant/components/icloud/.translations/en.json
@@ -1,0 +1,40 @@
+{
+    "config": {
+        "abort": {
+            "username_exists": "Account already configured"
+        },
+        "error": {
+            "2fa": "Error setting up 2FA: please check that your iCloud account has a trusted phone number",
+            "login": "Login error: please check your email & password",
+            "send_verification_code": "Failed to send verification code",
+            "unknown": "Unknown error: please check your credentials and/or retry later",
+            "username_exists": "Account already configured",
+            "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again"
+        },
+        "step": {
+            "trusted_device": {
+                "data": {
+                    "trusted_device": "Trusted device"
+                },
+                "description": "Select your trusted device",
+                "title": "iCloud trusted device"
+            },
+            "user": {
+                "data": {
+                    "password": "Password",
+                    "username": "Email"
+                },
+                "description": "Enter your credentials",
+                "title": "iCloud credentials"
+            },
+            "verification_code": {
+                "data": {
+                    "verification_code": "Verification code"
+                },
+                "description": "Please enter the verification code you just received from iCloud",
+                "title": "iCloud verification code"
+            }
+        },
+        "title": "Apple iCloud"
+    }
+}

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -57,42 +57,38 @@ ATTR_DEVICE_STATUS = "device_status"
 ATTR_LOW_POWER_MODE = "low_power_mode"
 ATTR_OWNER_NAME = "owner_fullname"
 
-_LOGGER = logging.getLogger(__name__)
-
+# services
 SERVICE_ICLOUD_PLAY_SOUND = "play_sound"
 SERVICE_ICLOUD_DISPLAY_MESSAGE = "display_message"
 SERVICE_ICLOUD_LOST_DEVICE = "lost_device"
 SERVICE_ICLOUD_UPDATE = "update"
 SERVICE_ICLOUD_RESET = "reset"
-SERVICE_ATTR_USERNAME = CONF_USERNAME
-SERVICE_ATTR_LOST_DEVICE_MESSAGE = "message"
-SERVICE_ATTR_LOST_DEVICE_NUMBER = "number"
-SERVICE_ATTR_LOST_DEVICE_SOUND = "sound"
+ATTR_USERNAME = CONF_USERNAME
+ATTR_LOST_DEVICE_MESSAGE = "message"
+ATTR_LOST_DEVICE_NUMBER = "number"
+ATTR_LOST_DEVICE_SOUND = "sound"
 
-SERVICE_SCHEMA = vol.Schema({vol.Optional(SERVICE_ATTR_USERNAME): cv.string})
+SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_USERNAME): cv.string})
 
 SERVICE_SCHEMA_PLAY_SOUND = vol.Schema(
-    {
-        vol.Required(SERVICE_ATTR_USERNAME): cv.string,
-        vol.Required(ATTR_DEVICE_NAME): cv.string,
-    }
+    {vol.Required(ATTR_USERNAME): cv.string, vol.Required(ATTR_DEVICE_NAME): cv.string}
 )
 
 SERVICE_SCHEMA_DISPLAY_MESSAGE = vol.Schema(
     {
-        vol.Required(SERVICE_ATTR_USERNAME): cv.string,
+        vol.Required(ATTR_USERNAME): cv.string,
         vol.Required(ATTR_DEVICE_NAME): cv.string,
-        vol.Required(SERVICE_ATTR_LOST_DEVICE_MESSAGE): cv.string,
-        vol.Optional(SERVICE_ATTR_LOST_DEVICE_SOUND): cv.boolean,
+        vol.Required(ATTR_LOST_DEVICE_MESSAGE): cv.string,
+        vol.Optional(ATTR_LOST_DEVICE_SOUND): cv.boolean,
     }
 )
 
 SERVICE_SCHEMA_LOST_DEVICE = vol.Schema(
     {
-        vol.Required(SERVICE_ATTR_USERNAME): cv.string,
+        vol.Required(ATTR_USERNAME): cv.string,
         vol.Required(ATTR_DEVICE_NAME): cv.string,
-        vol.Required(SERVICE_ATTR_LOST_DEVICE_NUMBER): cv.string,
-        vol.Required(SERVICE_ATTR_LOST_DEVICE_MESSAGE): cv.string,
+        vol.Required(ATTR_LOST_DEVICE_NUMBER): cv.string,
+        vol.Required(ATTR_LOST_DEVICE_MESSAGE): cv.string,
     }
 )
 
@@ -112,6 +108,8 @@ CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [ACCOUNT_SCHEMA]))},
     extra=vol.ALLOW_EXTRA,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
@@ -155,7 +153,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     def play_sound(service):
         """Play sound on the device."""
-        username = entry.data[SERVICE_ATTR_USERNAME]
+        username = entry.data[ATTR_USERNAME]
         devicename = service.data.get(ATTR_DEVICE_NAME)
         devicename = slugify(devicename.replace(" ", "", 99))
 
@@ -163,27 +161,27 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     def display_message(service):
         """Display a message on the device."""
-        username = entry.data[SERVICE_ATTR_USERNAME]
+        username = entry.data[ATTR_USERNAME]
         devicename = service.data.get(ATTR_DEVICE_NAME)
         devicename = slugify(devicename.replace(" ", "", 99))
-        message = service.data.get(SERVICE_ATTR_LOST_DEVICE_MESSAGE)
-        sound = service.data.get(SERVICE_ATTR_LOST_DEVICE_SOUND, False)
+        message = service.data.get(ATTR_LOST_DEVICE_MESSAGE)
+        sound = service.data.get(ATTR_LOST_DEVICE_SOUND, False)
 
         hass.data[DOMAIN][username].devices[devicename].display_message(message, sound)
 
     def lost_device(service):
         """Make the device in lost state."""
-        username = entry.data[SERVICE_ATTR_USERNAME]
+        username = entry.data[ATTR_USERNAME]
         devicename = service.data.get(ATTR_DEVICE_NAME)
         devicename = slugify(devicename.replace(" ", "", 99))
-        number = service.data.get(SERVICE_ATTR_LOST_DEVICE_NUMBER)
-        message = service.data.get(SERVICE_ATTR_LOST_DEVICE_MESSAGE)
+        number = service.data.get(ATTR_LOST_DEVICE_NUMBER)
+        message = service.data.get(ATTR_LOST_DEVICE_MESSAGE)
 
         hass.data[DOMAIN][username].devices[devicename].lost_device(number, message)
 
     def update_account(service):
         """Call the update function of an iCloud account."""
-        username = entry.data.get(SERVICE_ATTR_USERNAME)
+        username = entry.data.get(ATTR_USERNAME)
 
         if username is None:
             for account in hass.data[DOMAIN].items():
@@ -193,7 +191,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     def reset_account(service):
         """Reset an iCloud account."""
-        username = entry.data.get(SERVICE_ATTR_USERNAME)
+        username = entry.data.get(ATTR_USERNAME)
 
         if username is None:
             for account in hass.data[DOMAIN].items():
@@ -238,7 +236,7 @@ class IcloudAccount:
         hass,
         username: str,
         password: str,
-        accountname: str,
+        account_name: str,
         max_interval: int,
         gps_accuracy_threshold: int,
     ):
@@ -246,7 +244,7 @@ class IcloudAccount:
         self.hass = hass
         self._username = username
         self._password = password
-        self._name = accountname or slugify(username.partition("@")[0])
+        self._name = account_name or slugify(username.partition("@")[0])
         self._fetch_interval = max_interval
         self._max_interval = max_interval
         self._gps_accuracy_threshold = gps_accuracy_threshold

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -96,7 +96,7 @@ ACCOUNT_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_ACCOUNT_NAME): cv.slugify,
+        vol.Optional(CONF_ACCOUNT_NAME): cv.string,
         vol.Optional(CONF_MAX_INTERVAL, default=DEFAULT_MAX_INTERVAL): cv.positive_int,
         vol.Optional(
             CONF_GPS_ACCURACY_THRESHOLD, default=DEFAULT_GPS_ACCURACY_THRESHOLD

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -1,1 +1,593 @@
-"""The icloud component."""
+"""The iCloud component."""
+from datetime import timedelta
+import logging
+import operator
+
+from pyicloud import PyiCloudService
+from pyicloud.exceptions import PyiCloudFailedLoginException, PyiCloudNoDevicesException
+from pyicloud.services.findmyiphone import AppleDevice
+import voluptuous as vol
+
+from homeassistant.components.zone import async_active_zone
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_PASSWORD, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.util import slugify
+from homeassistant.util.async_ import run_callback_threadsafe
+from homeassistant.util.dt import utcnow
+from homeassistant.util.location import distance
+
+from .const import (
+    CONF_ACCOUNTNAME,
+    CONF_GPS_ACCURACY_THRESHOLD,
+    CONF_MAX_INTERVAL,
+    DEFAULT_GPS_ACCURACY_THRESHOLD,
+    DEFAULT_MAX_INTERVAL,
+    DOMAIN,
+    ICLOUD_COMPONENTS,
+    TRACKER_UPDATE,
+)
+
+ATTRIBUTION = "Data provided by Apple iCloud"
+
+# entity attributes
+ATTR_BATTERY = "battery"
+ATTR_BATTERYSTATUS = "battery_status"
+ATTR_DEVICENAME = "device_name"
+ATTR_DEVICESTATUS = "device_status"
+ATTR_LOWPOWERMODE = "low_power_mode"
+ATTR_OWNERNAME = "owner_fullname"
+
+DEVICE_STATUS_SET = [
+    "features",
+    "maxMsgChar",
+    "darkWake",
+    "fmlyShare",
+    "deviceStatus",
+    "remoteLock",
+    "activationLocked",
+    "deviceClass",
+    "id",
+    "deviceModel",
+    "rawDeviceModel",
+    "passcodeLength",
+    "canWipeAfterLock",
+    "trackingInfo",
+    "location",
+    "msg",
+    "batteryLevel",
+    "remoteWipe",
+    "thisDevice",
+    "snd",
+    "prsId",
+    "wipeInProgress",
+    "lowPowerMode",
+    "lostModeEnabled",
+    "isLocating",
+    "lostModeCapable",
+    "mesg",
+    "name",
+    "batteryStatus",
+    "lockedTimestamp",
+    "lostTimestamp",
+    "locationCapable",
+    "deviceDisplayName",
+    "lostDevice",
+    "deviceColor",
+    "wipedTimestamp",
+    "modelDisplayName",
+    "locationEnabled",
+    "isMac",
+    "locFoundEnabled",
+]
+
+DEVICE_STATUS_CODES = {
+    "200": "online",
+    "201": "offline",
+    "203": "pending",
+    "204": "unregistered",
+}
+
+_CONFIGURING = {}
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_ICLOUD_PLAY_SOUND = "play_sound"
+SERVICE_ICLOUD_DISPLAY_MESSAGE = "display_message"
+SERVICE_ICLOUD_LOST_DEVICE = "lost_device"
+SERVICE_ICLOUD_UPDATE = "update"
+SERVICE_ICLOUD_RESET = "reset"
+SERVICE_ATTR_LOST_DEVICE_MESSAGE = "message"
+SERVICE_ATTR_LOST_DEVICE_NUMBER = "number"
+SERVICE_ATTR_LOST_DEVICE_SOUND = "sound"
+
+SERVICE_SCHEMA = vol.Schema({vol.Optional(CONF_USERNAME): cv.string})
+
+SERVICE_SCHEMA_PLAY_SOUND = vol.Schema(
+    {vol.Required(CONF_USERNAME): cv.string, vol.Required(ATTR_DEVICENAME): cv.string}
+)
+
+SERVICE_SCHEMA_DISPLAY_MESSAGE = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(ATTR_DEVICENAME): cv.string,
+        vol.Required(SERVICE_ATTR_LOST_DEVICE_MESSAGE): cv.string,
+        vol.Optional(SERVICE_ATTR_LOST_DEVICE_SOUND): cv.boolean,
+    }
+)
+
+SERVICE_SCHEMA_LOST_DEVICE = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(ATTR_DEVICENAME): cv.string,
+        vol.Required(SERVICE_ATTR_LOST_DEVICE_NUMBER): cv.string,
+        vol.Required(SERVICE_ATTR_LOST_DEVICE_MESSAGE): cv.string,
+    }
+)
+
+ACCOUNT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_ACCOUNTNAME): cv.slugify,
+        vol.Optional(CONF_MAX_INTERVAL, default=DEFAULT_MAX_INTERVAL): cv.positive_int,
+        vol.Optional(
+            CONF_GPS_ACCURACY_THRESHOLD, default=DEFAULT_GPS_ACCURACY_THRESHOLD
+        ): cv.positive_int,
+    }
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {DOMAIN: vol.Schema(vol.All(cv.ensure_list, [ACCOUNT_SCHEMA]))},
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+    """Set up iCloud from legacy config file."""
+
+    conf = config.get(DOMAIN)
+    if conf is None:
+        return True
+
+    for account_conf in conf:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=account_conf.copy()
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Set up an iCloud account from a config entry."""
+
+    hass.data.setdefault(DOMAIN, {})
+
+    username = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
+    account_name = entry.data.get(CONF_ACCOUNTNAME, None)
+    max_interval = entry.data[CONF_MAX_INTERVAL]
+    gps_accuracy_threshold = entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+
+    account = IcloudAccount(
+        hass, username, password, account_name, max_interval, gps_accuracy_threshold
+    )
+    await hass.async_add_executor_job(account.reset_account)
+    hass.data[DOMAIN][username] = account
+
+    for component in ICLOUD_COMPONENTS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    def play_sound(service):
+        """Play sound on the device."""
+        username = entry.data[CONF_USERNAME]
+        devicename = service.data.get(ATTR_DEVICENAME)
+        devicename = slugify(devicename.replace(" ", "", 99))
+
+        hass.data[DOMAIN][username].devices[devicename].play_sound()
+
+    def display_message(service):
+        """Display a message on the device."""
+        username = entry.data[CONF_USERNAME]
+        devicename = service.data.get(ATTR_DEVICENAME)
+        devicename = slugify(devicename.replace(" ", "", 99))
+        message = service.data.get(SERVICE_ATTR_LOST_DEVICE_MESSAGE)
+        sound = service.data.get(SERVICE_ATTR_LOST_DEVICE_SOUND, False)
+
+        hass.data[DOMAIN][username].devices[devicename].display_message(message, sound)
+
+    def lost_device(service):
+        """Make the device in lost state."""
+        username = entry.data[CONF_USERNAME]
+        devicename = service.data.get(ATTR_DEVICENAME)
+        devicename = slugify(devicename.replace(" ", "", 99))
+        number = service.data.get(SERVICE_ATTR_LOST_DEVICE_NUMBER)
+        message = service.data.get(SERVICE_ATTR_LOST_DEVICE_MESSAGE)
+
+        hass.data[DOMAIN][username].devices[devicename].lost_device(number, message)
+
+    def update(service):
+        """Call the update function of an iCloud account."""
+        username = entry.data.get(CONF_USERNAME, None)
+
+        if username is None:
+            for account in hass.data[DOMAIN].items():
+                account.keep_alive(utcnow())
+        else:
+            hass.data[DOMAIN][username].keep_alive(utcnow())
+
+    def reset_account(service):
+        """Reset an iCloud account."""
+        username = entry.data.get(CONF_USERNAME, None)
+
+        if username is None:
+            for account in hass.data[DOMAIN].items():
+                account.reset_account()
+        else:
+            hass.data[DOMAIN][username].reset_account()
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ICLOUD_PLAY_SOUND, play_sound, schema=SERVICE_SCHEMA_PLAY_SOUND
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ICLOUD_DISPLAY_MESSAGE,
+        display_message,
+        schema=SERVICE_SCHEMA_DISPLAY_MESSAGE,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ICLOUD_LOST_DEVICE,
+        lost_device,
+        schema=SERVICE_SCHEMA_LOST_DEVICE,
+    )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ICLOUD_UPDATE, update, schema=SERVICE_SCHEMA
+    )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ICLOUD_RESET, reset_account, schema=SERVICE_SCHEMA
+    )
+
+    return True
+
+
+class IcloudAccount:
+    """Representation of an iCloud account."""
+
+    def __init__(
+        self,
+        hass,
+        username,
+        password,
+        accountname,
+        max_interval,
+        gps_accuracy_threshold,
+    ):
+        """Initialize an iCloud account."""
+        self.hass = hass
+        self.username = username
+        self._password = password
+        self._accountname = accountname or slugify(username.partition("@")[0])
+        self._max_interval = max_interval
+        self._gps_accuracy_threshold = gps_accuracy_threshold
+
+        self.api = None
+        self.account_owner_fullname = None
+        self.family_members_fullname = {}
+        self.devices = {}
+
+        self.unsub_device_tracker = None
+
+    def reset_account(self):
+        """Reset an iCloud account."""
+        icloud_dir = self.hass.config.path("icloud")
+
+        try:
+            self.api = PyiCloudService(
+                self.username, self._password, cookie_directory=icloud_dir, verify=True
+            )
+        except PyiCloudFailedLoginException as error:
+            self.api = None
+            _LOGGER.error("Error logging into iCloud Service: %s", error)
+            return
+
+        try:
+            # Gets device owners infos
+            user_info = self.api.devices.response["userInfo"]
+            self.account_owner_fullname = (
+                user_info["firstName"] + " " + user_info["lastName"]
+            )
+
+            self.family_members_fullname = {}
+            for prs_id, member in user_info["membersInfo"].items():
+                self.family_members_fullname[prs_id] = (
+                    member["firstName"] + " " + member["lastName"]
+                )
+
+            self.devices = {}
+            self.update_devices()
+
+        except PyiCloudNoDevicesException:
+            _LOGGER.error("No iCloud Devices found")
+
+    def update_devices(self):
+        """Update iCloud devices."""
+        if self.api is None:
+            return
+
+        try:
+            # Gets devices infos
+            for device in self.api.devices:
+                status = device.status(DEVICE_STATUS_SET)
+                devicename = slugify(status["name"].replace(" ", "", 99))
+
+                if self.devices.get(devicename, None) is not None:
+                    # Seen device -> updating
+                    _LOGGER.info("Updating iCloud device: %s", devicename)
+                    self.devices[devicename].update(status)
+                else:
+                    # New device, should be unique
+                    if devicename in self.devices:
+                        _LOGGER.error("Multiple devices with name: %s", devicename)
+                        continue
+
+                    _LOGGER.debug("Adding iCloud device: %s", devicename)
+                    self.devices[devicename] = IcloudDevice(self, device)
+
+        except PyiCloudNoDevicesException:
+            _LOGGER.error("No iCloud Devices found")
+
+        interval = self.determine_interval()
+        async_track_point_in_utc_time(
+            self.hass, self.keep_alive, utcnow() + timedelta(minutes=interval)
+        )
+
+    def determine_interval(self) -> int:
+        """Calculate new interval between to API fetch (in minutes)."""
+        intervals = {}
+        for device in self.devices.values():
+            if device.location is None:
+                continue
+
+            currentzone = self.hass.async_add_executor_job(
+                run_callback_threadsafe(
+                    self.hass.loop,
+                    async_active_zone,
+                    self.hass,
+                    device.location["latitude"],
+                    device.location["longitude"],
+                ).result
+            )
+
+            if currentzone is not None:
+                intervals[device.name] = self._max_interval
+                continue
+
+            zones = (
+                self.hass.states.get(entity_id)
+                for entity_id in sorted(self.hass.states.entity_ids("zone"))
+            )
+
+            distances = []
+            for zone_state in zones:
+                zone_state_lat = zone_state.attributes["latitude"]
+                zone_state_long = zone_state.attributes["longitude"]
+                zone_distance = distance(
+                    device.location["latitude"],
+                    device.location["longitude"],
+                    zone_state_lat,
+                    zone_state_long,
+                )
+                distances.append(round(zone_distance / 1000, 1))
+
+            if distances:
+                mindistance = min(distances)
+            else:
+                continue
+
+            # Calculate out how long it would take for the device to drive
+            # to the nearest zone at 120 km/h:
+            interval = round(mindistance / 2, 0)
+
+            # Never poll more than once per minute
+            interval = max(interval, 1)
+
+            if interval > 180:
+                # Three hour drive?
+                # This is far enough that they might be flying
+                interval = self._max_interval
+
+            if (
+                device.battery_level is not None
+                and device.battery_level <= 33
+                and mindistance > 3
+            ):
+                # Low battery - let's check half as often
+                interval = interval * 2
+
+            intervals[device.name] = interval
+
+        return max(
+            int(min(intervals.items(), key=operator.itemgetter(1))[1]),
+            self._max_interval,
+        )
+
+    def keep_alive(self, now):
+        """Keep the API alive."""
+        if self.api is None:
+            self.reset_account()
+
+        if self.api is None:
+            return
+
+        self.api.authenticate()
+        self.update_devices()
+
+    @property
+    def name(self):
+        """Return the account name."""
+        return self._accountname
+
+
+class IcloudDevice(Entity):
+    """Representation of a iCloud device."""
+
+    def __init__(self, account: IcloudAccount, device: AppleDevice):
+        """Initialize the iCloud device."""
+        self.hass = account.hass
+        self._account = account
+        self._accountname = account.name
+        self._accountname_slug = slugify(self._accountname.partition("@")[0])
+
+        self._device = device
+        self._status = device.status(DEVICE_STATUS_SET)
+        _LOGGER.debug("Device Status is %s", self._status)
+
+        self._name = self._status["name"]
+        self._dev_id = slugify(self._name.replace(" ", "", 99))  # devicename
+        self._unique_id = f"{self._accountname_slug}_{self._dev_id}"
+        self._device_class = self._status["deviceClass"]
+        self._device_name = self._status["deviceDisplayName"]
+        if self._status["prsId"]:
+            self._owner_fullname = account.family_members_fullname[
+                self._status["prsId"]
+            ]
+        else:
+            self._owner_fullname = account.account_owner_fullname
+
+        self._battery_level = None
+        self._battery_status = None
+        self._low_power_mode = None
+        self._location = None
+
+        self._seen = False
+
+        self.update(self._status)
+
+    def update(self, status):
+        """Update the iCloud device."""
+        self._status = status
+
+        self._device_status = DEVICE_STATUS_CODES.get(
+            self._status["deviceStatus"], "error"
+        )
+
+        self._attrs = {
+            CONF_ACCOUNTNAME: self._accountname,
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            ATTR_DEVICENAME: self._device_name,
+            ATTR_DEVICESTATUS: self._device_status,
+            ATTR_OWNERNAME: self._owner_fullname,
+        }
+
+        if self._status["batteryStatus"] != "Unknown":
+            self._battery_level = round(self._status.get("batteryLevel", 0) * 100)
+            self._battery_status = self._status["batteryStatus"]
+            self._low_power_mode = self._status["lowPowerMode"]
+
+            self._attrs[ATTR_BATTERY] = self._battery_level
+            self._attrs[ATTR_BATTERYSTATUS] = self._battery_status
+            self._attrs[ATTR_LOWPOWERMODE] = self._low_power_mode
+
+            if self._status["location"] and self._status["location"]["latitude"]:
+                location = self._status["location"]
+                self._location = location
+
+        # if self._account.unsub_device_tracker is not None:
+        async_dispatcher_send(self.hass, TRACKER_UPDATE, self)
+
+    def play_sound(self):
+        """Play sound on the device."""
+        if self._account.api is None:
+            return
+
+        self._account.api.authenticate()
+        _LOGGER.info("Playing Lost iPhone sound for %s", self.name)
+        self.device.play_sound()
+
+    def display_message(self, message: str, sound: bool = False):
+        """Display a message on the device."""
+        if self._account.api is None:
+            return
+
+        self._account.api.authenticate()
+        _LOGGER.info("Displaying message for %s", self.name)
+        self.device.display_message("Subject not working", message, sound)
+
+    def lost_device(self, number: str, message: str):
+        """Make the device in lost state."""
+        if self._account.api is None:
+            return
+
+        self._account.api.authenticate()
+        if self._status["lostModeCapable"]:
+            _LOGGER.info("Make device lost for %s", self.name)
+            self.device.lost_device(number, message, None)
+        else:
+            _LOGGER.error("Cannot make device lost for %s", self.name)
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
+    def name(self):
+        """Return the Apple device name."""
+        return self._name
+
+    @property
+    def device(self) -> AppleDevice:
+        """Return the Apple device."""
+        return self._device
+
+    @property
+    def dev_id(self):
+        """Return the device ID."""
+        return self._dev_id
+
+    @property
+    def device_class(self):
+        """Return the Apple device class."""
+        return self._device_class
+
+    @property
+    def battery_level(self):
+        """Return the Apple device battery level."""
+        return self._battery_level
+
+    @property
+    def battery_status(self):
+        """Return the Apple device battery status."""
+        return self._battery_status
+
+    @property
+    def location(self):
+        """Return the Apple device location."""
+        return self._location
+
+    @property
+    def state_attributes(self):
+        """Return the attributes."""
+        return self._attrs
+
+    @property
+    def seen(self):
+        """Return the seen value."""
+        return self._seen
+
+    def set_seen(self, seen):
+        """Set the seen value."""
+        self._seen = seen

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -263,9 +263,7 @@ class IcloudAccount:
         icloud_dir = self.hass.config.path("icloud")
 
         try:
-            self.api = PyiCloudService(
-                self._username, self._password, cookie_directory=icloud_dir, verify=True
-            )
+            self.api = PyiCloudService(self._username, self._password, icloud_dir)
         except PyiCloudFailedLoginException as error:
             self.api = None
             _LOGGER.error("Error logging into iCloud Service: %s", error)

--- a/homeassistant/components/icloud/__init__.py
+++ b/homeassistant/components/icloud/__init__.py
@@ -451,7 +451,7 @@ class IcloudDevice:
         self._dev_id = slugify(self._name.replace(" ", "", 99))  # devicename
         self._unique_id = f"{account_name_slug}_{self._dev_id}"
         self._device_class = self._status[DEVICE_CLASS]
-        device_name = self._status[DEVICE_DISPLAY_NAME]
+        self._device_model = self._status[DEVICE_DISPLAY_NAME]
 
         if self._status[DEVICE_PERSON_ID]:
             owner_fullname = account.family_members_fullname[
@@ -468,7 +468,7 @@ class IcloudDevice:
             ATTR_ATTRIBUTION: ATTRIBUTION,
             CONF_ACCOUNT_NAME: account_name,
             ATTR_ACCOUNT_FETCH_INTERVAL: self._account.fetch_interval,
-            ATTR_DEVICE_NAME: device_name,
+            ATTR_DEVICE_NAME: self._device_model,
             ATTR_DEVICE_STATUS: None,
             ATTR_OWNER_NAME: owner_fullname,
         }
@@ -534,6 +534,11 @@ class IcloudDevice:
         return self._unique_id
 
     @property
+    def dev_id(self) -> str:
+        """Return the device ID."""
+        return self._dev_id
+
+    @property
     def name(self) -> str:
         """Return the Apple device name."""
         return self._name
@@ -544,14 +549,14 @@ class IcloudDevice:
         return self._device
 
     @property
-    def dev_id(self) -> str:
-        """Return the device ID."""
-        return self._dev_id
-
-    @property
     def device_class(self) -> str:
         """Return the Apple device class."""
         return self._device_class
+
+    @property
+    def device_model(self) -> str:
+        """Return the Apple device model."""
+        return self._device_model
 
     @property
     def battery_level(self) -> int:

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -109,6 +109,8 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors[CONF_USERNAME] = "login"
             return await self._show_setup_form(user_input, errors)
 
+        _LOGGER.info("self.api.requires_2fa")
+        _LOGGER.info(self.api.requires_2fa)
         if self.api.requires_2fa:
             try:
                 if self._trusted_device is None:
@@ -157,6 +159,8 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         trusted_devices = {}
         devices = self.api.trusted_devices
+        _LOGGER.info("self.api.trusted_devices")
+        _LOGGER.info(devices)
         for i, device in enumerate(devices):
             trusted_devices[i] = device.get(
                 "deviceName", f"SMS to {device.get('phoneNumber')}"
@@ -171,6 +175,10 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             int(user_input[CONF_TRUSTED_DEVICE])
         ]
 
+        _LOGGER.info("self._trusted_device")
+        _LOGGER.info(self._trusted_device)
+        _LOGGER.info("self.api.send_verification_code(self._trusted_device)")
+        _LOGGER.info(self.api.send_verification_code(self._trusted_device))
         if not self.api.send_verification_code(self._trusted_device):
             _LOGGER.error("Failed to send verification code")
             self._trusted_device = None

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -49,8 +49,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if (
                 entry.data[CONF_USERNAME] == username
                 or entry.data.get(CONF_ACCOUNT_NAME) == account_name
-                or entry.data.get(CONF_ACCOUNT_NAME)
-                == slugify(username.partition("@")[0])
+                or slugify(entry.data[CONF_USERNAME].partition("@")[0]) == account_name
             ):
                 return True
         return False

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -100,11 +100,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             self.api = await self.hass.async_add_executor_job(
-                PyiCloudService,
-                self._username,
-                self._password,
-                cookie_directory=icloud_dir,
-                verify=True,
+                PyiCloudService, self._username, self._password, icloud_dir
             )
         except PyiCloudFailedLoginException as error:
             _LOGGER.error("Error logging into iCloud service: %s", error)

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -36,19 +36,19 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.api = None
         self._username = None
         self._password = None
-        self._accountname = None
+        self._account_name = None
         self._max_interval = None
         self._gps_accuracy_threshold = None
 
         self._trusted_device = None
         self._verification_code = None
 
-    def _configuration_exists(self, username: str, accountname: str) -> bool:
-        """Return True if username or accountname exists in configuration."""
+    def _configuration_exists(self, username: str, account_name: str) -> bool:
+        """Return True if username or account_name exists in configuration."""
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if (
                 entry.data[CONF_USERNAME] == username
-                or entry.data[CONF_ACCOUNT_NAME] == accountname
+                or entry.data[CONF_ACCOUNT_NAME] == account_name
                 or entry.data[CONF_ACCOUNT_NAME] == slugify(username.partition("@")[0])
             ):
                 return True
@@ -88,13 +88,13 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
-        self._accountname = user_input.get(CONF_ACCOUNT_NAME)
+        self._account_name = user_input.get(CONF_ACCOUNT_NAME)
         self._max_interval = user_input.get(CONF_MAX_INTERVAL, DEFAULT_MAX_INTERVAL)
         self._gps_accuracy_threshold = user_input.get(
             CONF_GPS_ACCURACY_THRESHOLD, DEFAULT_GPS_ACCURACY_THRESHOLD
         )
 
-        if self._configuration_exists(self._username, self._accountname):
+        if self._configuration_exists(self._username, self._account_name):
             errors[CONF_USERNAME] = "username_exists"
             return await self._show_setup_form(user_input, errors)
 
@@ -134,7 +134,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data={
                 CONF_USERNAME: self._username,
                 CONF_PASSWORD: self._password,
-                CONF_ACCOUNT_NAME: self._accountname,
+                CONF_ACCOUNT_NAME: self._account_name,
                 CONF_MAX_INTERVAL: self._max_interval,
                 CONF_GPS_ACCURACY_THRESHOLD: self._gps_accuracy_threshold,
             },
@@ -227,7 +227,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 CONF_USERNAME: self._username,
                 CONF_PASSWORD: self._password,
-                CONF_ACCOUNT_NAME: self._accountname,
+                CONF_ACCOUNT_NAME: self._account_name,
                 CONF_MAX_INTERVAL: self._max_interval,
                 CONF_GPS_ACCURACY_THRESHOLD: self._gps_accuracy_threshold,
             }

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -81,7 +81,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         icloud_dir = self.hass.config.path("icloud")
         if not os.path.exists(icloud_dir):
-            self.hass.async_add_executor_job(os.makedirs, icloud_dir)
+            await self.hass.async_add_executor_job(os.makedirs, icloud_dir)
 
         if user_input is None:
             return await self._show_setup_form(user_input, errors)
@@ -99,8 +99,12 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_setup_form(user_input, errors)
 
         try:
-            self.api = PyiCloudService(
-                self._username, self._password, cookie_directory=icloud_dir, verify=True
+            self.api = await self.hass.async_add_executor_job(
+                PyiCloudService,
+                self._username,
+                self._password,
+                cookie_directory=icloud_dir,
+                verify=True,
             )
         except PyiCloudFailedLoginException as error:
             _LOGGER.error("Error logging into iCloud service: %s", error)

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -48,8 +48,9 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if (
                 entry.data[CONF_USERNAME] == username
-                or entry.data[CONF_ACCOUNT_NAME] == account_name
-                or entry.data[CONF_ACCOUNT_NAME] == slugify(username.partition("@")[0])
+                or entry.data.get(CONF_ACCOUNT_NAME) == account_name
+                or entry.data.get(CONF_ACCOUNT_NAME)
+                == slugify(username.partition("@")[0])
             ):
                 return True
         return False

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -100,10 +100,9 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_setup_form(user_input, errors)
 
         try:
-            if self.api is None:
-                self.api = await self.hass.async_add_executor_job(
-                    PyiCloudService, self._username, self._password, icloud_dir
-                )
+            self.api = await self.hass.async_add_executor_job(
+                PyiCloudService, self._username, self._password, icloud_dir
+            )
         except PyiCloudFailedLoginException as error:
             _LOGGER.error("Error logging into iCloud service: %s", error)
             self.api = None

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -45,7 +45,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _configuration_exists(self, username: str, account_name: str) -> bool:
         """Return True if username or account_name exists in configuration."""
-        for entry in self.hass.config_entries.async_entries(DOMAIN):
+        for entry in self._async_current_entries():
             if (
                 entry.data[CONF_USERNAME] == username
                 or entry.data.get(CONF_ACCOUNT_NAME) == account_name

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -1,0 +1,247 @@
+"""Config flow to configure the iCloud integration."""
+import logging
+import os
+
+import voluptuous as vol
+from pyicloud import PyiCloudService
+from pyicloud.exceptions import PyiCloudException, PyiCloudFailedLoginException
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.util import slugify
+
+from .const import (
+    CONF_ACCOUNTNAME,
+    CONF_GPS_ACCURACY_THRESHOLD,
+    CONF_MAX_INTERVAL,
+    DEFAULT_MAX_INTERVAL,
+    DEFAULT_GPS_ACCURACY_THRESHOLD,
+    DOMAIN,
+)
+
+CONF_TRUSTED_DEVICE = "trusted_device"
+CONF_VERIFICATION_CODE = "verification_code"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a iCloud config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self):
+        """Initialize iCloud config flow."""
+        self.api = None
+        self._username = None
+        self._password = None
+        self._accountname = None
+        self._max_interval = None
+        self._gps_accuracy_threshold = None
+
+        self._trusted_device = None
+        self._verification_code = None
+
+    def _configuration_exists(self, username: str, accountname: str) -> bool:
+        """Return True if username or accountname exists in configuration."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if (
+                entry.data[CONF_USERNAME] == username
+                or entry.data[CONF_ACCOUNTNAME] == accountname
+                or entry.data[CONF_ACCOUNTNAME] == slugify(username.partition("@")[0])
+            ):
+                return True
+        return False
+
+    async def _show_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user."""
+
+        if user_input is None:
+            user_input = {}
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")
+                    ): str,
+                    vol.Required(
+                        CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")
+                    ): str,
+                }
+            ),
+            errors=errors or {},
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        icloud_dir = self.hass.config.path("icloud")
+        if not os.path.exists(icloud_dir):
+            os.makedirs(icloud_dir)
+
+        if user_input is None:
+            return await self._show_setup_form(user_input, errors)
+
+        self._username = user_input[CONF_USERNAME]
+        self._password = user_input[CONF_PASSWORD]
+        self._accountname = user_input.get(CONF_ACCOUNTNAME, None)
+        self._max_interval = user_input.get(CONF_MAX_INTERVAL, DEFAULT_MAX_INTERVAL)
+        self._gps_accuracy_threshold = user_input.get(
+            CONF_GPS_ACCURACY_THRESHOLD, DEFAULT_GPS_ACCURACY_THRESHOLD
+        )
+
+        if self._configuration_exists(self._username, self._accountname):
+            errors[CONF_USERNAME] = "username_exists"
+            return await self._show_setup_form(user_input, errors)
+
+        try:
+            self.api = PyiCloudService(
+                self._username, self._password, cookie_directory=icloud_dir, verify=True
+            )
+        except PyiCloudFailedLoginException as error:
+            _LOGGER.error("Error logging into iCloud service: %s", error)
+            self.api = None
+            errors[CONF_USERNAME] = "login"
+            return await self._show_setup_form(user_input, errors)
+
+        if self.api.requires_2fa:
+            try:
+                if self._trusted_device is None:
+                    _LOGGER.error("CONFIG_FLOW_ICLOUD:__trusted_device")
+                    return await self.async_step_trusted_device()
+
+                if self._verification_code is None:
+                    _LOGGER.error("CONFIG_FLOW_ICLOUD:__verification_code")
+                    return await self.async_step_verification_code()
+
+                self.api.authenticate()
+                if self.api.requires_2fa:
+                    _LOGGER.error("CONFIG_FLOW_ICLOUD:requires_2fa ERROR")
+                    errors["base"] = "unknown"
+                    return await self._show_setup_form(user_input, errors)
+
+                self._trusted_device = None
+                self._verification_code = None
+
+            except PyiCloudException as error:
+                _LOGGER.error("Error setting up 2FA: %s", error)
+                errors["base"] = "2fa"
+                return await self._show_setup_form(user_input, errors)
+
+        return self.async_create_entry(
+            title=self._username,
+            data={
+                CONF_USERNAME: self._username,
+                CONF_PASSWORD: self._password,
+                CONF_ACCOUNTNAME: self._accountname,
+                CONF_MAX_INTERVAL: self._max_interval,
+                CONF_GPS_ACCURACY_THRESHOLD: self._gps_accuracy_threshold,
+            },
+        )
+
+    async def async_step_import(self, user_input):
+        """Import a config entry."""
+        if self._configuration_exists(
+            user_input[CONF_USERNAME], user_input.get(CONF_ACCOUNTNAME, None)
+        ):
+            return self.async_abort(reason="username_exists")
+
+        return await self.async_step_user(user_input)
+
+    async def async_step_trusted_device(self, user_input=None, errors=None):
+        """We need a trusted device."""
+        if errors is None:
+            errors = {}
+
+        trusted_devices = {}
+        devices = self.api.trusted_devices
+        for i, device in enumerate(devices):
+            devicename = device.get(
+                "deviceName", "SMS to %s" % device.get("phoneNumber")
+            )
+            trusted_devices[i] = devicename
+
+        if user_input is None:
+            return await self._show_trusted_device_form(
+                trusted_devices, user_input, errors
+            )
+
+        self._trusted_device = self.api.trusted_devices[
+            int(user_input[CONF_TRUSTED_DEVICE])
+        ]
+
+        if not self.api.send_verification_code(self._trusted_device):
+            _LOGGER.error("Failed to send verification code")
+            self._trusted_device = None
+            errors[CONF_TRUSTED_DEVICE] = "send_verification_code"
+
+            return await self._show_trusted_device_form(
+                trusted_devices, user_input, errors
+            )
+
+        # Trigger the next step immediately
+        return await self.async_step_verification_code()
+
+    async def _show_trusted_device_form(
+        self, trusted_devices, user_input=None, errors=None
+    ):
+        """Show the trusted_device form to the user."""
+
+        return self.async_show_form(
+            step_id=CONF_TRUSTED_DEVICE,
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TRUSTED_DEVICE): vol.All(
+                        vol.Coerce(int), vol.In(trusted_devices)
+                    )
+                }
+            ),
+            errors=errors or {},
+        )
+
+    async def async_step_verification_code(self, user_input=None):
+        """Ask the verification code to the user."""
+        errors = {}
+
+        if user_input is None:
+            return await self._show_verification_code_form(user_input)
+
+        self._verification_code = user_input[CONF_VERIFICATION_CODE]
+
+        try:
+            if not self.api.validate_verification_code(
+                self._trusted_device, self._verification_code
+            ):
+                raise PyiCloudException("The code you entered is not valid.")
+        except PyiCloudException as error:
+            # Reset to the initial 2FA state to allow the user to retry
+            _LOGGER.error("Failed to verify verification code: %s", error)
+            self._trusted_device = None
+            self._verification_code = None
+            errors["base"] = "validate_verification_code"
+
+            # Trigger the next step immediately
+            return await self.async_step_trusted_device(None, errors)
+
+        return await self.async_step_user(
+            {
+                CONF_USERNAME: self._username,
+                CONF_PASSWORD: self._password,
+                CONF_ACCOUNTNAME: self._accountname,
+                CONF_MAX_INTERVAL: self._max_interval,
+                CONF_GPS_ACCURACY_THRESHOLD: self._gps_accuracy_threshold,
+            }
+        )
+
+    async def _show_verification_code_form(self, user_input=None):
+        """Show the verification_code form to the user."""
+
+        return self.async_show_form(
+            step_id=CONF_VERIFICATION_CODE,
+            data_schema=vol.Schema({vol.Required(CONF_VERIFICATION_CODE): str}),
+            errors=None,
+        )

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -10,13 +10,14 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.util import slugify
 
+# pylint: disable=unused-import
 from .const import (
     CONF_ACCOUNT_NAME,
     CONF_GPS_ACCURACY_THRESHOLD,
     CONF_MAX_INTERVAL,
     DEFAULT_MAX_INTERVAL,
     DEFAULT_GPS_ACCURACY_THRESHOLD,
-    DOMAIN,
+    DOMAIN,  # noqa
 )
 
 CONF_TRUSTED_DEVICE = "trusted_device"

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -110,25 +110,7 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_setup_form(user_input, errors)
 
         if self.api.requires_2fa:
-            try:
-                if self._trusted_device is None:
-                    return await self.async_step_trusted_device()
-
-                if self._verification_code is None:
-                    return await self.async_step_verification_code()
-
-                self.api.authenticate()
-                if self.api.requires_2fa:
-                    errors["base"] = "unknown"
-                    return await self._show_setup_form(user_input, errors)
-
-                self._trusted_device = None
-                self._verification_code = None
-
-            except PyiCloudException as error:
-                _LOGGER.error("Error setting up 2FA: %s", error)
-                errors["base"] = "2fa"
-                return await self._show_setup_form(user_input, errors)
+            return await self.async_step_trusted_device()
 
         return self.async_create_entry(
             title=self._username,
@@ -180,7 +162,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 trusted_devices, user_input, errors
             )
 
-        # Trigger the next step immediately
         return await self.async_step_verification_code()
 
     async def _show_trusted_device_form(
@@ -221,7 +202,6 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._verification_code = None
             errors["base"] = "validate_verification_code"
 
-            # Trigger the next step immediately
             return await self.async_step_trusted_device(None, errors)
 
         return await self.async_step_user(

--- a/homeassistant/components/icloud/const.py
+++ b/homeassistant/components/icloud/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "icloud"
 TRACKER_UPDATE = f"{DOMAIN}_tracker_update"
 
-CONF_ACCOUNTNAME = "account_name"
+CONF_ACCOUNT_NAME = "account_name"
 CONF_MAX_INTERVAL = "max_interval"
 CONF_GPS_ACCURACY_THRESHOLD = "gps_accuracy_threshold"
 

--- a/homeassistant/components/icloud/const.py
+++ b/homeassistant/components/icloud/const.py
@@ -18,6 +18,7 @@ DEVICE_BATTERY_LEVEL = "batteryLevel"
 DEVICE_BATTERY_STATUS = "batteryStatus"
 DEVICE_CLASS = "deviceClass"
 DEVICE_DISPLAY_NAME = "deviceDisplayName"
+DEVICE_ID = "id"
 DEVICE_LOCATION = "location"
 DEVICE_LOCATION_HORIZONTAL_ACCURACY = "horizontalAccuracy"
 DEVICE_LOCATION_LATITUDE = "latitude"
@@ -26,6 +27,7 @@ DEVICE_LOST_MODE_CAPABLE = "lostModeCapable"
 DEVICE_LOW_POWER_MODE = "lowPowerMode"
 DEVICE_NAME = "name"
 DEVICE_PERSON_ID = "prsId"
+DEVICE_RAW_DEVICE_MODEL = "rawDeviceModel"
 DEVICE_STATUS = "deviceStatus"
 
 DEVICE_STATUS_SET = [
@@ -37,9 +39,9 @@ DEVICE_STATUS_SET = [
     "remoteLock",
     "activationLocked",
     DEVICE_CLASS,
-    "id",
+    DEVICE_ID,
     "deviceModel",
-    "rawDeviceModel",
+    DEVICE_RAW_DEVICE_MODEL,
     "passcodeLength",
     "canWipeAfterLock",
     "trackingInfo",

--- a/homeassistant/components/icloud/const.py
+++ b/homeassistant/components/icloud/const.py
@@ -12,3 +12,68 @@ DEFAULT_GPS_ACCURACY_THRESHOLD = 500  # meters
 
 # Next PR will add sensor
 ICLOUD_COMPONENTS = ["device_tracker"]
+
+# pyicloud.AppleDevice status
+DEVICE_BATTERY_LEVEL = "batteryLevel"
+DEVICE_BATTERY_STATUS = "batteryStatus"
+DEVICE_CLASS = "deviceClass"
+DEVICE_DISPLAY_NAME = "deviceDisplayName"
+DEVICE_LOCATION = "location"
+DEVICE_LOCATION_HORIZONTAL_ACCURACY = "horizontalAccuracy"
+DEVICE_LOCATION_LATITUDE = "latitude"
+DEVICE_LOCATION_LONGITUDE = "longitude"
+DEVICE_LOST_MODE_CAPABLE = "lostModeCapable"
+DEVICE_LOW_POWER_MODE = "lowPowerMode"
+DEVICE_NAME = "name"
+DEVICE_PERSON_ID = "prsId"
+DEVICE_STATUS = "deviceStatus"
+
+DEVICE_STATUS_SET = [
+    "features",
+    "maxMsgChar",
+    "darkWake",
+    "fmlyShare",
+    DEVICE_STATUS,
+    "remoteLock",
+    "activationLocked",
+    DEVICE_CLASS,
+    "id",
+    "deviceModel",
+    "rawDeviceModel",
+    "passcodeLength",
+    "canWipeAfterLock",
+    "trackingInfo",
+    DEVICE_LOCATION,
+    "msg",
+    DEVICE_BATTERY_LEVEL,
+    "remoteWipe",
+    "thisDevice",
+    "snd",
+    DEVICE_PERSON_ID,
+    "wipeInProgress",
+    DEVICE_LOW_POWER_MODE,
+    "lostModeEnabled",
+    "isLocating",
+    DEVICE_LOST_MODE_CAPABLE,
+    "mesg",
+    DEVICE_NAME,
+    DEVICE_BATTERY_STATUS,
+    "lockedTimestamp",
+    "lostTimestamp",
+    "locationCapable",
+    DEVICE_DISPLAY_NAME,
+    "lostDevice",
+    "deviceColor",
+    "wipedTimestamp",
+    "modelDisplayName",
+    "locationEnabled",
+    "isMac",
+    "locFoundEnabled",
+]
+
+DEVICE_STATUS_CODES = {
+    "200": "online",
+    "201": "offline",
+    "203": "pending",
+    "204": "unregistered",
+}

--- a/homeassistant/components/icloud/const.py
+++ b/homeassistant/components/icloud/const.py
@@ -1,0 +1,14 @@
+"""iCloud component constants."""
+
+DOMAIN = "icloud"
+TRACKER_UPDATE = f"{DOMAIN}_tracker_update"
+
+CONF_ACCOUNTNAME = "account_name"
+CONF_MAX_INTERVAL = "max_interval"
+CONF_GPS_ACCURACY_THRESHOLD = "gps_accuracy_threshold"
+
+DEFAULT_MAX_INTERVAL = 30  # min
+DEFAULT_GPS_ACCURACY_THRESHOLD = 500  # meters
+
+# Next PR will add sensor
+ICLOUD_COMPONENTS = ["device_tracker"]

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -26,7 +26,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             _LOGGER.debug("No position found for device %s", device.name)
             continue
 
-        _LOGGER.debug("Updating device_tracker for %s", device.name)
+        _LOGGER.debug("Adding device_tracker for %s", device.name)
 
         async_add_entities([IcloudTrackerEntity(device)])
 

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -95,6 +95,16 @@ class IcloudTrackerEntity(TrackerEntity):
         """Return the device state attributes."""
         return self._device.state_attributes
 
+    @property
+    def device_info(self):
+        """Return the device information."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "manufacturer": "Apple",
+            "model": self._device.device_model,
+        }
+
     async def async_added_to_hass(self):
         """Register state update callback."""
         self._unsub_dispatcher = async_dispatcher_connect(

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -7,7 +7,13 @@ from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import IcloudDevice
-from .const import DOMAIN, TRACKER_UPDATE
+from .const import (
+    DOMAIN,
+    TRACKER_UPDATE,
+    DEVICE_LOCATION_HORIZONTAL_ACCURACY,
+    DEVICE_LOCATION_LATITUDE,
+    DEVICE_LOCATION_LONGITUDE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,17 +58,17 @@ class IcloudTrackerEntity(TrackerEntity):
     @property
     def location_accuracy(self):
         """Return the location accuracy of the device."""
-        return self._device.location["horizontalAccuracy"]
+        return self._device.location[DEVICE_LOCATION_HORIZONTAL_ACCURACY]
 
     @property
     def latitude(self):
         """Return latitude value of the device."""
-        return self._device.location["latitude"]
+        return self._device.location[DEVICE_LOCATION_LATITUDE]
 
     @property
     def longitude(self):
         """Return longitude value of the device."""
-        return self._device.location["longitude"]
+        return self._device.location[DEVICE_LOCATION_LONGITUDE]
 
     @property
     def should_poll(self):

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -1,7 +1,6 @@
 """Support for tracking for iCloud devices."""
 import logging
 
-from homeassistant.core import callback
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.const import CONF_USERNAME
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
@@ -93,17 +92,12 @@ class IcloudTrackerEntity(TrackerEntity):
     async def async_added_to_hass(self):
         """Register state update callback."""
         self._unsub_dispatcher = async_dispatcher_connect(
-            self.hass, TRACKER_UPDATE, self._async_receive_data
+            self.hass, TRACKER_UPDATE, self.async_write_ha_state
         )
 
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""
         self._unsub_dispatcher()
-
-    @callback
-    def _async_receive_data(self):
-        """Update device data."""
-        self.async_write_ha_state()
 
 
 def icon_for_icloud_device(icloud_device: IcloudDevice) -> str:

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -1,547 +1,134 @@
-"""Platform that supports scanning iCloud."""
+"""Support for tracking for iCloud devices."""
 import logging
-import random
-import os
 
-import voluptuous as vol
+from homeassistant.core import callback
+from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.const import CONF_USERNAME
+from homeassistant.components.device_tracker.const import ENTITY_ID_FORMAT
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
-from homeassistant.components.device_tracker.const import (
-    DOMAIN,
-    ATTR_ATTRIBUTES,
-    ENTITY_ID_FORMAT,
-)
-from homeassistant.components.device_tracker.legacy import DeviceScanner
-from homeassistant.components.zone import async_active_zone
-from homeassistant.helpers.event import track_utc_time_change
-import homeassistant.helpers.config_validation as cv
-from homeassistant.util import slugify
-import homeassistant.util.dt as dt_util
-from homeassistant.util.location import distance
-from homeassistant.util.async_ import run_callback_threadsafe
+from . import IcloudDevice
+from .const import DOMAIN, TRACKER_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ACCOUNTNAME = "account_name"
-CONF_MAX_INTERVAL = "max_interval"
-CONF_GPS_ACCURACY_THRESHOLD = "gps_accuracy_threshold"
 
-# entity attributes
-ATTR_ACCOUNTNAME = "account_name"
-ATTR_INTERVAL = "interval"
-ATTR_DEVICENAME = "device_name"
-ATTR_BATTERY = "battery"
-ATTR_DISTANCE = "distance"
-ATTR_DEVICESTATUS = "device_status"
-ATTR_LOWPOWERMODE = "low_power_mode"
-ATTR_BATTERYSTATUS = "battery_status"
+async def async_setup_scanner(hass, config, see, discovery_info=None):
+    """Old way of setting up the iCloud tracker."""
+    pass
 
-ICLOUDTRACKERS = {}
 
-_CONFIGURING = {}
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Configure a dispatcher connection based on a config entry."""
+    username = entry.data[CONF_USERNAME]
 
-DEVICESTATUSSET = [
-    "features",
-    "maxMsgChar",
-    "darkWake",
-    "fmlyShare",
-    "deviceStatus",
-    "remoteLock",
-    "activationLocked",
-    "deviceClass",
-    "id",
-    "deviceModel",
-    "rawDeviceModel",
-    "passcodeLength",
-    "canWipeAfterLock",
-    "trackingInfo",
-    "location",
-    "msg",
-    "batteryLevel",
-    "remoteWipe",
-    "thisDevice",
-    "snd",
-    "prsId",
-    "wipeInProgress",
-    "lowPowerMode",
-    "lostModeEnabled",
-    "isLocating",
-    "lostModeCapable",
-    "mesg",
-    "name",
-    "batteryStatus",
-    "lockedTimestamp",
-    "lostTimestamp",
-    "locationCapable",
-    "deviceDisplayName",
-    "lostDevice",
-    "deviceColor",
-    "wipedTimestamp",
-    "modelDisplayName",
-    "locationEnabled",
-    "isMac",
-    "locFoundEnabled",
-]
-
-DEVICESTATUSCODES = {
-    "200": "online",
-    "201": "offline",
-    "203": "pending",
-    "204": "unregistered",
-}
-
-SERVICE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_ACCOUNTNAME): vol.All(cv.ensure_list, [cv.slugify]),
-        vol.Optional(ATTR_DEVICENAME): cv.slugify,
-        vol.Optional(ATTR_INTERVAL): cv.positive_int,
-    }
-)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(ATTR_ACCOUNTNAME): cv.slugify,
-        vol.Optional(CONF_MAX_INTERVAL, default=30): cv.positive_int,
-        vol.Optional(CONF_GPS_ACCURACY_THRESHOLD, default=1000): cv.positive_int,
-    }
-)
-
-
-def setup_scanner(hass, config: dict, see, discovery_info=None):
-    """Set up the iCloud Scanner."""
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
-    account = config.get(CONF_ACCOUNTNAME, slugify(username.partition("@")[0]))
-    max_interval = config.get(CONF_MAX_INTERVAL)
-    gps_accuracy_threshold = config.get(CONF_GPS_ACCURACY_THRESHOLD)
-
-    icloudaccount = Icloud(
-        hass, username, password, account, max_interval, gps_accuracy_threshold, see
-    )
-
-    if icloudaccount.api is not None:
-        ICLOUDTRACKERS[account] = icloudaccount
-
-    else:
-        _LOGGER.error("No ICLOUDTRACKERS added")
-        return False
-
-    def lost_iphone(call):
-        """Call the lost iPhone function if the device is found."""
-        accounts = call.data.get(ATTR_ACCOUNTNAME, ICLOUDTRACKERS)
-        devicename = call.data.get(ATTR_DEVICENAME)
-        for account in accounts:
-            if account in ICLOUDTRACKERS:
-                ICLOUDTRACKERS[account].lost_iphone(devicename)
-
-    hass.services.register(
-        DOMAIN, "icloud_lost_iphone", lost_iphone, schema=SERVICE_SCHEMA
-    )
-
-    def update_icloud(call):
-        """Call the update function of an iCloud account."""
-        accounts = call.data.get(ATTR_ACCOUNTNAME, ICLOUDTRACKERS)
-        devicename = call.data.get(ATTR_DEVICENAME)
-        for account in accounts:
-            if account in ICLOUDTRACKERS:
-                ICLOUDTRACKERS[account].update_icloud(devicename)
-
-    hass.services.register(
-        DOMAIN, "icloud_update", update_icloud, schema=SERVICE_SCHEMA
-    )
-
-    def reset_account_icloud(call):
-        """Reset an iCloud account."""
-        accounts = call.data.get(ATTR_ACCOUNTNAME, ICLOUDTRACKERS)
-        for account in accounts:
-            if account in ICLOUDTRACKERS:
-                ICLOUDTRACKERS[account].reset_account_icloud()
-
-    hass.services.register(
-        DOMAIN, "icloud_reset_account", reset_account_icloud, schema=SERVICE_SCHEMA
-    )
-
-    def setinterval(call):
-        """Call the update function of an iCloud account."""
-        accounts = call.data.get(ATTR_ACCOUNTNAME, ICLOUDTRACKERS)
-        interval = call.data.get(ATTR_INTERVAL)
-        devicename = call.data.get(ATTR_DEVICENAME)
-        for account in accounts:
-            if account in ICLOUDTRACKERS:
-                ICLOUDTRACKERS[account].setinterval(interval, devicename)
-
-    hass.services.register(
-        DOMAIN, "icloud_set_interval", setinterval, schema=SERVICE_SCHEMA
-    )
-
-    # Tells the bootstrapper that the component was successfully initialized
-    return True
-
-
-class Icloud(DeviceScanner):
-    """Representation of an iCloud account."""
-
-    def __init__(
-        self, hass, username, password, name, max_interval, gps_accuracy_threshold, see
-    ):
-        """Initialize an iCloud account."""
-        self.hass = hass
-        self.username = username
-        self.password = password
-        self.api = None
-        self.accountname = name
-        self.devices = {}
-        self.seen_devices = {}
-        self._overridestates = {}
-        self._intervals = {}
-        self._max_interval = max_interval
-        self._gps_accuracy_threshold = gps_accuracy_threshold
-        self.see = see
-
-        self._trusted_device = None
-        self._verification_code = None
-
-        self._attrs = {}
-        self._attrs[ATTR_ACCOUNTNAME] = name
-
-        self.reset_account_icloud()
-
-        randomseconds = random.randint(10, 59)
-        track_utc_time_change(self.hass, self.keep_alive, second=randomseconds)
-
-    def reset_account_icloud(self):
-        """Reset an iCloud account."""
-        from pyicloud import PyiCloudService
-        from pyicloud.exceptions import (
-            PyiCloudFailedLoginException,
-            PyiCloudNoDevicesException,
-        )
-
-        icloud_dir = self.hass.config.path("icloud")
-        if not os.path.exists(icloud_dir):
-            os.makedirs(icloud_dir)
-
-        try:
-            self.api = PyiCloudService(
-                self.username, self.password, cookie_directory=icloud_dir, verify=True
-            )
-        except PyiCloudFailedLoginException as error:
-            self.api = None
-            _LOGGER.error("Error logging into iCloud Service: %s", error)
-            return
-
-        try:
-            self.devices = {}
-            self._overridestates = {}
-            self._intervals = {}
-            for device in self.api.devices:
-                status = device.status(DEVICESTATUSSET)
-                _LOGGER.debug("Device Status is %s", status)
-                devicename = slugify(status["name"].replace(" ", "", 99))
-                _LOGGER.info("Adding icloud device: %s", devicename)
-                if devicename in self.devices:
-                    _LOGGER.error("Multiple devices with name: %s", devicename)
-                    continue
-                self.devices[devicename] = device
-                self._intervals[devicename] = 1
-                self._overridestates[devicename] = None
-        except PyiCloudNoDevicesException:
-            _LOGGER.error("No iCloud Devices found!")
-
-    def icloud_trusted_device_callback(self, callback_data):
-        """Handle chosen trusted devices."""
-        self._trusted_device = int(callback_data.get("trusted_device"))
-        self._trusted_device = self.api.trusted_devices[self._trusted_device]
-
-        if not self.api.send_verification_code(self._trusted_device):
-            _LOGGER.error("Failed to send verification code")
-            self._trusted_device = None
-            return
-
-        if self.accountname in _CONFIGURING:
-            request_id = _CONFIGURING.pop(self.accountname)
-            configurator = self.hass.components.configurator
-            configurator.request_done(request_id)
-
-        # Trigger the next step immediately
-        self.icloud_need_verification_code()
-
-    def icloud_need_trusted_device(self):
-        """We need a trusted device."""
-        configurator = self.hass.components.configurator
-        if self.accountname in _CONFIGURING:
-            return
-
-        devicesstring = ""
-        devices = self.api.trusted_devices
-        for i, device in enumerate(devices):
-            devicename = device.get(
-                "deviceName", "SMS to %s" % device.get("phoneNumber")
-            )
-            devicesstring += f"{i}: {devicename};"
-
-        _CONFIGURING[self.accountname] = configurator.request_config(
-            f"iCloud {self.accountname}",
-            self.icloud_trusted_device_callback,
-            description=(
-                "Please choose your trusted device by entering"
-                " the index from this list: " + devicesstring
-            ),
-            entity_picture="/static/images/config_icloud.png",
-            submit_caption="Confirm",
-            fields=[{"id": "trusted_device", "name": "Trusted Device"}],
-        )
-
-    def icloud_verification_callback(self, callback_data):
-        """Handle the chosen trusted device."""
-        from pyicloud.exceptions import PyiCloudException
-
-        self._verification_code = callback_data.get("code")
-
-        try:
-            if not self.api.validate_verification_code(
-                self._trusted_device, self._verification_code
-            ):
-                raise PyiCloudException("Unknown failure")
-        except PyiCloudException as error:
-            # Reset to the initial 2FA state to allow the user to retry
-            _LOGGER.error("Failed to verify verification code: %s", error)
-            self._trusted_device = None
-            self._verification_code = None
-
-            # Trigger the next step immediately
-            self.icloud_need_trusted_device()
-
-        if self.accountname in _CONFIGURING:
-            request_id = _CONFIGURING.pop(self.accountname)
-            configurator = self.hass.components.configurator
-            configurator.request_done(request_id)
-
-    def icloud_need_verification_code(self):
-        """Return the verification code."""
-        configurator = self.hass.components.configurator
-        if self.accountname in _CONFIGURING:
-            return
-
-        _CONFIGURING[self.accountname] = configurator.request_config(
-            f"iCloud {self.accountname}",
-            self.icloud_verification_callback,
-            description=("Please enter the validation code:"),
-            entity_picture="/static/images/config_icloud.png",
-            submit_caption="Confirm",
-            fields=[{"id": "code", "name": "code"}],
-        )
-
-    def keep_alive(self, now):
-        """Keep the API alive."""
-        if self.api is None:
-            self.reset_account_icloud()
-
-        if self.api is None:
-            return
-
-        if self.api.requires_2fa:
-            from pyicloud.exceptions import PyiCloudException
-
-            try:
-                if self._trusted_device is None:
-                    self.icloud_need_trusted_device()
-                    return
-
-                if self._verification_code is None:
-                    self.icloud_need_verification_code()
-                    return
-
-                self.api.authenticate()
-                if self.api.requires_2fa:
-                    raise Exception("Unknown failure")
-
-                self._trusted_device = None
-                self._verification_code = None
-            except PyiCloudException as error:
-                _LOGGER.error("Error setting up 2FA: %s", error)
-        else:
-            self.api.authenticate()
-
-        currentminutes = dt_util.now().hour * 60 + dt_util.now().minute
-        try:
-            for devicename in self.devices:
-                interval = self._intervals.get(devicename, 1)
-                if (currentminutes % interval == 0) or (
-                    interval > 10 and currentminutes % interval in [2, 4]
-                ):
-                    self.update_device(devicename)
-        except ValueError:
-            _LOGGER.debug("iCloud API returned an error")
-
-    def determine_interval(self, devicename, latitude, longitude, battery):
-        """Calculate new interval."""
-        currentzone = run_callback_threadsafe(
-            self.hass.loop, async_active_zone, self.hass, latitude, longitude
-        ).result()
-
-        if (
-            currentzone is not None
-            and currentzone == self._overridestates.get(devicename)
-        ) or (currentzone is None and self._overridestates.get(devicename) == "away"):
-            return
-
-        zones = (
-            self.hass.states.get(entity_id)
-            for entity_id in sorted(self.hass.states.entity_ids("zone"))
-        )
-
-        distances = []
-        for zone_state in zones:
-            zone_state_lat = zone_state.attributes["latitude"]
-            zone_state_long = zone_state.attributes["longitude"]
-            zone_distance = distance(
-                latitude, longitude, zone_state_lat, zone_state_long
-            )
-            distances.append(round(zone_distance / 1000, 1))
-
-        if distances:
-            mindistance = min(distances)
-        else:
-            mindistance = None
-
-        self._overridestates[devicename] = None
-
-        if currentzone is not None:
-            self._intervals[devicename] = self._max_interval
-            return
-
-        if mindistance is None:
-            return
-
-        # Calculate out how long it would take for the device to drive to the
-        # nearest zone at 120 km/h:
-        interval = round(mindistance / 2, 0)
-
-        # Never poll more than once per minute
-        interval = max(interval, 1)
-
-        if interval > 180:
-            # Three hour drive?  This is far enough that they might be flying
-            interval = 30
-
-        if battery is not None and battery <= 33 and mindistance > 3:
-            # Low battery - let's check half as often
-            interval = interval * 2
-
-        self._intervals[devicename] = interval
-
-    def update_device(self, devicename):
-        """Update the device_tracker entity."""
-        from pyicloud.exceptions import PyiCloudNoDevicesException
+    for device in hass.data[DOMAIN][username].devices.values():
 
         # An entity will not be created by see() when track=false in
         # 'known_devices.yaml', but we need to see() it at least once
-        entity = self.hass.states.get(ENTITY_ID_FORMAT.format(devicename))
-        if entity is None and devicename in self.seen_devices:
+        entity = hass.states.get(ENTITY_ID_FORMAT.format(device.dev_id))
+        if entity is None and device.seen:
+            continue
+
+        if device.location is None:
+            _LOGGER.debug("No position found for device %s", device.name)
+            continue
+
+        _LOGGER.debug("Updating device_tracker for %s", device.name)
+
+        async_add_entities([IcloudTrackerEntity(device)])
+        device.set_seen(True)
+
+    return True
+
+
+class IcloudTrackerEntity(TrackerEntity):
+    """Represent a tracked device."""
+
+    def __init__(self, device: IcloudDevice):
+        """Set up the iCloud tracker entity."""
+        self._device = device
+        self._unsub_dispatcher = None
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._device.unique_id}_tracker"
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._device.name
+
+    @property
+    def location_accuracy(self):
+        """Return the location accuracy of the device."""
+        return self._device.location["horizontalAccuracy"]
+
+    @property
+    def latitude(self):
+        """Return latitude value of the device."""
+        return self._device.location["latitude"]
+
+    @property
+    def longitude(self):
+        """Return longitude value of the device."""
+        return self._device.location["longitude"]
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def battery_level(self):
+        """Return the battery level of the device."""
+        return self._device.battery_level
+
+    @property
+    def source_type(self):
+        """Return the source type, eg gps or router, of the device."""
+        return SOURCE_TYPE_GPS
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return icon_for_icloud_device(self._device)
+
+    @property
+    def state_attributes(self):
+        """Return the device state attributes."""
+        return self._device.state_attributes
+
+    async def async_added_to_hass(self):
+        """Register state update callback."""
+        self._unsub_dispatcher = async_dispatcher_connect(
+            self.hass, TRACKER_UPDATE, self._async_receive_data
+        )
+
+    async def async_will_remove_from_hass(self):
+        """Clean up after entity before removal."""
+        self._unsub_dispatcher()
+
+    @callback
+    def _async_receive_data(self, device: IcloudDevice):
+        """Update device data."""
+        if device.unique_id != self._device.unique_id:
             return
-        attrs = {}
-        kwargs = {}
 
-        if self.api is None:
-            return
+        self._device = device
+        self.async_write_ha_state()
 
-        try:
-            for device in self.api.devices:
-                if str(device) != str(self.devices[devicename]):
-                    continue
 
-                status = device.status(DEVICESTATUSSET)
-                _LOGGER.debug("Device Status is %s", status)
-                dev_id = status["name"].replace(" ", "", 99)
-                dev_id = slugify(dev_id)
-                attrs[ATTR_DEVICESTATUS] = DEVICESTATUSCODES.get(
-                    status["deviceStatus"], "error"
-                )
-                attrs[ATTR_LOWPOWERMODE] = status["lowPowerMode"]
-                attrs[ATTR_BATTERYSTATUS] = status["batteryStatus"]
-                attrs[ATTR_ACCOUNTNAME] = self.accountname
-                status = device.status(DEVICESTATUSSET)
-                battery = status.get("batteryLevel", 0) * 100
-                location = status["location"]
-                if location and location["horizontalAccuracy"]:
-                    horizontal_accuracy = int(location["horizontalAccuracy"])
-                    if horizontal_accuracy < self._gps_accuracy_threshold:
-                        self.determine_interval(
-                            devicename,
-                            location["latitude"],
-                            location["longitude"],
-                            battery,
-                        )
-                        interval = self._intervals.get(devicename, 1)
-                        attrs[ATTR_INTERVAL] = interval
-                        accuracy = location["horizontalAccuracy"]
-                        kwargs["dev_id"] = dev_id
-                        kwargs["host_name"] = status["name"]
-                        kwargs["gps"] = (location["latitude"], location["longitude"])
-                        kwargs["battery"] = battery
-                        kwargs["gps_accuracy"] = accuracy
-                        kwargs[ATTR_ATTRIBUTES] = attrs
-                        self.see(**kwargs)
-                        self.seen_devices[devicename] = True
-        except PyiCloudNoDevicesException:
-            _LOGGER.error("No iCloud Devices found")
+def icon_for_icloud_device(icloud_device: IcloudDevice) -> str:
+    """Return a battery icon valid identifier."""
+    switcher = {
+        "iPad": "mdi:tablet-ipad",
+        "iPhone": "mdi:cellphone-iphone",
+        "iPod": "mdi:ipod",
+        "iMac": "mdi:desktop-mac",
+        "MacBookPro": "mdi:laptop-mac",
+    }
 
-    def lost_iphone(self, devicename):
-        """Call the lost iPhone function if the device is found."""
-        if self.api is None:
-            return
-
-        self.api.authenticate()
-        for device in self.api.devices:
-            if str(device) == str(self.devices[devicename]):
-                _LOGGER.info("Playing Lost iPhone sound for %s", devicename)
-                device.play_sound()
-
-    def update_icloud(self, devicename=None):
-        """Request device information from iCloud and update device_tracker."""
-        from pyicloud.exceptions import PyiCloudNoDevicesException
-
-        if self.api is None:
-            return
-
-        try:
-            if devicename is not None:
-                if devicename in self.devices:
-                    self.update_device(devicename)
-                else:
-                    _LOGGER.error(
-                        "devicename %s unknown for account %s",
-                        devicename,
-                        self._attrs[ATTR_ACCOUNTNAME],
-                    )
-            else:
-                for device in self.devices:
-                    self.update_device(device)
-        except PyiCloudNoDevicesException:
-            _LOGGER.error("No iCloud Devices found")
-
-    def setinterval(self, interval=None, devicename=None):
-        """Set the interval of the given devices."""
-        devs = [devicename] if devicename else self.devices
-        for device in devs:
-            devid = f"{DOMAIN}.{device}"
-            devicestate = self.hass.states.get(devid)
-            if interval is not None:
-                if devicestate is not None:
-                    self._overridestates[device] = run_callback_threadsafe(
-                        self.hass.loop,
-                        async_active_zone,
-                        self.hass,
-                        float(devicestate.attributes.get("latitude", 0)),
-                        float(devicestate.attributes.get("longitude", 0)),
-                    ).result()
-                    if self._overridestates[device] is None:
-                        self._overridestates[device] = "away"
-                self._intervals[device] = interval
-            else:
-                self._overridestates[device] = None
-            self.update_device(device)
+    return switcher.get(icloud_device.device_class, "mdi:cellphone-link")

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -5,6 +5,8 @@ from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
 from homeassistant.const import CONF_USERNAME
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.typing import HomeAssistantType
+
 
 from . import IcloudDevice
 from .const import (
@@ -18,12 +20,14 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_scanner(hass, config, see, discovery_info=None):
+async def async_setup_scanner(
+    hass: HomeAssistantType, config, see, discovery_info=None
+):
     """Old way of setting up the iCloud tracker."""
     pass
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistantType, entry, async_add_entities):
     """Configure a dispatcher connection based on a config entry."""
     username = entry.data[CONF_USERNAME]
 

--- a/homeassistant/components/icloud/manifest.json
+++ b/homeassistant/components/icloud/manifest.json
@@ -1,10 +1,13 @@
 {
   "domain": "icloud",
-  "name": "Icloud",
-  "documentation": "https://www.home-assistant.io/integrations/icloud",
+  "name": "iCloud",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/components/icloud",
   "requirements": [
     "pyicloud==0.9.1"
   ],
-  "dependencies": ["configurator"],
-  "codeowners": []
+  "dependencies": [],
+  "codeowners": [
+    "@Quentame"
+  ]
 }

--- a/homeassistant/components/icloud/services.yaml
+++ b/homeassistant/components/icloud/services.yaml
@@ -1,0 +1,57 @@
+# Describes the format for available iCloud services
+
+reset:
+  description: Reset the iCloud account and re build it.
+  fields:
+    username:
+      description: Your iCloud email.
+      example: 'steve@apple.com'
+
+update:
+  description: Update iCloud devices.
+  fields:
+    username:
+      description: Your iCloud email.
+      example: 'steve@apple.com'
+
+play_sound:
+  description: Play sound on an Apple device.
+  fields:
+    username:
+      description: (required) Your iCloud email.
+      example: 'steve@apple.com'
+    device_name:
+      description: (required) The name of the Apple device to play a sound.
+      example: 'stevesiphone'
+
+display_message:
+  description: Display a message on an Apple device.
+  fields:
+    username:
+      description: (required) Your iCloud email.
+      example: 'steve@apple.com'
+    device_name:
+      description: (required) The name of the Apple device to display the message.
+      example: 'stevesiphone'
+    message:
+      description: (required) The content of your message.
+    sound:
+      description: To make a sound when displaying the message (boolean).
+      example: 'true'
+
+lost_device:
+  description: Make an Apple device in lost state.
+  fields:
+    username:
+      description: (required) Your iCloud email.
+      example: 'steve@apple.com'
+    device_name:
+      description: (required) The name of the Apple device to set lost.
+      example: 'stevesiphone'
+    number:
+      description: (required) The phone number to call in lost mode (must contain country code).
+      example: '+33450020100'
+    message:
+      description: (required) The message to display in lost mode.
+      example: 'Call me'
+

--- a/homeassistant/components/icloud/services.yaml
+++ b/homeassistant/components/icloud/services.yaml
@@ -3,22 +3,22 @@
 reset:
   description: Reset the iCloud account and re build it.
   fields:
-    username:
-      description: Your iCloud email.
+    account:
+      description: Your iCloud account username (email) or account name.
       example: 'steve@apple.com'
 
 update:
   description: Update iCloud devices.
   fields:
-    username:
-      description: Your iCloud email.
+    account:
+      description: Your iCloud account username (email) or account name.
       example: 'steve@apple.com'
 
 play_sound:
   description: Play sound on an Apple device.
   fields:
-    username:
-      description: (required) Your iCloud email.
+    account:
+      description: (required) Your iCloud account username (email) or account name.
       example: 'steve@apple.com'
     device_name:
       description: (required) The name of the Apple device to play a sound.
@@ -27,14 +27,15 @@ play_sound:
 display_message:
   description: Display a message on an Apple device.
   fields:
-    username:
-      description: (required) Your iCloud email.
+    account:
+      description: (required) Your iCloud account username (email) or account name.
       example: 'steve@apple.com'
     device_name:
       description: (required) The name of the Apple device to display the message.
       example: 'stevesiphone'
     message:
       description: (required) The content of your message.
+      example: 'Hey Steve !'
     sound:
       description: To make a sound when displaying the message (boolean).
       example: 'true'
@@ -42,8 +43,8 @@ display_message:
 lost_device:
   description: Make an Apple device in lost state.
   fields:
-    username:
-      description: (required) Your iCloud email.
+    account:
+      description: (required) Your iCloud account username (email) or account name.
       example: 'steve@apple.com'
     device_name:
       description: (required) The name of the Apple device to set lost.

--- a/homeassistant/components/icloud/strings.json
+++ b/homeassistant/components/icloud/strings.json
@@ -1,0 +1,40 @@
+{
+    "config": {
+        "title": "Apple iCloud",
+        "step": {
+            "user": {
+                "title": "iCloud credentials",
+                "description": "Enter your credentials",
+                "data": {
+                    "username": "Email",
+                    "password": "Password"
+                }
+            },
+            "trusted_device": {
+                "title": "iCloud trusted device",
+                "description": "Select your trusted device",
+                "data": {
+                    "trusted_device": "Trusted device"
+                }
+            },
+            "verification_code": {
+                "title": "iCloud verification code",
+                "description": "Please enter the verification code you just received from iCloud",
+                "data": {
+                    "verification_code": "Verification code"
+                }
+            }
+        },
+        "error":{
+            "username_exists": "Account already configured",
+            "2fa": "Error setting up 2FA: please check that your iCloud account has a trusted phone number",
+            "login": "Login error: please check your email & password",
+            "send_verification_code": "Failed to send verification code",
+            "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again",
+            "unknown": "Unknown error: please check your credentials and/or retry later"
+        },
+        "abort":{
+            "username_exists": "Account already configured"
+        }
+    }
+}

--- a/homeassistant/components/icloud/strings.json
+++ b/homeassistant/components/icloud/strings.json
@@ -27,11 +27,9 @@
         },
         "error":{
             "username_exists": "Account already configured",
-            "2fa": "Error setting up 2FA: please check that your iCloud account has a trusted phone number",
             "login": "Login error: please check your email & password",
             "send_verification_code": "Failed to send verification code",
             "validate_verification_code": "Failed to verify your verification code, choose a trust device and start the verification again",
-            "unknown": "Unknown error: please check your credentials and/or retry later"
         },
         "abort":{
             "username_exists": "Account already configured"

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -34,6 +34,7 @@ FLOWS = [
     "huawei_lte",
     "hue",
     "iaqualink",
+    "icloud",
     "ifttt",
     "ios",
     "ipma",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -424,6 +424,9 @@ pyheos==0.6.0
 # homeassistant.components.homematic
 pyhomematic==0.1.61
 
+# homeassistant.components.icloud
+pyicloud==0.9.1
+
 # homeassistant.components.ipma
 pyipma==1.2.1
 

--- a/tests/components/icloud/__init__.py
+++ b/tests/components/icloud/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the iCloud component."""

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -29,35 +29,32 @@ GPS_ACCURACY_THRESHOLD = 250
 @pytest.fixture(name="init")
 def mock_controller_init():
     """Mock a successful init."""
-    with patch("pyicloud.PyiCloudService"):
+    with patch("pyicloud.base.PyiCloudService"):
+        yield
+    with patch("pyicloud.base.PyiCloudService.authenticate", return_value=None):
         yield
 
 
 @pytest.fixture(name="session")
 def mock_controller_session():
     """Mock a successful session."""
-    with patch("pyicloud.PyiCloudSession"):
-        yield
-
-
-@pytest.fixture(name="authenticate")
-def mock_controller_authenticate():
-    """Mock a successful authenticate."""
-    with patch("pyicloud.PyiCloudService.authenticate", return_value=None):
+    with patch("pyicloud.base.PyiCloudSession"):
         yield
 
 
 @pytest.fixture(name="requires_2fa")
 def mock_controller_requires_2fa():
     """Mock a successful requires_2fa."""
-    with patch("pyicloud.PyiCloudService.requires_2fa", return_value=True):
+    with patch("pyicloud.base.PyiCloudService.requires_2fa", return_value=True):
         yield
 
 
 @pytest.fixture(name="send_verification_code")
 def mock_controller_send_verification_code():
     """Mock a successful send_verification_code."""
-    with patch("pyicloud.PyiCloudService.send_verification_code", return_value=True):
+    with patch(
+        "pyicloud.base.PyiCloudService.send_verification_code", return_value=True
+    ):
         yield
 
 
@@ -65,7 +62,7 @@ def mock_controller_send_verification_code():
 def mock_controller_validate_verification_code():
     """Mock a successful validate_verification_code."""
     with patch(
-        "pyicloud.PyiCloudService.validate_verification_code", return_value=True
+        "pyicloud.base.PyiCloudService.validate_verification_code", return_value=True
     ):
         yield
 
@@ -81,7 +78,6 @@ async def test_user(
     hass,
     init,
     session,
-    authenticate,
     requires_2fa,
     send_verification_code,
     validate_verification_code,
@@ -110,7 +106,6 @@ async def test_import(
     hass,
     init,
     session,
-    authenticate,
     requires_2fa,
     send_verification_code,
     validate_verification_code,
@@ -153,7 +148,6 @@ async def test_abort_if_already_setup(
     hass,
     init,
     session,
-    authenticate,
     requires_2fa,
     send_verification_code,
     validate_verification_code,
@@ -216,7 +210,7 @@ async def test_abort_on_login_failed(hass):
         assert result["errors"] == {CONF_USERNAME: "login"}
 
 
-async def test_abort_on_fetch_failed(hass, init, session, authenticate, requires_2fa):
+async def test_abort_on_fetch_failed(hass, init, session, requires_2fa):
     """Test when we have errors during fetch."""
     flow = init_config_flow(hass)
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -20,8 +20,8 @@ from tests.common import MockConfigEntry
 
 USERNAME = "username@me.com"
 PASSWORD = "password"
-ACCOUNTNAME = "Account name 1 2 3"
-ACCOUNTNAME_FROM_USERNAME = "username"
+ACCOUNT_NAME = "Account name 1 2 3"
+ACCOUNT_NAME_FROM_USERNAME = "username"
 MAX_INTERVAL = 15
 GPS_ACCURACY_THRESHOLD = 250
 
@@ -74,7 +74,7 @@ async def test_user(
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNTNAME_FROM_USERNAME
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME_FROM_USERNAME
     assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
@@ -93,7 +93,7 @@ async def test_import(
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNTNAME_FROM_USERNAME
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME_FROM_USERNAME
     assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
@@ -102,7 +102,7 @@ async def test_import(
         {
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNT_NAME: ACCOUNTNAME,
+            CONF_ACCOUNT_NAME: ACCOUNT_NAME,
             CONF_MAX_INTERVAL: MAX_INTERVAL,
             CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
         }
@@ -111,7 +111,7 @@ async def test_import(
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNTNAME
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME
     assert result["data"][CONF_MAX_INTERVAL] == MAX_INTERVAL
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
 
@@ -132,7 +132,7 @@ async def test_abort_if_already_setup(
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "username_exists"
 
-    # Should fail, same ACCOUNTNAME (import)
+    # Should fail, same ACCOUNT_NAME (import)
     result = await flow.async_step_import(
         {
             CONF_USERNAME: "other_username@icloud.com",
@@ -150,7 +150,7 @@ async def test_abort_if_already_setup(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {CONF_USERNAME: "username_exists"}
 
-    # Should fail, same ACCOUNTNAME (flow)
+    # Should fail, same ACCOUNT_NAME (flow)
     result = await flow.async_step_user(
         {
             CONF_USERNAME: "other_username@icloud.com",

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -1,21 +1,18 @@
 """Tests for the iCloud config flow."""
-import logging
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock
 import pytest
 
-from pyicloud import PyiCloudService
-
-# from pyicloud.exceptions import PyiCloudFailedLoginException
+from pyicloud.exceptions import PyiCloudFailedLoginException
 
 from homeassistant import data_entry_flow
 from homeassistant.components.icloud import config_flow
 
-# from homeassistant.components.icloud.config_flow import (
-#     CONF_TRUSTED_DEVICE,
-#     CONF_VERIFICATION_CODE,
-# )
+from homeassistant.components.icloud.config_flow import (
+    CONF_TRUSTED_DEVICE,
+    CONF_VERIFICATION_CODE,
+)
 from homeassistant.components.icloud.const import (
-    # DOMAIN,
+    DOMAIN,
     CONF_ACCOUNT_NAME,
     CONF_GPS_ACCURACY_THRESHOLD,
     CONF_MAX_INTERVAL,
@@ -23,10 +20,9 @@ from homeassistant.components.icloud.const import (
     DEFAULT_MAX_INTERVAL,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.typing import HomeAssistantType
 
-# from tests.common import MockConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
+from tests.common import MockConfigEntry
 
 USERNAME = "username@me.com"
 PASSWORD = "password"
@@ -40,125 +36,81 @@ TRUSTED_DEVICES = [
 ]
 
 
-def mock_icloud_service_with_cookie():
-    """Return a mocked iCloud service."""
-    service = MagicMock(spec=PyiCloudService)
-    service.return_value.authenticate.return_value = None
-    service.return_value.requires_2fa = PropertyMock(return_value=False)
-    service.return_value.trusted_devices = PropertyMock(return_value=TRUSTED_DEVICES)
-    _LOGGER.info("service")
-    _LOGGER.info(service)
-    return service
-
-
-# @pytest.fixture(name="session")
-# def mock_controller_session():
-#     """Mock a successful session."""
-#     with patch("pyicloud.base.PyiCloudSession"):
-#         yield
-
-
-# @pytest.fixture(name="service")
-# def mock_controller_service():
-#     """Mock a successful service."""
-#     with patch("pyicloud.base.PyiCloudService") as service_mock:
-#         service_mock.return_value.authenticate.return_value = None
-#         service_mock.return_value.requires_2fa = True
-#         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
-#         service_mock.return_value.send_verification_code.return_value = True
-#         service_mock.return_value.validate_verification_code.return_value = True
-#         yield service_mock
+@pytest.fixture(name="service")
+def mock_controller_service():
+    """Mock a successful service."""
+    with patch("pyicloud.base.PyiCloudSession"):
+        with patch("pyicloud.base.PyiCloudService", requires_2fa=True) as service_mock:
+            yield service_mock
 
 
 @pytest.fixture(name="service_with_cookie")
 def mock_controller_service_with_cookie():
     """Mock a successful service while already authenticate."""
     with patch("pyicloud.base.PyiCloudSession"):
+        with patch("pyicloud.base.PyiCloudService", requires_2fa=False) as service_mock:
+            yield service_mock
+
+
+@pytest.fixture(name="service_send_verification_code_failed")
+def mock_controller_service_send_verification_code_failed():
+    """Mock a failed service during sending verification code step."""
+    with patch("pyicloud.base.PyiCloudSession"):
         with patch(
             "pyicloud.base.PyiCloudService",
             requires_2fa=False,
             trusted_devices=TRUSTED_DEVICES,
         ) as service_mock:
-            # service_mock.return_value.authenticate.return_value = None
-            # service_mock.return_value.requires_2fa = PropertyMock(return_value=False)
-            # service_mock.return_value.trusted_devices = PropertyMock(return_value=TRUSTED_DEVICES)
-            # service_mock.requires_2fa = PropertyMock(return_value=False)
-            # service_mock.trusted_devices = PropertyMock(return_value=TRUSTED_DEVICES)
-            # service_mock.requires_2fa.return_value = False
-            # service_mock.trusted_devices.return_value = TRUSTED_DEVICES
-
-            # service_mock = MagicMock(
-            #     spec=PyiCloudService,
-            #     requires_2fa = False,
-            #     trusted_devices = TRUSTED_DEVICES
-            # )
-            _LOGGER.info("service_mock")
-            _LOGGER.info(service_mock)
-            _LOGGER.info("service_mock.requires_2fa")
-            _LOGGER.info(service_mock.requires_2fa)
-            _LOGGER.info("service_mock.trusted_devices")
-            _LOGGER.info(service_mock.trusted_devices)
+            service_mock.send_verification_code.return_value = False
             yield service_mock
 
 
-# @pytest.fixture(name="service_send_verification_code_failed")
-# def mock_controller_service_send_verification_code_failed():
-#     """Mock a failed service during sending verification code step."""
-#     with patch("pyicloud.base.PyiCloudService") as service_mock:
-#         service_mock.return_value.authenticate.return_value = None
-#         service_mock.return_value.requires_2fa = False
-#         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
-#         service_mock.return_value.send_verification_code.return_value = False
-#         service_mock.return_value.validate_verification_code.return_value = False
-#         yield service_mock
+@pytest.fixture(name="service_validate_verification_code_failed")
+def mock_controller_service_validate_verification_code_failed():
+    """Mock a failed service during validation of verification code step."""
+    with patch("pyicloud.base.PyiCloudSession"):
+        with patch(
+            "pyicloud.base.PyiCloudService",
+            requires_2fa=False,
+            trusted_devices=TRUSTED_DEVICES,
+        ) as service_mock:
+            service_mock.send_verification_code.return_value = True
+            service_mock.validate_verification_code.return_value = False
+            yield service_mock
 
 
-# @pytest.fixture(name="service_validate_verification_code_failed")
-# def mock_controller_service_validate_verification_code_failed():
-#     """Mock a failed service during validation of verification code step."""
-#     with patch("pyicloud.base.PyiCloudService") as service_mock:
-#         service_mock.return_value.authenticate.return_value = None
-#         service_mock.return_value.requires_2fa = False
-#         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
-#         service_mock.return_value.send_verification_code.return_value = True
-#         service_mock.return_value.validate_verification_code.return_value = False
-#         yield service_mock.return_value
-
-
-def init_config_flow(hass):
+def init_config_flow(hass: HomeAssistantType, service: MagicMock):
     """Init a configuration flow."""
     flow = config_flow.IcloudFlowHandler()
     flow.hass = hass
+    flow.api = service
     return flow
 
 
-# async def test_user(hass, session, service):
-#     """Test user config."""
-#     flow = init_config_flow(hass)
+async def test_user(hass, service):
+    """Test user config."""
+    flow = init_config_flow(hass, service)
 
-#     result = await flow.async_step_user()
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == "user"
-
-#     # test with all provided
-#     result = await flow.async_step_user(
-#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-#     )
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == CONF_TRUSTED_DEVICE
-
-
-async def test_user_with_cookie(hass, service_with_cookie):
-    """Test user config with presence of a cookie."""
-    flow = init_config_flow(hass)
-    # flow.api = service_with_cookie
-    # flow.api.return_value.requires_2fa = PropertyMock(return_value=False)
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
 
     # test with all provided
     result = await flow.async_step_user(
         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
     )
-    _LOGGER.info(result)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == CONF_TRUSTED_DEVICE
+
+
+async def test_user_with_cookie(hass, service_with_cookie):
+    """Test user config with presence of a cookie."""
+    flow = init_config_flow(hass, service_with_cookie)
+
+    # test with all provided
+    result = await flow.async_step_user(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
@@ -168,167 +120,160 @@ async def test_user_with_cookie(hass, service_with_cookie):
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
 
-# async def test_import(hass, session, service):
-#     """Test import step."""
-#     flow = init_config_flow(hass)
+async def test_import(hass, service):
+    """Test import step."""
+    flow = init_config_flow(hass, service)
 
-#     # import with username and password
-#     result = await flow.async_step_import(
-#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-#     )
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == "trusted_device"
+    # import with username and password
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "trusted_device"
 
-#     # import with all
-#     result = await flow.async_step_import(
-#         {
-#             CONF_USERNAME: USERNAME,
-#             CONF_PASSWORD: PASSWORD,
-#             CONF_ACCOUNT_NAME: ACCOUNT_NAME,
-#             CONF_MAX_INTERVAL: MAX_INTERVAL,
-#             CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
-#         }
-#     )
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == "trusted_device"
-
-
-# async def test_import_with_cookie(hass, session, service_with_cookie):
-#     """Test import step with presence of a cookie."""
-#     flow = init_config_flow(hass)
-
-#     # import with username and password
-#     result = await flow.async_step_import(
-#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-#     )
-#     _LOGGER.info(result)
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-#     assert result["title"] == USERNAME
-#     assert result["data"][CONF_USERNAME] == USERNAME
-#     assert result["data"][CONF_PASSWORD] == PASSWORD
-#     assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME_FROM_USERNAME
-#     assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
-#     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
-
-#     # import with all
-#     result = await flow.async_step_import(
-#         {
-#             CONF_USERNAME: USERNAME,
-#             CONF_PASSWORD: PASSWORD,
-#             CONF_ACCOUNT_NAME: ACCOUNT_NAME,
-#             CONF_MAX_INTERVAL: MAX_INTERVAL,
-#             CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
-#         }
-#     )
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-#     assert result["title"] == USERNAME
-#     assert result["data"][CONF_USERNAME] == USERNAME
-#     assert result["data"][CONF_PASSWORD] == PASSWORD
-#     assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME
-#     assert result["data"][CONF_MAX_INTERVAL] == MAX_INTERVAL
-#     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
+    # import with all
+    result = await flow.async_step_import(
+        {
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NAME: ACCOUNT_NAME,
+            CONF_MAX_INTERVAL: MAX_INTERVAL,
+            CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "trusted_device"
 
 
-# async def test_abort_if_already_setup(hass):
-#     """Test we abort if the account is already setup."""
-#     flow = init_config_flow(hass)
-#     MockConfigEntry(
-#         domain=DOMAIN, data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-#     ).add_to_hass(hass)
+async def test_import_with_cookie(hass, service_with_cookie):
+    """Test import step with presence of a cookie."""
+    flow = init_config_flow(hass, service_with_cookie)
 
-#     # Should fail, same USERNAME (import)
-#     result = await flow.async_step_import(
-#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-#     )
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-#     assert result["reason"] == "username_exists"
+    # import with username and password
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME_FROM_USERNAME
+    assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
+    assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
-#     # Should fail, same ACCOUNT_NAME (import)
-#     result = await flow.async_step_import(
-#         {
-#             CONF_USERNAME: "other_username@icloud.com",
-#             CONF_PASSWORD: PASSWORD,
-#             CONF_ACCOUNT_NAME: ACCOUNT_NAME_FROM_USERNAME,
-#         }
-#     )
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-#     assert result["reason"] == "username_exists"
-
-#     # Should fail, same USERNAME (flow)
-#     result = await flow.async_step_user(
-#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-#     )
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["errors"] == {CONF_USERNAME: "username_exists"}
-
-
-# async def test_abort_on_login_failed(hass):
-#     """Test when we have errors during login."""
-#     flow = init_config_flow(hass)
-
-#     with patch(
-#         "pyicloud.base.PyiCloudService.authenticate",
-#         side_effect=PyiCloudFailedLoginException(),
-#     ):
-#         result = await flow.async_step_user(
-#             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-#         )
-#         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#         assert result["errors"] == {CONF_USERNAME: "login"}
+    # import with all
+    result = await flow.async_step_import(
+        {
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NAME: ACCOUNT_NAME,
+            CONF_MAX_INTERVAL: MAX_INTERVAL,
+            CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME
+    assert result["data"][CONF_MAX_INTERVAL] == MAX_INTERVAL
+    assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
 
 
-# async def test_trusted_device(hass, session, service):
-#     """Test trusted_device step."""
-#     flow = init_config_flow(hass)
-#     flow.api = service
+async def test_abort_if_already_setup(hass):
+    """Test we abort if the account is already setup."""
+    flow = init_config_flow(hass, None)
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    ).add_to_hass(hass)
 
-#     result = await flow.async_step_trusted_device()
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == CONF_TRUSTED_DEVICE
+    # Should fail, same USERNAME (import)
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "username_exists"
 
+    # Should fail, same ACCOUNT_NAME (import)
+    result = await flow.async_step_import(
+        {
+            CONF_USERNAME: "other_username@icloud.com",
+            CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNT_NAME: ACCOUNT_NAME_FROM_USERNAME,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "username_exists"
 
-# async def test_trusted_device_success(hass, session, service):
-#     """Test trusted_device step success."""
-#     flow = init_config_flow(hass)
-#     flow.api = service
-
-#     result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == CONF_VERIFICATION_CODE
-
-
-# async def test_abort_on_send_verification_code_failed(
-#     hass, session, service_send_verification_code_failed
-# ):
-#     """Test when we have errors during send_verification_code."""
-#     flow = init_config_flow(hass)
-#     flow.api = service_send_verification_code_failed
-
-#     result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
-#     _LOGGER.info(result)
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == CONF_TRUSTED_DEVICE
-#     assert result["errors"] == {CONF_TRUSTED_DEVICE: "send_verification_code"}
-
-
-# async def test_verification_code(hass, session):
-#     """Test verification_code step."""
-#     flow = init_config_flow(hass)
-
-#     result = await flow.async_step_verification_code()
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == CONF_VERIFICATION_CODE
+    # Should fail, same USERNAME (flow)
+    result = await flow.async_step_user(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_USERNAME: "username_exists"}
 
 
-# async def test_abort_on_validate_verification_code_failed(
-#     hass, session, service_validate_verification_code_failed
-# ):
-#     """Test when we have errors during validate_verification_code."""
-#     flow = init_config_flow(hass)
-#     flow.api = service_validate_verification_code_failed
+async def test_abort_on_login_failed(hass):
+    """Test when we have errors during login."""
+    flow = init_config_flow(hass, None)
 
-#     result = await flow.async_step_verification_code({CONF_VERIFICATION_CODE: 0})
-#     _LOGGER.info(result)
-#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result["step_id"] == CONF_TRUSTED_DEVICE
-#     assert result["errors"] == {"base": "validate_verification_code"}
+    with patch(
+        "pyicloud.base.PyiCloudService.authenticate",
+        side_effect=PyiCloudFailedLoginException(),
+    ):
+        result = await flow.async_step_user(
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {CONF_USERNAME: "login"}
+
+
+async def test_trusted_device(hass, service):
+    """Test trusted_device step."""
+    flow = init_config_flow(hass, service)
+
+    result = await flow.async_step_trusted_device()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == CONF_TRUSTED_DEVICE
+
+
+async def test_trusted_device_success(hass, service):
+    """Test trusted_device step success."""
+    flow = init_config_flow(hass, service)
+
+    result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == CONF_VERIFICATION_CODE
+
+
+async def test_abort_on_send_verification_code_failed(
+    hass, service_send_verification_code_failed
+):
+    """Test when we have errors during send_verification_code."""
+    flow = init_config_flow(hass, service_send_verification_code_failed)
+
+    result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == CONF_TRUSTED_DEVICE
+    assert result["errors"] == {CONF_TRUSTED_DEVICE: "send_verification_code"}
+
+
+async def test_verification_code(hass):
+    """Test verification_code step."""
+    flow = init_config_flow(hass, None)
+
+    result = await flow.async_step_verification_code()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == CONF_VERIFICATION_CODE
+
+
+async def test_abort_on_validate_verification_code_failed(
+    hass, service_validate_verification_code_failed
+):
+    """Test when we have errors during validate_verification_code."""
+    flow = init_config_flow(hass, service_validate_verification_code_failed)
+
+    result = await flow.async_step_verification_code({CONF_VERIFICATION_CODE: 0})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == CONF_TRUSTED_DEVICE
+    assert result["errors"] == {"base": "validate_verification_code"}

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -29,7 +29,7 @@ GPS_ACCURACY_THRESHOLD = 250
 @pytest.fixture(name="init")
 def mock_controller_authenticate():
     """Mock a successful authenticate."""
-    with patch("pyicloud.PyiCloudService.__init__"):
+    with patch("pyicloud.PyiCloudService", return_value=None):
         yield
 
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -29,7 +29,7 @@ GPS_ACCURACY_THRESHOLD = 250
 @pytest.fixture(name="init")
 def mock_controller_authenticate():
     """Mock a successful authenticate."""
-    with patch("pyicloud.PyiCloudService", return_value=None):
+    with patch("pyicloud.PyiCloudService"):
         yield
 
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -79,7 +79,9 @@ async def test_user(
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
 
-async def test_import(hass, login, fetch_data, close_session):
+async def test_import(
+    hass, requires_2fa, send_verification_code, validate_verification_code
+):
     """Test import step."""
     flow = init_config_flow(hass)
 
@@ -114,7 +116,9 @@ async def test_import(hass, login, fetch_data, close_session):
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
 
 
-async def test_abort_if_already_setup(hass, login, fetch_data, close_session):
+async def test_abort_if_already_setup(
+    hass, requires_2fa, send_verification_code, validate_verification_code
+):
     """Test we abort if Linky is already setup."""
     flow = init_config_flow(hass)
     MockConfigEntry(
@@ -158,7 +162,7 @@ async def test_abort_if_already_setup(hass, login, fetch_data, close_session):
     assert result["reason"] == {CONF_USERNAME: "username_exists"}
 
 
-async def test_abort_on_login_failed(hass, close_session):
+async def test_abort_on_login_failed(hass):
     """Test when we have errors during login."""
     flow = init_config_flow(hass)
 
@@ -173,7 +177,7 @@ async def test_abort_on_login_failed(hass, close_session):
         assert result["errors"] == {"base": "login"}
 
 
-async def test_abort_on_fetch_failed(hass, login, close_session):
+async def test_abort_on_fetch_failed(hass, requires_2fa):
     """Test when we have errors during fetch."""
     flow = init_config_flow(hass)
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -29,10 +29,9 @@ GPS_ACCURACY_THRESHOLD = 250
 @pytest.fixture(name="init")
 def mock_controller_init():
     """Mock a successful init."""
-    with patch("pyicloud.base.PyiCloudService"):
-        yield
-    with patch("pyicloud.base.PyiCloudService.authenticate", return_value=None):
-        yield
+    with patch("pyicloud.base.PyiCloudService") as mock_service:
+        mock_service.return_value.authenticate.return_value = None
+        yield mock_service
 
 
 @pytest.fixture(name="session")

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -26,6 +26,13 @@ MAX_INTERVAL = 15
 GPS_ACCURACY_THRESHOLD = 250
 
 
+@pytest.fixture(name="authenticate")
+def mock_controller_authenticate():
+    """Mock a successful authenticate."""
+    with patch("pyicloud.PyiCloudService.authenticate"):
+        yield
+
+
 @pytest.fixture(name="requires_2fa")
 def mock_controller_requires_2fa():
     """Mock a successful requires_2fa."""
@@ -57,7 +64,7 @@ def init_config_flow(hass):
 
 
 async def test_user(
-    hass, requires_2fa, send_verification_code, validate_verification_code
+    hass, authenticate, requires_2fa, send_verification_code, validate_verification_code
 ):
     """Test user config."""
     flow = init_config_flow(hass)
@@ -80,7 +87,7 @@ async def test_user(
 
 
 async def test_import(
-    hass, requires_2fa, send_verification_code, validate_verification_code
+    hass, authenticate, requires_2fa, send_verification_code, validate_verification_code
 ):
     """Test import step."""
     flow = init_config_flow(hass)
@@ -117,7 +124,7 @@ async def test_import(
 
 
 async def test_abort_if_already_setup(
-    hass, requires_2fa, send_verification_code, validate_verification_code
+    hass, authenticate, requires_2fa, send_verification_code, validate_verification_code
 ):
     """Test we abort if Linky is already setup."""
     flow = init_config_flow(hass)
@@ -177,7 +184,7 @@ async def test_abort_on_login_failed(hass):
         assert result["errors"] == {CONF_USERNAME: "login"}
 
 
-async def test_abort_on_fetch_failed(hass, requires_2fa):
+async def test_abort_on_fetch_failed(hass, authenticate, requires_2fa):
     """Test when we have errors during fetch."""
     flow = init_config_flow(hass)
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -26,10 +26,10 @@ MAX_INTERVAL = 15
 GPS_ACCURACY_THRESHOLD = 250
 
 
-@pytest.fixture(name="authenticate")
+@pytest.fixture(name="init")
 def mock_controller_authenticate():
     """Mock a successful authenticate."""
-    with patch("pyicloud.PyiCloudService.authenticate"):
+    with patch("pyicloud.PyiCloudService.__init__"):
         yield
 
 
@@ -64,7 +64,7 @@ def init_config_flow(hass):
 
 
 async def test_user(
-    hass, authenticate, requires_2fa, send_verification_code, validate_verification_code
+    hass, init, requires_2fa, send_verification_code, validate_verification_code
 ):
     """Test user config."""
     flow = init_config_flow(hass)
@@ -87,7 +87,7 @@ async def test_user(
 
 
 async def test_import(
-    hass, authenticate, requires_2fa, send_verification_code, validate_verification_code
+    hass, init, requires_2fa, send_verification_code, validate_verification_code
 ):
     """Test import step."""
     flow = init_config_flow(hass)
@@ -124,7 +124,7 @@ async def test_import(
 
 
 async def test_abort_if_already_setup(
-    hass, authenticate, requires_2fa, send_verification_code, validate_verification_code
+    hass, init, requires_2fa, send_verification_code, validate_verification_code
 ):
     """Test we abort if Linky is already setup."""
     flow = init_config_flow(hass)
@@ -184,7 +184,7 @@ async def test_abort_on_login_failed(hass):
         assert result["errors"] == {CONF_USERNAME: "login"}
 
 
-async def test_abort_on_fetch_failed(hass, authenticate, requires_2fa):
+async def test_abort_on_fetch_failed(hass, init, requires_2fa):
     """Test when we have errors during fetch."""
     flow = init_config_flow(hass)
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -33,6 +33,13 @@ def mock_controller_init():
         yield
 
 
+@pytest.fixture(name="session")
+def mock_controller_session():
+    """Mock a successful session."""
+    with patch("pyicloud.PyiCloudSession"):
+        yield
+
+
 @pytest.fixture(name="authenticate")
 def mock_controller_authenticate():
     """Mock a successful authenticate."""
@@ -73,6 +80,7 @@ def init_config_flow(hass):
 async def test_user(
     hass,
     init,
+    session,
     authenticate,
     requires_2fa,
     send_verification_code,
@@ -101,6 +109,7 @@ async def test_user(
 async def test_import(
     hass,
     init,
+    session,
     authenticate,
     requires_2fa,
     send_verification_code,
@@ -143,6 +152,7 @@ async def test_import(
 async def test_abort_if_already_setup(
     hass,
     init,
+    session,
     authenticate,
     requires_2fa,
     send_verification_code,
@@ -206,7 +216,7 @@ async def test_abort_on_login_failed(hass):
         assert result["errors"] == {CONF_USERNAME: "login"}
 
 
-async def test_abort_on_fetch_failed(hass, init, authenticate, requires_2fa):
+async def test_abort_on_fetch_failed(hass, init, session, authenticate, requires_2fa):
     """Test when we have errors during fetch."""
     flow = init_config_flow(hass)
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -1,19 +1,21 @@
 """Tests for the iCloud config flow."""
 import logging
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, PropertyMock
 import pytest
 
 from pyicloud import PyiCloudService
-from pyicloud.exceptions import PyiCloudFailedLoginException
+
+# from pyicloud.exceptions import PyiCloudFailedLoginException
 
 from homeassistant import data_entry_flow
 from homeassistant.components.icloud import config_flow
-from homeassistant.components.icloud.config_flow import (
-    CONF_TRUSTED_DEVICE,
-    CONF_VERIFICATION_CODE,
-)
+
+# from homeassistant.components.icloud.config_flow import (
+#     CONF_TRUSTED_DEVICE,
+#     CONF_VERIFICATION_CODE,
+# )
 from homeassistant.components.icloud.const import (
-    DOMAIN,
+    # DOMAIN,
     CONF_ACCOUNT_NAME,
     CONF_GPS_ACCURACY_THRESHOLD,
     CONF_MAX_INTERVAL,
@@ -22,7 +24,7 @@ from homeassistant.components.icloud.const import (
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from tests.common import MockConfigEntry
+# from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,65 +42,87 @@ TRUSTED_DEVICES = [
 
 def mock_icloud_service_with_cookie():
     """Return a mocked iCloud service."""
-    service = MagicMock(
-        spec=PyiCloudService, requires_2fa=False, trusted_devices=TRUSTED_DEVICES
-    )
+    service = MagicMock(spec=PyiCloudService)
     service.return_value.authenticate.return_value = None
+    service.return_value.requires_2fa = PropertyMock(return_value=False)
+    service.return_value.trusted_devices = PropertyMock(return_value=TRUSTED_DEVICES)
+    _LOGGER.info("service")
+    _LOGGER.info(service)
     return service
 
 
-@pytest.fixture(name="session")
-def mock_controller_session():
-    """Mock a successful session."""
-    with patch("pyicloud.base.PyiCloudSession"):
-        yield
+# @pytest.fixture(name="session")
+# def mock_controller_session():
+#     """Mock a successful session."""
+#     with patch("pyicloud.base.PyiCloudSession"):
+#         yield
 
 
-@pytest.fixture(name="service")
-def mock_controller_service():
-    """Mock a successful service."""
-    with patch("pyicloud.base.PyiCloudService") as service_mock:
-        service_mock.return_value.authenticate.return_value = None
-        service_mock.return_value.requires_2fa = True
-        service_mock.return_value.trusted_devices = TRUSTED_DEVICES
-        service_mock.return_value.send_verification_code.return_value = True
-        service_mock.return_value.validate_verification_code.return_value = True
-        yield service_mock
+# @pytest.fixture(name="service")
+# def mock_controller_service():
+#     """Mock a successful service."""
+#     with patch("pyicloud.base.PyiCloudService") as service_mock:
+#         service_mock.return_value.authenticate.return_value = None
+#         service_mock.return_value.requires_2fa = True
+#         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
+#         service_mock.return_value.send_verification_code.return_value = True
+#         service_mock.return_value.validate_verification_code.return_value = True
+#         yield service_mock
 
 
 @pytest.fixture(name="service_with_cookie")
 def mock_controller_service_with_cookie():
     """Mock a successful service while already authenticate."""
-    with patch(
-        "pyicloud.base.PyiCloudService",
-        autospec=True,
-        side_effect=mock_icloud_service_with_cookie,
-    ):
-        yield
+    with patch("pyicloud.base.PyiCloudSession"):
+        with patch(
+            "pyicloud.base.PyiCloudService",
+            requires_2fa=False,
+            trusted_devices=TRUSTED_DEVICES,
+        ) as service_mock:
+            # service_mock.return_value.authenticate.return_value = None
+            # service_mock.return_value.requires_2fa = PropertyMock(return_value=False)
+            # service_mock.return_value.trusted_devices = PropertyMock(return_value=TRUSTED_DEVICES)
+            # service_mock.requires_2fa = PropertyMock(return_value=False)
+            # service_mock.trusted_devices = PropertyMock(return_value=TRUSTED_DEVICES)
+            # service_mock.requires_2fa.return_value = False
+            # service_mock.trusted_devices.return_value = TRUSTED_DEVICES
+
+            # service_mock = MagicMock(
+            #     spec=PyiCloudService,
+            #     requires_2fa = False,
+            #     trusted_devices = TRUSTED_DEVICES
+            # )
+            _LOGGER.info("service_mock")
+            _LOGGER.info(service_mock)
+            _LOGGER.info("service_mock.requires_2fa")
+            _LOGGER.info(service_mock.requires_2fa)
+            _LOGGER.info("service_mock.trusted_devices")
+            _LOGGER.info(service_mock.trusted_devices)
+            yield service_mock
 
 
-@pytest.fixture(name="service_send_verification_code_failed")
-def mock_controller_service_send_verification_code_failed():
-    """Mock a failed service during sending verification code step."""
-    with patch("pyicloud.base.PyiCloudService") as service_mock:
-        service_mock.return_value.authenticate.return_value = None
-        service_mock.return_value.requires_2fa = False
-        service_mock.return_value.trusted_devices = TRUSTED_DEVICES
-        service_mock.return_value.send_verification_code.return_value = False
-        service_mock.return_value.validate_verification_code.return_value = False
-        yield service_mock
+# @pytest.fixture(name="service_send_verification_code_failed")
+# def mock_controller_service_send_verification_code_failed():
+#     """Mock a failed service during sending verification code step."""
+#     with patch("pyicloud.base.PyiCloudService") as service_mock:
+#         service_mock.return_value.authenticate.return_value = None
+#         service_mock.return_value.requires_2fa = False
+#         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
+#         service_mock.return_value.send_verification_code.return_value = False
+#         service_mock.return_value.validate_verification_code.return_value = False
+#         yield service_mock
 
 
-@pytest.fixture(name="service_validate_verification_code_failed")
-def mock_controller_service_validate_verification_code_failed():
-    """Mock a failed service during validation of verification code step."""
-    with patch("pyicloud.base.PyiCloudService") as service_mock:
-        service_mock.return_value.authenticate.return_value = None
-        service_mock.return_value.requires_2fa = False
-        service_mock.return_value.trusted_devices = TRUSTED_DEVICES
-        service_mock.return_value.send_verification_code.return_value = True
-        service_mock.return_value.validate_verification_code.return_value = False
-        yield service_mock.return_value
+# @pytest.fixture(name="service_validate_verification_code_failed")
+# def mock_controller_service_validate_verification_code_failed():
+#     """Mock a failed service during validation of verification code step."""
+#     with patch("pyicloud.base.PyiCloudService") as service_mock:
+#         service_mock.return_value.authenticate.return_value = None
+#         service_mock.return_value.requires_2fa = False
+#         service_mock.return_value.trusted_devices = TRUSTED_DEVICES
+#         service_mock.return_value.send_verification_code.return_value = True
+#         service_mock.return_value.validate_verification_code.return_value = False
+#         yield service_mock.return_value
 
 
 def init_config_flow(hass):
@@ -108,25 +132,27 @@ def init_config_flow(hass):
     return flow
 
 
-async def test_user(hass, session, service):
-    """Test user config."""
-    flow = init_config_flow(hass)
+# async def test_user(hass, session, service):
+#     """Test user config."""
+#     flow = init_config_flow(hass)
 
-    result = await flow.async_step_user()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
+#     result = await flow.async_step_user()
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == "user"
 
-    # test with all provided
-    result = await flow.async_step_user(
-        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == CONF_TRUSTED_DEVICE
+#     # test with all provided
+#     result = await flow.async_step_user(
+#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+#     )
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == CONF_TRUSTED_DEVICE
 
 
-async def test_user_with_cookie(hass, session, service_with_cookie):
+async def test_user_with_cookie(hass, service_with_cookie):
     """Test user config with presence of a cookie."""
     flow = init_config_flow(hass)
+    # flow.api = service_with_cookie
+    # flow.api.return_value.requires_2fa = PropertyMock(return_value=False)
 
     # test with all provided
     result = await flow.async_step_user(
@@ -142,167 +168,167 @@ async def test_user_with_cookie(hass, session, service_with_cookie):
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
 
-async def test_import(hass, session, service):
-    """Test import step."""
-    flow = init_config_flow(hass)
+# async def test_import(hass, session, service):
+#     """Test import step."""
+#     flow = init_config_flow(hass)
 
-    # import with username and password
-    result = await flow.async_step_import(
-        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "trusted_device"
+#     # import with username and password
+#     result = await flow.async_step_import(
+#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+#     )
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == "trusted_device"
 
-    # import with all
-    result = await flow.async_step_import(
-        {
-            CONF_USERNAME: USERNAME,
-            CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNT_NAME: ACCOUNT_NAME,
-            CONF_MAX_INTERVAL: MAX_INTERVAL,
-            CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
-        }
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "trusted_device"
-
-
-async def test_import_with_cookie(hass, session, service_with_cookie):
-    """Test import step with presence of a cookie."""
-    flow = init_config_flow(hass)
-
-    # import with username and password
-    result = await flow.async_step_import(
-        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-    )
-    _LOGGER.info(result)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == USERNAME
-    assert result["data"][CONF_USERNAME] == USERNAME
-    assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME_FROM_USERNAME
-    assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
-    assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
-
-    # import with all
-    result = await flow.async_step_import(
-        {
-            CONF_USERNAME: USERNAME,
-            CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNT_NAME: ACCOUNT_NAME,
-            CONF_MAX_INTERVAL: MAX_INTERVAL,
-            CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
-        }
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == USERNAME
-    assert result["data"][CONF_USERNAME] == USERNAME
-    assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME
-    assert result["data"][CONF_MAX_INTERVAL] == MAX_INTERVAL
-    assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
+#     # import with all
+#     result = await flow.async_step_import(
+#         {
+#             CONF_USERNAME: USERNAME,
+#             CONF_PASSWORD: PASSWORD,
+#             CONF_ACCOUNT_NAME: ACCOUNT_NAME,
+#             CONF_MAX_INTERVAL: MAX_INTERVAL,
+#             CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
+#         }
+#     )
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == "trusted_device"
 
 
-async def test_abort_if_already_setup(hass):
-    """Test we abort if the account is already setup."""
-    flow = init_config_flow(hass)
-    MockConfigEntry(
-        domain=DOMAIN, data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-    ).add_to_hass(hass)
+# async def test_import_with_cookie(hass, session, service_with_cookie):
+#     """Test import step with presence of a cookie."""
+#     flow = init_config_flow(hass)
 
-    # Should fail, same USERNAME (import)
-    result = await flow.async_step_import(
-        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "username_exists"
+#     # import with username and password
+#     result = await flow.async_step_import(
+#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+#     )
+#     _LOGGER.info(result)
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+#     assert result["title"] == USERNAME
+#     assert result["data"][CONF_USERNAME] == USERNAME
+#     assert result["data"][CONF_PASSWORD] == PASSWORD
+#     assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME_FROM_USERNAME
+#     assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
+#     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
-    # Should fail, same ACCOUNT_NAME (import)
-    result = await flow.async_step_import(
-        {
-            CONF_USERNAME: "other_username@icloud.com",
-            CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNT_NAME: ACCOUNT_NAME_FROM_USERNAME,
-        }
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "username_exists"
-
-    # Should fail, same USERNAME (flow)
-    result = await flow.async_step_user(
-        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {CONF_USERNAME: "username_exists"}
-
-
-async def test_abort_on_login_failed(hass):
-    """Test when we have errors during login."""
-    flow = init_config_flow(hass)
-
-    with patch(
-        "pyicloud.base.PyiCloudService.authenticate",
-        side_effect=PyiCloudFailedLoginException(),
-    ):
-        result = await flow.async_step_user(
-            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {CONF_USERNAME: "login"}
+#     # import with all
+#     result = await flow.async_step_import(
+#         {
+#             CONF_USERNAME: USERNAME,
+#             CONF_PASSWORD: PASSWORD,
+#             CONF_ACCOUNT_NAME: ACCOUNT_NAME,
+#             CONF_MAX_INTERVAL: MAX_INTERVAL,
+#             CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
+#         }
+#     )
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+#     assert result["title"] == USERNAME
+#     assert result["data"][CONF_USERNAME] == USERNAME
+#     assert result["data"][CONF_PASSWORD] == PASSWORD
+#     assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNT_NAME
+#     assert result["data"][CONF_MAX_INTERVAL] == MAX_INTERVAL
+#     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
 
 
-async def test_trusted_device(hass, session, service):
-    """Test trusted_device step."""
-    flow = init_config_flow(hass)
-    flow.api = service
+# async def test_abort_if_already_setup(hass):
+#     """Test we abort if the account is already setup."""
+#     flow = init_config_flow(hass)
+#     MockConfigEntry(
+#         domain=DOMAIN, data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+#     ).add_to_hass(hass)
 
-    result = await flow.async_step_trusted_device()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == CONF_TRUSTED_DEVICE
+#     # Should fail, same USERNAME (import)
+#     result = await flow.async_step_import(
+#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+#     )
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+#     assert result["reason"] == "username_exists"
 
+#     # Should fail, same ACCOUNT_NAME (import)
+#     result = await flow.async_step_import(
+#         {
+#             CONF_USERNAME: "other_username@icloud.com",
+#             CONF_PASSWORD: PASSWORD,
+#             CONF_ACCOUNT_NAME: ACCOUNT_NAME_FROM_USERNAME,
+#         }
+#     )
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+#     assert result["reason"] == "username_exists"
 
-async def test_trusted_device_success(hass, session, service):
-    """Test trusted_device step success."""
-    flow = init_config_flow(hass)
-    flow.api = service
-
-    result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == CONF_VERIFICATION_CODE
-
-
-async def test_abort_on_send_verification_code_failed(
-    hass, session, service_send_verification_code_failed
-):
-    """Test when we have errors during send_verification_code."""
-    flow = init_config_flow(hass)
-    flow.api = service_send_verification_code_failed
-
-    result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
-    _LOGGER.info(result)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == CONF_TRUSTED_DEVICE
-    assert result["errors"] == {CONF_TRUSTED_DEVICE: "send_verification_code"}
-
-
-async def test_verification_code(hass, session):
-    """Test verification_code step."""
-    flow = init_config_flow(hass)
-
-    result = await flow.async_step_verification_code()
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == CONF_VERIFICATION_CODE
+#     # Should fail, same USERNAME (flow)
+#     result = await flow.async_step_user(
+#         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+#     )
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["errors"] == {CONF_USERNAME: "username_exists"}
 
 
-async def test_abort_on_validate_verification_code_failed(
-    hass, session, service_validate_verification_code_failed
-):
-    """Test when we have errors during validate_verification_code."""
-    flow = init_config_flow(hass)
-    flow.api = service_validate_verification_code_failed
+# async def test_abort_on_login_failed(hass):
+#     """Test when we have errors during login."""
+#     flow = init_config_flow(hass)
 
-    result = await flow.async_step_verification_code({CONF_VERIFICATION_CODE: 0})
-    _LOGGER.info(result)
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == CONF_TRUSTED_DEVICE
-    assert result["errors"] == {"base": "validate_verification_code"}
+#     with patch(
+#         "pyicloud.base.PyiCloudService.authenticate",
+#         side_effect=PyiCloudFailedLoginException(),
+#     ):
+#         result = await flow.async_step_user(
+#             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+#         )
+#         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#         assert result["errors"] == {CONF_USERNAME: "login"}
+
+
+# async def test_trusted_device(hass, session, service):
+#     """Test trusted_device step."""
+#     flow = init_config_flow(hass)
+#     flow.api = service
+
+#     result = await flow.async_step_trusted_device()
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == CONF_TRUSTED_DEVICE
+
+
+# async def test_trusted_device_success(hass, session, service):
+#     """Test trusted_device step success."""
+#     flow = init_config_flow(hass)
+#     flow.api = service
+
+#     result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == CONF_VERIFICATION_CODE
+
+
+# async def test_abort_on_send_verification_code_failed(
+#     hass, session, service_send_verification_code_failed
+# ):
+#     """Test when we have errors during send_verification_code."""
+#     flow = init_config_flow(hass)
+#     flow.api = service_send_verification_code_failed
+
+#     result = await flow.async_step_trusted_device({CONF_TRUSTED_DEVICE: 0})
+#     _LOGGER.info(result)
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == CONF_TRUSTED_DEVICE
+#     assert result["errors"] == {CONF_TRUSTED_DEVICE: "send_verification_code"}
+
+
+# async def test_verification_code(hass, session):
+#     """Test verification_code step."""
+#     flow = init_config_flow(hass)
+
+#     result = await flow.async_step_verification_code()
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == CONF_VERIFICATION_CODE
+
+
+# async def test_abort_on_validate_verification_code_failed(
+#     hass, session, service_validate_verification_code_failed
+# ):
+#     """Test when we have errors during validate_verification_code."""
+#     flow = init_config_flow(hass)
+#     flow.api = service_validate_verification_code_failed
+
+#     result = await flow.async_step_verification_code({CONF_VERIFICATION_CODE: 0})
+#     _LOGGER.info(result)
+#     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result["step_id"] == CONF_TRUSTED_DEVICE
+#     assert result["errors"] == {"base": "validate_verification_code"}

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -70,7 +70,7 @@ async def test_user(
     result = await flow.async_step_user(
         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
@@ -89,7 +89,7 @@ async def test_import(
     result = await flow.async_step_import(
         {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
@@ -107,7 +107,7 @@ async def test_import(
             CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
         }
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
@@ -174,7 +174,7 @@ async def test_abort_on_login_failed(hass):
             {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": "login"}
+        assert result["errors"] == {CONF_USERNAME: "login"}
 
 
 async def test_abort_on_fetch_failed(hass, requires_2fa):

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -27,9 +27,16 @@ GPS_ACCURACY_THRESHOLD = 250
 
 
 @pytest.fixture(name="init")
+def mock_controller_init():
+    """Mock a successful init."""
+    with patch("pyicloud.PyiCloudService"):
+        yield
+
+
+@pytest.fixture(name="authenticate")
 def mock_controller_authenticate():
     """Mock a successful authenticate."""
-    with patch("pyicloud.PyiCloudService"):
+    with patch("pyicloud.PyiCloudService.authenticate"):
         yield
 
 
@@ -64,7 +71,12 @@ def init_config_flow(hass):
 
 
 async def test_user(
-    hass, init, requires_2fa, send_verification_code, validate_verification_code
+    hass,
+    init,
+    authenticate,
+    requires_2fa,
+    send_verification_code,
+    validate_verification_code,
 ):
     """Test user config."""
     flow = init_config_flow(hass)
@@ -87,7 +99,12 @@ async def test_user(
 
 
 async def test_import(
-    hass, init, requires_2fa, send_verification_code, validate_verification_code
+    hass,
+    init,
+    authenticate,
+    requires_2fa,
+    send_verification_code,
+    validate_verification_code,
 ):
     """Test import step."""
     flow = init_config_flow(hass)
@@ -124,9 +141,14 @@ async def test_import(
 
 
 async def test_abort_if_already_setup(
-    hass, init, requires_2fa, send_verification_code, validate_verification_code
+    hass,
+    init,
+    authenticate,
+    requires_2fa,
+    send_verification_code,
+    validate_verification_code,
 ):
-    """Test we abort if Linky is already setup."""
+    """Test we abort if the account is already setup."""
     flow = init_config_flow(hass)
     MockConfigEntry(
         domain=DOMAIN, data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
@@ -144,7 +166,7 @@ async def test_abort_if_already_setup(
         {
             CONF_USERNAME: "other_username@icloud.com",
             CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNT_NAME: USERNAME,
+            CONF_ACCOUNT_NAME: ACCOUNT_NAME_FROM_USERNAME,
         }
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -162,7 +184,7 @@ async def test_abort_if_already_setup(
         {
             CONF_USERNAME: "other_username@icloud.com",
             CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNT_NAME: USERNAME,
+            CONF_ACCOUNT_NAME: ACCOUNT_NAME_FROM_USERNAME,
         }
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -184,7 +206,7 @@ async def test_abort_on_login_failed(hass):
         assert result["errors"] == {CONF_USERNAME: "login"}
 
 
-async def test_abort_on_fetch_failed(hass, init, requires_2fa):
+async def test_abort_on_fetch_failed(hass, init, authenticate, requires_2fa):
     """Test when we have errors during fetch."""
     flow = init_config_flow(hass)
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -1,0 +1,194 @@
+"""Tests for the iCloud config flow."""
+import pytest
+from unittest.mock import patch
+from pyicloud.exceptions import PyiCloudFailedLoginException
+
+from homeassistant import data_entry_flow
+from homeassistant.components.icloud import config_flow
+from homeassistant.components.icloud.config_flow import CONF_TRUSTED_DEVICE
+from homeassistant.components.icloud.const import (
+    DOMAIN,
+    CONF_ACCOUNTNAME,
+    CONF_GPS_ACCURACY_THRESHOLD,
+    CONF_MAX_INTERVAL,
+    DEFAULT_GPS_ACCURACY_THRESHOLD,
+    DEFAULT_MAX_INTERVAL,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+USERNAME = "username@me.com"
+PASSWORD = "password"
+ACCOUNTNAME = "Account name 1 2 3"
+ACCOUNTNAME_FROM_USERNAME = "username"
+MAX_INTERVAL = 15
+GPS_ACCURACY_THRESHOLD = 250
+
+
+@pytest.fixture(name="requires_2fa")
+def mock_controller_requires_2fa():
+    """Mock a successful requires_2fa."""
+    with patch("pyicloud.PyiCloudService.requires_2fa", return_value=True):
+        yield
+
+
+@pytest.fixture(name="send_verification_code")
+def mock_controller_send_verification_code():
+    """Mock a successful send_verification_code."""
+    with patch("pyicloud.PyiCloudService.send_verification_code", return_value=True):
+        yield
+
+
+@pytest.fixture(name="validate_verification_code")
+def mock_controller_validate_verification_code():
+    """Mock a successful validate_verification_code."""
+    with patch(
+        "pyicloud.PyiCloudService.validate_verification_code", return_value=True
+    ):
+        yield
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    flow = config_flow.IcloudFlowHandler()
+    flow.hass = hass
+    return flow
+
+
+async def test_user(
+    hass, requires_2fa, send_verification_code, validate_verification_code
+):
+    """Test user config."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    # test with all provided
+    result = await flow.async_step_user(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_ACCOUNTNAME] == ACCOUNTNAME_FROM_USERNAME
+    assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
+    assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
+
+
+async def test_import(hass, login, fetch_data, close_session):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with username and password
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_ACCOUNTNAME] == ACCOUNTNAME_FROM_USERNAME
+    assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
+    assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
+
+    # import with all
+    result = await flow.async_step_import(
+        {
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNTNAME: ACCOUNTNAME,
+            CONF_MAX_INTERVAL: MAX_INTERVAL,
+            CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_ACCOUNTNAME] == ACCOUNTNAME
+    assert result["data"][CONF_MAX_INTERVAL] == MAX_INTERVAL
+    assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
+
+
+async def test_abort_if_already_setup(hass, login, fetch_data, close_session):
+    """Test we abort if Linky is already setup."""
+    flow = init_config_flow(hass)
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    ).add_to_hass(hass)
+
+    # Should fail, same USERNAME (import)
+    result = await flow.async_step_import(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "username_exists"
+
+    # Should fail, same ACCOUNTNAME (import)
+    result = await flow.async_step_import(
+        {
+            CONF_USERNAME: "other_username@icloud.com",
+            CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNTNAME: USERNAME,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "username_exists"
+
+    # Should fail, same USERNAME (flow)
+    result = await flow.async_step_user(
+        {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {CONF_USERNAME: "username_exists"}
+
+    # Should fail, same ACCOUNTNAME (flow)
+    result = await flow.async_step_user(
+        {
+            CONF_USERNAME: "other_username@icloud.com",
+            CONF_PASSWORD: PASSWORD,
+            CONF_ACCOUNTNAME: USERNAME,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["reason"] == {CONF_USERNAME: "username_exists"}
+
+
+async def test_abort_on_login_failed(hass, close_session):
+    """Test when we have errors during login."""
+    flow = init_config_flow(hass)
+
+    with patch(
+        "pyicloud.PyiCloudService.authenticate",
+        side_effect=PyiCloudFailedLoginException(),
+    ):
+        result = await flow.async_step_user(
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "login"}
+
+
+async def test_abort_on_fetch_failed(hass, login, close_session):
+    """Test when we have errors during fetch."""
+    flow = init_config_flow(hass)
+
+    with patch("pyicloud.PyiCloudService.send_verification_code", side_effect=False):
+        result = await flow.async_step_user(
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {CONF_TRUSTED_DEVICE: "send_verification_code"}
+
+    with patch(
+        "pyicloud.PyiCloudService.validate_verification_code", side_effect=False
+    ):
+        result = await flow.async_step_user(
+            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "validate_verification_code"}

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.components.icloud import config_flow
 from homeassistant.components.icloud.config_flow import CONF_TRUSTED_DEVICE
 from homeassistant.components.icloud.const import (
     DOMAIN,
-    CONF_ACCOUNTNAME,
+    CONF_ACCOUNT_NAME,
     CONF_GPS_ACCURACY_THRESHOLD,
     CONF_MAX_INTERVAL,
     DEFAULT_GPS_ACCURACY_THRESHOLD,
@@ -74,7 +74,7 @@ async def test_user(
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNTNAME] == ACCOUNTNAME_FROM_USERNAME
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNTNAME_FROM_USERNAME
     assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
@@ -93,7 +93,7 @@ async def test_import(
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNTNAME] == ACCOUNTNAME_FROM_USERNAME
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNTNAME_FROM_USERNAME
     assert result["data"][CONF_MAX_INTERVAL] == DEFAULT_MAX_INTERVAL
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == DEFAULT_GPS_ACCURACY_THRESHOLD
 
@@ -102,7 +102,7 @@ async def test_import(
         {
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNTNAME: ACCOUNTNAME,
+            CONF_ACCOUNT_NAME: ACCOUNTNAME,
             CONF_MAX_INTERVAL: MAX_INTERVAL,
             CONF_GPS_ACCURACY_THRESHOLD: GPS_ACCURACY_THRESHOLD,
         }
@@ -111,7 +111,7 @@ async def test_import(
     assert result["title"] == USERNAME
     assert result["data"][CONF_USERNAME] == USERNAME
     assert result["data"][CONF_PASSWORD] == PASSWORD
-    assert result["data"][CONF_ACCOUNTNAME] == ACCOUNTNAME
+    assert result["data"][CONF_ACCOUNT_NAME] == ACCOUNTNAME
     assert result["data"][CONF_MAX_INTERVAL] == MAX_INTERVAL
     assert result["data"][CONF_GPS_ACCURACY_THRESHOLD] == GPS_ACCURACY_THRESHOLD
 
@@ -137,7 +137,7 @@ async def test_abort_if_already_setup(
         {
             CONF_USERNAME: "other_username@icloud.com",
             CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNTNAME: USERNAME,
+            CONF_ACCOUNT_NAME: USERNAME,
         }
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -155,7 +155,7 @@ async def test_abort_if_already_setup(
         {
             CONF_USERNAME: "other_username@icloud.com",
             CONF_PASSWORD: PASSWORD,
-            CONF_ACCOUNTNAME: USERNAME,
+            CONF_ACCOUNT_NAME: USERNAME,
         }
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -36,7 +36,7 @@ def mock_controller_init():
 @pytest.fixture(name="authenticate")
 def mock_controller_authenticate():
     """Mock a successful authenticate."""
-    with patch("pyicloud.PyiCloudService.authenticate"):
+    with patch("pyicloud.PyiCloudService.authenticate", return_value=None):
         yield
 
 

--- a/tests/components/icloud/test_config_flow.py
+++ b/tests/components/icloud/test_config_flow.py
@@ -47,32 +47,28 @@ def mock_controller_session():
 @pytest.fixture(name="requires_2fa")
 def mock_controller_requires_2fa():
     """Mock a successful requires_2fa."""
-    with patch("pyicloud.base.PyiCloudService.requires_2fa", return_value=True):
+    with patch("pyicloud.PyiCloudService.requires_2fa", return_value=True):
         yield
 
 
 @pytest.fixture(name="not_requires_2fa")
 def mock_controller_not_requires_2fa():
     """Mock a successful not requires_2fa."""
-    with patch("pyicloud.base.PyiCloudService.requires_2fa", return_value=False):
+    with patch("pyicloud.PyiCloudService.requires_2fa", return_value=False):
         yield
 
 
 @pytest.fixture(name="send_verification_code")
 def mock_controller_send_verification_code():
     """Mock a successful send_verification_code."""
-    with patch(
-        "pyicloud.base.PyiCloudService.send_verification_code", return_value=True
-    ):
+    with patch("pyicloud.PyiCloudService.send_verification_code", return_value=True):
         yield
 
 
 @pytest.fixture(name="send_verification_code_failed")
 def mock_controller_send_verification_code_failed():
     """Mock a successful send_verification_code failed."""
-    with patch(
-        "pyicloud.base.PyiCloudService.send_verification_code", return_value=False
-    ):
+    with patch("pyicloud.PyiCloudService.send_verification_code", return_value=False):
         yield
 
 
@@ -80,7 +76,7 @@ def mock_controller_send_verification_code_failed():
 def mock_controller_validate_verification_code():
     """Mock a successful validate_verification_code."""
     with patch(
-        "pyicloud.base.PyiCloudService.validate_verification_code", return_value=True
+        "pyicloud.PyiCloudService.validate_verification_code", return_value=True
     ):
         yield
 
@@ -89,7 +85,7 @@ def mock_controller_validate_verification_code():
 def mock_controller_validate_verification_code_failed():
     """Mock a successful validate_verification_code failed."""
     with patch(
-        "pyicloud.base.PyiCloudService.validate_verification_code", return_value=False
+        "pyicloud.PyiCloudService.validate_verification_code", return_value=False
     ):
         yield
 


### PR DESCRIPTION
## Breaking Change:

The iCloud component leaves the device_tracker platform to become an integration.

From:
```yml
device_tracker:
  - platform: icloud
    username: __email__
    password: __password__
```

To:
```yml
icloud:
  - username: __email__
    password: __password__
```

Here are all the services : 
SERVICE_ICLOUD_PLAY_SOUND = "play_sound"
SERVICE_ICLOUD_DISPLAY_MESSAGE = "display_message"
SERVICE_ICLOUD_LOST_DEVICE = "lost_device"
SERVICE_ICLOUD_UPDATE = "update"
SERVICE_ICLOUD_RESET = "reset"

Some services are renamed :
'icloud_lost_device'  --> 'lost_device'
'icloud_update'  --> 'update'
'icloud_reset'  --> 'reset'

## Description:

Dramatically improve the iCloud integration addition UX with config flow, translated steps (will do),
and list selection while choosing the trusted device (instead of a number).

It also adds documentation to services, and should fix two issues.

Following the draft PR #24053

PR doing : 
- add config flow
- fix existing services
- add play_sound & display_message services
- document services
- prepare to add sensor platform (battery for devices)

**Related issue (if applicable):**
fixes #13312
fixes #20195
fixes #28826

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

**NOT YET**

## Example entry for `configuration.yaml` (if applicable):
```yaml
icloud:
  - username: __email__
    password: __password__
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html