### PR TITLE
Add EEP A5-02-01 support by implementing another EnOcean device

### DIFF
--- a/homeassistant/components/enocean/binary_sensor.py
+++ b/homeassistant/components/enocean/binary_sensor.py
@@ -34,7 +34,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev_id = config.get(CONF_ID)
     dev_name = config.get(CONF_NAME)
     device_class = config.get(CONF_DEVICE_CLASS)
-    
+
     if device_class == DEVICE_CLASS_OCCUPANCY:
         add_entities([EnOceanOccupancySensor(dev_id, dev_name, device_class)])
     else:
@@ -119,7 +119,7 @@ class EnOceanBinarySensor(enocean.EnOceanDevice, BinarySensorDevice):
 
 
 class EnOceanOccupancySensor(enocean.EnOceanDevice, BinarySensorDevice):
-    """Representation of EnOcean occupancy sensor
+    """Representation of EnOcean occupancy sensor.
 
     Supported EEPs (EnOcean Equipment Profiles):
     - A5-07-01 (Occupancy Sensor with Supply voltage monitor)


### PR DESCRIPTION
Breaking Change:
None

## Description:
Only events are emitted, since the sensor doesn't have a state.
The type is automatically selected depending on the configured device class.
Packets are checked if they really origin from a compatible device

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
...
device_type: occupancy
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
it doesn't

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
