### PR TITLE
Fix flash for esphome lights

### DIFF
--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -74,7 +74,7 @@ class EsphomeLight(EsphomeEntity, Light):
             red, green, blue = color_util.color_hsv_to_RGB(hue, sat, 100)
             data["rgb"] = (red / 255, green / 255, blue / 255)
         if ATTR_FLASH in kwargs:
-            data["flash"] = FLASH_LENGTHS[kwargs[ATTR_FLASH]]
+            data["flash_length"] = FLASH_LENGTHS[kwargs[ATTR_FLASH]]
         if ATTR_TRANSITION in kwargs:
             data["transition_length"] = kwargs[ATTR_TRANSITION]
         if ATTR_BRIGHTNESS in kwargs:


### PR DESCRIPTION
Fix for esphome lights to use the flash feature

## Description:
Previously the flash function would not pass as the esp api client was expecting the attribute 'flash_length' and not 'flash'.

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x ] There is no commented out code in this PR.
  - [ x ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
