### PR TITLE
deCONZ -  create deconz_events through sensor platform

### DIFF
--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -4,8 +4,6 @@ import async_timeout
 
 from pydeconz import DeconzSession, errors
 
-# from pydeconz.sensor import Switch
-
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
@@ -33,21 +31,6 @@ from .const import (
     SUPPORTED_PLATFORMS,
 )
 
-# from .const import (
-#     _LOGGER,
-#     CONF_ALLOW_CLIP_SENSOR,
-#     CONF_ALLOW_DECONZ_GROUPS,
-#     CONF_BRIDGEID,
-#     CONF_MASTER_GATEWAY,
-#     DEFAULT_ALLOW_CLIP_SENSOR,
-#     DEFAULT_ALLOW_DECONZ_GROUPS,
-#     DOMAIN,
-#     NEW_DEVICE,
-#     NEW_SENSOR,
-#     SUPPORTED_PLATFORMS,
-# )
-
-# from .deconz_event import DeconzEvent
 from .errors import AuthenticationRequired, CannotConnect
 
 
@@ -134,14 +117,6 @@ class DeconzGateway:
                 )
             )
 
-        # self.listeners.append(
-        #     async_dispatcher_connect(
-        #         hass, self.async_signal_new_device(NEW_SENSOR), self.async_add_remote
-        #     )
-        # )
-
-        # self.async_add_remote(self.api.sensors.values())
-
         self.api.start()
 
         self.config_entry.add_update_listener(self.async_new_address)
@@ -199,17 +174,6 @@ class DeconzGateway:
         async_dispatcher_send(
             self.hass, self.async_signal_new_device(device_type), device
         )
-
-    # @callback
-    # def async_add_remote(self, sensors):
-    #     """Set up remote from deCONZ."""
-    #     for sensor in sensors:
-    #         if sensor.type in Switch.ZHATYPE and not (
-    #             not self.option_allow_clip_sensor and sensor.type.startswith("CLIP")
-    #         ):
-    #             event = DeconzEvent(sensor, self)
-    #             self.hass.async_create_task(event.async_update_device_registry())
-    #             self.events.append(event)
 
     @callback
     def shutdown(self, event):

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -3,7 +3,8 @@ import asyncio
 import async_timeout
 
 from pydeconz import DeconzSession, errors
-from pydeconz.sensor import Switch
+
+# from pydeconz.sensor import Switch
 
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_HOST
@@ -29,10 +30,24 @@ from .const import (
     DEFAULT_ALLOW_DECONZ_GROUPS,
     DOMAIN,
     NEW_DEVICE,
-    NEW_SENSOR,
     SUPPORTED_PLATFORMS,
 )
-from .deconz_event import DeconzEvent
+
+# from .const import (
+#     _LOGGER,
+#     CONF_ALLOW_CLIP_SENSOR,
+#     CONF_ALLOW_DECONZ_GROUPS,
+#     CONF_BRIDGEID,
+#     CONF_MASTER_GATEWAY,
+#     DEFAULT_ALLOW_CLIP_SENSOR,
+#     DEFAULT_ALLOW_DECONZ_GROUPS,
+#     DOMAIN,
+#     NEW_DEVICE,
+#     NEW_SENSOR,
+#     SUPPORTED_PLATFORMS,
+# )
+
+# from .deconz_event import DeconzEvent
 from .errors import AuthenticationRequired, CannotConnect
 
 
@@ -119,13 +134,13 @@ class DeconzGateway:
                 )
             )
 
-        self.listeners.append(
-            async_dispatcher_connect(
-                hass, self.async_signal_new_device(NEW_SENSOR), self.async_add_remote
-            )
-        )
+        # self.listeners.append(
+        #     async_dispatcher_connect(
+        #         hass, self.async_signal_new_device(NEW_SENSOR), self.async_add_remote
+        #     )
+        # )
 
-        self.async_add_remote(self.api.sensors.values())
+        # self.async_add_remote(self.api.sensors.values())
 
         self.api.start()
 
@@ -185,16 +200,16 @@ class DeconzGateway:
             self.hass, self.async_signal_new_device(device_type), device
         )
 
-    @callback
-    def async_add_remote(self, sensors):
-        """Set up remote from deCONZ."""
-        for sensor in sensors:
-            if sensor.type in Switch.ZHATYPE and not (
-                not self.option_allow_clip_sensor and sensor.type.startswith("CLIP")
-            ):
-                event = DeconzEvent(sensor, self)
-                self.hass.async_create_task(event.async_update_device_registry())
-                self.events.append(event)
+    # @callback
+    # def async_add_remote(self, sensors):
+    #     """Set up remote from deCONZ."""
+    #     for sensor in sensors:
+    #         if sensor.type in Switch.ZHATYPE and not (
+    #             not self.option_allow_clip_sensor and sensor.type.startswith("CLIP")
+    #         ):
+    #             event = DeconzEvent(sensor, self)
+    #             self.hass.async_create_task(event.async_update_device_registry())
+    #             self.events.append(event)
 
     @callback
     def shutdown(self, event):

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.util import slugify
 
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
+from .deconz_event import DeconzEvent
 from .gateway import get_gateway_from_config_entry, DeconzEntityHandler
 
 ATTR_CURRENT = "current"
