### PR TITLE
deCONZ - Improve discovery by storing uuid in config entry

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -71,10 +71,7 @@ async def async_update_master_gateway(hass, config_entry):
     Makes sure there is always one master available.
     """
     master = not get_master_gateway(hass)
-
-    old_options = dict(config_entry.options)
-
-    options = {**old_options, CONF_MASTER_GATEWAY: master}
+    options = {**config_entry.options, CONF_MASTER_GATEWAY: master}
 
     hass.config_entries.async_update_entry(config_entry, options=options)
 
@@ -82,9 +79,6 @@ async def async_update_master_gateway(hass, config_entry):
 async def async_add_uuid_to_config_entry(hass, config_entry):
     """Add UUID to config entry to help discovery identify entries."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
-
-    old_config = dict(config_entry.data)
-
-    config = {**old_config, CONF_UUID: gateway.api.config.uuid}
+    config = {**config_entry.data, CONF_UUID: gateway.api.config.uuid}
 
     hass.config_entries.async_update_entry(config_entry, data=config)

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -39,7 +39,8 @@ async def async_setup_entry(hass, config_entry):
 
     await gateway.async_update_device_registry()
 
-    await async_add_uuid_to_config_entry(hass, config_entry)
+    if CONF_UUID not in config_entry.data:
+        await async_add_uuid_to_config_entry(hass, config_entry)
 
     await async_setup_services(hass)
 
@@ -73,23 +74,17 @@ async def async_update_master_gateway(hass, config_entry):
 
     old_options = dict(config_entry.options)
 
-    new_options = {CONF_MASTER_GATEWAY: master}
-
-    options = {**old_options, **new_options}
+    options = {**old_options, CONF_MASTER_GATEWAY: master}
 
     hass.config_entries.async_update_entry(config_entry, options=options)
 
 
 async def async_add_uuid_to_config_entry(hass, config_entry):
     """Add UUID to config entry to help discovery identify entries."""
-    if CONF_UUID in config_entry.data:
-        return
-
     gateway = get_gateway_from_config_entry(hass, config_entry)
 
     old_config = dict(config_entry.data)
-    new_config = {CONF_UUID: gateway.api.config.uuid}
 
-    config = {**old_config, **new_config}
+    config = {**old_config, CONF_UUID: gateway.api.config.uuid}
 
     hass.config_entries.async_update_entry(config_entry, data=config)

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -5,13 +5,15 @@ _LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "deconz"
 
+CONF_BRIDGEID = "bridgeid"
+CONF_UUID = "uuid"
+
 DEFAULT_PORT = 80
 DEFAULT_ALLOW_CLIP_SENSOR = False
 DEFAULT_ALLOW_DECONZ_GROUPS = True
 
 CONF_ALLOW_CLIP_SENSOR = "allow_clip_sensor"
 CONF_ALLOW_DECONZ_GROUPS = "allow_deconz_groups"
