### PR TITLE
Add device automation support to ZHA

### DIFF
--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -27,8 +27,12 @@
       "remote_button_triple_press": "\"{subtype}\" button triple clicked",
       "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
       "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
-      "remote_button_rotated": "Button rotated \"{subtype}\"",
-      "remote_gyro_activated": "Device shaken"
+      "device_rotated": "Device rotated \"{subtype}\"",
+      "device_shaken": "Device shaken",
+      "device_slid": "Device slid \"{subtype}\"",
+      "device_knocked": "Device knocked \"{subtype}\"",
+      "device_dropped": "Device dropped",
+      "device_flipped": "Device flipped \"{subtype}\""
     },
     "trigger_subtype": {
       "turn_on": "Turn on",
@@ -43,7 +47,9 @@
       "button_1": "First button",
       "button_2": "Second button",
       "button_3": "Third button",
-      "button_4": "Fourth button"
+      "button_4": "Fourth button",
+      "button_5": "Fifth button",
+      "button_6": "Sixth button"
     }
   }
 }

--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -49,7 +49,13 @@
       "button_3": "Third button",
       "button_4": "Fourth button",
       "button_5": "Fifth button",
-      "button_6": "Sixth button"
+      "button_6": "Sixth button",
+      "face_1": "with face 1 activated",
+      "face_2": "with face 2 activated",
+      "face_3": "with face 3 activated",
+      "face_4": "with face 4 activated",
+      "face_5": "with face 5 activated",
+      "face_6": "with face 6 activated"
     }
   }
 }

--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -30,6 +30,7 @@
       "device_rotated": "Device rotated \"{subtype}\"",
       "device_shaken": "Device shaken",
       "device_slid": "Device slid \"{subtype}\"",
+      "device_tilted": "Device tilted",
       "device_knocked": "Device knocked \"{subtype}\"",
       "device_dropped": "Device dropped",
       "device_flipped": "Device flipped \"{subtype}\""

--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -1,20 +1,49 @@
 {
-    "config": {
-        "abort": {
-            "single_instance_allowed": "Only a single configuration of ZHA is allowed."
-        },
-        "error": {
-            "cannot_connect": "Unable to connect to ZHA device."
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "radio_type": "Radio Type",
-                    "usb_path": "USB Device Path"
-                },
-                "title": "ZHA"
-            }
+  "config": {
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of ZHA is allowed."
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to ZHA device."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "radio_type": "Radio Type",
+          "usb_path": "USB Device Path"
         },
         "title": "ZHA"
+      }
+    },
+    "title": "ZHA"
+  },
+  "device_automation": {
+    "trigger_type": {
+      "remote_button_short_press": "\"{subtype}\" button pressed",
+      "remote_button_short_release": "\"{subtype}\" button released",
+      "remote_button_long_press": "\"{subtype}\" button continuously pressed",
+      "remote_button_long_release": "\"{subtype}\" button released after long press",
+      "remote_button_double_press": "\"{subtype}\" button double clicked",
+      "remote_button_triple_press": "\"{subtype}\" button triple clicked",
+      "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
+      "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
+      "remote_button_rotated": "Button rotated \"{subtype}\"",
+      "remote_gyro_activated": "Device shaken"
+    },
+    "trigger_subtype": {
+      "turn_on": "Turn on",
+      "turn_off": "Turn off",
+      "dim_up": "Dim up",
+      "dim_down": "Dim down",
+      "left": "Left",
+      "right": "Right",
+      "open": "Open",
+      "close": "Close",
+      "both_buttons": "Both buttons",
+      "button_1": "First button",
+      "button_2": "Second button",
+      "button_3": "Third button",
+      "button_4": "Fourth button"
     }
+  }
 }

--- a/homeassistant/components/zha/.translations/en.json
+++ b/homeassistant/components/zha/.translations/en.json
@@ -50,12 +50,13 @@
       "button_4": "Fourth button",
       "button_5": "Fifth button",
       "button_6": "Sixth button",
-      "face_1": "with face 1 activated",
-      "face_2": "with face 2 activated",
-      "face_3": "with face 3 activated",
-      "face_4": "with face 4 activated",
-      "face_5": "with face 5 activated",
-      "face_6": "with face 6 activated"
+      "face_any": "With any/specified face(s) activated",
+      "face_1": "With face 1 activated",
+      "face_2": "With face 2 activated",
+      "face_3": "With face 3 activated",
+      "face_4": "With face 4 activated",
+      "face_5": "With face 5 activated",
+      "face_6": "With face 6 activated"
     }
   }
 }

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -240,6 +240,7 @@ class ZigbeeChannel(LogMixin):
             {
                 "unique_id": self._unique_id,
                 "device_ieee": str(self._zha_device.ieee),
+                "endpoint_id": cluster.endpoint.endpoint_id,
                 "command": command,
                 "args": args,
             },

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -241,6 +241,7 @@ class ZigbeeChannel(LogMixin):
                 "unique_id": self._unique_id,
                 "device_ieee": str(self._zha_device.ieee),
                 "endpoint_id": cluster.endpoint.endpoint_id,
