### PR TITLE
Add Plex config options support

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -136,6 +136,8 @@ async def async_setup_entry(hass, entry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
+    entry.add_update_listener(plex_server.async_options_updated)
+
     return True
 
 

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -136,7 +136,7 @@ async def async_setup_entry(hass, entry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
-    entry.add_update_listener(plex_server.async_options_updated)
+    entry.add_update_listener(async_options_updated)
 
     return True
 
@@ -157,3 +157,9 @@ async def async_unload_entry(hass, entry):
     hass.data[PLEX_DOMAIN][SERVERS].pop(server_id)
 
     return True
+
+
+async def async_options_updated(hass, entry):
+    """Triggered by config entry options updates."""
+    server_id = entry.data[CONF_SERVER_IDENTIFIER]
+    hass.data[PLEX_DOMAIN][SERVERS][server_id].options = entry.options

--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -104,7 +104,7 @@ async def async_setup_entry(hass, entry):
         )
         hass.config_entries.async_update_entry(entry, options=options)
 
-    plex_server = PlexServer(server_config)
+    plex_server = PlexServer(server_config, entry.options)
     try:
         await hass.async_add_executor_job(plex_server.connect)
     except requests.exceptions.ConnectionError as error:

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -6,6 +6,7 @@ import requests.exceptions
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -20,6 +21,8 @@ from homeassistant.util.json import load_json
 from .const import (  # pylint: disable=unused-import
     CONF_SERVER,
     CONF_SERVER_IDENTIFIER,
+    CONF_USE_EPISODE_ART,
+    CONF_SHOW_ALL_CONTROLS,
     DEFAULT_PORT,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
@@ -51,6 +54,12 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return PlexOptionsFlowHandler(config_entry)
 
     def __init__(self):
         """Initialize the Plex flow."""
@@ -214,3 +223,42 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Import from Plex configuration."""
         _LOGGER.debug("Imported Plex configuration")
         return await self.async_step_server_validate(import_config)
+
+
+class PlexOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Plex options."""
+
+    def __init__(self, config_entry):
+        """Initialize Plex options flow."""
+        self.options = dict(config_entry.options)
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Plex options."""
+        return await self.async_step_plex_mp_settings()
+
+    async def async_step_plex_mp_settings(self, user_input=None):
+        """Manage the Plex media_player options."""
+        if user_input is not None:
+            self.options[MP_DOMAIN][CONF_USE_EPISODE_ART] = user_input[
+                CONF_USE_EPISODE_ART
+            ]
+            self.options[MP_DOMAIN][CONF_SHOW_ALL_CONTROLS] = user_input[
+                CONF_SHOW_ALL_CONTROLS
+            ]
+            return self.async_create_entry(title="", data=self.options)
+
+        return self.async_show_form(
+            step_id="plex_mp_settings",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USE_EPISODE_ART,
+                        default=self.options[MP_DOMAIN][CONF_USE_EPISODE_ART],
+                    ): bool,
+                    vol.Required(
+                        CONF_SHOW_ALL_CONTROLS,
+                        default=self.options[MP_DOMAIN][CONF_SHOW_ALL_CONTROLS],
+                    ): bool,
+                }
+            ),
+        )

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Plex."""
+import copy
 import logging
 
 import plexapi.exceptions
@@ -230,7 +231,7 @@ class PlexOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize Plex options flow."""
-        self.options = dict(config_entry.options)
+        self.options = copy.deepcopy(config_entry.options)
 
     async def async_step_init(self, user_input=None):
         """Manage the Plex options."""

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -8,7 +8,7 @@ import plexapi.playlist
 import plexapi.playqueue
 import requests.exceptions
 
-from homeassistant.components.media_player import DOMAIN as MP_DOMAIN, MediaPlayerDevice
+from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
@@ -33,8 +33,6 @@ from homeassistant.helpers.event import track_time_interval
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    CONF_USE_EPISODE_ART,
-    CONF_SHOW_ALL_CONTROLS,
     CONF_SERVER_IDENTIFIER,
     DOMAIN as PLEX_DOMAIN,
     NAME_FORMAT,
@@ -66,8 +64,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 def _setup_platform(hass, config_entry, add_entities_callback):
     """Set up the Plex media_player platform."""
     server_id = config_entry.data[CONF_SERVER_IDENTIFIER]
-    config = config_entry.options[MP_DOMAIN]
-
     plexserver = hass.data[PLEX_DOMAIN][SERVERS][server_id]
     plex_clients = {}
     plex_sessions = {}
@@ -101,7 +97,7 @@ def _setup_platform(hass, config_entry, add_entities_callback):
 
             if device.machineIdentifier not in plex_clients:
                 new_client = PlexClient(
-                    config, device, None, plex_sessions, update_devices
+                    plexserver, device, None, plex_sessions, update_devices
                 )
                 plex_clients[device.machineIdentifier] = new_client
                 _LOGGER.debug("New device: %s", device.machineIdentifier)
@@ -140,7 +136,7 @@ def _setup_platform(hass, config_entry, add_entities_callback):
                 and machine_identifier is not None
             ):
                 new_client = PlexClient(
-                    config, player, session, plex_sessions, update_devices
+                    plexserver, player, session, plex_sessions, update_devices
                 )
                 plex_clients[machine_identifier] = new_client
                 _LOGGER.debug("New session: %s", machine_identifier)
@@ -169,7 +165,7 @@ def _setup_platform(hass, config_entry, add_entities_callback):
 class PlexClient(MediaPlayerDevice):
     """Representation of a Plex device."""
 
-    def __init__(self, config, device, session, plex_sessions, update_devices):
+    def __init__(self, plex_server, device, session, plex_sessions, update_devices):
         """Initialize the Plex device."""
         self._app_name = ""
         self._device = None
@@ -190,7 +186,7 @@ class PlexClient(MediaPlayerDevice):
         self._state = STATE_IDLE
         self._volume_level = 1  # since we can't retrieve remotely
         self._volume_muted = False  # since we can't retrieve remotely
-        self.config = config
+        self.plex_server = plex_server
         self.plex_sessions = plex_sessions
         self.update_devices = update_devices
         # General
@@ -316,8 +312,9 @@ class PlexClient(MediaPlayerDevice):
 
     def _set_media_image(self):
         thumb_url = self._session.thumbUrl
-        if self.media_content_type is MEDIA_TYPE_TVSHOW and not self.config.get(
-            CONF_USE_EPISODE_ART
+        if (
+            self.media_content_type is MEDIA_TYPE_TVSHOW
+            and not self.plex_server.use_episode_art
         ):
             thumb_url = self._session.url(self._session.grandparentThumb)
 
@@ -550,7 +547,7 @@ class PlexClient(MediaPlayerDevice):
             return 0
 
         # force show all controls
-        if self.config.get(CONF_SHOW_ALL_CONTROLS):
+        if self.plex_server.show_all_controls:
             return (
                 SUPPORT_PAUSE
                 | SUPPORT_PREVIOUS_TRACK

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -8,7 +8,7 @@ import plexapi.playlist
 import plexapi.playqueue
 import requests.exceptions
 
-from homeassistant.components.media_player import MediaPlayerDevice
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN, MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MOVIE,
     MEDIA_TYPE_MUSIC,
@@ -38,7 +38,6 @@ from .const import (
     CONF_SERVER_IDENTIFIER,
     DOMAIN as PLEX_DOMAIN,
     NAME_FORMAT,
-    PLEX_MEDIA_PLAYER_OPTIONS,
     REFRESH_LISTENERS,
     SERVERS,
 )
@@ -67,7 +66,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 def _setup_platform(hass, config_entry, add_entities_callback):
     """Set up the Plex media_player platform."""
     server_id = config_entry.data[CONF_SERVER_IDENTIFIER]
-    config = hass.data[PLEX_MEDIA_PLAYER_OPTIONS]
+    config = config_entry.options[MP_DOMAIN]
 
     plexserver = hass.data[PLEX_DOMAIN][SERVERS][server_id]
     plex_clients = {}

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -3,22 +3,29 @@ import plexapi.myplex
 import plexapi.server
 from requests import Session
 
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
-from .const import CONF_SERVER, DEFAULT_VERIFY_SSL
+from .const import (
+    CONF_SERVER,
+    CONF_SHOW_ALL_CONTROLS,
+    CONF_USE_EPISODE_ART,
+    DEFAULT_VERIFY_SSL,
+)
 from .errors import NoServersFound, ServerNotSpecified
 
 
 class PlexServer:
     """Manages a single Plex server connection."""
 
-    def __init__(self, server_config):
+    def __init__(self, server_config, options=None):
         """Initialize a Plex server instance."""
         self._plex_server = None
         self._url = server_config.get(CONF_URL)
         self._token = server_config.get(CONF_TOKEN)
         self._server_name = server_config.get(CONF_SERVER)
         self._verify_ssl = server_config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+        self.options = options
 
     def connect(self):
         """Connect to a Plex server directly, obtaining direct URL if necessary."""
@@ -80,3 +87,13 @@ class PlexServer:
     def url_in_use(self):
         """Return URL used for connected Plex server."""
         return self._plex_server._baseurl  # pylint: disable=W0212
+
+    @property
+    def use_episode_art(self):
+        """Return use_episode_art option."""
+        return self.options[MP_DOMAIN][CONF_USE_EPISODE_ART]
+
+    @property
+    def show_all_controls(self):
+        """Return show_all_controls option."""
+        return self.options[MP_DOMAIN][CONF_SHOW_ALL_CONTROLS]

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -8,9 +8,12 @@ from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
 from .const import (
     CONF_SERVER,
+    CONF_SERVER_IDENTIFIER,
     CONF_SHOW_ALL_CONTROLS,
     CONF_USE_EPISODE_ART,
     DEFAULT_VERIFY_SSL,
+    DOMAIN as PLEX_DOMAIN,
+    SERVERS,
 )
 from .errors import NoServersFound, ServerNotSpecified
 
@@ -26,6 +29,12 @@ class PlexServer:
         self._server_name = server_config.get(CONF_SERVER)
         self._verify_ssl = server_config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
         self.options = options
+
+    @staticmethod
+    async def async_options_updated(hass, entry):
+        """Triggered by config entry options updates."""
+        server_id = entry.data[CONF_SERVER_IDENTIFIER]
+        hass.data[PLEX_DOMAIN][SERVERS][server_id].options = entry.options
 
     def connect(self):
         """Connect to a Plex server directly, obtaining direct URL if necessary."""

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -8,12 +8,9 @@ from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
 from .const import (
     CONF_SERVER,
-    CONF_SERVER_IDENTIFIER,
     CONF_SHOW_ALL_CONTROLS,
     CONF_USE_EPISODE_ART,
     DEFAULT_VERIFY_SSL,
-    DOMAIN as PLEX_DOMAIN,
-    SERVERS,
 )
 from .errors import NoServersFound, ServerNotSpecified
 
@@ -29,12 +26,6 @@ class PlexServer:
         self._server_name = server_config.get(CONF_SERVER)
         self._verify_ssl = server_config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
         self.options = options
-
-    @staticmethod
-    async def async_options_updated(hass, entry):
-        """Triggered by config entry options updates."""
-        server_id = entry.data[CONF_SERVER_IDENTIFIER]
-        hass.data[PLEX_DOMAIN][SERVERS][server_id].options = entry.options
 
     def connect(self):
         """Connect to a Plex server directly, obtaining direct URL if necessary."""

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -41,5 +41,16 @@
             "invalid_import": "Imported configuration is invalid",
             "unknown": "Failed for unknown reason"
         }
+    },
+    "options": {
+        "step": {
+            "plex_mp_settings": {
+                "description": "Options for Plex Media Players",
+                "data": {
+                    "use_episode_art": "Use episode art",
+                    "show_all_controls": "Show all controls"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description:
Add config options support for Plex `media_player` platform options (`use_episode_art` and `show_all_controls`).

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10450

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html