### PR TITLE
Switch py_nextbus to py_nextbusnext

### DIFF
--- a/homeassistant/components/nextbus/manifest.json
+++ b/homeassistant/components/nextbus/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://www.home-assistant.io/components/nextbus",
     "dependencies": [],
     "codeowners": ["@vividboarder"],
-    "requirements": ["py_nextbus==0.1.2"]
+    "requirements": ["py_nextbusnext==0.1.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1035,7 +1035,7 @@ pyW215==0.6.0
 pyW800rf32==0.1
 
 # homeassistant.components.nextbus
-py_nextbus==0.1.2
+py_nextbusnext==0.1.4
 
 # homeassistant.components.noaa_tides
 # py_noaa==0.3.0


### PR DESCRIPTION
## Description:

The original package maintainer seems to be unresponsive. I've forked
the package and added the bug fixes to the new fork.

**Related issue (if applicable):** fixes #24561

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
