### PR TITLE
Removes unnecessary else/elif blocks

### DIFF
--- a/homeassistant/components/eddystone_temperature/sensor.py
+++ b/homeassistant/components/eddystone_temperature/sensor.py
@@ -60,8 +60,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if instance is None or namespace is None:
             _LOGGER.error("Skipping %s", dev_name)
             continue
-        else:
-            devices.append(EddystoneTemp(name, namespace, instance))
+
+        devices.append(EddystoneTemp(name, namespace, instance))
 
     if devices:
         mon = Monitor(hass, devices, bt_device_id)

--- a/homeassistant/components/filesize/sensor.py
+++ b/homeassistant/components/filesize/sensor.py
@@ -27,8 +27,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if not hass.config.is_allowed_path(path):
             _LOGGER.error("Filepath %s is not valid or allowed", path)
             continue
-        else:
-            sensors.append(Filesize(path))
+        sensors.append(Filesize(path))
 
     if sensors:
         add_entities(sensors, True)

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -323,9 +323,9 @@ def _categorize_nodes(
             # determine if it should be a binary_sensor.
             if _is_sensor_a_binary_sensor(hass, node):
                 continue
-            else:
-                hass.data[ISY994_NODES]["sensor"].append(node)
-                continue
+
+            hass.data[ISY994_NODES]["sensor"].append(node)
+            continue
 
         # We have a bunch of different methods for determining the device type,
         # each of which works with different ISY firmware versions or device

--- a/homeassistant/components/mvglive/sensor.py
+++ b/homeassistant/components/mvglive/sensor.py
@@ -189,17 +189,19 @@ class MVGLiveData:
                 and _departure["destination"] not in self._destinations
             ):
                 continue
-            elif (
+
+            if (
                 "" not in self._directions[:1]
                 and _departure["direction"] not in self._directions
             ):
                 continue
-            elif (
-                "" not in self._lines[:1] and _departure["linename"] not in self._lines
-            ):
+
+            if "" not in self._lines[:1] and _departure["linename"] not in self._lines:
                 continue
-            elif _departure["time"] < self._timeoffset:
+
+            if _departure["time"] < self._timeoffset:
                 continue
+
             # now select the relevant data
             _nextdep = {ATTR_ATTRIBUTION: ATTRIBUTION}
             for k in ["destination", "linename", "time", "direction", "product"]:

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -264,8 +264,7 @@ class OnkyoDevice(MediaPlayerDevice):
             if source in self._source_mapping:
                 self._current_source = self._source_mapping[source]
                 break
-            else:
-                self._current_source = "_".join([i for i in current_source_tuples[1]])
+            self._current_source = "_".join([i for i in current_source_tuples[1]])
         if preset_raw and self._current_source.lower() == "radio":
             self._attributes[ATTR_PRESET] = preset_raw[1]
         elif ATTR_PRESET in self._attributes:
@@ -414,8 +413,7 @@ class OnkyoDeviceZone(OnkyoDevice):
             if source in self._source_mapping:
                 self._current_source = self._source_mapping[source]
                 break
-            else:
-                self._current_source = "_".join([i for i in current_source_tuples[1]])
+            self._current_source = "_".join([i for i in current_source_tuples[1]])
         self._muted = bool(mute_raw[1] == "on")
         if preset_raw and self._current_source.lower() == "radio":
             self._attributes[ATTR_PRESET] = preset_raw[1]

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -320,10 +320,10 @@ class Recorder(threading.Thread):
                 purge.purge_old_data(self, event.keep_days, event.repack)
                 self.queue.task_done()
                 continue
-            elif event.event_type == EVENT_TIME_CHANGED:
+            if event.event_type == EVENT_TIME_CHANGED:
                 self.queue.task_done()
                 continue
-            elif event.event_type in self.exclude_t:
+            if event.event_type in self.exclude_t:
                 self.queue.task_done()
                 continue
 

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -484,39 +484,44 @@ class TodoistProjectData:
         for proposed_event in project_tasks:
             if event == proposed_event:
                 continue
+
             if proposed_event[COMPLETED]:
                 # Event is complete!
                 continue
+
             if proposed_event[END] is None:
                 # No end time:
                 if event[END] is None and (proposed_event[PRIORITY] < event[PRIORITY]):
                     # They also have no end time,
                     # but we have a higher priority.
                     event = proposed_event
-                    continue
-                else:
-                    continue
-            elif event[END] is None:
+                continue
+
+            if event[END] is None:
                 # We have an end time, they do not.
                 event = proposed_event
                 continue
+
             if proposed_event[END].date() > event[END].date():
                 # Event is too late.
                 continue
-            elif proposed_event[END].date() < event[END].date():
+
+            if proposed_event[END].date() < event[END].date():
                 # Event is earlier than current, select it.
                 event = proposed_event
                 continue
-            else:
-                if proposed_event[PRIORITY] > event[PRIORITY]:
-                    # Proposed event has a higher priority.
-                    event = proposed_event
-                    continue
-                elif proposed_event[PRIORITY] == event[PRIORITY] and (
-                    proposed_event[END] < event[END]
-                ):
-                    event = proposed_event
-                    continue
+
+            if proposed_event[PRIORITY] > event[PRIORITY]:
+                # Proposed event has a higher priority.
+                event = proposed_event
+                continue
+
+            if proposed_event[PRIORITY] == event[PRIORITY] and (
+                proposed_event[END] < event[END]
+            ):
+                event = proposed_event
+                continue
+
         return event
 
     async def async_get_events(self, hass, start_date, end_date):

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -396,10 +396,12 @@ class LgWebOSDevice(MediaPlayerDevice):
                 if media_id == channel["channelNumber"]:
                     perfect_match_channel_id = channel["channelId"]
                     continue
-                elif media_id.lower() == channel["channelName"].lower():
+
+                if media_id.lower() == channel["channelName"].lower():
                     perfect_match_channel_id = channel["channelId"]
                     continue
-                elif media_id.lower() in channel["channelName"].lower():
+
+                if media_id.lower() in channel["channelName"].lower():
                     partial_match_channel_id = channel["channelId"]
 
             if perfect_match_channel_id is not None:

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -165,7 +165,7 @@ class WebSocketHandler:
                 if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSING):
                     break
 
