### PR TITLE
deCONZ - Increase bridge discovery robustness in config flow

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -90,7 +90,7 @@ class DeconzFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             with async_timeout.timeout(10):
                 self.bridges = await async_discovery(session)
 
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, ResponseError):
             self.bridges = []
 
         if len(self.bridges) == 1:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #24960

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
