### PR TITLE
Group Linky sensors to Linky meter device

### DIFF
--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -145,7 +145,7 @@ class LinkySensor(Entity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, "meter")},
+            "identifiers": {(DOMAIN, self._username)},
             "name": "Linky meter",
             "manufacturer": "Enedis",
         }

--- a/homeassistant/components/linky/sensor.py
+++ b/homeassistant/components/linky/sensor.py
@@ -145,8 +145,8 @@ class LinkySensor(Entity):
     def device_info(self):
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
+            "identifiers": {(DOMAIN, "meter")},
+            "name": "Linky meter",
             "manufacturer": "Enedis",
         }
 


### PR DESCRIPTION
## Breaking Change:
Users will need to remove and re-add the linky integration to clear the device registry.

## Description:

I think it's better to group linky sensors to one unique device (to avoid setting area for all the sensor for example)

Before:
<img width="914" alt="Capture d’écran 2019-09-19 à 20 44 50" src="https://user-images.githubusercontent.com/5878303/65272211-f5273500-db1e-11e9-87f4-393a6269de74.png">

After: 
<img width="911" alt="Capture d’écran 2019-09-19 à 20 45 04" src="https://user-images.githubusercontent.com/5878303/65272217-f7898f00-db1e-11e9-8ad8-0116c4250278.png">

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
