### PR TITLE
Add config flow to ecobee

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -158,6 +158,7 @@ omit =
     homeassistant/components/ecoal_boiler/*
     homeassistant/components/ecobee/__init__.py
     homeassistant/components/ecobee/binary_sensor.py
+    homeassistant/components/ecobee/climate.py
     homeassistant/components/ecobee/notify.py
     homeassistant/components/ecobee/sensor.py
     homeassistant/components/ecobee/weather.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -156,6 +156,7 @@ omit =
     homeassistant/components/ebox/sensor.py
     homeassistant/components/ebusd/*
     homeassistant/components/ecoal_boiler/*
+    homeassistant/components/ecobee/__init__.py
     homeassistant/components/ecobee/binary_sensor.py
     homeassistant/components/ecobee/notify.py
     homeassistant/components/ecobee/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -156,7 +156,10 @@ omit =
     homeassistant/components/ebox/sensor.py
     homeassistant/components/ebusd/*
     homeassistant/components/ecoal_boiler/*
-    homeassistant/components/ecobee/*
+    homeassistant/components/ecobee/binary_sensor.py
+    homeassistant/components/ecobee/notify.py
+    homeassistant/components/ecobee/sensor.py
+    homeassistant/components/ecobee/weather.py
     homeassistant/components/econet/water_heater.py
     homeassistant/components/ecovacs/*
     homeassistant/components/eddystone_temperature/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -73,6 +73,7 @@ homeassistant/components/digital_ocean/* @fabaff
 homeassistant/components/discogs/* @thibmaek
 homeassistant/components/doorbird/* @oblogic7
 homeassistant/components/dweet/* @fabaff
+homeassistant/components/ecobee/* @marthoc
 homeassistant/components/ecovacs/* @OverloadUT
 homeassistant/components/egardia/* @jeroenterheerdt
 homeassistant/components/eight_sleep/* @mezz64

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -72,26 +72,6 @@ set_swing_mode:
     swing_mode:
       description: New value of swing mode.
 
-ecobee_set_fan_min_on_time:
-  description: Set the minimum fan on time.
-  fields:
-    entity_id:
-      description: Name(s) of entities to change.
-      example: 'climate.kitchen'
-    fan_min_on_time:
-      description: New value of fan min on time.
-      example: 5
-
-ecobee_resume_program:
-  description: Resume the programmed schedule.
-  fields:
-    entity_id:
-      description: Name(s) of entities to change.
-      example: 'climate.kitchen'
-    resume_all:
-      description: Resume all events and return to the scheduled program. This default to false which removes only the top event.
-      example: true
-
 mill_set_room_temperature:
   description: Set Mill room temperatures.
   fields:

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -17,9 +17,7 @@
             "token_request_failed": "Error requesting tokens from ecobee; please try again."
         },
         "abort": {
-            "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
-            "one_instance_only": "This integration currently supports only one ecobee instance.",
-            "refresh_token_expired": "Your refresh token has expired; please re-start configuration."
+            "one_instance_only": "This integration currently supports only one ecobee instance."
         }
     },
     "options": {

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -10,10 +10,6 @@
             "authorize": {
                 "title": "Authorize app on ecobee.com",
                 "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit."
-            },
-            "import": {
-                "title": "Import ecobee configuration",
-                "description": "Press Submit to import existing configuration data."
             }
         },
         "error": {

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -10,6 +10,10 @@
             "authorize": {
                 "title": "Authorize app on ecobee.com",
                 "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit."
+            },
+            "import": {
+                "title": "Import ecobee configuration",
+                "description": "Press Submit to import existing configuration data."
             }
         },
         "error": {

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "title": "ecobee",
         "step": {
-            "init": {
+            "user": {
                 "title": "ecobee API key",
                 "description": "Please enter the API key obtained from ecobee.com.",
                 "data": {"api_key": "API Key"}

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -9,17 +9,17 @@
             },
             "authorize": {
                 "title": "Authorize app on ecobee.com",
-                "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit.",
+                "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit."
             }
         },
         "error": {
             "pin_request_failed": "Error requesting PIN from ecobee; please verify API key is correct.",
-            "token_request_failed": "Error requesting tokens from ecobee; please try again.",
+            "token_request_failed": "Error requesting tokens from ecobee; please try again."
         },
         "abort": {
             "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
             "one_instance_only": "This integration currently supports only one ecobee instance.",
-            "refresh_token_expired": "Your refresh token has expired; please re-start configuration.",
+            "refresh_token_expired": "Your refresh token has expired; please re-start configuration."
         }
     },
     "options": {

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -19,15 +19,5 @@
         "abort": {
             "one_instance_only": "This integration currently supports only one ecobee instance."
         }
-    },
-    "options": {
-        "step": {
-            "ecobee_options": {
-                "description": "ecobee Options",
-                "data": {
-                    "hold_temp": "Hold changes indefinitely (checked) or until the next scheduled event (unchecked)."
-                }
-            }
-        }
     }
 }

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -5,12 +5,12 @@
             "init": {
                 "title": "ecobee API key",
                 "description": "Please enter the API key obtained from ecobee.com.",
-                "data": {"api_key": "API Key"},
+                "data": {"api_key": "API Key"}
             },
             "authorize": {
                 "title": "Authorize app on ecobee.com",
                 "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit.",
-            },
+            }
         },
         "error": {
             "pin_request_failed": "Error requesting PIN from ecobee; please verify API key is correct.",
@@ -20,7 +20,7 @@
             "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
             "one_instance_only": "This integration currently supports only one ecobee instance.",
             "refresh_token_expired": "Your refresh token has expired; please re-start configuration.",
-        },
+        }
     },
     "options": {
         "step": {
@@ -28,8 +28,8 @@
                 "description": "ecobee Options",
                 "data": {
                     "hold_temp": "Hold changes indefinitely (checked) or until the next scheduled event (unchecked)."
-                },
+                }
             }
         }
-    },
+    }
 }

--- a/homeassistant/components/ecobee/.translations/en.json
+++ b/homeassistant/components/ecobee/.translations/en.json
@@ -1,0 +1,35 @@
+{
+    "config": {
+        "title": "ecobee",
+        "step": {
+            "init": {
+                "title": "ecobee API key",
+                "description": "Please enter the API key obtained from ecobee.com.",
+                "data": {"api_key": "API Key"},
+            },
+            "authorize": {
+                "title": "Authorize app on ecobee.com",
+                "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit.",
+            },
+        },
+        "error": {
+            "pin_request_failed": "Error requesting PIN from ecobee; please verify API key is correct.",
+            "token_request_failed": "Error requesting tokens from ecobee; please try again.",
+        },
+        "abort": {
+            "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
+            "one_instance_only": "This integration currently supports only one ecobee instance.",
+            "refresh_token_expired": "Your refresh token has expired; please re-start configuration.",
+        },
+    },
+    "options": {
+        "step": {
+            "ecobee_options": {
+                "description": "ecobee Options",
+                "data": {
+                    "hold_temp": "Hold changes indefinitely (checked) or until the next scheduled event (unchecked)."
+                },
+            }
+        }
+    },
+}

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -60,9 +60,6 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up ecobee via a config entry."""
-    if DATA_ECOBEE_CONFIG not in hass.data:
-        hass.data[DATA_ECOBEE_CONFIG] = {}
-
     if not entry.options:
         """Loading via config entry for the first time, set up options."""
         await async_populate_options(hass, entry)

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -11,6 +11,8 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.util import Throttle
 from homeassistant.util.json import save_json
 
+from . import config_flow  # noqa  pylint_disable=unused-import
+
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -154,3 +154,14 @@ async def async_populate_options(hass, config_entry):
     options = {CONF_HOLD_TEMP: hold_temp}
 
     hass.config_entries.async_update_entry(config_entry, options=options)
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload the config entry, but store the ecobee API key for later."""
+    hass.data.pop(DOMAIN)
+    hass.data[DATA_ECOBEE_CONFIG] = {CONF_API_KEY: config_entry.data[CONF_API_KEY]}
+
+    for platform in ECOBEE_PLATFORMS:
+        await hass.config_entries.async_forward_entry_unload(config_entry, platform)
+
+    return True

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -47,8 +47,8 @@ async def async_setup(hass, config):
     """
     hass.data[DATA_ECOBEE_CONFIG] = config.get(DOMAIN, {})
 
-    if not hass.config_entries.async_entries(DOMAIN):
-        """No config entry exists; trigger the import flow."""
+    if not hass.config_entries.async_entries(DOMAIN) and hass.data[DATA_ECOBEE_CONFIG]:
+        """No config entry exists and configuration.yaml config exists, trigger the import flow."""
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_IMPORT}

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -1,32 +1,32 @@
-"""Support for Ecobee devices."""
-import logging
+"""Support for ecobee."""
 import os
 from datetime import timedelta
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers import discovery
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_API_KEY
+from homeassistant.helpers import config_validation as cv
 from homeassistant.util import Throttle
-from homeassistant.util.json import save_json
 
-from . import config_flow  # noqa  pylint_disable=unused-import
-from .const import CONF_HOLD_TEMP, DOMAIN, ECOBEE_CONFIG_FILE
-
-_CONFIGURING = {}
-_LOGGER = logging.getLogger(__name__)
+from .const import (
+    CONF_HOLD_TEMP,
+    CONF_REFRESH_TOKEN,
+    DATA_ECOBEE_CONFIG,
+    DEFAULT_HOLD_TEMP,
+    DOMAIN,
+    ECOBEE_PLATFORMS,
+    _LOGGER,
+)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=180)
-
-NETWORK = None
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
                 vol.Optional(CONF_API_KEY): cv.string,
-                vol.Optional(CONF_HOLD_TEMP, default=False): cv.boolean,
+                vol.Optional(CONF_HOLD_TEMP, DEFAULT_HOLD_TEMP): cv.boolean,
             }
         )
     },
@@ -34,87 +34,123 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def request_configuration(network, hass, config):
-    """Request configuration steps from the user."""
-    configurator = hass.components.configurator
-    if "ecobee" in _CONFIGURING:
-        configurator.notify_errors(
-            _CONFIGURING["ecobee"], "Failed to register, please try again."
+async def async_setup(hass, config):
+    """
+    Ecobee only uses config flow for configuration.
+
+    But, an existing configuration.yaml config and ecobee.conf
+    will trigger an import flow if a config entry doesn't
+    already exist to help users migrating from the old ecobee
+    component.
+    """
+    from pyecobee import ECOBEE_CONFIG_FILENAME
+
+    if not hass.config_entries.async_entries(DOMAIN) and os.path.isfile(
+        hass.config.path(ECOBEE_CONFIG_FILENAME)
+    ):
+        """Store legacy config to later populate options."""
+        hass.data[DATA_ECOBEE_CONFIG] = config[DOMAIN]
+        """No config entry exists and ecobee.conf exists; trigger the import flow."""
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}
+            )
         )
 
-        return
-
-    def ecobee_configuration_callback(callback_data):
-        """Handle configuration callbacks."""
-        network.request_tokens()
-        network.update()
-        setup_ecobee(hass, network, config)
-
-    _CONFIGURING["ecobee"] = configurator.request_config(
-        "Ecobee",
-        ecobee_configuration_callback,
-        description=(
-            "Please authorize this app at https://www.ecobee.com/consumer"
-            "portal/index.html with pin code: " + network.pin
-        ),
-        description_image="/static/images/config_ecobee_thermostat.png",
-        submit_caption="I have authorized the app.",
-    )
+    return True
 
 
-def setup_ecobee(hass, network, config):
-    """Set up the Ecobee thermostat."""
-    # If ecobee has a PIN then it needs to be configured.
-    if network.pin is not None:
-        request_configuration(network, hass, config)
-        return
+async def async_setup_entry(hass, entry):
+    """Set up ecobee via a config entry."""
 
-    if "ecobee" in _CONFIGURING:
-        configurator = hass.components.configurator
-        configurator.request_done(_CONFIGURING.pop("ecobee"))
+    if not entry.options:
+        """Loading via config entry for the first time, set up options."""
+        await async_populate_options(hass, entry)
 
-    hold_temp = config[DOMAIN].get(CONF_HOLD_TEMP)
+    api_key = entry.data[CONF_API_KEY]
+    refresh_token = entry.data[CONF_REFRESH_TOKEN]
 
-    discovery.load_platform(hass, "climate", DOMAIN, {"hold_temp": hold_temp}, config)
-    discovery.load_platform(hass, "sensor", DOMAIN, {}, config)
-    discovery.load_platform(hass, "binary_sensor", DOMAIN, {}, config)
-    discovery.load_platform(hass, "weather", DOMAIN, {}, config)
+    ecobee = EcobeeData(hass, entry, api_key=api_key, refresh_token=refresh_token)
+
+    if not await ecobee.refresh():
+        return False
+
+    await ecobee.update()
+
+    if ecobee.account.thermostats is None:
+        _LOGGER.error("No ecobee devices found to set up.")
+        return False
+
+    hass.data[DOMAIN] = ecobee
+
+    for component in ECOBEE_PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
 
 
 class EcobeeData:
-    """Get the latest data and update the states."""
+    """
+    Handle getting the latest data from ecobee.com so platforms can use it.
 
-    def __init__(self, config_file):
-        """Init the Ecobee data object."""
-        from pyecobee import Ecobee
+    Also handle refreshing tokens and updating config entry with refreshed tokens.
+    """
 
-        self.ecobee = Ecobee(config_file)
+    def __init__(self, hass, entry, api_key, refresh_token):
+        """Initialize the Ecobee data object."""
+        from pyecobee import Ecobee, ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
+
+        self._hass = hass
+        self._entry = entry
+        self.account = Ecobee(
+            config={ECOBEE_API_KEY: api_key, ECOBEE_REFRESH_TOKEN: refresh_token}
+        )
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
-        """Get the latest data from pyecobee."""
-        self.ecobee.update()
-        _LOGGER.debug("Ecobee data updated successfully")
+    async def update(self):
+        """Get the latest data from ecobee.com."""
+        from pyecobee import ExpiredTokenError
+
+        try:
+            await self._hass.async_add_executor_job(self.account.update)
+            _LOGGER.debug("Updating ecobee.")
+        except ExpiredTokenError:
+            _LOGGER.warn("ecobee update failed; attempting to refresh expired tokens.")
+            await self.refresh()
+
+    async def refresh(self) -> bool:
+        """Refresh ecobee tokens and update config entry."""
+        from pyecobee import ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
+
+        _LOGGER.debug("Refreshing ecobee tokens and updating config entry.")
+        if await self._hass.async_add_executor_job(self.account.refresh_tokens):
+            self._hass.config_entries.async_update_entry(
+                self._entry,
+                data={
+                    CONF_API_KEY: self.account.config[ECOBEE_API_KEY],
+                    CONF_REFRESH_TOKEN: self.account.config[ECOBEE_REFRESH_TOKEN],
+                },
+            )
+            return True
+        else:
+            _LOGGER.error("Error updating ecobee tokens.")
+            return False
 
 
-def setup(hass, config):
-    """Set up the Ecobee.
-
-    Will automatically load thermostat and sensor components to support
-    devices discovered on the network.
+async def async_populate_options(hass, config_entry):
     """
-    global NETWORK
+    Populate options for ecobee. Called by async_setup_entry.
 
-    if "ecobee" in _CONFIGURING:
-        return
+    Options will be initially set to the values specified in
+    configuration.yaml, if they exist, or, if not, the default.
+    """
+    try:
+        hold_temp = hass.data[DATA_ECOBEE_CONFIG].get(CONF_HOLD_TEMP, DEFAULT_HOLD_TEMP)
+    except KeyError:
+        hold_temp = DEFAULT_HOLD_TEMP
 
-    # Create ecobee.conf if it doesn't exist
-    if not os.path.isfile(hass.config.path(ECOBEE_CONFIG_FILE)):
-        jsonconfig = {"API_KEY": config[DOMAIN].get(CONF_API_KEY)}
-        save_json(hass.config.path(ECOBEE_CONFIG_FILE), jsonconfig)
+    options = {CONF_HOLD_TEMP: hold_temp}
 
-    NETWORK = EcobeeData(hass.config.path(ECOBEE_CONFIG_FILE))
-
-    setup_ecobee(hass, NETWORK.ecobee, config)
-
-    return True
+    hass.config_entries.async_update_entry(config_entry, options=options)

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -69,10 +69,10 @@ async def async_setup_entry(hass, entry):
 
     data = EcobeeData(hass, entry, api_key=api_key, refresh_token=refresh_token)
 
-    if not await hass.async_add_executor_job(data.refresh):
+    if not await data.refresh():
         return False
 
-    await hass.async_add_executor_job(data.update)
+    await data.update()
 
     if data.ecobee.thermostats is None:
         _LOGGER.error("No ecobee devices found to set up")

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -48,7 +48,7 @@ async def async_setup(hass, config):
     hass.data[DATA_ECOBEE_CONFIG] = config.get(DOMAIN, {})
 
     if not hass.config_entries.async_entries(DOMAIN) and hass.data[DATA_ECOBEE_CONFIG]:
-        """No config entry exists and configuration.yaml config exists, trigger the import flow."""
+        # No config entry exists and configuration.yaml config exists, trigger the import flow.
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_IMPORT}
@@ -61,7 +61,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, entry):
     """Set up ecobee via a config entry."""
     if not entry.options:
-        """Loading via config entry for the first time, set up options."""
+        # Loading via config entry for the first time, set up options.
         await async_populate_options(hass, entry)
 
     api_key = entry.data[CONF_API_KEY]

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -45,7 +45,7 @@ async def async_setup(hass, config):
     migrating from the old ecobee component. Otherwise, the user will have to
     continue setting up the integration via the config flow.
     """
-    hass.data[DATA_ECOBEE_CONFIG] = config[DOMAIN]
+    hass.data[DATA_ECOBEE_CONFIG] = config.get(DOMAIN, {})
 
     if not hass.config_entries.async_entries(DOMAIN):
         """No config entry exists; trigger the import flow."""

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -1,4 +1,5 @@
 """Support for ecobee."""
+import asyncio
 from datetime import timedelta
 import voluptuous as vol
 
@@ -152,7 +153,10 @@ async def async_unload_entry(hass, config_entry):
     """Unload the config entry and platforms."""
     hass.data.pop(DOMAIN)
 
+    tasks = []
     for platform in ECOBEE_PLATFORMS:
-        await hass.config_entries.async_forward_entry_unload(config_entry, platform)
+        tasks.append(
+            hass.config_entries.async_forward_entry_unload(config_entry, platform)
+        )
 
-    return True
+    return all(await asyncio.gather(*tasks))

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -104,19 +104,19 @@ class EcobeeData:
         )
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
+    async def update(self):
         """Get the latest data from ecobee.com."""
         try:
-            self.ecobee.update()
+            await self._hass.async_add_executor_job(self.ecobee.update)
             _LOGGER.debug("Updating ecobee")
         except ExpiredTokenError:
             _LOGGER.warn("ecobee update failed; attempting to refresh expired tokens")
-            self.refresh()
+            await self.refresh()
 
-    def refresh(self) -> bool:
+    async def refresh(self) -> bool:
         """Refresh ecobee tokens and update config entry."""
         _LOGGER.debug("Refreshing ecobee tokens and updating config entry")
-        if self.ecobee.refresh_tokens():
+        if await self._hass.async_add_executor_job(self.ecobee.refresh_tokens):
             self._hass.config_entries.async_update_entry(
                 self._entry,
                 data={

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -11,10 +11,8 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.util import Throttle
 
 from .const import (
-    CONF_HOLD_TEMP,
     CONF_REFRESH_TOKEN,
     DATA_ECOBEE_CONFIG,
-    DEFAULT_HOLD_TEMP,
     DOMAIN,
     ECOBEE_PLATFORMS,
     _LOGGER,
@@ -23,15 +21,7 @@ from .const import (
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=180)
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_API_KEY): cv.string,
-                vol.Optional(CONF_HOLD_TEMP, default=DEFAULT_HOLD_TEMP): cv.boolean,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
+    {DOMAIN: vol.Schema({vol.Optional(CONF_API_KEY): cv.string})}, extra=vol.ALLOW_EXTRA
 )
 
 
@@ -60,10 +50,6 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up ecobee via a config entry."""
-    if not entry.options:
-        # Loading via config entry for the first time, set up options.
-        await async_populate_options(hass, entry)
-
     api_key = entry.data[CONF_API_KEY]
     refresh_token = entry.data[CONF_REFRESH_TOKEN]
 
@@ -129,22 +115,6 @@ class EcobeeData:
             return True
         _LOGGER.error("Error updating ecobee tokens")
         return False
-
-
-async def async_populate_options(hass, config_entry):
-    """
-    Populate options for ecobee. Called by async_setup_entry.
-
-    Options will be initially set to the values specified in
-    configuration.yaml, if they exist, or, if not, the default.
-    """
-    options = {
-        CONF_HOLD_TEMP: hass.data[DATA_ECOBEE_CONFIG].get(
-            CONF_HOLD_TEMP, DEFAULT_HOLD_TEMP
-        )
-    }
-
-    hass.config_entries.async_update_entry(config_entry, options=options)
 
 
 async def async_unload_entry(hass, config_entry):

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -110,7 +110,9 @@ class EcobeeData:
             await self._hass.async_add_executor_job(self.ecobee.update)
             _LOGGER.debug("Updating ecobee")
         except ExpiredTokenError:
-            _LOGGER.warn("ecobee update failed; attempting to refresh expired tokens")
+            _LOGGER.warning(
+                "ecobee update failed; attempting to refresh expired tokens"
+            )
             await self.refresh()
 
     async def refresh(self) -> bool:
@@ -125,9 +127,8 @@ class EcobeeData:
                 },
             )
             return True
-        else:
-            _LOGGER.error("Error updating ecobee tokens")
-            return False
+        _LOGGER.error("Error updating ecobee tokens")
+        return False
 
 
 async def async_populate_options(hass, config_entry):

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -111,7 +111,7 @@ class EcobeeData:
             _LOGGER.debug("Updating ecobee")
         except ExpiredTokenError:
             _LOGGER.warning(
-                "ecobee update failed; attempting to refresh expired tokens"
+                "Ecobee update failed; attempting to refresh expired tokens"
             )
             await self.refresh()
 

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -149,9 +149,8 @@ async def async_populate_options(hass, config_entry):
 
 
 async def async_unload_entry(hass, config_entry):
-    """Unload the config entry, but store the ecobee API key for later."""
+    """Unload the config entry and platforms."""
     hass.data.pop(DOMAIN)
-    hass.data[DATA_ECOBEE_CONFIG][CONF_API_KEY] = config_entry.data[CONF_API_KEY]
 
     for platform in ECOBEE_PLATFORMS:
         await hass.config_entries.async_forward_entry_unload(config_entry, platform)

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -1,15 +1,8 @@
 """Support for ecobee."""
-import os
 from datetime import timedelta
 import voluptuous as vol
 
-from pyecobee import (
-    Ecobee,
-    ECOBEE_CONFIG_FILENAME,
-    ECOBEE_API_KEY,
-    ECOBEE_REFRESH_TOKEN,
-    ExpiredTokenError,
-)
+from pyecobee import Ecobee, ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN, ExpiredTokenError
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_API_KEY
@@ -43,19 +36,18 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """
-    Ecobee only uses config flow for configuration.
+    Ecobee uses config flow for configuration.
 
-    But, an existing configuration.yaml config and ecobee.conf
-    will trigger an import flow if a config entry doesn't
-    already exist to help users migrating from the old ecobee
-    component.
+    But, an existing configuration.yaml config will trigger
+    an import flow if a config entry doesn't already exist
+    to help users migrating from the old ecobee component,
+    and parameters specified in configuration.yaml will
+    overwrite options specified in the options flow.
     """
-    if not hass.config_entries.async_entries(DOMAIN) and os.path.isfile(
-        hass.config.path(ECOBEE_CONFIG_FILENAME)
-    ):
-        """Store legacy config."""
-        hass.data[DATA_ECOBEE_CONFIG] = config[DOMAIN]
-        """No config entry exists and ecobee.conf exists; trigger the import flow."""
+    hass.data[DATA_ECOBEE_CONFIG] = config[DOMAIN]
+
+    if not hass.config_entries.async_entries(DOMAIN):
+        """No config entry exists; trigger the import flow."""
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN, context={"source": SOURCE_IMPORT}

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -12,15 +12,10 @@ from homeassistant.util import Throttle
 from homeassistant.util.json import save_json
 
 from . import config_flow  # noqa  pylint_disable=unused-import
+from .const import CONF_HOLD_TEMP, DOMAIN, ECOBEE_CONFIG_FILE
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
-
-CONF_HOLD_TEMP = "hold_temp"
-
-DOMAIN = "ecobee"
-
-ECOBEE_CONFIG_FILE = "ecobee.conf"
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=180)
 

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -83,7 +83,7 @@ async def async_setup_entry(hass, entry):
     await hass.async_add_executor_job(data.update)
 
     if data.ecobee.thermostats is None:
-        _LOGGER.error("No ecobee devices found to set up.")
+        _LOGGER.error("No ecobee devices found to set up")
         return False
 
     hass.data[DOMAIN] = data
@@ -116,14 +116,14 @@ class EcobeeData:
         """Get the latest data from ecobee.com."""
         try:
             self.ecobee.update()
-            _LOGGER.debug("Updating ecobee.")
+            _LOGGER.debug("Updating ecobee")
         except ExpiredTokenError:
-            _LOGGER.warn("ecobee update failed; attempting to refresh expired tokens.")
+            _LOGGER.warn("ecobee update failed; attempting to refresh expired tokens")
             self.refresh()
 
     def refresh(self) -> bool:
         """Refresh ecobee tokens and update config entry."""
-        _LOGGER.debug("Refreshing ecobee tokens and updating config entry.")
+        _LOGGER.debug("Refreshing ecobee tokens and updating config entry")
         if self.ecobee.refresh_tokens():
             self._hass.config_entries.async_update_entry(
                 self._entry,
@@ -134,7 +134,7 @@ class EcobeeData:
             )
             return True
         else:
-            _LOGGER.error("Error updating ecobee tokens.")
+            _LOGGER.error("Error updating ecobee tokens")
             return False
 
 

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -48,7 +48,7 @@ async def async_setup(hass, config):
     if not hass.config_entries.async_entries(DOMAIN) and os.path.isfile(
         hass.config.path(ECOBEE_CONFIG_FILENAME)
     ):
-        """Store legacy config to later populate options."""
+        """Store legacy config."""
         hass.data[DATA_ECOBEE_CONFIG] = config[DOMAIN]
         """No config entry exists and ecobee.conf exists; trigger the import flow."""
         hass.async_create_task(

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -1,8 +1,15 @@
 """Support for ecobee."""
 import os
 from datetime import timedelta
-
 import voluptuous as vol
+
+from pyecobee import (
+    Ecobee,
+    ECOBEE_CONFIG_FILENAME,
+    ECOBEE_API_KEY,
+    ECOBEE_REFRESH_TOKEN,
+    ExpiredTokenError,
+)
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_API_KEY
@@ -43,8 +50,6 @@ async def async_setup(hass, config):
     already exist to help users migrating from the old ecobee
     component.
     """
-    from pyecobee import ECOBEE_CONFIG_FILENAME
-
     if not hass.config_entries.async_entries(DOMAIN) and os.path.isfile(
         hass.config.path(ECOBEE_CONFIG_FILENAME)
     ):
@@ -100,8 +105,6 @@ class EcobeeData:
 
     def __init__(self, hass, entry, api_key, refresh_token):
         """Initialize the Ecobee data object."""
-        from pyecobee import Ecobee, ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
-
         self._hass = hass
         self._entry = entry
         self.ecobee = Ecobee(
@@ -111,8 +114,6 @@ class EcobeeData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from ecobee.com."""
-        from pyecobee import ExpiredTokenError
-
         try:
             self.ecobee.update()
             _LOGGER.debug("Updating ecobee.")
@@ -122,8 +123,6 @@ class EcobeeData:
 
     def refresh(self) -> bool:
         """Refresh ecobee tokens and update config entry."""
-        from pyecobee import ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
-
         _LOGGER.debug("Refreshing ecobee tokens and updating config entry.")
         if self.ecobee.refresh_tokens():
             self._hass.config_entries.async_update_entry(

--- a/homeassistant/components/ecobee/__init__.py
+++ b/homeassistant/components/ecobee/__init__.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = vol.Schema(
         DOMAIN: vol.Schema(
             {
                 vol.Optional(CONF_API_KEY): cv.string,
-                vol.Optional(CONF_HOLD_TEMP, DEFAULT_HOLD_TEMP): cv.boolean,
+                vol.Optional(CONF_HOLD_TEMP, default=DEFAULT_HOLD_TEMP): cv.boolean,
             }
         )
     },

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -1,15 +1,20 @@
 """Support for Ecobee binary sensors."""
-from homeassistant.components import ecobee
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice,
+    DEVICE_CLASS_OCCUPANCY,
+)
 
-ECOBEE_CONFIG_FILE = "ecobee.conf"
+from .const import DOMAIN
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Ecobee sensors."""
-    if discovery_info is None:
-        return
-    data = ecobee.NETWORK
+    """Old way of setting up ecobee binary sensors."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up ecobee binary (occupancy) sensors."""
+    data = hass.data[DOMAIN]
     dev = list()
     for index in range(len(data.ecobee.thermostats)):
         for sensor in data.ecobee.get_remote_sensors(index):
@@ -17,21 +22,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 if item["type"] != "occupancy":
                     continue
 
-                dev.append(EcobeeBinarySensor(sensor["name"], index))
+                dev.append(EcobeeBinarySensor(data, sensor["name"], index))
 
-    add_entities(dev, True)
+    async_add_entities(dev, True)
 
 
 class EcobeeBinarySensor(BinarySensorDevice):
     """Representation of an Ecobee sensor."""
 
-    def __init__(self, sensor_name, sensor_index):
+    def __init__(self, data, sensor_name, sensor_index):
         """Initialize the Ecobee sensor."""
+        self.data = data
         self._name = sensor_name + " Occupancy"
         self.sensor_name = sensor_name
         self.index = sensor_index
         self._state = None
-        self._device_class = "occupancy"
 
     @property
     def name(self):
@@ -46,13 +51,12 @@ class EcobeeBinarySensor(BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of this sensor, from DEVICE_CLASSES."""
-        return self._device_class
+        return DEVICE_CLASS_OCCUPANCY
 
     def update(self):
         """Get the latest state of the sensor."""
-        data = ecobee.NETWORK
-        data.update()
-        for sensor in data.ecobee.get_remote_sensors(self.index):
+        self.data.update()
+        for sensor in self.data.ecobee.get_remote_sensors(self.index):
             for item in sensor["capability"]:
                 if item["type"] == "occupancy" and self.sensor_name == sensor["name"]:
                     self._state = item["value"]

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.binary_sensor import (
 from .const import DOMAIN
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up ecobee binary sensors."""
     pass
 

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -53,9 +53,9 @@ class EcobeeBinarySensor(BinarySensorDevice):
         """Return the class of this sensor, from DEVICE_CLASSES."""
         return DEVICE_CLASS_OCCUPANCY
 
-    def update(self):
+    async def async_update(self):
         """Get the latest state of the sensor."""
-        self.data.update()
+        await self.data.update()
         for sensor in self.data.ecobee.get_remote_sensors(self.index):
             for item in sensor["capability"]:
                 if item["type"] == "occupancy" and self.sensor_name == sensor["name"]:

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -84,8 +84,8 @@ PRESET_TO_ECOBEE_HOLD = {
     PRESET_HOLD_INDEFINITE: "indefinite",
 }
 
-SERVICE_SET_FAN_MIN_ON_TIME = "ecobee_set_fan_min_on_time"
-SERVICE_RESUME_PROGRAM = "ecobee_resume_program"
+SERVICE_SET_FAN_MIN_ON_TIME = "set_fan_min_on_time"
+SERVICE_RESUME_PROGRAM = "resume_program"
 
 SET_FAN_MIN_ON_TIME_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -111,7 +111,7 @@ SUPPORT_FLAGS = (
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up ecobee thermostat."""
     pass
 

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -210,14 +210,13 @@ class Thermostat(ClimateDevice):
         self._fan_modes = [FAN_AUTO, FAN_ON]
         self.update_without_throttle = False
 
-    def update(self):
+    async def async_update(self):
         """Get the latest state from the thermostat."""
         if self.update_without_throttle:
-            self.data.update(no_throttle=True)
+            await self.data.update(no_throttle=True)
             self.update_without_throttle = False
         else:
-            self.data.update()
-
+            await self.data.update()
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
 
     @property

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
+    DOMAIN as CLIMATE_DOMAIN,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_AUTO,
@@ -167,14 +168,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             thermostat.schedule_update_ha_state(True)
 
     hass.services.async_register(
-        DOMAIN,
+        CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MIN_ON_TIME,
         fan_min_on_time_set_service,
         schema=SET_FAN_MIN_ON_TIME_SCHEMA,
     )
 
     hass.services.async_register(
-        DOMAIN,
+        CLIMATE_DOMAIN,
         SERVICE_RESUME_PROGRAM,
         resume_program_set_service,
         schema=RESUME_PROGRAM_SCHEMA,

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 
 from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
-    DOMAIN as CLIMATE_DOMAIN,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_AUTO,
@@ -168,14 +167,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             thermostat.schedule_update_ha_state(True)
 
     hass.services.async_register(
-        CLIMATE_DOMAIN,
+        DOMAIN,
         SERVICE_SET_FAN_MIN_ON_TIME,
         fan_min_on_time_set_service,
         schema=SET_FAN_MIN_ON_TIME_SCHEMA,
     )
 
     hass.services.async_register(
-        CLIMATE_DOMAIN,
+        DOMAIN,
         SERVICE_RESUME_PROGRAM,
         resume_program_set_service,
         schema=RESUME_PROGRAM_SCHEMA,

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -117,18 +117,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the ecobee thermostat."""
+
     data = hass.data[DOMAIN]
     hold_temp = config_entry.options[CONF_HOLD_TEMP]
-    devices = list()
 
     _LOGGER.info(
         "Loading ecobee thermostat component with hold_temp set to %s", hold_temp
     )
 
-    for index in range(len(data.ecobee.thermostats)):
-        dev = Thermostat(data, index, hold_temp)
-        config_entry.add_update_listener(dev.option_update_listener)
-        devices.append(dev)
+    devices = [
+        Thermostat(data, index, hold_temp)
+        for index in range(len(data.ecobee.thermostats))
+    ]
 
     async_add_entities(devices, True)
 
@@ -217,11 +217,6 @@ class Thermostat(ClimateDevice):
         else:
             await self.data.update()
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
-
-    async def option_update_listener(self, hass, entry):
-        """Update relevant options in this entity."""
-        _LOGGER.debug("Updating options in ecobee thermostat {}".format(self.name))
-        self.hold_temp = entry.options[CONF_HOLD_TEMP]
 
     @property
     def available(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -35,7 +35,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_HOLD_TEMP, DOMAIN, _LOGGER
+from .const import DOMAIN, _LOGGER
 
 ATTR_FAN_MIN_ON_TIME = "fan_min_on_time"
 ATTR_RESUME_ALL = "resume_all"
@@ -119,16 +119,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the ecobee thermostat."""
 
     data = hass.data[DOMAIN]
-    hold_temp = config_entry.options[CONF_HOLD_TEMP]
 
-    _LOGGER.info(
-        "Loading ecobee thermostat component with hold_temp set to %s", hold_temp
-    )
-
-    devices = [
-        Thermostat(data, index, hold_temp)
-        for index in range(len(data.ecobee.thermostats))
-    ]
+    devices = [Thermostat(data, index) for index in range(len(data.ecobee.thermostats))]
 
     async_add_entities(devices, True)
 
@@ -184,13 +176,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class Thermostat(ClimateDevice):
     """A thermostat class for Ecobee."""
 
-    def __init__(self, data, thermostat_index, hold_temp):
+    def __init__(self, data, thermostat_index):
         """Initialize the thermostat."""
         self.data = data
         self.thermostat_index = thermostat_index
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
         self._name = self.thermostat["name"]
-        self.hold_temp = hold_temp
         self.vacation = None
 
         self._operation_list = []

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -59,9 +59,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if await self.hass.async_add_executor_job(self._ecobee.request_pin):
                 """We have a PIN; move to the next step of the flow."""
                 return await self.async_step_authorize()
-            else:
-                """Obtaining the PIN failed. Maybe the wrong API key?"""
-                errors["base"] = "pin_request_failed"
+            errors["base"] = "pin_request_failed"
 
         return self.async_show_form(
             step_id="init",
@@ -84,8 +82,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_REFRESH_TOKEN: self._ecobee.refresh_token,
                 }
                 return self.async_create_entry(title=DOMAIN, data=config)
-            else:
-                errors["base"] = "token_request_failed"
+            errors["base"] = "token_request_failed"
 
         return self.async_show_form(
             step_id="authorize",

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow to configure ecobee."""
-import voluptuous as vol
 from copy import copy
+import voluptuous as vol
 
 from pyecobee import (
     Ecobee,

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -94,7 +94,11 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.debug(
                 "No valid ecobee.conf configuration found for import, delegating to user step"
             )
-            return await self.async_step_user()
+            return await self.async_step_user(
+                user_input={
+                    CONF_API_KEY: self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
+                }
+            )
 
         ecobee = Ecobee(config=config)
         if await self.hass.async_add_executor_job(ecobee.refresh_tokens):
@@ -109,4 +113,8 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_REFRESH_TOKEN: ecobee.refresh_token,
                 },
             )
-        return await self.async_step_user()
+        return await self.async_step_user(
+            user_input={
+                CONF_API_KEY: self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
+            }
+        )

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -1,0 +1,139 @@
+"""Config flow to configure ecobee."""
+import voluptuous as vol
+from copy import copy
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import callback
+
+from . import CONF_HOLD_TEMP, DOMAIN, ECOBEE_CONFIG_FILE
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle an ecobee config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return EcobeeOptionsFlowHandler(config_entry)
+
+    def __init__(self):
+        """Initialize the ecobee flow."""
+        self._ecobee = None
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        return await self.async_step_init(user_input)
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow start."""
+        errors = {}
+
+        if self._async_current_entries():
+            """Config entry currently exists, only one allowed."""
+            return self.async_abort(reason="one_instance_only")
+
+        if user_input is not None:
+            """Use the user-supplied API key to attempt to obtain a PIN from ecobee."""
+            from pyecobee import Ecobee
+
+            config = {CONF_API_KEY: user_input[CONF_API_KEY]}
+
+            self._ecobee = Ecobee(config=config)
+
+            await self.hass.async_add_executor_job(self._ecobee.request_pin())
+
+            if self._ecobee.pin is None:
+                """Obtaining the PIN failed. Maybe the wrong API key?"""
+                errors["base"] = "pin_request_failed"
+            else:
+                """Move to the next step of the flow."""
+                return await self.async_step_authorize()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            errors=errors,
+        )
+
+    async def async_step_authorize(self, user_input=None):
+        """Present the user with the PIN so that the app can be authorized on ecobee.com."""
+        errors = {}
+
+        if user_input is not None:
+            """Attempt to obtain tokens from ecobee and finish the flow."""
+            await self.hass.async_add_executor_job(self._ecobee.request_tokens())
+            if len(self._ecobee.refresh_token) > 0:
+                """Refresh token obtained; create the config entry."""
+                return self.async_create_entry(title=DOMAIN, data=self._ecobee.config)
+            else:
+                errors["base"] = "token_request_failed"
+
+        return self.async_show_form(
+            step_id="authorize",
+            errors=errors,
+            description_placeholders={"pin": self._ecobee.pin},
+        )
+
+    async def async_step_import(self, import_data):
+        """Import ecobee config from an existing ecobee.conf file.
+
+        This flow is triggered by `async_setup` if no existing entry exists
+        and if ecobee.conf exists, allowing pre-config-flow ecobee component
+        users an easy migration path to using a config entry.
+
+        We will attempt to validate the credentials found in ecobee.conf
+        and create an entry if valid. Otherwise, we will abort and the user
+        will need to redo the authorization process via the config flow.
+        """
+        config_file = self.hass.config.path(ECOBEE_CONFIG_FILE)
+
+        from pyecobee import Ecobee
+
+        self._ecobee = Ecobee(config_filename=config_file)
+
+        if len(self._ecobee.refresh_token) > 0:
+            """Refresh token loaded from existing config, attempt refresh to validate it."""
+            await self.hass.async_add_executor_job(self._ecobee.refresh_tokens())
+            if self._ecobee.pin is None:
+                return self.async_create_entry(title=DOMAIN, data=self._ecobee.config)
+            else:
+                self.async_abort(reason="refresh_token_expired")
+        else:
+            self.async_abort(reason="credentials_not_found")
+
+
+class EcobeeOptionsFlowHandler(config_entries.OptionsFlow):
+    """Manage ecobee options."""
+
+    def __init__(self, config_entry):
+        """Initialize ecobee options flow."""
+        self.config_entry = config_entry
+        self.options = copy(config_entry.options)
+
+    async def async_step_init(self, user_input=None):
+        """Handle an options flow start."""
+        return await self.async_step_ecobee_options()
+
+    async def async_step_ecobee_options(self, user_input=None):
+        """Manage the ecobee options."""
+        if user_input is not None:
+            self.options[CONF_HOLD_TEMP] = user_input[CONF_HOLD_TEMP]
+            return self.async_create_entry(title="", data=self.options)
+
+        return self.async_show_form(
+            step_id="ecobee_options",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_HOLD_TEMP,
+                        default=self.config_entry.options[CONF_HOLD_TEMP],
+                    ): bool
+                }
+            ),
+        )

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -88,7 +88,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={"pin": self._ecobee.pin},
         )
 
-    async def async_step_import(self, import_data):
+    async def async_step_import(self, import_data, user_input=None):
         """Import ecobee config from an existing ecobee.conf file.
 
         This flow is triggered by `async_setup` if no existing entry exists
@@ -99,40 +99,43 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         and create an entry if valid. Otherwise, we will abort and the user
         will need to redo the authorization process via a new config flow.
         """
-        import aiofiles
-        import json
-        from pyecobee import (
-            Ecobee,
-            ECOBEE_CONFIG_FILENAME,
-            ECOBEE_API_KEY,
-            ECOBEE_REFRESH_TOKEN,
-        )
-
-        config_file = self.hass.config.path(ECOBEE_CONFIG_FILENAME)
-
-        async with aiofiles.open(config_file, "r") as f:
-            legacy_config = json.loads(await f.read())
-
-        try:
-            ecobee = Ecobee(
-                config={
-                    ECOBEE_API_KEY: legacy_config[ECOBEE_API_KEY],
-                    ECOBEE_REFRESH_TOKEN: legacy_config[ECOBEE_REFRESH_TOKEN],
-                }
+        if user_input is not None:
+            import aiofiles
+            import json
+            from pyecobee import (
+                Ecobee,
+                ECOBEE_CONFIG_FILENAME,
+                ECOBEE_API_KEY,
+                ECOBEE_REFRESH_TOKEN,
             )
 
-            if await self.hass.async_add_executor_job(ecobee.refresh_tokens):
-                return self.async_create_entry(
-                    title=DOMAIN,
-                    data={
-                        CONF_API_KEY: legacy_config[ECOBEE_API_KEY],
-                        CONF_REFRESH_TOKEN: legacy_config[ECOBEE_REFRESH_TOKEN],
-                    },
+            config_file = self.hass.config.path(ECOBEE_CONFIG_FILENAME)
+
+            async with aiofiles.open(config_file, "r") as f:
+                legacy_config = json.loads(await f.read())
+
+            try:
+                ecobee = Ecobee(
+                    config={
+                        ECOBEE_API_KEY: legacy_config[ECOBEE_API_KEY],
+                        ECOBEE_REFRESH_TOKEN: legacy_config[ECOBEE_REFRESH_TOKEN],
+                    }
                 )
-            else:
-                self.async_abort(reason="refresh_token_expired")
-        except (KeyError, TypeError):
-            self.async_abort(reason="credentials_not_found")
+
+                if await self.hass.async_add_executor_job(ecobee.refresh_tokens):
+                    return self.async_create_entry(
+                        title=DOMAIN,
+                        data={
+                            CONF_API_KEY: legacy_config[ECOBEE_API_KEY],
+                            CONF_REFRESH_TOKEN: legacy_config[ECOBEE_REFRESH_TOKEN],
+                        },
+                    )
+                else:
+                    self.async_abort(reason="refresh_token_expired")
+            except (KeyError, TypeError):
+                self.async_abort(reason="credentials_not_found")
+
+        return self.async_show_form(step_id="import")
 
 
 class EcobeeOptionsFlowHandler(config_entries.OptionsFlow):

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -46,11 +46,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="one_instance_only")
 
         errors = {}
-        stored_api_key = (
-            self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
-            if DATA_ECOBEE_CONFIG in self.hass.data
-            else None
-        )
+        stored_api_key = self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
 
         if user_input is not None:
             """Use the user-supplied API key to attempt to obtain a PIN from ecobee."""

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import callback
 
-from . import CONF_HOLD_TEMP, DOMAIN, ECOBEE_CONFIG_FILE
+from .const import CONF_HOLD_TEMP, DOMAIN, ECOBEE_CONFIG_FILE
 
 
 @config_entries.HANDLERS.register(DOMAIN)

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow to configure ecobee."""
 from copy import copy
+
 import voluptuous as vol
 
 from pyecobee import (

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import callback
 
-from .const import CONF_HOLD_TEMP, CONF_REFRESH_TOKEN, DOMAIN
+from .const import CONF_HOLD_TEMP, CONF_REFRESH_TOKEN, DATA_ECOBEE_CONFIG, DOMAIN
 
 
 @config_entries.HANDLERS.register(DOMAIN)
@@ -33,6 +33,11 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_init(self, user_input=None):
         """Handle a flow start."""
         errors = {}
+        stored_api_key = (
+            self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
+            if DATA_ECOBEE_CONFIG in self.hass.data
+            else None
+        )
 
         if self._async_current_entries():
             """Config entry currently exists, only one allowed."""
@@ -55,7 +60,9 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            data_schema=vol.Schema(
+                {vol.Required(CONF_API_KEY, default=stored_api_key): str}
+            ),
             errors=errors,
         )
 

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -1,6 +1,4 @@
 """Config flow to configure ecobee."""
-from copy import copy
-
 import voluptuous as vol
 
 from pyecobee import (
@@ -12,16 +10,10 @@ from pyecobee import (
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
-from homeassistant.core import callback, HomeAssistantError
+from homeassistant.core import HomeAssistantError
 from homeassistant.util.json import load_json
 
-from .const import (
-    CONF_HOLD_TEMP,
-    CONF_REFRESH_TOKEN,
-    DATA_ECOBEE_CONFIG,
-    DOMAIN,
-    _LOGGER,
-)
+from .const import CONF_REFRESH_TOKEN, DATA_ECOBEE_CONFIG, DOMAIN, _LOGGER
 
 
 class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -29,12 +21,6 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return EcobeeOptionsFlowHandler(config_entry)
 
     def __init__(self):
         """Initialize the ecobee flow."""
@@ -124,34 +110,3 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
         return await self.async_step_user()
-
-
-class EcobeeOptionsFlowHandler(config_entries.OptionsFlow):
-    """Manage ecobee options."""
-
-    def __init__(self, config_entry):
-        """Initialize ecobee options flow."""
-        self.config_entry = config_entry
-        self.options = copy(config_entry.options)
-
-    async def async_step_init(self, user_input=None):
-        """Handle an options flow start."""
-        return await self.async_step_ecobee_options()
-
-    async def async_step_ecobee_options(self, user_input=None):
-        """Manage the ecobee options."""
-        if user_input is not None:
-            self.options[CONF_HOLD_TEMP] = user_input[CONF_HOLD_TEMP]
-            return self.async_create_entry(title="", data=self.options)
-
-        return self.async_show_form(
-            step_id="ecobee_options",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_HOLD_TEMP,
-                        default=self.config_entry.options[CONF_HOLD_TEMP],
-                    ): bool
-                }
-            ),
-        )

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -99,29 +99,29 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             legacy_config = await self.hass.async_add_executor_job(
                 load_json, self.hass.config.path(ECOBEE_CONFIG_FILENAME)
             )
-            ecobee = Ecobee(
-                config={
-                    ECOBEE_API_KEY: legacy_config[ECOBEE_API_KEY],
-                    ECOBEE_REFRESH_TOKEN: legacy_config[ECOBEE_REFRESH_TOKEN],
-                }
-            )
-            if await self.hass.async_add_executor_job(ecobee.refresh_tokens):
-                """Credentials found and validated; create the entry."""
-                _LOGGER.debug(
-                    "Valid ecobee configuration found for import, creating config entry"
-                )
-                return self.async_create_entry(
-                    title=DOMAIN,
-                    data={
-                        CONF_API_KEY: ecobee.api_key,
-                        CONF_REFRESH_TOKEN: ecobee.refresh_token,
-                    },
-                )
+            config = {
+                ECOBEE_API_KEY: legacy_config[ECOBEE_API_KEY],
+                ECOBEE_REFRESH_TOKEN: legacy_config[ECOBEE_REFRESH_TOKEN],
+            }
         except (HomeAssistantError, KeyError):
             _LOGGER.debug(
                 "No valid ecobee.conf configuration found for import, delegating to user step"
             )
+            return await self.async_step_user()
 
+        ecobee = Ecobee(config=config)
+        if await self.hass.async_add_executor_job(ecobee.refresh_tokens):
+            """Credentials found and validated; create the entry."""
+            _LOGGER.debug(
+                "Valid ecobee configuration found for import, creating config entry"
+            )
+            return self.async_create_entry(
+                title=DOMAIN,
+                data={
+                    CONF_API_KEY: ecobee.api_key,
+                    CONF_REFRESH_TOKEN: ecobee.refresh_token,
+                },
+            )
         return await self.async_step_user()
 
 

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -58,7 +58,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "pin_request_failed"
 
         return self.async_show_form(
-            step_id="init",
+            step_id="user",
             data_schema=vol.Schema(
                 {vol.Required(CONF_API_KEY, default=stored_api_key): str}
             ),

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -11,7 +11,7 @@ from pyecobee import (
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
-from homeassistant.core import callback
+from homeassistant.core import callback, HomeAssistantError
 from homeassistant.util.json import load_json
 
 from .const import (
@@ -117,7 +117,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_REFRESH_TOKEN: ecobee.refresh_token,
                     },
                 )
-        except Exception:  # pylint: disable=broad-except
+        except (HomeAssistantError, KeyError):
             _LOGGER.debug(
                 "No valid ecobee.conf configuration found for import, delegating to user step"
             )

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -42,18 +42,18 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
         if self._async_current_entries():
-            """Config entry already exists, only one allowed."""
+            # Config entry already exists, only one allowed.
             return self.async_abort(reason="one_instance_only")
 
         errors = {}
         stored_api_key = self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
 
         if user_input is not None:
-            """Use the user-supplied API key to attempt to obtain a PIN from ecobee."""
+            # Use the user-supplied API key to attempt to obtain a PIN from ecobee.
             self._ecobee = Ecobee(config={ECOBEE_API_KEY: user_input[CONF_API_KEY]})
 
             if await self.hass.async_add_executor_job(self._ecobee.request_pin):
-                """We have a PIN; move to the next step of the flow."""
+                # We have a PIN; move to the next step of the flow.
                 return await self.async_step_authorize()
             errors["base"] = "pin_request_failed"
 
@@ -70,9 +70,9 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            """Attempt to obtain tokens from ecobee and finish the flow."""
+            # Attempt to obtain tokens from ecobee and finish the flow.
             if await self.hass.async_add_executor_job(self._ecobee.request_tokens):
-                """Refresh token obtained; create the config entry."""
+                # Refresh token obtained; create the config entry.
                 config = {
                     CONF_API_KEY: self._ecobee.api_key,
                     CONF_REFRESH_TOKEN: self._ecobee.refresh_token,
@@ -111,7 +111,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         ecobee = Ecobee(config=config)
         if await self.hass.async_add_executor_job(ecobee.refresh_tokens):
-            """Credentials found and validated; create the entry."""
+            # Credentials found and validated; create the entry.
             _LOGGER.debug(
                 "Valid ecobee configuration found for import, creating config entry"
             )

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -1,6 +1,14 @@
 """Constants for the ecobee integration."""
+import logging
 
 DOMAIN = "ecobee"
-ECOBEE_CONFIG_FILE = "ecobee.conf"
+DATA_ECOBEE_CONFIG = "ecobee_config"
 
 CONF_HOLD_TEMP = "hold_temp"
+DEFAULT_HOLD_TEMP = False
+
+CONF_REFRESH_TOKEN = "refresh_token"
+
+ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]
+
+_LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -1,14 +1,15 @@
 """Constants for the ecobee integration."""
 import logging
 
+_LOGGER = logging.getLogger(__package__)
+
 DOMAIN = "ecobee"
 DATA_ECOBEE_CONFIG = "ecobee_config"
 
 CONF_HOLD_TEMP = "hold_temp"
-DEFAULT_HOLD_TEMP = False
-
+CONF_INDEX = "index"
 CONF_REFRESH_TOKEN = "refresh_token"
 
-ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]
+DEFAULT_HOLD_TEMP = False
 
-_LOGGER = logging.getLogger(__package__)
+ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -1,0 +1,6 @@
+"""Constants for the ecobee integration."""
+
+DOMAIN = "ecobee"
+ECOBEE_CONFIG_FILE = "ecobee.conf"
+
+CONF_HOLD_TEMP = "hold_temp"

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -6,10 +6,7 @@ _LOGGER = logging.getLogger(__package__)
 DOMAIN = "ecobee"
 DATA_ECOBEE_CONFIG = "ecobee_config"
 
-CONF_HOLD_TEMP = "hold_temp"
 CONF_INDEX = "index"
 CONF_REFRESH_TOKEN = "refresh_token"
-
-DEFAULT_HOLD_TEMP = False
 
 ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -3,5 +3,7 @@
     "name": "Ecobee",
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/ecobee",
-    "requirements": ["python-ecobee-api==0.0.21"]
+    "dependencies": [],
+    "requirements": ["python-ecobee-api==0.0.21"],
+    "codeowners": []
 }

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -4,6 +4,6 @@
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/ecobee",
     "dependencies": [],
-    "requirements": ["python-ecobee-api==0.1.2", "aiofiles"],
+    "requirements": ["python-ecobee-api==0.1.2"],
     "codeowners": []
 }

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -4,6 +4,6 @@
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/ecobee",
     "dependencies": [],
-    "requirements": ["python-ecobee-api==0.0.21"],
+    "requirements": ["python-ecobee-api==0.1.1", "aiofiles"],
     "codeowners": []
 }

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -1,10 +1,9 @@
 {
-  "domain": "ecobee",
-  "name": "Ecobee",
-  "documentation": "https://www.home-assistant.io/components/ecobee",
-  "requirements": [
-    "python-ecobee-api==0.0.21"
-  ],
-  "dependencies": ["configurator"],
-  "codeowners": []
+    "domain": "ecobee",
+    "name": "Ecobee",
+    "config_flow": true,
+    "documentation": "https://www.home-assistant.io/components/ecobee",
+    "requirements": ["python-ecobee-api==0.0.21"],
+    "dependencies": [],
+    "codeowners": [],
 }

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -3,7 +3,5 @@
     "name": "Ecobee",
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/ecobee",
-    "requirements": ["python-ecobee-api==0.0.21"],
-    "dependencies": [],
-    "codeowners": [],
+    "requirements": ["python-ecobee-api==0.0.21"]
 }

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -5,5 +5,5 @@
     "documentation": "https://www.home-assistant.io/components/ecobee",
     "dependencies": [],
     "requirements": ["python-ecobee-api==0.1.2"],
-    "codeowners": []
+    "codeowners": ["@marthoc"]
 }

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -4,6 +4,6 @@
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/ecobee",
     "dependencies": [],
-    "requirements": ["python-ecobee-api==0.1.1", "aiofiles"],
+    "requirements": ["python-ecobee-api==0.1.2", "aiofiles"],
     "codeowners": []
 }

--- a/homeassistant/components/ecobee/notify.py
+++ b/homeassistant/components/ecobee/notify.py
@@ -1,15 +1,10 @@
 """Support for Ecobee Send Message service."""
-import logging
-
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components import ecobee
 from homeassistant.components.notify import BaseNotificationService, PLATFORM_SCHEMA
 
-_LOGGER = logging.getLogger(__name__)
-
-CONF_INDEX = "index"
+from .const import CONF_INDEX, DOMAIN
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Optional(CONF_INDEX, default=0): cv.positive_int}
@@ -18,17 +13,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_service(hass, config, discovery_info=None):
     """Get the Ecobee notification service."""
+    data = hass.data[DOMAIN]
     index = config.get(CONF_INDEX)
-    return EcobeeNotificationService(index)
+    return EcobeeNotificationService(data, index)
 
 
 class EcobeeNotificationService(BaseNotificationService):
     """Implement the notification service for the Ecobee thermostat."""
 
-    def __init__(self, thermostat_index):
+    def __init__(self, data, thermostat_index):
         """Initialize the service."""
+        self.data = data
         self.thermostat_index = thermostat_index
 
     def send_message(self, message="", **kwargs):
-        """Send a message to a command line."""
-        ecobee.NETWORK.ecobee.send_message(self.thermostat_index, message)
+        """Send a message."""
+        self.data.ecobee.send_message(self.thermostat_index, message)

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -15,7 +15,7 @@ SENSOR_TYPES = {
 }
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up ecobee sensors."""
     pass
 

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -66,10 +66,9 @@ class EcobeeSensor(Entity):
         """Return the state of the sensor."""
         if self._state in [ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN]:
             return None
-        elif self.type == "temperature":
+        elif self.type == "temperature":  # pylint disable=no-else-return
             return float(self._state) / 10
-        else:
-            return self._state
+        return self._state
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -76,9 +76,9 @@ class EcobeeSensor(Entity):
         """Return the unit of measurement this sensor expresses itself in."""
         return self._unit_of_measurement
 
-    def update(self):
+    async def async_update(self):
         """Get the latest state of the sensor."""
-        self.data.update()
+        await self.data.update()
         for sensor in self.data.ecobee.get_remote_sensors(self.index):
             for item in sensor["capability"]:
                 if item["type"] == self.type and self.sensor_name == sensor["name"]:

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -1,8 +1,9 @@
 """Support for Ecobee sensors."""
+from pyecobee.const import ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN
+
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
-    STATE_UNKNOWN,
     TEMP_FAHRENHEIT,
 )
 from homeassistant.helpers.entity import Entity
@@ -63,10 +64,8 @@ class EcobeeSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        from pyecobee.const import ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN
-
         if self._state in [ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN]:
-            return STATE_UNKNOWN
+            return None
         elif self.type == "temperature":
             return float(self._state) / 10
         else:

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -66,8 +66,10 @@ class EcobeeSensor(Entity):
         """Return the state of the sensor."""
         if self._state in [ECOBEE_STATE_CALIBRATING, ECOBEE_STATE_UNKNOWN]:
             return None
-        elif self.type == "temperature":  # pylint disable=no-else-return
+
+        if self.type == "temperature":
             return float(self._state) / 10
+
         return self._state
 
     @property

--- a/homeassistant/components/ecobee/services.yaml
+++ b/homeassistant/components/ecobee/services.yaml
@@ -1,0 +1,19 @@
+resume_program:
+  description: Resume the programmed schedule.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'climate.kitchen'
+    resume_all:
+      description: Resume all events and return to the scheduled program. This default to false which removes only the top event.
+      example: true
+
+set_fan_min_on_time:
+  description: Set the minimum fan on time.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'climate.kitchen'
+    fan_min_on_time:
+      description: New value of fan min on time.
+      example: 5

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -17,9 +17,7 @@
             "token_request_failed": "Error requesting tokens from ecobee; please try again."
         },
         "abort": {
-            "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
-            "one_instance_only": "This integration currently supports only one ecobee instance.",
-            "refresh_token_expired": "Your refresh token has expired; please re-start configuration."
+            "one_instance_only": "This integration currently supports only one ecobee instance."
         }
     },
     "options": {

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -10,10 +10,6 @@
             "authorize": {
                 "title": "Authorize app on ecobee.com",
                 "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit."
-            },
-            "import": {
-                "title": "Import ecobee configuration",
-                "description": "Press Submit to import existing configuration data."
             }
         },
         "error": {

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -10,6 +10,10 @@
             "authorize": {
                 "title": "Authorize app on ecobee.com",
                 "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit."
+            },
+            "import": {
+                "title": "Import ecobee configuration",
+                "description": "Press Submit to import existing configuration data."
             }
         },
         "error": {

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -2,7 +2,7 @@
     "config": {
         "title": "ecobee",
         "step": {
-            "init": {
+            "user": {
                 "title": "ecobee API key",
                 "description": "Please enter the API key obtained from ecobee.com.",
                 "data": {"api_key": "API Key"}

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -9,17 +9,17 @@
             },
             "authorize": {
                 "title": "Authorize app on ecobee.com",
-                "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit.",
+                "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit."
             }
         },
         "error": {
             "pin_request_failed": "Error requesting PIN from ecobee; please verify API key is correct.",
-            "token_request_failed": "Error requesting tokens from ecobee; please try again.",
+            "token_request_failed": "Error requesting tokens from ecobee; please try again."
         },
         "abort": {
             "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
             "one_instance_only": "This integration currently supports only one ecobee instance.",
-            "refresh_token_expired": "Your refresh token has expired; please re-start configuration.",
+            "refresh_token_expired": "Your refresh token has expired; please re-start configuration."
         }
     },
     "options": {

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -19,15 +19,5 @@
         "abort": {
             "one_instance_only": "This integration currently supports only one ecobee instance."
         }
-    },
-    "options": {
-        "step": {
-            "ecobee_options": {
-                "description": "ecobee Options",
-                "data": {
-                    "hold_temp": "Hold changes indefinitely (checked) or until the next scheduled event (unchecked)."
-                }
-            }
-        }
     }
 }

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -5,12 +5,12 @@
             "init": {
                 "title": "ecobee API key",
                 "description": "Please enter the API key obtained from ecobee.com.",
-                "data": {"api_key": "API Key"},
+                "data": {"api_key": "API Key"}
             },
             "authorize": {
                 "title": "Authorize app on ecobee.com",
                 "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit.",
-            },
+            }
         },
         "error": {
             "pin_request_failed": "Error requesting PIN from ecobee; please verify API key is correct.",
@@ -20,7 +20,7 @@
             "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
             "one_instance_only": "This integration currently supports only one ecobee instance.",
             "refresh_token_expired": "Your refresh token has expired; please re-start configuration.",
-        },
+        }
     },
     "options": {
         "step": {
@@ -28,8 +28,8 @@
                 "description": "ecobee Options",
                 "data": {
                     "hold_temp": "Hold changes indefinitely (checked) or until the next scheduled event (unchecked)."
-                },
+                }
             }
         }
-    },
+    }
 }

--- a/homeassistant/components/ecobee/strings.json
+++ b/homeassistant/components/ecobee/strings.json
@@ -1,0 +1,35 @@
+{
+    "config": {
+        "title": "ecobee",
+        "step": {
+            "init": {
+                "title": "ecobee API key",
+                "description": "Please enter the API key obtained from ecobee.com.",
+                "data": {"api_key": "API Key"},
+            },
+            "authorize": {
+                "title": "Authorize app on ecobee.com",
+                "description": "Please authorize this app at https://www.ecobee.com/consumerportal/index.html with pin code:\n\n{pin}\n\nThen, press Submit.",
+            },
+        },
+        "error": {
+            "pin_request_failed": "Error requesting PIN from ecobee; please verify API key is correct.",
+            "token_request_failed": "Error requesting tokens from ecobee; please try again.",
+        },
+        "abort": {
+            "credentials_not_found": "No valid credentials found in ecobee.conf; please re-start configuration.",
+            "one_instance_only": "This integration currently supports only one ecobee instance.",
+            "refresh_token_expired": "Your refresh token has expired; please re-start configuration.",
+        },
+    },
+    "options": {
+        "step": {
+            "ecobee_options": {
+                "description": "ecobee Options",
+                "data": {
+                    "hold_temp": "Hold changes indefinitely (checked) or until the next scheduled event (unchecked)."
+                },
+            }
+        }
+    },
+}

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -1,6 +1,8 @@
 """Support for displaying weather info from Ecobee API."""
 from datetime import datetime
 
+from pyecobee.const import ECOBEE_STATE_UNKNOWN
+
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_TEMP,
@@ -132,8 +134,6 @@ class EcobeeWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
-        from pyecobee.const import ECOBEE_STATE_UNKNOWN
-
         try:
             forecasts = []
             for day in self.weather["forecasts"]:

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -162,8 +162,8 @@ class EcobeeWeather(WeatherEntity):
         except (ValueError, IndexError, KeyError):
             return None
 
-    def update(self):
+    async def async_update(self):
         """Get the latest weather data."""
-        self.data.update()
+        await self.data.update()
         thermostat = self.data.ecobee.get_thermostat(self._index)
         self.weather = thermostat.get("weather", None)

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -1,7 +1,6 @@
 """Support for displaying weather info from Ecobee API."""
 from datetime import datetime
 
-from homeassistant.components import ecobee
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_TEMP,
@@ -12,33 +11,37 @@ from homeassistant.components.weather import (
 )
 from homeassistant.const import TEMP_FAHRENHEIT
 
+from .const import DOMAIN
+
 ATTR_FORECAST_TEMP_HIGH = "temphigh"
 ATTR_FORECAST_PRESSURE = "pressure"
 ATTR_FORECAST_VISIBILITY = "visibility"
 ATTR_FORECAST_HUMIDITY = "humidity"
 
-MISSING_DATA = -5002
-
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Ecobee weather platform."""
-    if discovery_info is None:
-        return
+    """Old way of setting up the ecobee weather platform."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the ecobee weather platform."""
+    data = hass.data[DOMAIN]
     dev = list()
-    data = ecobee.NETWORK
     for index in range(len(data.ecobee.thermostats)):
         thermostat = data.ecobee.get_thermostat(index)
         if "weather" in thermostat:
-            dev.append(EcobeeWeather(thermostat["name"], index))
+            dev.append(EcobeeWeather(data, thermostat["name"], index))
 
-    add_entities(dev, True)
+    async_add_entities(dev, True)
 
 
 class EcobeeWeather(WeatherEntity):
     """Representation of Ecobee weather data."""
 
-    def __init__(self, name, index):
+    def __init__(self, data, name, index):
         """Initialize the Ecobee weather platform."""
+        self.data = data
         self._name = name
         self._index = index
         self.weather = None
@@ -129,6 +132,8 @@ class EcobeeWeather(WeatherEntity):
     @property
     def forecast(self):
         """Return the forecast array."""
+        from pyecobee.const import ECOBEE_STATE_UNKNOWN
+
         try:
             forecasts = []
             for day in self.weather["forecasts"]:
@@ -140,17 +145,17 @@ class EcobeeWeather(WeatherEntity):
                     ATTR_FORECAST_CONDITION: day["condition"],
                     ATTR_FORECAST_TEMP: float(day["tempHigh"]) / 10,
                 }
-                if day["tempHigh"] == MISSING_DATA:
+                if day["tempHigh"] == ECOBEE_STATE_UNKNOWN:
                     break
-                if day["tempLow"] != MISSING_DATA:
+                if day["tempLow"] != ECOBEE_STATE_UNKNOWN:
                     forecast[ATTR_FORECAST_TEMP_LOW] = float(day["tempLow"]) / 10
-                if day["pressure"] != MISSING_DATA:
+                if day["pressure"] != ECOBEE_STATE_UNKNOWN:
                     forecast[ATTR_FORECAST_PRESSURE] = int(day["pressure"])
-                if day["windSpeed"] != MISSING_DATA:
+                if day["windSpeed"] != ECOBEE_STATE_UNKNOWN:
                     forecast[ATTR_FORECAST_WIND_SPEED] = int(day["windSpeed"])
-                if day["visibility"] != MISSING_DATA:
+                if day["visibility"] != ECOBEE_STATE_UNKNOWN:
                     forecast[ATTR_FORECAST_WIND_SPEED] = int(day["visibility"])
-                if day["relativeHumidity"] != MISSING_DATA:
+                if day["relativeHumidity"] != ECOBEE_STATE_UNKNOWN:
                     forecast[ATTR_FORECAST_HUMIDITY] = int(day["relativeHumidity"])
                 forecasts.append(forecast)
             return forecasts
@@ -158,8 +163,7 @@ class EcobeeWeather(WeatherEntity):
             return None
 
     def update(self):
-        """Get the latest state of the sensor."""
-        data = ecobee.NETWORK
-        data.update()
-        thermostat = data.ecobee.get_thermostat(self._index)
+        """Get the latest weather data."""
+        self.data.update()
+        thermostat = self.data.ecobee.get_thermostat(self._index)
         self.weather = thermostat.get("weather", None)

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -19,7 +19,7 @@ ATTR_FORECAST_VISIBILITY = "visibility"
 ATTR_FORECAST_HUMIDITY = "humidity"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way of setting up the ecobee weather platform."""
     pass
 

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -15,6 +15,7 @@ FLOWS = [
     "daikin",
     "deconz",
     "dialogflow",
+    "ecobee",
     "emulated_roku",
     "esphome",
     "geofency",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1483,7 +1483,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.0.21
+python-ecobee-api==0.1.2
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -354,6 +354,9 @@ pysonos==0.0.23
 # homeassistant.components.spc
 pyspcwebgw==0.4.0
 
+# homeassistant.components.ecobee
+python-ecobee-api==0.1.2
+
 # homeassistant.components.darksky
 python-forecastio==1.4.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -146,6 +146,7 @@ TEST_REQUIREMENTS = (
     "pysonos",
     "pyspcwebgw",
     "python_awair",
+    "python-ecobee-api",
     "python-forecastio",
     "python-izone",
     "python-nest",

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -54,7 +54,7 @@ class TestEcobee(unittest.TestCase):
 
         self.data = mock.Mock()
         self.data.ecobee.get_thermostat.return_value = self.ecobee
-        self.thermostat = ecobee.Thermostat(self.data, 1, False)
+        self.thermostat = ecobee.Thermostat(self.data, 1)
 
     def test_name(self):
         """Test name property."""

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -6,7 +6,6 @@ from pyecobee import ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
 from homeassistant import data_entry_flow
 from homeassistant.components.ecobee import config_flow
 from homeassistant.components.ecobee.const import (
-    CONF_HOLD_TEMP,
     CONF_REFRESH_TOKEN,
     DATA_ECOBEE_CONFIG,
     DOMAIN,
@@ -197,17 +196,3 @@ async def test_import_flow_triggered_with_ecobee_conf_and_valid_data_and_stale_t
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "user"
-
-
-async def test_option_flow(hass):
-    """Test option flow."""
-    entry = MockConfigEntry(domain=DOMAIN, options={CONF_HOLD_TEMP: None})
-    flow = config_flow.EcobeeFlowHandler().async_get_options_flow(entry)
-
-    result = await flow.async_step_init()
-    assert result["type"] == "form"
-    assert result["step_id"] == "ecobee_options"
-
-    result = await flow.async_step_ecobee_options(user_input={CONF_HOLD_TEMP: False})
-    assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_HOLD_TEMP: False}

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -6,6 +6,7 @@ from pyecobee import ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
 from homeassistant import data_entry_flow
 from homeassistant.components.ecobee import config_flow
 from homeassistant.components.ecobee.const import (
+    CONF_HOLD_TEMP,
     CONF_REFRESH_TOKEN,
     DATA_ECOBEE_CONFIG,
     DOMAIN,
@@ -196,3 +197,17 @@ async def test_import_flow_triggered_with_ecobee_conf_and_valid_data_and_stale_t
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "user"
+
+
+async def test_option_flow(hass):
+    """Test option flow."""
+    entry = MockConfigEntry(domain=DOMAIN, options={CONF_HOLD_TEMP: None})
+    flow = config_flow.EcobeeFlowHandler().async_get_options_flow(entry)
+
+    result = await flow.async_step_init()
+    assert result["type"] == "form"
+    assert result["step_id"] == "ecobee_options"
+
+    result = await flow.async_step_ecobee_options(user_input={CONF_HOLD_TEMP: False})
+    assert result["type"] == "create_entry"
+    assert result["data"] == {CONF_HOLD_TEMP: False}

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.ecobee import config_flow
+from homeassistant.components.ecobee.const import DATA_ECOBEE_CONFIG
 from homeassistant.const import CONF_API_KEY
 
 from homeassistant.components.ecobee.const import CONF_REFRESH_TOKEN
@@ -24,26 +25,28 @@ async def test_full_flow_implementation(hass):
     """Test full ecobee flow works."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
+    flow.hass.data[DATA_ECOBEE_CONFIG] = {}
 
     result = await flow.async_step_user()
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    with patch("config_flow.Ecobee") as mock_ecobee:
-        mock_ecobee.get_pin.return_value = True
-        mock_ecobee.pin = "test_pin"
+    with patch("homeassistant.components.ecobee.config_flow.Ecobee") as mock_ecobee:
+        mock_ecobee.request_pin.return_value = True
+        mock_ecobee.get_tokens.return_value = True
+        mock_ecobee.return_value.pin = "test_pin"
+        mock_ecobee.return_value.refresh_token = "reftoken"
+        mock_ecobee.return_value.api_key = "abcdef123456"
+
         result = await flow.async_step_user(user_input={CONF_API_KEY: "abcdef123456"})
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "authorize"
         assert result["description_placeholders"] == {"pin": "test_pin"}
 
-        mock_ecobee.get_tokens.return_value = True
-        mock_ecobee.refresh_token = "reftoken"
-
         result = await flow.async_step_authorize(user_input={})
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["data"]["title"] == "ecobee"
+        assert result["title"] == "ecobee"
         assert result["data"][CONF_API_KEY] == "abcdef123456"
         assert result["data"][CONF_REFRESH_TOKEN] == "reftoken"

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.ecobee.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_API_KEY
+from tests.common import MockConfigEntry
 
 
 async def test_abort_if_already_setup(hass):
@@ -16,8 +17,9 @@ async def test_abort_if_already_setup(hass):
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
 
-    with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
-        result = await flow.async_step_user()
+    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
+
+    result = await flow.async_step_user()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "one_instance_only"

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -1,0 +1,49 @@
+"""Tests for the ecobee config flow."""
+from unittest.mock import patch
+
+from homeassistant import data_entry_flow
+from homeassistant.components.ecobee import config_flow
+from homeassistant.const import CONF_API_KEY
+
+from homeassistant.components.ecobee.const import CONF_REFRESH_TOKEN
+
+
+async def test_abort_if_already_setup(hass):
+    """Test we abort if ecobee is already setup."""
+    flow = config_flow.EcobeeFlowHandler()
+    flow.hass = hass
+
+    with patch.object(hass.config_entries, "async_entries", return_value=[{}]):
+        result = await flow.async_step_user()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "one_instance_only"
+
+
+async def test_full_flow_implementation(hass):
+    """Test full ecobee flow works."""
+    flow = config_flow.EcobeeFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_user()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    with patch("config_flow.Ecobee") as mock_ecobee:
+        mock_ecobee.get_pin.return_value = True
+        mock_ecobee.pin = "test_pin"
+        result = await flow.async_step_user(user_input={CONF_API_KEY: "abcdef123456"})
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "authorize"
+        assert result["description_placeholders"] == {"pin": "test_pin"}
+
+        mock_ecobee.get_tokens.return_value = True
+        mock_ecobee.refresh_token = "reftoken"
+
+        result = await flow.async_step_authorize(user_input={})
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["data"]["title"] == "ecobee"
+        assert result["data"][CONF_API_KEY] == "abcdef123456"
+        assert result["data"][CONF_REFRESH_TOKEN] == "reftoken"

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -1,12 +1,10 @@
 """Tests for the ecobee config flow."""
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.ecobee import config_flow
 from homeassistant.components.ecobee.const import DATA_ECOBEE_CONFIG
 from homeassistant.const import CONF_API_KEY
-
-from homeassistant.components.ecobee.const import CONF_REFRESH_TOKEN
 
 
 async def test_abort_if_already_setup(hass):
@@ -21,8 +19,8 @@ async def test_abort_if_already_setup(hass):
     assert result["reason"] == "one_instance_only"
 
 
-async def test_full_flow_implementation(hass):
-    """Test full ecobee flow works."""
+async def test_user_step_without_user_input(hass):
+    """Test expected result if user step is called."""
     flow = config_flow.EcobeeFlowHandler()
     flow.hass = hass
     flow.hass.data[DATA_ECOBEE_CONFIG] = {}
@@ -31,22 +29,37 @@ async def test_full_flow_implementation(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    with patch("homeassistant.components.ecobee.config_flow.Ecobee") as mock_ecobee:
-        mock_ecobee.request_pin.return_value = True
-        mock_ecobee.get_tokens.return_value = True
-        mock_ecobee.return_value.pin = "test_pin"
-        mock_ecobee.return_value.refresh_token = "reftoken"
-        mock_ecobee.return_value.api_key = "abcdef123456"
 
-        result = await flow.async_step_user(user_input={CONF_API_KEY: "abcdef123456"})
+async def test_pin_request_succeeds(hass):
+    """Test expected result if pin request succeeds."""
+    flow = config_flow.EcobeeFlowHandler()
+    flow.hass = hass
+    flow.hass.data[DATA_ECOBEE_CONFIG] = {}
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["step_id"] == "authorize"
-        assert result["description_placeholders"] == {"pin": "test_pin"}
+    mock_ecobee = Mock()
+    mock_ecobee.request_pin.return_value = True
+    mock_ecobee.return_value.pin = "test-pin"
+    config_flow.Ecobee = mock_ecobee
 
-        result = await flow.async_step_authorize(user_input={})
+    result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "ecobee"
-        assert result["data"][CONF_API_KEY] == "abcdef123456"
-        assert result["data"][CONF_REFRESH_TOKEN] == "reftoken"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "authorize"
+    assert result["description_placeholders"] == {"pin": "test-pin"}
+
+
+async def test_pin_request_fails(hass):
+    """Test expected result if pin request fails."""
+    flow = config_flow.EcobeeFlowHandler()
+    flow.hass = hass
+    flow.hass.data[DATA_ECOBEE_CONFIG] = {}
+
+    mock_ecobee = Mock()
+    mock_ecobee.request_pin.return_value = False
+    config_flow.Ecobee = mock_ecobee
+
+    result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"]["base"] == "pin_request_failed"

--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -1,5 +1,5 @@
 """Tests for the ecobee config flow."""
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.ecobee import config_flow
@@ -36,16 +36,15 @@ async def test_pin_request_succeeds(hass):
     flow.hass = hass
     flow.hass.data[DATA_ECOBEE_CONFIG] = {}
 
-    mock_ecobee = Mock()
-    mock_ecobee.request_pin.return_value = True
-    mock_ecobee.return_value.pin = "test-pin"
-    config_flow.Ecobee = mock_ecobee
+    with patch("homeassistant.components.ecobee.config_flow.Ecobee") as mock_ecobee:
+        mock_ecobee.request_pin.return_value = True
+        mock_ecobee.return_value.pin = "test-pin"
 
-    result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
+        result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "authorize"
-    assert result["description_placeholders"] == {"pin": "test-pin"}
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "authorize"
+        assert result["description_placeholders"] == {"pin": "test-pin"}
 
 
 async def test_pin_request_fails(hass):
@@ -54,12 +53,11 @@ async def test_pin_request_fails(hass):
     flow.hass = hass
     flow.hass.data[DATA_ECOBEE_CONFIG] = {}
 
-    mock_ecobee = Mock()
-    mock_ecobee.request_pin.return_value = False
-    config_flow.Ecobee = mock_ecobee
+    with patch("homeassistant.components.ecobee.config_flow.Ecobee") as mock_ecobee:
+        mock_ecobee.request_pin.return_value = False
 
-    result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
+        result = await flow.async_step_user(user_input={CONF_API_KEY: "api-key"})
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-    assert result["errors"]["base"] == "pin_request_failed"
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "pin_request_failed"


### PR DESCRIPTION
## Breaking Change:

Ecobee will now be set up via config flow. Existing users will have their config imported from ecobee.conf via an import flow so it shouldn't break their experience. Users configuring via configuration.yaml will have their api key and options imported into the flow but will still need to finish authorization via the flow (instead of the configurator component as previously).

The configuration parameter `hold_temp` has been removed, as it was not being used in the climate platform and had no effect on whether the temperature was held indefinitely or not. Users will need to remove the parameter `hold_temp` from configuration.yaml.

Ecobee-specific services will now be registered under the `ecobee` domain rather than the `climate` domain, and service names will not include the prefix "ecobee_" (e.g. the service "climate.ecobee_resume_program" will become "ecobee.resume_program").

## Description:

Adds a config flow to the ecobee component. This PR is Phase 1 of my planned updates to the ecobee component to make it a first-class integration - in this PR I've tried to make only the minimal changes that were necessary to support loading ecobee via a config entry to aid reviewability.
 
Phase 2 will follow the merging of this PR and add support for the entity and device registries. Phase 3 will make everything async. 

Upstream library has been updated with needed changes for the config flow.

Tests have been added for the config flow.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10428

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html