### PR TITLE
Unload Plex config entries

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_USE_EPISODE_ART,
     CONF_SHOW_ALL_CONTROLS,
     CONF_SERVER,
+    CONF_SERVER_IDENTIFIER,
     DEFAULT_PORT,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
@@ -28,6 +29,7 @@ from .const import (
     PLATFORMS,
     PLEX_MEDIA_PLAYER_OPTIONS,
     PLEX_SERVER_CONFIG,
+    REFRESH_LISTENERS,
     SERVERS,
 )
 from .server import PlexServer
@@ -61,7 +63,7 @@ _LOGGER = logging.getLogger(__package__)
 
 def setup(hass, config):
     """Set up the Plex component."""
-    hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}})
+    hass.data.setdefault(PLEX_DOMAIN, {SERVERS: {}, REFRESH_LISTENERS: {}})
 
     plex_config = config.get(PLEX_DOMAIN, {})
     if plex_config:
@@ -127,5 +129,22 @@ async def async_setup_entry(hass, entry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
+
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    server_id = entry.data[CONF_SERVER_IDENTIFIER]
+
+    cancel = hass.data[PLEX_DOMAIN][REFRESH_LISTENERS].pop(server_id)
+    await hass.async_add_executor_job(cancel)
+
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_unload(entry, platform)
+        )
+
+    hass.data[PLEX_DOMAIN][SERVERS].pop(server_id)
 
     return True

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -1,4 +1,5 @@
 """Support to embed Plex."""
+import asyncio
 import logging
 
 import plexapi.exceptions
@@ -140,10 +141,13 @@ async def async_unload_entry(hass, entry):
     cancel = hass.data[PLEX_DOMAIN][REFRESH_LISTENERS].pop(server_id)
     await hass.async_add_executor_job(cancel)
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
+    tasks = [
+        asyncio.ensure_future(
             hass.config_entries.async_forward_entry_unload(entry, platform)
         )
+        for platform in PLATFORMS
+    ]
+    await asyncio.gather(*tasks)
 
     hass.data[PLEX_DOMAIN][SERVERS].pop(server_id)
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -142,9 +142,7 @@ async def async_unload_entry(hass, entry):
     await hass.async_add_executor_job(cancel)
 
     tasks = [
-        asyncio.ensure_future(
-            hass.config_entries.async_forward_entry_unload(entry, platform)
-        )
+        hass.config_entries.async_forward_entry_unload(entry, platform)
         for platform in PLATFORMS
     ]
     await asyncio.gather(*tasks)

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -7,6 +7,7 @@ DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
 PLATFORMS = ["media_player", "sensor"]
+REFRESH_LISTENERS = "refresh_listeners"
 SERVERS = "servers"
 
 PLEX_CONFIG_FILE = "plex.conf"

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -39,6 +39,7 @@ from .const import (
     DOMAIN as PLEX_DOMAIN,
     NAME_FORMAT,
     PLEX_MEDIA_PLAYER_OPTIONS,
+    REFRESH_LISTENERS,
     SERVERS,
 )
 
@@ -71,7 +72,9 @@ def _setup_platform(hass, config_entry, add_entities_callback):
     plexserver = hass.data[PLEX_DOMAIN][SERVERS][server_id]
     plex_clients = {}
     plex_sessions = {}
-    track_time_interval(hass, lambda now: update_devices(), timedelta(seconds=10))
+    hass.data[PLEX_DOMAIN][REFRESH_LISTENERS][server_id] = track_time_interval(
+        hass, lambda now: update_devices(), timedelta(seconds=10)
+    )
 
     def update_devices():
         """Update the devices objects."""


### PR DESCRIPTION
## Description:
Properly unload removed Plex config entries. Followup from #26548.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io# N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
