### PR TITLE
Add support for `for` to binary_sensor, light and switch device triggers

### DIFF
--- a/homeassistant/components/automation/device.py
+++ b/homeassistant/components/automation/device.py
@@ -5,6 +5,7 @@ from homeassistant.components.device_automation import (
     TRIGGER_BASE_SCHEMA,
     async_get_device_automation_platform,
 )
+from homeassistant.const import CONF_DOMAIN
 
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
@@ -14,11 +15,15 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
 
 async def async_validate_trigger_config(hass, config):
     """Validate config."""
-    platform = await async_get_device_automation_platform(hass, config, "trigger")
+    platform = await async_get_device_automation_platform(
+        hass, config[CONF_DOMAIN], "trigger"
+    )
     return platform.TRIGGER_SCHEMA(config)
 
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for trigger."""
-    platform = await async_get_device_automation_platform(hass, config, "trigger")
+    platform = await async_get_device_automation_platform(
+        hass, config[CONF_DOMAIN], "trigger"
+    )
     return await platform.async_attach_trigger(hass, config, action, automation_info)

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -7,7 +7,7 @@ from homeassistant.components.device_automation.const import (
     CONF_TURNED_OFF,
     CONF_TURNED_ON,
 )
-from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, CONF_TYPE
+from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, CONF_FOR, CONF_TYPE
 from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.helpers import config_validation as cv
 
@@ -175,6 +175,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In(TURNED_OFF + TURNED_ON),
+        vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
     }
 )
 
@@ -195,6 +196,8 @@ async def async_attach_trigger(hass, config, action, automation_info):
         state_automation.CONF_FROM: from_state,
         state_automation.CONF_TO: to_state,
     }
+    if "for" in config:
+        state_config["for"] = config["for"]
 
     return await state_automation.async_attach_trigger(
         hass, state_config, action, automation_info, platform_type="device"

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -2,10 +2,7 @@
 import voluptuous as vol
 
 from homeassistant.components.automation import state as state_automation
-from homeassistant.components.device_automation import (
-    POSITIVE_TIME_DELTA_DICT,
-    TRIGGER_BASE_SCHEMA,
-)
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.const import (
     CONF_TURNED_OFF,
     CONF_TURNED_ON,
@@ -178,7 +175,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In(TURNED_OFF + TURNED_ON),
-        vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT,
+        vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
 )
 
@@ -247,5 +244,7 @@ async def async_get_triggers(hass, device_id):
 async def async_get_trigger_capabilities(hass, trigger):
     """List trigger capabilities."""
     return {
-        "extra_fields": vol.Schema({vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT})
+        "extra_fields": vol.Schema(
+            {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
+        )
     }

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -2,9 +2,11 @@
 import voluptuous as vol
 
 from homeassistant.components.automation import state as state_automation
-from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation import (
+    POSITIVE_TIME_DELTA_DICT,
+    TRIGGER_BASE_SCHEMA,
+)
 from homeassistant.components.device_automation.const import (
-    CONF_SUPPORTS,
     CONF_TURNED_OFF,
     CONF_TURNED_ON,
 )
@@ -176,7 +178,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In(TURNED_OFF + TURNED_ON),
-        vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT,
     }
 )
 
@@ -244,4 +246,6 @@ async def async_get_triggers(hass, device_id):
 
 async def async_get_trigger_capabilities(hass, trigger):
     """List trigger capabilities."""
-    return {CONF_SUPPORTS: [CONF_FOR]}
+    return {
+        "extra_fields": vol.Schema({vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT})
+    }

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -4,6 +4,7 @@ import voluptuous as vol
 from homeassistant.components.automation import state as state_automation
 from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.const import (
+    CONF_SUPPORTS,
     CONF_TURNED_OFF,
     CONF_TURNED_ON,
 )
@@ -239,3 +240,8 @@ async def async_get_triggers(hass, device_id):
         )
 
     return triggers
+
+
+async def async_get_trigger_capabilities(hass, trigger):
+    """List trigger capabilities."""
+    return {CONF_SUPPORTS: [CONF_FOR]}

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -182,7 +182,6 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
-    config = TRIGGER_SCHEMA(config)
     trigger_type = config[CONF_TYPE]
     if trigger_type in TURNED_ON:
         from_state = "off"

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -193,8 +193,6 @@ def _get_deconz_event_from_device_id(hass, device_id):
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
-    config = TRIGGER_SCHEMA(config)
-
     device_registry = await hass.helpers.device_registry.async_get_registry()
     device = device_registry.async_get(config[CONF_DEVICE_ID])
 

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -1,5 +1,6 @@
 """Helpers for device automations."""
 import asyncio
+from datetime import timedelta
 import logging
 from typing import Any, List, MutableMapping
 
@@ -43,7 +44,9 @@ TYPES = {
     "action": ("device_action", "async_get_actions", "async_get_action_capabilities"),
 }
 
-POSITIVE_TIME_DELTA_DICT = vol.All(cv.time_period, cv.positive_timedelta)
+POSITIVE_TIME_DELTA_DICT = vol.All(
+    vol.Any(timedelta, cv.time_period_dict), cv.positive_timedelta
+)
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, List, MutableMapping
 
 import voluptuous as vol
+import voluptuous_serialize
 
 from homeassistant.const import CONF_PLATFORM, CONF_DOMAIN, CONF_DEVICE_ID
 from homeassistant.components import websocket_api
@@ -62,7 +63,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def _async_get_device_automation_platform(hass, domain, automation_type):
+async def async_get_device_automation_platform(hass, domain, automation_type):
     """Load device automation platform for integration.
 
     Throws InvalidDeviceAutomationConfig if the integration is not found or does not support device automation.
