### PR TITLE
Add full state view for emulated_hue (apps using emulated_hue, 'sleep cycle' and 'sleep as android')

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -19,6 +19,7 @@ from .hue_api import (
     HueOneLightChangeView,
     HueGroupView,
     HueAllGroupsStateView,
+    HueFullStateView,
 )
 from .upnp import DescriptionXmlView, UPNPResponderThread
 
@@ -118,6 +119,7 @@ async def async_setup(hass, yaml_config):
     HueOneLightChangeView(config).register(app, app.router)
     HueAllGroupsStateView(config).register(app, app.router)
     HueGroupView(config).register(app, app.router)
+    HueFullStateView(config).register(app, app.router)
 
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr,

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.components.http import real_ip
 
 from .hue_api import (
     HueUsernameView,
+    HueUnauthorizedUser,
     HueAllLightsStateView,
     HueOneLightStateView,
     HueOneLightChangeView,
@@ -114,6 +115,7 @@ async def async_setup(hass, yaml_config):
 
     DescriptionXmlView(config).register(app, app.router)
     HueUsernameView().register(app, app.router)
+    HueUnauthorizedUser().register(app, app.router)
     HueAllLightsStateView(config).register(app, app.router)
     HueOneLightStateView(config).register(app, app.router)
     HueOneLightChangeView(config).register(app, app.router)

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -227,9 +227,7 @@ class HueFullStateView(HomeAssistantView):
                 "mac": "00:00:00:00:00:00",
                 "swversion": "01003542",
                 "whitelist": {HUE_API_USERNAME: {"name": "HASS BRIDGE"}},
-                "ipaddress": str(self.config.advertise_ip)
-                + ":"
-                + str(self.config.advertise_port),
+                "ipaddress": f"{self.config.advertise_ip}:{self.config.advertise_port}",
             },
         }
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -217,7 +217,7 @@ class HueFullStateView(HomeAssistantView):
     def get(self, request, username):
         """Process a request to get the list of available lights."""
         if not is_local(request[KEY_REAL_IP]):
-            return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
+            return self.json_message("only local IPs allowed", HTTP_UNAUTHORIZED)
         if username != HUE_API_USERNAME:
             return self.json(UNAUTHORIZED_USER)
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -90,6 +90,22 @@ HUE_API_STATE_CT_MIN = 153  # Color temp
 HUE_API_STATE_CT_MAX = 500
 
 HUE_API_USERNAME = "12345678901234567890"
+UNAUTHORIZED_USER = [
+    {"error": {"address": "/", "description": "unauthorized user", "type": "1"}}
+]
+
+
+class HueUnauthorizedUser(HomeAssistantView):
+    """Handle requests to find the emulated hue bridge."""
+
+    url = "/api"
+    name = "emulated_hue:api:unauthorized_user"
+    extra_urls = ["/api/"]
+    requires_auth = False
+
+    async def get(self, request):
+        """Handle a GET request."""
+        return self.json(UNAUTHORIZED_USER)
 
 
 class HueUsernameView(HomeAssistantView):
@@ -199,7 +215,7 @@ class HueFullStateView(HomeAssistantView):
     """Return full state view of emulated hue."""
 
     url = "/api/{username}"
-    name = "emulated_hue:username:lights:state"
+    name = "emulated_hue:username:state"
     requires_auth = False
 
     def __init__(self, config):
@@ -211,37 +227,29 @@ class HueFullStateView(HomeAssistantView):
         """Process a request to get the list of available lights."""
         if not is_local(request[KEY_REAL_IP]):
             return self.json_message("only local IPs allowed", HTTP_BAD_REQUEST)
-        if username not in HUE_API_USERNAME:
-            json_response = [
-                {
-                    "error": {
-                        "address": "/",
-                        "description": "unauthorized user",
-                        "type": "1",
-                    }
-                }
-            ]
-        else:
-            hass = request.app["hass"]
-            json_response = {}
+        if username != HUE_API_USERNAME:
+            return self.json(UNAUTHORIZED_USER)
 
-            for entity in hass.states.async_all():
-                if self.config.is_entity_exposed(entity):
-                    state = get_entity_state(self.config, entity)
-                    number = self.config.entity_id_to_number(entity.entity_id)
-                    json_response[number] = entity_to_json(self.config, entity, state)
+        hass = request.app["hass"]
+        json_response = {}
 
