### PR TITLE
Bumps aiohttp to 3.6.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==1.7.1
 PyNaCl==1.3.0
-aiohttp==3.5.4
+aiohttp==3.6.0
 aiohttp_cors==0.7.0
 astral==1.10.1
 async_timeout==3.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-aiohttp==3.5.4
+aiohttp==3.6.0
 astral==1.10.1
 async_timeout==3.0.1
 attrs==19.1.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ PROJECT_URLS = {
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 
 REQUIRES = [
-    "aiohttp==3.5.4",
+    "aiohttp==3.6.0",
     "astral==1.10.1",
     "async_timeout==3.0.1",
     "attrs==19.1.0",

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -84,7 +84,10 @@ async def test_token_unauthorized(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.apps.side_effect = ClientResponseError(None, None, status=401)
+    request_info = Mock(real_url="http://example.com")
+    smartthings_mock.apps.side_effect = ClientResponseError(
+        request_info=request_info, history=None, status=401
+    )
 
     result = await flow.async_step_user({"access_token": str(uuid4())})
 
@@ -98,7 +101,10 @@ async def test_token_forbidden(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.apps.side_effect = ClientResponseError(None, None, status=403)
+    request_info = Mock(real_url="http://example.com")
+    smartthings_mock.apps.side_effect = ClientResponseError(
+        request_info=request_info, history=None, status=403
+    )
 
     result = await flow.async_step_user({"access_token": str(uuid4())})
 
@@ -113,7 +119,10 @@ async def test_webhook_error(hass, smartthings_mock):
     flow.hass = hass
 
     data = {"error": {}}
-    error = APIResponseError(None, None, data=data, status=422)
+    request_info = Mock(real_url="http://example.com")
+    error = APIResponseError(
+        request_info=request_info, history=None, data=data, status=422
+    )
     error.is_target_error = Mock(return_value=True)
 
     smartthings_mock.apps.side_effect = error
@@ -131,7 +140,10 @@ async def test_api_error(hass, smartthings_mock):
     flow.hass = hass
 
     data = {"error": {}}
-    error = APIResponseError(None, None, data=data, status=400)
+    request_info = Mock(real_url="http://example.com")
+    error = APIResponseError(
+        request_info=request_info, history=None, data=data, status=400
+    )
 
     smartthings_mock.apps.side_effect = error
 
@@ -147,7 +159,10 @@ async def test_unknown_api_error(hass, smartthings_mock):
     flow = SmartThingsFlowHandler()
     flow.hass = hass
 
-    smartthings_mock.apps.side_effect = ClientResponseError(None, None, status=404)
+    request_info = Mock(real_url="http://example.com")
+    smartthings_mock.apps.side_effect = ClientResponseError(
+        request_info=request_info, history=None, status=404
+    )
 
     result = await flow.async_step_user({"access_token": str(uuid4())})
 

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -54,7 +54,10 @@ async def test_unrecoverable_api_errors_create_new_flow(
     """
     assert await async_setup_component(hass, "persistent_notification", {})
     config_entry.add_to_hass(hass)
-    smartthings_mock.app.side_effect = ClientResponseError(None, None, status=401)
+    request_info = Mock(real_url="http://example.com")
+    smartthings_mock.app.side_effect = ClientResponseError(
+        request_info=request_info, history=None, status=401
+    )
 
     # Assert setup returns false
     result = await smartthings.async_setup_entry(hass, config_entry)
@@ -75,7 +78,10 @@ async def test_recoverable_api_errors_raise_not_ready(
 ):
     """Test config entry not ready raised for recoverable API errors."""
     config_entry.add_to_hass(hass)
-    smartthings_mock.app.side_effect = ClientResponseError(None, None, status=500)
+    request_info = Mock(real_url="http://example.com")
+    smartthings_mock.app.side_effect = ClientResponseError(
+        request_info=request_info, history=None, status=500
+    )
 
     with pytest.raises(ConfigEntryNotReady):
         await smartthings.async_setup_entry(hass, config_entry)
@@ -86,9 +92,12 @@ async def test_scenes_api_errors_raise_not_ready(
 ):
     """Test if scenes are unauthorized we continue to load platforms."""
     config_entry.add_to_hass(hass)
+    request_info = Mock(real_url="http://example.com")
     smartthings_mock.app.return_value = app
     smartthings_mock.installed_app.return_value = installed_app
-    smartthings_mock.scenes.side_effect = ClientResponseError(None, None, status=500)
+    smartthings_mock.scenes.side_effect = ClientResponseError(
+        request_info=request_info, history=None, status=500
+    )
     with pytest.raises(ConfigEntryNotReady):
         await smartthings.async_setup_entry(hass, config_entry)
 
@@ -140,10 +149,13 @@ async def test_scenes_unauthorized_loads_platforms(
 ):
     """Test if scenes are unauthorized we continue to load platforms."""
     config_entry.add_to_hass(hass)
+    request_info = Mock(real_url="http://example.com")
     smartthings_mock.app.return_value = app
     smartthings_mock.installed_app.return_value = installed_app
     smartthings_mock.devices.return_value = [device]
-    smartthings_mock.scenes.side_effect = ClientResponseError(None, None, status=403)
+    smartthings_mock.scenes.side_effect = ClientResponseError(
+        request_info=request_info, history=None, status=403
+    )
     mock_token = Mock()
     mock_token.access_token.return_value = str(uuid4())
     mock_token.refresh_token.return_value = str(uuid4())
@@ -290,12 +302,13 @@ async def test_remove_entry_app_in_use(hass, config_entry, smartthings_mock):
 
 async def test_remove_entry_already_deleted(hass, config_entry, smartthings_mock):
     """Test handles when the apps have already been removed."""
+    request_info = Mock(real_url="http://example.com")
     # Arrange
     smartthings_mock.delete_installed_app.side_effect = ClientResponseError(
-        None, None, status=403
+        request_info=request_info, history=None, status=403
     )
     smartthings_mock.delete_app.side_effect = ClientResponseError(
-        None, None, status=403
+        request_info=request_info, history=None, status=403
     )
     # Act
     await smartthings.async_remove_entry(hass, config_entry)
@@ -308,9 +321,10 @@ async def test_remove_entry_installedapp_api_error(
     hass, config_entry, smartthings_mock
 ):
     """Test raises exceptions removing the installed app."""
+    request_info = Mock(real_url="http://example.com")
     # Arrange
     smartthings_mock.delete_installed_app.side_effect = ClientResponseError(
-        None, None, status=500
+        request_info=request_info, history=None, status=500
     )
     # Act
     with pytest.raises(ClientResponseError):
@@ -337,8 +351,9 @@ async def test_remove_entry_installedapp_unknown_error(
 async def test_remove_entry_app_api_error(hass, config_entry, smartthings_mock):
     """Test raises exceptions removing the app."""
     # Arrange
+    request_info = Mock(real_url="http://example.com")
     smartthings_mock.delete_app.side_effect = ClientResponseError(
-        None, None, status=500
+        request_info=request_info, history=None, status=500
     )
     # Act
     with pytest.raises(ClientResponseError):

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -244,8 +244,12 @@ class AiohttpClientMockResponse:
     def raise_for_status(self):
         """Raise error if status is 400 or higher."""
         if self.status >= 400:
+            request_info = mock.Mock(real_url="http://example.com")
             raise ClientResponseError(
-                None, None, code=self.status, headers=self.headers
+                request_info=request_info,
+                history=None,
+                code=self.status,
+                headers=self.headers,
             )
 
     def close(self):


### PR DESCRIPTION
## Description:

Bumps aiohttp to 3.6.0

Changelog: https://github.com/aio-libs/aiohttp/releases/tag/v3.6.0

Unit tests have been updated to be compatible with this release.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
