### PR TITLE
Add support for automation description

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -43,7 +43,7 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 GROUP_NAME_ALL_AUTOMATIONS = "all automations"
 
 CONF_ALIAS = "alias"
-CONF_ANNOTATION = "annotation"
+CONF_DESCRIPTION = "description"
 CONF_HIDE_ENTITY = "hide_entity"
 
 CONF_CONDITION = "condition"
@@ -96,7 +96,7 @@ PLATFORM_SCHEMA = vol.Schema(
         # str on purpose
         CONF_ID: str,
         CONF_ALIAS: cv.string,
-        vol.Optional(CONF_ANNOTATION): cv.string,
+        vol.Optional(CONF_DESCRIPTION): cv.string,
         vol.Optional(CONF_INITIAL_STATE): cv.boolean,
         vol.Optional(CONF_HIDE_ENTITY, default=DEFAULT_HIDE_ENTITY): cv.boolean,
         vol.Required(CONF_TRIGGER): _TRIGGER_SCHEMA,

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -43,6 +43,7 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 GROUP_NAME_ALL_AUTOMATIONS = "all automations"
 
 CONF_ALIAS = "alias"
+CONF_ANNOTATION = "annotation"
 CONF_HIDE_ENTITY = "hide_entity"
 
 CONF_CONDITION = "condition"
@@ -95,6 +96,7 @@ PLATFORM_SCHEMA = vol.Schema(
         # str on purpose
         CONF_ID: str,
         CONF_ALIAS: cv.string,
+        vol.Optional(CONF_ANNOTATION): cv.string,
         vol.Optional(CONF_INITIAL_STATE): cv.boolean,
         vol.Optional(CONF_HIDE_ENTITY, default=DEFAULT_HIDE_ENTITY): cv.boolean,
         vol.Required(CONF_TRIGGER): _TRIGGER_SCHEMA,

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -53,7 +53,7 @@ class EditAutomationConfigView(EditIdBasedConfigView):
 
         # Iterate through some keys that we want to have ordered in the output
         updated_value = OrderedDict()
-        for key in ("id", "alias", "annotation", "trigger", "condition", "action"):
+        for key in ("id", "alias", "description", "trigger", "condition", "action"):
             if key in cur_value:
                 updated_value[key] = cur_value[key]
             if key in new_value:

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -53,7 +53,7 @@ class EditAutomationConfigView(EditIdBasedConfigView):
 
         # Iterate through some keys that we want to have ordered in the output
         updated_value = OrderedDict()
-        for key in ("id", "alias", "trigger", "condition", "action"):
+        for key in ("id", "alias", "annotation", "trigger", "condition", "action"):
             if key in cur_value:
                 updated_value[key] = cur_value[key]
             if key in new_value:


### PR DESCRIPTION
## Description:
When using the automation editor, any manually added comments are wiped.
Allow adding a `description` string to the automation instead, with the same purpose as a comment.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<TODO>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

