### PR TITLE
Add abode config entries and device registry

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,7 +10,15 @@ omit =
     homeassistant/util/async.py
 
     # omit pieces of code that rely on external devices being present
-    homeassistant/components/abode/*
+    homeassistant/components/abode/__init__.py
+    homeassistant/components/abode/alarm_control_panel.py
+    homeassistant/components/abode/binary_sensor.py
+    homeassistant/components/abode/camera.py
+    homeassistant/components/abode/cover.py
+    homeassistant/components/abode/light.py
+    homeassistant/components/abode/lock.py
+    homeassistant/components/abode/sensor.py
+    homeassistant/components/abode/switch.py
     homeassistant/components/acer_projector/switch.py
     homeassistant/components/actiontec/device_tracker.py
     homeassistant/components/adguard/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,7 @@ homeassistant/util/* @home-assistant/core
 homeassistant/scripts/check_config.py @kellerza
 
 # Integrations
+homeassistant/components/abode/* @shred86
 homeassistant/components/adguard/* @frenck
 homeassistant/components/airly/* @bieniu
 homeassistant/components/airvisual/* @bachya

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -93,7 +93,7 @@ class AbodeSystem:
 
 
 async def async_setup(hass, config):
-    """Set up Abode platform."""
+    """Set up Abode integration."""
     if DOMAIN not in config:
         return True
 
@@ -109,7 +109,7 @@ async def async_setup(hass, config):
 
 
 async def async_setup_entry(hass, config_entry):
-    """Set up Abode platform from a config entry."""
+    """Set up Abode integration from a config entry."""
     username = config_entry.data.get(CONF_USERNAME)
     password = config_entry.data.get(CONF_PASSWORD)
     polling = config_entry.data.get(CONF_POLLING)

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -285,7 +285,7 @@ class AbodeDevice(Entity):
     async def async_will_remove_from_hass(self):
         """Unsubscribe from device events."""
         self.hass.async_add_job(
-            self._data.abode.events.remove_device_all_callbacks, self._device.device_id
+            self._data.abode.events.remove_all_device_callbacks, self._device.device_id
         )
 
     @property

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -1,17 +1,13 @@
 """Support for the Abode Security System."""
-import logging
 from asyncio import gather
 from copy import deepcopy
 from functools import partial
-from requests.exceptions import HTTPError, ConnectTimeout
+import logging
 
-import abodepy
-import abodepy.helpers.constants as CONST
+from abodepy import Abode
 from abodepy.exceptions import AbodeException
 import abodepy.helpers.timeline as TIMELINE
-
-from abodepy.exceptions import AbodeException
-
+from requests.exceptions import HTTPError, ConnectTimeout
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -142,7 +142,7 @@ async def async_setup(hass, config):
 
     if config_user in configured_instances(hass):
         _LOGGER.warning(
-            f"Account {config_user} already exists! Ignoring account settings in configuration.yaml"
+            "Account already exists! Ignoring account settings in configuration.yaml"
         )
         return True
 

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -90,6 +90,7 @@ class AbodeSystem:
         self.abode = abode
         self.polling = polling
         self.devices = []
+        self.logout_listener = None
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_USERNAME,
     CONF_PASSWORD,
-    CONF_NAME,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.helpers import config_validation as cv
@@ -35,15 +34,6 @@ _LOGGER = logging.getLogger(__name__)
 CONF_POLLING = "polling"
 
 DEFAULT_CACHEDB = "./abodepy_cache.pickle"
-
-NOTIFICATION_ID = "abode_notification"
-NOTIFICATION_TITLE = "Abode Security Setup"
-
-EVENT_ABODE_ALARM = "abode_alarm"
-EVENT_ABODE_ALARM_END = "abode_alarm_end"
-EVENT_ABODE_AUTOMATION = "abode_automation"
-EVENT_ABODE_FAULT = "abode_panel_fault"
-EVENT_ABODE_RESTORE = "abode_panel_restore"
 
 SERVICE_SETTINGS = "change_setting"
 SERVICE_CAPTURE_IMAGE = "capture_image"
@@ -68,7 +58,6 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_NAME): cv.string,
                 vol.Optional(CONF_POLLING, default=False): cv.boolean,
             }
         )

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -93,7 +93,7 @@ class AbodeSystem:
 
 
 async def async_setup(hass, config):
-    """Set up Abode component."""
+    """Set up Abode platform."""
     if DOMAIN not in config:
         return True
 
@@ -109,7 +109,7 @@ async def async_setup(hass, config):
 
 
 async def async_setup_entry(hass, config_entry):
-    """Set up Abode component via config entry (Integrations UI)."""
+    """Set up Abode platform from a config entry."""
     username = config_entry.data.get(CONF_USERNAME)
     password = config_entry.data.get(CONF_PASSWORD)
     polling = config_entry.data.get(CONF_POLLING)
@@ -270,16 +270,22 @@ class AbodeDevice(Entity):
     """Representation of an Abode device."""
 
     def __init__(self, data, device):
-        """Initialize a sensor for Abode device."""
+        """Initialize Abode device."""
         self._data = data
         self._device = device
 
     async def async_added_to_hass(self):
-        """Subscribe Abode events."""
+        """Subscribe to device events."""
         self.hass.async_add_job(
             self._data.abode.events.add_device_callback,
             self._device.device_id,
             self._update_callback,
+        )
+
+    async def async_will_remove_from_hass(self):
+        """Unsubscribe from device events."""
+        self.hass.async_add_job(
+            self._data.abode.events.remove_device_all_callbacks, self._device.device_id
         )
 
     @property
@@ -293,7 +299,7 @@ class AbodeDevice(Entity):
 
     @property
     def name(self):
-        """Return the name of the sensor."""
+        """Return the name of the device."""
         return self._device.name
 
     @property
@@ -356,7 +362,7 @@ class AbodeAutomation(Entity):
 
     @property
     def name(self):
-        """Return the name of the sensor."""
+        """Return the name of the automation."""
         return self._automation.name
 
     @property
@@ -370,6 +376,6 @@ class AbodeAutomation(Entity):
         }
 
     def _update_callback(self, device):
-        """Update the device state."""
+        """Update the automation state."""
         self._automation.refresh()
         self.schedule_update_ha_state()

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -3,14 +3,13 @@ import logging
 from copy import deepcopy
 from functools import partial
 from requests.exceptions import HTTPError, ConnectTimeout
-<<<<<<< HEAD
+
 import abodepy
 import abodepy.helpers.constants as CONST
 from abodepy.exceptions import AbodeException
 import abodepy.helpers.timeline as TIMELINE
-=======
+
 from abodepy.exceptions import AbodeException
->>>>>>> Several fixes from code review
 
 import voluptuous as vol
 
@@ -99,18 +98,10 @@ ABODE_PLATFORMS = [
 class AbodeSystem:
     """Abode System class."""
 
-    def __init__(self, username, password, cache, name, polling):
+    def __init__(self, abode, username, password, cache, polling):
         """Initialize the system."""
 
-        self.abode = abodepy.Abode(
-            username,
-            password,
-            auto_login=True,
-            get_devices=True,
-            get_automations=True,
-            cache_path=cache,
-        )
-        self.name = name
+        self.abode = abode
         self.polling = polling
         self.devices = []
 
@@ -135,13 +126,20 @@ async def async_setup_entry(hass, config_entry):
     """Set up Abode component via config entry (Integrations UI)."""
     username = config_entry.data.get(CONF_USERNAME)
     password = config_entry.data.get(CONF_PASSWORD)
-    name = config_entry.data.get(CONF_NAME)
     polling = config_entry.data.get(CONF_POLLING)
 
     try:
         cache = hass.config.path(DEFAULT_CACHEDB)
+        abode = Abode(
+            username,
+            password,
+            auto_login=True,
+            get_devices=True,
+            get_automations=True,
+            cache_path=cache,
+        )
         hass.data[DOMAIN] = await hass.async_add_executor_job(
-            AbodeSystem, username, password, cache, name, polling
+            AbodeSystem, abode, username, password, cache, polling
         )
     except (AbodeException, ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Abode: %s", str(ex))

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -22,27 +22,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up an alarm control panel for an Abode device."""
     data = hass.data[DOMAIN]
 
-    async_add_devices(
-        [
-            AbodeAlarm(
-                data, await hass.async_add_executor_job(data.abode.get_alarm), data.name
-            )
-        ],
+    async_add_entities(
+        [AbodeAlarm(data, await hass.async_add_executor_job(data.abode.get_alarm))],
         True,
     )
 
 
 class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
     """An alarm_control_panel implementation for Abode."""
-
-    def __init__(self, data, device, name):
-        """Initialize the alarm control panel."""
-        super().__init__(data, device)
-        self._name = name
 
     @property
     def icon(self):
@@ -73,11 +64,6 @@ class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
         self._device.set_away()
-
-    @property
-    def name(self):
-        """Return the name of the alarm."""
-        return self._name or super().name
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
 )
 
 from . import AbodeDevice
-from .const import DOMAIN, ATTRIBUTION
+from .const import ATTRIBUTION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,8 +27,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     data = hass.data[DOMAIN]
 
     async_add_entities(
-        [AbodeAlarm(data, await hass.async_add_executor_job(data.abode.get_alarm))],
-        True,
+        [AbodeAlarm(data, await hass.async_add_executor_job(data.abode.get_alarm))]
     )
 
 
@@ -74,3 +73,8 @@ class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
             "battery_backup": self._device.battery,
             "cellular_backup": self._device.is_cellular,
         }
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for this device."""
+        return f"{self._device.name} {self._device.device_id}"

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -26,7 +26,14 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up an alarm control panel for an Abode device."""
     data = hass.data[DOMAIN]
 
-    async_add_devices([AbodeAlarm(data, data.abode.get_alarm(), data.name)], True)
+    async_add_devices(
+        [
+            AbodeAlarm(
+                data, await hass.async_add_executor_job(data.abode.get_alarm), data.name
+            )
+        ],
+        True,
+    )
 
 
 class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -73,8 +73,3 @@ class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
             "battery_backup": self._device.battery,
             "cellular_backup": self._device.is_cellular,
         }
-
-    @property
-    def unique_id(self):
-        """Return a unique ID to use for this device."""
-        return f"{self._device.name} {self._device.device_id}"

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -9,22 +9,24 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
 )
 
-from . import ATTRIBUTION, DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN, ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
 
 ICON = "mdi:security"
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up an alarm control panel for an Abode device."""
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
-    alarm_devices = [AbodeAlarm(data, data.abode.get_alarm(), data.name)]
-
-    data.devices.extend(alarm_devices)
-
-    add_entities(alarm_devices)
+    async_add_devices([AbodeAlarm(data, data.abode.get_alarm(), data.name)], True)
 
 
 class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -32,16 +32,11 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     ]
 
     devices = []
-    for device in data.abode.get_devices(generic_type=device_types):
-        if data.is_excluded(device):
-            continue
 
+    for device in data.abode.get_devices(generic_type=device_types):
         devices.append(AbodeBinarySensor(data, device))
 
     for automation in data.abode.get_automations(generic_type=CONST.TYPE_QUICK_ACTION):
-        if data.is_automation_excluded(automation):
-            continue
-
         devices.append(
             AbodeQuickActionBinarySensor(
                 data, automation, TIMELINE.AUTOMATION_EDIT_GROUP

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -4,9 +4,6 @@ import logging
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
 
-import abodepy.helpers.constants as CONST
-import abodepy.helpers.timeline as TIMELINE
-
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
 from . import AbodeAutomation, AbodeDevice

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -1,5 +1,6 @@
 """Support for Abode Security System binary sensors."""
 import logging
+
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
 

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -1,20 +1,27 @@
 """Support for Abode Security System binary sensors."""
 import logging
+import abodepy.helpers.constants as CONST
+import abodepy.helpers.timeline as TIMELINE
 
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeAutomation, AbodeDevice
+from . import AbodeAutomation, AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up a sensor for an Abode device."""
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
 
-    data = hass.data[ABODE_DOMAIN]
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up a sensor for an Abode device."""
+    data = hass.data[DOMAIN]
 
     device_types = [
         CONST.TYPE_CONNECTIVITY,
@@ -41,9 +48,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             )
         )
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):

--- a/homeassistant/components/abode/binary_sensor.py
+++ b/homeassistant/components/abode/binary_sensor.py
@@ -19,7 +19,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a sensor for an Abode device."""
     data = hass.data[DOMAIN]
 
@@ -43,7 +43,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             )
         )
 
-    async_add_devices(devices)
+    async_add_entities(devices)
 
 
 class AbodeBinarySensor(AbodeDevice, BinarySensorDevice):

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -9,17 +9,25 @@ import abodepy.helpers.timeline as TIMELINE
 from homeassistant.components.camera import Camera
 from homeassistant.util import Throttle
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=90)
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up Abode camera devices."""
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
 
-    data = hass.data[ABODE_DOMAIN]
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up a camera for an Abode device."""
+    import abodepy.helpers.constants as CONST
+    import abodepy.helpers.timeline as TIMELINE
+
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA):
@@ -28,9 +36,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeCamera(AbodeDevice, Camera):

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -1,7 +1,6 @@
 """Support for Abode Security System cameras."""
 from datetime import timedelta
 import logging
-
 import requests
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
@@ -24,8 +23,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up a camera for an Abode device."""
-    import abodepy.helpers.constants as CONST
-    import abodepy.helpers.timeline as TIMELINE
 
     data = hass.data[DOMAIN]
 

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -21,7 +21,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a camera for an Abode device."""
 
     data = hass.data[DOMAIN]
@@ -30,7 +30,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA):
         devices.append(AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE))
 
-    async_add_devices(devices)
+    async_add_entities(devices)
 
 
 class AbodeCamera(AbodeDevice, Camera):

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -31,9 +31,6 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_CAMERA):
-        if data.is_excluded(device):
-            continue
-
         devices.append(AbodeCamera(data, device, TIMELINE.CAPTURE_IMAGE))
 
     async_add_devices(devices)

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -1,10 +1,10 @@
 """Support for Abode Security System cameras."""
 from datetime import timedelta
 import logging
-import requests
 
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
+import requests
 
 from homeassistant.components.camera import Camera
 from homeassistant.util import Throttle

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 import requests
+
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
 

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from .const import DOMAIN
 
+CONF_POLLING = "polling"
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -24,6 +26,7 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.data_schema = {
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str,
+            vol.Optional(CONF_POLLING, default=False): bool,
         }
 
     async def async_step_user(self, user_input=None):
@@ -37,6 +40,7 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
+        polling = user_input[CONF_POLLING]
 
         try:
             await self.hass.async_add_executor_job(Abode, username, password, True)
@@ -48,7 +52,11 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(
             title=user_input[CONF_USERNAME],
-            data={CONF_USERNAME: username, CONF_PASSWORD: password},
+            data={
+                CONF_USERNAME: username,
+                CONF_PASSWORD: password,
+                CONF_POLLING: polling,
+            },
         )
 
     @callback

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -21,9 +21,10 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize."""
-        self.data_schema = vol.Schema(
-            {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
-        )
+        self.data_schema = {
+            vol.Required(CONF_USERNAME): str,
+            vol.Required(CONF_PASSWORD): str,
+        }
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -1,0 +1,72 @@
+"""Config flow for the Abode Security System component."""
+from collections import OrderedDict
+import voluptuous as vol
+
+from abodepy.exceptions import AbodeAuthenticationException
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from .const import DOMAIN
+
+
+@callback
+def configured_instances(hass):
+    """Return a set of configured Abode instances."""
+    return set(
+        entry.data[CONF_USERNAME] for entry in hass.config_entries.async_entries(DOMAIN)
+    )
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class AbodeFlowHandler(config_entries.ConfigFlow):
+    """Config flow for Abode."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize."""
+        self.data_schema = OrderedDict()
+        self.data_schema[vol.Required(CONF_USERNAME)] = str
+        self.data_schema[vol.Required(CONF_PASSWORD)] = str
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        from abodepy import Abode
+
+        if not user_input:
+            return await self._show_form()
+
+        if user_input[CONF_USERNAME] in configured_instances(self.hass):
+            return await self._show_form({CONF_USERNAME: "identifier_exists"})
+
+        username = user_input[CONF_USERNAME]
+        password = user_input[CONF_PASSWORD]
+
+        try:
+            Abode(username, password, auto_login=True)
+
+        # Need to add error checking if Abode server is down/not responding
+        except AbodeAuthenticationException:
+            return await self._show_form({"base": "invalid_credentials"})
+
+        return self.async_create_entry(
+            title=user_input[CONF_USERNAME],
+            data={CONF_USERNAME: username, CONF_PASSWORD: password},
+        )
+
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(self.data_schema),
+            errors=errors if errors else {},
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        if import_config[CONF_USERNAME] in configured_instances(self.hass):
+            return await self._show_form({CONF_USERNAME: "identifier_exists"})
+
+        return self.async_create_entry(
+            title=import_config["username"], data=import_config
+        )

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -1,22 +1,22 @@
 """Config flow for the Abode Security System component."""
 import logging
-
 import voluptuous as vol
-
+from abodepy import Abode
 from abodepy.exceptions import AbodeAuthenticationException
-from homeassistant import config_entries
 
+from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class AbodeFlowHandler(config_entries.ConfigFlow):
+class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Abode."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self):
         """Initialize."""
@@ -26,7 +26,6 @@ class AbodeFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
-        from abodepy import Abode
 
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -38,11 +37,12 @@ class AbodeFlowHandler(config_entries.ConfigFlow):
         password = user_input[CONF_PASSWORD]
 
         try:
-            self.hass.async_add_executor_job(Abode, username, password, True)
+            await self.hass.async_add_executor_job(Abode, username, password, True)
 
-        # Need to add error checking if Abode server is down/not responding
-        except AbodeAuthenticationException:
-            return await self._show_form({"base": "invalid_credentials"})
+        except AbodeAuthenticationException as error:
+            if error.errcode == 400:
+                return await self._show_form({"base": "invalid_credentials"})
+            return await self._show_form({"base": "abode_error"})
 
         return self.async_create_entry(
             title=user_input[CONF_USERNAME],
@@ -59,7 +59,7 @@ class AbodeFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_import(self, import_config):
         """Import a config entry from configuration.yaml."""
-        if self.hass.data.get(DOMAIN):
+        if self._async_current_entries():
             _LOGGER.warning("Only one configuration of abode is allowed.")
             return self.async_abort(reason="single_instance_allowed")
 

--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN
+from .const import DOMAIN  # pylint: disable=W0611
 
 CONF_POLLING = "polling"
 
@@ -26,7 +26,6 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.data_schema = {
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str,
-            vol.Optional(CONF_POLLING, default=False): bool,
         }
 
     async def async_step_user(self, user_input=None):
@@ -40,7 +39,7 @@ class AbodeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
-        polling = user_input[CONF_POLLING]
+        polling = user_input[CONF_POLLING] if CONF_POLLING in user_input else False
 
         try:
             await self.hass.async_add_executor_job(Abode, username, password, True)

--- a/homeassistant/components/abode/const.py
+++ b/homeassistant/components/abode/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Abode Security System component."""
+DOMAIN = "abode"
+ATTRIBUTION = "Data provided by goabode.com"

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -5,15 +5,21 @@ import abodepy.helpers.constants as CONST
 
 from homeassistant.components.cover import CoverDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode cover devices."""
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_COVER):
@@ -22,9 +28,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeCover(data, device))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeCover(AbodeDevice, CoverDevice):

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -23,9 +23,6 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_COVER):
-        if data.is_excluded(device):
-            continue
-
         devices.append(AbodeCover(data, device))
 
     async_add_devices(devices)

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -1,5 +1,6 @@
 """Support for Abode Security System covers."""
 import logging
+import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST
 

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -17,7 +17,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode cover devices."""
 
     data = hass.data[DOMAIN]
@@ -26,7 +26,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     for device in data.abode.get_devices(generic_type=CONST.TYPE_COVER):
         devices.append(AbodeCover(data, device))
 
-    async_add_devices(devices)
+    async_add_entities(devices)
 
 
 class AbodeCover(AbodeDevice, CoverDevice):

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -1,5 +1,6 @@
 """Support for Abode Security System covers."""
 import logging
+
 import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST

--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -3,8 +3,6 @@ import logging
 
 import abodepy.helpers.constants as CONST
 
-import abodepy.helpers.constants as CONST
-
 from homeassistant.components.cover import CoverDevice
 
 from . import AbodeDevice

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -30,7 +30,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode light devices."""
 
     data = hass.data[DOMAIN]
@@ -42,7 +42,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     for device in data.abode.get_devices(generic_type=device_types):
         devices.append(AbodeLight(data, device))
 
-    async_add_devices(devices)
+    async_add_entities(devices)
 
 
 class AbodeLight(AbodeDevice, Light):

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -4,8 +4,6 @@ from math import ceil
 
 import abodepy.helpers.constants as CONST
 
-import abodepy.helpers.constants as CONST
-
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -1,6 +1,7 @@
 """Support for Abode Security System lights."""
 import logging
 from math import ceil
+import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST
 

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -18,15 +18,21 @@ from homeassistant.util.color import (
     color_temperature_mired_to_kelvin,
 )
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode light devices."""
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     device_types = [CONST.TYPE_LIGHT, CONST.TYPE_SWITCH]
 
@@ -39,9 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeLight(data, device))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeLight(AbodeDevice, Light):

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -1,6 +1,7 @@
 """Support for Abode Security System lights."""
 import logging
 from math import ceil
+
 import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST
@@ -32,14 +33,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode light devices."""
-
     data = hass.data[DOMAIN]
-
-    device_types = [CONST.TYPE_LIGHT, CONST.TYPE_SWITCH]
 
     devices = []
 
-    for device in data.abode.get_devices(generic_type=device_types):
+    for device in data.abode.get_devices(generic_type=CONST.TYPE_LIGHT):
         devices.append(AbodeLight(data, device))
 
     async_add_entities(devices)

--- a/homeassistant/components/abode/light.py
+++ b/homeassistant/components/abode/light.py
@@ -38,11 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     devices = []
 
-    # Get all regular lights that are not excluded or switches marked as lights
     for device in data.abode.get_devices(generic_type=device_types):
-        if data.is_excluded(device) or not data.is_light(device):
-            continue
-
         devices.append(AbodeLight(data, device))
 
     async_add_devices(devices)

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -1,5 +1,6 @@
 """Support for the Abode Security System locks."""
 import logging
+import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST
 

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -1,5 +1,6 @@
 """Support for the Abode Security System locks."""
 import logging
+
 import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -23,9 +23,6 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_LOCK):
-        if data.is_excluded(device):
-            continue
-
         devices.append(AbodeLock(data, device))
 
     async_add_devices(devices)

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -17,7 +17,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode lock devices."""
 
     data = hass.data[DOMAIN]
@@ -26,7 +26,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     for device in data.abode.get_devices(generic_type=CONST.TYPE_LOCK):
         devices.append(AbodeLock(data, device))
 
-    async_add_devices(devices)
+    async_add_entities(devices)
 
 
 class AbodeLock(AbodeDevice, LockDevice):

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -1,19 +1,25 @@
-"""Support for Abode Security System locks."""
+"""Support for the Abode Security System locks."""
 import logging
 
 import abodepy.helpers.constants as CONST
 
 from homeassistant.components.lock import LockDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode lock devices."""
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_LOCK):
@@ -22,9 +28,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(AbodeLock(data, device))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeLock(AbodeDevice, LockDevice):

--- a/homeassistant/components/abode/lock.py
+++ b/homeassistant/components/abode/lock.py
@@ -3,8 +3,6 @@ import logging
 
 import abodepy.helpers.constants as CONST
 
-import abodepy.helpers.constants as CONST
-
 from homeassistant.components.lock import LockDevice
 
 from . import AbodeDevice

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/abode",
   "requirements": [
-    "abodepy==0.15.0"
+    "abodepy==0.16.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/abode",
   "requirements": [
-    "abodepy==0.16.1"
+    "abodepy==0.16.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/abode",
   "requirements": [
-    "abodepy==0.16.3"
+    "abodepy==0.16.5"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -2,7 +2,7 @@
   "domain": "abode",
   "name": "Abode",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/components/abode",
+  "documentation": "https://www.home-assistant.io/integrations/abode",
   "requirements": [
     "abodepy==0.15.0"
   ],

--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -1,10 +1,13 @@
 {
   "domain": "abode",
   "name": "Abode",
-  "documentation": "https://www.home-assistant.io/integrations/abode",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/components/abode",
   "requirements": [
     "abodepy==0.15.0"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@shred86"
+  ]
 }

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -34,9 +34,6 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
-        if data.is_excluded(device):
-            continue
-
         for sensor_type in SENSOR_TYPES:
             devices.append(AbodeSensor(data, device, sensor_type))
 

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -9,7 +9,8 @@ from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
 )
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeDevice
+from . import AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,10 +22,15 @@ SENSOR_TYPES = {
 }
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up a sensor for an Abode device."""
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SENSOR):
@@ -34,9 +40,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for sensor_type in SENSOR_TYPES:
             devices.append(AbodeSensor(data, device, sensor_type))
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeSensor(AbodeDevice):

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -1,5 +1,6 @@
 """Support for Abode Security System sensors."""
 import logging
+
 import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -3,8 +3,6 @@ import logging
 
 import abodepy.helpers.constants as CONST
 
-import abodepy.helpers.constants as CONST
-
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -28,7 +28,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a sensor for an Abode device."""
 
     data = hass.data[DOMAIN]
@@ -38,7 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         for sensor_type in SENSOR_TYPES:
             devices.append(AbodeSensor(data, device, sensor_type))
 
-    async_add_devices(devices)
+    async_add_entities(devices)
 
 
 class AbodeSensor(AbodeDevice):

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -1,5 +1,6 @@
 """Support for Abode Security System sensors."""
 import logging
+import abodepy.helpers.constants as CONST
 
 import abodepy.helpers.constants as CONST
 

--- a/homeassistant/components/abode/strings.json
+++ b/homeassistant/components/abode/strings.json
@@ -1,21 +1,22 @@
 {
-    "config": {
-      "title": "Abode",
-      "step": {
-        "user": {
-          "title": "Fill in your login information",
-          "data": {
-            "username": "Email Address",
-            "password": "Password"
-          }
+  "config": {
+    "title": "Abode",
+    "step": {
+      "user": {
+        "title": "Fill in your login information",
+        "data": {
+          "username": "Email Address",
+          "password": "Password"
         }
-      },
-      "error": {
-        "identifier_exists": "Account already registered.",
-        "invalid_credentials": "Invalid credentials."
-      },
-      "abort": {
-        "single_instance_allowed": "Only a single configuration of Abode is allowed."
       }
+    },
+    "error": {
+      "identifier_exists": "Account already registered.",
+      "invalid_credentials": "Invalid credentials.",
+      "abode_error": "Error occured with Abode server."
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of Abode is allowed."
     }
   }
+}

--- a/homeassistant/components/abode/strings.json
+++ b/homeassistant/components/abode/strings.json
@@ -1,18 +1,21 @@
 {
-  "config": {
-    "title": "Abode",
-    "step": {
-      "user": {
-        "title": "Fill in your login information",
-        "data": {
-          "username": "Email Address",
-          "password": "Password"
+    "config": {
+      "title": "Abode",
+      "step": {
+        "user": {
+          "title": "Fill in your login information",
+          "data": {
+            "username": "Email Address",
+            "password": "Password"
+          }
         }
+      },
+      "error": {
+        "identifier_exists": "Account already registered.",
+        "invalid_credentials": "Invalid credentials."
+      },
+      "abort": {
+        "single_instance_allowed": "Only a single configuration of Abode is allowed."
       }
-    },
-    "error": {
-      "identifier_exists": "Account already registered",
-      "invalid_credentials": "Invalid credentials"
     }
   }
-}

--- a/homeassistant/components/abode/strings.json
+++ b/homeassistant/components/abode/strings.json
@@ -3,7 +3,7 @@
     "title": "Abode",
     "step": {
       "user": {
-        "title": "Fill in your login information",
+        "title": "Fill in your Abode login information",
         "data": {
           "username": "Email Address",
           "password": "Password"
@@ -13,7 +13,7 @@
     "error": {
       "identifier_exists": "Account already registered.",
       "invalid_credentials": "Invalid credentials.",
-      "abode_error": "Error occured with Abode server."
+      "connection_error": "Unable to connect to Abode."
     },
     "abort": {
       "single_instance_allowed": "Only a single configuration of Abode is allowed."

--- a/homeassistant/components/abode/strings.json
+++ b/homeassistant/components/abode/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "title": "Abode",
+    "step": {
+      "user": {
+        "title": "Fill in your login information",
+        "data": {
+          "username": "Email Address",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "identifier_exists": "Account already registered",
+      "invalid_credentials": "Invalid credentials"
+    }
+  }
+}

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -1,5 +1,7 @@
 """Support for Abode Security System switches."""
 import logging
+import abodepy.helpers.constants as CONST
+import abodepy.helpers.timeline as TIMELINE
 
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
@@ -19,7 +21,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode switch devices."""
-
     data = hass.data[DOMAIN]
 
     devices = []

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -19,7 +19,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     pass
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Abode switch devices."""
     data = hass.data[DOMAIN]
 
@@ -33,7 +33,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             AbodeAutomationSwitch(data, automation, TIMELINE.AUTOMATION_EDIT_GROUP)
         )
 
-    async_add_devices(devices)
+    async_add_entities(devices)
 
 
 class AbodeSwitch(AbodeDevice, SwitchDevice):

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -1,5 +1,6 @@
 """Support for Abode Security System switches."""
 import logging
+
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
 

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -6,15 +6,21 @@ import abodepy.helpers.timeline as TIMELINE
 
 from homeassistant.components.switch import SwitchDevice
 
-from . import DOMAIN as ABODE_DOMAIN, AbodeAutomation, AbodeDevice
+from . import AbodeAutomation, AbodeDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Abode switch devices."""
 
-    data = hass.data[ABODE_DOMAIN]
+    data = hass.data[DOMAIN]
 
     devices = []
 
@@ -34,9 +40,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             AbodeAutomationSwitch(data, automation, TIMELINE.AUTOMATION_EDIT_GROUP)
         )
 
-    data.devices.extend(devices)
-
-    add_entities(devices)
+    async_add_devices(devices)
 
 
 class AbodeSwitch(AbodeDevice, SwitchDevice):

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -4,9 +4,6 @@ import logging
 import abodepy.helpers.constants as CONST
 import abodepy.helpers.timeline as TIMELINE
 
-import abodepy.helpers.constants as CONST
-import abodepy.helpers.timeline as TIMELINE
-
 from homeassistant.components.switch import SwitchDevice
 
 from . import AbodeAutomation, AbodeDevice

--- a/homeassistant/components/abode/switch.py
+++ b/homeassistant/components/abode/switch.py
@@ -24,18 +24,10 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     devices = []
 
-    # Get all regular switches that are not excluded or marked as lights
     for device in data.abode.get_devices(generic_type=CONST.TYPE_SWITCH):
-        if data.is_excluded(device) or data.is_light(device):
-            continue
-
         devices.append(AbodeSwitch(data, device))
 
-    # Get all Abode automations that can be enabled/disabled
     for automation in data.abode.get_automations(generic_type=CONST.TYPE_AUTOMATION):
-        if data.is_automation_excluded(automation):
-            continue
-
         devices.append(
             AbodeAutomationSwitch(data, automation, TIMELINE.AUTOMATION_EDIT_GROUP)
         )

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -6,6 +6,7 @@ To update, run python3 -m script.hassfest
 # fmt: off
 
 FLOWS = [
+    "abode",
     "adguard",
     "airly",
     "ambiclimate",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -103,7 +103,7 @@ WazeRouteCalculator==0.10
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.3
+abodepy==0.16.5
 
 # homeassistant.components.mcp23017
 adafruit-blinka==1.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -103,7 +103,7 @@ WazeRouteCalculator==0.10
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.15.0
+abodepy==0.16.1
 
 # homeassistant.components.mcp23017
 adafruit-blinka==1.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -103,7 +103,7 @@ WazeRouteCalculator==0.10
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.1
+abodepy==0.16.3
 
 # homeassistant.components.mcp23017
 adafruit-blinka==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -47,6 +47,7 @@ YesssSMS==0.4.1
 
 # homeassistant.components.androidtv
 adb-shell==0.0.4
+
 # homeassistant.components.abode
 abodepy==0.16.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -45,11 +45,11 @@ RtmAPI==0.7.2
 # homeassistant.components.yessssms
 YesssSMS==0.4.1
 
-# homeassistant.components.androidtv
-adb-shell==0.0.4
-
 # homeassistant.components.abode
 abodepy==0.16.1
+
+# homeassistant.components.androidtv
+adb-shell==0.0.4
 
 # homeassistant.components.adguard
 adguardhome==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -46,7 +46,7 @@ RtmAPI==0.7.2
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.3
+abodepy==0.16.5
 
 # homeassistant.components.androidtv
 adb-shell==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -46,7 +46,7 @@ RtmAPI==0.7.2
 YesssSMS==0.4.1
 
 # homeassistant.components.abode
-abodepy==0.16.1
+abodepy==0.16.3
 
 # homeassistant.components.androidtv
 adb-shell==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -47,6 +47,8 @@ YesssSMS==0.4.1
 
 # homeassistant.components.androidtv
 adb-shell==0.0.4
+# homeassistant.components.abode
+abodepy==0.16.1
 
 # homeassistant.components.adguard
 adguardhome==0.2.1

--- a/tests/components/abode/__init__.py
+++ b/tests/components/abode/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Abode component."""

--- a/tests/components/abode/test_config_flow.py
+++ b/tests/components/abode/test_config_flow.py
@@ -1,0 +1,80 @@
+"""Tests for the Abode config flow."""
+from unittest.mock import patch
+
+from homeassistant import data_entry_flow
+from homeassistant.components.abode import config_flow
+from homeassistant.components.abode.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+
+async def test_show_form(hass):
+    """Test that the form is served with no input."""
+    flow = config_flow.AbodeFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_user(user_input=None)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_duplicate_error(hass):
+    """Test that errors are shown when duplicates are added."""
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
+
+    MockConfigEntry(domain=DOMAIN, data=conf).add_to_hass(hass)
+    flow = config_flow.AbodeFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_user(user_input=conf)
+    assert result["errors"] == {CONF_USERNAME: "identifier_exists"}
+
+
+async def test_invalid_credentials(hass):
+    """Test that invalid credentials throws an error."""
+    from abodepy.exceptions import AbodeAuthenticationException
+
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
+
+    flow = config_flow.AbodeFlowHandler()
+    flow.hass = hass
+
+    with patch("abodepy.Abode", side_effect=AbodeAuthenticationException("errors")):
+        result = await flow.async_step_user(user_input=conf)
+        assert result["errors"] == {"base": "invalid_credentials"}
+
+
+async def test_step_import(hass):
+    """Test that the import step works."""
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
+
+    flow = config_flow.AbodeFlowHandler()
+    flow.hass = hass
+
+    with patch("abodepy.Abode"):
+        result = await flow.async_step_import(import_config=conf)
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "user@email.com"
+        assert result["data"] == {
+            CONF_USERNAME: "user@email.com",
+            CONF_PASSWORD: "password",
+        }
+
+
+async def test_step_user(hass):
+    """Test that the user step works."""
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
+
+    flow = config_flow.AbodeFlowHandler()
+    flow.hass = hass
+
+    with patch("abodepy.Abode"):
+        result = await flow.async_step_user(user_input=conf)
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == "user@email.com"
+        assert result["data"] == {
+            CONF_USERNAME: "user@email.com",
+            CONF_PASSWORD: "password",
+        }

--- a/tests/components/abode/test_config_flow.py
+++ b/tests/components/abode/test_config_flow.py
@@ -40,7 +40,6 @@ async def test_one_config_allowed(hass):
 
 async def test_invalid_credentials(hass):
     """Test that invalid credentials throws an error."""
-
     conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
 
     flow = config_flow.AbodeFlowHandler()
@@ -54,9 +53,8 @@ async def test_invalid_credentials(hass):
         assert result["errors"] == {"base": "invalid_credentials"}
 
 
-async def test_abode_server_error(hass):
+async def test_connection_error(hass):
     """Test other than invalid credentials throws an error."""
-
     conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
 
     flow = config_flow.AbodeFlowHandler()
@@ -64,10 +62,10 @@ async def test_abode_server_error(hass):
 
     with patch(
         "homeassistant.components.abode.config_flow.Abode",
-        side_effect=AbodeAuthenticationException((500, "server error")),
+        side_effect=AbodeAuthenticationException((500, "connection error")),
     ):
         result = await flow.async_step_user(user_input=conf)
-        assert result["errors"] == {"base": "abode_error"}
+        assert result["errors"] == {"base": "connection_error"}
 
 
 async def test_step_import(hass):

--- a/tests/components/abode/test_config_flow.py
+++ b/tests/components/abode/test_config_flow.py
@@ -32,10 +32,21 @@ async def test_one_config_allowed(hass):
         data={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
     ).add_to_hass(hass)
 
-    result = await flow.async_step_user()
+    step_user_result = await flow.async_step_user()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert step_user_result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert step_user_result["reason"] == "single_instance_allowed"
+
+    conf = {
+        CONF_USERNAME: "user@email.com",
+        CONF_PASSWORD: "password",
+        CONF_POLLING: False,
+    }
+
+    import_config_result = await flow.async_step_import(conf)
+
+    assert import_config_result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert import_config_result["reason"] == "single_instance_allowed"
 
 
 async def test_invalid_credentials(hass):

--- a/tests/components/abode/test_config_flow.py
+++ b/tests/components/abode/test_config_flow.py
@@ -29,11 +29,7 @@ async def test_one_config_allowed(hass):
 
     MockConfigEntry(
         domain="abode",
-        data={
-            CONF_USERNAME: "user@email.com",
-            CONF_PASSWORD: "password",
-            CONF_POLLING: False,
-        },
+        data={CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"},
     ).add_to_hass(hass)
 
     result = await flow.async_step_user()
@@ -45,18 +41,14 @@ async def test_one_config_allowed(hass):
 async def test_invalid_credentials(hass):
     """Test that invalid credentials throws an error."""
 
-    conf = {
-        CONF_USERNAME: "user@email.com",
-        CONF_PASSWORD: "password",
-        CONF_POLLING: False,
-    }
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
 
     flow = config_flow.AbodeFlowHandler()
     flow.hass = hass
 
     with patch(
         "homeassistant.components.abode.config_flow.Abode",
-        side_effect=AbodeAuthenticationException((400, "error")),
+        side_effect=AbodeAuthenticationException((400, "auth error")),
     ):
         result = await flow.async_step_user(user_input=conf)
         assert result["errors"] == {"base": "invalid_credentials"}
@@ -65,18 +57,14 @@ async def test_invalid_credentials(hass):
 async def test_abode_server_error(hass):
     """Test other than invalid credentials throws an error."""
 
-    conf = {
-        CONF_USERNAME: "user@email.com",
-        CONF_PASSWORD: "password",
-        CONF_POLLING: False,
-    }
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
 
     flow = config_flow.AbodeFlowHandler()
     flow.hass = hass
 
     with patch(
         "homeassistant.components.abode.config_flow.Abode",
-        side_effect=AbodeAuthenticationException((500, "error")),
+        side_effect=AbodeAuthenticationException((500, "server error")),
     ):
         result = await flow.async_step_user(user_input=conf)
         assert result["errors"] == {"base": "abode_error"}
@@ -107,11 +95,7 @@ async def test_step_import(hass):
 
 async def test_step_user(hass):
     """Test that the user step works."""
-    conf = {
-        CONF_USERNAME: "user@email.com",
-        CONF_PASSWORD: "password",
-        CONF_POLLING: False,
-    }
+    conf = {CONF_USERNAME: "user@email.com", CONF_PASSWORD: "password"}
 
     flow = config_flow.AbodeFlowHandler()
     flow.hass = hass


### PR DESCRIPTION
## Breaking Changes:

This PR removes the following configuration variables: `name`, `exclude` and `lights`, which were all previously optional. Existing users of the abode integration that use these configuration variables will have to remove them from the configuration.yaml file. Entities that users wish to disable can be done from the Entity Registry in the Configuration UI.

## Description:

Adds config entry and entity registry support for the Abode component. This implementation will create a config entry if a user has added the abode component configured via the configuration.yaml file. The entity registry unique ID is based on `device_id` from Abode (no devices in Abode should ever have the same device_id).

Tested on my Abode setup which includes sensors and lights.

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/10467

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.