### PR TITLE
Bump pyobihai to fix issue with user account

### DIFF
--- a/homeassistant/components/obihai/manifest.json
+++ b/homeassistant/components/obihai/manifest.json
@@ -3,7 +3,7 @@
     "name": "Obihai",
     "documentation": "https://www.home-assistant.io/components/obihai",
     "requirements": [
-      "pyobihai==1.0.2"
+      "pyobihai==1.1.0"
     ],
     "dependencies": [],
     "codeowners": ["@dshokouhi"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1351,7 +1351,7 @@ pynx584==0.4
 pynzbgetapi==0.2.0
 
 # homeassistant.components.obihai
-pyobihai==1.0.2
+pyobihai==1.1.0
 
 # homeassistant.components.openuv
 pyopenuv==1.0.9


### PR DESCRIPTION
## Breaking Change:

Nothing breaks
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Not all accounts were supported by mistake, this library fix corrects the issue for `user` accounts.

**Related issue (if applicable):** fixes #26732

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: obihai
    host: 192.168.1.x
    username: user
    password: user
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
