### PR TITLE
Fix tahoma reversed closed status for non horizontal awnings

### DIFF
--- a/homeassistant/components/tahoma/cover.py
+++ b/homeassistant/components/tahoma/cover.py
@@ -137,14 +137,13 @@ class TahomaCover(TahomaDevice, CoverDevice):
         if self._closure is not None:
             if self.tahoma_device.type == HORIZONTAL_AWNING:
                 self._position = self._closure
-                self._closed = self._position == 0
             else:
                 self._position = 100 - self._closure
-                self._closed = self._position == 100
             if self._position <= 5:
                 self._position = 0
             if self._position >= 95:
                 self._position = 100
+            self._closed = self._position == 0
         else:
             self._position = None
             if "core:OpenClosedState" in self.tahoma_device.active_states:


### PR DESCRIPTION
### Home Assistant release with the issue:
0.99.2

### Operating environment (Hass.io/Docker/Windows/etc.):
Hass.io

### Description:

**Related issue:** fixes #25240
Also fixes the closed status when the position is changed when the position is `<= 5` or when the position is `>= 95`.

The problem appeared in #23257 where the right closed status has been modified for non horizontal awnings (file `homeassistant/components/tahoma/cover.py`, removed line 117).

## Example entry for `configuration.yaml`
```yaml
tahoma:
  username: TAHOMA_USERNAME
  password: TAHOMA_PASSWORD
```
