### PR TITLE
Fix doods missing detector name kwarg

### DIFF
--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -139,6 +139,7 @@ class Doods(ImageProcessingEntity):
             self._name = f"Doods {name}"
         self._doods = doods
         self._file_out = config[CONF_FILE_OUT]
+        self._detector_name = detector["name"]
 
         # detector config and aspect ratio
         self._width = None
@@ -289,7 +290,7 @@ class Doods(ImageProcessingEntity):
 
         # Run detection
         start = time.time()
-        response = self._doods.detect(image, self._dconfig)
+        response = self._doods.detect(image, dconfig=self._dconfig, detector_name=self._detector_name)
         _LOGGER.debug(
             "doods detect: %s response: %s duration: %s",
             self._dconfig,

--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -290,7 +290,9 @@ class Doods(ImageProcessingEntity):
 
         # Run detection
         start = time.time()
-        response = self._doods.detect(image, dconfig=self._dconfig, detector_name=self._detector_name)
+        response = self._doods.detect(
+            image, dconfig=self._dconfig, detector_name=self._detector_name
+        )
         _LOGGER.debug(
             "doods detect: %s response: %s duration: %s",
             self._dconfig,

--- a/homeassistant/components/doods/manifest.json
+++ b/homeassistant/components/doods/manifest.json
@@ -3,7 +3,7 @@
     "name": "DOODS - Distributed Outside Object Detection Service",
     "documentation": "https://www.home-assistant.io/components/doods",
     "requirements": [
-        "pydoods==1.0.1"
+        "pydoods==1.0.2"
     ],
     "dependencies": [],
     "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1140,7 +1140,7 @@ pydelijn==0.5.1
 pydispatcher==2.0.5
 
 # homeassistant.components.doods
-pydoods==1.0.1
+pydoods==1.0.2
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==0.8


### PR DESCRIPTION
## Breaking Change:

No breaking changes

## Description:

The new doods component is missing an option to select the detector being used. In its current form it will only use the default detector and ignores the detector config option.

No documentation or configuration changes are required. The documentation is already correct.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
