### PR TITLE
Don't update HA state when entity is not added yet

### DIFF
--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -105,7 +105,8 @@ class LGDevice(MediaPlayerDevice):
                 self._equaliser = data["i_curr_eq"]
             if "s_user_name" in data:
                 self._name = data["s_user_name"]
-        self.schedule_update_ha_state()
+        if self.hass:
+            self.schedule_update_ha_state()
 
     def update(self):
         """Trigger updates from the device."""


### PR DESCRIPTION
## Description:

`handle_event` is a callback set for temescal (library used to communicate with LG soundbars) and can be called before entity is added (and `self.hass` is set), so this early call result in exception because `self.hass` was `None`. Guarding `self.schedule_update_ha_state()` fixes this problem.

**Related issue (if applicable):** none

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
