### PR TITLE
Don't crash when losing nzbget connection

### DIFF
--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 import logging
 
 import pynzbgetapi
-import requests
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -101,6 +100,6 @@ class NZBGetData:
             self.status = self._api.status()
             self.available = True
             dispatcher_send(self.hass, DATA_UPDATED)
-        except requests.exceptions.ConnectionError:
+        except pynzbgetapi.NZBGetAPIException:
             self.available = False
             _LOGGER.error("Unable to refresh NZBGet data")


### PR DESCRIPTION
## Description:
Fixes a crash when using the nzbget component and nzbget becomes unavailable.  Crash was caused by not catching the proper exception type. 

Tested this manually by stopping nzbget, ensuring no crash, re-starting nzbget and ensuring sensor monitoring worked again.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