-            json_response = {
-                "lights": json_response,
-                "config": {
-                    "mac": "00:00:00:00:00:00",
-                    "swversion": "01003542",
-                    "whitelist": {HUE_API_USERNAME: {"name": "HASS BRIDGE"}},
-                    "ipaddress": str(self.config.advertise_ip)
-                    + ":"
-                    + str(self.config.advertise_port),
-                },
-            }
+        for entity in hass.states.async_all():
+            if self.config.is_entity_exposed(entity):
+                state = get_entity_state(self.config, entity)
+                number = self.config.entity_id_to_number(entity.entity_id)
+                json_response[number] = entity_to_json(self.config, entity, state)
+
+        json_response = {
+            "lights": json_response,
+            "config": {
+                "mac": "00:00:00:00:00:00",
+                "swversion": "01003542",
+                "whitelist": {HUE_API_USERNAME: {"name": "HASS BRIDGE"}},
+                "ipaddress": str(self.config.advertise_ip)
+                + ":"
+                + str(self.config.advertise_port),
+            },
+        }
 
         return self.json(json_response)
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -129,7 +129,6 @@ class HueUsernameView(HomeAssistantView):
         if "devicetype" not in data:
             return self.json_message("devicetype not specified", HTTP_BAD_REQUEST)
 
-
         return self.json([{"success": {"username": HUE_API_USERNAME}}])
 
 
@@ -199,7 +198,6 @@ class HueAllLightsStateView(HomeAssistantView):
         """Process a request to get the list of available lights."""
         if not is_local(request[KEY_REAL_IP]):
             return self.json_message("Only local IPs allowed", HTTP_UNAUTHORIZED)
-
 
         return self.json(create_list_of_entities(self.config, request))
 

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -282,7 +282,6 @@ def test_discover_full_state(hue_client):
     # Make sure the config wrapper added to the config is there
     assert "mac" in config_json
     assert "00:00:00:00:00:00" in config_json["mac"]
-    assert "FF:FF:FF:FF:FF:FF" not in config_json["mac"]
 
     # Make sure the correct version in config
     assert "swversion" in config_json
@@ -297,24 +296,6 @@ def test_discover_full_state(hue_client):
     # Make sure the correct ip in config
     assert "ipaddress" in config_json
     assert "127.0.0.1:8300" in config_json["ipaddress"]
-
-    devices = set(val["uniqueid"] for val in result_json["lights"].values())
-
-    # Make sure the lights we added to the config are there
-    assert "00:2f:d2:31:ce:c5:55:cc-ee" in devices  # light.ceiling_lights
-    assert "00:b6:14:77:34:b7:bb:06-e8" not in devices  # light.bed_light
-    assert "00:95:b7:51:16:58:6c:c0-c5" in devices  # script.set_kitchen_light
-    assert "00:64:7b:e4:96:c3:fe:90-c3" not in devices  # light.kitchen_lights
-    assert "00:7e:8a:42:35:66:db:86-c5" in devices  # media_player.living_room
-    assert "00:05:44:c2:d6:0a:e5:17-b7" in devices  # media_player.bedroom
-    assert "00:f3:5f:fa:31:f3:32:21-a8" in devices  # media_player.walkman
-    assert "00:b4:06:2e:91:95:23:97-fb" in devices  # media_player.lounge_room
-    assert "00:b2:bd:f9:2c:ad:22:ae-58" in devices  # fan.living_room_fan
-    assert "00:77:4c:8a:23:7d:27:4b-7f" not in devices  # fan.ceiling_fan
-    assert "00:02:53:b9:d5:1a:b3:67-b2" in devices  # cover.living_room_window
-    assert "00:42:03:fe:97:58:2d:b1-50" in devices  # climate.hvac
-    assert "00:7b:2a:c7:08:d6:66:bf-80" in devices  # climate.heatpump
-    assert "00:57:77:a1:6a:8e:ef:b3-6c" not in devices  # climate.ecobee
 
 
 @asyncio.coroutine

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -301,20 +301,20 @@ def test_discover_full_state(hue_client):
     devices = set(val["uniqueid"] for val in result_json["lights"].values())
 
     # Make sure the lights we added to the config are there
