### PR TITLE
deCONZ - Remove mechanisms to import a configuration from configuration.yaml

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -1,48 +1,20 @@
 """Support for deCONZ devices."""
 import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_STOP,
-)
-from homeassistant.helpers import config_validation as cv
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 from .config_flow import get_master_gateway
-from .const import CONF_BRIDGEID, CONF_MASTER_GATEWAY, DEFAULT_PORT, DOMAIN
+from .const import CONF_BRIDGEID, CONF_MASTER_GATEWAY, DOMAIN
 from .gateway import DeconzGateway
 from .services import async_setup_services, async_unload_services
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_API_KEY): cv.string,
-                vol.Optional(CONF_HOST): cv.string,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
+    {DOMAIN: vol.Schema({}, extra=vol.ALLOW_EXTRA)}, extra=vol.ALLOW_EXTRA
 )
 
 
 async def async_setup(hass, config):
-    """Load configuration for deCONZ component.
-
-    Discovery has loaded the component if DOMAIN is not present in config.
-    """
-    if not hass.config_entries.async_entries(DOMAIN) and DOMAIN in config:
-        deconz_config = config[DOMAIN]
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_IMPORT},
-                data=deconz_config,
-            )
-        )
+    """Old way of setting up deCONZ integrations."""
     return True
 
 

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -191,31 +191,12 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # pylint: disable=unsupported-assignment-operation
         self.context[CONF_BRIDGEID] = bridgeid
 