+                "cluster_id": cluster.cluster_id,
                 "command": command,
                 "args": args,
             },

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -188,6 +188,11 @@ class ZHADevice(LogMixin):
         return self._all_channels
 
     @property
+    def device_automation_triggers(self):
+        """Return the device automation triggers for this device."""
+        return self._zigpy_device.device_automation_triggers
+
+    @property
     def available_signal(self):
         """Signal to use to subscribe to device availability changes."""
         return self._available_signal

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -190,7 +190,9 @@ class ZHADevice(LogMixin):
     @property
     def device_automation_triggers(self):
         """Return the device automation triggers for this device."""
-        return self._zigpy_device.device_automation_triggers
+        if hasattr(self._zigpy_device, "device_automation_triggers"):
+            return self._zigpy_device.device_automation_triggers
+        return None
 
     @property
     def available_signal(self):

--- a/homeassistant/components/zha/device_automation.py
+++ b/homeassistant/components/zha/device_automation.py
@@ -99,7 +99,7 @@ async def async_trigger(hass, config, action, automation_info):
 
     if (
         not zha_device.device_automation_triggers
-        and trigger not in zha_device.device_automation_triggers
+        or trigger not in zha_device.device_automation_triggers
     ):
         raise InvalidDeviceAutomationConfig
 

--- a/homeassistant/components/zha/device_automation.py
+++ b/homeassistant/components/zha/device_automation.py
@@ -2,7 +2,6 @@
 import voluptuous as vol
 
 import homeassistant.components.automation.event as event
-
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
@@ -13,70 +12,16 @@ from .core.const import DATA_ZHA, DATA_ZHA_GATEWAY
 from .core.helpers import convert_ieee
 
 CONF_SUBTYPE = "subtype"
-
-CONF_SHORT_PRESS = "remote_button_short_press"
-CONF_SHORT_RELEASE = "remote_button_short_release"
-CONF_LONG_PRESS = "remote_button_long_press"
-CONF_LONG_RELEASE = "remote_button_long_release"
-CONF_DOUBLE_PRESS = "remote_button_double_press"
-CONF_TRIPLE_PRESS = "remote_button_triple_press"
-CONF_QUADRUPLE_PRESS = "remote_button_quadruple_press"
-CONF_QUINTUPLE_PRESS = "remote_button_quintuple_press"
-CONF_ROTATED = "device_rotated"
-CONF_SHAKEN = "device_shaken"
-CONF_DROPPED = "device_dropped"
-CONF_SLID = "device_slid"
-CONF_KNOCKED = "device_knocked"
-CONF_FLIPPED = "device_flipped"
-
-CONF_TURN_ON = "turn_on"
-CONF_TURN_OFF = "turn_off"
-CONF_DIM_UP = "dim_up"
-CONF_DIM_DOWN = "dim_down"
-CONF_LEFT = "left"
-CONF_RIGHT = "right"
-CONF_OPEN = "open"
-CONF_CLOSE = "close"
-CONF_BOTH_BUTTONS = "both_buttons"
-CONF_BUTTON_1 = "button_1"
-CONF_BUTTON_2 = "button_2"
-CONF_BUTTON_3 = "button_3"
-CONF_BUTTON_4 = "button_4"
-CONF_BUTTON_5 = "button_5"
-CONF_BUTTON_6 = "button_6"
-
-AQARA_ROUND_SWITCH_MODEL = "lumi.sensor_switch"
-AQARA_ROUND_SWITCH = {
-    (CONF_SHORT_PRESS, CONF_TURN_ON): {
-        "command": "click",
-        "args": {"click_type": "single"},
-    },
-    (CONF_DOUBLE_PRESS, CONF_TURN_ON): {
-        "command": "click",
-        "args": {"click_type": "double"},
-    },
-    (CONF_TRIPLE_PRESS, CONF_TURN_ON): {
-        "command": "click",
-        "args": {"click_type": "triple"},
-    },
-    (CONF_QUADRUPLE_PRESS, CONF_TURN_ON): {
-        "command": "click",
-        "args": {"click_type": "quadruple"},
-    },
-    (CONF_QUINTUPLE_PRESS, CONF_TURN_ON): {
-        "command": "click",
-        "args": {"click_type": "furious"},
-    },
-}
-
-REMOTES = {AQARA_ROUND_SWITCH_MODEL: AQARA_ROUND_SWITCH}
+DEVICE = "device"
+DEVICE_IEEE = "device_ieee"
+ZHA_EVENT = "zha_event"
 
 TRIGGER_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Required(CONF_DEVICE_ID): str,
             vol.Required(CONF_DOMAIN): DOMAIN,
