### PR TITLE
pytfiac version bump to 0.4

### DIFF
--- a/homeassistant/components/tfiac/manifest.json
+++ b/homeassistant/components/tfiac/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tfiac",
   "documentation": "https://www.home-assistant.io/components/tfiac",
   "requirements": [
-    "pytfiac==0.3"
+    "pytfiac==0.4"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1470,7 +1470,7 @@ pytautulli==0.5.0
 pyteleloisirs==3.5
 
 # homeassistant.components.tfiac
-pytfiac==0.3
+pytfiac==0.4
 
 # homeassistant.components.thinkingcleaner
 pythinkingcleaner==0.0.3


### PR DESCRIPTION
## Description:

pytfiac version bump to 0.4. 

Fixes:

> By default ON_MODE contains value from last "_status" dict. In case if AC was stopped (off state), ON_MODE always will have "off" value, which means that you will not able to turn on AC again.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
