### PR TITLE
Add option to specify mDNS advertised IP address for HomeKit Bridge

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -32,7 +32,6 @@ from homeassistant.util.decorator import Registry
 from .const import (
     BRIDGE_NAME,
     CONF_ADVERTISE_IP,
-    CONF_ADVERTISE_MAC,
     CONF_AUTO_START,
     CONF_ENTITY_CONFIG,
     CONF_FEATURE_LIST,
@@ -94,7 +93,6 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_ADVERTISE_IP): vol.All(
                     ipaddress.ip_address, cv.string
                 ),
-                vol.Optional(CONF_ADVERTISE_MAC): cv.string,
                 vol.Optional(CONF_AUTO_START, default=DEFAULT_AUTO_START): cv.boolean,
                 vol.Optional(CONF_SAFE_MODE, default=DEFAULT_SAFE_MODE): cv.boolean,
                 vol.Optional(CONF_FILTER, default={}): FILTER_SCHEMA,
@@ -119,7 +117,6 @@ async def async_setup(hass, config):
     port = conf[CONF_PORT]
     ip_address = conf.get(CONF_IP_ADDRESS)
     advertise_ip = conf.get(CONF_ADVERTISE_IP)
-    advertise_mac = conf.get(CONF_ADVERTISE_MAC)
     auto_start = conf[CONF_AUTO_START]
     safe_mode = conf[CONF_SAFE_MODE]
     entity_filter = conf[CONF_FILTER]
@@ -134,7 +131,6 @@ async def async_setup(hass, config):
         entity_config,
         safe_mode,
         advertise_ip,
-        advertise_mac,
     )
     await hass.async_add_executor_job(homekit.setup)
 
@@ -290,7 +286,6 @@ class HomeKit:
         entity_config,
         safe_mode,
         advertise_ip=None,
-        advertise_mac=None,
     ):
         """Initialize a HomeKit object."""
         self.hass = hass
@@ -301,7 +296,6 @@ class HomeKit:
         self._config = entity_config
         self._safe_mode = safe_mode
         self._advertise_ip = advertise_ip
-        self._advertise_mac = advertise_mac
         self.status = STATUS_READY
 
         self.bridge = None
@@ -321,7 +315,6 @@ class HomeKit:
             port=self._port,
             persist_file=path,
             advertised_address=self._advertise_ip,
