### PR TITLE
Bump aiowwlln to 2.0.2

### DIFF
--- a/homeassistant/components/wwlln/manifest.json
+++ b/homeassistant/components/wwlln/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/wwlln",
   "requirements": [
-    "aiowwlln==2.0.1"
+    "aiowwlln==2.0.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,7 +179,7 @@ aioswitcher==2019.4.26
 aiounifi==11
 
 # homeassistant.components.wwlln
-aiowwlln==2.0.1
+aiowwlln==2.0.2
 
 # homeassistant.components.aladdin_connect
 aladdin_connect==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -73,7 +73,7 @@ aioswitcher==2019.4.26
 aiounifi==11
 
 # homeassistant.components.wwlln
-aiowwlln==2.0.1
+aiowwlln==2.0.2
 
 # homeassistant.components.ambiclimate
 ambiclimate==0.2.1


### PR DESCRIPTION
## Description:

This PR bumps `aiowwlln` to 2.0.2. Changelog: https://github.com/bachya/aiowwlln/releases/tag/2.0.2

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/26460

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
wwlln:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
