### PR TITLE
Fix Onvif setup error: premature end of connection on GetStreamURI

### DIFF
--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -256,7 +256,8 @@ class ONVIFHassCamera(Camera):
 
             _LOGGER.debug("Retrieving stream uri")
 
-            #Fix Onvif setup error on Goke GK7102 based IP camera where we need to recreate media_service  #26781
+            # Fix Onvif setup error on Goke GK7102 based IP camera
+            # where we need to recreate media_service  #26781
             media_service = self._camera.create_media_service()
             
             req = media_service.create_type("GetStreamUri")

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -256,7 +256,9 @@ class ONVIFHassCamera(Camera):
 
             _LOGGER.debug("Retrieving stream uri")
 
+            #Fix Onvif setup error on Goke GK7102 based IP camera where we need to recreate media_service  #26781
             media_service = self._camera.create_media_service()
+            
             req = media_service.create_type("GetStreamUri")
             req.ProfileToken = profiles[self._profile_index].token
             req.StreamSetup = {

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -259,7 +259,7 @@ class ONVIFHassCamera(Camera):
             # Fix Onvif setup error on Goke GK7102 based IP camera
             # where we need to recreate media_service  #26781
             media_service = self._camera.create_media_service()
-            
+
             req = media_service.create_type("GetStreamUri")
             req.ProfileToken = profiles[self._profile_index].token
             req.StreamSetup = {

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -256,6 +256,7 @@ class ONVIFHassCamera(Camera):
 
             _LOGGER.debug("Retrieving stream uri")
 
+            media_service = self._camera.create_media_service()
             req = media_service.create_type("GetStreamUri")
             req.ProfileToken = profiles[self._profile_index].token
             req.StreamSetup = {


### PR DESCRIPTION
## Description:
Reconnect to onvif camera after getting profiles to fix this error :
```
[homeassistant.components.onvif.camera] Retrieving stream uri                                                                                                                                 
[zeep.asyncio.transport] HTTP Post to http://192.168.1.15/onvif/Media:                                                                                                                        
b'<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<soap-env:Envelope xmlns:soap-env="http://www.w3.org/2003/05/soap-envelope"><soap-env:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecur
2019-09-20 01:08:51 ERROR (MainThread) [homeassistant.components.camera] Error while setting up platform onvif                                                                                                                       
Traceback (most recent call last):                                                                                                                                                                                                   
  File "/usr/local/lib/python3.7/site-packages/aiohttp/client_reqrep.py", line 553, in write_bytes                                                                                                                                   
    await self.body.write(writer)                                                                                                                                                                                                    
  File "/usr/local/lib/python3.7/site-packages/aiohttp/payload.py", line 231, in write                                                                                                                                               
    await writer.write(self._value)                                                                                                                                                                                                  
  File "/usr/local/lib/python3.7/site-packages/aiohttp/http_writer.py", line 101, in write                                                                                                                                           
    self._write(chunk)                                                                                                                                                                                                               
  File "/usr/local/lib/python3.7/site-packages/aiohttp/http_writer.py", line 67, in _write                                                                                                                                           
    raise ConnectionResetError('Cannot write to closing transport')                                                                                                                                                                  
ConnectionResetError: Cannot write to closing transport                                                                                                                                                                              
                                                                                                                                                                                                                                     
The above exception was the direct cause of the following exception:                                                                                                                                                                 
                                                                                                                                                                                                                                     
Traceback (most recent call last):                                                                                                                                                                                                   
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 150, in _async_setup_platform                                                                                                                         
    await asyncio.wait_for(asyncio.shield(task), SLOW_SETUP_MAX_WAIT)                                                                                                                                                                
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 442, in wait_for                                                                                                                                                            
    return fut.result()                                                                                                                                                                                                              
  File "/usr/src/homeassistant/homeassistant/components/onvif/camera.py", line 110, in async_setup_platform                                                                                                                          
    await hass_camera.async_initialize()                                                                                                                                                                                             
  File "/usr/src/homeassistant/homeassistant/components/onvif/camera.py", line 168, in async_initialize                                                                                                                              
    await self.async_obtain_input_uri()                                                                                                                                                                                              
  File "/usr/src/homeassistant/homeassistant/components/onvif/camera.py", line 266, in async_obtain_input_uri                                                                                                                        
    stream_uri = await media_service.GetStreamUri(req)                                                                                                                                                                               
  File "/usr/local/lib/python3.7/site-packages/zeep/asyncio/bindings.py", line 13, in send                                                                                                                                           
    options["address"], envelope, http_headers                                                                                                                                                                                       
  File "/usr/local/lib/python3.7/site-packages/zeep/asyncio/transport.py", line 107, in post_xml                                                                                                                                     
    response = await self.post(address, message, headers)                                                                                                                                                                            
  File "/usr/local/lib/python3.7/site-packages/zeep/asyncio/transport.py", line 95, in post                                                                                                                                          
    proxy=self.proxy,                                                                                                                                                                                                                
  File "/usr/local/lib/python3.7/site-packages/aiohttp/client.py", line 497, in _request                                                                                                                                             
    await resp.start(conn)                                                                                                                                                                                                           
  File "/usr/local/lib/python3.7/site-packages/aiohttp/client_reqrep.py", line 844, in start                                                                                                                                         
    message, payload = await self._protocol.read()  # type: ignore  # noqa                                                                                                                                                           
  File "/usr/local/lib/python3.7/site-packages/aiohttp/streams.py", line 588, in read                                                                                                                                                
    await self._waiter                                                                                                                                                                                                               
aiohttp.client_exceptions.ClientOSError: [Errno None] Can not write request body for http://192.168.1.15/onvif/Media
```

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