-    assert "light.ceiling_lights" in devices
-    assert "light.bed_light" not in devices
-    assert "script.set_kitchen_light" in devices
-    assert "light.kitchen_lights" not in devices
-    assert "media_player.living_room" in devices
-    assert "media_player.bedroom" in devices
-    assert "media_player.walkman" in devices
-    assert "media_player.lounge_room" in devices
-    assert "fan.living_room_fan" in devices
-    assert "fan.ceiling_fan" not in devices
-    assert "cover.living_room_window" in devices
-    assert "climate.hvac" in devices
-    assert "climate.heatpump" in devices
-    assert "climate.ecobee" not in devices
+    assert "00:2f:d2:31:ce:c5:55:cc-ee" in devices  # light.ceiling_lights
+    assert "00:b6:14:77:34:b7:bb:06-e8" not in devices  # light.bed_light
+    assert "00:95:b7:51:16:58:6c:c0-c5" in devices  # script.set_kitchen_light
+    assert "00:64:7b:e4:96:c3:fe:90-c3" not in devices  # light.kitchen_lights
+    assert "00:7e:8a:42:35:66:db:86-c5" in devices  # media_player.living_room
+    assert "00:05:44:c2:d6:0a:e5:17-b7" in devices  # media_player.bedroom
+    assert "00:f3:5f:fa:31:f3:32:21-a8" in devices  # media_player.walkman
+    assert "00:b4:06:2e:91:95:23:97-fb" in devices  # media_player.lounge_room
+    assert "00:b2:bd:f9:2c:ad:22:ae-58" in devices  # fan.living_room_fan
+    assert "00:77:4c:8a:23:7d:27:4b-7f" not in devices  # fan.ceiling_fan
+    assert "00:02:53:b9:d5:1a:b3:67-b2" in devices  # cover.living_room_window
+    assert "00:42:03:fe:97:58:2d:b1-50" in devices  # climate.hvac
+    assert "00:7b:2a:c7:08:d6:66:bf-80" in devices  # climate.heatpump
+    assert "00:57:77:a1:6a:8e:ef:b3-6c" not in devices  # climate.ecobee
 
 
 @asyncio.coroutine
@@ -842,12 +842,12 @@ async def test_external_ip_blocked(hue_client):
     ):
         for getUrl in getUrls:
             result = await hue_client.get(getUrl)
-            assert result.status == 400
+            assert result.status == 401
 
         for postUrl in postUrls:
             result = await hue_client.post(postUrl)
-            assert result.status == 400
+            assert result.status == 401
 
         for putUrl in putUrls:
             result = await hue_client.put(putUrl)
-            assert result.status == 400
+            assert result.status == 401

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -25,11 +25,13 @@ from homeassistant.components.emulated_hue.hue_api import (
     HUE_API_STATE_BRI,
     HUE_API_STATE_HUE,
     HUE_API_STATE_SAT,
+    HUE_API_USERNAME,
     HueUsernameView,
     HueOneLightStateView,
     HueAllLightsStateView,
     HueOneLightChangeView,
     HueAllGroupsStateView,
+    HueFullStateView,
 )
 from homeassistant.const import STATE_ON, STATE_OFF
 
@@ -188,6 +190,7 @@ def hue_client(loop, hass_hue, aiohttp_client):
     HueOneLightStateView(config).register(web_app, web_app.router)
     HueOneLightChangeView(config).register(web_app, web_app.router)
     HueAllGroupsStateView(config).register(web_app, web_app.router)
+    HueFullStateView(config).register(web_app, web_app.router)
 
     return loop.run_until_complete(aiohttp_client(web_app))
 
@@ -250,6 +253,68 @@ def test_reachable_for_state(hass_hue, hue_client, state, is_reachable):
     state_json = yield from perform_get_light_state(hue_client, entity_id, 200)
 
     assert state_json["state"]["reachable"] == is_reachable, state_json
+
+
+@asyncio.coroutine
+def test_discover_full_state(hue_client):
+    """Test the discovery of full state."""
+    result = yield from hue_client.get("/api/" + HUE_API_USERNAME)
+
+    assert result.status == 200
+    assert "application/json" in result.headers["content-type"]
+
+    result_json = yield from result.json()
+
+    # Make sure array has correct content
+    assert "lights" in result_json
+    assert "lights" not in result_json["config"]
+    assert "config" in result_json
+    assert "config" not in result_json["lights"]
+
+    lights_json = result_json["lights"]
+    config_json = result_json["config"]
+
+    # Make sure array is correct size
+    assert len(result_json) == 2
+    assert len(config_json) == 4
+    assert len(lights_json) >= 1
+
+    # Make sure the config wrapper added to the config is there
+    assert "mac" in config_json
+    assert "00:00:00:00:00:00" in config_json["mac"]
+    assert "FF:FF:FF:FF:FF:FF" not in config_json["mac"]
+
+    # Make sure the correct version in config
+    assert "swversion" in config_json
+    assert "01003542" in config_json["swversion"]
+
+    # Make sure the correct username in config
+    assert "whitelist" in config_json
+    assert HUE_API_USERNAME in config_json["whitelist"]
+    assert "name" in config_json["whitelist"][HUE_API_USERNAME]
+    assert "HASS BRIDGE" in config_json["whitelist"][HUE_API_USERNAME]["name"]
+
+    # Make sure the correct ip in config
+    assert "ipaddress" in config_json
+    assert "127.0.0.1:8300" in config_json["ipaddress"]
+
+    devices = set(val["uniqueid"] for val in result_json["lights"].values())
+
+    # Make sure the lights we added to the config are there
+    assert "light.ceiling_lights" in devices
+    assert "light.bed_light" not in devices
+    assert "script.set_kitchen_light" in devices
+    assert "light.kitchen_lights" not in devices
+    assert "media_player.living_room" in devices
+    assert "media_player.bedroom" in devices
+    assert "media_player.walkman" in devices
+    assert "media_player.lounge_room" in devices
+    assert "fan.living_room_fan" in devices
+    assert "fan.ceiling_fan" not in devices
+    assert "cover.living_room_window" in devices
+    assert "climate.hvac" in devices
+    assert "climate.heatpump" in devices
+    assert "climate.ecobee" not in devices
 
 
 @asyncio.coroutine
