### PR TITLE
Use Python3 new super syntax sugar

### DIFF
--- a/homeassistant/components/bloomsky/camera.py
+++ b/homeassistant/components/bloomsky/camera.py
@@ -19,7 +19,7 @@ class BloomSkyCamera(Camera):
 
     def __init__(self, bs, device):
         """Initialize access to the BloomSky camera images."""
-        super(BloomSkyCamera, self).__init__()
+        super().__init__()
         self._name = device["DeviceName"]
         self._id = device["DeviceID"]
         self._bloomsky = bs

--- a/homeassistant/components/foscam/camera.py
+++ b/homeassistant/components/foscam/camera.py
@@ -41,7 +41,7 @@ class FoscamCam(Camera):
         """Initialize a Foscam camera."""
         from libpyfoscam import FoscamCamera
 
-        super(FoscamCam, self).__init__()
+        super().__init__()
 
         ip_address = device_info.get(CONF_IP)
         port = device_info.get(CONF_PORT)

--- a/homeassistant/components/graphite/__init__.py
+++ b/homeassistant/components/graphite/__init__.py
@@ -64,7 +64,7 @@ class GraphiteFeeder(threading.Thread):
 
     def __init__(self, hass, host, port, prefix):
         """Initialize the feeder."""
-        super(GraphiteFeeder, self).__init__(daemon=True)
+        super().__init__(daemon=True)
         self._hass = hass
         self._host = host
         self._port = port

--- a/homeassistant/components/loopenergy/sensor.py
+++ b/homeassistant/components/loopenergy/sensor.py
@@ -122,7 +122,7 @@ class LoopEnergyElec(LoopEnergyDevice):
 
     def __init__(self, controller):
         """Initialize the sensor."""
-        super(LoopEnergyElec, self).__init__(controller)
+        super().__init__(controller)
         self._name = "Power Usage"
         self._controller.subscribe_elecricity(self._callback)
 
@@ -136,7 +136,7 @@ class LoopEnergyGas(LoopEnergyDevice):
 
     def __init__(self, controller):
         """Initialize the sensor."""
-        super(LoopEnergyGas, self).__init__(controller)
+        super().__init__(controller)
         self._name = "Gas Usage"
         self._controller.subscribe_gas(self._callback)
 

--- a/homeassistant/components/mochad/__init__.py
+++ b/homeassistant/components/mochad/__init__.py
@@ -64,7 +64,7 @@ class MochadCtrl:
 
     def __init__(self, host, port):
         """Initialize a PyMochad controller."""
-        super(MochadCtrl, self).__init__()
+        super().__init__()
         self._host = host
         self._port = port
 

--- a/homeassistant/components/nest/binary_sensor.py
+++ b/homeassistant/components/nest/binary_sensor.py
@@ -141,7 +141,7 @@ class NestActivityZoneSensor(NestBinarySensor):
 
     def __init__(self, structure, device, zone):
         """Initialize the sensor."""
-        super(NestActivityZoneSensor, self).__init__(structure, device, "")
+        super().__init__(structure, device, "")
         self.zone = zone
         self._name = f"{self._name} {self.zone.name} activity"
 

--- a/homeassistant/components/nest/camera.py
+++ b/homeassistant/components/nest/camera.py
@@ -34,7 +34,7 @@ class NestCamera(Camera):
 
     def __init__(self, structure, device):
         """Initialize a Nest Camera."""
-        super(NestCamera, self).__init__()
+        super().__init__()
         self.structure = structure
         self.device = device
         self._location = None

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -69,7 +69,7 @@ class NetatmoCamera(Camera):
 
     def __init__(self, data, camera_name, home, camera_type, verify_ssl, quality):
         """Set up for access to the Netatmo camera images."""
-        super(NetatmoCamera, self).__init__()
+        super().__init__()
         self._data = data
         self._camera_name = camera_name
         self._verify_ssl = verify_ssl

--- a/homeassistant/components/nuimo_controller/__init__.py
+++ b/homeassistant/components/nuimo_controller/__init__.py
@@ -76,7 +76,7 @@ class NuimoThread(threading.Thread):
 
     def __init__(self, hass, mac, name):
         """Initialize thread object."""
-        super(NuimoThread, self).__init__()
+        super().__init__()
         self._hass = hass
         self._mac = mac
         self._name = name

