### PR TITLE
Move alexa integration to use dt_util

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1,5 +1,4 @@
 """Alexa capabilities."""
-from datetime import datetime
 import logging
 
 from homeassistant.const import (
@@ -16,6 +15,7 @@ from homeassistant.const import (
 import homeassistant.components.climate.const as climate
 from homeassistant.components import light, fan, cover
 import homeassistant.util.color as color_util
+import homeassistant.util.dt as dt_util
 
 from .const import (
     API_TEMP_UNITS,
@@ -109,7 +109,7 @@ class AlexaCapibility:
                     "name": prop_name,
                     "namespace": self.name(),
                     "value": prop_value,
-                    "timeOfSample": datetime.now().strftime(DATE_FORMAT),
+                    "timeOfSample": dt_util.utcnow().strftime(DATE_FORMAT),
                     "uncertaintyInMilliseconds": 0,
                 }
 

--- a/homeassistant/components/alexa/flash_briefings.py
+++ b/homeassistant/components/alexa/flash_briefings.py
@@ -1,9 +1,9 @@
 """Support for Alexa skill service end point."""
 import copy
-from datetime import datetime
 import logging
 import uuid
 
+import homeassistant.util.dt as dt_util
 from homeassistant.components import http
 from homeassistant.core import callback
 from homeassistant.helpers import template
@@ -89,7 +89,7 @@ class AlexaFlashBriefingView(http.HomeAssistantView):
                 else:
                     output[ATTR_REDIRECTION_URL] = item.get(CONF_DISPLAY_URL)
 
-            output[ATTR_UPDATE_DATE] = datetime.now().strftime(DATE_FORMAT)
+            output[ATTR_UPDATE_DATE] = dt_util.utcnow().strftime(DATE_FORMAT)
 
             briefing.append(output)
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1,5 +1,4 @@
 """Alexa message handlers."""
-from datetime import datetime
 import logging
 import math
 
@@ -28,6 +27,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 import homeassistant.util.color as color_util
+import homeassistant.util.dt as dt_util
 from homeassistant.util.decorator import Registry
 from homeassistant.util.temperature import convert as convert_temperature
 
@@ -275,7 +275,7 @@ async def async_api_activate(hass, config, directive, context):
 
     payload = {
         "cause": {"type": Cause.VOICE_INTERACTION},
-        "timestamp": "%sZ" % (datetime.utcnow().isoformat(),),
+        "timestamp": f"{dt_util.utcnow().replace(tzinfo=None).isoformat()}Z",
     }
 
     return directive.response(
@@ -299,7 +299,7 @@ async def async_api_deactivate(hass, config, directive, context):
 
     payload = {
         "cause": {"type": Cause.VOICE_INTERACTION},
-        "timestamp": "%sZ" % (datetime.utcnow().isoformat(),),
+        "timestamp": f"{dt_util.utcnow().replace(tzinfo=None).isoformat()}Z",
     }
 
     return directive.response(


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Move Alexa to use dt_util instead of native datetime.

@MartinHjelmare The next ones I'm going one by one. I changed use of datetime.now() to utcnow() as we are formatting it for UTC (appended Z according to ISO8601 means UTC).


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
