### PR TITLE
HM-CC-TC was not recognized

### DIFF
--- a/homeassistant/components/homematic/climate.py
+++ b/homeassistant/components/homematic/climate.py
@@ -94,9 +94,13 @@ class HMThermostat(HMDevice, ClimateDevice):
         if self._data.get("BOOST_MODE", False):
             return "boost"
 
-        # Get the name of the mode
-        mode = HM_ATTRIBUTE_SUPPORT[HM_CONTROL_MODE][1][self._hm_control_mode]
-        mode = mode.lower()
+        try:
+            # Get the name of the mode
+            mode = HM_ATTRIBUTE_SUPPORT[HM_CONTROL_MODE][1][self._hm_control_mode]
+            mode = mode.lower()
+        except KeyError:
+            # In case that the device has no control mode
+            return None
 
         # Filter HVAC states
         if mode not in (HVAC_MODE_AUTO, HVAC_MODE_HEAT):
@@ -177,8 +181,13 @@ class HMThermostat(HMDevice, ClimateDevice):
         """Return Control mode."""
         if HMIP_CONTROL_MODE in self._data:
             return self._data[HMIP_CONTROL_MODE]
-        # Homematic
-        return self._data["CONTROL_MODE"]
+
+        try:
+            # Homematic
+            return self._data["CONTROL_MODE"]
+        except KeyError:
+            # In case that the device has no control mode
+            return None
 
     def _init_data_struct(self):
         """Generate a data dict (self._data) from the Homematic metadata."""

--- a/homeassistant/components/homematic/climate.py
+++ b/homeassistant/components/homematic/climate.py
@@ -94,13 +94,11 @@ class HMThermostat(HMDevice, ClimateDevice):
         if self._data.get("BOOST_MODE", False):
             return "boost"
 
-        try:
-            # Get the name of the mode
-            mode = HM_ATTRIBUTE_SUPPORT[HM_CONTROL_MODE][1][self._hm_control_mode]
-            mode = mode.lower()
-        except KeyError:
-            # In case that the device has no control mode
+        if not self._hm_control_mode:
             return None
+
+        mode = HM_ATTRIBUTE_SUPPORT[HM_CONTROL_MODE][1][self._hm_control_mode]
+        mode = mode.lower()
 
         # Filter HVAC states
         if mode not in (HVAC_MODE_AUTO, HVAC_MODE_HEAT):
@@ -182,12 +180,8 @@ class HMThermostat(HMDevice, ClimateDevice):
         if HMIP_CONTROL_MODE in self._data:
             return self._data[HMIP_CONTROL_MODE]
 
-        try:
-            # Homematic
-            return self._data["CONTROL_MODE"]
-        except KeyError:
-            # In case that the device has no control mode
-            return None
+        # Homematic
+        return self._data.get("CONTROL_MODE")
 
     def _init_data_struct(self):
         """Generate a data dict (self._data) from the Homematic metadata."""


### PR DESCRIPTION
#25196  Description: Fixes Homematic HM-TC-CC exception. This device has no control mode what leads to an ecxeption.


**Related issue (if applicable):** fixes #25455

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]



[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
