### PR TITLE
Add MySensors ACK

### DIFF
--- a/homeassistant/components/mysensors/climate.py
+++ b/homeassistant/components/mysensors/climate.py
@@ -156,7 +156,9 @@ class MySensorsHVAC(mysensors.device.MySensorsEntity, ClimateDevice):
                 (set_req.V_HVAC_SETPOINT_COOL, high),
             ]
         for value_type, value in updates:
-            self.gateway.set_child_value(self.node_id, self.child_id, value_type, value, ack=1)
+            self.gateway.set_child_value(
+                self.node_id, self.child_id, value_type, value, ack=1
+            )
             if self.gateway.optimistic:
                 # Optimistically assume that device has changed state
                 self._values[value_type] = value
@@ -176,7 +178,11 @@ class MySensorsHVAC(mysensors.device.MySensorsEntity, ClimateDevice):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target temperature."""
         self.gateway.set_child_value(
-            self.node_id, self.child_id, self.value_type, DICT_HA_TO_MYS[hvac_mode], ack=1
+            self.node_id,
+            self.child_id,
+            self.value_type,
+            DICT_HA_TO_MYS[hvac_mode],
+            ack=1,
         )
         if self.gateway.optimistic:
             # Optimistically assume that device has changed state

--- a/homeassistant/components/mysensors/climate.py
+++ b/homeassistant/components/mysensors/climate.py
@@ -156,7 +156,7 @@ class MySensorsHVAC(mysensors.device.MySensorsEntity, ClimateDevice):
                 (set_req.V_HVAC_SETPOINT_COOL, high),
             ]
         for value_type, value in updates:
-            self.gateway.set_child_value(self.node_id, self.child_id, value_type, value)
+            self.gateway.set_child_value(self.node_id, self.child_id, value_type, value, ack=1)
             if self.gateway.optimistic:
                 # Optimistically assume that device has changed state
                 self._values[value_type] = value
@@ -166,7 +166,7 @@ class MySensorsHVAC(mysensors.device.MySensorsEntity, ClimateDevice):
         """Set new target temperature."""
         set_req = self.gateway.const.SetReq
         self.gateway.set_child_value(
-            self.node_id, self.child_id, set_req.V_HVAC_SPEED, fan_mode
+            self.node_id, self.child_id, set_req.V_HVAC_SPEED, fan_mode, ack=1
         )
         if self.gateway.optimistic:
             # Optimistically assume that device has changed state
@@ -176,7 +176,7 @@ class MySensorsHVAC(mysensors.device.MySensorsEntity, ClimateDevice):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target temperature."""
         self.gateway.set_child_value(
-            self.node_id, self.child_id, self.value_type, DICT_HA_TO_MYS[hvac_mode]
+            self.node_id, self.child_id, self.value_type, DICT_HA_TO_MYS[hvac_mode], ack=1
         )
         if self.gateway.optimistic:
             # Optimistically assume that device has changed state

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -43,7 +43,9 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverDevice):
     async def async_open_cover(self, **kwargs):
         """Move the cover up."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_UP, 1, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, set_req.V_UP, 1, ack=1
+        )
         if self.gateway.optimistic:
             # Optimistically assume that cover has changed state.
             if set_req.V_DIMMER in self._values:
@@ -55,7 +57,9 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverDevice):
     async def async_close_cover(self, **kwargs):
         """Move the cover down."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_DOWN, 1, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, set_req.V_DOWN, 1, ack=1
+        )
         if self.gateway.optimistic:
             # Optimistically assume that cover has changed state.
             if set_req.V_DIMMER in self._values:
@@ -79,4 +83,6 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverDevice):
     async def async_stop_cover(self, **kwargs):
         """Stop the device."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_STOP, 1, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, set_req.V_STOP, 1, ack=1
+        )

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -43,7 +43,7 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverDevice):
     async def async_open_cover(self, **kwargs):
         """Move the cover up."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_UP, 1)
+        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_UP, 1, ack=1)
         if self.gateway.optimistic:
             # Optimistically assume that cover has changed state.
             if set_req.V_DIMMER in self._values:
@@ -55,7 +55,7 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverDevice):
     async def async_close_cover(self, **kwargs):
         """Move the cover down."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_DOWN, 1)
+        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_DOWN, 1, ack=1)
         if self.gateway.optimistic:
             # Optimistically assume that cover has changed state.
             if set_req.V_DIMMER in self._values:
@@ -69,7 +69,7 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverDevice):
         position = kwargs.get(ATTR_POSITION)
         set_req = self.gateway.const.SetReq
         self.gateway.set_child_value(
-            self.node_id, self.child_id, set_req.V_DIMMER, position
+            self.node_id, self.child_id, set_req.V_DIMMER, position, ack=1
         )
         if self.gateway.optimistic:
             # Optimistically assume that cover has changed state.
@@ -79,4 +79,4 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverDevice):
     async def async_stop_cover(self, **kwargs):
         """Stop the device."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_STOP, 1)
+        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_STOP, 1, ack=1)

--- a/homeassistant/components/mysensors/light.py
+++ b/homeassistant/components/mysensors/light.py
@@ -75,7 +75,9 @@ class MySensorsLight(mysensors.device.MySensorsEntity, Light):
 
         if self._state:
             return
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 1, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, set_req.V_LIGHT, 1, ack=1
+        )
 
         if self.gateway.optimistic:
             # optimistically assume that light has changed state

