### PR TITLE
Bump restrictedpython to 5.0

### DIFF
--- a/homeassistant/components/python_script/manifest.json
+++ b/homeassistant/components/python_script/manifest.json
@@ -3,7 +3,7 @@
   "name": "Python script",
   "documentation": "https://www.home-assistant.io/components/python_script",
   "requirements": [
-    "restrictedpython==4.0"
+    "restrictedpython==5.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1666,7 +1666,7 @@ recollect-waste==1.0.1
 regenmaschine==1.5.1
 
 # homeassistant.components.python_script
-restrictedpython==4.0
+restrictedpython==5.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -368,7 +368,7 @@ pywebpush==1.9.2
 regenmaschine==1.5.1
 
 # homeassistant.components.python_script
-restrictedpython==4.0
+restrictedpython==5.0
 
 # homeassistant.components.rflink
 rflink==0.0.46


### PR DESCRIPTION
## Description:

Bump restrictedpython to 5.0
https://restrictedpython.readthedocs.io/en/latest/CHANGES.html#id1

- Add support for f-strings in Python 3.6+
- Revert the Allowance of the `...` (Ellipsis) statement, as of 4.0. It is not needed to support Python 3.8. The security implications of the Ellipsis Statement is not 100 % clear and is not checked. `...` (Ellipsis) is disallowed again.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
