### PR TITLE
Adds config entry and entity registry support for Abode

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,7 @@ homeassistant/util/* @home-assistant/core
 homeassistant/scripts/check_config.py @kellerza
 
 # Integrations
+homeassistant/components/abode/* @shred86
 homeassistant/components/adguard/* @frenck
 homeassistant/components/airvisual/* @bachya
 homeassistant/components/alarm_control_panel/* @colinodell

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -5,6 +5,7 @@ from requests.exceptions import HTTPError, ConnectTimeout
 
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_DATE,
@@ -19,16 +20,15 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
+
+from .config_flow import configured_instances
+from .const import DOMAIN, ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTRIBUTION = "Data provided by goabode.com"
-
 CONF_POLLING = "polling"
 
-DOMAIN = "abode"
 DEFAULT_CACHEDB = "./abodepy_cache.pickle"
 
 NOTIFICATION_ID = "abode_notification"
@@ -103,7 +103,7 @@ class AbodeSystem:
         self.abode = abodepy.Abode(
             username,
             password,
-            auto_login=True,
+            auto_login=False,
             get_devices=True,
             get_automations=True,
             cache_path=cache,
@@ -131,17 +131,55 @@ class AbodeSystem:
         )
 
 
-def setup(hass, config):
+async def async_setup(hass, config):
     """Set up Abode component."""
-    from abodepy.exceptions import AbodeException
+    if DOMAIN not in config:
+        return True
+
+    config_user = config[DOMAIN][CONF_USERNAME]
+
+    if config_user in configured_instances(hass):
+        _LOGGER.warning(
+            f"Account {config_user} already exists! Ignoring account settings in configuration.yaml"
+        )
+        return True
+
+    hass.data[DOMAIN] = {}
 
     conf = config[DOMAIN]
-    username = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASSWORD)
-    name = conf.get(CONF_NAME)
-    polling = conf.get(CONF_POLLING)
-    exclude = conf.get(CONF_EXCLUDE)
-    lights = conf.get(CONF_LIGHTS)
+
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_USERNAME: conf.get(CONF_USERNAME),
+                CONF_PASSWORD: conf.get(CONF_PASSWORD),
+                CONF_NAME: conf.get(CONF_NAME),
+                CONF_POLLING: conf.get(CONF_POLLING),
+                CONF_EXCLUDE: conf.get(CONF_EXCLUDE),
+                CONF_LIGHTS: conf.get(CONF_LIGHTS),
+            },
+        )
+    )
+
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set up Abode component via config entry (Integrations UI)."""
+    from abodepy.exceptions import AbodeException
+
+    username = config_entry.data.get(CONF_USERNAME)
+    password = config_entry.data.get(CONF_PASSWORD)
+    name = config_entry.data.get(CONF_NAME)
+    polling = config_entry.data.get(CONF_POLLING)
+    exclude = config_entry.data.get(CONF_EXCLUDE)
+    lights = config_entry.data.get(CONF_LIGHTS)
+
+    # 'exclude' has to be iterable, can't be of type None
+    if not exclude:
+        exclude = []
 
     try:
         cache = hass.config.path(DEFAULT_CACHEDB)
@@ -160,12 +198,14 @@ def setup(hass, config):
         )
         return False
 
-    setup_hass_services(hass)
-    setup_hass_events(hass)
-    setup_abode_events(hass)
-
     for platform in ABODE_PLATFORMS:
-        discovery.load_platform(hass, platform, DOMAIN, {}, config)
+        hass.async_add_job(
+            hass.config_entries.async_forward_entry_setup(config_entry, platform)
+        )
+
+    await hass.async_add_executor_job(setup_hass_services, hass)
+    await hass.async_add_executor_job(setup_hass_events, hass)
+    await hass.async_add_executor_job(setup_abode_events, hass)
 
     return True
 
@@ -210,15 +250,15 @@ def setup_hass_services(hass):
         for device in target_devices:
             device.trigger()
 
-    hass.services.register(
+    hass.services.async_register(
         DOMAIN, SERVICE_SETTINGS, change_setting, schema=CHANGE_SETTING_SCHEMA
     )
 
-    hass.services.register(
+    hass.services.async_register(
         DOMAIN, SERVICE_CAPTURE_IMAGE, capture_image, schema=CAPTURE_IMAGE_SCHEMA
     )
 
-    hass.services.register(
+    hass.services.async_register(
         DOMAIN, SERVICE_TRIGGER, trigger_quick_action, schema=TRIGGER_SCHEMA
     )
 
@@ -317,6 +357,21 @@ class AbodeDevice(Entity):
             "device_id": self._device.device_id,
             "battery_low": self._device.battery_low,
             "no_response": self._device.no_response,
+            "device_type": self._device.type,
+        }
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for this device."""
+        return self._device.device_id
+
+    @property
+    def device_info(self):
+        """Return device registry information for this entity."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "manufacturer": "Abode",
+            "name": self._device.name,
             "device_type": self._device.type,
         }
 

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -9,22 +9,24 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
 )
 
-from . import ATTRIBUTION, DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN, ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
 
 ICON = "mdi:security"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up an alarm control panel for an Abode device."""
-    data = hass.data[ABODE_DOMAIN]
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
 
-    alarm_devices = [AbodeAlarm(data, data.abode.get_alarm(), data.name)]
 
-    data.devices.extend(alarm_devices)
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Setup an Abode alarm control panel platform based on a config entry."""
+    data = hass.data[DOMAIN]
 
-    add_entities(alarm_devices)
+    async_add_devices([AbodeAlarm(data, data.abode.get_alarm(), data.name)], True)
 
 
 class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -1,19 +1,24 @@
 """Support for Abode Security System binary sensors."""
 import logging
+import abodepy.helpers.constants as CONST
+import abodepy.helpers.timeline as TIMELINE
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeAutomation, AbodeDevice
+from . import AbodeAutomation, AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up a sensor for an Abode device."""
-    import abodepy.helpers.constants as CONST
-    import abodepy.helpers.timeline as TIMELINE
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
 
-    data = hass.data[ABODE_DOMAIN]
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up a sensor for an Abode device."""
+    data = hass.data[DOMAIN]
 
     device_types = [
         CONST.TYPE_CONNECTIVITY,
@@ -40,9 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             )
         )
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -7,19 +7,25 @@ import requests
 from homeassistant.components.camera import Camera
 from homeassistant.util import Throttle
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=90)
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up Abode camera devices."""
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up a camera for an Abode device."""
     import abodepy.helpers.constants as CONST
     import abodepy.helpers.timeline as TIMELINE
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA):
@@ -28,9 +34,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeCamera(AbodeDevice, Camera):

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -1,0 +1,72 @@
+"""Config flow for the Abode component."""
+from collections import OrderedDict
+import voluptuous as vol
+
+from abodepy.exceptions import AbodeAuthenticationException
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from .const import DOMAIN
+
+
+@callback
+def configured_instances(hass):
+    """Return a set of configured Abode instances."""
+    return set(
+        entry.data[CONF_USERNAME] for entry in hass.config_entries.async_entries(DOMAIN)
+    )
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class AbodeFlowHandler(config_entries.ConfigFlow):
+    """Config flow for Abode."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize."""
+        self.data_schema = OrderedDict()
+        self.data_schema[vol.Required(CONF_USERNAME)] = str
+        self.data_schema[vol.Required(CONF_PASSWORD)] = str
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        from abodepy import Abode
+
+        if not user_input:
+            return await self._show_form()
+
+        if user_input[CONF_USERNAME] in configured_instances(self.hass):
+            return await self._show_form({CONF_USERNAME: "identifier_exists"})
+
+        username = user_input[CONF_USERNAME]
+        password = user_input[CONF_PASSWORD]
+
+        try:
+            Abode(username, password, auto_login=True)
+
+        # Need to add error checking if Abode server is down/not responding
+        except AbodeAuthenticationException:
+            return await self._show_form({"base": "invalid_credentials"})
+
+        return self.async_create_entry(
+            title=user_input[CONF_USERNAME],
+            data={CONF_USERNAME: username, CONF_PASSWORD: password},
+        )
+
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(self.data_schema),
+            errors=errors if errors else {},
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        if import_config[CONF_USERNAME] in configured_instances(self.hass):
+            return await self._show_form({CONF_USERNAME: "identifier_exists"})
+
+        return self.async_create_entry(
+            title=import_config["username"], data=import_config
+        )

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -1,35 +1,3 @@
 """Constants for Abode."""
-# Base component constants
 DOMAIN = "abode"
-DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.0.1"
-# PLATFORMS = ["binary_sensor", "sensor", "switch"]
-# REQUIRED_FILES = [
-#     ".translations/en.json",
-#     "binary_sensor.py",
-#     "const.py",
-#     "config_flow.py",
-#     "manifest.json",
-#     "sensor.py",
-#     "switch.py",
-# ]
-# ISSUE_URL = "https://github.com/custom-components/blueprint/issues"
 ATTRIBUTION = "Data provided by goabode.com"
-
-# Icons
-ICON = "mdi:format-quote-close"
-
-# Device classes
-BINARY_SENSOR_DEVICE_CLASS = "connectivity"
-
-# Configuration
-CONF_BINARY_SENSOR = "binary_sensor"
-CONF_SENSOR = "sensor"
-CONF_SWITCH = "switch"
-CONF_ENABLED = "enabled"
-CONF_NAME = "name"
-CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
-
-# Defaults
-DEFAULT_NAME = DOMAIN

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -1,0 +1,35 @@
+"""Constants for Abode."""
+# Base component constants
+DOMAIN = "abode"
+DOMAIN_DATA = f"{DOMAIN}_data"
+VERSION = "0.0.1"
+# PLATFORMS = ["binary_sensor", "sensor", "switch"]
+# REQUIRED_FILES = [
+#     ".translations/en.json",
+#     "binary_sensor.py",
+#     "const.py",
+#     "config_flow.py",
+#     "manifest.json",
+#     "sensor.py",
+#     "switch.py",
+# ]
+# ISSUE_URL = "https://github.com/custom-components/blueprint/issues"
+ATTRIBUTION = "Data provided by goabode.com"
+
+# Icons
+ICON = "mdi:format-quote-close"
+
+# Device classes
+BINARY_SENSOR_DEVICE_CLASS = "connectivity"
+
+# Configuration
+CONF_BINARY_SENSOR = "binary_sensor"
+CONF_SENSOR = "sensor"
+CONF_SWITCH = "switch"
+CONF_ENABLED = "enabled"
+CONF_NAME = "name"
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+
+# Defaults
+DEFAULT_NAME = DOMAIN

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -3,16 +3,22 @@ import logging
 
 from homeassistant.components.cover import CoverDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode cover devices."""
     import abodepy.helpers.constants as CONST
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_COVER):
@@ -21,9 +27,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeCover(data, device))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeCover(AbodeDevice, CoverDevice):

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -16,16 +16,22 @@ from homeassistant.util.color import (
     color_temperature_mired_to_kelvin,
 )
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode light devices."""
     import abodepy.helpers.constants as CONST
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     device_types = [CONST.TYPE_LIGHT, CONST.TYPE_SWITCH]
 
@@ -38,9 +44,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeLight(data, device))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeLight(AbodeDevice, Light):

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -3,16 +3,22 @@ import logging
 
 from homeassistant.components.lock import LockDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode lock devices."""
     import abodepy.helpers.constants as CONST
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_LOCK):
@@ -21,9 +27,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeLock(data, device))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeLock(AbodeDevice, LockDevice):

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -1,10 +1,12 @@
 {
-  "domain": "abode",
-  "name": "Abode",
-  "documentation": "https://www.home-assistant.io/components/abode",
-  "requirements": [
-    "abodepy==0.15.0"
-  ],
-  "dependencies": [],
-  "codeowners": []
-}
+    "domain": "abode",
+    "name": "Abode",
+    "config_flow": true,
+    "documentation": "https://www.home-assistant.io/components/abode",
+    "requirements": [
+      "abodepy==0.15.0"
+    ],
+    "dependencies": [],
+    "codeowners": ["@shred86"]
+  }
+  

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -7,7 +7,8 @@ from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
 )
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,11 +20,16 @@ SENSOR_TYPES = {
 }
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up a sensor for an Abode device."""
     import abodepy.helpers.constants as CONST
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
@@ -33,9 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for sensor_type in SENSOR_TYPES:
             devices.append(AbodeSensor(data, device, sensor_type))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeSensor(AbodeDevice):

--- a/homeassistant/components/abode/strings.json
+++ b/homeassistant/components/abode/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "title": "Abode",
+    "step": {
+      "user": {
+        "title": "Fill in your login information",
+        "data": {
+          "username": "Email Address",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "identifier_exists": "Account already registered",
+      "invalid_credentials": "Invalid credentials"
+    }
+  }
+}

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -3,17 +3,23 @@ import logging
 
 from homeassistant.components.switch import SwitchDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeAutomation, AbodeDevice
+from . import AbodeAutomation, AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """This platform uses config entries."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode switch devices."""
     import abodepy.helpers.constants as CONST
     import abodepy.helpers.timeline as TIMELINE
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
 
@@ -33,9 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             AbodeAutomationSwitch(data, automation, TIMELINE.AUTOMATION_EDIT_GROUP)
         )
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeSwitch(AbodeDevice, SwitchDevice):

--- a/homeassistant/components/volumio/media_player.py
+++ b/homeassistant/components/volumio/media_player.py
@@ -306,7 +306,7 @@ class Volumio(MediaPlayerDevice):
     def async_set_shuffle(self, shuffle):
         """Enable/disable shuffle mode."""
         return self.send_volumio_msg(
-            "commands", params={"cmd": "random", "value": str(shuffle)}
+            "commands", params={"cmd": "random", "value": str(shuffle).lower()}
         )
 
     def async_select_source(self, source):

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -6,6 +6,7 @@ To update, run python3 -m script.hassfest
 # fmt: off
 
 FLOWS = [
+    "abode",
     "adguard",
     "ambiclimate",
     "ambient_station",


### PR DESCRIPTION
## Description:

Adds config entry and entity registry support for the Abode component. This implementation will create a config entry if a user has added the abode component configured via the configuration.yaml file. The entity registry unique ID is based on `device_id` from Abode (no devices in Abode should ever have the same device_id).

Tested on my Abode setup which includes binary sensors and lights.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.