--- a/homeassistant/components/nx584/binary_sensor.py
+++ b/homeassistant/components/nx584/binary_sensor.py
@@ -107,7 +107,7 @@ class NX584Watcher(threading.Thread):
 
     def __init__(self, client, zone_sensors):
         """Initialize NX584 watcher thread."""
-        super(NX584Watcher, self).__init__()
+        super().__init__()
         self.daemon = True
         self._client = client
         self._zone_sensors = zone_sensors

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -374,7 +374,7 @@ class OnkyoDeviceZone(OnkyoDevice):
         """Initialize the Zone with the zone identifier."""
         self._zone = zone
         self._supports_volume = True
-        super(OnkyoDeviceZone, self).__init__(receiver, sources, name)
+        super().__init__(receiver, sources, name)
 
     def update(self):
         """Get the latest state from the device."""

--- a/homeassistant/components/ring/binary_sensor.py
+++ b/homeassistant/components/ring/binary_sensor.py
@@ -65,7 +65,7 @@ class RingBinarySensor(BinarySensorDevice):
 
     def __init__(self, hass, data, sensor_type):
         """Initialize a sensor for Ring device."""
-        super(RingBinarySensor, self).__init__()
+        super().__init__()
         self._sensor_type = sensor_type
         self._data = data
         self._name = "{0} {1}".format(

--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -75,7 +75,7 @@ class RingCam(Camera):
 
     def __init__(self, hass, camera, device_info):
         """Initialize a Ring Door Bell camera."""
-        super(RingCam, self).__init__()
+        super().__init__()
         self._camera = camera
         self._hass = hass
         self._name = self._camera.name

--- a/homeassistant/components/ring/sensor.py
+++ b/homeassistant/components/ring/sensor.py
@@ -110,7 +110,7 @@ class RingSensor(Entity):
 
     def __init__(self, hass, data, sensor_type):
         """Initialize a sensor for Ring device."""
-        super(RingSensor, self).__init__()
+        super().__init__()
         self._sensor_type = sensor_type
         self._data = data
         self._extra = None

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -246,7 +246,7 @@ class SqueezeBoxDevice(MediaPlayerDevice):
 
     def __init__(self, lms, player_id, name):
         """Initialize the SqueezeBox device."""
-        super(SqueezeBoxDevice, self).__init__()
+        super().__init__()
         self._lms = lms
         self._id = player_id
         self._status = {}

--- a/homeassistant/components/tcp/sensor.py
+++ b/homeassistant/components/tcp/sensor.py
@@ -81,7 +81,7 @@ class TcpSensor(Entity):
         name = self._config[CONF_NAME]
         if name is not None:
             return name
-        return super(TcpSensor, self).name
+        return super().name
 
     @property
     def state(self):

--- a/homeassistant/components/tplink/device_tracker.py
+++ b/homeassistant/components/tplink/device_tracker.py
@@ -245,7 +245,7 @@ class Tplink3DeviceScanner(Tplink1DeviceScanner):
         """Initialize the scanner."""
         self.stok = ""
         self.sysauth = ""
-        super(Tplink3DeviceScanner, self).__init__(config)
+        super().__init__(config)
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
@@ -365,7 +365,7 @@ class Tplink4DeviceScanner(Tplink1DeviceScanner):
         """Initialize the scanner."""
         self.credentials = ""
         self.token = ""
-        super(Tplink4DeviceScanner, self).__init__(config)
+        super().__init__(config)
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""

--- a/homeassistant/components/ubus/device_tracker.py
+++ b/homeassistant/components/ubus/device_tracker.py
@@ -146,7 +146,7 @@ class DnsmasqUbusDeviceScanner(UbusDeviceScanner):
 
     def __init__(self, config):
         """Initialize the scanner."""
-        super(DnsmasqUbusDeviceScanner, self).__init__(config)
+        super().__init__(config)
         self.leasefile = None
 
     def _generate_mac2name(self):

--- a/homeassistant/components/uvc/camera.py
+++ b/homeassistant/components/uvc/camera.py
@@ -78,7 +78,7 @@ class UnifiVideoCamera(Camera):
 
     def __init__(self, nvr, uuid, name, password):
         """Initialize an Unifi camera."""
-        super(UnifiVideoCamera, self).__init__()
+        super().__init__()
         self._nvr = nvr
         self._uuid = uuid
         self._name = name

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -863,7 +863,7 @@ class WinkSirenDevice(WinkDevice):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        attributes = super(WinkSirenDevice, self).device_state_attributes
+        attributes = super().device_state_attributes
 
         auto_shutoff = self.wink.auto_shutoff()
         if auto_shutoff is not None:
@@ -921,7 +921,7 @@ class WinkNimbusDialDevice(WinkDevice):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        attributes = super(WinkNimbusDialDevice, self).device_state_attributes
+        attributes = super().device_state_attributes
         dial_attributes = self.dial_attributes()
 
         return {**attributes, **dial_attributes}

--- a/homeassistant/components/wink/switch.py
+++ b/homeassistant/components/wink/switch.py
@@ -53,7 +53,7 @@ class WinkToggleDevice(WinkDevice, ToggleEntity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attributes = super(WinkToggleDevice, self).device_state_attributes
+        attributes = super().device_state_attributes
         try:
             event = self.wink.last_event()
             if event is not None:

--- a/homeassistant/components/zigbee/__init__.py
+++ b/homeassistant/components/zigbee/__init__.py
@@ -172,7 +172,7 @@ class ZigBeeDigitalInConfig(ZigBeePinConfig):
 
     def __init__(self, config):
         """Initialise the Zigbee Digital input config."""
-        super(ZigBeeDigitalInConfig, self).__init__(config)
+        super().__init__(config)
         self._bool2state, self._state2bool = self.boolean_maps
 
     @property
@@ -216,7 +216,7 @@ class ZigBeeDigitalOutConfig(ZigBeePinConfig):
 
     def __init__(self, config):
         """Initialize the Zigbee Digital out."""
-        super(ZigBeeDigitalOutConfig, self).__init__(config)
+        super().__init__(config)
         self._bool2state, self._state2bool = self.boolean_maps
         self._should_poll = config.get("poll", False)
 

--- a/homeassistant/components/zwave/binary_sensor.py
+++ b/homeassistant/components/zwave/binary_sensor.py
@@ -71,7 +71,7 @@ class ZWaveTriggerSensor(ZWaveBinarySensor):
 
     def __init__(self, values, device_class):
         """Initialize the sensor."""
-        super(ZWaveTriggerSensor, self).__init__(values, device_class)
+        super().__init__(values, device_class)
         # Set default off delay to 60 sec
         self.re_arm_sec = 60
         self.invalidate_after = None

--- a/homeassistant/helpers/logging.py
+++ b/homeassistant/helpers/logging.py
@@ -29,7 +29,7 @@ class KeywordStyleAdapter(logging.LoggerAdapter):
 
     def __init__(self, logger, extra=None):
         """Initialize a new StyleAdapter for the provided logger."""
-        super(KeywordStyleAdapter, self).__init__(logger, extra or {})
+        super().__init__(logger, extra or {})
 
     def log(self, level, msg, *args, **kwargs):
         """Log the message provided at the appropriate level."""

--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -48,7 +48,7 @@ class SafeLineLoader(yaml.SafeLoader):
     def compose_node(self, parent: yaml.nodes.Node, index: int) -> yaml.nodes.Node:
         """Annotate a node with the first line it was seen."""
         last_line: int = self.line
-        node: yaml.nodes.Node = super(SafeLineLoader, self).compose_node(parent, index)
+        node: yaml.nodes.Node = super().compose_node(parent, index)
         node.__line__ = last_line + 1  # type: ignore
         return node
 

--- a/tests/components/smhi/common.py
+++ b/tests/components/smhi/common.py
@@ -8,4 +8,4 @@ class AsyncMock(Mock):
     # pylint: disable=W0235
     async def __call__(self, *args, **kwargs):
         """Hack for async support for Mock."""
-        return super(AsyncMock, self).__call__(*args, **kwargs)
+        return super().__call__(*args, **kwargs)


### PR DESCRIPTION
## Description:

Consistently uses syntactic sugar for the super type to automatically construct instances of the super type binding to the class that a method was defined in, and the instance (or class object for classmethods) that the method is currently acting upon.

`super(Foo, self).foo(1, 2)` == `super().foo(1, 2)`

See: [PEP 3135](https://www.python.org/dev/peps/pep-3135/)

Used the following regex to find them: `super\(.+\)\.`

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):

n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
