### PR TITLE
0.99.3

### DIFF
--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -2,9 +2,7 @@
   "domain": "frontend",
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/components/frontend",
-  "requirements": [
-    "home-assistant-frontend==20190919.0"
-  ],
+  "requirements": ["home-assistant-frontend==20190919.1"],
   "dependencies": [
     "api",
     "auth",

--- a/homeassistant/components/homematic/climate.py
+++ b/homeassistant/components/homematic/climate.py
@@ -94,7 +94,9 @@ class HMThermostat(HMDevice, ClimateDevice):
         if self._data.get("BOOST_MODE", False):
             return "boost"
 
-        # Get the name of the mode
+        if not self._hm_control_mode:
+            return None
+
         mode = HM_ATTRIBUTE_SUPPORT[HM_CONTROL_MODE][1][self._hm_control_mode]
         mode = mode.lower()
 
@@ -177,8 +179,9 @@ class HMThermostat(HMDevice, ClimateDevice):
         """Return Control mode."""
         if HMIP_CONTROL_MODE in self._data:
             return self._data[HMIP_CONTROL_MODE]
+
         # Homematic
-        return self._data["CONTROL_MODE"]
+        return self._data.get("CONTROL_MODE")
 
     def _init_data_struct(self):
         """Generate a data dict (self._data) from the Homematic metadata."""

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -9,7 +9,7 @@
     "zigpy-deconz==0.3.0",
     "zigpy-homeassistant==0.8.0",
     "zigpy-xbee-homeassistant==0.4.0",
-    "zigpy-zigate==0.2.0"
+    "zigpy-zigate==0.3.1"
   ],
   "dependencies": [],
   "codeowners": ["@dmulcahey", "@adminiuga"]

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 99
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = "{}.{}".format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = "{}.{}".format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 6, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,7 +11,7 @@ contextvars==2.4;python_version<"3.7"
 cryptography==2.7
 distro==1.4.0
 hass-nabucasa==0.17
-home-assistant-frontend==20190919.0
+home-assistant-frontend==20190919.1
 importlib-metadata==0.19
 jinja2>=2.10.1
 netdisco==2.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -639,7 +639,7 @@ hole==0.5.0
 holidays==0.9.11
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190919.0
+home-assistant-frontend==20190919.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.4
@@ -2025,7 +2025,7 @@ zigpy-homeassistant==0.8.0
 zigpy-xbee-homeassistant==0.4.0
 
 # homeassistant.components.zha
-zigpy-zigate==0.2.0
+zigpy-zigate==0.3.1
 
 # homeassistant.components.zoneminder
 zm-py==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -178,7 +178,7 @@ hole==0.5.0
 holidays==0.9.11
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190919.0
+home-assistant-frontend==20190919.1
 
 # homeassistant.components.homekit_controller
 homekit[IP]==0.15.0


### PR DESCRIPTION
- Bump zigpy-zigate to 0.3.1 ([@doudz] - [#26600]) ([zha docs])
- HM-CC-TC was not recognized ([@MajestyIV] - [#26623]) ([homematic docs])
- Bring back babel for ES5 builds @bramkragten

[#26600]: https://github.com/home-assistant/home-assistant/pull/26600
[#26623]: https://github.com/home-assistant/home-assistant/pull/26623
[@MajestyIV]: https://github.com/MajestyIV
[@doudz]: https://github.com/doudz
[homematic docs]: https://www.home-assistant.io/components/homematic/
[zha docs]: https://www.home-assistant.io/components/zha/