### PR TITLE
Bump shodan to 1.17.0

### DIFF
--- a/homeassistant/components/shodan/manifest.json
+++ b/homeassistant/components/shodan/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shodan",
   "documentation": "https://www.home-assistant.io/components/shodan",
   "requirements": [
-    "shodan==1.15.0"
+    "shodan==1.16.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/shodan/manifest.json
+++ b/homeassistant/components/shodan/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shodan",
   "documentation": "https://www.home-assistant.io/components/shodan",
   "requirements": [
-    "shodan==1.16.0"
+    "shodan==1.17.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1732,7 +1732,7 @@ sense_energy==0.7.0
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.shodan
-shodan==1.15.0
+shodan==1.16.0
 
 # homeassistant.components.simplepush
 simplepush==1.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1732,7 +1732,7 @@ sense_energy==0.7.0
 sharp_aquos_rc==0.3.2
 
 # homeassistant.components.shodan
-shodan==1.16.0
+shodan==1.17.0
 
 # homeassistant.components.simplepush
 simplepush==1.1.4


### PR DESCRIPTION
# Description:

Bumps shodan to 1.17.0
https://github.com/achillean/shodan-python/releases/tag/1.17.0


**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: shodan
    api_key: SHODAN_API_KEY
    query: 'home-assistant'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
