### PR TITLE
Fix KeyError exception when triggering an alarm that is already triggered

### DIFF
--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -318,10 +318,9 @@ class ManualAlarm(alarm.AlarmControlPanel, RestoreEntity):
         No code needed, a trigger time of zero for the current state
         disables the alarm.
         """
-        try:
-            if not self._trigger_time_by_state[self._active_state]:
-                return
-        except KeyError:
+        if self._active_state == STATE_ALARM_TRIGGERED:
+            return
+        if not self._trigger_time_by_state[self._active_state]:
             return
         self._update_state(STATE_ALARM_TRIGGERED)
 

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -318,7 +318,10 @@ class ManualAlarm(alarm.AlarmControlPanel, RestoreEntity):
         No code needed, a trigger time of zero for the current state
         disables the alarm.
         """
-        if not self._trigger_time_by_state[self._active_state]:
+        try:
+            if not self._trigger_time_by_state[self._active_state]:
+                return
+        except KeyError:
             return
         self._update_state(STATE_ALARM_TRIGGERED)
 


### PR DESCRIPTION
## Description:

_trigger_time_by_state doesn't have a value for 'triggered' so it seems calling
alarm_trigger while self._active_state is 'triggered' results in the
following exception being raised:

```
2019-09-10 21:11:32 ERROR (MainThread) [homeassistant.components.automation] Error while executing automation automation.automation_name. Unknown error for call_service at pos 2:
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/homeassistant/components/automation/__init__.py", line 431, in action
    await script_obj.async_run(variables, context)
  File "/usr/lib/python3.7/site-packages/homeassistant/helpers/script.py", line 151, in async_run
    await self._handle_action(action, variables, context)
  File "/usr/lib/python3.7/site-packages/homeassistant/helpers/script.py", line 235, in _handle_action
    await self._actions[_determine_action(action)](action, variables, context)
  File "/usr/lib/python3.7/site-packages/homeassistant/helpers/script.py", line 318, in _async_call_service
    context=context,
  File "/usr/lib/python3.7/site-packages/homeassistant/helpers/service.py", line 98, in async_call_from_config
    domain, service_name, service_data, blocking=blocking, context=context
  File "/usr/lib/python3.7/site-packages/homeassistant/core.py", line 1235, in async_call
    await asyncio.shield(self._execute_service(handler, service_call))
  File "/usr/lib/python3.7/site-packages/homeassistant/core.py", line 1260, in _execute_service
    await handler.func(service_call)
  File "/usr/lib/python3.7/site-packages/homeassistant/helpers/entity_component.py", line 210, in handle_service
    self._platforms.values(), func, call, service_name, required_features
  File "/usr/lib/python3.7/site-packages/homeassistant/helpers/service.py", line 349, in entity_service_call
    future.result()  # pop exception if have
  File "/usr/lib/python3.7/site-packages/homeassistant/helpers/service.py", line 371, in _handle_service_platform_call
    await getattr(entity, func)(**data)
  File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.7/site-packages/homeassistant/components/manual/alarm_control_panel.py", line 321, in alarm_trigger
    if not self._trigger_time_by_state[self._active_state]:
KeyError: 'triggered'
```

In that case, just ignore the call to alarm_trigger since it wouldn't do
anything anyway.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