-            mac=self._advertise_mac,
         )
         self.bridge = HomeBridge(self.hass, self.driver, self._name)
         if self._safe_mode:

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -31,6 +31,8 @@ from homeassistant.util.decorator import Registry
 
 from .const import (
     BRIDGE_NAME,
+    CONF_ADVERTISE_IP,
+    CONF_ADVERTISE_MAC,
     CONF_AUTO_START,
     CONF_ENTITY_CONFIG,
     CONF_FEATURE_LIST,
@@ -89,6 +91,10 @@ CONFIG_SCHEMA = vol.Schema(
                 ),
                 vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
                 vol.Optional(CONF_IP_ADDRESS): vol.All(ipaddress.ip_address, cv.string),
+                vol.Optional(CONF_ADVERTISE_IP): vol.All(
+                    ipaddress.ip_address, cv.string
+                ),
+                vol.Optional(CONF_ADVERTISE_MAC): cv.string,
                 vol.Optional(CONF_AUTO_START, default=DEFAULT_AUTO_START): cv.boolean,
                 vol.Optional(CONF_SAFE_MODE, default=DEFAULT_SAFE_MODE): cv.boolean,
                 vol.Optional(CONF_FILTER, default={}): FILTER_SCHEMA,
@@ -112,13 +118,23 @@ async def async_setup(hass, config):
     name = conf[CONF_NAME]
     port = conf[CONF_PORT]
     ip_address = conf.get(CONF_IP_ADDRESS)
+    advertise_ip = conf.get(CONF_ADVERTISE_IP)
+    advertise_mac = conf.get(CONF_ADVERTISE_MAC)
     auto_start = conf[CONF_AUTO_START]
     safe_mode = conf[CONF_SAFE_MODE]
     entity_filter = conf[CONF_FILTER]
     entity_config = conf[CONF_ENTITY_CONFIG]
 
     homekit = HomeKit(
-        hass, name, port, ip_address, entity_filter, entity_config, safe_mode
+        hass,
+        name,
+        port,
+        ip_address,
+        entity_filter,
+        entity_config,
+        safe_mode,
+        advertise_ip,
+        advertise_mac,
     )
     await hass.async_add_executor_job(homekit.setup)
 
@@ -265,7 +281,16 @@ class HomeKit:
     """Class to handle all actions between HomeKit and Home Assistant."""
 
     def __init__(
-        self, hass, name, port, ip_address, entity_filter, entity_config, safe_mode
+        self,
+        hass,
+        name,
+        port,
+        ip_address,
+        entity_filter,
+        entity_config,
+        safe_mode,
+        advertise_ip=None,
+        advertise_mac=None,
     ):
         """Initialize a HomeKit object."""
         self.hass = hass
@@ -275,6 +300,8 @@ class HomeKit:
         self._filter = entity_filter
         self._config = entity_config
         self._safe_mode = safe_mode
+        self._advertise_ip = advertise_ip
+        self._advertise_mac = advertise_mac
         self.status = STATUS_READY
 
         self.bridge = None
@@ -289,7 +316,12 @@ class HomeKit:
         ip_addr = self._ip_address or get_local_ip()
         path = self.hass.config.path(HOMEKIT_FILE)
         self.driver = HomeDriver(
-            self.hass, address=ip_addr, port=self._port, persist_file=path
+            self.hass,
+            address=ip_addr,
+            port=self._port,
+            persist_file=path,
+            advertised_address=self._advertise_ip,
+            mac=self._advertise_mac,
         )
         self.bridge = HomeBridge(self.hass, self.driver, self._name)
         if self._safe_mode:

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -11,7 +11,6 @@ ATTR_VALUE = "value"
 
 # #### Config ####
 CONF_ADVERTISE_IP = "advertise_ip"
-CONF_ADVERTISE_MAC = "advertise_mac"
 CONF_AUTO_START = "auto_start"
 CONF_ENTITY_CONFIG = "entity_config"
 CONF_FEATURE = "feature"

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -10,6 +10,8 @@ ATTR_DISPLAY_NAME = "display_name"
 ATTR_VALUE = "value"
 
 # #### Config ####
+CONF_ADVERTISE_IP = "advertise_ip"
+CONF_ADVERTISE_MAC = "advertise_mac"
 CONF_AUTO_START = "auto_start"
 CONF_ENTITY_CONFIG = "entity_config"
 CONF_FEATURE = "feature"

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -69,7 +69,7 @@ async def test_setup_min(hass):
         assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
     mock_homekit.assert_any_call(
-        hass, BRIDGE_NAME, DEFAULT_PORT, None, ANY, {}, DEFAULT_SAFE_MODE, None, None
+        hass, BRIDGE_NAME, DEFAULT_PORT, None, ANY, {}, DEFAULT_SAFE_MODE, None
     )
     assert mock_homekit().setup.called is True
 
@@ -98,7 +98,7 @@ async def test_setup_auto_start_disabled(hass):
         assert await setup.async_setup_component(hass, DOMAIN, config)
 
     mock_homekit.assert_any_call(
-        hass, "Test Name", 11111, "172.0.0.0", ANY, {}, DEFAULT_SAFE_MODE, None, None
+        hass, "Test Name", 11111, "172.0.0.0", ANY, {}, DEFAULT_SAFE_MODE, None
     )
     assert mock_homekit().setup.called is True
 
@@ -141,7 +141,6 @@ async def test_homekit_setup(hass, hk_driver):
         port=DEFAULT_PORT,
         persist_file=path,
         advertised_address=None,
-        mac=None,
     )
     assert homekit.driver.safe_mode is False
 
@@ -163,22 +162,13 @@ async def test_homekit_setup_ip_address(hass, hk_driver):
         port=DEFAULT_PORT,
         persist_file=ANY,
         advertised_address=None,
-        mac=None,
     )
 
 
-async def test_homekit_setup_advertise_ip_and_mac(hass, hk_driver):
-    """Test setup with given IP address."""
+async def test_homekit_setup_advertise_ip(hass, hk_driver):
+    """Test setup with given IP address to advertise."""
     homekit = HomeKit(
-        hass,
-        BRIDGE_NAME,
-        DEFAULT_PORT,
-        "0.0.0.0",
-        {},
-        {},
-        None,
-        "192.168.1.100",
-        "11:22:33:44:55:66",
+        hass, BRIDGE_NAME, DEFAULT_PORT, "0.0.0.0", {}, {}, None, "192.168.1.100"
     )
 
     with patch(
@@ -191,7 +181,6 @@ async def test_homekit_setup_advertise_ip_and_mac(hass, hk_driver):
         port=DEFAULT_PORT,
         persist_file=ANY,
         advertised_address="192.168.1.100",
-        mac="11:22:33:44:55:66",
     )
 
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -69,7 +69,7 @@ async def test_setup_min(hass):
         assert await setup.async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
     mock_homekit.assert_any_call(
-        hass, BRIDGE_NAME, DEFAULT_PORT, None, ANY, {}, DEFAULT_SAFE_MODE
+        hass, BRIDGE_NAME, DEFAULT_PORT, None, ANY, {}, DEFAULT_SAFE_MODE, None, None
     )
     assert mock_homekit().setup.called is True
 
