### PR TITLE
Extend add_item conditional in shopping list

### DIFF
--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -66,7 +66,7 @@ def async_setup(hass, config):
         """Add an item with `name`."""
         data = hass.data[DOMAIN]
         name = call.data.get(ATTR_NAME)
-        if name is not None:
+        if name is not None and name != '':
             data.async_add(name)
 
     @asyncio.coroutine


### PR DESCRIPTION
## Description:

Do not add empty strings to shopping list besides `None`. This helps, if `name` is defined by a `data_template`, which can not be `None` by definition.

## Example entry for `configuration.yaml` (if applicable):
```yaml

intent_script:
  ShoppingListAddItems:
    action:
      - service: shopping_list.add_item
        data_template:
          name: "{{item if item}}"
      - service: shopping_list.add_item
        data_template:
          name: "{{ item_two if item_two }}"
    speech:
      text: "{{item}} {{item_two}} added"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]