### PR TITLE
Fix missing whitespace around arithmetic operator

### DIFF
--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -324,7 +324,7 @@ class XiaomiDevice(Entity):
         max_volt = 3300
         min_volt = 2800
         voltage = data[voltage_key]
-        self._device_state_attributes[ATTR_VOLTAGE] = round(voltage/1000.0, 2)
+        self._device_state_attributes[ATTR_VOLTAGE] = round(voltage / 1000.0, 2)
         voltage = min(voltage, max_volt)
         voltage = max(voltage, min_volt)
         percent = ((voltage - min_volt) / (max_volt - min_volt)) * 100


### PR DESCRIPTION
## Description:

Fixes the build.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

```
homeassistant/components/xiaomi_aqara/__init__.py:327:68: E226 missing whitespace around arithmetic operator
```