### PR TITLE
Refactor Bluetooth Tracker to async

### DIFF
--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -126,20 +126,6 @@ async def async_setup_scanner(
     if not devices_to_track and not track_new:
         _LOGGER.debug("No Bluetooth devices to track and not tracking new devices")
 
-    if track_new:
-        devices = await hass.async_add_executor_job(discover_devices, device_id)
-
-        tasks = []
-        for mac, device_name in devices:
-            if mac not in devices_to_track and mac not in devices_to_not_track:
-                devices_to_track.add(mac)
-
-            if mac in devices_to_track:
-                tasks.append(see_device(hass, async_see, mac, device_name))
-
-        if tasks:
-            await asyncio.wait(tasks)
-
     if request_rssi:
         _LOGGER.debug("Detecting RSSI for devices")
 

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -73,13 +73,11 @@ async def see_device(
     if rssi is not None:
         attributes["rssi"] = rssi
 
-    await hass.async_create_task(
-        async_see(
-            mac=f"{BT_PREFIX}{mac}",
-            host_name=device_name,
-            attributes=attributes,
-            source_type=SOURCE_TYPE_BLUETOOTH,
-        )
+    await async_see(
+        mac=f"{BT_PREFIX}{mac}",
+        host_name=device_name,
+        attributes=attributes,
+        source_type=SOURCE_TYPE_BLUETOOTH,
     )
 
 

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -134,6 +134,8 @@ async def async_setup_scanner(
         _LOGGER.debug("Detecting RSSI for devices")
 
     def perform_bluetooth_update():
+        """Discover Bluetooth devices and update status."""
+
         if track_new:
             for mac, device_name in discover_devices(device_id):
                 if mac not in devices_to_track and mac not in devices_to_not_track:

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -124,6 +124,8 @@ async def async_setup_scanner(
         for mac, device_name in discover_devices(device_id):
             if mac not in devices_to_track and mac not in devices_to_not_track:
                 devices_to_track.add(mac)
+
+            if mac in devices_to_track:
                 see_device(hass, async_see, mac, device_name)
 
     if request_rssi:

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -129,7 +129,7 @@ async def async_setup_scanner(
     if request_rssi:
         _LOGGER.debug("Detecting RSSI for devices")
 
-    async def update_bluetooth():
+    async def update_bluetooth(now=None):
         """Lookup Bluetooth devices and update status."""
         try:
             if track_new:

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -121,7 +121,7 @@ async def async_setup_scanner(
 
     # If track new devices is true discover new devices on startup.
     track_new: bool = config.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
-    _LOGGER.debug("Tracking new devices = %s", track_new)
+    _LOGGER.debug("Tracking new devices is set to %s", track_new)
 
     devices_to_track, devices_to_not_track = await get_tracking_devices(hass)
 
@@ -142,6 +142,7 @@ async def async_setup_scanner(
 
     async def perform_bluetooth_update():
         """Discover Bluetooth devices and update status."""
+
         _LOGGER.debug("Performing Bluetooth devices discovery and update")
         try:
             if track_new:
@@ -170,13 +171,10 @@ async def async_setup_scanner(
     async def update_bluetooth(now=None):
         """Lookup Bluetooth devices and update status."""
 
-        _LOGGER.debug("Preparing to update Bluetooth devices")
-
         # If an update is in progress, we don't do anything
         if update_bluetooth_lock.locked():
-            _LOGGER.warning(
-                "Updating %s took longer than the scheduled update of interval %s",
-                DOMAIN,
+            _LOGGER.info(
+                "Previous execution of update_bluetooth is taking longer than the scheduled update of interval %s",
                 interval,
             )
             return

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -154,7 +154,7 @@ async def async_setup_scanner(
         except bluetooth.BluetoothError:
             _LOGGER.exception("Error looking up Bluetooth device")
 
-    async def handle_update_bluetooth(call):
+    async def handle_manual_update_bluetooth(call):
         """Update bluetooth devices on demand."""
 
         await update_bluetooth()
@@ -163,7 +163,7 @@ async def async_setup_scanner(
     async_track_time_interval(hass, update_bluetooth, interval)
 
     hass.services.async_register(
-        DOMAIN, "bluetooth_tracker_update", handle_update_bluetooth
+        DOMAIN, "bluetooth_tracker_update", handle_manual_update_bluetooth
     )
 
     return True


### PR DESCRIPTION
## Description:

This PR refactors the Bluetooth Tracker code to async. It has much better control flow, and code is simplified. It also leaves room for creating race timeouts on some of the bluetooth methods in case they are not working correctly.

Also added locking to the `update_bluetooth` method to prevent parallel runs if an execution runs too long.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]