### PR TITLE
Fix volumio set shuffle

### DIFF
--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -306,7 +306,7 @@ class Volumio(MediaPlayerDevice):
     def async_set_shuffle(self, shuffle):
         """Enable/disable shuffle mode."""
         return self.send_volumio_msg(
-            "commands", params={"cmd": "random", "value": str(shuffle)}
+            "commands", params={"cmd": "random", "value": str(shuffle).lower()}
         )
 
     def async_select_source(self, source):


### PR DESCRIPTION
## Description:
Volumio expects true / false ( lowercase ). From https://volumio.github.io/docs/API/REST_API.html
"Where key is true or false; if value is absent it toggles.". Now its possible to turn on shuffle, but then volumio responds with value "True"or "False" in getState json, which is wrong and breaks reading current shuffle state. 