### PR TITLE
deCONZ - battery sensor instead of battery attribute

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -2,7 +2,7 @@
 from pydeconz.sensor import Presence, Vibration
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_TEMPERATURE
+from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -17,7 +17,6 @@ ATTR_VIBRATIONSTRENGTH = "vibrationstrength"
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up deCONZ platforms."""
-    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -56,7 +55,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorDevice):
     def async_update_callback(self, force_update=False):
         """Update the sensor's state."""
         changed = set(self._device.changed_keys)
-        keys = {"battery", "on", "reachable", "state"}
+        keys = {"on", "reachable", "state"}
         if force_update or any(key in changed for key in keys):
             self.async_schedule_update_ha_state()
 
@@ -79,8 +78,6 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorDevice):
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         attr = {}
-        if self._device.battery:
-            attr[ATTR_BATTERY_LEVEL] = self._device.battery
 
         if self._device.on is not None:
             attr[ATTR_ON] = self._device.on

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -8,7 +8,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     SUPPORT_TARGET_TEMPERATURE,
 )
-from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -21,7 +21,6 @@ SUPPORT_HVAC = [HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF]
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up deCONZ platforms."""
-    pass
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -119,9 +118,6 @@ class DeconzThermostat(DeconzDevice, ClimateDevice):
     def device_state_attributes(self):
         """Return the state attributes of the thermostat."""
         attr = {}
-
-        if self._device.battery:
-            attr[ATTR_BATTERY_LEVEL] = self._device.battery
 
         if self._device.offset:
             attr[ATTR_OFFSET] = self._device.offset

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -24,10 +24,10 @@ class DeconzBase:
     @property
     def serial(self):
         """Return a serial number for this device."""
-        if self.unique_id is None or self.unique_id.count(":") != 7:
+        if self._device.uniqueid is None or self._device.uniqueid.count(":") != 7:
             return None
 
-        return self.unique_id.split("-", 1)[0]
+        return self._device.uniqueid.split("-", 1)[0]
 
     @property
     def device_info(self):

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -27,6 +27,11 @@ class DeconzEvent(DeconzBase):
         self.event_id = slugify(self._device.name)
         _LOGGER.debug("deCONZ event created: %s", self.event_id)
 
+    @property
+    def device(self):
+        """Return Event device."""
+        return self._device
+
     @callback
     def async_will_remove_from_hass(self) -> None:
         """Disconnect event object when removed."""

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ sensors."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
 
-    batteries = []
+    batteries = set()
     entity_handler = DeconzEntityHandler(gateway)
 
     @callback
@@ -57,7 +57,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if sensor.battery:
                 new_battery = DeconzBattery(sensor, gateway)
                 if new_battery.unique_id not in batteries:
-                    batteries.append(new_battery.unique_id)
+                    batteries.add(new_battery.unique_id)
                     entities.append(new_battery)
 
         async_add_entities(entities, True)

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -168,7 +168,7 @@ class DeconzBattery(DeconzDevice):
 
         if self._device.type in Switch.ZHATYPE:
             for event in self.gateway.events:
-                if self._device == event._device:
+                if self._device == event.device:
                     attr[ATTR_EVENT_ID] = event.event_id
 
         return attr

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -4,7 +4,6 @@ from pydeconz.sensor import Consumption, Daylight, LightLevel, Power, Switch
 from homeassistant.const import ATTR_TEMPERATURE, ATTR_VOLTAGE, DEVICE_CLASS_BATTERY
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util import slugify
 
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
@@ -168,6 +167,8 @@ class DeconzBattery(DeconzDevice):
         attr = {}
 
         if self._device.type in Switch.ZHATYPE:
-            attr[ATTR_EVENT_ID] = slugify(self._device.name)
+            for event in self.gateway.events:
+                if self._device == event._device:
+                    attr[ATTR_EVENT_ID] = event.event_id
 
         return attr

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -129,14 +129,6 @@ class DeconzSensor(DeconzDevice):
 class DeconzBattery(DeconzDevice):
     """Battery class for when a device is only represented as an event."""
 
-    def __init__(self, device, gateway):
-        """Register dispatcher callback for update of battery state."""
-        super().__init__(device, gateway)
-
-        self._battery_unique_id = f"{self.serial}-battery"
-        self._name = f"{self._device.name} Battery Level"
-        self._unit_of_measurement = "%"
-
     @callback
     def async_update_callback(self, force_update=False):
         """Update the battery's state, if needed."""
@@ -148,7 +140,7 @@ class DeconzBattery(DeconzDevice):
     @property
     def unique_id(self):
         """Return a unique identifier for this device."""
-        return self._battery_unique_id
+        return f"{self.serial}-battery"
 
     @property
     def state(self):
@@ -158,7 +150,7 @@ class DeconzBattery(DeconzDevice):
     @property
     def name(self):
         """Return the name of the battery."""
-        return self._name
+        return f"{self._device.name} Battery Level"
 
     @property
     def device_class(self):
@@ -168,7 +160,7 @@ class DeconzBattery(DeconzDevice):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
-        return self._unit_of_measurement
+        return "%"
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -144,7 +144,7 @@ class DeconzBattery(DeconzDevice):
         if self._device.type in Switch.ZHATYPE:
             self._battery_unique_id = self._device.uniqueid
 
-        self._name = "{} {}".format(self._device.name, "Battery Level")
+        self._name = f"{self._device.name} Battery Level"
         self._unit_of_measurement = "%"
 
     @callback


### PR DESCRIPTION
## Breaking Change:
Standardizes battery sensor unique id to the serial number of device + battery.
Entity attribute battery level will no longer be available, this will instead be exposed as a separate entity just as with remotes previously.

## Description:
Move battery attribute to a standalone sensor per physical device

**Related issue (if applicable):** fixes https://github.com/Kane610/deconz/issues/42

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
