### PR TITLE
Forget amcrest auth token when going offline so we can reconnect

### DIFF
--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -167,6 +167,8 @@ class AmcrestChecker(Http):
                 offline = not self.available
             if offline and was_online:
                 _LOGGER.error("%s camera offline: Too many errors", self._wrap_name)
+                with self._token_lock:
+                    self._token = None
                 dispatcher_send(
                     self._hass, service_signal(SERVICE_UPDATE, self._wrap_name)
                 )


### PR DESCRIPTION
## Description:
When an amcrest camera was unplugged and then plugged again it was impossible to reconnect to it, since the old auth token was reused while we need to use a new one.

In fact, the method that is called every minute to check the camera availability is going to fail always since we're reusing an old token.

By forgetting the token (setting it to None) when going offline, we ensure that we'll regenerate it in the next commands thus allowing to reconnect to the camera when it comes back online.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