-            vol.Required(CONF_PLATFORM): "device",
+            vol.Required(CONF_PLATFORM): DEVICE,
             vol.Required(CONF_TYPE): str,
             vol.Required(CONF_SUBTYPE): str,
         }
@@ -87,15 +32,8 @@ TRIGGER_SCHEMA = vol.All(
 async def async_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
     config = TRIGGER_SCHEMA(config)
-
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    registry_device = device_registry.async_get(config[CONF_DEVICE_ID])
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
-    ieee_address = list(list(registry_device.identifiers)[0])[1]
-    ieee = convert_ieee(ieee_address)
-    zha_device = zha_gateway.devices[ieee]
-
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
+    zha_device = await _async_get_zha_device(hass, config[CONF_DEVICE_ID])
 
     if (
         not zha_device.device_automation_triggers
@@ -106,8 +44,8 @@ async def async_trigger(hass, config, action, automation_info):
     trigger = zha_device.device_automation_triggers[trigger]
 
     state_config = {
-        event.CONF_EVENT_TYPE: "zha_event",
-        event.CONF_EVENT_DATA: {"device_ieee": ieee_address, **trigger},
+        event.CONF_EVENT_TYPE: ZHA_EVENT,
+        event.CONF_EVENT_DATA: {DEVICE_IEEE: str(zha_device.ieee), **trigger},
     }
 
     return await event.async_trigger(hass, state_config, action, automation_info)
@@ -116,16 +54,10 @@ async def async_trigger(hass, config, action, automation_info):
 async def async_get_triggers(hass, device_id):
     """List device triggers.
 
-    Make sure device is a supported remote model.
-    Retrieve the deconz event object matching device entry.
-    Generate device trigger list.
+    Make sure the device supports device automations and
+    if it does return the trigger list.
     """
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    registry_device = device_registry.async_get(device_id)
-    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
-    ieee_address = list(list(registry_device.identifiers)[0])[1]
-    ieee = convert_ieee(ieee_address)
-    zha_device = zha_gateway.devices[ieee]
+    zha_device = await _async_get_zha_device(hass, device_id)
 
     if not zha_device.device_automation_triggers:
         return
@@ -136,10 +68,22 @@ async def async_get_triggers(hass, device_id):
             {
                 CONF_DEVICE_ID: device_id,
                 CONF_DOMAIN: DOMAIN,
-                CONF_PLATFORM: "device",
+                CONF_PLATFORM: DEVICE,
                 CONF_TYPE: trigger,
                 CONF_SUBTYPE: subtype,
             }
         )
 
     return triggers
+
+
+async def _async_get_zha_device(hass, device_id):
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    registry_device = device_registry.async_get(device_id)
+    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    ieee_address = list(list(registry_device.identifiers)[0])[1]
+    ieee = convert_ieee(ieee_address)
+    zha_device = zha_gateway.devices[ieee]
+    if not zha_device:
+        raise InvalidDeviceAutomationConfig
+    return zha_device

--- a/homeassistant/components/zha/device_automation.py
+++ b/homeassistant/components/zha/device_automation.py
@@ -36,7 +36,7 @@ async def async_trigger(hass, config, action, automation_info):
     zha_device = await _async_get_zha_device(hass, config[CONF_DEVICE_ID])
 
     if (
-        not zha_device.device_automation_triggers
+        zha_device.device_automation_triggers is None
         or trigger not in zha_device.device_automation_triggers
     ):
         raise InvalidDeviceAutomationConfig

--- a/homeassistant/components/zha/device_automation.py
+++ b/homeassistant/components/zha/device_automation.py
@@ -1,0 +1,133 @@
+"""Provides device automations for ZHA devices that emit events."""
+import voluptuous as vol
+
+import homeassistant.components.automation.event as event
+
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+
+from . import DOMAIN
+
+CONF_SUBTYPE = "subtype"
+
+CONF_SHORT_PRESS = "remote_button_short_press"
+CONF_SHORT_RELEASE = "remote_button_short_release"
+CONF_LONG_PRESS = "remote_button_long_press"
+CONF_LONG_RELEASE = "remote_button_long_release"
+CONF_DOUBLE_PRESS = "remote_button_double_press"
+CONF_TRIPLE_PRESS = "remote_button_triple_press"
+CONF_QUADRUPLE_PRESS = "remote_button_quadruple_press"
+CONF_QUINTUPLE_PRESS = "remote_button_quintuple_press"
+CONF_ROTATE = "device_rotate"
+CONF_SHAKE = "device_shake"
+CONF_DROP = "device_drop"
+CONF_SLIDE = "device_slide"
+CONF_KNOCK = "device_knock"
+CONF_FLIP = "device_flip"
+
+CONF_TURN_ON = "turn_on"
+CONF_TURN_OFF = "turn_off"
+CONF_DIM_UP = "dim_up"
+CONF_DIM_DOWN = "dim_down"
+CONF_LEFT = "left"
+CONF_RIGHT = "right"
+CONF_OPEN = "open"
+CONF_CLOSE = "close"
+CONF_BOTH_BUTTONS = "both_buttons"
+CONF_BUTTON_1 = "button_1"
+CONF_BUTTON_2 = "button_2"
+CONF_BUTTON_3 = "button_3"
+CONF_BUTTON_4 = "button_4"
+
+AQARA_ROUND_SWITCH_MODEL = "lumi.sensor_switch"
+AQARA_ROUND_SWITCH = {
+    (CONF_SHORT_PRESS, CONF_TURN_ON): {
+        "command": "click",
+        "args": {"click_type": "single"},
+    },
+    (CONF_DOUBLE_PRESS, CONF_TURN_ON): {
+        "command": "click",
+        "args": {"click_type": "double"},
+    },
+    (CONF_TRIPLE_PRESS, CONF_TURN_ON): {
+        "command": "click",
+        "args": {"click_type": "triple"},
+    },
+    (CONF_QUADRUPLE_PRESS, CONF_TURN_ON): {
+        "command": "click",
+        "args": {"click_type": "quadruple"},
+    },
+    (CONF_QUINTUPLE_PRESS, CONF_TURN_ON): {
+        "command": "click",
+        "args": {"click_type": "furious"},
+    },
+}
+
+REMOTES = {AQARA_ROUND_SWITCH_MODEL: AQARA_ROUND_SWITCH}
+
+TRIGGER_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Required(CONF_DEVICE_ID): str,
+            vol.Required(CONF_DOMAIN): DOMAIN,
+            vol.Required(CONF_PLATFORM): "device",
+            vol.Required(CONF_TYPE): str,
+            vol.Required(CONF_SUBTYPE): str,
+        }
+    )
+)
+
+
+async def async_trigger(hass, config, action, automation_info):
+    """Listen for state changes based on configuration."""
+    config = TRIGGER_SCHEMA(config)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get(config[CONF_DEVICE_ID])
+
+    trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
+
+    if device.model not in REMOTES and trigger not in REMOTES[device.model]:
+        raise InvalidDeviceAutomationConfig
+
+    trigger = REMOTES[device.model][trigger]
+
+    state_config = {
+        event.CONF_EVENT_TYPE: "zha_event",
+        event.CONF_EVENT_DATA: {
+            "device_ieee": list(list(device.identifiers)[0])[1],
+            **trigger,
+        },
+    }
+
+    return await event.async_trigger(hass, state_config, action, automation_info)
+
+
+async def async_get_triggers(hass, device_id):
+    """List device triggers.
+
+    Make sure device is a supported remote model.
+    Retrieve the deconz event object matching device entry.
+    Generate device trigger list.
+    """
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get(device_id)
+
+    if device.model not in REMOTES:
+        return
+
+    triggers = []
+    for trigger, subtype in REMOTES[device.model].keys():
+        triggers.append(
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_PLATFORM: "device",
+                CONF_TYPE: trigger,
+                CONF_SUBTYPE: subtype,
+            }
+        )
+
+    return triggers