@@ -42,6 +43,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if not sensor.BINARY:
 
                 if sensor.type in Switch.ZHATYPE:
+
+                    # if not (
+                    #     not gateway.option_allow_clip_sensor
+                    #     and sensor.type.startswith("CLIP")
+                    # ):
+                    if gateway.option_allow_clip_sensor or not sensor.type.startswith(
+                        "CLIP"
+                    ):
+                        event = DeconzEvent(sensor, gateway)
+                        hass.async_create_task(event.async_update_device_registry())
+                        gateway.events.append(event)
+
                     if sensor.battery:
                         entities.append(DeconzBattery(sensor, gateway))
 

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -44,10 +44,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
                 if sensor.type in Switch.ZHATYPE:
 
-                    # if not (
-                    #     not gateway.option_allow_clip_sensor
-                    #     and sensor.type.startswith("CLIP")
-                    # ):
                     if gateway.option_allow_clip_sensor or not sensor.type.startswith(
                         "CLIP"
                     ):

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -1,9 +1,12 @@
 """Test deCONZ remote events."""
+import pytest
+
 from unittest.mock import Mock
 
 from homeassistant.components.deconz import deconz_event
 
 
+@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
 async def test_create_event(hass):
     """Successfully created a deCONZ event."""
     mock_remote = Mock()
@@ -34,6 +37,7 @@ async def test_update_event(hass):
     assert len(hass.bus.async_fire.mock_calls) == 1
 
 
+@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
 async def test_remove_event(hass):
     """Successfully update a deCONZ event."""
     mock_remote = Mock()

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -1,0 +1,48 @@
+"""Test deCONZ remote events."""
+from unittest.mock import Mock
+
+from homeassistant.components.deconz import deconz_event
+
+
+async def test_create_event(hass):
+    """Successfully created a deCONZ event."""
+    mock_remote = Mock()
+    mock_remote.name = "Name"
+
+    mock_gateway = Mock()
+    mock_gateway.hass = hass
+
+    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
+
+    assert event.event_id == "name"
+
+
+async def test_update_event(hass):
+    """Successfully update a deCONZ event."""
+    hass.bus.async_fire = Mock()
+
+    mock_remote = Mock()
+    mock_remote.name = "Name"
+
+    mock_gateway = Mock()
+    mock_gateway.hass = hass
+
+    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
+    mock_remote.changed_keys = {"state": True}
+    event.async_update_callback()
+
+    assert len(hass.bus.async_fire.mock_calls) == 1
+
+
+async def test_remove_event(hass):
+    """Successfully update a deCONZ event."""
+    mock_remote = Mock()
+    mock_remote.name = "Name"
+
+    mock_gateway = Mock()
+    mock_gateway.hass = hass
+
+    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
+    event.async_will_remove_from_hass()
+
+    assert event._device is None

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -1,12 +1,10 @@
 """Test deCONZ remote events."""
-import pytest
-
 from unittest.mock import Mock
 
-from homeassistant.components.deconz import deconz_event
+from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT, DeconzEvent
+from homeassistant.core import callback
 
 
-@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
 async def test_create_event(hass):
     """Successfully created a deCONZ event."""
     mock_remote = Mock()
@@ -15,29 +13,39 @@ async def test_create_event(hass):
     mock_gateway = Mock()
     mock_gateway.hass = hass
 
-    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
+    event = DeconzEvent(mock_remote, mock_gateway)
 
     assert event.event_id == "name"
 
 
 async def test_update_event(hass):
     """Successfully update a deCONZ event."""
-    hass.bus.async_fire = Mock()
-
     mock_remote = Mock()
     mock_remote.name = "Name"
 
     mock_gateway = Mock()
     mock_gateway.hass = hass
 
-    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
+    event = DeconzEvent(mock_remote, mock_gateway)
     mock_remote.changed_keys = {"state": True}
+
+    calls = []
+
+    @callback
+    def listener(event):
+        """Mock listener."""
+        calls.append(event)
+
+    unsub = hass.bus.async_listen(CONF_DECONZ_EVENT, listener)
+
     event.async_update_callback()
+    await hass.async_block_till_done()
 
