### PR TITLE
Nzbget services

### DIFF
--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -2,7 +2,6 @@
 from datetime import timedelta
 import logging
 
-import pynzbgetapi
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -62,6 +61,8 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the NZBGet sensors."""
+    import pynzbgetapi
+
     host = config[DOMAIN][CONF_HOST]
     port = config[DOMAIN][CONF_PORT]
     ssl = "s" if config[DOMAIN][CONF_SSL] else ""
@@ -85,11 +86,11 @@ def setup(hass, config):
     def service_handler(service):
         """Handle service calls."""
         if service.service == SERVICE_PAUSE:
-            nzbget_data.pausedownload()
+            nzbget_data.pause_download()
         elif service.service == SERVICE_RESUME:
-            nzbget_data.resumedownload()
+            nzbget_data.resume_download()
         elif service.service == SERVICE_SET_SPEED:
-            limit = service.data.get(ATTR_SPEED)
+            limit = service.data[ATTR_SPEED]
             nzbget_data.rate(limit)
 
     hass.services.register(
@@ -129,6 +130,8 @@ class NZBGetData:
 
     def update(self):
         """Get the latest data from NZBGet instance."""
+        import pynzbgetapi
+
         try:
             self.status = self._api.status()
             self.available = True
@@ -137,15 +140,19 @@ class NZBGetData:
             self.available = False
             _LOGGER.error("Unable to refresh NZBGet data: %s", err)
 
-    def pausedownload(self):
+    def pause_download(self):
         """Pause download queue."""
+        import pynzbgetapi
+
         try:
             self._api.pausedownload()
         except pynzbgetapi.NZBGetAPIException as err:
             _LOGGER.error("Unable to pause queue: %s", err)
 
-    def resumedownload(self):
+    def resume_download(self):
         """Resume download queue."""
+        import pynzbgetapi
+
         try:
             self._api.resumedownload()
         except pynzbgetapi.NZBGetAPIException as err:
@@ -153,6 +160,8 @@ class NZBGetData:
 
     def rate(self, limit):
         """Set download speed."""
+        import pynzbgetapi
+
         try:
             if not self._api.rate(limit):
                 _LOGGER.error("Limit was out of range")

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -154,6 +154,7 @@ class NZBGetData:
     def rate(self, limit):
         """Set download speed."""
         try:
-            self._api.rate(limit)
+            if not self._api.rate(limit):
+                _LOGGER.error("Limit was out of range")
         except pynzbgetapi.NZBGetAPIException as err:
-            _LOGGER.error("Uanble to resume download queue: %s", err)
+            _LOGGER.error("Unable to set download speed: %s", err)

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -20,14 +20,25 @@ from homeassistant.helpers.event import track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_SPEED = "speed"
+
 DOMAIN = "nzbget"
 DATA_NZBGET = "data_nzbget"
 DATA_UPDATED = "nzbget_data_updated"
 
 DEFAULT_NAME = "NZBGet"
 DEFAULT_PORT = 6789
+DEFAULT_SPEED_LIMIT = 1000  # 1 Megabyte/Sec
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=5)
+
+SERVICE_PAUSE = "pause"
+SERVICE_RESUME = "resume"
+SERVICE_SET_SPEED = "set_speed"
+
+SPEED_LIMIT_SCHEMA = vol.Schema(
+    {vol.Optional(ATTR_SPEED, default=DEFAULT_SPEED_LIMIT): cv.positive_int}
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -71,6 +82,28 @@ def setup(hass, config):
     nzbget_data = hass.data[DATA_NZBGET] = NZBGetData(hass, nzbget_api)
     nzbget_data.update()
 
+    def service_handler(service):
+        """Handle service calls."""
+        if service.service == SERVICE_PAUSE:
+            nzbget_data.pausedownload()
+        elif service.service == SERVICE_RESUME:
+            nzbget_data.resumedownload()
+        elif service.service == SERVICE_SET_SPEED:
+            limit = service.data.get(ATTR_SPEED)
+            nzbget_data.rate(limit)
+
+    hass.services.register(
+        DOMAIN, SERVICE_PAUSE, service_handler, schema=vol.Schema({})
+    )
+
+    hass.services.register(
+        DOMAIN, SERVICE_RESUME, service_handler, schema=vol.Schema({})
+    )
+
+    hass.services.register(
+        DOMAIN, SERVICE_SET_SPEED, service_handler, schema=SPEED_LIMIT_SCHEMA
+    )
+
     def refresh(event_time):
         """Get the latest data from NZBGet."""
         nzbget_data.update()
@@ -100,6 +133,27 @@ class NZBGetData:
             self.status = self._api.status()
             self.available = True
             dispatcher_send(self.hass, DATA_UPDATED)
-        except pynzbgetapi.NZBGetAPIException:
+        except pynzbgetapi.NZBGetAPIException as err:
             self.available = False
-            _LOGGER.error("Unable to refresh NZBGet data")
+            _LOGGER.error("Unable to refresh NZBGet data: %s", err)
+
+    def pausedownload(self):
+        """Pause download queue."""
+        try:
+            self._api.pausedownload()
+        except pynzbgetapi.NZBGetAPIException as err:
+            _LOGGER.error("Unable to pause queue: %s", err)
+
+    def resumedownload(self):
+        """Resume download queue."""
+        try:
+            self._api.resumedownload()
+        except pynzbgetapi.NZBGetAPIException as err:
+            _LOGGER.error("Unable to resume download queue: %s", err)
+
+    def rate(self, limit):
+        """Set download speed."""
+        try:
+            self._api.rate(limit)
+        except pynzbgetapi.NZBGetAPIException as err:
+            _LOGGER.error("Uanble to resume download queue: %s", err)

--- a/homeassistant/components/nzbget/__init__.py
+++ b/homeassistant/components/nzbget/__init__.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+import pynzbgetapi
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -61,7 +62,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the NZBGet sensors."""
-    import pynzbgetapi
 
     host = config[DOMAIN][CONF_HOST]
     port = config[DOMAIN][CONF_PORT]
@@ -130,7 +130,6 @@ class NZBGetData:
 
     def update(self):
         """Get the latest data from NZBGet instance."""
-        import pynzbgetapi
 
         try:
             self.status = self._api.status()
@@ -142,7 +141,6 @@ class NZBGetData:
 
     def pause_download(self):
         """Pause download queue."""
-        import pynzbgetapi
 
         try:
             self._api.pausedownload()
@@ -151,7 +149,6 @@ class NZBGetData:
 
     def resume_download(self):
         """Resume download queue."""
-        import pynzbgetapi
 
         try:
             self._api.resumedownload()
@@ -160,7 +157,6 @@ class NZBGetData:
 
     def rate(self, limit):
         """Set download speed."""
-        import pynzbgetapi
 
         try:
             if not self._api.rate(limit):

--- a/homeassistant/components/nzbget/services.yaml
+++ b/homeassistant/components/nzbget/services.yaml
@@ -1,0 +1,14 @@
+# Describes the format for available nzbget services
+
+pause:
+  description: Pause download queue.
+
+resume:
+  description: Resume download queue.
+
+set_speed:
+  description: Set download speed limit
+  fields:
+    speed:
+      description: Speed limit in KB/s. 0 is unlimited.
+      example: 1000


### PR DESCRIPTION
## Description:
Adding nzbget pause, resume, and set_speed services to control the download queue.

Tested by manually pausing and resuming the queue and setting the download speed. 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10454

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [N/A ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [N/A] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
