### PR TITLE
Use Nabu Casa url if no https url set

### DIFF
--- a/homeassistant/components/cast/home_assistant_cast.py
+++ b/homeassistant/components/cast/home_assistant_cast.py
@@ -40,10 +40,20 @@ async def async_setup_ha_cast(
 
     async def handle_show_view(call: core.ServiceCall):
         """Handle a Show View service call."""
+        hass_url = hass.config.api.base_url
+
+        # Home Assistant Cast only works with https urls. If user has no configured
+        # base url, use their remote url.
+        if not hass_url.lower().startswith("https://"):
+            try:
+                hass_url = hass.components.cloud.async_remote_ui_url()
+            except hass.components.cloud.CloudNotAvailable:
+                pass
+
         controller = HomeAssistantController(
             # If you are developing Home Assistant Cast, uncomment and set to your dev app id.
             # app_id="5FE44367",
-            hass_url=hass.config.api.base_url,
+            hass_url=hass_url,
             client_id=None,
             refresh_token=refresh_token.token,
         )

--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -1,5 +1,5 @@
 """Test Home Assistant Cast."""
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from homeassistant.components.cast import home_assistant_cast
 
 from tests.common import MockConfigEntry, async_mock_signal
@@ -26,3 +26,25 @@ async def test_service_show_view(hass):
     assert controller.supporting_app_id == "B12CE3CA"
     assert entity_id == "media_player.kitchen"
     assert view_path == "mock_path"
+
+
+async def test_use_cloud_url(hass):
+    """Test we don't set app id in prod."""
+    hass.config.api = Mock(base_url="http://example.com")
+    await home_assistant_cast.async_setup_ha_cast(hass, MockConfigEntry())
+    calls = async_mock_signal(hass, home_assistant_cast.SIGNAL_HASS_CAST_SHOW_VIEW)
+
+    with patch(
+        "homeassistant.components.cloud.async_remote_ui_url",
+        return_value="https://something.nabu.acas",
+    ):
+        await hass.services.async_call(
+            "cast",
+            "show_lovelace_view",
+            {"entity_id": "media_player.kitchen", "view_path": "mock_path"},
+            blocking=True,
+        )
+
+    assert len(calls) == 1
+    controller = calls[0][0]
+    assert controller.hass_url == "https://something.nabu.acas"

--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -29,7 +29,7 @@ async def test_service_show_view(hass):
 
 
 async def test_use_cloud_url(hass):
-    """Test we don't set app id in prod."""
+    """Test that we fall back to cloud url."""
     hass.config.api = Mock(base_url="http://example.com")
     await home_assistant_cast.async_setup_ha_cast(hass, MockConfigEntry())
     calls = async_mock_signal(hass, home_assistant_cast.SIGNAL_HASS_CAST_SHOW_VIEW)


### PR DESCRIPTION
## Description:
Home Assistant Cast is limited to https urls. This will automatically fill in the Nabu Casa remote url if there is no https url set as base url. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