--- a/homeassistant/components/zha/device_automation.py
+++ b/homeassistant/components/zha/device_automation.py
@@ -20,12 +20,12 @@ CONF_DOUBLE_PRESS = "remote_button_double_press"
 CONF_TRIPLE_PRESS = "remote_button_triple_press"
 CONF_QUADRUPLE_PRESS = "remote_button_quadruple_press"
 CONF_QUINTUPLE_PRESS = "remote_button_quintuple_press"
-CONF_ROTATE = "device_rotate"
-CONF_SHAKE = "device_shake"
-CONF_DROP = "device_drop"
-CONF_SLIDE = "device_slide"
-CONF_KNOCK = "device_knock"
-CONF_FLIP = "device_flip"
+CONF_ROTATED = "device_rotated"
+CONF_SHAKEN = "device_shaken"
+CONF_DROPPED = "device_dropped"
+CONF_SLID = "device_slid"
+CONF_KNOCKED = "device_knocked"
+CONF_FLIPPED = "device_flipped"
 
 CONF_TURN_ON = "turn_on"
 CONF_TURN_OFF = "turn_off"
@@ -40,6 +40,8 @@ CONF_BUTTON_1 = "button_1"
 CONF_BUTTON_2 = "button_2"
 CONF_BUTTON_3 = "button_3"
 CONF_BUTTON_4 = "button_4"