--- a/homeassistant/components/mysensors/light.py
+++ b/homeassistant/components/mysensors/light.py
@@ -75,7 +75,7 @@ class MySensorsLight(mysensors.device.MySensorsEntity, Light):
 
         if self._state:
             return
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 1)
+        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 1, ack=1)
 
         if self.gateway.optimistic:
             # optimistically assume that light has changed state
@@ -96,7 +96,7 @@ class MySensorsLight(mysensors.device.MySensorsEntity, Light):
         brightness = kwargs[ATTR_BRIGHTNESS]
         percent = round(100 * brightness / 255)
         self.gateway.set_child_value(
-            self.node_id, self.child_id, set_req.V_DIMMER, percent
+            self.node_id, self.child_id, set_req.V_DIMMER, percent, ack=1
         )
 
         if self.gateway.optimistic:
@@ -129,7 +129,7 @@ class MySensorsLight(mysensors.device.MySensorsEntity, Light):
         if len(rgb) > 3:
             white = rgb.pop()
         self.gateway.set_child_value(
-            self.node_id, self.child_id, self.value_type, hex_color
+            self.node_id, self.child_id, self.value_type, hex_color, ack=1
         )
 
         if self.gateway.optimistic:
@@ -141,7 +141,7 @@ class MySensorsLight(mysensors.device.MySensorsEntity, Light):
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
         value_type = self.gateway.const.SetReq.V_LIGHT
-        self.gateway.set_child_value(self.node_id, self.child_id, value_type, 0)
+        self.gateway.set_child_value(self.node_id, self.child_id, value_type, 0, ack=1)
         if self.gateway.optimistic:
             # optimistically assume that light has changed state
             self._state = False

--- a/homeassistant/components/mysensors/switch.py
+++ b/homeassistant/components/mysensors/switch.py
@@ -92,7 +92,7 @@ class MySensorsSwitch(mysensors.device.MySensorsEntity, SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
-        self.gateway.set_child_value(self.node_id, self.child_id, self.value_type, 1)
+        self.gateway.set_child_value(self.node_id, self.child_id, self.value_type, 1, ack=1)
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[self.value_type] = STATE_ON
@@ -100,7 +100,7 @@ class MySensorsSwitch(mysensors.device.MySensorsEntity, SwitchDevice):
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
-        self.gateway.set_child_value(self.node_id, self.child_id, self.value_type, 0)
+        self.gateway.set_child_value(self.node_id, self.child_id, self.value_type, 0, ack=1)
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[self.value_type] = STATE_OFF
@@ -129,7 +129,7 @@ class MySensorsIRSwitch(MySensorsSwitch):
         self.gateway.set_child_value(
             self.node_id, self.child_id, self.value_type, self._ir_code
         )
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 1)
+        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 1, ack=1)
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[self.value_type] = self._ir_code
@@ -141,7 +141,7 @@ class MySensorsIRSwitch(MySensorsSwitch):
     async def async_turn_off(self, **kwargs):
         """Turn the IR switch off."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 0)
+        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 0, ack=1)
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[set_req.V_LIGHT] = STATE_OFF

--- a/homeassistant/components/mysensors/switch.py
+++ b/homeassistant/components/mysensors/switch.py
@@ -92,7 +92,9 @@ class MySensorsSwitch(mysensors.device.MySensorsEntity, SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
-        self.gateway.set_child_value(self.node_id, self.child_id, self.value_type, 1, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, self.value_type, 1, ack=1
+        )
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[self.value_type] = STATE_ON
@@ -100,7 +102,9 @@ class MySensorsSwitch(mysensors.device.MySensorsEntity, SwitchDevice):
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
-        self.gateway.set_child_value(self.node_id, self.child_id, self.value_type, 0, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, self.value_type, 0, ack=1
+        )
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[self.value_type] = STATE_OFF
@@ -129,7 +133,9 @@ class MySensorsIRSwitch(MySensorsSwitch):
         self.gateway.set_child_value(
             self.node_id, self.child_id, self.value_type, self._ir_code
         )
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 1, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, set_req.V_LIGHT, 1, ack=1
+        )
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[self.value_type] = self._ir_code
@@ -141,7 +147,9 @@ class MySensorsIRSwitch(MySensorsSwitch):
     async def async_turn_off(self, **kwargs):
         """Turn the IR switch off."""
         set_req = self.gateway.const.SetReq
-        self.gateway.set_child_value(self.node_id, self.child_id, set_req.V_LIGHT, 0, ack=1)
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, set_req.V_LIGHT, 0, ack=1
+        )
         if self.gateway.optimistic:
             # Optimistically assume that switch has changed state
             self._values[set_req.V_LIGHT] = STATE_OFF


### PR DESCRIPTION
## Description:
The addition of the ACK will ask MySensors devices to respond to commands sent to them which will then update the MySensors device in Home Assistant.  Currently, if a default MySensors sketch is used the device will update but Home Assistant does not reflect the update and custom code has to be added to tell Home Assistant the command was received.  With the ACK set to 1 in the message all this is taken care of by MySensors.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.
