### PR TITLE
Run black without --quiet in CI to help debug build

### DIFF
--- a/script/check_format
+++ b/script/check_format
@@ -6,5 +6,4 @@ cd "$(dirname "$0")/.."
 black \
   --check \
   --fast \
-  --quiet \
   homeassistant tests script *.py


### PR DESCRIPTION
## Description:

Whilst developing https://github.com/home-assistant/home-assistant/pull/26671 I couldn't figure out why the check_format step was failing as there was no meaningful output to help me fix the formatting issues.

<img width="996" alt="image" src="https://user-images.githubusercontent.com/1289759/65227335-c9e71a80-db0b-11e9-8af3-b9db1d3407d2.png">

I haven't recently contributed to Home Assistant so the switch to `black` is a new change to me, and I think other devs might find this confusing too


(sorry if this is just noise and there is a good reason for this being the way it is, but thought it was worthwhile proposing)