### PR TITLE
Bump TRADFRI

### DIFF
--- a/homeassistant/components/tradfri/manifest.json
+++ b/homeassistant/components/tradfri/manifest.json
@@ -3,17 +3,11 @@
   "name": "Tradfri",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/tradfri",
-  "requirements": [
-    "pytradfri[async]==6.0.1"
-  ],
+  "requirements": ["pytradfri[async]==6.3.1"],
   "homekit": {
-    "models": [
-      "TRADFRI"
-    ]
+    "models": ["TRADFRI"]
   },
   "dependencies": [],
   "zeroconf": ["_coap._udp.local."],
-  "codeowners": [
-    "@ggravlingen"
-  ]
+  "codeowners": ["@ggravlingen"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1596,7 +1596,7 @@ pytraccar==0.9.0
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri[async]==6.0.1
+pytradfri[async]==6.3.1
 
 # homeassistant.components.trafikverket_train
 # homeassistant.components.trafikverket_weatherstation

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -356,7 +356,7 @@ python-velbus==2.0.27
 python_awair==0.0.4
 
 # homeassistant.components.tradfri
-pytradfri[async]==6.0.1
+pytradfri[async]==6.3.1
 
 # homeassistant.components.vesync
 pyvesync==1.1.0

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -4,7 +4,9 @@ from copy import deepcopy
 from unittest.mock import Mock, MagicMock, patch, PropertyMock
 
 import pytest
-from pytradfri.device import Device, LightControl, Light
+from pytradfri.device import Device
+from pytradfri.device.light import Light
+from pytradfri.device.light_control import LightControl
 
 from homeassistant.components import tradfri
 


### PR DESCRIPTION
## Description:
PyTradfri didn't had a pinned version of a dependency and it's not compatible with the recently released version. This new pytradfri version fixes it.

Fix by @ggravlingen 

**Related issue (if applicable):** fixes #26673

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
