### PR TITLE
Add call direction sensor for Obihai

### DIFF
--- a/homeassistant/components/obihai/manifest.json
+++ b/homeassistant/components/obihai/manifest.json
@@ -3,7 +3,7 @@
     "name": "Obihai",
     "documentation": "https://www.home-assistant.io/components/obihai",
     "requirements": [
-      "pyobihai==1.1.0"
+      "pyobihai==1.1.1"
     ],
     "dependencies": [],
     "codeowners": ["@dshokouhi"]

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -49,7 +49,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     login = pyobihai.check_account(host, username, password)
     if not login:
         _LOGGER.error("Invalid credentials")
-        return False
+        return
 
     services = pyobihai.get_state(host, username, password)
 

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -47,33 +47,26 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     pyobihai = PyObihai()
 
     login = pyobihai.check_account(host, username, password)
-    if login:
-
-        services = pyobihai.get_state(host, username, password)
-
-        line_services = pyobihai.get_line_state(host, username, password)
-
-        call_direction = pyobihai.get_call_direction(host, username, password)
-
-        for key in services:
-            sensors.append(
-                ObihaiServiceSensors(pyobihai, host, username, password, key)
-            )
-
-        for key in line_services:
-            sensors.append(
-                ObihaiServiceSensors(pyobihai, host, username, password, key)
-            )
-
-        for key in call_direction:
-            sensors.append(
-                ObihaiServiceSensors(pyobihai, host, username, password, key)
-            )
-
-        add_entities(sensors)
-    else:
+    if not login:
         _LOGGER.error("Invalid credentials")
         return False
+
+    services = pyobihai.get_state(host, username, password)
+
+    line_services = pyobihai.get_line_state(host, username, password)
+
+    call_direction = pyobihai.get_call_direction(host, username, password)
+
+    for key in services:
+        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+
+    for key in line_services:
+        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+
+    for key in call_direction:
+        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+
+    add_entities(sensors)
 
 
 class ObihaiServiceSensors(Entity):

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -50,10 +50,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     line_services = pyobihai.get_line_state(host, username, password)
 
+    call_direction = pyobihai.get_call_direction(host, username, password)
+
     for key in services:
         sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
 
     for key in line_services:
+        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+
+    for key in call_direction:
         sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
 
     add_entities(sensors)
@@ -102,3 +107,10 @@ class ObihaiServiceSensors(Entity):
 
         if self._service_name in services:
             self._state = services.get(self._service_name)
+
+        call_direction = self._pyobihai.get_call_direction(
+            self._host, self._username, self._password
+        )
+
+        if self._service_name in call_direction:
+            self._state = call_direction.get(self._service_name)

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -46,22 +46,34 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     pyobihai = PyObihai()
 
-    services = pyobihai.get_state(host, username, password)
+    login = pyobihai.check_account(host, username, password)
+    if login:
 
-    line_services = pyobihai.get_line_state(host, username, password)
+        services = pyobihai.get_state(host, username, password)
 
-    call_direction = pyobihai.get_call_direction(host, username, password)
+        line_services = pyobihai.get_line_state(host, username, password)
 
-    for key in services:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        call_direction = pyobihai.get_call_direction(host, username, password)
 
-    for key in line_services:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        for key in services:
+            sensors.append(
+                ObihaiServiceSensors(pyobihai, host, username, password, key)
+            )
 
-    for key in call_direction:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        for key in line_services:
+            sensors.append(
+                ObihaiServiceSensors(pyobihai, host, username, password, key)
+            )
 
-    add_entities(sensors)
+        for key in call_direction:
+            sensors.append(
+                ObihaiServiceSensors(pyobihai, host, username, password, key)
+            )
+
+        add_entities(sensors)
+    else:
+        _LOGGER.error("Invalid credentials")
+        return False
 
 
 class ObihaiServiceSensors(Entity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1346,7 +1346,7 @@ pynx584==0.4
 pynzbgetapi==0.2.0
 
 # homeassistant.components.obihai
-pyobihai==1.1.0
+pyobihai==1.1.1
 
 # homeassistant.components.ombi
 pyombi==0.1.5


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Add a call direction sensor for Obihai.  States are `No Active Calls` `Inbound Call` or `Outbound Call`

**Related issue (if applicable):** fixes #N/A
**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: obihai
    host: 192.168.1.x
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
