### PR TITLE
Bump pynws version to 0.8.1

### DIFF
--- a/homeassistant/components/nws/manifest.json
+++ b/homeassistant/components/nws/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://www.home-assistant.io/components/nws",
     "dependencies": [],
     "codeowners": ["@MatthewFlamm"],
-    "requirements": ["pynws==0.7.4"]
+    "requirements": ["pynws==0.8.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1342,7 +1342,7 @@ pynuki==1.3.3
 pynut2==2.1.2
 
 # homeassistant.components.nws
-pynws==0.7.4
+pynws==0.8.1
 
 # homeassistant.components.nx584
 pynx584==0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -312,7 +312,7 @@ pymfy==0.5.2
 pymonoprice==0.3
 
 # homeassistant.components.nws
-pynws==0.7.4
+pynws==0.8.1
 
 # homeassistant.components.nx584
 pynx584==0.4

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -110,9 +110,7 @@ async def test_imperial(hass, aioclient_mock):
         STAURL.format(40.0, -85.0), text=load_fixture("nws-weather-sta-valid.json")
     )
     aioclient_mock.get(
-        OBSURL.format("KMIE"),
-        text=load_fixture("nws-weather-obs-valid.json"),
-        params={"limit": 1},
+        OBSURL.format("KMIE"), text=load_fixture("nws-weather-obs-valid.json")
     )
     aioclient_mock.get(
         FORCURL.format(40.0, -85.0), text=load_fixture("nws-weather-fore-valid.json")
@@ -142,9 +140,7 @@ async def test_metric(hass, aioclient_mock):
         STAURL.format(40.0, -85.0), text=load_fixture("nws-weather-sta-valid.json")
     )
     aioclient_mock.get(
-        OBSURL.format("KMIE"),
-        text=load_fixture("nws-weather-obs-valid.json"),
-        params={"limit": 1},
+        OBSURL.format("KMIE"), text=load_fixture("nws-weather-obs-valid.json")
     )
     aioclient_mock.get(
         FORCURL.format(40.0, -85.0), text=load_fixture("nws-weather-fore-valid.json")
@@ -174,9 +170,7 @@ async def test_none(hass, aioclient_mock):
         STAURL.format(40.0, -85.0), text=load_fixture("nws-weather-sta-valid.json")
     )
     aioclient_mock.get(
-        OBSURL.format("KMIE"),
-        text=load_fixture("nws-weather-obs-null.json"),
-        params={"limit": 1},
+        OBSURL.format("KMIE"), text=load_fixture("nws-weather-obs-null.json")
     )
     aioclient_mock.get(
         FORCURL.format(40.0, -85.0), text=load_fixture("nws-weather-fore-null.json")
@@ -208,7 +202,6 @@ async def test_fail_obs(hass, aioclient_mock):
     aioclient_mock.get(
         OBSURL.format("KMIE"),
         text=load_fixture("nws-weather-obs-valid.json"),
-        params={"limit": 1},
         status=400,
     )
     aioclient_mock.get(
@@ -234,9 +227,7 @@ async def test_fail_stn(hass, aioclient_mock):
         status=400,
     )
     aioclient_mock.get(
-        OBSURL.format("KMIE"),
-        text=load_fixture("nws-weather-obs-valid.json"),
-        params={"limit": 1},
+        OBSURL.format("KMIE"), text=load_fixture("nws-weather-obs-valid.json")
     )
     aioclient_mock.get(
         FORCURL.format(40.0, -85.0), text=load_fixture("nws-weather-fore-valid.json")
@@ -257,9 +248,7 @@ async def test_invalid_config(hass, aioclient_mock):
         STAURL.format(40.0, -85.0), text=load_fixture("nws-weather-sta-valid.json")
     )
     aioclient_mock.get(
-        OBSURL.format("KMIE"),
-        text=load_fixture("nws-weather-obs-valid.json"),
-        params={"limit": 1},
+        OBSURL.format("KMIE"), text=load_fixture("nws-weather-obs-valid.json")
     )
     aioclient_mock.get(
         FORCURL.format(40.0, -85.0), text=load_fixture("nws-weather-fore-valid.json")


### PR DESCRIPTION
## Description:
Bumps version of library to handle observations that are missing items.

**Related issue (if applicable):** fixes  #26753 

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