@@ -763,10 +828,30 @@ def perform_put_light_state(
 
 async def test_external_ip_blocked(hue_client):
     """Test external IP blocked."""
+    getUrls = [
+        "/api/username/groups",
+        "/api/username",
+        "/api/username/lights",
+        "/api/username/lights/light.ceiling_lights",
+    ]
+    postUrls = ["/api"]
+    putUrls = ["/api/username/lights/light.ceiling_lights/state"]
     with patch(
         "homeassistant.components.http.real_ip.ip_address",
         return_value=ip_address("45.45.45.45"),
     ):
-        result = await hue_client.get("/api/username/lights")
+        for getUrl in getUrls:
+            result = await hue_client.get(getUrl)
+            assert result.status == 400
 
+<<<<<<< HEAD
     assert result.status == 401
+=======
+        for postUrl in postUrls:
+            result = await hue_client.post(postUrl)
+            assert result.status == 400
+
+        for putUrl in putUrls:
+            result = await hue_client.put(putUrl)
+            assert result.status == 400
+>>>>>>> Add full state view for emulated_hue

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -844,9 +844,7 @@ async def test_external_ip_blocked(hue_client):
             result = await hue_client.get(getUrl)
             assert result.status == 400
 
-<<<<<<< HEAD
-    assert result.status == 401
-=======
+
         for postUrl in postUrls:
             result = await hue_client.post(postUrl)
             assert result.status == 400
@@ -854,4 +852,3 @@ async def test_external_ip_blocked(hue_client):
         for putUrl in putUrls:
             result = await hue_client.put(putUrl)
             assert result.status == 400
->>>>>>> Add full state view for emulated_hue

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -844,7 +844,6 @@ async def test_external_ip_blocked(hue_client):
             result = await hue_client.get(getUrl)
             assert result.status == 400
 
-
         for postUrl in postUrls:
             result = await hue_client.post(postUrl)
             assert result.status == 400

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -82,6 +82,31 @@ class TestEmulatedHue(unittest.TestCase):
         assert "success" in success_json
         assert "username" in success_json["success"]
 
+    def test_unauthorized_view(self):
+        """Test unauthorized view."""
+        request_json = {"devicetype": "my_device"}
+
+        result = requests.get(
+            BRIDGE_URL_BASE.format("/api/unauthorized"),
+            data=json.dumps(request_json),
+            timeout=5,
+        )
+
+        assert result.status_code == 200
+        assert "application/json" in result.headers["content-type"]
+
+        resp_json = result.json()
+        assert len(resp_json) == 1
+        success_json = resp_json[0]
+        assert len(success_json) == 1
+
+        assert "error" in success_json
+        error_json = success_json["error"]
+        assert len(error_json) == 3
+        assert "/" in error_json["address"]
+        assert "unauthorized user" in error_json["description"]
+        assert "1" in error_json["type"]
+
     def test_valid_username_request(self):
         """Test request with a valid username."""
         request_json = {"invalid_key": "my_device"}


### PR DESCRIPTION
## Description:
This is renewed pr, since last got a lot of unnecessary commits.
Difference in this is that it will also provide support for 'sleep with android', and does not have the unwanted `/api/(null)` urls.
#23775 

Hue api: [7.5. Get full state (datastore)](https://developers.meethue.com/develop/hue-api/7-configuration-api/#get-full-state)

The difference from current implementation of emualted_hue are two things.
1. The apps first uses a dummy name to find the bridge, after that they go thru the `create_username`. This is handled by responding of a not authorized message. 

2. Second they uses a full state view (which is a response of all the data in the emulated_hue combined with the lights information) and require some dummy information in the response, as for now i minimized it so all functionality works with sleep cycle and sleep for android. 

As discussed in the earlier PR, there has to be some control if username is "correct" otherwise the apps will never connect.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10368
## Example entry for `configuration.yaml` (if applicable):
```yaml
emulated_hue:
  listen_port: 80
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html