### PR TITLE
Bump pyobihai, add unique ID and availability

### DIFF
--- a/homeassistant/components/obihai/manifest.json
+++ b/homeassistant/components/obihai/manifest.json
@@ -3,7 +3,7 @@
     "name": "Obihai",
     "documentation": "https://www.home-assistant.io/components/obihai",
     "requirements": [
-      "pyobihai==1.1.1"
+      "pyobihai==1.2.0"
     ],
     "dependencies": [],
     "codeowners": ["@dshokouhi"]

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -44,27 +44,27 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sensors = []
 
-    pyobihai = PyObihai()
+    pyobihai = PyObihai(host, username, password)
 
-    login = pyobihai.check_account(host, username, password)
+    login = pyobihai.check_account()
     if not login:
         _LOGGER.error("Invalid credentials")
         return
 
-    services = pyobihai.get_state(host, username, password)
+    services = pyobihai.get_state()
 
-    line_services = pyobihai.get_line_state(host, username, password)
+    line_services = pyobihai.get_line_state()
 
-    call_direction = pyobihai.get_call_direction(host, username, password)
+    call_direction = pyobihai.get_call_direction()
 
     for key in services:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, key))
 
     for key in line_services:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, key))
 
     for key in call_direction:
-        sensors.append(ObihaiServiceSensors(pyobihai, host, username, password, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, key))
 
     add_entities(sensors)
 
@@ -72,11 +72,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ObihaiServiceSensors(Entity):
     """Get the status of each Obihai Lines."""
 
-    def __init__(self, pyobihai, host, username, password, service_name):
+    def __init__(self, pyobihai, service_name):
         """Initialize monitor sensor."""
-        self._host = host
-        self._username = username
-        self._password = password
         self._service_name = service_name
         self._state = None
         self._name = f"{OBIHAI} {self._service_name}"
@@ -93,6 +90,20 @@ class ObihaiServiceSensors(Entity):
         return self._state
 
     @property
+    def available(self):
+        """Return if sensor is available."""
+        if self._state is not None:
+            return True
+        return False
+
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        serial = self._pyobihai.get_device_serial()
+        unique_id = f"{serial}-{self._service_name}"
+        return unique_id
+
+    @property
     def device_class(self):
         """Return the device class for uptime sensor."""
         if self._service_name == "Last Reboot":
@@ -101,21 +112,17 @@ class ObihaiServiceSensors(Entity):
 
     def update(self):
         """Update the sensor."""
-        services = self._pyobihai.get_state(self._host, self._username, self._password)
+        services = self._pyobihai.get_state()
 
         if self._service_name in services:
             self._state = services.get(self._service_name)
 
-        services = self._pyobihai.get_line_state(
-            self._host, self._username, self._password
-        )
+        services = self._pyobihai.get_line_state()
 
         if self._service_name in services:
             self._state = services.get(self._service_name)
 
-        call_direction = self._pyobihai.get_call_direction(
-            self._host, self._username, self._password
-        )
+        call_direction = self._pyobihai.get_call_direction()
 
         if self._service_name in call_direction:
             self._state = call_direction.get(self._service_name)

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -78,6 +78,7 @@ class ObihaiServiceSensors(Entity):
         self._state = None
         self._name = f"{OBIHAI} {self._service_name}"
         self._pyobihai = pyobihai
+        self._unique_id = f"{self._pyobihai.get_device_serial()}-{self._service_name}"
 
     @property
     def name(self):
@@ -99,9 +100,7 @@ class ObihaiServiceSensors(Entity):
     @property
     def unique_id(self):
         """Return the unique ID."""
-        serial = self._pyobihai.get_device_serial()
-        unique_id = f"{serial}-{self._service_name}"
-        return unique_id
+        return self._unique_id
 
     @property
     def device_class(self):

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -51,6 +51,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.error("Invalid credentials")
         return
 
+    serial = pyobihai.get_device_serial()
+
     services = pyobihai.get_state()
 
     line_services = pyobihai.get_line_state()
@@ -58,13 +60,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     call_direction = pyobihai.get_call_direction()
 
     for key in services:
-        sensors.append(ObihaiServiceSensors(pyobihai, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, serial, key))
 
     for key in line_services:
-        sensors.append(ObihaiServiceSensors(pyobihai, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, serial, key))
 
     for key in call_direction:
-        sensors.append(ObihaiServiceSensors(pyobihai, key))
+        sensors.append(ObihaiServiceSensors(pyobihai, serial, key))
 
     add_entities(sensors)
 
@@ -72,13 +74,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ObihaiServiceSensors(Entity):
     """Get the status of each Obihai Lines."""
 
-    def __init__(self, pyobihai, service_name):
+    def __init__(self, pyobihai, serial, service_name):
         """Initialize monitor sensor."""
         self._service_name = service_name
         self._state = None
         self._name = f"{OBIHAI} {self._service_name}"
         self._pyobihai = pyobihai
-        self._unique_id = f"{self._pyobihai.get_device_serial()}-{self._service_name}"
+        self._unique_id = f"{serial}-{self._service_name}"
 
     @property
     def name(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1346,7 +1346,7 @@ pynx584==0.4
 pynzbgetapi==0.2.0
 
 # homeassistant.components.obihai
-pyobihai==1.1.1
+pyobihai==1.2.0
 
 # homeassistant.components.ombi
 pyombi==0.1.5


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Bump pyobihai so credentials are stored and not used in each method per recommendation https://github.com/home-assistant/home-assistant/pull/26867#discussion_r327768206.  Add unique ID as device serial for entity registry.  Add availability if there is a state.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: obihai
    host: 192.168.1.x
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
