### PR TITLE
Bump aiohttp to 3.6.1

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==1.7.1
 PyNaCl==1.3.0
-aiohttp==3.6.0
+aiohttp==3.6.1
 aiohttp_cors==0.7.0
 astral==1.10.1
 async_timeout==3.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-aiohttp==3.6.0
+aiohttp==3.6.1
 astral==1.10.1
 async_timeout==3.0.1
 attrs==19.1.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ PROJECT_URLS = {
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 
 REQUIRES = [
-    "aiohttp==3.6.0",
+    "aiohttp==3.6.1",
     "astral==1.10.1",
     "async_timeout==3.0.1",
     "attrs==19.1.0",


### PR DESCRIPTION
## Description:

Bumps aiohttp to 3.6.1
https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#361-2019-09-19

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