-        deconz_config = {
+        self.deconz_config = {
             CONF_HOST: discovery_info[CONF_HOST],
             CONF_PORT: discovery_info[CONF_PORT],
         }
 
-        return await self.async_step_import(deconz_config)
-
-    async def async_step_import(self, import_config):
-        """Import a deCONZ bridge as a config entry.
-
-        This flow is triggered by `async_setup` for configured bridges.
-        This flow is also triggered by `async_step_discovery`.
-
-        This will execute for any bridge that does not have a
-        config entry yet (based on host).
-
-        If an API key is provided, we will create an entry.
-        Otherwise we will delegate to `link` step which
-        will ask user to link the bridge.
-        """
-        self.deconz_config = import_config
-        if CONF_API_KEY not in import_config:
-            return await self.async_step_link()
-
-        return await self._create_entry()
+        return await self.async_step_link()
 
     async def async_step_hassio(self, user_input=None):
         """Prepare configuration for a Hass.io deCONZ bridge.

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -234,41 +234,6 @@ async def test_bridge_discovery_update_existing_entry(hass):
     assert entry.data[config_flow.CONF_HOST] == "mock-deconz"
 
 
-async def test_import_without_api_key(hass):
-    """Test importing a host without an API key."""
-    result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
-        data={config_flow.CONF_HOST: "1.2.3.4"},
-        context={"source": "import"},
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "link"
-
-
-async def test_import_with_api_key(hass):
-    """Test importing a host with an API key."""
-    result = await hass.config_entries.flow.async_init(
-        config_flow.DOMAIN,
-        data={
-            config_flow.CONF_BRIDGEID: "id",
-            config_flow.CONF_HOST: "mock-deconz",
-            config_flow.CONF_PORT: 80,
-            config_flow.CONF_API_KEY: "1234567890ABCDEF",
-        },
-        context={"source": "import"},
-    )
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "deCONZ-id"
-    assert result["data"] == {
-        config_flow.CONF_BRIDGEID: "id",
-        config_flow.CONF_HOST: "mock-deconz",
-        config_flow.CONF_PORT: 80,
-        config_flow.CONF_API_KEY: "1234567890ABCDEF",
-    }
-
-
 async def test_create_entry(hass, aioclient_mock):
     """Test that _create_entry work and that bridgeid can be requested."""
     aioclient_mock.get(

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -6,7 +6,6 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.setup import async_setup_component
 from homeassistant.components import deconz
 
 from tests.common import mock_coro, MockConfigEntry
@@ -34,74 +33,13 @@ async def setup_entry(hass, entry):
         assert await deconz.async_setup_entry(hass, entry) is True
 
 
-async def test_config_with_host_passed_to_config_entry(hass):
-    """Test that configured options for a host are loaded via config entry."""
-    with patch.object(hass.config_entries, "flow") as mock_config_flow:
-        assert (
-            await async_setup_component(
-                hass,
-                deconz.DOMAIN,
-                {
-                    deconz.DOMAIN: {
-                        deconz.CONF_HOST: ENTRY1_HOST,
-                        deconz.CONF_PORT: ENTRY1_PORT,
-                    }
-                },
-            )
-            is True
-        )
-    # Import flow started
-    assert len(mock_config_flow.mock_calls) == 1
-
-
-async def test_config_without_host_not_passed_to_config_entry(hass):
-    """Test that a configuration without a host does not initiate an import."""
-    MockConfigEntry(domain=deconz.DOMAIN, data={}).add_to_hass(hass)
-    with patch.object(hass.config_entries, "flow") as mock_config_flow:
-        assert (
-            await async_setup_component(hass, deconz.DOMAIN, {deconz.DOMAIN: {}})
-            is True
-        )
-    # No flow started
-    assert len(mock_config_flow.mock_calls) == 0
-
-
-async def test_config_import_entry_fails_when_entries_exist(hass):
-    """Test that an already registered host does not initiate an import."""
-    MockConfigEntry(domain=deconz.DOMAIN, data={}).add_to_hass(hass)
-    with patch.object(hass.config_entries, "flow") as mock_config_flow:
-        assert (
-            await async_setup_component(
-                hass,
-                deconz.DOMAIN,
-                {
-                    deconz.DOMAIN: {
-                        deconz.CONF_HOST: ENTRY1_HOST,
-                        deconz.CONF_PORT: ENTRY1_PORT,
-                    }
-                },
-            )
-            is True
-        )
-    # No flow started
-    assert len(mock_config_flow.mock_calls) == 0
-
-
-async def test_config_discovery(hass):
-    """Test that a discovered bridge does not initiate an import."""
-    with patch.object(hass, "config_entries") as mock_config_entries:
-        assert await async_setup_component(hass, deconz.DOMAIN, {}) is True
-    # No flow started
-    assert len(mock_config_entries.flow.mock_calls) == 0
-
-
 async def test_setup_entry_fails(hass):
     """Test setup entry fails if deCONZ is not available."""
     entry = Mock()
     entry.data = {
-        deconz.CONF_HOST: ENTRY1_HOST,
-        deconz.CONF_PORT: ENTRY1_PORT,
-        deconz.CONF_API_KEY: ENTRY1_API_KEY,
+        deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+        deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+        deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
     }
     with patch("pydeconz.DeconzSession.async_load_parameters", side_effect=Exception):
         await deconz.async_setup_entry(hass, entry)
@@ -111,9 +49,9 @@ async def test_setup_entry_no_available_bridge(hass):
     """Test setup entry fails if deCONZ is not available."""
     entry = Mock()
     entry.data = {
-        deconz.CONF_HOST: ENTRY1_HOST,
-        deconz.CONF_PORT: ENTRY1_PORT,
-        deconz.CONF_API_KEY: ENTRY1_API_KEY,
+        deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+        deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+        deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
     }
     with patch(
         "pydeconz.DeconzSession.async_load_parameters", side_effect=asyncio.TimeoutError
@@ -126,9 +64,9 @@ async def test_setup_entry_successful(hass):
     entry = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY1_HOST,
-            deconz.CONF_PORT: ENTRY1_PORT,
-            deconz.CONF_API_KEY: ENTRY1_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
         },
     )
@@ -145,9 +83,9 @@ async def test_setup_entry_multiple_gateways(hass):
     entry = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY1_HOST,
-            deconz.CONF_PORT: ENTRY1_PORT,
-            deconz.CONF_API_KEY: ENTRY1_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
         },
     )
@@ -156,9 +94,9 @@ async def test_setup_entry_multiple_gateways(hass):
     entry2 = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY2_HOST,
-            deconz.CONF_PORT: ENTRY2_PORT,
-            deconz.CONF_API_KEY: ENTRY2_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY2_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY2_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY2_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY2_BRIDGEID,
         },
     )
@@ -178,9 +116,9 @@ async def test_unload_entry(hass):
     entry = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY1_HOST,
-            deconz.CONF_PORT: ENTRY1_PORT,
-            deconz.CONF_API_KEY: ENTRY1_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
         },
     )
@@ -201,9 +139,9 @@ async def test_unload_entry_multiple_gateways(hass):
     entry = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY1_HOST,
-            deconz.CONF_PORT: ENTRY1_PORT,
-            deconz.CONF_API_KEY: ENTRY1_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
         },
     )
@@ -212,9 +150,9 @@ async def test_unload_entry_multiple_gateways(hass):
     entry2 = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY2_HOST,
-            deconz.CONF_PORT: ENTRY2_PORT,
-            deconz.CONF_API_KEY: ENTRY2_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY2_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY2_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY2_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY2_BRIDGEID,
         },
     )
@@ -237,9 +175,9 @@ async def test_service_configure(hass):
     entry = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY1_HOST,
-            deconz.CONF_PORT: ENTRY1_PORT,
-            deconz.CONF_API_KEY: ENTRY1_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
         },
     )
@@ -304,9 +242,9 @@ async def test_service_refresh_devices(hass):
     entry = MockConfigEntry(
         domain=deconz.DOMAIN,
         data={
-            deconz.CONF_HOST: ENTRY1_HOST,
-            deconz.CONF_PORT: ENTRY1_PORT,
-            deconz.CONF_API_KEY: ENTRY1_API_KEY,
+            deconz.config_flow.CONF_HOST: ENTRY1_HOST,
+            deconz.config_flow.CONF_PORT: ENTRY1_PORT,
+            deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
         },
     )


### PR DESCRIPTION
## Breaking Change:

With Home Assistant releases 0.100 and 0.101 deCONZ will end support of importing configurations from configuration.yaml

In 0.100, deCONZ will ignore what is in the `deconz:`
In 0.101, deCONZ will fail on config validation and not allow the `deconz` section to exist in configuration.yaml.

TL;DR This will no longer work:
```yaml
deconz:
```

## Description:
Remove import mechanism of configuration.yaml, but allow `deconz:` to exist

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
