### PR TITLE
Remove lamps and groups from ha when removed from Hue

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -8,6 +8,9 @@ import random
 import aiohue
 import async_timeout
 
+from homeassistant.helpers.entity_registry import async_get_registry as get_ent_reg
+from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
+
 from homeassistant.components import hue
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -147,6 +150,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         tasks.append(
             async_update_items(
                 hass,
+                config_entry,
                 bridge,
                 async_add_entities,
                 request_update,
@@ -160,6 +164,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             tasks.append(
                 async_update_items(
                     hass,
+                    config_entry,
                     bridge,
                     async_add_entities,
                     request_update,
@@ -176,6 +181,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 async def async_update_items(
     hass,
+    config_entry,
     bridge,
     async_add_entities,
     request_bridge_update,
@@ -204,9 +210,9 @@ async def async_update_items(
         _LOGGER.error("Unable to reach bridge %s (%s)", bridge.host, err)
         bridge.available = False
 
-        for light_id, light in current.items():
-            if light_id not in progress_waiting:
-                light.async_schedule_update_ha_state()
+        for item_id, item in current.items():
+            if item_id not in progress_waiting:
+                item.async_schedule_update_ha_state()
 
         return
 
@@ -219,7 +225,8 @@ async def async_update_items(
         _LOGGER.info("Reconnected to bridge %s", bridge.host)
         bridge.available = True
 
-    new_lights = []
+    new_items = []
+    removed_items = []
 
     for item_id in api:
         if item_id not in current:
@@ -227,12 +234,30 @@ async def async_update_items(
                 api[item_id], request_bridge_update, bridge, is_group
             )
 
-            new_lights.append(current[item_id])
+            new_items.append(current[item_id])
         elif item_id not in progress_waiting:
             current[item_id].async_schedule_update_ha_state()
 
-    if new_lights:
-        async_add_entities(new_lights)
+    for item_id in current:
+        if item_id not in api:
+            entity = current[item_id]
+            removed_items.append(item_id)
+            hass.async_create_task(entity.async_remove())
+            ent_registry = await get_ent_reg(hass)
+            if entity.entity_id in ent_registry.entities:
+                ent_registry.async_remove(entity.entity_id)
+            dev_registry = await get_dev_reg(hass)
+            device = dev_registry.async_get_device(
+                identifiers={(hue.DOMAIN, entity.unique_id)}, connections=set()
+            )
+            # dev_registry._async_update_device(device.id, remove_config_entry_id=config_entry.entry_id)
+            dev_registry.async_remove_device(device.id)
+
+    if new_items:
+        async_add_entities(new_items)
+
+    for item_id in removed_items:
+        del current[item_id]
 
 
 class HueLight(Light):

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -240,6 +240,7 @@ async def async_update_items(
 
     for item_id in current:
         if item_id not in api:
+            # Device is removed from Hue, so we remove it from Home Assistant
             entity = current[item_id]
             removed_items.append(item_id)
             hass.async_create_task(entity.async_remove())
@@ -250,8 +251,9 @@ async def async_update_items(
             device = dev_registry.async_get_device(
                 identifiers={(hue.DOMAIN, entity.unique_id)}, connections=set()
             )
-            # dev_registry._async_update_device(device.id, remove_config_entry_id=config_entry.entry_id)
-            dev_registry.async_remove_device(device.id)
+            dev_registry.async_update_device(
+                device.id, remove_config_entry_id=config_entry.entry_id
+            )
 
     if new_items:
         async_add_entities(new_items)

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -239,21 +239,23 @@ async def async_update_items(
             current[item_id].async_schedule_update_ha_state()
 
     for item_id in current:
-        if item_id not in api:
-            # Device is removed from Hue, so we remove it from Home Assistant
-            entity = current[item_id]
-            removed_items.append(item_id)
-            hass.async_create_task(entity.async_remove())
-            ent_registry = await get_ent_reg(hass)
-            if entity.entity_id in ent_registry.entities:
-                ent_registry.async_remove(entity.entity_id)
-            dev_registry = await get_dev_reg(hass)
-            device = dev_registry.async_get_device(
-                identifiers={(hue.DOMAIN, entity.unique_id)}, connections=set()
-            )
-            dev_registry.async_update_device(
-                device.id, remove_config_entry_id=config_entry.entry_id
-            )
+        if item_id in api:
+            continue
+
+        # Device is removed from Hue, so we remove it from Home Assistant
+        entity = current[item_id]
+        removed_items.append(item_id)
+        await entity.async_remove()
+        ent_registry = await get_ent_reg(hass)
+        if entity.entity_id in ent_registry.entities:
+            ent_registry.async_remove(entity.entity_id)
+        dev_registry = await get_dev_reg(hass)
+        device = dev_registry.async_get_device(
+            identifiers={(hue.DOMAIN, entity.unique_id)}, connections=set()
+        )
+        dev_registry.async_update_device(
+            device.id, remove_config_entry_id=config_entry.entry_id
+        )
 
     if new_items:
         async_add_entities(new_items)

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/hue",
   "requirements": [
-    "aiohue==1.9.1"
+    "aiohue==1.9.2"
   ],
   "ssdp": {
     "manufacturer": [

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -157,6 +157,7 @@ class DeviceRegistry:
         name_by_user=_UNDEF,
         new_identifiers=_UNDEF,
         via_device_id=_UNDEF,
+        remove_config_entry_id=_UNDEF,
     ):
         """Update properties of a device."""
         return self._async_update_device(
@@ -166,6 +167,7 @@ class DeviceRegistry:
             name_by_user=name_by_user,
             new_identifiers=new_identifiers,
             via_device_id=via_device_id,
+            remove_config_entry_id=remove_config_entry_id,
         )
 
     @callback
@@ -203,7 +205,11 @@ class DeviceRegistry:
             remove_config_entry_id is not _UNDEF
             and remove_config_entry_id in config_entries
         ):
-            config_entries = config_entries - {remove_config_entry_id}
+            if config_entries == {remove_config_entry_id}:
+                self.async_remove_device(device_id)
+                return
+            else:
+                config_entries = config_entries - {remove_config_entry_id}
 
         if config_entries is not old.config_entries:
             changes["config_entries"] = config_entries

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -208,8 +208,8 @@ class DeviceRegistry:
             if config_entries == {remove_config_entry_id}:
                 self.async_remove_device(device_id)
                 return
-            else:
-                config_entries = config_entries - {remove_config_entry_id}
+
+            config_entries = config_entries - {remove_config_entry_id}
 
         if config_entries is not old.config_entries:
             changes["config_entries"] = config_entries

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -152,7 +152,7 @@ aioharmony==0.1.13
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.1
+aiohue==1.9.2
 
 # homeassistant.components.imap
 aioimaplib==0.7.15

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -62,7 +62,7 @@ aioesphomeapi==2.2.0
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.9.1
+aiohue==1.9.2
 
 # homeassistant.components.notion
 aionotion==1.1.0

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -409,6 +409,64 @@ async def test_update(registry):
     assert updated_entry.via_device_id == "98765B"
 
 
+async def test_update_remove_config_entries(hass, registry, update_events):
+    """Make sure we do not get duplicate entries."""
+    entry = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+    entry2 = registry.async_get_or_create(
+        config_entry_id="456",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+    entry3 = registry.async_get_or_create(
+        config_entry_id="123",
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
+        identifiers={("bridgeid", "4567")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    assert len(registry.devices) == 2
+    assert entry.id == entry2.id
+    assert entry.id != entry3.id
+    assert entry2.config_entries == {"123", "456"}
+
+    updated_entry = registry.async_update_device(
+        entry2.id, remove_config_entry_id="123"
+    )
+    removed_entry = registry.async_update_device(
+        entry3.id, remove_config_entry_id="123"
+    )
+
+    assert updated_entry.config_entries == {"456"}
+    assert removed_entry is None
+
+    removed_entry = registry.async_get_device({("bridgeid", "4567")}, set())
+
+    assert removed_entry is None
+
+    await hass.async_block_till_done()
+
+    assert len(update_events) == 5
+    assert update_events[0]["action"] == "create"
+    assert update_events[0]["device_id"] == entry.id
+    assert update_events[1]["action"] == "update"
+    assert update_events[1]["device_id"] == entry2.id
+    assert update_events[2]["action"] == "create"
+    assert update_events[2]["device_id"] == entry3.id
+    assert update_events[3]["action"] == "update"
+    assert update_events[3]["device_id"] == entry.id
+    assert update_events[4]["action"] == "remove"
+    assert update_events[4]["device_id"] == entry3.id
+
+
 async def test_loading_race_condition(hass):
     """Test only one storage load called when concurrent loading occurred ."""
     with asynctest.patch(


### PR DESCRIPTION
## Description:
This PR removes lamps and groups that are removed in Hue.

- [x] add tests.

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