@@ -98,7 +98,7 @@ async def test_setup_auto_start_disabled(hass):
         assert await setup.async_setup_component(hass, DOMAIN, config)
 
     mock_homekit.assert_any_call(
-        hass, "Test Name", 11111, "172.0.0.0", ANY, {}, DEFAULT_SAFE_MODE
+        hass, "Test Name", 11111, "172.0.0.0", ANY, {}, DEFAULT_SAFE_MODE, None, None
     )
     assert mock_homekit().setup.called is True
 
@@ -136,7 +136,12 @@ async def test_homekit_setup(hass, hk_driver):
     path = hass.config.path(HOMEKIT_FILE)
     assert isinstance(homekit.bridge, HomeBridge)
     mock_driver.assert_called_with(
-        hass, address=IP_ADDRESS, port=DEFAULT_PORT, persist_file=path
+        hass,
+        address=IP_ADDRESS,
+        port=DEFAULT_PORT,
+        persist_file=path,
+        advertised_address=None,
+        mac=None,
     )
     assert homekit.driver.safe_mode is False
 
@@ -153,7 +158,40 @@ async def test_homekit_setup_ip_address(hass, hk_driver):
     ) as mock_driver:
         await hass.async_add_job(homekit.setup)
     mock_driver.assert_called_with(
-        hass, address="172.0.0.0", port=DEFAULT_PORT, persist_file=ANY
+        hass,
+        address="172.0.0.0",
+        port=DEFAULT_PORT,
+        persist_file=ANY,
+        advertised_address=None,
+        mac=None,
+    )
+
+
+async def test_homekit_setup_advertise_ip_and_mac(hass, hk_driver):
+    """Test setup with given IP address."""
+    homekit = HomeKit(
+        hass,
+        BRIDGE_NAME,
+        DEFAULT_PORT,
+        "0.0.0.0",
+        {},
+        {},
+        None,
+        "192.168.1.100",
+        "11:22:33:44:55:66",
+    )
+
+    with patch(
+        PATH_HOMEKIT + ".accessories.HomeDriver", return_value=hk_driver
+    ) as mock_driver:
+        await hass.async_add_job(homekit.setup)
+    mock_driver.assert_called_with(
+        hass,
+        address="0.0.0.0",
+        port=DEFAULT_PORT,
+        persist_file=ANY,
+        advertised_address="192.168.1.100",
+        mac="11:22:33:44:55:66",
     )
 
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
This is not a breaking change, as the default behaviour will be unchanged.

## Description:

This makes use of HAP-python's new feature in version 2.6.0
that allows to specify the mDNS advertised IP address.

This is a requirement for the following use cases:
- Running Home Assistant behind a NAT, e.g. inside Docker.
- Running it on a system with multiple interfaces there
  the default IP address, DNS entry and hostname diverge.

The forwarding of the required mDNS packets can be done with
an avahi-daemon based gateway, e.g. by using enable-reflector=yes.

Whitespace changes were performed due to black and flake8.

**Related PRs:**
Makes use of the following addition to HAP-python: https://github.com/ikalchev/HAP-python/pull/203
which was merged into HA via: https://github.com/home-assistant/home-assistant/pull/26783
with commit: https://github.com/home-assistant/home-assistant/commit/ed21019b7a4c746b443b7d1192db11880da06c90

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10410

## Example entry for `configuration.yaml` (if applicable):
Example configuration for HA running inside Docker on a machine with IP address `192.168.1.100`:
```yaml
homekit:
  name: "Test HA"
  ip_address: "0.0.0.0"
  advertise_ip: "192.168.1.100"
  port: 51827
  filter:
    include_domains:
      - climate
      - light
      - sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

>   - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
>   - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
>   - [x] Untested files have been added to `.coveragerc`.

**Above is not relevant, as tests were updated. Manifest and requirements are already in place.**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