+CONF_BUTTON_5 = "button_5"
+CONF_BUTTON_6 = "button_6"
 
 AQARA_ROUND_SWITCH_MODEL = "lumi.sensor_switch"
 AQARA_ROUND_SWITCH = {
@@ -65,7 +67,33 @@ AQARA_ROUND_SWITCH = {
     },
 }
 
-REMOTES = {AQARA_ROUND_SWITCH_MODEL: AQARA_ROUND_SWITCH}
+AQARA_CUBE_MODEL = "lumi.sensor_cube.aqgl01"
+AQARA_CUBE = {
+    (CONF_ROTATED, CONF_RIGHT): {"command": "rotate_right"},
+    (CONF_ROTATED, CONF_LEFT): {"command": "rotate_left"},
+    (CONF_SHAKEN, CONF_TURN_ON): {"command": "shake"},
+    (CONF_DROPPED, CONF_TURN_ON): {"command": "drop"},
+    (CONF_SLID, CONF_BUTTON_1): {"command": "slide", "args": {"activated_face": 1}},
+    (CONF_SLID, CONF_BUTTON_2): {"command": "slide", "args": {"activated_face": 2}},
+    (CONF_SLID, CONF_BUTTON_3): {"command": "slide", "args": {"activated_face": 3}},
+    (CONF_SLID, CONF_BUTTON_4): {"command": "slide", "args": {"activated_face": 4}},
+    (CONF_SLID, CONF_BUTTON_5): {"command": "slide", "args": {"activated_face": 5}},
+    (CONF_SLID, CONF_BUTTON_6): {"command": "slide", "args": {"activated_face": 6}},
+    (CONF_KNOCKED, CONF_BUTTON_1): {"command": "knock", "args": {"activated_face": 1}},
+    (CONF_KNOCKED, CONF_BUTTON_2): {"command": "knock", "args": {"activated_face": 2}},
+    (CONF_KNOCKED, CONF_BUTTON_3): {"command": "knock", "args": {"activated_face": 3}},
+    (CONF_KNOCKED, CONF_BUTTON_4): {"command": "knock", "args": {"activated_face": 4}},
+    (CONF_KNOCKED, CONF_BUTTON_5): {"command": "knock", "args": {"activated_face": 5}},
+    (CONF_KNOCKED, CONF_BUTTON_6): {"command": "knock", "args": {"activated_face": 6}},
+    (CONF_FLIPPED, CONF_BUTTON_1): {"command": "flip", "args": {"activated_face": 1}},
+    (CONF_FLIPPED, CONF_BUTTON_2): {"command": "flip", "args": {"activated_face": 2}},
+    (CONF_FLIPPED, CONF_BUTTON_3): {"command": "flip", "args": {"activated_face": 3}},
+    (CONF_FLIPPED, CONF_BUTTON_4): {"command": "flip", "args": {"activated_face": 4}},
+    (CONF_FLIPPED, CONF_BUTTON_5): {"command": "flip", "args": {"activated_face": 5}},
+    (CONF_FLIPPED, CONF_BUTTON_6): {"command": "flip", "args": {"activated_face": 6}},
+}
+
+REMOTES = {AQARA_ROUND_SWITCH_MODEL: AQARA_ROUND_SWITCH, AQARA_CUBE_MODEL: AQARA_CUBE}
 
 TRIGGER_SCHEMA = vol.All(
     vol.Schema(

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -27,8 +27,12 @@
       "remote_button_triple_press": "\"{subtype}\" button triple clicked",
       "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
       "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
-      "remote_button_rotated": "Button rotated \"{subtype}\"",
-      "remote_gyro_activated": "Device shaken"
+      "device_rotated": "Device rotated \"{subtype}\"",
+      "device_shaken": "Device shaken",
+      "device_slid": "Device slid \"{subtype}\"",
+      "device_knocked": "Device knocked \"{subtype}\"",
+      "device_dropped": "Device dropped",
+      "device_flipped": "Device flipped \"{subtype}\""
     },
     "trigger_subtype": {
       "turn_on": "Turn on",
@@ -43,7 +47,9 @@
       "button_1": "First button",
       "button_2": "Second button",
       "button_3": "Third button",
-      "button_4": "Fourth button"
+      "button_4": "Fourth button",
+      "button_5": "Fifth button",
+      "button_6": "Sixth button"
     }
   }
 }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -49,7 +49,13 @@
       "button_3": "Third button",
       "button_4": "Fourth button",
       "button_5": "Fifth button",
