### PR TITLE
Add mode off to coolmaster climate

### DIFF
--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -38,6 +38,7 @@ AVAILABLE_MODES = [
 ]
 
 CM_TO_HA_STATE = {
+    "off": HVAC_MODE_OFF,
     "heat": HVAC_MODE_HEAT,
     "cool": HVAC_MODE_COOL,
     "auto": HVAC_MODE_HEAT_COOL,


### PR DESCRIPTION
## Description:
Add the ability to turn the CoolMasterNet climate device off

## Example entry for `configuration.yaml` (if applicable):
```
climate:
  - platform: coolmaster_test
    host: 192.168.100.100
    supported_modes:
      - "off"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.