@@ -81,22 +82,12 @@ async def _async_get_device_automation_platform(hass, domain, automation_type):
     return platform
 
 
-async def async_get_device_automation_platform(hass, config, automation_type):
-    """Load device automation platform for integration.
-
-    Throws InvalidDeviceAutomationConfig if the integration is not found or does not support device automation.
-    """
-    return await _async_get_device_automation_platform(
-        hass, config[CONF_DOMAIN], automation_type
-    )
-
-
 async def _async_get_device_automations_from_domain(
     hass, domain, automation_type, device_id
 ):
     """List device automations."""
     try:
-        platform = await _async_get_device_automation_platform(
+        platform = await async_get_device_automation_platform(
             hass, domain, automation_type
         )
     except InvalidDeviceAutomationConfig:
@@ -143,7 +134,7 @@ async def _async_get_device_automations(hass, automation_type, device_id):
 async def _async_get_device_automation_capabilities(hass, automation_type, automation):
     """List device automations."""
     try:
-        platform = await _async_get_device_automation_platform(
+        platform = await async_get_device_automation_platform(
             hass, automation[CONF_DOMAIN], automation_type
         )
     except InvalidDeviceAutomationConfig:
@@ -156,9 +147,6 @@ async def _async_get_device_automation_capabilities(hass, automation_type, autom
         return {}
 
     capabilities = await getattr(platform, function_name)(hass, automation)
-
-    import voluptuous_serialize
-
     capabilities = capabilities.copy()
 
     extra_fields = capabilities.get("extra_fields")

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -142,8 +142,12 @@ async def _async_get_device_automations(hass, automation_type, device_id):
 
 
 def _custom_serializer(schema):
+    import voluptuous_serialize
+
     if schema == POSITIVE_TIME_DELTA_DICT:
         return {"type": "positive_time_delta_dict"}
+
+    return voluptuous_serialize.UNSUPPORTED
 
 
 async def _async_get_device_automation_capabilities(hass, automation_type, automation):

--- a/homeassistant/components/device_automation/const.py
+++ b/homeassistant/components/device_automation/const.py
@@ -1,6 +1,7 @@
 """Constants for device automations."""
 CONF_IS_OFF = "is_off"
 CONF_IS_ON = "is_on"
+CONF_SUPPORTS = "supports"
 CONF_TOGGLE = "toggle"
 CONF_TURN_OFF = "turn_off"
 CONF_TURN_ON = "turn_on"

--- a/homeassistant/components/device_automation/const.py
+++ b/homeassistant/components/device_automation/const.py
@@ -1,7 +1,6 @@
 """Constants for device automations."""
 CONF_IS_OFF = "is_off"
 CONF_IS_ON = "is_on"
-CONF_SUPPORTS = "supports"
 CONF_TOGGLE = "toggle"
 CONF_TURN_OFF = "turn_off"
 CONF_TURN_ON = "turn_on"

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -13,7 +13,13 @@ from homeassistant.components.device_automation.const import (
     CONF_TURNED_OFF,
     CONF_TURNED_ON,
 )
-from homeassistant.const import CONF_CONDITION, CONF_ENTITY_ID, CONF_PLATFORM, CONF_TYPE
+from homeassistant.const import (
+    CONF_CONDITION,
+    CONF_ENTITY_ID,
+    CONF_FOR,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
 from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.helpers import condition, config_validation as cv, service
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
@@ -81,6 +87,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In([CONF_TURNED_OFF, CONF_TURNED_ON]),
+        vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
     }
 )
 
@@ -149,6 +156,8 @@ async def async_attach_trigger(
         state.CONF_FROM: from_state,
         state.CONF_TO: to_state,
     }
+    if "for" in config:
+        state_config["for"] = config["for"]
 
     return await state.async_attach_trigger(
         hass, state_config, action, automation_info, platform_type="device"

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -7,6 +7,7 @@ from homeassistant.components.automation import state, AutomationActionType
 from homeassistant.components.device_automation.const import (
     CONF_IS_OFF,
     CONF_IS_ON,
+    CONF_SUPPORTS,
     CONF_TOGGLE,
     CONF_TURN_OFF,
     CONF_TURN_ON,
@@ -212,3 +213,8 @@ async def async_get_triggers(
 ) -> List[dict]:
     """List device triggers."""
     return await _async_get_automations(hass, device_id, ENTITY_TRIGGERS, domain)
+
+
+async def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict) -> dict:
+    """List trigger capabilities."""
+    return {CONF_SUPPORTS: [CONF_FOR]}

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -4,10 +4,10 @@ import voluptuous as vol
 
 from homeassistant.core import Context, HomeAssistant, CALLBACK_TYPE
 from homeassistant.components.automation import state, AutomationActionType
+from homeassistant.components.device_automation import POSITIVE_TIME_DELTA_DICT
 from homeassistant.components.device_automation.const import (
     CONF_IS_OFF,
     CONF_IS_ON,
-    CONF_SUPPORTS,
     CONF_TOGGLE,
     CONF_TURN_OFF,
     CONF_TURN_ON,
@@ -88,7 +88,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In([CONF_TURNED_OFF, CONF_TURNED_ON]),
-        vol.Optional(CONF_FOR): vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT,
     }
 )
 
@@ -217,4 +217,6 @@ async def async_get_triggers(
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict) -> dict:
     """List trigger capabilities."""
-    return {CONF_SUPPORTS: [CONF_FOR]}
+    return {
+        "extra_fields": vol.Schema({vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT})
+    }

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -100,7 +100,6 @@ async def async_call_action_from_config(
     domain: str,
 ) -> None:
     """Change state based on configuration."""
-    config = ACTION_SCHEMA(config)
     action_type = config[CONF_TYPE]
     if action_type == CONF_TURN_ON:
         action = "turn_on"

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -4,7 +4,6 @@ import voluptuous as vol
 
 from homeassistant.core import Context, HomeAssistant, CALLBACK_TYPE
 from homeassistant.components.automation import state, AutomationActionType
-from homeassistant.components.device_automation import POSITIVE_TIME_DELTA_DICT
 from homeassistant.components.device_automation.const import (
     CONF_IS_OFF,
     CONF_IS_ON,
@@ -88,7 +87,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In([CONF_TURNED_OFF, CONF_TURNED_ON]),
-        vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT,
+        vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
 )
 
@@ -218,5 +217,7 @@ async def async_get_triggers(
 async def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict) -> dict:
     """List trigger capabilities."""
     return {
-        "extra_fields": vol.Schema({vol.Optional(CONF_FOR): POSITIVE_TIME_DELTA_DICT})
+        "extra_fields": vol.Schema(
+            {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
+        )
     }

--- a/homeassistant/components/light/device_action.py
+++ b/homeassistant/components/light/device_action.py
@@ -19,7 +19,6 @@ async def async_call_action_from_config(
     context: Context,
 ) -> None:
     """Change state based on configuration."""
-    config = ACTION_SCHEMA(config)
     await toggle_entity.async_call_action_from_config(
         hass, config, variables, context, DOMAIN
     )

--- a/homeassistant/components/light/device_trigger.py
+++ b/homeassistant/components/light/device_trigger.py
@@ -35,4 +35,4 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict) -> dict:
     """List trigger capabilities."""
-    return await toggle_entity.async_get_trigger_capabilities(hass, dict)
+    return await toggle_entity.async_get_trigger_capabilities(hass, trigger)

--- a/homeassistant/components/light/device_trigger.py
+++ b/homeassistant/components/light/device_trigger.py
@@ -22,7 +22,6 @@ async def async_attach_trigger(
     automation_info: dict,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
-    config = TRIGGER_SCHEMA(config)
     return await toggle_entity.async_attach_trigger(
         hass, config, action, automation_info
     )

--- a/homeassistant/components/light/device_trigger.py
+++ b/homeassistant/components/light/device_trigger.py
@@ -31,3 +31,8 @@ async def async_attach_trigger(
 async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
     """List device triggers."""
     return await toggle_entity.async_get_triggers(hass, device_id, DOMAIN)
+
+
+async def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict) -> dict:
+    """List trigger capabilities."""
+    return await toggle_entity.async_get_trigger_capabilities(hass, dict)

--- a/homeassistant/components/switch/device_action.py
+++ b/homeassistant/components/switch/device_action.py
@@ -19,7 +19,6 @@ async def async_call_action_from_config(
     context: Context,
 ) -> None:
     """Change state based on configuration."""
-    config = ACTION_SCHEMA(config)
     await toggle_entity.async_call_action_from_config(
         hass, config, variables, context, DOMAIN
     )

--- a/homeassistant/components/switch/device_trigger.py
+++ b/homeassistant/components/switch/device_trigger.py
@@ -35,4 +35,4 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict) -> dict:
     """List trigger capabilities."""
-    return await toggle_entity.async_get_trigger_capabilities(hass, dict)
+    return await toggle_entity.async_get_trigger_capabilities(hass, trigger)

--- a/homeassistant/components/switch/device_trigger.py
+++ b/homeassistant/components/switch/device_trigger.py
@@ -22,7 +22,6 @@ async def async_attach_trigger(
     automation_info: dict,
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
-    config = TRIGGER_SCHEMA(config)
     return await toggle_entity.async_attach_trigger(
         hass, config, action, automation_info
     )

--- a/homeassistant/components/switch/device_trigger.py
+++ b/homeassistant/components/switch/device_trigger.py
@@ -31,3 +31,8 @@ async def async_attach_trigger(
 async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
     """List device triggers."""
     return await toggle_entity.async_get_triggers(hass, device_id, DOMAIN)
+
+
+async def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict) -> dict:
+    """List trigger capabilities."""
+    return await toggle_entity.async_get_trigger_capabilities(hass, dict)

--- a/homeassistant/components/zha/device_action.py
+++ b/homeassistant/components/zha/device_action.py
@@ -49,7 +49,6 @@ async def async_call_action_from_config(
     context: Context,
 ) -> None:
     """Perform an action based on configuration."""
-    config = ACTION_SCHEMA(config)
     await ZHA_ACTION_TYPES[DEVICE_ACTION_TYPES[config[CONF_TYPE]]](
         hass, config, variables, context
     )

--- a/homeassistant/components/zha/device_trigger.py
+++ b/homeassistant/components/zha/device_trigger.py
@@ -23,7 +23,6 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
-    config = TRIGGER_SCHEMA(config)
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
     zha_device = await async_get_zha_device(hass, config[CONF_DEVICE_ID])
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -15,8 +15,9 @@ from typing import Any, Union, TypeVar, Callable, List, Dict, Optional
 from urllib.parse import urlparse
 from uuid import UUID
 
-import voluptuous as vol
 from pkg_resources import parse_version
+import voluptuous as vol
+import voluptuous_serialize
 
 import homeassistant.util.dt as dt_util
 from homeassistant.const import (
@@ -374,9 +375,7 @@ def positive_timedelta(value: timedelta) -> timedelta:
     return value
 
 
-positive_time_period_dict = vol.All(
-    vol.Any(timedelta, time_period_dict), positive_timedelta
-)
+positive_time_period_dict = vol.All(time_period_dict, positive_timedelta)
 
 
 def remove_falsy(value: List[T]) -> List[T]:
@@ -697,9 +696,7 @@ def key_dependency(key, dependency):
 
 def custom_serializer(schema):
     """Serialize additional types for voluptuous_serialize."""
-    import voluptuous_serialize
-
-    if schema == positive_time_period_dict:
+    if schema is positive_time_period_dict:
         return {"type": "positive_time_period_dict"}
 
     return voluptuous_serialize.UNSUPPORTED

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -374,6 +374,11 @@ def positive_timedelta(value: timedelta) -> timedelta:
     return value
 
 
+positive_time_period_dict = vol.All(
+    vol.Any(timedelta, time_period_dict), positive_timedelta
+)
+
+
 def remove_falsy(value: List[T]) -> List[T]:
     """Remove falsy values from a list."""
     return [v for v in value if v]
@@ -688,6 +693,16 @@ def key_dependency(key, dependency):
         return value
 
     return validator
+
+
+def custom_serializer(schema):
+    """Serialize additional types for voluptuous_serialize."""
+    import voluptuous_serialize
+
+    if schema == positive_time_period_dict:
+        return {"type": "positive_time_period_dict"}
+
+    return voluptuous_serialize.UNSUPPORTED
 
 
 # Schemas

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -10,7 +10,12 @@ import voluptuous as vol
 
 import homeassistant.components.device_automation as device_automation
 from homeassistant.core import HomeAssistant, Context, callback, CALLBACK_TYPE
-from homeassistant.const import CONF_CONDITION, CONF_DEVICE_ID, CONF_TIMEOUT
+from homeassistant.const import (
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_TIMEOUT,
+)
 from homeassistant import exceptions
 from homeassistant.helpers import (
     service,
@@ -89,7 +94,7 @@ async def async_validate_action_config(
 
     if action_type == ACTION_DEVICE_AUTOMATION:
         platform = await device_automation.async_get_device_automation_platform(
-            hass, config, "action"
+            hass, config[CONF_DOMAIN], "action"
         )
         config = platform.ACTION_SCHEMA(config)
 
@@ -346,7 +351,7 @@ class Script:
         self.last_action = action.get(CONF_ALIAS, "device automation")
         self._log("Executing step %s" % self.last_action)
         platform = await device_automation.async_get_device_automation_platform(
-            self.hass, action, "action"
+            self.hass, action[CONF_DOMAIN], "action"
         )
         await platform.async_call_action_from_config(
             self.hass, action, variables, context

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ pyyaml==5.1.2
 requests==2.22.0
 ruamel.yaml==0.15.100
 sqlalchemy==1.3.8
-voluptuous-serialize==2.2.0
+voluptuous-serialize==2.3.0
 voluptuous==0.11.7
 zeroconf==0.23.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -17,7 +17,7 @@ pyyaml==5.1.2
 requests==2.22.0
 ruamel.yaml==0.15.100
 voluptuous==0.11.7
-voluptuous-serialize==2.2.0
+voluptuous-serialize==2.3.0
 
 # homeassistant.components.nuimo_controller
 --only-binary=all nuimo==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ REQUIRES = [
     "requests==2.22.0",
     "ruamel.yaml==0.15.100",
     "voluptuous==0.11.7",
-    "voluptuous-serialize==2.2.0",
+    "voluptuous-serialize==2.3.0",
 ]
 
 MIN_PY_VERSION = ".".join(map(str, hass_const.REQUIRED_PYTHON_VER))

--- a/tests/common.py
+++ b/tests/common.py
@@ -56,6 +56,7 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.components.device_automation import (  # noqa
     _async_get_device_automations as async_get_device_automations,
+    _async_get_device_automation_capabilities as async_get_device_automation_capabilities,
 )
 
 _TEST_INSTANCE_PORT = SERVER_PORT

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -86,7 +86,7 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
         ]
     }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -84,7 +84,11 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
-    expected_capabilities = {"supports": ["for"]}
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+        ]
+    }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -17,6 +17,7 @@ from tests.common import (
     mock_device_registry,
     mock_registry,
     async_get_device_automations,
+    async_get_device_automation_capabilities,
 )
 
 
@@ -72,6 +73,24 @@ async def test_get_triggers(hass, device_reg, entity_reg):
     ]
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     assert triggers == expected_triggers
+
+
+async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
+    """Test we get the expected capabilities from a binary_sensor trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_capabilities = {"supports": ["for"]}
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    for trigger in triggers:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, "trigger", trigger
+        )
+        assert capabilities == expected_capabilities
 
 
 async def test_if_fires_on_state_change(hass, calls):

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -176,7 +176,11 @@ async def test_websocket_get_trigger_capabilities(
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create("light", "test", "5678", device_id=device_entry.id)
-    expected_capabilities = {"supports": ["for"]}
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+        ]
+    }
 
     client = await hass_ws_client(hass)
     await client.send_json(

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -214,7 +214,7 @@ async def test_websocket_get_trigger_capabilities(
 async def test_websocket_get_bad_trigger_capabilities(
     hass, hass_ws_client, device_reg, entity_reg
 ):
-    """Test we get the expected trigger capabilities for a light through websocket."""
+    """Test we get no trigger capabilities for a non existing domain."""
     await async_setup_component(hass, "device_automation", {})
     expected_capabilities = {}
 
@@ -224,6 +224,29 @@ async def test_websocket_get_bad_trigger_capabilities(
             "id": 1,
             "type": "device_automation/trigger/capabilities",
             "trigger": {"domain": "beer"},
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["id"] == 1
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    capabilities = msg["result"]
+    assert capabilities == expected_capabilities
+
+
+async def test_websocket_get_no_trigger_capabilities(
+    hass, hass_ws_client, device_reg, entity_reg
+):
+    """Test we get no trigger capabilities for a domain with no device trigger capabilities."""
+    await async_setup_component(hass, "device_automation", {})
+    expected_capabilities = {}
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "device_automation/trigger/capabilities",
+            "trigger": {"domain": "deconz"},
         }
     )
     msg = await client.receive_json()

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -178,7 +178,7 @@ async def test_websocket_get_trigger_capabilities(
     entity_reg.async_get_or_create("light", "test", "5678", device_id=device_entry.id)
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
         ]
     }
 

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -211,6 +211,29 @@ async def test_websocket_get_trigger_capabilities(
         id = id + 1
 
 
+async def test_websocket_get_bad_trigger_capabilities(
+    hass, hass_ws_client, device_reg, entity_reg
+):
+    """Test we get the expected trigger capabilities for a light through websocket."""
+    await async_setup_component(hass, "device_automation", {})
+    expected_capabilities = {}
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "device_automation/trigger/capabilities",
+            "trigger": {"domain": "beer"},
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["id"] == 1
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    capabilities = msg["result"]
+    assert capabilities == expected_capabilities
+
+
 async def test_automation_with_non_existing_integration(hass, caplog):
     """Test device automation with non existing integration."""
     assert await async_setup_component(

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -164,6 +164,53 @@ async def test_websocket_get_triggers(hass, hass_ws_client, device_reg, entity_r
     assert _same_lists(triggers, expected_triggers)
 
 
+async def test_websocket_get_trigger_capabilities(
+    hass, hass_ws_client, device_reg, entity_reg
+):
+    """Test we get the expected trigger capabilities for a light through websocket."""
+    await async_setup_component(hass, "device_automation", {})
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create("light", "test", "5678", device_id=device_entry.id)
+    expected_capabilities = {"supports": ["for"]}
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "device_automation/trigger/list",
+            "device_id": device_entry.id,
+        }
+    )
+    msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    triggers = msg["result"]
+
+    id = 2
+    for trigger in triggers:
+        await client.send_json(
+            {
+                "id": id,
+                "type": "device_automation/trigger/capabilities",
+                "trigger": trigger,
+            }
+        )
+        msg = await client.receive_json()
+        assert msg["id"] == id
+        assert msg["type"] == TYPE_RESULT
+        assert msg["success"]
+        capabilities = msg["result"]
+        assert capabilities == expected_capabilities
+        id = id + 1
+
+
 async def test_automation_with_non_existing_integration(hass, caplog):
     """Test device automation with non existing integration."""
     assert await async_setup_component(

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The test for light device automation."""
+from datetime import timedelta
 import pytest
 
 from homeassistant.components.light import DOMAIN
@@ -6,9 +7,11 @@ from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
 from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    async_fire_time_changed,
     async_mock_service,
     mock_device_registry,
     mock_registry,
@@ -143,5 +146,63 @@ async def test_if_fires_on_state_change(hass, calls):
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert calls[1].data["some"] == "turn_on device - {} - off - on - None".format(
+        ent1.entity_id
+    )
+
+
+async def test_if_fires_on_state_change_with_for(hass, calls):
+    """Test for triggers firing with delay."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    ent1, ent2, ent3 = platform.ENTITIES
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": ent1.entity_id,
+                        "type": "turned_off",
+                        "for": {"seconds": 5},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_off {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(ent1.entity_id).state == STATE_ON
+    assert len(calls) == 0
+
+    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await hass.async_block_till_done()
+    assert calls[0].data["some"] == "turn_off device - {} - on - off - 0:00:05".format(
         ent1.entity_id
     )

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -16,6 +16,7 @@ from tests.common import (
     mock_device_registry,
     mock_registry,
     async_get_device_automations,
+    async_get_device_automation_capabilities,
 )
 
 
@@ -64,6 +65,24 @@ async def test_get_triggers(hass, device_reg, entity_reg):
     ]
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     assert triggers == expected_triggers
+
+
+async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
+    """Test we get the expected capabilities from a light trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_capabilities = {"supports": ["for"]}
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    for trigger in triggers:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, "trigger", trigger
+        )
+        assert capabilities == expected_capabilities
 
 
 async def test_if_fires_on_state_change(hass, calls):

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -78,7 +78,7 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
         ]
     }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -76,7 +76,11 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
