### PR TITLE
Bump homematicip_cloud to 0.10.11

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/homematicip_cloud",
   "requirements": [
-    "homematicip==0.10.10"
+    "homematicip==0.10.11"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -647,7 +647,7 @@ homeassistant-pyozw==0.1.4
 homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.10
+homematicip==0.10.11
 
 # homeassistant.components.horizon
 horimote==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -187,7 +187,7 @@ home-assistant-frontend==20190919.0
 homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.10
+homematicip==0.10.11
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk


### PR DESCRIPTION
## Description:
Bump homematicip_cloud to 0.10.11

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
