### PR TITLE
Fix lint with wrong zigate lib handling

### DIFF
--- a/azure-pipelines-wheels.yml
+++ b/azure-pipelines-wheels.yml
@@ -49,7 +49,6 @@ jobs:
           sed -i "s|# pybluez|pybluez|g" ${requirement_file}
           sed -i "s|# bluepy|bluepy|g" ${requirement_file}
           sed -i "s|# beacontools|beacontools|g" ${requirement_file}
-          sed -i "s|# RPi.GPIO|RPi.GPIO|g" ${requirement_file}
           sed -i "s|# raspihats|raspihats|g" ${requirement_file}
           sed -i "s|# rpi-rf|rpi-rf|g" ${requirement_file}
           sed -i "s|# blinkt|blinkt|g" ${requirement_file}
@@ -67,5 +66,6 @@ jobs:
           sed -i "s|# pySwitchmate|pySwitchmate|g" ${requirement_file}
           sed -i "s|# face_recognition|face_recognition|g" ${requirement_file}
           sed -i "s|# py_noaa|py_noaa|g" ${requirement_file}
+          sed -i "s|# VL53L1X|VL53L1X|g" ${requirement_file}
         done
       displayName: 'Prepare requirements files for Hass.io'

--- a/homeassistant/components/mcp23017/binary_sensor.py
+++ b/homeassistant/components/mcp23017/binary_sensor.py
@@ -1,9 +1,13 @@
 """Support for binary sensor using I2C MCP23017 chip."""
 import logging
 
+import adafruit_mcp230xx
+import board
+import busio
+import digitalio
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice, PLATFORM_SCHEMA
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 import homeassistant.helpers.config_validation as cv
 
@@ -37,10 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MCP23017 binary sensors."""
-    import board
-    import busio
-    import adafruit_mcp230xx
-
     pull_mode = config[CONF_PULL_MODE]
     invert_logic = config[CONF_INVERT_LOGIC]
     i2c_address = config[CONF_I2C_ADDRESS]
@@ -65,8 +65,6 @@ class MCP23017BinarySensor(BinarySensorDevice):
 
     def __init__(self, name, pin, pull_mode, invert_logic):
         """Initialize the MCP23017 binary sensor."""
-        import digitalio
-
         self._name = name or DEVICE_DEFAULT_NAME
         self._pin = pin
         self._pull_mode = pull_mode

--- a/homeassistant/components/mcp23017/switch.py
+++ b/homeassistant/components/mcp23017/switch.py
@@ -1,12 +1,15 @@
 """Support for switch sensor using I2C MCP23017 chip."""
 import logging
 
+import adafruit_mcp230xx
+import board
+import busio
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA
 from homeassistant.const import DEVICE_DEFAULT_NAME
-from homeassistant.helpers.entity import ToggleEntity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,10 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the MCP23017 devices."""
-    import board
-    import busio
-    import adafruit_mcp230xx
-
     invert_logic = config.get(CONF_INVERT_LOGIC)
     i2c_address = config.get(CONF_I2C_ADDRESS)
 
@@ -54,8 +53,6 @@ class MCP23017Switch(ToggleEntity):
 
     def __init__(self, name, pin, invert_logic):
         """Initialize the pin."""
-        import digitalio
-
         self._name = name or DEVICE_DEFAULT_NAME
         self._pin = pin
         self._invert_logic = invert_logic

--- a/homeassistant/components/mcp23017/switch.py
+++ b/homeassistant/components/mcp23017/switch.py
@@ -4,6 +4,7 @@ import logging
 import adafruit_mcp230xx
 import board
 import busio
+import digitalio
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA

--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -1,7 +1,10 @@
 """Support for controlling GPIO pins of a Raspberry Pi."""
 import logging
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+# pylint: disable=no-member
+from RPi import GPIO
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -10,51 +13,36 @@ DOMAIN = "rpi_gpio"
 
 def setup(hass, config):
     """Set up the Raspberry PI GPIO component."""
-    from RPi import GPIO  # pylint: disable=import-error
 
     def cleanup_gpio(event):
         """Stuff to do before stopping."""
         GPIO.cleanup()
 
-    def prepare_gpio(event):
-        """Stuff to do when home assistant starts."""
-        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
-
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup_gpio)
     GPIO.setmode(GPIO.BCM)
     return True
 
 
 def setup_output(port):
     """Set up a GPIO as output."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.setup(port, GPIO.OUT)
 
 
 def setup_input(port, pull_mode):
     """Set up a GPIO as input."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.setup(port, GPIO.IN, GPIO.PUD_DOWN if pull_mode == "DOWN" else GPIO.PUD_UP)
 
 
 def write_output(port, value):
     """Write a value to a GPIO."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.output(port, value)
 
 
 def read_input(port):
     """Read a value from a GPIO."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     return GPIO.input(port)
 
 
 def edge_detect(port, event_callback, bounce):
     """Add detection for RISING and FALLING events."""
-    from RPi import GPIO  # pylint: disable=import-error
-
     GPIO.add_event_detect(port, GPIO.BOTH, callback=event_callback, bouncetime=bounce)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -82,7 +82,7 @@ PyXiaomiGateway==0.12.4
 
 # homeassistant.components.mcp23017
 # homeassistant.components.rpi_gpio
-# RPi.GPIO==0.6.5
+RPi.GPIO==0.6.5
 
 # homeassistant.components.remember_the_milk
 RtmAPI==0.7.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -35,7 +35,6 @@ COMMENT_REQUIREMENTS = (
     "pyuserinput",
     "raspihats",
     "rpi-rf",
-    "RPi.GPIO",
     "smbus-cffi",
     "tensorflow",
     "VL53L1X2",


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
