### PR TITLE
DO NOT MERGE - Refactor bluetooth tracker to config entry

### DIFF
--- a/homeassistant/components/bluetooth_tracker/const.py
+++ b/homeassistant/components/bluetooth_tracker/const.py
@@ -1,0 +1,3 @@
+"""Constants for bluetooth tracker."""
+
+DOMAIN = "bluetooth_tracker"

--- a/homeassistant/components/bluetooth_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_tracker/device_tracker.py
@@ -1,6 +1,5 @@
 """Tracking for bluetooth devices."""
 import asyncio
-import datetime
 import logging
 from typing import Any, Callable, List, Optional, Set, Tuple
 
@@ -192,14 +191,6 @@ async def async_setup_entry(
 class BluetoothEntity(ScannerEntity):
     """Represent a tracked device that is on a scanned bluetooth network."""
 
-    mac: str
-
-    _attributes: dict
-    _config_entry: ConfigEntry
-    _last_seen: datetime.datetime
-    _name: str
-    _unsub_dispatcher: Optional[Callable]
-
     def __init__(
         self, config_entry: ConfigEntry, mac: str, device_name: str, attributes: dict
     ):
@@ -209,17 +200,7 @@ class BluetoothEntity(ScannerEntity):
         self._config_entry = config_entry
         self._last_seen = dt_util.utcnow()
         self._name = device_name
-        self._unsub_dispatcher = None
-
-    def __hash__(self):
-        """Return the hash for the entity."""
-        return hash(self.mac)
-
-    def __eq__(self, other):
-        """Check whether this entity is equal to another."""
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self.mac == other.mac
+        self._unsub_dispatcher: Optional[Callable] = None
 
     @property
     def device_info(self):


### PR DESCRIPTION
## Description:
Bluetooth Tracker used to rely on `track_new_devices` in the root of the device tracker definition (platform). This was undocumented, and was basically a bad usage of it - it should actually go into `new_device_defaults.track_new_devices` and means that when a new device is discovered - should it be tracked, which is not the same as whether the platform should discover new devices.

This PR adds a new option to the platform schema - `discover_new_devices` which indicates whether the tracker should discover new devices. The reason not to discover devices is obvious - you just want to work with a finite set of known devices which you are tracking. The discovery of new devices also takes considerable delay of several seconds.

This PR also maintains backwards compatibility by first verifying if the user defined the legacy `track_new_devices`. If so it warns the user about the deprecated usage but still uses it, so no breaking change here.

I couldn't for the life of me get the `cv.deprecated` schema validation to work with both fields, if anyone can show me how to get it to work I'd love that.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10364

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: bluetooth_tracker
    discover_new_devices: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
