### PR TITLE
Bump openwrt-luci-rpc to version 1.1.1

### DIFF
--- a/homeassistant/components/luci/manifest.json
+++ b/homeassistant/components/luci/manifest.json
@@ -3,7 +3,7 @@
   "name": "Luci",
   "documentation": "https://www.home-assistant.io/components/luci",
   "requirements": [
-    "openwrt-luci-rpc==1.1.0"
+    "openwrt-luci-rpc==1.1.1"
   ],
   "dependencies": [],
   "codeowners": ["@fbradyirl"]

--- a/homeassistant/components/luci/manifest.json
+++ b/homeassistant/components/luci/manifest.json
@@ -3,8 +3,7 @@
   "name": "Luci",
   "documentation": "https://www.home-assistant.io/components/luci",
   "requirements": [
-    "openwrt-luci-rpc==1.1.0",
-    "packaging==19.1"
+    "openwrt-luci-rpc==1.1.0"
   ],
   "dependencies": [],
   "codeowners": ["@fbradyirl"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -918,9 +918,6 @@ openwrt-luci-rpc==1.1.0
 # homeassistant.components.orvibo
 orvibo==1.1.1
 
-# homeassistant.components.luci
-packaging==19.1
-
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
 paho-mqtt==1.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -913,7 +913,7 @@ opensensemap-api==0.1.5
 openwebifpy==3.1.1
 
 # homeassistant.components.luci
-openwrt-luci-rpc==1.1.0
+openwrt-luci-rpc==1.1.1
 
 # homeassistant.components.orvibo
 orvibo==1.1.1


### PR DESCRIPTION
## Description:

permanent fix for #26215, bumping to new version of openwrt-luci-rpc 1.1.1, which adds requirement of 'packaging'.

**Related issue (if applicable):** fixes #25758

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
