### PR TITLE
Encode prometheus metric names per the prom spec

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -1,5 +1,6 @@
 """Support for Prometheus metrics export."""
 import logging
+import string
 
 from aiohttp import web
 import voluptuous as vol
@@ -159,9 +160,22 @@ class PrometheusMetrics:
         try:
             return self._metrics[metric]
         except KeyError:
-            full_metric_name = f"{self.metrics_prefix}{metric}"
+            full_metric_name = self._sanitize_metric_name(
+                f"{self.metrics_prefix}{metric}"
+            )
             self._metrics[metric] = factory(full_metric_name, documentation, labels)
             return self._metrics[metric]
+
+    @staticmethod
+    def _sanitize_metric_name(metric: str) -> str:
+        return "".join(
+            [
+                c
+                if c in string.ascii_letters or c.isdigit() or c == "_" or c == ":"
+                else f"u{hex(ord(c))}"
+                for c in metric
+            ]
+        )
 
     @staticmethod
     def state_as_number(state):

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -41,6 +41,11 @@ async def prometheus_client(loop, hass, hass_client):
     sensor3.entity_id = "sensor.electricity_price"
     await sensor3.async_update_ha_state()
 
+    sensor4 = DemoSensor("Wind Direction", 25, None, "°", None)
+    sensor4.hass = hass
+    sensor4.entity_id = "sensor.wind_direction"
+    await sensor4.async_update_ha_state()
+
     return await hass_client()
 
 
@@ -102,4 +107,10 @@ def test_view(prometheus_client):  # pylint: disable=redefined-outer-name
         'sensor_unit_sek_per_kwh{domain="sensor",'
         'entity="sensor.electricity_price",'
         'friendly_name="Electricity price"} 0.123' in body
+    )
+
+    assert (
+        'sensor_unit_u0xb0{domain="sensor",'
+        'entity="sensor.wind_direction",'
+        'friendly_name="Wind Direction"} 25.0' in body
     )


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Referencing issue #26418.

Prometheus metric names can only contain chars a-zA-Z0-9, : and _
(https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).

HA currently generates invalid prometheus names, e.g. if the unit for a
sensor is a non-ASCII character containing  ° or μ. To resolve, we need
to sanitize the name before creating, replacing non-valid characters
with a valid representation. In this case, I've used
"u{unicode-hex-code}".

Also updated the test case to make sure that the ° case is handled.

**Related issue (if applicable):** 
fixes #26418

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
