### PR TITLE
Nuki bridge fixes

### DIFF
--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -22,7 +22,7 @@ ATTR_NUKI_ID = "nuki_id"
 ATTR_UNLATCH = "unlatch"
 
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=5)
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=5)
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
 
 NUKI_DATA = "nuki"
 
@@ -50,7 +50,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Nuki lock platform. Enforce strict queuing of requests."""
     enforce_queuing = True
     bridge = NukiBridge(
-        config[CONF_HOST], config[CONF_TOKEN], config[CONF_PORT], 5, enforce_queuing
+        config[CONF_HOST],
+        config[CONF_TOKEN],
+        config[CONF_PORT],
+        DEFAULT_TIMEOUT,
+        enforce_queuing,
     )
     devices = [NukiLock(lock) for lock in bridge.locks]
 

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -2,8 +2,8 @@
 from datetime import timedelta
 import logging
 import time
-from pynuki import NukiBridge
 import voluptuous as vol
+from pynuki import NukiBridge
 
 from homeassistant.components.lock import PLATFORM_SCHEMA, SUPPORT_OPEN, LockDevice
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, CONF_TOKEN
@@ -81,7 +81,6 @@ class NukiLock(LockDevice):
     def __init__(self, nuki_lock):
         """Initialize the lock."""
         self._nuki_lock = nuki_lock
-        #        self._locked = nuki_lock.is_locked
         self._name = nuki_lock.name
         self._battery_critical = nuki_lock.battery_critical
         self._available = nuki_lock.state not in ERROR_STATES
@@ -142,6 +141,8 @@ class NukiLock(LockDevice):
                     self._name = self._nuki_lock.name
                     self._battery_critical = self._nuki_lock.battery_critical
                     break
+            if self._available:
+                break
 
     def lock(self, **kwargs):
         """Lock. Make blocking API request, so status is correct and reusable."""


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


Note this PR relies on [this PR ](https://github.com/pschmitt/pynuki/pull/31 )for pynuki, If we can't update pynuki in a reasonable timeframe I can look at adding  queuing / blocking requests here in nuki/lock.py.

I have a new nuki v2 lock and bridge and experienced a lot of issues, many described here: https://developer.nuki.io/t/random-http-503-unavailable/909

This is as per current state of firmware and bridge, September 2019.
Issues:
a) bridge can only support one connection at a time
b) bridge enters uncommunicative state if a request received within 0.5 of another
c) bridge gets overwhelmed by several requests

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#26780
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: nuki
    host: 192.168.86.49
    token: xxx
```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
