### PR TITLE
[BLOCKED] Added device_id Argument to spotify.play_playlist

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -52,7 +52,7 @@ PLAY_PLAYLIST_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_MEDIA_CONTENT_ID): cv.string,
         vol.Optional(ATTR_RANDOM_SONG, default=False): cv.boolean,
-        vol.Optional(ATTR_DEVICE_ID, default=""): cv.string
+        vol.Optional(ATTR_DEVICE_ID, default=""): cv.string,
     }
 )
 

--- a/homeassistant/components/spotify/services.yaml
+++ b/homeassistant/components/spotify/services.yaml
@@ -7,3 +7,6 @@ play_playlist:
     random_song:
       description: True to select random song at start, False to start from beginning.
       example: true
+    device_id:
+      description: Spotify device id to start playback on.
+      example: 'abcdef123'


### PR DESCRIPTION
Description:

spotipy.client.Spotify.start_playback accepts a device_id. Not passing a device_id starts playback on an active device. If there are no active devices, this call fails. Passing a device id allows triggering playback on known but inactive devices.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10359

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
