### PR TITLE
Add onvif local datetime support

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -193,33 +193,36 @@ class ONVIFHassCamera(Camera):
             system_date = dt_util.utcnow()
             device_time = await devicemgmt.GetSystemDateAndTime()
             if device_time:
-                cdate = device_time.UTCDateTime
-                cam_date = dt.datetime(
-                    cdate.Date.Year,
-                    cdate.Date.Month,
-                    cdate.Date.Day,
-                    cdate.Time.Hour,
-                    cdate.Time.Minute,
-                    cdate.Time.Second,
-                    0,
-                    dt_util.UTC,
-                )
-
-                _LOGGER.debug("Camera date/time: %s", cam_date)
-
-                _LOGGER.debug("System date/time: %s", system_date)
-
-                dt_diff = cam_date - system_date
-                dt_diff_seconds = dt_diff.total_seconds()
-
-                if dt_diff_seconds > 5:
-                    _LOGGER.warning(
-                        "The date/time on the camera is '%s', "
-                        "which is different from the system '%s', "
-                        "this could lead to authentication issues",
-                        cam_date,
-                        system_date,
+                cdate = device_time.UTCDateTime or device_time.LocalDateTime
+                if cdate is None:
+                    _LOGGER.warning("Could not retrieve date/time on this camera")
+                else:
+                    cam_date = dt.datetime(
+                        cdate.Date.Year,
+                        cdate.Date.Month,
+                        cdate.Date.Day,
+                        cdate.Time.Hour,
+                        cdate.Time.Minute,
+                        cdate.Time.Second,
+                        0,
+                        dt_util.UTC,
                     )
+
+                    _LOGGER.debug("Camera date/time: %s", cam_date)
+
+                    _LOGGER.debug("System date/time: %s", system_date)
+
+                    dt_diff = cam_date - system_date
+                    dt_diff_seconds = dt_diff.total_seconds()
+
+                    if dt_diff_seconds > 5:
+                        _LOGGER.warning(
+                            "The date/time on the camera is '%s', "
+                            "which is different from the system '%s', "
+                            "this could lead to authentication issues",
+                            cam_date,
+                            system_date,
+                        )
         except ServerDisconnectedError as err:
             _LOGGER.warning(
                 "Couldn't get camera '%s' date/time. Error: %s", self._name, err

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -203,7 +203,11 @@ class ONVIFHassCamera(Camera):
             tzone, cdate = (
                 (dt_util.UTC, device_time.UTCDateTime)
                 if device_time.UTCDateTime
-                else (dt_util.DEFAULT_TIME_ZONE, device_time.LocalDateTime)
+                else (
+                    dt_util.get_time_zone(device_time.TimeZone)
+                    or dt_util.DEFAULT_TIME_ZONE,
+                    device_time.LocalDateTime,
+                )
             )
             if cdate is None:
                 _LOGGER.warning("Could not retrieve date/time on this camera")

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -200,15 +200,16 @@ class ONVIFHassCamera(Camera):
                 )
                 return
 
-            tzone, cdate = (
-                (dt_util.UTC, device_time.UTCDateTime)
-                if device_time.UTCDateTime
-                else (
+            if device_time.UTCDateTime:
+                tzone = dt_util.UTC
+                cdate = device_time.UTCDateTime
+            else:
+                tzone = (
                     dt_util.get_time_zone(device_time.TimeZone)
                     or dt_util.DEFAULT_TIME_ZONE,
-                    device_time.LocalDateTime,
                 )
-            )
+                cdate = device_time.LocalDateTime
+
             if cdate is None:
                 _LOGGER.warning("Could not retrieve date/time on this camera")
             else:


### PR DESCRIPTION
## Description:
Retrieve date/time from camera using `LocalDateTime` if `UTCDateTime` not available/empty, and also according to the camera's `TimeZone` or Home Assistant default.

**Related issue (if applicable):** fixes #25604

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html