### PR TITLE
Add group attribute to Homematic IP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -38,7 +38,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
-from .device import ATTR_GROUP_MEMBER_UNREACHABLE, ATTR_MODEL_TYPE
+from .device import ATTR_GROUP_MEMBER_UNREACHABLE, ATTR_IS_GROUP, ATTR_MODEL_TYPE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -312,7 +312,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericDevice, BinarySensorD
     @property
     def device_state_attributes(self):
         """Return the state attributes of the security zone group."""
-        state_attr = {ATTR_MODEL_TYPE: self._device.modelType}
+        state_attr = {ATTR_MODEL_TYPE: self._device.modelType, ATTR_IS_GROUP: True}
 
         for attr, attr_key in GROUP_ATTRIBUTES.items():
             attr_value = getattr(self._device, attr, None)

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_MODEL_TYPE = "model_type"
 ATTR_ID = "id"
+ATTR_IS_GROUP = "is_group"
 # RSSI HAP -> Device
 ATTR_RSSI_DEVICE = "rssi_device"
 # RSSI Device -> HAP
@@ -130,5 +131,7 @@ class HomematicipGenericDevice(Entity):
                 attr_value = getattr(self._device, attr, None)
                 if attr_value:
                     state_attr[attr_key] = attr_value
+
+            state_attr[ATTR_IS_GROUP] = False
 
         return state_attr

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -150,7 +150,7 @@ class HomematicipAccesspointStatus(HomematicipGenericDevice):
 
     @property
     def device_state_attributes(self):
-        """Return the state attributes of the security zone group."""
+        """Return the state attributes of the access point."""
         return {ATTR_MODEL_TYPE: self._device.modelType, ATTR_IS_GROUP: False}
 
 

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -35,7 +35,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
-from .device import ATTR_MODEL_TYPE
+from .device import ATTR_IS_GROUP, ATTR_MODEL_TYPE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -151,7 +151,7 @@ class HomematicipAccesspointStatus(HomematicipGenericDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the security zone group."""
-        return {ATTR_MODEL_TYPE: self._device.modelType}
+        return {ATTR_MODEL_TYPE: self._device.modelType, ATTR_IS_GROUP: False}
 
 
 class HomematicipHeatingThermostat(HomematicipGenericDevice):

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -19,7 +19,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice
-from .device import ATTR_GROUP_MEMBER_UNREACHABLE
+from .device import ATTR_GROUP_MEMBER_UNREACHABLE, ATTR_IS_GROUP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ class HomematicipGroupSwitch(HomematicipGenericDevice, SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the switch-group."""
-        state_attr = {}
+        state_attr = {ATTR_IS_GROUP: True}
         if self._device.unreach:
             state_attr[ATTR_GROUP_MEMBER_UNREACHABLE] = True
         return state_attr


### PR DESCRIPTION
## Description:
This PR adds an attribute (is_group) to identify group based entities e.g. for filtering.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
