### PR TITLE
Bump up ZHA dependencies

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -762,6 +762,7 @@ omit =
     homeassistant/components/zha/core/device.py
     homeassistant/components/zha/core/gateway.py
     homeassistant/components/zha/core/helpers.py
+    homeassistant/components/zha/core/patches.py
     homeassistant/components/zha/core/registries.py
     homeassistant/components/zha/device_entity.py
     homeassistant/components/zha/entity.py

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -310,7 +310,7 @@ class ZHAGateway:
 
     @callback
     def async_device_became_available(
-        self, sender, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args
+        self, sender, profile, cluster, src_ep, dst_ep, message
     ):
         """Handle tasks when a device becomes available."""
         self.async_update_device(sender)

--- a/homeassistant/components/zha/core/patches.py
+++ b/homeassistant/components/zha/core/patches.py
@@ -9,9 +9,7 @@ https://home-assistant.io/components/zha/
 def apply_application_controller_patch(zha_gateway):
     """Apply patches to ZHA objects."""
     # Patch handle_message until zigpy can provide an event here
-    def handle_message(
-        sender, is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args
-    ):
+    def handle_message(sender, profile, cluster, src_ep, dst_ep, message):
         """Handle message from a device."""
         if (
             not sender.initializing
@@ -19,18 +17,8 @@ def apply_application_controller_patch(zha_gateway):
             and not zha_gateway.devices[sender.ieee].available
         ):
             zha_gateway.async_device_became_available(
-                sender,
-                is_reply,
-                profile,
-                cluster,
-                src_ep,
-                dst_ep,
-                tsn,
-                command_id,
-                args,
+                sender, profile, cluster, src_ep, dst_ep, message
             )
-        return sender.handle_message(
-            is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args
-        )
+        return sender.handle_message(profile, cluster, src_ep, dst_ep, message)
 
     zha_gateway.application_controller.handle_message = handle_message

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,11 +4,11 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/zha",
   "requirements": [
-    "bellows-homeassistant==0.9.1",
+    "bellows-homeassistant==0.10.0",
     "zha-quirks==0.0.23",
-    "zigpy-deconz==0.3.0",
-    "zigpy-homeassistant==0.8.0",
-    "zigpy-xbee-homeassistant==0.4.0",
+    "zigpy-deconz==0.4.0",
+    "zigpy-homeassistant==0.9.0",
+    "zigpy-xbee-homeassistant==0.5.0",
     "zigpy-zigate==0.3.1"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -267,7 +267,7 @@ beautifulsoup4==4.8.0
 beewi_smartclim==0.0.7
 
 # homeassistant.components.zha
-bellows-homeassistant==0.9.1
+bellows-homeassistant==0.10.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.6.0
@@ -2020,13 +2020,13 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.3.0
+zigpy-deconz==0.4.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.8.0
+zigpy-homeassistant==0.9.0
 
 # homeassistant.components.zha
-zigpy-xbee-homeassistant==0.4.0
+zigpy-xbee-homeassistant==0.5.0
 
 # homeassistant.components.zha
 zigpy-zigate==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -94,7 +94,7 @@ av==6.1.2
 axis==25
 
 # homeassistant.components.zha
-bellows-homeassistant==0.9.1
+bellows-homeassistant==0.10.0
 
 # homeassistant.components.caldav
 caldav==0.6.1
@@ -434,4 +434,4 @@ wakeonlan==1.1.6
 zeroconf==0.23.0
 
 # homeassistant.components.zha
-zigpy-homeassistant==0.8.0
+zigpy-homeassistant==0.9.0

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -74,13 +74,13 @@ async def async_test_binary_sensor_on_off(hass, cluster, entity_id):
     """Test getting on and off messages for binary sensors."""
     # binary sensor on
     attr = make_attribute(0, 1)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_ON
 
     # binary sensor off
     attr.value.value = 0
-    cluster.handle_message(False, 0, 0x0A, [[attr]])
+    cluster.handle_message(0, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -67,10 +67,10 @@ async def test_device_tracker(hass, config_entry, zha_gateway):
 
     # turn state flip
     attr = make_attribute(0x0020, 23)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
 
     attr = make_attribute(0x0021, 200)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
 
     zigpy_device.last_seen = time.time() + 10
     next_update = dt_util.utcnow() + timedelta(seconds=30)

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -44,13 +44,13 @@ async def test_fan(hass, config_entry, zha_gateway):
 
     # turn on at fan
     attr = make_attribute(0, 1)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_ON
 
     # turn off at fan
     attr.value.value = 0
-    cluster.handle_message(False, 0, 0x0A, [[attr]])
+    cluster.handle_message(0, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -123,13 +123,13 @@ async def async_test_on_off_from_light(hass, cluster, entity_id):
     """Test on off functionality from the light."""
     # turn on at light
     attr = make_attribute(0, 1)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_ON
 
     # turn off at light
     attr.value.value = 0
-    cluster.handle_message(False, 0, 0x0A, [[attr]])
+    cluster.handle_message(0, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -138,7 +138,7 @@ async def async_test_on_from_light(hass, cluster, entity_id):
     """Test on off functionality from the light."""
     # turn on at light
     attr = make_attribute(0, 1)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_ON
 
@@ -243,7 +243,7 @@ async def async_test_level_on_off_from_hass(
 async def async_test_dimmer_from_light(hass, cluster, entity_id, level, expected_state):
     """Test dimmer functionality from the light."""
     attr = make_attribute(0, level)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == expected_state
     # hass uses None for brightness of 0 in state attributes

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -43,13 +43,13 @@ async def test_lock(hass, config_entry, zha_gateway):
 
     # set state to locked
     attr = make_attribute(0, 1)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_LOCKED
 
     # set state to unlocked
     attr.value.value = 2
-    cluster.handle_message(False, 0, 0x0A, [[attr]])
+    cluster.handle_message(0, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_UNLOCKED
 

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -177,7 +177,7 @@ async def send_attribute_report(hass, cluster, attrid, value):
     device is paired to the zigbee network.
     """
     attr = make_attribute(attrid, value)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
 
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -44,13 +44,13 @@ async def test_switch(hass, config_entry, zha_gateway):
 
     # turn on at switch
     attr = make_attribute(0, 1)
-    cluster.handle_message(False, 1, 0x0A, [[attr]])
+    cluster.handle_message(1, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_ON
 
     # turn off at switch
     attr.value.value = 0
-    cluster.handle_message(False, 0, 0x0A, [[attr]])
+    cluster.handle_message(0, 0x0A, [[attr]])
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 


### PR DESCRIPTION
## Description:
Bump up zha dependencies. Syncs with Zigpy API changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