-CONF_BRIDGEID = "bridgeid"
 CONF_MASTER_GATEWAY = "master"
 
 SUPPORTED_PLATFORMS = [

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/deconz",
   "requirements": [
-    "pydeconz==62"
+    "pydeconz==63"
   ],
   "ssdp": {
     "manufacturer": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1129,7 +1129,7 @@ pydaikin==1.6.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==62
+pydeconz==63
 
 # homeassistant.components.delijn
 pydelijn==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -294,7 +294,7 @@ pyblackbird==0.5
 pychromecast==4.0.1
 
 # homeassistant.components.deconz
-pydeconz==62
+pydeconz==63
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -20,6 +20,7 @@ ENTRY_CONFIG = {
     deconz.config_flow.CONF_BRIDGEID: BRIDGEID,
     deconz.config_flow.CONF_HOST: "1.2.3.4",
     deconz.config_flow.CONF_PORT: 80,
+    deconz.config_flow.CONF_UUID: "456DEF",
 }
 
 DECONZ_CONFIG = {
@@ -147,7 +148,7 @@ async def test_update_address(hass):
             deconz.config_flow.CONF_PORT: 80,
             ssdp.ATTR_SERIAL: BRIDGEID,
             ssdp.ATTR_MANUFACTURERURL: deconz.config_flow.DECONZ_MANUFACTURERURL,
-            deconz.config_flow.ATTR_UUID: "uuid:1234",
+            deconz.config_flow.ATTR_UUID: "uuid:456DEF",
         },
         context={"source": "ssdp"},
     )

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -1,33 +1,34 @@
 """Test deCONZ component setup process."""
-from unittest.mock import Mock, patch
-
 import asyncio
+
+from asynctest import Mock, patch
+
 import pytest
 
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components import deconz
 
-from tests.common import mock_coro, MockConfigEntry
+from tests.common import MockConfigEntry
 
 ENTRY1_HOST = "1.2.3.4"
 ENTRY1_PORT = 80
 ENTRY1_API_KEY = "1234567890ABCDEF"
 ENTRY1_BRIDGEID = "12345ABC"
+ENTRY1_UUID = "456DEF"
 
 ENTRY2_HOST = "2.3.4.5"
 ENTRY2_PORT = 80
 ENTRY2_API_KEY = "1234567890ABCDEF"
 ENTRY2_BRIDGEID = "23456DEF"
+ENTRY2_UUID = "789ACE"
 
 
 async def setup_entry(hass, entry):
     """Test that setup entry works."""
     with patch.object(
-        deconz.DeconzGateway, "async_setup", return_value=mock_coro(True)
+        deconz.DeconzGateway, "async_setup", return_value=True
     ), patch.object(
-        deconz.DeconzGateway,
-        "async_update_device_registry",
-        return_value=mock_coro(True),
+        deconz.DeconzGateway, "async_update_device_registry", return_value=True
     ):
         assert await deconz.async_setup_entry(hass, entry) is True
 
@@ -67,6 +68,7 @@ async def test_setup_entry_successful(hass):
             deconz.config_flow.CONF_PORT: ENTRY1_PORT,
             deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
+            deconz.CONF_UUID: ENTRY1_UUID,
         },
     )
     entry.add_to_hass(hass)
@@ -86,6 +88,7 @@ async def test_setup_entry_multiple_gateways(hass):
             deconz.config_flow.CONF_PORT: ENTRY1_PORT,
             deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
+            deconz.CONF_UUID: ENTRY1_UUID,
         },
     )
     entry.add_to_hass(hass)
@@ -97,6 +100,7 @@ async def test_setup_entry_multiple_gateways(hass):
             deconz.config_flow.CONF_PORT: ENTRY2_PORT,
             deconz.config_flow.CONF_API_KEY: ENTRY2_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY2_BRIDGEID,
+            deconz.CONF_UUID: ENTRY2_UUID,
         },
     )
     entry2.add_to_hass(hass)
@@ -119,15 +123,14 @@ async def test_unload_entry(hass):
             deconz.config_flow.CONF_PORT: ENTRY1_PORT,
             deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
+            deconz.CONF_UUID: ENTRY1_UUID,
         },
     )
     entry.add_to_hass(hass)
 
     await setup_entry(hass, entry)
 
-    with patch.object(
-        deconz.DeconzGateway, "async_reset", return_value=mock_coro(True)
-    ):
+    with patch.object(deconz.DeconzGateway, "async_reset", return_value=True):
         assert await deconz.async_unload_entry(hass, entry)
 
     assert not hass.data[deconz.DOMAIN]
@@ -142,6 +145,7 @@ async def test_unload_entry_multiple_gateways(hass):
             deconz.config_flow.CONF_PORT: ENTRY1_PORT,
             deconz.config_flow.CONF_API_KEY: ENTRY1_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY1_BRIDGEID,
+            deconz.CONF_UUID: ENTRY1_UUID,
         },
     )
     entry.add_to_hass(hass)
@@ -153,6 +157,7 @@ async def test_unload_entry_multiple_gateways(hass):
             deconz.config_flow.CONF_PORT: ENTRY2_PORT,
             deconz.config_flow.CONF_API_KEY: ENTRY2_API_KEY,
             deconz.CONF_BRIDGEID: ENTRY2_BRIDGEID,
+            deconz.CONF_UUID: ENTRY2_UUID,
         },
     )
     entry2.add_to_hass(hass)
@@ -160,9 +165,7 @@ async def test_unload_entry_multiple_gateways(hass):
     await setup_entry(hass, entry)
     await setup_entry(hass, entry2)
 
-    with patch.object(
-        deconz.DeconzGateway, "async_reset", return_value=mock_coro(True)
-    ):
+    with patch.object(deconz.DeconzGateway, "async_reset", return_value=True):
         assert await deconz.async_unload_entry(hass, entry)
 
     assert ENTRY2_BRIDGEID in hass.data[deconz.DOMAIN]


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Allow discovery to update any deconz entry, loaded or not

**Related issue (if applicable):** fixes #25863

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
