### PR TITLE
Fix bed_activity history chart of the Xiaomi Aqara vibration sensor

### DIFF
--- a/homeassistant/components/xiaomi_aqara/sensor.py
+++ b/homeassistant/components/xiaomi_aqara/sensor.py
@@ -19,7 +19,7 @@ SENSOR_TYPES = {
     "illumination": ["lm", None, DEVICE_CLASS_ILLUMINANCE],
     "lux": ["lx", None, DEVICE_CLASS_ILLUMINANCE],
     "pressure": ["hPa", None, DEVICE_CLASS_PRESSURE],
-    "bed_activity": ["μm", None, DEVICE_CLASS_PRESSURE],
+    "bed_activity": ["μm", None, None],
 }
 
 

--- a/homeassistant/components/xiaomi_aqara/sensor.py
+++ b/homeassistant/components/xiaomi_aqara/sensor.py
@@ -19,6 +19,7 @@ SENSOR_TYPES = {
     "illumination": ["lm", None, DEVICE_CLASS_ILLUMINANCE],
     "lux": ["lx", None, DEVICE_CLASS_ILLUMINANCE],
     "pressure": ["hPa", None, DEVICE_CLASS_PRESSURE],
+    "bed_activity": ["μm", None, DEVICE_CLASS_PRESSURE],
 }
 
 


### PR DESCRIPTION
## Description:
fix xiaom activity sensor show in history chart.

changed before like this, not show x-y chart:
![image](https://user-images.githubusercontent.com/40521367/65516639-f2a84f00-df13-11e9-94d0-eb6477487499.png)



changed after:
![image](https://user-images.githubusercontent.com/40521367/65514967-f4bcde80-df10-11e9-8671-ea812c859895.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]


