### PR TITLE
Bump pytest to 5.1.3

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,5 +17,5 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.7.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
-pytest==5.1.2
+pytest==5.1.3
 requests_mock==1.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -18,7 +18,7 @@ pytest-aiohttp==0.3.0
 pytest-cov==2.7.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
-pytest==5.1.2
+pytest==5.1.3
 requests_mock==1.6.0
 
 


### PR DESCRIPTION
## Description:

Bumps pytest to 5.1.3

https://docs.pytest.org/en/latest/changelog.html#pytest-5-1-3-2019-09-18

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
