### PR TITLE
Add unit to 'charging_level_hv' bwm_connected_drive sensor

### DIFF
--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -24,6 +24,8 @@ ATTR_TO_HA_METRIC = {
     "remaining_fuel": ["mdi:gas-station", VOLUME_LITERS],
     "charging_time_remaining": ["mdi:update", "h"],
     "charging_status": ["mdi:battery-charging", None],
+    #No icon as this is dealt with directly as a special case in icon()
+    "charging_level_hv": [None, "%"],
 }
 
 ATTR_TO_HA_IMPERIAL = {
@@ -35,6 +37,8 @@ ATTR_TO_HA_IMPERIAL = {
     "remaining_fuel": ["mdi:gas-station", VOLUME_GALLONS],
     "charging_time_remaining": ["mdi:update", "h"],
     "charging_status": ["mdi:battery-charging", None],
+    #No icon as this is dealt with directly as a special case in icon()
+    "charging_level_hv": [None, "%"],
 }
 
 

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -24,7 +24,7 @@ ATTR_TO_HA_METRIC = {
     "remaining_fuel": ["mdi:gas-station", VOLUME_LITERS],
     "charging_time_remaining": ["mdi:update", "h"],
     "charging_status": ["mdi:battery-charging", None],
-    #No icon as this is dealt with directly as a special case in icon()
+    # No icon as this is dealt with directly as a special case in icon()
     "charging_level_hv": [None, "%"],
 }
 
@@ -37,7 +37,7 @@ ATTR_TO_HA_IMPERIAL = {
     "remaining_fuel": ["mdi:gas-station", VOLUME_GALLONS],
     "charging_time_remaining": ["mdi:update", "h"],
     "charging_status": ["mdi:battery-charging", None],
-    #No icon as this is dealt with directly as a special case in icon()
+    # No icon as this is dealt with directly as a special case in icon()
     "charging_level_hv": [None, "%"],
 }
 


### PR DESCRIPTION
## Description:

This PR adds a unit to the 'charging_level_hv' sensor, which allows the UI to graph the values as a line graph rather than a bar graph of individual values.

**Related issue (if applicable):** fixes # n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io# n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