-      "button_6": "Sixth button"
+      "button_6": "Sixth button",
+      "face_1": "with face 1 activated",
+      "face_2": "with face 2 activated",
+      "face_3": "with face 3 activated",
+      "face_4": "with face 4 activated",
+      "face_5": "with face 5 activated",
+      "face_6": "with face 6 activated"
     }
   }
 }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -30,6 +30,7 @@
       "device_rotated": "Device rotated \"{subtype}\"",
       "device_shaken": "Device shaken",
       "device_slid": "Device slid \"{subtype}\"",
+      "device_tilted": "Device tilted",
       "device_knocked": "Device knocked \"{subtype}\"",
       "device_dropped": "Device dropped",
       "device_flipped": "Device flipped \"{subtype}\""

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -50,6 +50,7 @@
       "button_4": "Fourth button",
       "button_5": "Fifth button",
       "button_6": "Sixth button",
+      "face_any": "With any/specified face(s) activated",
       "face_1": "with face 1 activated",
       "face_2": "with face 2 activated",
       "face_3": "with face 3 activated",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1,20 +1,49 @@
 {
-    "config": {
+  "config": {
+    "title": "ZHA",
+    "step": {
+      "user": {
         "title": "ZHA",
-        "step": {
-            "user": {
-                "title": "ZHA",
-                "data": {
-                    "radio_type": "Radio Type",
-                    "usb_path": "USB Device Path"
-                }
-            }
-        },
-        "error": {
-            "cannot_connect": "Unable to connect to ZHA device."
-        },
-        "abort": {
-            "single_instance_allowed": "Only a single configuration of ZHA is allowed."
+        "data": {
+          "radio_type": "Radio Type",
+          "usb_path": "USB Device Path"
         }
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to ZHA device."
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of ZHA is allowed."
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "remote_button_short_press": "\"{subtype}\" button pressed",
+      "remote_button_short_release": "\"{subtype}\" button released",
+      "remote_button_long_press": "\"{subtype}\" button continuously pressed",
+      "remote_button_long_release": "\"{subtype}\" button released after long press",
+      "remote_button_double_press": "\"{subtype}\" button double clicked",
+      "remote_button_triple_press": "\"{subtype}\" button triple clicked",
+      "remote_button_quadruple_press": "\"{subtype}\" button quadruple clicked",
+      "remote_button_quintuple_press": "\"{subtype}\" button quintuple clicked",
+      "remote_button_rotated": "Button rotated \"{subtype}\"",
+      "remote_gyro_activated": "Device shaken"
+    },
+    "trigger_subtype": {
+      "turn_on": "Turn on",
+      "turn_off": "Turn off",
+      "dim_up": "Dim up",
+      "dim_down": "Dim down",
+      "left": "Left",
+      "right": "Right",
+      "open": "Open",
+      "close": "Close",
+      "both_buttons": "Both buttons",
+      "button_1": "First button",
+      "button_2": "Second button",
+      "button_3": "Third button",
+      "button_4": "Fourth button"
+    }
+  }
 }

--- a/tests/components/zha/test_device_automation.py
+++ b/tests/components/zha/test_device_automation.py
@@ -1,4 +1,4 @@
-"""deCONZ device automation tests."""
+"""ZHA device automation tests."""
 from homeassistant.components.device_automation import (
     _async_get_device_automations as async_get_device_automations,
 )

--- a/tests/components/zha/test_device_automation.py
+++ b/tests/components/zha/test_device_automation.py
@@ -1,9 +1,14 @@
 """ZHA device automation tests."""
+from unittest.mock import patch
+
 import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import (
     _async_get_device_automations as async_get_device_automations,
+)
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
 )
 from homeassistant.components.switch import DOMAIN
 from homeassistant.components.zha.core.const import CHANNEL_ON_OFF
@@ -140,8 +145,8 @@ async def test_no_triggers(hass, config_entry, zha_gateway):
     assert triggers == []
 
 
-async def test_if_fires_on_state_change(hass, config_entry, zha_gateway, calls):
-    """Test for on and off triggers firing."""
+async def test_if_fires_on_event(hass, config_entry, zha_gateway, calls):
+    """Test for remote triggers firing."""
     from zigpy.zcl.clusters.general import OnOff, Basic
 
     # create zigpy device
@@ -200,3 +205,58 @@ async def test_if_fires_on_state_change(hass, config_entry, zha_gateway, calls):
 
     assert len(calls) == 1
     assert calls[0].data["message"] == "service called"
+
+
+async def test_exception_on_event(hass, config_entry, zha_gateway, calls):
+    """Test for exception on event triggers firing."""
+    from zigpy.zcl.clusters.general import OnOff, Basic
+
+    # create zigpy device
+    zigpy_device = await async_init_zigpy_device(
+        hass, [Basic.cluster_id], [OnOff.cluster_id], None, zha_gateway
+    )
+
+    await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
+    await hass.async_block_till_done()
+    hass.config_entries._entries.append(config_entry)
+
+    zha_device = zha_gateway.get_device(zigpy_device.ieee)
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, zha_gateway, [zha_device])
+
+    ieee_address = str(zha_device.ieee)
+    ha_device_registry = await async_get_registry(hass)
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+
+    exception_patch = patch(
+        "homeassistant.components.zha.device_automation.async_trigger",
+        side_effect=InvalidDeviceAutomationConfig,
+    )
+    with exception_patch:
+        await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: [
+                    {
+                        "trigger": {
+                            "device_id": reg_device.id,
+                            "domain": "zha",
+                            "platform": "device",
+                            "type": "junk",
+                            "subtype": "junk",
+                        },
+                        "action": {
+                            "service": "test.automation",
+                            "data": {"message": "service called"},
+                        },
+                    }
+                ]
+            },
+        )
+
+        await hass.async_block_till_done()
+        on_off_channel = zha_device.cluster_channels[CHANNEL_ON_OFF]
+        on_off_channel.zha_send_event(on_off_channel.cluster, COMMAND_SINGLE, [])
+        await hass.async_block_till_done()

