### PR TITLE
Add OPNSense device tracker

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -498,6 +498,7 @@ omit =
     homeassistant/components/openuv/sensor.py
     homeassistant/components/openweathermap/sensor.py
     homeassistant/components/openweathermap/weather.py
+    homeassistant/components/opnsense/*
     homeassistant/components/opple/light.py
     homeassistant/components/orangepi_gpio/*
     homeassistant/components/oru/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -238,6 +238,7 @@ homeassistant/components/onboarding/* @home-assistant/core
 homeassistant/components/opentherm_gw/* @mvn23
 homeassistant/components/openuv/* @bachya
 homeassistant/components/openweathermap/* @fabaff
+homeassistant/components/opnsense/* @mtreinish
 homeassistant/components/orangepi_gpio/* @pascallj
 homeassistant/components/oru/* @bvlaicu
 homeassistant/components/owlet/* @oblogic7

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -1,0 +1,64 @@
+"""Support for OPNSense Routers."""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL)
+from homeassistant.helpers.discovery import async_load_platform
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_API_SECRET = 'api_secret'
+CONF_TRACKER_INTERFACE = 'tracker_interfaces'
+
+DOMAIN = 'opnsense'
+
+OPNSENSE_DATA = DOMAIN
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_URL): cv.url,
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Required(CONF_API_SECRET): cv.string,
+        vol.Optional(CONF_VERIFY_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_TRACKER_INTERFACE): vol.All(
+            cv.ensure_list, [cv.string]),
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up the opnsense component."""
+    conf = config[DOMAIN]
+    url = conf[CONF_URL]
+    api_key = conf[CONF_API_KEY]
+    api_secret = conf[CONF_API_SECRET]
+    verify_ssl = conf.get(CONF_VERIFY_SSL, False)
+    tracker_interfaces = conf.get(CONF_TRACKER_INTERFACE, None)
+
+    from pyopnsense import diagnostics
+    if tracker_interfaces:
+        # Verify that specified tracker interfaces are valid
+        netinsight_client = diagnostics.NetworkInsightClient(api_key,
+                                                             api_secret,
+                                                             url, verify_ssl)
+        interfaces = list(netinsight_client.get_interfaces().values())
+        for interface in tracker_interfaces:
+            if interface not in interfaces:
+                _LOGGER.error('Specified OPNsense tracker interface %s is not '
+                              'found', interface)
+                return False
+    else:
+        tracker_interfaces = ['LAN']
+
+    interfaces_client = diagnostics.InterfaceClient(api_key, api_secret, url,
+                                                    verify_ssl)
+    clients = {
+        'interfaces': interfaces_client
+    }
+    hass.data[OPNSENSE_DATA] = clients
+
+    hass.async_create_task(async_load_platform(
+        hass, 'device_tracker', DOMAIN, tracker_interfaces, config))
+    return True

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -67,7 +67,10 @@ def setup(hass, config):
                 )
                 return False
 
-    hass.data[OPNSENSE_DATA] = {"interfaces": interfaces_client}
+    hass.data[OPNSENSE_DATA] = {
+        "interfaces": interfaces_client,
+        CONF_TRACKER_INTERFACE: tracker_interfaces,
+    }
 
     load_platform(hass, "device_tracker", DOMAIN, tracker_interfaces, config)
     return True

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -64,7 +64,7 @@ def setup(hass, config):
         api_key, api_secret, url, verify_ssl
     )
     clients = {"interfaces": interfaces_client}
-    hass.data[OPNSENSE_DATA] = clients
+    hass.data[OPNSENSE_DATA] = {"interfaces": interfaces_client}
 
     hass.async_create_task(
         async_load_platform(hass, "device_tracker", DOMAIN, tracker_interfaces, config)

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -1,7 +1,6 @@
 """Support for OPNSense Routers."""
 import logging
 
-from pyopnsense import diagnostics
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -37,6 +36,9 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the opnsense component."""
+
+    from pyopnsense import diagnostics
+
     conf = config[DOMAIN]
     url = conf[CONF_URL]
     api_key = conf[CONF_API_KEY]

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -1,6 +1,7 @@
 """Support for OPNSense Routers."""
 import logging
 
+from pyopnsense import diagnostics
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -36,8 +37,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the opnsense component."""
-
-    from pyopnsense import diagnostics
 
     conf = config[DOMAIN]
     url = conf[CONF_URL]

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -1,6 +1,7 @@
 """Support for OPNSense Routers."""
 import logging
 
+from pyopnsense import diagnostics
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -40,10 +41,8 @@ def setup(hass, config):
     url = conf[CONF_URL]
     api_key = conf[CONF_API_KEY]
     api_secret = conf[CONF_API_SECRET]
-    verify_ssl = conf.get(CONF_VERIFY_SSL, False)
+    verify_ssl = conf.get(CONF_VERIFY_SSL)
     tracker_interfaces = conf.get(CONF_TRACKER_INTERFACE, None)
-
-    from pyopnsense import diagnostics
 
     if tracker_interfaces:
         # Verify that specified tracker interfaces are valid

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -54,7 +54,7 @@ def setup(hass, config):
         for interface in tracker_interfaces:
             if interface not in interfaces:
                 _LOGGER.error(
-                    "Specified OPNsense tracker interface %s is not " "found", interface
+                    "Specified OPNsense tracker interface %s is not found", interface
                 )
                 return False
     else:

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -62,7 +62,6 @@ def setup(hass, config):
     interfaces_client = diagnostics.InterfaceClient(
         api_key, api_secret, url, verify_ssl
     )
-    clients = {"interfaces": interfaces_client}
     hass.data[OPNSENSE_DATA] = {"interfaces": interfaces_client}
 
     hass.async_create_task(

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -4,8 +4,8 @@ import logging
 from pyopnsense import diagnostics
 import voluptuous as vol
 
+from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
 from homeassistant.helpers.discovery import load_platform
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -41,7 +41,7 @@ def setup(hass, config):
     url = conf[CONF_URL]
     api_key = conf[CONF_API_KEY]
     api_secret = conf[CONF_API_SECRET]
-    verify_ssl = conf.get(CONF_VERIFY_SSL)
+    verify_ssl = conf[CONF_VERIFY_SSL]
     tracker_interfaces = conf.get(CONF_TRACKER_INTERFACE, None)
 
     if tracker_interfaces:

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -45,6 +45,15 @@ def setup(hass, config):
     verify_ssl = conf[CONF_VERIFY_SSL]
     tracker_interfaces = conf[CONF_TRACKER_INTERFACE]
 
+    interfaces_client = diagnostics.InterfaceClient(
+        api_key, api_secret, url, verify_ssl
+    )
+    try:
+        interfaces_client.get_arp()
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception("Failure while connecting to OPNsense API endpoint.")
+        return False
+
     if tracker_interfaces:
         # Verify that specified tracker interfaces are valid
         netinsight_client = diagnostics.NetworkInsightClient(
@@ -58,9 +67,6 @@ def setup(hass, config):
                 )
                 return False
 
-    interfaces_client = diagnostics.InterfaceClient(
-        api_key, api_secret, url, verify_ssl
-    )
     hass.data[OPNSENSE_DATA] = {"interfaces": interfaces_client}
 
     load_platform(hass, "device_tracker", DOMAIN, tracker_interfaces, config)

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -4,28 +4,34 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL)
+from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
 from homeassistant.helpers.discovery import async_load_platform
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_API_SECRET = 'api_secret'
-CONF_TRACKER_INTERFACE = 'tracker_interfaces'
+CONF_API_SECRET = "api_secret"
+CONF_TRACKER_INTERFACE = "tracker_interfaces"
 
-DOMAIN = 'opnsense'
+DOMAIN = "opnsense"
 
 OPNSENSE_DATA = DOMAIN
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_URL): cv.url,
-        vol.Required(CONF_API_KEY): cv.string,
-        vol.Required(CONF_API_SECRET): cv.string,
-        vol.Optional(CONF_VERIFY_SSL, default=False): cv.boolean,
-        vol.Optional(CONF_TRACKER_INTERFACE): vol.All(
-            cv.ensure_list, [cv.string]),
-    })
-}, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_URL): cv.url,
+                vol.Required(CONF_API_KEY): cv.string,
+                vol.Required(CONF_API_SECRET): cv.string,
+                vol.Optional(CONF_VERIFY_SSL, default=False): cv.boolean,
+                vol.Optional(CONF_TRACKER_INTERFACE): vol.All(
+                    cv.ensure_list, [cv.string]
+                ),
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 def setup(hass, config):
@@ -38,27 +44,29 @@ def setup(hass, config):
     tracker_interfaces = conf.get(CONF_TRACKER_INTERFACE, None)
 
     from pyopnsense import diagnostics
+
     if tracker_interfaces:
         # Verify that specified tracker interfaces are valid
-        netinsight_client = diagnostics.NetworkInsightClient(api_key,
-                                                             api_secret,
-                                                             url, verify_ssl)
+        netinsight_client = diagnostics.NetworkInsightClient(
+            api_key, api_secret, url, verify_ssl
+        )
         interfaces = list(netinsight_client.get_interfaces().values())
         for interface in tracker_interfaces:
             if interface not in interfaces:
-                _LOGGER.error('Specified OPNsense tracker interface %s is not '
-                              'found', interface)
+                _LOGGER.error(
+                    "Specified OPNsense tracker interface %s is not " "found", interface
+                )
                 return False
     else:
-        tracker_interfaces = ['LAN']
+        tracker_interfaces = ["LAN"]
 
-    interfaces_client = diagnostics.InterfaceClient(api_key, api_secret, url,
-                                                    verify_ssl)
-    clients = {
-        'interfaces': interfaces_client
-    }
+    interfaces_client = diagnostics.InterfaceClient(
+        api_key, api_secret, url, verify_ssl
+    )
+    clients = {"interfaces": interfaces_client}
     hass.data[OPNSENSE_DATA] = clients
 
-    hass.async_create_task(async_load_platform(
-        hass, 'device_tracker', DOMAIN, tracker_interfaces, config))
+    hass.async_create_task(
+        async_load_platform(hass, "device_tracker", DOMAIN, tracker_interfaces, config)
+    )
     return True

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -2,6 +2,7 @@
 import logging
 
 from pyopnsense import diagnostics
+from pyopnsense.exceptions import APIException
 import voluptuous as vol
 
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
@@ -50,7 +51,7 @@ def setup(hass, config):
     )
     try:
         interfaces_client.get_arp()
-    except Exception:  # pylint: disable=broad-except
+    except APIException:
         _LOGGER.exception("Failure while connecting to OPNsense API endpoint.")
         return False
 

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.device_tracker import DeviceScanner
 
-from homeassistant.components.opnsense import OPNSENSE_DATA
+from homeassistant.components.opnsense import OPNSENSE_DATA, CONF_TRACKER_INTERFACE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,7 +11,9 @@ _LOGGER = logging.getLogger(__name__)
 async def async_get_scanner(hass, config, discovery_info=None):
     """Configure the OPNSense device_tracker."""
     interface_client = hass.data[OPNSENSE_DATA]["interfaces"]
-    scanner = OPNSenseDeviceScanner(interface_client, discovery_info)
+    scanner = OPNSenseDeviceScanner(
+        interface_client, hass.data[OPNSENSE_DATA][CONF_TRACKER_INTERFACE]
+    )
     return scanner
 
 

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -17,7 +17,7 @@ async def async_get_scanner(hass, config, tracker_interfaces=None):
 
 
 class OPNSenseDeviceScanner(DeviceScanner):
-    """This class queries a router running ASUSWRT firmware."""
+    """This class queries a router running OPNsense."""
 
     # Eighth attribute needed for mode (AP mode vs router mode)
     def __init__(self, client, interfaces):
@@ -28,6 +28,7 @@ class OPNSenseDeviceScanner(DeviceScanner):
         self.interfaces = interfaces
 
     def _get_mac_addrs(self, devices):
+        """Create dict with mac address keys from list of devices."""
         out_devices = {}
         for device in devices:
             if device["intf_description"] in self.interfaces:

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -2,8 +2,7 @@
 import logging
 
 from homeassistant.components.device_tracker import DeviceScanner
-
-from homeassistant.components.opnsense import OPNSENSE_DATA, CONF_TRACKER_INTERFACE
+from homeassistant.components.opnsense import CONF_TRACKER_INTERFACE, OPNSENSE_DATA
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -8,11 +8,10 @@ from homeassistant.components.opnsense import OPNSENSE_DATA
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_get_scanner(hass, config, tracker_interfaces=None):
+async def async_get_scanner(hass, config, discovery_info=None):
     """Configure the OPNSense device_tracker."""
     interface_client = hass.data[OPNSENSE_DATA]["interfaces"]
-    interfaces = tracker_interfaces or ["LAN"]
-    scanner = OPNSenseDeviceScanner(interface_client, interfaces)
+    scanner = OPNSenseDeviceScanner(interface_client, discovery_info)
     return scanner
 
 
@@ -23,7 +22,6 @@ class OPNSenseDeviceScanner(DeviceScanner):
     def __init__(self, client, interfaces):
         """Initialize the scanner."""
         self.last_results = {}
-        self.success_init = False
         self.client = client
         self.interfaces = interfaces
 
@@ -38,7 +36,7 @@ class OPNSenseDeviceScanner(DeviceScanner):
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self.update_info()
-        return list(self.last_results.keys())
+        return list(self.last_results)
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
@@ -52,11 +50,9 @@ class OPNSenseDeviceScanner(DeviceScanner):
 
         Return boolean if scanning successful.
         """
-        _LOGGER.info("Checking Devices")
 
         devices = self.client.get_arp()
         self.last_results = self._get_mac_addrs(devices)
-        return True
 
     def get_extra_attributes(self, device):
         """Return the extra attrs of the given device."""

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -1,0 +1,67 @@
+"""Device tracker support for OPNSense routers."""
+import logging
+
+from homeassistant.components.device_tracker import DeviceScanner
+
+from homeassistant.components.opnsense import OPNSENSE_DATA
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_get_scanner(hass, config, tracker_interfaces=None):
+    """Configure the OPNSense device_tracker."""
+    interface_client = hass.data[OPNSENSE_DATA]['interfaces']
+    interfaces = tracker_interfaces or ['LAN']
+    scanner = OPNSenseDeviceScanner(interface_client, interfaces)
+    return scanner
+
+
+class OPNSenseDeviceScanner(DeviceScanner):
+    """This class queries a router running ASUSWRT firmware."""
+
+    # Eighth attribute needed for mode (AP mode vs router mode)
+    def __init__(self, client, interfaces):
+        """Initialize the scanner."""
+        self.last_results = {}
+        self.success_init = False
+        self.client = client
+        self.interfaces = interfaces
+
+    def _get_mac_addrs(self, devices):
+        out_devices = {}
+        for device in devices:
+            if device['intf_description'] in self.interfaces:
+                out_devices[device['mac']] = device
+        return out_devices
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self.update_info()
+        return list(self.last_results.keys())
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        if device not in self.last_results:
+            return None
+        hostname = self.last_results[device].get('hostname') or None
+        return hostname
+
+    def update_info(self):
+        """Ensure the information from the OPNSense router is up to date.
+
+        Return boolean if scanning successful.
+        """
+        _LOGGER.info('Checking Devices')
+
+        devices = self.client.get_arp()
+        self.last_results = self._get_mac_addrs(devices)
+        return True
+
+    def get_extra_attributes(self, device):
+        """Return the extra attrs of the given device."""
+        if device not in self.last_results:
+            return None
+        mfg = self.last_results[device].get('manufacturer')
+        if mfg:
+            return {'manufacturer': mfg}
+        return {}

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -10,8 +10,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_get_scanner(hass, config, tracker_interfaces=None):
     """Configure the OPNSense device_tracker."""
-    interface_client = hass.data[OPNSENSE_DATA]['interfaces']
-    interfaces = tracker_interfaces or ['LAN']
+    interface_client = hass.data[OPNSENSE_DATA]["interfaces"]
+    interfaces = tracker_interfaces or ["LAN"]
     scanner = OPNSenseDeviceScanner(interface_client, interfaces)
     return scanner
 
@@ -30,8 +30,8 @@ class OPNSenseDeviceScanner(DeviceScanner):
     def _get_mac_addrs(self, devices):
         out_devices = {}
         for device in devices:
-            if device['intf_description'] in self.interfaces:
-                out_devices[device['mac']] = device
+            if device["intf_description"] in self.interfaces:
+                out_devices[device["mac"]] = device
         return out_devices
 
     def scan_devices(self):
@@ -43,7 +43,7 @@ class OPNSenseDeviceScanner(DeviceScanner):
         """Return the name of the given device or None if we don't know."""
         if device not in self.last_results:
             return None
-        hostname = self.last_results[device].get('hostname') or None
+        hostname = self.last_results[device].get("hostname") or None
         return hostname
 
     def update_info(self):
@@ -51,7 +51,7 @@ class OPNSenseDeviceScanner(DeviceScanner):
 
         Return boolean if scanning successful.
         """
-        _LOGGER.info('Checking Devices')
+        _LOGGER.info("Checking Devices")
 
         devices = self.client.get_arp()
         self.last_results = self._get_mac_addrs(devices)
@@ -61,7 +61,7 @@ class OPNSenseDeviceScanner(DeviceScanner):
         """Return the extra attrs of the given device."""
         if device not in self.last_results:
             return None
-        mfg = self.last_results[device].get('manufacturer')
+        mfg = self.last_results[device].get("manufacturer")
         if mfg:
-            return {'manufacturer': mfg}
+            return {"manufacturer": mfg}
         return {}

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -18,7 +18,6 @@ async def async_get_scanner(hass, config, discovery_info=None):
 class OPNSenseDeviceScanner(DeviceScanner):
     """This class queries a router running OPNsense."""
 
-    # Eighth attribute needed for mode (AP mode vs router mode)
     def __init__(self, client, interfaces):
         """Initialize the scanner."""
         self.last_results = {}
@@ -29,7 +28,9 @@ class OPNSenseDeviceScanner(DeviceScanner):
         """Create dict with mac address keys from list of devices."""
         out_devices = {}
         for device in devices:
-            if device["intf_description"] in self.interfaces:
+            if not self.interfaces:
+                out_devices[device["mac"]] = device
+            elif device["intf_description"] in self.interfaces:
                 out_devices[device["mac"]] = device
         return out_devices
 

--- a/homeassistant/components/opnsense/manifest.json
+++ b/homeassistant/components/opnsense/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "opnsense",
+  "name": "OPNSense",
+  "documentation": "https://www.home-assistant.io/components/opnsense",
+  "requirements": [
+    "pyopnsense==0.2.0"
+  ],
+  "dependencies": [],
+  "codeowners": []
+}

--- a/homeassistant/components/opnsense/manifest.json
+++ b/homeassistant/components/opnsense/manifest.json
@@ -6,5 +6,5 @@
     "pyopnsense==0.2.0"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@mtreinish"]
 }

--- a/homeassistant/components/opnsense/manifest.json
+++ b/homeassistant/components/opnsense/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "opnsense",
   "name": "OPNSense",
-  "documentation": "https://www.home-assistant.io/components/opnsense",
+  "documentation": "https://www.home-assistant.io/integrations/opnsense",
   "requirements": [
     "pyopnsense==0.2.0"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1409,6 +1409,9 @@ pyombi==0.1.10
 # homeassistant.components.openuv
 pyopenuv==1.0.9
 
+# homeassistant.components.opnsense
+pyopnsense==0.2.0
+
 # homeassistant.components.opple
 pyoppleio==1.0.5
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -472,11 +472,11 @@ pynx584==0.4
 # homeassistant.components.openuv
 pyopenuv==1.0.9
 
-# homeassistant.components.opentherm_gw
-pyotgw==0.5b1
-
 # homeassistant.components.opnsense
 pyopnsense==0.2.0
+
+# homeassistant.components.opentherm_gw
+pyotgw==0.5b1
 
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -475,6 +475,9 @@ pyopenuv==1.0.9
 # homeassistant.components.opentherm_gw
 pyotgw==0.5b1
 
+# homeassistant.components.opnsense
+pyopnsense==0.2.0
+
 # homeassistant.auth.mfa_modules.notify
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.otp

--- a/tests/components/opnsense/__init__.py
+++ b/tests/components/opnsense/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the opnsense component."""

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -1,36 +1,36 @@
 """The tests for the opnsense device tracker platform."""
-from homeassistant.setup import async_setup_component
 
+import unittest
+from unittest import mock
+
+from homeassistant.components import opnsense
 from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN, OPNSENSE_DATA
 from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
+from homeassistant.setup import setup_component
 
-from tests.common import MockDependency, mock_coro_func
-
-FAKEFILE = None
-
-VALID_CONFIG_ROUTER_SSH = {
-    DOMAIN: {
-        CONF_URL: "https://fakehost",
-        CONF_API_KEY: "fake_key",
-        CONF_API_SECRET: "fake_secret",
-        CONF_VERIFY_SSL: False,
-    }
-}
+from tests.common import get_test_home_assistant
 
 
-async def test_get_scanner(hass):
-    """Test creating an opnsense scanner."""
-    with MockDependency("pyopnsense") as mocked_opnsense:
-        mocked_opnsense.diagnostic.InterfaceClient().get_arp = mock_coro_func()
-        mocked_opnsense.diagnostic.NetworkInsightClient().get_interfaces = mock_coro_func(
-            return_value={}
-        )
-        result = await async_setup_component(
-            hass,
+class TestOpnSenseDeviceTrackerSetup(unittest.TestCase):
+    """Test opnsense device tracker setup."""
+
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @mock.patch.object(opnsense, 'diagnostics')
+    def test_get_scanner(self, pyopnsense_mock):
+        """Test creating an opnsense scanner."""
+        result = setup_component(
+            self.hass,
             DOMAIN,
             {
                 DOMAIN: {
-                    CONF_URL: "https://fakehost",
+                    CONF_URL: "https://fake_host_fun/api",
                     CONF_API_KEY: "fake_key",
                     CONF_API_SECRET: "fake_secret",
                     CONF_VERIFY_SSL: False,
@@ -38,4 +38,5 @@ async def test_get_scanner(hass):
             },
         )
         assert result
-        assert hass.data[OPNSENSE_DATA] is not None
+        assert self.hass.data[OPNSENSE_DATA] is not None
+        assert pyopnsense_mock.has_calls()

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components import opnsense
 from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN
-from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
+from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.setup import async_setup_component
 
 

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -1,0 +1,45 @@
+"""The tests for the opnsense device tracker platform."""
+from homeassistant.setup import async_setup_component
+
+from homeassistant.components.opnsense import (
+    CONF_API_SECRET,
+    DOMAIN,
+    OPNSENSE_DATA,
+)
+from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
+
+from tests.common import MockDependency, mock_coro_func
+
+FAKEFILE = None
+
+VALID_CONFIG_ROUTER_SSH = {
+    DOMAIN: {
+        CONF_URL: "https://fakehost",
+        CONF_API_KEY: "fake_key",
+        CONF_API_SECRET: "fake_secret",
+        CONF_VERIFY_SSL: False,
+    }
+}
+
+
+async def test_get_scanner(hass):
+    """Test creating an opnsense scanner."""
+    with MockDependency("pyopnsense") as mocked_opnsense:
+        mocked_opnsense.diagnostic.InterfaceClient().get_arp = mock_coro_func()
+        mocked_opnsense.diagnostic.NetworkInsightClient().get_interfaces = mock_coro_func(
+            return_value={}
+        )
+        result = await async_setup_component(
+            hass,
+            DOMAIN,
+            {
+                DOMAIN: {
+                    CONF_URL: "https://fakehost",
+                    CONF_API_KEY: "fake_key",
+                    CONF_API_SECRET: "fake_secret",
+                    CONF_VERIFY_SSL: False,
+                }
+            },
+        )
+        assert result
+        assert hass.data[OPNSENSE_DATA] is not None

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -2,7 +2,7 @@
 
 from unittest import mock
 
-from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN, OPNSENSE_DATA
+from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN
 from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
 from homeassistant.setup import async_setup_component
 import homeassistant.components.device_tracker as device_tracker

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -2,59 +2,63 @@
 
 from unittest import mock
 
+import pytest
+
+from homeassistant.components import opnsense
 from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN
 from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
 from homeassistant.setup import async_setup_component
-import homeassistant.components.device_tracker as device_tracker
-
-from tests.common import MockDependency
 
 
-async def test_get_scanner(hass):
+@pytest.fixture(name="mocked_opnsense")
+def mocked_opnsense():
+    """Mock for pyopnense.diagnostics."""
+    with mock.patch.object(opnsense, "diagnostics") as mocked_opn:
+        yield mocked_opn
+
+
+async def test_get_scanner(hass, mocked_opnsense):
     """Test creating an opnsense scanner."""
-    with MockDependency("pyopnsense") as mocked_opnsense:
-        interface_client = mock.MagicMock()
-        mocked_opnsense.diagnostics.InterfaceClient.return_value = interface_client
-        interface_client.get_arp.return_value = [
-            {
-                "hostname": "",
-                "intf": "igb1",
-                "intf_description": "LAN",
-                "ip": "192.168.0.123",
-                "mac": "ff:ff:ff:ff:ff:ff",
-                "manufacturer": "",
-            },
-            {
-                "hostname": "Desktop",
-                "intf": "igb1",
-                "intf_description": "LAN",
-                "ip": "192.168.0.167",
-                "mac": "ff:ff:ff:ff:ff:fe",
-                "manufacturer": "OEM",
-            },
-        ]
-        network_insight_client = mock.MagicMock()
-        mocked_opnsense.diagnostics.NetworkInsightClient = network_insight_client
-        network_insight_client.get_interfaces.return_value = {
-            "igb0": "WAN",
-            "igb1": "LAN",
-        }
+    interface_client = mock.MagicMock()
+    mocked_opnsense.InterfaceClient.return_value = interface_client
+    interface_client.get_arp.return_value = [
+        {
+            "hostname": "",
+            "intf": "igb1",
+            "intf_description": "LAN",
+            "ip": "192.168.0.123",
+            "mac": "ff:ff:ff:ff:ff:ff",
+            "manufacturer": "",
+        },
+        {
+            "hostname": "Desktop",
+            "intf": "igb1",
+            "intf_description": "LAN",
+            "ip": "192.168.0.167",
+            "mac": "ff:ff:ff:ff:ff:fe",
+            "manufacturer": "OEM",
+        },
+    ]
+    network_insight_client = mock.MagicMock()
+    mocked_opnsense.NetworkInsightClient.return_value = network_insight_client
+    network_insight_client.get_interfaces.return_value = {"igb0": "WAN", "igb1": "LAN"}
 
-        result = await async_setup_component(
-            hass,
-            device_tracker.DOMAIN,
-            {
-                DOMAIN: {
-                    CONF_URL: "https://fake_host_fun/api",
-                    CONF_API_KEY: "fake_key",
-                    CONF_API_SECRET: "fake_secret",
-                    CONF_VERIFY_SSL: False,
-                }
-            },
-        )
-        assert result
-        device_1 = hass.states.get("device_tracker.desktop")
-        assert device_1 is not None
-        assert device_1.state == "not_home"
-        device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
-        assert device_2.state == "not_home"
+    result = await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_URL: "https://fake_host_fun/api",
+                CONF_API_KEY: "fake_key",
+                CONF_API_SECRET: "fake_secret",
+                CONF_VERIFY_SSL: False,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert result
+    device_1 = hass.states.get("device_tracker.desktop")
+    assert device_1 is not None
+    assert device_1.state == "home"
+    device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+    assert device_2.state == "home"

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -16,23 +16,29 @@ async def test_get_scanner(hass):
         interface_client = mock.MagicMock()
         mocked_opnsense.diagnostics.InterfaceClient.return_value = interface_client
         interface_client.get_arp.return_value = [
-            {'hostname': '',
-             'intf': 'igb1',
-             'intf_description': 'LAN',
-             'ip': '192.168.0.123',
-             'mac': 'ff:ff:ff:ff:ff:ff',
-             'manufacturer': ''},
-            {'hostname': 'Desktop',
-             'intf': 'igb1',
-             'intf_description': 'LAN',
-             'ip': '192.168.0.167',
-             'mac': 'ff:ff:ff:ff:ff:fe',
-             'manufacturer': 'OEM'}]
+            {
+                "hostname": "",
+                "intf": "igb1",
+                "intf_description": "LAN",
+                "ip": "192.168.0.123",
+                "mac": "ff:ff:ff:ff:ff:ff",
+                "manufacturer": "",
+            },
+            {
+                "hostname": "Desktop",
+                "intf": "igb1",
+                "intf_description": "LAN",
+                "ip": "192.168.0.167",
+                "mac": "ff:ff:ff:ff:ff:fe",
+                "manufacturer": "OEM",
+            },
+        ]
         network_insight_client = mock.MagicMock()
         mocked_opnsense.diagnostics.NetworkInsightClient = network_insight_client
         network_insight_client.get_interfaces.return_value = {
-            'igb0': 'WAN',
-            'igb1': 'LAN'}
+            "igb0": "WAN",
+            "igb1": "LAN",
+        }
 
         result = await async_setup_component(
             hass,
@@ -47,8 +53,8 @@ async def test_get_scanner(hass):
             },
         )
         assert result
-        device_1 = hass.states.get('device_tracker.desktop')
+        device_1 = hass.states.get("device_tracker.desktop")
         assert device_1 is not None
-        assert device_1.state == 'not_home'
-        device_2 = hass.states.get('device_tracker.ff_ff_ff_ff_ff_ff')
-        assert device_2.state == 'not_home'
+        assert device_1.state == "not_home"
+        device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+        assert device_2.state == "not_home"

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -1,11 +1,7 @@
 """The tests for the opnsense device tracker platform."""
 from homeassistant.setup import async_setup_component
 
-from homeassistant.components.opnsense import (
-    CONF_API_SECRET,
-    DOMAIN,
-    OPNSENSE_DATA,
-)
+from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN, OPNSENSE_DATA
 from homeassistant.const import CONF_URL, CONF_API_KEY, CONF_VERIFY_SSL
 
 from tests.common import MockDependency, mock_coro_func


### PR DESCRIPTION
## Description:

This commit adds a new component for using an OPNSense router as a
device tracker. It uses pyopnsense to query the api to look at the
arptable for a list of devices on the network.


**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10427

## Example entry for `configuration.yaml` (if applicable):
```yaml
opnsense:
   url: http://$router_ip/api
   api_key: api_key
   api_secret: api_secret
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
