### PR TITLE
Bump HAP-python to 2.6.0 for homekit

### DIFF
--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -3,7 +3,7 @@
   "name": "Homekit",
   "documentation": "https://www.home-assistant.io/components/homekit",
   "requirements": [
-    "HAP-python==2.5.0"
+    "HAP-python==2.6.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.0.0
 
 # homeassistant.components.homekit
-HAP-python==2.5.0
+HAP-python==2.6.0
 
 # homeassistant.components.mastodon
 Mastodon.py==1.4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -23,7 +23,7 @@ requests_mock==1.6.0
 
 
 # homeassistant.components.homekit
-HAP-python==2.5.0
+HAP-python==2.6.0
 
 # homeassistant.components.mobile_app
 # homeassistant.components.owntracks


### PR DESCRIPTION
## Description:

Version bump to get [this](https://github.com/ikalchev/HAP-python/pull/202), which should resolve #25890 for iOS 13 users.

**Related issue (if applicable):** fixes #25890

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
