### PR TITLE
Remove initial rest switch http call

### DIFF
--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -93,11 +93,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             verify_ssl,
         )
 
-        req = await switch.get_device_state(hass)
-        if req.status >= 400:
-            _LOGGER.error("Got non-ok response from resource: %s", req.status)
-        else:
-            async_add_entities([switch])
+        async_add_entities([switch])
     except (TypeError, ValueError):
         _LOGGER.error(
             "Missing resource or schema in configuration. "


### PR DESCRIPTION
## Description:
If a rest switch is not available during startup of home assistant it can't be reached for the entire runtime of the server. This fix ignores the state during startup.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
