### PR TITLE
Bump ZHA quirks module

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/components/zha",
   "requirements": [
     "bellows-homeassistant==0.10.0",
-    "zha-quirks==0.0.23",
+    "zha-quirks==0.0.25",
     "zigpy-deconz==0.4.0",
     "zigpy-homeassistant==0.9.0",
     "zigpy-xbee-homeassistant==0.5.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2011,7 +2011,7 @@ zengge==0.2
 zeroconf==0.23.0
 
 # homeassistant.components.zha
-zha-quirks==0.0.23
+zha-quirks==0.0.25
 
 # homeassistant.components.zhong_hong
 zhong_hong_hvac==1.0.9


### PR DESCRIPTION
## Description:
Bump the version on the ZHA quirks module. This includes device triggers for device automations as well. 

**Related issue (if applicable):** fixes  #26214

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]