### PR TITLE
Remove logging from package

### DIFF
--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -268,7 +268,7 @@ class WazeTravelTimeData:
                     self.destination,
                     self.region,
                     self.vehicle_type,
-                    log_lvl=logging.DEBUG,
+                    log_lvl=None,
                 )
                 routes = params.calc_all_routes_info(real_time=self.realtime)
 


### PR DESCRIPTION
WazeRouteCalculator debug-log fills HASS log file for no good.


## Checklist:
  - [X] The code change is tested and works locally.