### PR TITLE
Add and corrects typehints in Entity helper & core class

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -703,7 +703,7 @@ class State:
     def __init__(
         self,
         entity_id: str,
-        state: Any,
+        state: str,
         attributes: Optional[Dict] = None,
         last_changed: Optional[datetime.datetime] = None,
         last_updated: Optional[datetime.datetime] = None,
@@ -732,7 +732,7 @@ class State:
             )
 
         self.entity_id = entity_id.lower()
-        self.state: str = state
+        self.state = state
         self.attributes = MappingProxyType(attributes or {})
         self.last_updated = last_updated or dt_util.utcnow()
         self.last_changed = last_changed or self.last_updated
@@ -924,7 +924,7 @@ class StateMachine:
     def set(
         self,
         entity_id: str,
-        new_state: Any,
+        new_state: str,
         attributes: Optional[Dict] = None,
         force_update: bool = False,
         context: Optional[Context] = None,
@@ -950,7 +950,7 @@ class StateMachine:
     def async_set(
         self,
         entity_id: str,
-        new_state: Any,
+        new_state: str,
         attributes: Optional[Dict] = None,
         force_update: bool = False,
         context: Optional[Context] = None,

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import logging
 import functools as ft
 from timeit import default_timer as timer
-from typing import Any, Optional, List, Iterable
+from typing import Any, Optional, List, Iterable, Dict
 
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity_registry import (
     EVENT_ENTITY_REGISTRY_UPDATED,
     RegistryEntry,
 )
-from homeassistant.core import HomeAssistant, callback, CALLBACK_TYPE
+from homeassistant.core import HomeAssistant, callback, CALLBACK_TYPE, Context
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.exceptions import NoEntitySpecifiedError
 from homeassistant.util import ensure_unique_string, slugify
@@ -137,12 +137,12 @@ class Entity:
         return None
 
     @property
-    def state(self) -> str:
+    def state(self) -> Optional[str]:
         """Return the state of the entity."""
         return STATE_UNKNOWN
 
     @property
-    def state_attributes(self):
+    def state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return the state attributes.
 
         Implemented by component base class.
@@ -150,7 +150,7 @@ class Entity:
         return None
 
     @property
-    def device_state_attributes(self):
+    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return device specific state attributes.
 
         Implemented by platform classes.
@@ -158,7 +158,7 @@ class Entity:
         return None
 
     @property
-    def device_info(self):
+    def device_info(self) -> Optional[Dict[str, Any]]:
         """Return device specific attributes.
 
         Implemented by platform classes.
@@ -171,17 +171,17 @@ class Entity:
         return None
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement of this entity, if any."""
         return None
 
     @property
-    def icon(self):
+    def icon(self) -> Optional[str]:
         """Return the icon to use in the frontend, if any."""
         return None
 
     @property
-    def entity_picture(self):
+    def entity_picture(self) -> Optional[str]:
         """Return the entity picture to use in the frontend, if any."""
         return None
 
@@ -215,12 +215,12 @@ class Entity:
         return None
 
     @property
-    def context_recent_time(self):
+    def context_recent_time(self) -> timedelta:
         """Time that a context is considered recent."""
         return timedelta(seconds=5)
 
     @property
-    def entity_registry_enabled_default(self):
+    def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
         return True
 
@@ -230,12 +230,12 @@ class Entity:
     # produce undesirable effects in the entity's operation.
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Return if the entity is enabled in the entity registry."""
         return self.registry_entry is None or not self.registry_entry.disabled
 
     @callback
-    def async_set_context(self, context):
+    def async_set_context(self, context: Context) -> None:
         """Set the context the entity currently operates under."""
         self._context = context
         self._context_set = dt_util.utcnow()
@@ -540,7 +540,7 @@ class Entity:
 
         return self.unique_id == other.unique_id
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the representation."""
         return "<Entity {}: {}>".format(self.name, self.state)
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import logging
 import functools as ft
 from timeit import default_timer as timer
-from typing import Any, Optional, List, Iterable, Dict
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -137,7 +137,7 @@ class Entity:
         return None
 
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> Union[None, str, int, float]:
         """Return the state of the entity."""
         return STATE_UNKNOWN
 


### PR DESCRIPTION
## Description:

Adds and corrects a bunch of type hints in the `Entity` class.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