-                elif msg.type != WSMsgType.TEXT:
+                if msg.type != WSMsgType.TEXT:
                     disconnect_warn = "Received non-Text message."
                     break
 

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -199,11 +199,13 @@ def _async_handle_single_cluster_matches(
                 zha_device.is_mains_powered or matched_power_configuration
             ):
                 continue
-            elif (
+
+            if (
                 cluster.cluster_id == PowerConfiguration.cluster_id
                 and not zha_device.is_mains_powered
             ):
                 matched_power_configuration = True
+
             cluster_match_results.append(
                 _async_handle_single_cluster_match(
                     hass,

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -851,7 +851,8 @@ async def async_setup_entry(hass, config_entry):
                     # Need to be in STATE_AWAKED before talking to nodes.
                     _LOGGER.info("Z-Wave ready after %d seconds", waited)
                     break
-                elif waited >= const.NETWORK_READY_WAIT_SECS:
+
+                if waited >= const.NETWORK_READY_WAIT_SECS:
                     # Wait up to NETWORK_READY_WAIT_SECS seconds for the Z-Wave
                     # network to be ready.
                     _LOGGER.warning(
@@ -861,8 +862,8 @@ async def async_setup_entry(hass, config_entry):
                         "final network state: %d %s", network.state, network.state_str
                     )
                     break
-                else:
-                    await asyncio.sleep(1)
+
+                await asyncio.sleep(1)
 
             hass.async_add_job(_finalize_start)
 

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -19,7 +19,8 @@ def config_per_platform(config: ConfigType, domain: str) -> Iterable[Tuple[Any, 
 
         if not platform_config:
             continue
-        elif not isinstance(platform_config, list):
+
+        if not isinstance(platform_config, list):
             platform_config = [platform_config]
 
         for item in platform_config:

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -23,7 +23,8 @@ def run(args: List) -> int:
     for fil in os.listdir(path):
         if fil == "__pycache__":
             continue
-        elif os.path.isdir(os.path.join(path, fil)):
+
+        if os.path.isdir(os.path.join(path, fil)):
             scripts.append(fil)
         elif fil != "__init__.py" and fil.endswith(".py"):
             scripts.append(fil[:-3])


### PR DESCRIPTION
## Description:

Removes unnecessary ``else`` and ``elif`` blocks after ``break`` and ``continue`` statements.

In preparation for `pylint>=2.4.0`, which added new checks, ``no-else-break`` and ``no-else-continue``.

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