--- a/tests/components/zha/test_device_automation.py
+++ b/tests/components/zha/test_device_automation.py
@@ -7,9 +7,6 @@ import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import (
     _async_get_device_automations as async_get_device_automations,
 )
-from homeassistant.components.device_automation.exceptions import (
-    InvalidDeviceAutomationConfig,
-)
 from homeassistant.components.switch import DOMAIN
 from homeassistant.components.zha.core.const import CHANNEL_ON_OFF
 from homeassistant.helpers.device_registry import async_get_registry
@@ -207,7 +204,7 @@ async def test_if_fires_on_event(hass, config_entry, zha_gateway, calls):
     assert calls[0].data["message"] == "service called"
 
 
-async def test_exception_on_event(hass, config_entry, zha_gateway, calls):
+async def test_exception_no_triggers(hass, config_entry, zha_gateway, calls):
     """Test for exception on event triggers firing."""
     from zigpy.zcl.clusters.general import OnOff, Basic
 
@@ -229,11 +226,7 @@ async def test_exception_on_event(hass, config_entry, zha_gateway, calls):
     ha_device_registry = await async_get_registry(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
 
-    exception_patch = patch(
-        "homeassistant.components.zha.device_automation.async_trigger",
-        side_effect=InvalidDeviceAutomationConfig,
-    )
-    with exception_patch:
+    with patch("logging.Logger.error") as mock:
         await async_setup_component(
             hass,
             automation.DOMAIN,
@@ -255,8 +248,61 @@ async def test_exception_on_event(hass, config_entry, zha_gateway, calls):
                 ]
             },
         )
+        await hass.async_block_till_done()
+        mock.assert_called_with("Error setting up trigger %s", "automation 0")
 
+
+async def test_exception_bad_trigger(hass, config_entry, zha_gateway, calls):
+    """Test for exception on event triggers firing."""
+    from zigpy.zcl.clusters.general import OnOff, Basic
+
+    # create zigpy device
+    zigpy_device = await async_init_zigpy_device(
+        hass, [Basic.cluster_id], [OnOff.cluster_id], None, zha_gateway
+    )
+
+    zigpy_device.device_automation_triggers = {
+        (SHAKEN, SHAKEN): {COMMAND: COMMAND_SHAKE},
+        (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
+        (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
+        (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
+        (LONG_RELEASE, LONG_RELEASE): {COMMAND: COMMAND_HOLD},
+    }
+
+    await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
+    await hass.async_block_till_done()
+    hass.config_entries._entries.append(config_entry)
+
+    zha_device = zha_gateway.get_device(zigpy_device.ieee)
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, zha_gateway, [zha_device])
+
+    ieee_address = str(zha_device.ieee)
+    ha_device_registry = await async_get_registry(hass)
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+
+    with patch("logging.Logger.error") as mock:
+        await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: [
+                    {
+                        "trigger": {
+                            "device_id": reg_device.id,
+                            "domain": "zha",
+                            "platform": "device",
+                            "type": "junk",
+                            "subtype": "junk",
+                        },
+                        "action": {
+                            "service": "test.automation",
+                            "data": {"message": "service called"},
+                        },
+                    }
+                ]
+            },
+        )
         await hass.async_block_till_done()
