### PR TITLE
Fix Nuki issues

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -195,7 +195,7 @@ homeassistant/components/notify/* @home-assistant/core
 homeassistant/components/notion/* @bachya
 homeassistant/components/nsw_fuel_station/* @nickw444
 homeassistant/components/nsw_rural_fire_service_feed/* @exxamalte
-homeassistant/components/nuki/* @pschmitt
+homeassistant/components/nuki/* @pvizeli
 homeassistant/components/nws/* @MatthewFlamm
 homeassistant/components/nzbget/* @chriscla
 homeassistant/components/obihai/* @dshokouhi

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -1,1 +1,3 @@
 """The nuki component."""
+
+DOMAIN = "nuki"

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -1,15 +1,16 @@
 """Nuki.io lock platform."""
 from datetime import timedelta
 import logging
-import requests
 
+from pynuki import NukiBridge
+from requests.exceptions import RequestException
 import voluptuous as vol
 
 from homeassistant.components.lock import (
     DOMAIN,
     PLATFORM_SCHEMA,
-    LockDevice,
     SUPPORT_OPEN,
+    LockDevice,
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, CONF_TOKEN
 import homeassistant.helpers.config_validation as cv
@@ -30,7 +31,8 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
 NUKI_DATA = "nuki"
 
 SERVICE_LOCK_N_GO = "lock_n_go"
-SERVICE_CHECK_CONNECTION = "check_connection"
+
+ERROR_STATES = (0, 254, 255)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -47,47 +49,29 @@ LOCK_N_GO_SERVICE_SCHEMA = vol.Schema(
     }
 )
 
-CHECK_CONNECTION_SERVICE_SCHEMA = vol.Schema(
-    {vol.Optional(ATTR_ENTITY_ID): cv.entity_ids}
-)
-
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Nuki lock platform."""
-    from pynuki import NukiBridge
-
     bridge = NukiBridge(
         config[CONF_HOST], config[CONF_TOKEN], config[CONF_PORT], DEFAULT_TIMEOUT
     )
-    add_entities([NukiLock(lock) for lock in bridge.locks])
+    devices = [NukiLock(lock) for lock in bridge.locks]
 
     def service_handler(service):
         """Service handler for nuki services."""
         entity_ids = extract_entity_ids(hass, service)
-        all_locks = hass.data[NUKI_DATA][DOMAIN]
-        target_locks = []
-        if not entity_ids:
-            target_locks = all_locks
-        else:
-            for lock in all_locks:
-                if lock.entity_id in entity_ids:
-                    target_locks.append(lock)
-        for lock in target_locks:
-            if service.service == SERVICE_LOCK_N_GO:
-                unlatch = service.data[ATTR_UNLATCH]
-                lock.lock_n_go(unlatch=unlatch)
-            elif service.service == SERVICE_CHECK_CONNECTION:
-                lock.check_connection()
+        unlatch = service.data[ATTR_UNLATCH]
+
+        for lock in devices:
+            if lock.entity_id not in entity_ids:
+                continue
+            lock.lock_n_go(unlatch=unlatch)
 
     hass.services.register(
         "nuki", SERVICE_LOCK_N_GO, service_handler, schema=LOCK_N_GO_SERVICE_SCHEMA
     )
-    hass.services.register(
-        "nuki",
-        SERVICE_CHECK_CONNECTION,
-        service_handler,
-        schema=CHECK_CONNECTION_SERVICE_SCHEMA,
-    )
+
+    add_entities(devices)
 
 
 class NukiLock(LockDevice):
@@ -99,15 +83,7 @@ class NukiLock(LockDevice):
         self._locked = nuki_lock.is_locked
         self._name = nuki_lock.name
         self._battery_critical = nuki_lock.battery_critical
-        self._available = nuki_lock.state != 255
-
-    async def async_added_to_hass(self):
-        """Call when entity is added to hass."""
-        if NUKI_DATA not in self.hass.data:
-            self.hass.data[NUKI_DATA] = {}
-        if DOMAIN not in self.hass.data[NUKI_DATA]:
-            self.hass.data[NUKI_DATA][DOMAIN] = []
-        self.hass.data[NUKI_DATA][DOMAIN].append(self)
+        self._available = nuki_lock.state not in ERROR_STATES
 
     @property
     def name(self):
@@ -140,13 +116,18 @@ class NukiLock(LockDevice):
 
     def update(self):
         """Update the nuki lock properties."""
-        try:
-            self._nuki_lock.update(aggressive=False)
-        except requests.exceptions.RequestException:
-            self._available = False
-            return
+        for level in (False, True):
+            try:
+                self._nuki_lock.update(aggressive=level)
+            except RequestException:
+                _LOGGER.warning("Network issues detect with %s", self.name)
+                self._available = False
+                return
+            else:
+                self._available = True
+                break
 
-        self._available = True
+        self._available = self._nuki_lock.state not in ERROR_STATES
         self._name = self._nuki_lock.name
         self._locked = self._nuki_lock.is_locked
         self._battery_critical = self._nuki_lock.battery_critical
@@ -170,12 +151,3 @@ class NukiLock(LockDevice):
         amount of time depending on the lock settings) and relock.
         """
         self._nuki_lock.lock_n_go(unlatch, kwargs)
-
-    def check_connection(self, **kwargs):
-        """Update the nuki lock properties."""
-        try:
-            self._nuki_lock.update(aggressive=True)
-        except requests.exceptions.RequestException:
-            self._available = False
-        else:
-            self._available = self._nuki_lock.state != 255

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -6,15 +6,12 @@ from pynuki import NukiBridge
 from requests.exceptions import RequestException
 import voluptuous as vol
 
-from homeassistant.components.lock import (
-    DOMAIN,
-    PLATFORM_SCHEMA,
-    SUPPORT_OPEN,
-    LockDevice,
-)
+from homeassistant.components.lock import PLATFORM_SCHEMA, SUPPORT_OPEN, LockDevice
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, CONF_TOKEN
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import extract_entity_ids
+
+from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,7 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             lock.lock_n_go(unlatch=unlatch)
 
     hass.services.register(
-        "nuki", SERVICE_LOCK_N_GO, service_handler, schema=LOCK_N_GO_SERVICE_SCHEMA
+        DOMAIN, SERVICE_LOCK_N_GO, service_handler, schema=LOCK_N_GO_SERVICE_SCHEMA
     )
 
     add_entities(devices)

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -124,7 +124,6 @@ class NukiLock(LockDevice):
                 self._available = False
                 return
             else:
-                self._available = True
                 break
 
         self._available = self._nuki_lock.state not in ERROR_STATES

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -123,10 +123,12 @@ class NukiLock(LockDevice):
                 _LOGGER.warning("Network issues detect with %s", self.name)
                 self._available = False
                 return
-            else:
+
+            # If in error state, we force an update and repoll data
+            self._available = self._nuki_lock.state not in ERROR_STATES
+            if self._available:
                 break
 
-        self._available = self._nuki_lock.state not in ERROR_STATES
         self._name = self._nuki_lock.name
         self._locked = self._nuki_lock.is_locked
         self._battery_critical = self._nuki_lock.battery_critical

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -2,11 +2,7 @@
   "domain": "nuki",
   "name": "Nuki",
   "documentation": "https://www.home-assistant.io/components/nuki",
-  "requirements": [
-    "pynuki==1.3.3"
-  ],
+  "requirements": ["pynuki==1.3.3"],
   "dependencies": [],
-  "codeowners": [
-    "@pschmitt"
-  ]
+  "codeowners": ["@pvizeli"]
 }


### PR DESCRIPTION
## Breaking Change:
- The `nuki.check_connect` service has been removed. Users using the service in automations need to remove it.
- The `nuki.lock_n_go` service now requires one or more entity_id as service data. Users using this service in automations need to update their automations.

## Description:
Remove the nuki.check_connect service. I don't know why we merge that before, we should fix issues and not enter workarounds. The service follow now also the core rules about no entity_id on service calls.

It cleanup the handling and split the requests (network error) from logic of device error (manifactore specific). Remove not needed code. Add my self as code owner because I know now the API and have full understand of process behind

Fix: #25786

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
