### PR TITLE
Exempt 'Help wanted' issue from stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,6 +13,7 @@ onlyLabels: []
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - under investigation
+  - Help wanted
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true


### PR DESCRIPTION
## Description:

Added "Help wanted" label to the stale bot exempt list.

This way, we can ask our contributors for help on issues/features to implement, without them being closed as stale.

The reasoning for this label, "Help wanted" is a default label by GitHub, is also shows on the repository separate from the issue count and is being indexes by a lot of sites.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
