### PR TITLE
Add tplink support for KP400 outdoor two-outlet switches

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -16,6 +16,7 @@ from .common import (
     CONF_DISCOVERY,
     CONF_LIGHT,
     CONF_SWITCH,
+    CONF_STRIP,
     SmartDevices,
 )
 
@@ -34,6 +35,9 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [TPLINK_HOST_SCHEMA]
                 ),
                 vol.Optional(CONF_SWITCH, default=[]): vol.All(
+                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
+                ),
+                vol.Optional(CONF_STRIP, default=[]): vol.All(
                     cv.ensure_list, [TPLINK_HOST_SCHEMA]
                 ),
                 vol.Optional(CONF_DIMMER, default=[]): vol.All(

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -4,7 +4,7 @@ import logging
 from datetime import timedelta
 from typing import Any, Callable, List
 
-from pyHS100 import SmartBulb, SmartDevice, SmartPlug, SmartDeviceException
+from pyHS100 import SmartBulb, SmartDevice, SmartPlug, SmartStrip, SmartDeviceException
 
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -16,6 +16,7 @@ CONF_DIMMER = "dimmer"
 CONF_DISCOVERY = "discovery"
 CONF_LIGHT = "light"
 CONF_SWITCH = "switch"
+CONF_STRIP = "strip"
 
 
 class SmartDevices:
@@ -100,7 +101,7 @@ def get_static_devices(config_data) -> SmartDevices:
     lights = []
     switches = []
 
-    for type_ in [CONF_LIGHT, CONF_SWITCH, CONF_DIMMER]:
+    for type_ in [CONF_LIGHT, CONF_SWITCH, CONF_STRIP, CONF_DIMMER]:
         for entry in config_data[type_]:
             host = entry["host"]
 
@@ -108,6 +109,8 @@ def get_static_devices(config_data) -> SmartDevices:
                 lights.append(SmartBulb(host))
             elif type_ == CONF_SWITCH:
                 switches.append(SmartPlug(host))
+            elif type_ == CONF_STRIP:
+                switches.append(SmartStrip(host))
             # Dimmers need to be defined as smart plugs to work correctly.
             elif type_ == CONF_DIMMER:
                 lights.append(SmartPlug(host))

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -42,14 +42,14 @@ def add_entity(device: SmartPlug, async_add_entities):
     # will try again later.
     device.get_sysinfo()
     children = device.sys_info.get("children")
-    ds = []
+    devices = []
     if children:
         for i in range(len(children)):
-            ds.append(SmartPlugSwitch(device, i))
+            devices.append(SmartPlugSwitch(device, i))
     else:
-        ds.append(SmartPlugSwitch(device))
+        devices.append(SmartPlugSwitch(device))
 
-    async_add_entities(ds, update_before_add=True)
+    async_add_entities(devices, update_before_add=True)
 
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -118,14 +118,14 @@ class SmartPlugSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         if self._child_num >= 0:
-            self.smartplug.turn_on(index = self._child_num)
+            self.smartplug.turn_on(index=self._child_num)
         else:
             self.smartplug.turn_on()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         if self._child_num >= 0:
-            self.smartplug.turn_off(index = self._child_num)
+            self.smartplug.turn_off(index=self._child_num)
         else:
             self.smartplug.turn_off()
 

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -138,7 +138,9 @@ class SmartPlugSwitch(SwitchDevice):
         """Update the TP-Link switch's state."""
         try:
             if not self._sysinfo:
-                _LOGGER.debug("tplink sysinfo for %s is %s", self, self.smartplug.sys_info)
+                _LOGGER.debug(
+                    "tplink sysinfo for %s is %s", self, self.smartplug.sys_info
+                )
                 self._sysinfo = self.smartplug.sys_info
                 self._mac = self.smartplug.mac
                 if self._child_num >= 0:


### PR DESCRIPTION
## Breaking Change:

None

## Description:

Support new TPLink KP400 outdoor two-outlet smart switches which need to show up as two separately-controllable SmartPlug outlet.s

**Related issue (if applicable):**

https://community.home-assistant.io/t/tp-link-kasa-kp400-2-outlet-support/113135

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
