### PR TITLE
Add iaqualink binary sensor and unique_id

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -289,6 +289,7 @@ omit =
     homeassistant/components/hydrawise/*
     homeassistant/components/hyperion/light.py
     homeassistant/components/ialarm/alarm_control_panel.py
+    homeassistant/components/iaqualink/binary_sensor.py
     homeassistant/components/iaqualink/climate.py
     homeassistant/components/iaqualink/light.py
     homeassistant/components/iaqualink/sensor.py

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from iaqualink import (
     AqualinkBinarySensor,
     AqualinkClient,
+    AqualinkDevice,
     AqualinkLight,
     AqualinkLoginException,
     AqualinkSensor,
@@ -30,6 +31,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
@@ -173,7 +175,7 @@ def refresh_system(func):
     return wrapper
 
 
-class AqualinkEntityMixin:
+class AqualinkEntity(Entity):
     """Abstract class for all Aqualink platforms.
 
     Entity state is updated via the interval timer within the integration.
@@ -182,6 +184,10 @@ class AqualinkEntityMixin:
     via the refresh_system decorator above to the _update_callback in this
     class.
     """
+
+    def __init__(self, dev: AqualinkDevice):
+        """Initialize the entity."""
+        self.dev = dev
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
@@ -203,4 +209,4 @@ class AqualinkEntityMixin:
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this entity."""
-        return "iaqualink_{0}_{1}".format(self.dev.system.serial, self.dev.name)
+        return "{0}_{1}".format(self.dev.system.serial, self.dev.name)

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -209,4 +209,4 @@ class AqualinkEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique identifier for this entity."""
-        return "{0}_{1}".format(self.dev.system.serial, self.dev.name)
+        return f"{self.dev.system.serial}_{self.dev.name}"

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -1,0 +1,54 @@
+"""Support for Aqualink temperature sensors."""
+import logging
+
+from iaqualink import AqualinkBinarySensor
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice,
+    DEVICE_CLASS_COLD,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import AqualinkEntityMixin
+from .const import DOMAIN as AQUALINK_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up discovered binary sensors."""
+    devs = []
+    for dev in hass.data[AQUALINK_DOMAIN][DOMAIN]:
+        devs.append(HassAqualinkBinarySensor(dev))
+    async_add_entities(devs, True)
+
+
+class HassAqualinkBinarySensor(BinarySensorDevice, AqualinkEntityMixin):
+    """Representation of a binary sensor."""
+
+    def __init__(self, dev: AqualinkBinarySensor):
+        """Initialize the binary sensor."""
+        self.dev = dev
+
+    @property
+    def name(self) -> str:
+        """Return the name of the binary sensor."""
+        return self.dev.label
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the binary sensor is on or not."""
+        return self.dev.is_on
+
+    @property
+    def device_class(self) -> str:
+        """Return the class of the binary sensor."""
+        if self.name == "Freeze Protection":
+            return DEVICE_CLASS_COLD
+        return None

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntityMixin
+from . import AqualinkEntity
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,12 +29,12 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkBinarySensor(BinarySensorDevice, AqualinkEntityMixin):
+class HassAqualinkBinarySensor(BinarySensorDevice, AqualinkEntity):
     """Representation of a binary sensor."""
 
     def __init__(self, dev: AqualinkBinarySensor):
         """Initialize the binary sensor."""
-        self.dev = dev
+        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -1,8 +1,6 @@
 """Support for Aqualink temperature sensors."""
 import logging
 
-from iaqualink import AqualinkBinarySensor
-
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice,
     DEVICE_CLASS_COLD,
@@ -29,12 +27,8 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkBinarySensor(BinarySensorDevice, AqualinkEntity):
+class HassAqualinkBinarySensor(AqualinkEntity, BinarySensorDevice):
     """Representation of a binary sensor."""
-
-    def __init__(self, dev: AqualinkBinarySensor):
-        """Initialize the binary sensor."""
-        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -3,10 +3,10 @@ import logging
 from typing import List, Optional
 
 from iaqualink import (
-    AqualinkState,
     AqualinkHeater,
     AqualinkPump,
     AqualinkSensor,
+    AqualinkState,
     AqualinkThermostat,
 )
 from iaqualink.const import (
@@ -27,7 +27,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntityMixin, refresh_system
+from . import AqualinkEntity, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN, CLIMATE_SUPPORTED_MODES
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,12 +45,12 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkThermostat(ClimateDevice, AqualinkEntityMixin):
+class HassAqualinkThermostat(ClimateDevice, AqualinkEntity):
     """Representation of a thermostat."""
 
     def __init__(self, dev: AqualinkThermostat):
         """Initialize the thermostat."""
-        self.dev = dev
+        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -2,13 +2,7 @@
 import logging
 from typing import List, Optional
 
-from iaqualink import (
-    AqualinkHeater,
-    AqualinkPump,
-    AqualinkSensor,
-    AqualinkState,
-    AqualinkThermostat,
-)
+from iaqualink import AqualinkHeater, AqualinkPump, AqualinkSensor, AqualinkState
 from iaqualink.const import (
     AQUALINK_TEMP_CELSIUS_HIGH,
     AQUALINK_TEMP_CELSIUS_LOW,
@@ -45,12 +39,8 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkThermostat(ClimateDevice, AqualinkEntity):
+class HassAqualinkThermostat(AqualinkEntity, ClimateDevice):
     """Representation of a thermostat."""
-
-    def __init__(self, dev: AqualinkThermostat):
-        """Initialize the thermostat."""
-        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -27,7 +27,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntity, refresh_system
+from . import AqualinkEntityMixin, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN, CLIMATE_SUPPORTED_MODES
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkThermostat(ClimateDevice, AqualinkEntity):
+class HassAqualinkThermostat(ClimateDevice, AqualinkEntityMixin):
     """Representation of a thermostat."""
 
     def __init__(self, dev: AqualinkThermostat):

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -1,7 +1,7 @@
 """Support for Aqualink pool lights."""
 import logging
 
-from iaqualink import AqualinkLight, AqualinkLightEffect
+from iaqualink import AqualinkLightEffect
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -32,12 +32,8 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkLight(Light, AqualinkEntity):
+class HassAqualinkLight(AqualinkEntity, Light):
     """Representation of a light."""
-
-    def __init__(self, dev: AqualinkLight):
-        """Initialize the light."""
-        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntityMixin, refresh_system
+from . import AqualinkEntity, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,12 +32,12 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkLight(Light, AqualinkEntityMixin):
+class HassAqualinkLight(Light, AqualinkEntity):
     """Representation of a light."""
 
     def __init__(self, dev: AqualinkLight):
         """Initialize the light."""
-        self.dev = dev
+        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntity, refresh_system
+from . import AqualinkEntityMixin, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkLight(Light, AqualinkEntity):
+class HassAqualinkLight(Light, AqualinkEntityMixin):
     """Representation of a light."""
 
     def __init__(self, dev: AqualinkLight):

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -2,8 +2,6 @@
 import logging
 from typing import Optional
 
-from iaqualink import AqualinkSensor
-
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
@@ -29,10 +27,6 @@ async def async_setup_entry(
 
 class HassAqualinkSensor(AqualinkEntity):
     """Representation of a sensor."""
-
-    def __init__(self, dev: AqualinkSensor):
-        """Initialize the sensor."""
-        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -7,10 +7,9 @@ from iaqualink import AqualinkSensor
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntityMixin
+from . import AqualinkEntity
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,12 +27,12 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkSensor(Entity, AqualinkEntityMixin):
+class HassAqualinkSensor(AqualinkEntity):
     """Representation of a sensor."""
 
     def __init__(self, dev: AqualinkSensor):
         """Initialize the sensor."""
-        self.dev = dev
+        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -7,9 +7,10 @@ from iaqualink import AqualinkSensor
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntity
+from . import AqualinkEntityMixin
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkSensor(AqualinkEntity):
+class HassAqualinkSensor(Entity, AqualinkEntityMixin):
     """Representation of a sensor."""
 
     def __init__(self, dev: AqualinkSensor):

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -1,8 +1,6 @@
 """Support for Aqualink pool feature switches."""
 import logging
 
-from iaqualink import AqualinkToggle
-
 from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
@@ -25,12 +23,8 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkSwitch(SwitchDevice, AqualinkEntity):
+class HassAqualinkSwitch(AqualinkEntity, SwitchDevice):
     """Representation of a switch."""
-
-    def __init__(self, dev: AqualinkToggle):
-        """Initialize the switch."""
-        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -7,7 +7,7 @@ from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntityMixin, refresh_system
+from . import AqualinkEntity, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,12 +25,12 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkSwitch(SwitchDevice, AqualinkEntityMixin):
+class HassAqualinkSwitch(SwitchDevice, AqualinkEntity):
     """Representation of a switch."""
 
     def __init__(self, dev: AqualinkToggle):
         """Initialize the switch."""
-        self.dev = dev
+        AqualinkEntity.__init__(self, dev)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -7,7 +7,7 @@ from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import AqualinkEntity, refresh_system
+from . import AqualinkEntityMixin, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ async def async_setup_entry(
     async_add_entities(devs, True)
 
 
-class HassAqualinkSwitch(SwitchDevice, AqualinkEntity):
+class HassAqualinkSwitch(SwitchDevice, AqualinkEntityMixin):
     """Representation of a switch."""
 
     def __init__(self, dev: AqualinkToggle):


### PR DESCRIPTION
## Description:

This PR introduces a new binary_sensor platform solving the issue with the freeze_protection sensor not being identified properly.

This also introduces the use of unique_id for all existing platforms to allow future multi-pool support.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10354

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
