### PR TITLE
Bump iperf3 to 0.1.11

### DIFF
--- a/homeassistant/components/iperf3/manifest.json
+++ b/homeassistant/components/iperf3/manifest.json
@@ -3,7 +3,7 @@
   "name": "Iperf3",
   "documentation": "https://www.home-assistant.io/components/iperf3",
   "requirements": [
-    "iperf3==0.1.10"
+    "iperf3==0.1.11"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ influxdb==5.2.3
 insteonplm==0.16.5
 
 # homeassistant.components.iperf3
-iperf3==0.1.10
+iperf3==0.1.11
 
 # homeassistant.components.route53
 ipify==1.0.0


### PR DESCRIPTION
## Description:

Bump `iperf3` to 0.1.11
https://github.com/thiezn/iperf3-python/blob/master/HISTORY.rst#0111-2019-04-13


**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
iperf3:
  hosts:
    - host: iperf.he.net
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
