### PR TITLE
added wait-for-it package in requirements so those using docker-compose…

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -24,6 +24,7 @@ ruamel.yaml==0.15.100
 sqlalchemy==1.3.8
 voluptuous-serialize==2.2.0
 voluptuous==0.11.7
+wait-for-it==1.1.2
 zeroconf==0.23.0
 
 pycryptodome>=3.6.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,6 +18,7 @@ requests==2.22.0
 ruamel.yaml==0.15.100
 voluptuous==0.11.7
 voluptuous-serialize==2.2.0
+wait-for-it==1.1.2
 
 # homeassistant.components.nuimo_controller
 --only-binary=all nuimo==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -20,7 +20,7 @@ pytest-sugar==0.9.2
 pytest-timeout==1.3.3
 pytest==5.1.3
 requests_mock==1.7.0
-wait-for-it==1.1.2
+
 
 # homeassistant.components.homekit
 HAP-python==2.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -20,7 +20,7 @@ pytest-sugar==0.9.2
 pytest-timeout==1.3.3
 pytest==5.1.3
 requests_mock==1.7.0
-
+wait-for-it==1.1.2
 
 # homeassistant.components.homekit
 HAP-python==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ REQUIRES = [
     "ruamel.yaml==0.15.100",
     "voluptuous==0.11.7",
     "voluptuous-serialize==2.2.0",
+    "wait-for-it==1.1.2",
 ]
 
 MIN_PY_VERSION = ".".join(map(str, hass_const.REQUIRED_PYTHON_VER))


### PR DESCRIPTION
…can use it to wait for whatever sql server before starting home-assistant

**Adding the wait-for-it package so those using docker-compose can use it to wait for whatver sql server they are using like so:**

> If using MySQL:

`command: ["wait-for-it", "--service 192.168.19.xx:3306", "--timeout 0", "--", "python", "-m", "homeassistant", "--config", "/config"]`

## Breaking Change:

**None!**

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
