### PR TITLE
Add Apprise notification integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -47,7 +47,6 @@ omit =
     homeassistant/components/apache_kafka/*
     homeassistant/components/apcupsd/*
     homeassistant/components/apple_tv/*
-    homeassistant/components/apprise/*
     homeassistant/components/aqualogic/*
     homeassistant/components/aquostv/media_player.py
     homeassistant/components/arcam_fmj/media_player.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -47,6 +47,7 @@ omit =
     homeassistant/components/apache_kafka/*
     homeassistant/components/apcupsd/*
     homeassistant/components/apple_tv/*
+    homeassistant/components/apprise/*
     homeassistant/components/aqualogic/*
     homeassistant/components/aquostv/media_player.py
     homeassistant/components/arcam_fmj/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,6 +26,7 @@ homeassistant/components/ambient_station/* @bachya
 homeassistant/components/androidtv/* @JeffLIrion
 homeassistant/components/apache_kafka/* @bachya
 homeassistant/components/api/* @home-assistant/core
+homeassistant/components/apprise/* @caronc
 homeassistant/components/aprs/* @PhilRW
 homeassistant/components/arcam_fmj/* @elupus
 homeassistant/components/arduino/* @fabaff

--- a/homeassistant/components/apprise/__init__.py
+++ b/homeassistant/components/apprise/__init__.py
@@ -1,0 +1,1 @@
+"""The apprise component."""

--- a/homeassistant/components/apprise/manifest.json
+++ b/homeassistant/components/apprise/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "apprise",
+  "name": "Apprise",
+  "documentation": "https://www.home-assistant.io/components/apprise",
+  "requirements": [
+    "apprise==0.8.0"
+  ],
+  "dependencies": [],
+  "codeowners": []
+}

--- a/homeassistant/components/apprise/manifest.json
+++ b/homeassistant/components/apprise/manifest.json
@@ -6,5 +6,7 @@
     "apprise==0.8.0"
   ],
   "dependencies": [],
-  "codeowners": ["@caronc"]
+  "codeowners": [
+    "@caronc"
+  ]
 }

--- a/homeassistant/components/apprise/manifest.json
+++ b/homeassistant/components/apprise/manifest.json
@@ -6,5 +6,5 @@
     "apprise==0.8.0"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@caronc"]
 }

--- a/homeassistant/components/apprise/manifest.json
+++ b/homeassistant/components/apprise/manifest.json
@@ -3,7 +3,7 @@
   "name": "Apprise",
   "documentation": "https://www.home-assistant.io/components/apprise",
   "requirements": [
-    "apprise==0.8.0"
+    "apprise==0.8.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -8,6 +8,7 @@ import apprise
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.notify import (
+    ATTR_TARGET,
     ATTR_TITLE,
     ATTR_TITLE_DEFAULT,
     PLATFORM_SCHEMA,
@@ -61,6 +62,12 @@ class AppriseNotificationService(BaseNotificationService):
         self.apprise = a_obj
 
     def send_message(self, message="", **kwargs):
-        """Send a message to a specified target."""
+        """Send a message to a specified target.
+
+        If no target/tags are specified, then services are notified as is
+        However, if any tags are specified, then they will be applied
+        to the notification causing filtering (if set up that way)
+        """
+        targets = kwargs.get(ATTR_TARGET)
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
-        self.apprise.notify(body=message, title=title)
+        self.apprise.notify(body=message, title=title, tag=targets)

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 
-from apprise import Apprise, AppriseConfig
+import apprise
 
 import homeassistant.helpers.config_validation as cv
 
@@ -31,11 +31,11 @@ def get_service(hass, config, discovery_info=None):
     """Get the Apprise notification service."""
 
     # Create our object
-    a_obj = Apprise()
+    a_obj = apprise.Apprise()
 
     if config.get(CONF_FILE):
         # Sourced from a Configuration File
-        a_config = AppriseConfig()
+        a_config = apprise.AppriseConfig()
         if not a_config.add(config[CONF_FILE]):
             _LOGGER.error("Invalid Apprise config url provided")
             return None
@@ -50,12 +50,6 @@ def get_service(hass, config, discovery_info=None):
             _LOGGER.error("Invalid Apprise URL(s) supplied")
             return None
 
-    loaded = len(a_obj)
-    if not loaded:
-        _LOGGER.error("No Apprise services were loaded")
-        return None
-
-    _LOGGER.debug("Loaded %d Apprise service(s).", loaded)
     return AppriseNotificationService(a_obj)
 
 

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -30,30 +30,32 @@ def get_service(hass, config, discovery_info=None):
     from apprise import Apprise, AppriseConfig
 
     # Create our object
-    a = Apprise()
+    a_obj = Apprise()
 
     if config.get(CONF_FILE):
         # Sourced from a Configuration File
-        ac = AppriseConfig()
-        if not ac.add(config[CONF_FILE]):
+        a_config = AppriseConfig()
+        if not a_config.add(config[CONF_FILE]):
             _LOGGER.error("Invalid Apprise config url provided")
             return None
 
-        elif not a.add(ac):
+        if not a_obj.add(a_config):
             _LOGGER.error("Invalid Apprise config url provided")
             return None
 
     if config.get(CONF_URL):
         # Ordered list of URLs
-        if not a.add(config[CONF_URL]):
+        if not a_obj.add(config[CONF_URL]):
             _LOGGER.error("Invalid Apprise URL(s) supplied")
             return None
 
-    if len(a) == 0:
+    loaded = len(a_obj)
+    if not loaded:
         _LOGGER.error("No Apprise services were loaded.")
         return None
 
-    return AppriseNotificationService(a)
+    _LOGGER.info("Loaded %d Apprise service(s).", loaded)
+    return AppriseNotificationService(a_obj)
 
 
 class AppriseNotificationService(BaseNotificationService):

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -52,10 +52,10 @@ def get_service(hass, config, discovery_info=None):
 
     loaded = len(a_obj)
     if not loaded:
-        _LOGGER.error("No Apprise services were loaded.")
+        _LOGGER.error("No Apprise services were loaded")
         return None
 
-    _LOGGER.info("Loaded %d Apprise service(s).", loaded)
+    _LOGGER.debug("Loaded %d Apprise service(s).", loaded)
     return AppriseNotificationService(a_obj)
 
 

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -3,6 +3,8 @@ import logging
 
 import voluptuous as vol
 
+from apprise import Apprise, AppriseConfig
+
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.notify import (
@@ -27,7 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_service(hass, config, discovery_info=None):
     """Get the Apprise notification service."""
-    from apprise import Apprise, AppriseConfig
 
     # Create our object
     a_obj = Apprise()

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -1,0 +1,71 @@
+"""Apprise platform for notify component."""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+from homeassistant.components.notify import (
+    ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
+    PLATFORM_SCHEMA,
+    BaseNotificationService,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FILE = "config"
+CONF_URL = "url"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_URL): vol.All(cv.ensure_list, [str]),
+        vol.Optional(CONF_FILE): cv.string
+    }
+)
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Apprise notification service."""
+    from apprise import Apprise
+    from apprise import AppriseConfig
+
+    # Create our object
+    a = Apprise()
+
+    if config.get(CONF_FILE):
+        # Sourced from a Configuration File
+        ac = AppriseConfig()
+        if not ac.add(config[CONF_FILE]):
+            _LOGGER.error("Invalid Apprise config url provided")
+            return None
+
+        elif not a.add(ac):
+            _LOGGER.error("Invalid Apprise config url provided")
+            return None
+
+    if config.get(CONF_URL):
+        # Ordered list of URLs
+        if not a.add(config[CONF_URL]):
+            _LOGGER.error("Invalid Apprise URL(s) supplied")
+            return None
+
+    if len(a) == 0:
+        _LOGGER.error("No Apprise services were loaded.")
+        return None
+
+    return AppriseNotificationService(a)
+
+
+class AppriseNotificationService(BaseNotificationService):
+    """Implement the notification service for Apprise."""
+
+    def __init__(self, a_obj):
+        """Initialize the service."""
+        self.apprise = a_obj
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to a specified target.
+        """
+        title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+        self.apprise.notify(body=message, title=title)

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -66,7 +66,7 @@ class AppriseNotificationService(BaseNotificationService):
 
         If no target/tags are specified, then services are notified as is
         However, if any tags are specified, then they will be applied
-        to the notification causing filtering (if set up that way)
+        to the notification causing filtering (if set up that way).
         """
         targets = kwargs.get(ATTR_TARGET)
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -20,15 +20,14 @@ CONF_URL = "url"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_URL): vol.All(cv.ensure_list, [str]),
-        vol.Optional(CONF_FILE): cv.string
+        vol.Optional(CONF_FILE): cv.string,
     }
 )
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the Apprise notification service."""
-    from apprise import Apprise
-    from apprise import AppriseConfig
+    from apprise import Apprise, AppriseConfig
 
     # Create our object
     a = Apprise()
@@ -65,7 +64,6 @@ class AppriseNotificationService(BaseNotificationService):
         self.apprise = a_obj
 
     def send_message(self, message="", **kwargs):
-        """Send a message to a specified target.
-        """
+        """Send a message to a specified target."""
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         self.apprise.notify(body=message, title=title)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -217,6 +217,9 @@ apcaccess==0.0.13
 # homeassistant.components.apns
 apns2==0.3.0
 
+# homeassistant.components.apprise
+apprise==0.8.0
+
 # homeassistant.components.aprs
 aprslib==0.6.46
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -218,7 +218,7 @@ apcaccess==0.0.13
 apns2==0.3.0
 
 # homeassistant.components.apprise
-apprise==0.8.0
+apprise==0.8.1
 
 # homeassistant.components.aprs
 aprslib==0.6.46

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -104,7 +104,7 @@ androidtv==0.0.30
 apns2==0.3.0
 
 # homeassistant.components.apprise
-apprise==0.8.0
+apprise==0.8.1
 
 # homeassistant.components.aprs
 aprslib==0.6.46

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -103,6 +103,9 @@ androidtv==0.0.30
 # homeassistant.components.apns
 apns2==0.3.0
 
+# homeassistant.components.apprise
+apprise==0.8.0
+
 # homeassistant.components.aprs
 aprslib==0.6.46
 

--- a/tests/components/apprise/__init__.py
+++ b/tests/components/apprise/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the apprise component."""

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -25,11 +25,7 @@ class TestApprise(unittest.TestCase):
     def test_apprise_config(self, mock__get_data):
         """Test setup."""
         config = {
-            notify.DOMAIN: {
-                "name": "test",
-                "platform": "apprise",
-                "url": "dbus://",
-            }
+            notify.DOMAIN: {"name": "test", "platform": "apprise", "url": "dbus://"}
         }
         with assert_setup_component(1) as handle_config:
             assert setup_component(self.hass, notify.DOMAIN, config)
@@ -54,11 +50,7 @@ class TestApprise(unittest.TestCase):
     def test_apprise_push_default(self, mock, mock__get_data):
         """Test simple apprise push."""
         config = {
-            notify.DOMAIN: {
-                "name": "test",
-                "platform": "apprise",
-                "url": "windows://",
-            }
+            notify.DOMAIN: {"name": "test", "platform": "apprise", "url": "windows://"}
         }
         with assert_setup_component(1) as handle_config:
             assert setup_component(self.hass, notify.DOMAIN, config)

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -1,9 +1,11 @@
 """The tests for the apprise notification platform."""
+import os
 import unittest
 from unittest.mock import patch
+from tempfile import mkdtemp
 
 from apprise import Apprise
-import requests_mock
+from apprise import AppriseConfig
 
 from homeassistant.setup import setup_component
 import homeassistant.components.notify as notify
@@ -13,17 +15,44 @@ from tests.common import assert_setup_component, get_test_home_assistant
 class TestApprise(unittest.TestCase):
     """Tests the Apprise Component."""
 
+    tmp_dir = None
+
     def setUp(self):
         """Initialize values for this test case class."""
         self.hass = get_test_home_assistant()
+        self.tmp_dir = mkdtemp()
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop everything that we started."""
         self.hass.stop()
+        for fname in os.listdir(self.tmp_dir):
+            os.remove(os.path.join(self.tmp_dir, fname))
+        os.rmdir(self.tmp_dir)
 
-    @patch.object(Apprise, "notify", return_value=True)
-    def test_apprise_config(self, mock__get_data):
-        """Test setup."""
+    @patch.object(AppriseConfig, "add", return_value=False)
+    def test_apprise_config_bad_conf_add(self, __mockcfg_add):
+        """Test set up the platform with bad/missing file configuration."""
+        config = {
+            notify.DOMAIN: {"name": "test", "platform": "apprise", "config": "/path/"}
+        }
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+
+    @patch.object(Apprise, "add", return_value=False)
+    @patch.object(AppriseConfig, "add", return_value=True)
+    def test_apprise_config_bad_conf_save(self, __mock_add, __mockcfg_add):
+        """Test set up the platform failing to save config data."""
+        config = {
+            notify.DOMAIN: {"name": "test", "platform": "apprise", "config": "/path/"}
+        }
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+
+    @patch.object(Apprise, "add", return_value=False)
+    def test_apprise_bad_url(self, __mock_notify):
+        """Test set up the platform with bad/missing configuration."""
         config = {
             notify.DOMAIN: {"name": "test", "platform": "apprise", "url": "dbus://"}
         }
@@ -31,13 +60,13 @@ class TestApprise(unittest.TestCase):
             assert setup_component(self.hass, notify.DOMAIN, config)
         assert handle_config[notify.DOMAIN]
 
-    def test_apprise_config_bad(self):
-        """Test set up the platform with bad/missing configuration."""
+    def test_apprise_config_bad_url(self):
+        """Test set up the platform with bad/missing url configuration."""
         config = {
             notify.DOMAIN: {
                 "name": "test",
                 "platform": "apprise",
-                # Expects a list
+                # Expects an actual URL
                 "url": 1,
             }
         }
@@ -45,13 +74,31 @@ class TestApprise(unittest.TestCase):
             assert setup_component(self.hass, notify.DOMAIN, config)
         assert not handle_config[notify.DOMAIN]
 
-    @requests_mock.Mocker()
     @patch.object(Apprise, "notify", return_value=True)
-    def test_apprise_push_default(self, mock, mock__get_data):
-        """Test simple apprise push."""
+    def test_apprise_url(self, __mock_notify):
+        """Test simple apprise push using URL config."""
         config = {
             notify.DOMAIN: {"name": "test", "platform": "apprise", "url": "windows://"}
         }
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        data = {"title": "Test Title", "message": "Test Message"}
+        assert not self.hass.services.call(notify.DOMAIN, "test", data)
+        self.hass.block_till_done()
+
+    @patch.object(Apprise, "notify", return_value=True)
+    def test_apprise_config(self, __mock_notify):
+        """Test simple apprise push using AppriseConfig."""
+        tmp_cfg = os.path.join(self.tmp_dir, "apprise.txt")
+        config = {
+            notify.DOMAIN: {"name": "test", "platform": "apprise", "config": tmp_cfg}
+        }
+
+        with open(tmp_cfg, "w+") as f:
+            # Write a simple text based configuration file
+            f.write("windows://")
+
         with assert_setup_component(1) as handle_config:
             assert setup_component(self.hass, notify.DOMAIN, config)
         assert handle_config[notify.DOMAIN]

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -1,0 +1,68 @@
+"""The tests for the apprise notification platform."""
+import unittest
+from unittest.mock import patch
+
+from apprise import Apprise
+import requests_mock
+
+from homeassistant.setup import setup_component
+import homeassistant.components.notify as notify
+from tests.common import assert_setup_component, get_test_home_assistant
+
+
+class TestApprise(unittest.TestCase):
+    """Tests the Apprise Component."""
+
+    def setUp(self):
+        """Initialize values for this test case class."""
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that we started."""
+        self.hass.stop()
+
+    @patch.object(Apprise, "notify", return_value=True)
+    def test_apprise_config(self, mock__get_data):
+        """Test setup."""
+        config = {
+            notify.DOMAIN: {
+                "name": "test",
+                "platform": "apprise",
+                "url": "dbus://",
+            }
+        }
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+
+    def test_apprise_config_bad(self):
+        """Test set up the platform with bad/missing configuration."""
+        config = {
+            notify.DOMAIN: {
+                "name": "test",
+                "platform": "apprise",
+                # Expects a list
+                "url": 1,
+            }
+        }
+        with assert_setup_component(0) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert not handle_config[notify.DOMAIN]
+
+    @requests_mock.Mocker()
+    @patch.object(Apprise, "notify", return_value=True)
+    def test_apprise_push_default(self, mock, mock__get_data):
+        """Test simple apprise push."""
+        config = {
+            notify.DOMAIN: {
+                "name": "test",
+                "platform": "apprise",
+                "url": "windows://",
+            }
+        }
+        with assert_setup_component(1) as handle_config:
+            assert setup_component(self.hass, notify.DOMAIN, config)
+        assert handle_config[notify.DOMAIN]
+        data = {"title": "Test Title", "message": "Test Message"}
+        assert not self.hass.services.call(notify.DOMAIN, "test", data)
+        self.hass.block_till_done()

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -128,10 +128,10 @@ async def test_apprise_notification_with_target(hass, tmp_path):
     data = {"title": "Test Title", "message": "Test Message", "target": ["devops"]}
 
     with patch("apprise.Apprise") as mock_apprise:
-        obj = MagicMock()
-        obj.add.return_value = True
-        obj.notify.return_value = True
-        mock_apprise.return_value = obj
+        apprise_obj = MagicMock()
+        apprise_obj.add.return_value = True
+        apprise_obj.notify.return_value = True
+        mock_apprise.return_value = apprise_obj
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
 
@@ -143,6 +143,6 @@ async def test_apprise_notification_with_target(hass, tmp_path):
         await hass.async_block_till_done()
 
         # Validate calls were made under the hood correctly
-        obj.notify.assert_called_once_with(
+        apprise_obj.notify.assert_called_once_with(
             **{"body": data["message"], "title": data["title"], "tag": data["target"]}
         )

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -6,8 +6,8 @@ from homeassistant.setup import async_setup_component
 BASE_COMPONENT = "notify"
 
 
-async def test_apprise_config_load_fail(hass):
-    """Test apprise configuration failures."""
+async def test_apprise_config_load_fail01(hass):
+    """Test apprise configuration failures 1."""
 
     config = {
         BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": "/path/"}
@@ -17,8 +17,16 @@ async def test_apprise_config_load_fail(hass):
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
 
-    with patch("apprise.AppriseConfig.add", return_value=True):
-        with patch("apprise.Apprise.add", return_value=False):
+
+async def test_apprise_config_load_fail02(hass):
+    """Test apprise configuration failures 2."""
+
+    config = {
+        BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": "/path/"}
+    }
+
+    with patch("apprise.Apprise.add", return_value=False):
+        with patch("apprise.AppriseConfig.add", return_value=True):
             assert await async_setup_component(hass, BASE_COMPONENT, config)
             await hass.async_block_till_done()
 

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -1,107 +1,77 @@
 """The tests for the apprise notification platform."""
-import os
-import unittest
 from unittest.mock import patch
-from tempfile import mkdtemp
 
-from apprise import Apprise
-from apprise import AppriseConfig
+from homeassistant.setup import async_setup_component
 
-from homeassistant.setup import setup_component
-import homeassistant.components.notify as notify
-from tests.common import assert_setup_component, get_test_home_assistant
+BASE_COMPONENT = "notify"
 
 
-class TestApprise(unittest.TestCase):
-    """Tests the Apprise Component."""
+async def test_apprise_config_load_fail(hass):
+    """Test apprise configuration failures."""
 
-    tmp_dir = None
+    config = {
+        BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": "/path/"}
+    }
 
-    def setUp(self):
-        """Initialize values for this test case class."""
-        self.hass = get_test_home_assistant()
-        self.tmp_dir = mkdtemp()
+    with patch("apprise.AppriseConfig.add", return_value=False):
+        assert await async_setup_component(hass, BASE_COMPONENT, config)
+        await hass.async_block_till_done()
 
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop everything that we started."""
-        self.hass.stop()
-        for fname in os.listdir(self.tmp_dir):
-            os.remove(os.path.join(self.tmp_dir, fname))
-        os.rmdir(self.tmp_dir)
+    with patch("apprise.AppriseConfig.add", return_value=True):
+        with patch("apprise.Apprise.add", return_value=False):
+            assert await async_setup_component(hass, BASE_COMPONENT, config)
+            await hass.async_block_till_done()
 
-    @patch.object(AppriseConfig, "add", return_value=False)
-    def test_apprise_config_bad_conf_add(self, __mockcfg_add):
-        """Test set up the platform with bad/missing file configuration."""
-        config = {
-            notify.DOMAIN: {"name": "test", "platform": "apprise", "config": "/path/"}
+
+async def test_apprise_config_load_okay(hass, tmp_path):
+    """Test apprise configuration failures."""
+
+    # Test cases where our URL is invalid
+    d = tmp_path / "apprise-config"
+    d.mkdir()
+    f = d / "apprise"
+    f.write_text("mailto://user:pass@example.com/")
+
+    config = {BASE_COMPONENT: {"name": "test", "platform": "apprise", "config": str(f)}}
+
+    assert await async_setup_component(hass, BASE_COMPONENT, config)
+    await hass.async_block_till_done()
+
+
+async def test_apprise_url_load_fail(hass):
+    """Test apprise url failure."""
+
+    config = {
+        BASE_COMPONENT: {
+            "name": "test",
+            "platform": "apprise",
+            "url": "mailto://user:pass@example.com",
         }
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert handle_config[notify.DOMAIN]
+    }
+    with patch("apprise.Apprise.add", return_value=False):
+        assert await async_setup_component(hass, BASE_COMPONENT, config)
+        await hass.async_block_till_done()
 
-    @patch.object(Apprise, "add", return_value=False)
-    @patch.object(AppriseConfig, "add", return_value=True)
-    def test_apprise_config_bad_conf_save(self, __mock_add, __mockcfg_add):
-        """Test set up the platform failing to save config data."""
-        config = {
-            notify.DOMAIN: {"name": "test", "platform": "apprise", "config": "/path/"}
+
+async def test_apprise_notification(hass):
+    """Test apprise notification."""
+
+    config = {
+        BASE_COMPONENT: {
+            "name": "test",
+            "platform": "apprise",
+            "url": "mailto://user:pass@example.com",
         }
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert handle_config[notify.DOMAIN]
+    }
 
-    @patch.object(Apprise, "add", return_value=False)
-    def test_apprise_bad_url(self, __mock_notify):
-        """Test set up the platform with bad/missing configuration."""
-        config = {
-            notify.DOMAIN: {"name": "test", "platform": "apprise", "url": "dbus://"}
-        }
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert handle_config[notify.DOMAIN]
+    # Our Message
+    data = {"title": "Test Title", "message": "Test Message"}
 
-    def test_apprise_config_bad_url(self):
-        """Test set up the platform with bad/missing url configuration."""
-        config = {
-            notify.DOMAIN: {
-                "name": "test",
-                "platform": "apprise",
-                # Expects an actual URL
-                "url": 1,
-            }
-        }
-        with assert_setup_component(0) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert not handle_config[notify.DOMAIN]
+    with patch("apprise.Apprise") as mock_apprise:
+        mock_apprise.notify.return_value = True
+        assert await async_setup_component(hass, BASE_COMPONENT, config)
+        await hass.async_block_till_done()
 
-    @patch.object(Apprise, "notify", return_value=True)
-    def test_apprise_url(self, __mock_notify):
-        """Test simple apprise push using URL config."""
-        config = {
-            notify.DOMAIN: {"name": "test", "platform": "apprise", "url": "windows://"}
-        }
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert handle_config[notify.DOMAIN]
-        data = {"title": "Test Title", "message": "Test Message"}
-        assert not self.hass.services.call(notify.DOMAIN, "test", data)
-        self.hass.block_till_done()
-
-    @patch.object(Apprise, "notify", return_value=True)
-    def test_apprise_config(self, __mock_notify):
-        """Test simple apprise push using AppriseConfig."""
-        tmp_cfg = os.path.join(self.tmp_dir, "apprise.txt")
-        config = {
-            notify.DOMAIN: {"name": "test", "platform": "apprise", "config": tmp_cfg}
-        }
-
-        with open(tmp_cfg, "w+") as f:
-            # Write a simple text based configuration file
-            f.write("windows://")
-
-        with assert_setup_component(1) as handle_config:
-            assert setup_component(self.hass, notify.DOMAIN, config)
-        assert handle_config[notify.DOMAIN]
-        data = {"title": "Test Title", "message": "Test Message"}
-        assert not self.hass.services.call(notify.DOMAIN, "test", data)
-        self.hass.block_till_done()
+        # Test the call to our underlining notify() call
+        await hass.services.async_call(BASE_COMPONENT, "test", data)
+        await hass.async_block_till_done()

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -18,6 +18,9 @@ async def test_apprise_config_load_fail01(hass):
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
 
+        # Test that our service failed to load
+        assert hass.services.has_service(BASE_COMPONENT, "test") is False
+
 
 async def test_apprise_config_load_fail02(hass):
     """Test apprise configuration failures 2."""
@@ -30,6 +33,9 @@ async def test_apprise_config_load_fail02(hass):
         with patch("apprise.AppriseConfig.add", return_value=True):
             assert await async_setup_component(hass, BASE_COMPONENT, config)
             await hass.async_block_till_done()
+
+            # Test that our service failed to load
+            assert hass.services.has_service(BASE_COMPONENT, "test") is False
 
 
 async def test_apprise_config_load_okay(hass, tmp_path):
@@ -46,6 +52,9 @@ async def test_apprise_config_load_okay(hass, tmp_path):
     assert await async_setup_component(hass, BASE_COMPONENT, config)
     await hass.async_block_till_done()
 
+    # Valid configuration was loaded; our service is good
+    assert hass.services.has_service(BASE_COMPONENT, "test") is True
+
 
 async def test_apprise_url_load_fail(hass):
     """Test apprise url failure."""
@@ -60,6 +69,9 @@ async def test_apprise_url_load_fail(hass):
     with patch("apprise.Apprise.add", return_value=False):
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
+
+        # Test that our service failed to load
+        assert hass.services.has_service(BASE_COMPONENT, "test") is False
 
 
 async def test_apprise_notification(hass):
@@ -83,6 +95,9 @@ async def test_apprise_notification(hass):
         mock_apprise.return_value = obj
         assert await async_setup_component(hass, BASE_COMPONENT, config)
         await hass.async_block_till_done()
+
+        # Test the existance of our service
+        assert hass.services.has_service(BASE_COMPONENT, "test") is True
 
         # Test the call to our underlining notify() call
         await hass.services.async_call(BASE_COMPONENT, "test", data)

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -19,7 +19,7 @@ async def test_apprise_config_load_fail01(hass):
         await hass.async_block_till_done()
 
         # Test that our service failed to load
-        assert hass.services.has_service(BASE_COMPONENT, "test") is False
+        assert not hass.services.has_service(BASE_COMPONENT, "test")
 
 
 async def test_apprise_config_load_fail02(hass):
@@ -35,7 +35,7 @@ async def test_apprise_config_load_fail02(hass):
             await hass.async_block_till_done()
 
             # Test that our service failed to load
-            assert hass.services.has_service(BASE_COMPONENT, "test") is False
+            assert not hass.services.has_service(BASE_COMPONENT, "test")
 
 
 async def test_apprise_config_load_okay(hass, tmp_path):
@@ -53,7 +53,7 @@ async def test_apprise_config_load_okay(hass, tmp_path):
     await hass.async_block_till_done()
 
     # Valid configuration was loaded; our service is good
-    assert hass.services.has_service(BASE_COMPONENT, "test") is True
+    assert hass.services.has_service(BASE_COMPONENT, "test")
 
 
 async def test_apprise_url_load_fail(hass):
@@ -71,7 +71,7 @@ async def test_apprise_url_load_fail(hass):
         await hass.async_block_till_done()
 
         # Test that our service failed to load
-        assert hass.services.has_service(BASE_COMPONENT, "test") is False
+        assert not hass.services.has_service(BASE_COMPONENT, "test")
 
 
 async def test_apprise_notification(hass):
@@ -97,7 +97,7 @@ async def test_apprise_notification(hass):
         await hass.async_block_till_done()
 
         # Test the existance of our service
-        assert hass.services.has_service(BASE_COMPONENT, "test") is True
+        assert hass.services.has_service(BASE_COMPONENT, "test")
 
         # Test the call to our underlining notify() call
         await hass.services.async_call(BASE_COMPONENT, "test", data)
@@ -136,7 +136,7 @@ async def test_apprise_notification_with_target(hass, tmp_path):
         await hass.async_block_till_done()
 
         # Test the existance of our service
-        assert hass.services.has_service(BASE_COMPONENT, "test") is True
+        assert hass.services.has_service(BASE_COMPONENT, "test")
 
         # Test the call to our underlining notify() call
         await hass.services.async_call(BASE_COMPONENT, "test", data)


### PR DESCRIPTION
## Description:
Added notification support for [Apprise](https://github.com/caronc/apprise) which drastically increases the number off notification services supported by Home Assistant.  It also, unfortunately, provides some over-lap to services already supported.

## Docs PR:
https://github.com/home-assistant/home-assistant.io/pull/10451

## Example entry for `configuration.yaml` (if applicable):

```yaml
# Example configuration.yaml entry using Apprise URLs
notify:
  - name: NOTIFIER_NAME
    platform: apprise
    url: Define one ore more Apprise URLs
```

Configuration files can also be sourced (via another location on the same server, or a remote server.  Apprise supports [TEXT](https://github.com/caronc/apprise/wiki/config_text) and [YAML](https://github.com/caronc/apprise/wiki/config_yaml) based configuration formats.
```yaml
# Example configuration.yaml entry using Apprise Configuration URLs
notify:
  - name: NOTIFIER_NAME
    platform: apprise
    config: Define one ore more Apprise Configuration URLs
```

Apprise URLs loaded directly (using the `url` directive) or through configuration files are all appended together in one list.  You can use both `config` and `url` in the same configuration if you wish.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
