### PR TITLE
Use no break space with state_with_unit()

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -426,7 +426,7 @@ class TemplateState(State):
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         if unit is None:
             return state.state
-        return f"{state.state} {unit}"
+        return f"{state.state}\N{NO-BREAK SPACE}{unit}"
 
     def __getattribute__(self, name):
         """Return an attribute of the state."""

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1737,7 +1737,7 @@ def test_state_with_unit(hass):
 
     tpl = template.Template("{{ states.sensor.test.state_with_unit }}", hass)
 
-    assert tpl.async_render() == "23 beers"
+    assert tpl.async_render() == "23\N{NO-BREAK SPACE}beers"
 
     tpl = template.Template("{{ states.sensor.test2.state_with_unit }}", hass)
 
@@ -1747,7 +1747,7 @@ def test_state_with_unit(hass):
         "{% for state in states %}{{ state.state_with_unit }} {% endfor %}", hass
     )
 
-    assert tpl.async_render() == "23 beers wow"
+    assert tpl.async_render() == "23\N{NO-BREAK SPACE}beers wow"
 
     tpl = template.Template("{{ states.sensor.non_existing.state_with_unit }}", hass)
 


### PR DESCRIPTION
## Breaking Change:

Not sure it's a breaking chante but if someone is making a comparison in a template using the `state_with_unit`method, it will break.

## Description:

The standard rule for displaying values with unit is to always have value and unit on the same line. So we have to use a `no break space` character.

**Related issue (if applicable): N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable): https://github.com/home-assistant/home-assistant.io/pull/10417

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html