-        on_off_channel = zha_device.cluster_channels[CHANNEL_ON_OFF]
-        on_off_channel.zha_send_event(on_off_channel.cluster, COMMAND_SINGLE, [])
-        await hass.async_block_till_done()
+        mock.assert_called_with("Error setting up trigger %s", "automation 0")

--- a/tests/components/zha/test_device_automation.py
+++ b/tests/components/zha/test_device_automation.py
@@ -1,0 +1,102 @@
+"""deCONZ device automation tests."""
+from homeassistant.components.device_automation import (
+    _async_get_device_automations as async_get_device_automations,
+)
+from homeassistant.components.switch import DOMAIN
+from homeassistant.helpers.device_registry import async_get_registry
+
+from .common import async_init_zigpy_device
+
+ON = 1
+OFF = 0
+SHAKEN = "device_shaken"
+COMMAND = "command"
+COMMAND_SHAKE = "shake"
+COMMAND_HOLD = "hold"
+COMMAND_SINGLE = "single"
+COMMAND_DOUBLE = "double"
+DOUBLE_PRESS = "remote_button_double_press"
+SHORT_PRESS = "remote_button_short_press"
+LONG_PRESS = "remote_button_long_press"
+LONG_RELEASE = "remote_button_long_release"
+
+
+def _same_lists(list_a, list_b):
+    if len(list_a) != len(list_b):
+        return False
+
+    for item in list_a:
+        if item not in list_b:
+            return False
+    return True
+
+
+async def test_switch(hass, config_entry, zha_gateway):
+    """Test zha switch platform."""
+    from zigpy.zcl.clusters.general import OnOff, Basic
+
+    # create zigpy device
+    zigpy_device = await async_init_zigpy_device(
+        hass, [Basic.cluster_id], [OnOff.cluster_id], None, zha_gateway
+    )
+
+    zigpy_device.device_automation_triggers = {
+        (SHAKEN, SHAKEN): {COMMAND: COMMAND_SHAKE},
+        (DOUBLE_PRESS, DOUBLE_PRESS): {COMMAND: COMMAND_DOUBLE},
+        (SHORT_PRESS, SHORT_PRESS): {COMMAND: COMMAND_SINGLE},
+        (LONG_PRESS, LONG_PRESS): {COMMAND: COMMAND_HOLD},
+        (LONG_RELEASE, LONG_RELEASE): {COMMAND: COMMAND_HOLD},
+    }
+
+    await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
+    await hass.async_block_till_done()
+    hass.config_entries._entries.append(config_entry)
+
+    zha_device = zha_gateway.get_device(zigpy_device.ieee)
+    ieee_address = str(zha_device.ieee)
+
+    ha_device_registry = await async_get_registry(hass)
+    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)}, set())
+
+    triggers = await async_get_device_automations(
+        hass, "async_get_triggers", reg_device.id
+    )
+
+    expected_triggers = [
+        {
+            "device_id": reg_device.id,
+            "domain": "zha",
+            "platform": "device",
+            "type": SHAKEN,
+            "subtype": SHAKEN,
+        },
+        {
+            "device_id": reg_device.id,
+            "domain": "zha",
+            "platform": "device",
+            "type": DOUBLE_PRESS,
+            "subtype": DOUBLE_PRESS,
+        },
+        {
+            "device_id": reg_device.id,
+            "domain": "zha",
+            "platform": "device",
+            "type": SHORT_PRESS,
+            "subtype": SHORT_PRESS,
+        },
+        {
+            "device_id": reg_device.id,
+            "domain": "zha",
+            "platform": "device",
+            "type": LONG_PRESS,
+            "subtype": LONG_PRESS,
+        },
+        {
+            "device_id": reg_device.id,
+            "domain": "zha",
+            "platform": "device",
+            "type": LONG_RELEASE,
+            "subtype": LONG_RELEASE,
+        },
+    ]
+    assert _same_lists(triggers, expected_triggers)


### PR DESCRIPTION
## Description:
This PR adds device automation support to ZHA.  An update to the quirks module is needed to add per device triggers. See https://github.com/dmulcahey/zha-device-handlers/pull/160 for the ongoing work to create triggers.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]
