### PR TITLE
Store ZHA light brightness when fading off to turn on at the correct brightness

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -210,7 +210,6 @@ class Light(ZhaEntity, light.Light):
 
         if brightness is None and self._off_brightness is not None:
             brightness = self._off_brightness
-        self._off_brightness = None
 
         t_log = {}
         if (
@@ -294,6 +293,7 @@ class Light(ZhaEntity, light.Light):
             t_log["color_loop_set"] = result
             self._effect = None
 
+        self._off_brightness = None
         self.debug("turned on: %s", t_log)
         self.async_schedule_update_ha_state()
 
@@ -301,8 +301,6 @@ class Light(ZhaEntity, light.Light):
         """Turn the entity off."""
         duration = kwargs.get(light.ATTR_TRANSITION)
         supports_level = self.supported_features & light.SUPPORT_BRIGHTNESS
-        # store current brightness so that the next turn_on uses it.
-        self._off_brightness = self._brightness
 
         if duration and supports_level:
             result = await self._level_channel.move_to_level_with_on_off(
@@ -314,6 +312,11 @@ class Light(ZhaEntity, light.Light):
         if not isinstance(result, list) or result[1] is not Status.SUCCESS:
             return
         self._state = False
+
+        if duration and supports_level:
+            # store current brightness so that the next turn_on uses it.
+            self._off_brightness = self._brightness
+
         self.async_schedule_update_ha_state()
 
     async def async_update(self):

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -129,7 +129,9 @@ class Light(ZhaEntity, light.Light):
     @property
     def device_state_attributes(self):
         """Return state attributes."""
-        return self.state_attributes
+        state_attrs = self.state_attributes.copy()
+        state_attrs["off_brightness"] = self._off_brightness
+        return state_attrs
 
     def set_level(self, value):
         """Set the brightness of this light between 0..254.

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -230,7 +230,7 @@ async def async_test_level_on_off_from_hass(
         4,
         (types.uint8_t, types.uint16_t),
         10,
-        5.0,
+        0,
         expect_reply=True,
         manufacturer=None,
     )


### PR DESCRIPTION
## Description:
Previously, if the light is turned off with a time transition, the brightness level stored in the light will be 1. The next time the light is turned on with no explicit brightness, it will be at 1.

This can be solved by storing the current brightness before turning off, and then using that when turning on.

**Related issue (if applicable):** fixes #26374


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