-    assert len(hass.bus.async_fire.mock_calls) == 1
+    assert len(calls) == 1
+
+    unsub()
 
 
-@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
 async def test_remove_event(hass):
     """Successfully update a deCONZ event."""
     mock_remote = Mock()
@@ -46,7 +54,7 @@ async def test_remove_event(hass):
     mock_gateway = Mock()
     mock_gateway.hass = hass
 
-    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
+    event = DeconzEvent(mock_remote, mock_gateway)
     event.async_will_remove_from_hass()
 
     assert event._device is None

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.components.deconz import errors, gateway
+from homeassistant.components.deconz import deconz_event, errors, gateway
 
 from tests.common import mock_coro
 
@@ -126,24 +126,6 @@ async def test_add_device(hass):
         assert len(mock_dispatch_send.mock_calls[0]) == 3
 
 
-@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
-async def test_add_remote(hass):
-    """Successful add remote."""
-    entry = Mock()
-    entry.data = ENTRY_CONFIG
-
-    remote = Mock()
-    remote.name = "name"
-    remote.type = "ZHASwitch"
-    remote.register_async_callback = Mock()
-
-    deconz_gateway = gateway.DeconzGateway(hass, entry)
-    deconz_gateway.async_add_remote([remote])
-    await hass.async_block_till_done()
-
-    assert len(deconz_gateway.events) == 1
-
-
 async def test_shutdown():
     """Successful shutdown."""
     hass = Mock()
@@ -220,7 +202,6 @@ async def test_get_gateway_fails_cannot_connect(hass):
         assert await gateway.get_gateway(hass, ENTRY_CONFIG, Mock(), Mock()) is False
 
 
-@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
 async def test_create_event(hass):
     """Successfully created a deCONZ event."""
     mock_remote = Mock()
@@ -229,13 +210,11 @@ async def test_create_event(hass):
     mock_gateway = Mock()
     mock_gateway.hass = hass
 
-    event = gateway.DeconzEvent(mock_remote, mock_gateway)
-    await hass.async_block_till_done()
+    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
 
     assert event.event_id == "name"
 
 
-@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
 async def test_update_event(hass):
     """Successfully update a deCONZ event."""
     hass.bus.async_fire = Mock()
@@ -246,15 +225,13 @@ async def test_update_event(hass):
     mock_gateway = Mock()
     mock_gateway.hass = hass
 
-    event = gateway.DeconzEvent(mock_remote, mock_gateway)
-    await hass.async_block_till_done()
+    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
     mock_remote.changed_keys = {"state": True}
     event.async_update_callback()
 
     assert len(hass.bus.async_fire.mock_calls) == 1
 
 
-@pytest.mark.skip(reason="fails for unkown reason, will refactor in a separate PR")
 async def test_remove_event(hass):
     """Successfully update a deCONZ event."""
     mock_remote = Mock()
@@ -263,8 +240,7 @@ async def test_remove_event(hass):
     mock_gateway = Mock()
     mock_gateway.hass = hass
 
-    event = gateway.DeconzEvent(mock_remote, mock_gateway)
-    await hass.async_block_till_done()
+    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
     event.async_will_remove_from_hass()
 
     assert event._device is None

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.components.deconz import deconz_event, errors, gateway
+from homeassistant.components.deconz import errors, gateway
 
 from tests.common import mock_coro
 
@@ -200,47 +200,3 @@ async def test_get_gateway_fails_cannot_connect(hass):
         side_effect=pydeconz.errors.RequestError,
     ), pytest.raises(errors.CannotConnect):
         assert await gateway.get_gateway(hass, ENTRY_CONFIG, Mock(), Mock()) is False
-
-
-async def test_create_event(hass):
-    """Successfully created a deCONZ event."""
-    mock_remote = Mock()
-    mock_remote.name = "Name"
-
-    mock_gateway = Mock()
-    mock_gateway.hass = hass
-
-    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
-
-    assert event.event_id == "name"
-
-
-async def test_update_event(hass):
-    """Successfully update a deCONZ event."""
-    hass.bus.async_fire = Mock()
-
-    mock_remote = Mock()
-    mock_remote.name = "Name"
-
-    mock_gateway = Mock()
-    mock_gateway.hass = hass
-
-    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
-    mock_remote.changed_keys = {"state": True}
-    event.async_update_callback()
-
-    assert len(hass.bus.async_fire.mock_calls) == 1
-
-
-async def test_remove_event(hass):
-    """Successfully update a deCONZ event."""
-    mock_remote = Mock()
-    mock_remote.name = "Name"
-
-    mock_gateway = Mock()
-    mock_gateway.hass = hass
-
-    event = deconz_event.DeconzEvent(mock_remote, mock_gateway)
-    event.async_will_remove_from_hass()
-
-    assert event._device is None


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Gateway class shouldn't be responsible for creating deconz_events

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