-    expected_capabilities = {"supports": ["for"]}
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+        ]
+    }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The test for switch device automation."""
+from datetime import timedelta
 import pytest
 
 from homeassistant.components.switch import DOMAIN
@@ -6,9 +7,11 @@ from homeassistant.const import STATE_ON, STATE_OFF, CONF_PLATFORM
 from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
 from homeassistant.helpers import device_registry
+import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    async_fire_time_changed,
     async_mock_service,
     mock_device_registry,
     mock_registry,
@@ -143,5 +146,63 @@ async def test_if_fires_on_state_change(hass, calls):
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert calls[1].data["some"] == "turn_on device - {} - off - on - None".format(
+        ent1.entity_id
+    )
+
+
+async def test_if_fires_on_state_change_with_for(hass, calls):
+    """Test for triggers firing with delay."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    ent1, ent2, ent3 = platform.ENTITIES
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": ent1.entity_id,
+                        "type": "turned_off",
+                        "for": {"seconds": 5},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_off {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(ent1.entity_id).state == STATE_ON
+    assert len(calls) == 0
+
+    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await hass.async_block_till_done()
+    assert calls[0].data["some"] == "turn_off device - {} - on - off - 0:00:05".format(
         ent1.entity_id
     )

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -78,7 +78,7 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
         ]
     }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -76,7 +76,11 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
-    expected_capabilities = {"supports": ["for"]}
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_delta_dict"}
+        ]
+    }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -16,6 +16,7 @@ from tests.common import (
     mock_device_registry,
     mock_registry,
     async_get_device_automations,
+    async_get_device_automation_capabilities,
 )
 
 
@@ -64,6 +65,24 @@ async def test_get_triggers(hass, device_reg, entity_reg):
     ]
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     assert triggers == expected_triggers
+
+
+async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
+    """Test we get the expected capabilities from a switch trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_capabilities = {"supports": ["for"]}
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    for trigger in triggers:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, "trigger", trigger
+        )
+        assert capabilities == expected_capabilities
 
 
 async def test_if_fires_on_state_change(hass, calls):


### PR DESCRIPTION
## Description:
Add support for `for` to binary_sensor, light and switch device triggers.
Add WS API `device_automation/trigger/capabilities`

Depends on balloob/voluptuous-serialize#9

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
