### PR TITLE
Hide "PTZ is not available on this camera" warning

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -282,7 +282,7 @@ class ONVIFHassCamera(Camera):
         """Set up PTZ if available."""
         _LOGGER.debug("Setting up the ONVIF PTZ service")
         if self._camera.get_service("ptz", create=False) is None:
-            _LOGGER.warning("PTZ is not available on this camera")
+            _LOGGER.info("PTZ is not available on this camera")
         else:
             self._ptz_service = self._camera.create_ptz_service()
             _LOGGER.debug("Completed set up of the ONVIF camera component")

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -282,7 +282,7 @@ class ONVIFHassCamera(Camera):
         """Set up PTZ if available."""
         _LOGGER.debug("Setting up the ONVIF PTZ service")
         if self._camera.get_service("ptz", create=False) is None:
-            _LOGGER.info("PTZ is not available on this camera")
+            _LOGGER.debug("PTZ is not available")
         else:
             self._ptz_service = self._camera.create_ptz_service()
             _LOGGER.debug("Completed set up of the ONVIF camera component")


### PR DESCRIPTION
## Description:
Home Assistant prints "PTZ is not available on this camera" warning on every start because my camera doesn't support PTZ. It's really annoying. I think that message should has 'info' severity because there is no problem.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
