### PR TITLE
Add reproduce state template

### DIFF
--- a/script/scaffold/__main__.py
+++ b/script/scaffold/__main__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import subprocess
 import sys
 
-from . import gather_info, generate, error
+from . import gather_info, generate, error, docs
 from .const import COMPONENT_DIR
 
 
@@ -65,15 +65,19 @@ def main():
     print()
 
     print("Running tests")
-    print(f"$ pytest tests/components/{info.domain}")
+    print(f"$ pytest -v tests/components/{info.domain}")
     if (
-        subprocess.run(f"pytest tests/components/{info.domain}", shell=True).returncode
+        subprocess.run(
+            f"pytest -v tests/components/{info.domain}", shell=True
+        ).returncode
         != 0
     ):
         return 1
     print()
 
     print(f"Done!")
+
+    docs.print_relevant_docs(args.template, info)
 
     return 0
 

--- a/script/scaffold/docs.py
+++ b/script/scaffold/docs.py
@@ -20,3 +20,14 @@ https://developers.home-assistant.io/docs/en/creating_integration_file_structure
 The config flow has been added to the {info.domain} integration. Next step is to fill in the blanks for the code marked with TODO.
 """
         )
+
+    elif template == "reproduce_state":
+        print(
+            f"""
+Reproduce state code has been added to the {info.domain} integration:
+ - {info.integration_dir / "reproduce_state.py"}
+ - {info.tests_dir / "test_reproduce_state.py"}
+
+Please update the relevant items marked as TODO before submitting a pull request.
+"""
+        )

--- a/script/scaffold/templates/reproduce_state/integration/reproduce_state.py
+++ b/script/scaffold/templates/reproduce_state/integration/reproduce_state.py
@@ -66,6 +66,8 @@ async def async_reproduce_states(
     hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
 ) -> None:
     """Reproduce NEW_NAME states."""
+    # TODO pick one and remove other one
+
     # Reproduce states in parallel.
     await asyncio.gather(
         *(_async_reproduce_state(hass, state, context) for state in states)

--- a/script/scaffold/templates/reproduce_state/integration/reproduce_state.py
+++ b/script/scaffold/templates/reproduce_state/integration/reproduce_state.py
@@ -1,0 +1,76 @@
+"""Reproduce an NEW_NAME state."""
+import asyncio
+import logging
+from typing import Iterable, Optional
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_ON,
+    STATE_OFF,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.core import Context, State
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# TODO add valid states here
+VALID_STATES = {STATE_ON, STATE_OFF}
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistantType, state: State, context: Optional[Context] = None
+) -> None:
+    """Reproduce a single state."""
+    cur_state = hass.states.get(state.entity_id)
+
+    if cur_state is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if state.state not in VALID_STATES:
+        _LOGGER.warning(
+            "Invalid state specified for %s: %s", state.entity_id, state.state
+        )
+        return
+
+    # Return if we are already at the right state.
+    if (
+        cur_state.state == state.state
+        and
+        # TODO this is an example attribute
+        cur_state.attributes.get("color") == state.attributes.get("color")
+    ):
+        return
+
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    # TODO determine the services to call to achieve desired state
+    if state.state == STATE_ON:
+        service = SERVICE_TURN_ON
+        if "color" in state.attributes:
+            service_data["color"] = state.attributes["color"]
+
+    elif state.state == STATE_OFF:
+        service = SERVICE_TURN_OFF
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
+) -> None:
+    """Reproduce NEW_NAME states."""
+    # Reproduce states in parallel.
+    await asyncio.gather(
+        *(_async_reproduce_state(hass, state, context) for state in states)
+    )
+
+    # Alternative: Reproduce states in sequence
+    # for state in states:
+    #     await _async_reproduce_state(hass, state, context)

--- a/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
+++ b/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
@@ -1,0 +1,47 @@
+"""Test reproduce state for NEW_NAME."""
+from homeassistant.core import State
+
+from tests.common import async_mock_service
+
+
+async def test_reproducing_states(hass):
+    """Test reproducing NEW_NAME states."""
+    hass.states.async_set("NEW_DOMAIN.entity_off", "off", {})
+    hass.states.async_set("NEW_DOMAIN.entity_on", "on", {"color": "red"})
+
+    turn_on_calls = async_mock_service(hass, "NEW_DOMAIN", "turn_on")
+    turn_off_calls = async_mock_service(hass, "NEW_DOMAIN", "turn_off")
+
+    # These calls should do nothing as entities already in desired state
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("NEW_DOMAIN.entity_off", "off"),
+            State("NEW_DOMAIN.entity_on", "on", {"color": "red"}),
+        ],
+        blocking=True,
+    )
+
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+
+    # Make sure correct services are called
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("NEW_DOMAIN.entity_on", "off"),
+            State("NEW_DOMAIN.entity_off", "on", {"color": "red"}),
+            # Should not raise
+            State("NEW_DOMAIN.non_existing", "on"),
+        ],
+        blocking=True,
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "NEW_DOMAIN"
+    assert turn_on_calls[0].data == {
+        "entity_id": "NEW_DOMAIN.entity_off",
+        "color": "red",
+    }
+
+    assert len(turn_off_calls) == 1
+    assert turn_off_calls[0].domain == "NEW_DOMAIN"
+    assert turn_off_calls[0].data == {"entity_id": "NEW_DOMAIN.entity_on"}

--- a/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
+++ b/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
@@ -4,7 +4,7 @@ from homeassistant.core import State
 from tests.common import async_mock_service
 
 
-async def test_reproducing_states(hass):
+async def test_reproducing_states(hass, caplog):
     """Test reproducing NEW_NAME states."""
     hass.states.async_set("NEW_DOMAIN.entity_off", "off", {})
     hass.states.async_set("NEW_DOMAIN.entity_on", "on", {"color": "red"})
@@ -21,6 +21,15 @@ async def test_reproducing_states(hass):
         blocking=True,
     )
 
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+
+    # Test invalid state is handled
+    await hass.helpers.state.async_reproduce_state(
+        [State("NEW_DOMAIN.entity_off", "not_supported")], blocking=True
+    )
+
+    assert "not_supported" in caplog.text
     assert len(turn_on_calls) == 0
     assert len(turn_off_calls) == 0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,13 @@ max-line-length = 88
 # W503: Line break occurred before a binary operator
 # E203: Whitespace before ':'
 # D202 No blank lines allowed after function docstring
+# W504 line break after binary operator
 ignore =
     E501,
     W503,
     E203,
-    D202
+    D202,
+    W504
 
 [isort]
 # https://github.com/timothycrosley/isort


### PR DESCRIPTION
## Description:
This adds a reproduce_state template to the scaffold script. To get started adding reproduce_state support to a new integration, type `python3 -m script.scaffold reproduce_state`.

This should help with #25681

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
