### PR TITLE
Fix Environment Canada weather forecast, retain icon_code sensor

### DIFF
--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -3,7 +3,7 @@
   "name": "Environment Canada",
   "documentation": "https://www.home-assistant.io/components/environment_canada",
   "requirements": [
-    "env_canada==0.0.24"
+    "env_canada==0.0.25"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -68,7 +68,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ec_data = ECData(coordinates=(lat, lon), language=config.get(CONF_LANGUAGE))
 
     sensor_list = list(ec_data.conditions.keys()) + list(ec_data.alerts.keys())
-    sensor_list.remove("icon_code")
     add_entities([ECSensor(sensor_type, ec_data) for sensor_type in sensor_list], True)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -446,7 +446,7 @@ enocean==0.50
 enturclient==0.2.0
 
 # homeassistant.components.environment_canada
-env_canada==0.0.24
+env_canada==0.0.25
 
 # homeassistant.components.envirophat
 # envirophat==0.0.6


### PR DESCRIPTION
## Description:

* Bumps `env_canada` to 0.0.25 to address issue of weather forecasts not updating
* Retains `icon_code` sensor for use with TileBoard

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10365

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
