### PR TITLE
Add ecobee services to create and delete vacations

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     TEMP_FAHRENHEIT,
 )
+from homeassistant.util.temperature import convert
 import homeassistant.helpers.config_validation as cv
 
 from .const import DOMAIN, _LOGGER
@@ -614,21 +615,22 @@ class Thermostat(ClimateDevice):
     def create_vacation(self, service_data):
         """Create a vacation with user-specified parameters."""
         vacation_name = service_data[ATTR_VACATION_NAME]
-        cool_temp = service_data[ATTR_COOL_TEMP]
-        heat_temp = service_data[ATTR_HEAT_TEMP]
-
+        cool_temp = convert(
+            service_data[ATTR_COOL_TEMP],
+            self.hass.config.units.temperature_unit,
+            TEMP_FAHRENHEIT,
+        )
+        heat_temp = convert(
+            service_data[ATTR_HEAT_TEMP],
+            self.hass.config.units.temperature_unit,
+            TEMP_FAHRENHEIT,
+        )
         start_date = service_data.get(ATTR_START_DATE)
         start_time = service_data.get(ATTR_START_TIME)
         end_date = service_data.get(ATTR_END_DATE)
         end_time = service_data.get(ATTR_END_TIME)
         fan_mode = service_data[ATTR_FAN_MODE]
         fan_min_on_time = service_data[ATTR_FAN_MIN_ON_TIME]
-
-        if cool_temp < 35:
-            # Assume user has specified cool_temp and heat_temp in celsius
-            # Convert to fahrenheit before calling function
-            cool_temp = (cool_temp * (9 / 5)) + 32
-            heat_temp = (heat_temp * (9 / 5)) + 32
 
         kwargs = {
             key: value

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -97,16 +97,21 @@ SERVICE_DELETE_VACATION = "delete_vacation"
 SERVICE_RESUME_PROGRAM = "resume_program"
 SERVICE_SET_FAN_MIN_ON_TIME = "set_fan_min_on_time"
 
+DTGROUP_INCLUSIVE_MSG = (
+    f"{ATTR_START_DATE}, {ATTR_START_TIME}, {ATTR_END_DATE}, "
+    f"and {ATTR_END_TIME} must be specified together"
+)
+
 CREATE_VACATION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_id,
         vol.Required(ATTR_VACATION_NAME): cv.string,
-        vol.Required(ATTR_COOL_TEMP): vol.Any(cv.positive_int, float),
-        vol.Required(ATTR_HEAT_TEMP): vol.Any(cv.positive_int, float),
-        vol.Optional(ATTR_START_DATE): cv.string,
-        vol.Optional(ATTR_START_TIME): cv.string,
-        vol.Optional(ATTR_END_DATE): cv.string,
-        vol.Optional(ATTR_END_TIME): cv.string,
+        vol.Required(ATTR_COOL_TEMP): vol.Coerce(float),
+        vol.Required(ATTR_HEAT_TEMP): vol.Coerce(float),
+        vol.Inclusive(ATTR_START_DATE, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG): cv.string,
+        vol.Inclusive(ATTR_START_TIME, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG): cv.string,
+        vol.Inclusive(ATTR_END_DATE, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG): cv.string,
+        vol.Inclusive(ATTR_END_TIME, "dtgroup", msg=DTGROUP_INCLUSIVE_MSG): cv.string,
         vol.Optional(ATTR_FAN_MODE, default="auto"): vol.Any("auto", "on"),
         vol.Optional(ATTR_FAN_MIN_ON_TIME, default=0): vol.All(
             int, vol.Range(min=0, max=60)

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -168,11 +168,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     def create_vacation_service(service):
         """Create a vacation on the target thermostat."""
         entity_id = service.data[ATTR_ENTITY_ID]
-        data = service.data
 
-        for device in devices:
-            if device.entity_id == entity_id:
-                device.create_vacation(data)
+        for thermostat in devices:
+            if thermostat.entity_id == entity_id:
+                thermostat.create_vacation(service.data)
+                thermostat.schedule_update_ha_state(True)
                 break
 
     def delete_vacation_service(service):
@@ -180,9 +180,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entity_id = service.data[ATTR_ENTITY_ID]
         vacation_name = service.data[ATTR_VACATION_NAME]
 
-        for device in devices:
-            if device.entity_id == entity_id:
-                device.delete_vacation(vacation_name)
+        for thermostat in devices:
+            if thermostat.entity_id == entity_id:
+                thermostat.delete_vacation(vacation_name)
+                thermostat.schedule_update_ha_state(True)
                 break
 
     def fan_min_on_time_set_service(service):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -639,10 +639,13 @@ class Thermostat(ClimateDevice):
         }
 
         _LOGGER.debug(
-            "Creating a vacation on thermostat {} with name {}, cool temp {}, heat temp {}, "
-            "and the following other parameters: {}".format(
-                self.name, vacation_name, cool_temp, heat_temp, kwargs
-            )
+            "Creating a vacation on thermostat %s with name %s, cool temp %s, heat temp %s, "
+            "and the following other parameters: %s",
+            self.name,
+            vacation_name,
+            cool_temp,
+            heat_temp,
+            kwargs,
         )
         self.data.ecobee.create_vacation(
             self.thermostat_index, vacation_name, cool_temp, heat_temp, **kwargs
@@ -651,8 +654,8 @@ class Thermostat(ClimateDevice):
     def delete_vacation(self, vacation_name):
         """Delete a vacation with the specified name."""
         _LOGGER.debug(
-            "Deleting a vacation on thermostat {} with name {}".format(
-                self.name, vacation_name
-            )
+            "Deleting a vacation on thermostat %s with name %s",
+            self.name,
+            vacation_name,
         )
         self.data.ecobee.delete_vacation(self.thermostat_index, vacation_name)

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -4,6 +4,6 @@
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/ecobee",
     "dependencies": [],
-    "requirements": ["python-ecobee-api==0.1.2"],
+    "requirements": ["python-ecobee-api==0.1.3"],
     "codeowners": ["@marthoc"]
 }

--- a/homeassistant/components/ecobee/services.yaml
+++ b/homeassistant/components/ecobee/services.yaml
@@ -5,38 +5,38 @@ create_vacation:
     vacation will start immediately and last 14 days (unless deleted earlier).
   fields:
     entity_id:
-      description: Thermostat on which to create the vacation (required).
+      description: ecobee thermostat on which to create the vacation (required).
       example: "climate.kitchen"
     vacation_name:
-      description: The name of the vacation to create; must be unique on the thermostat (required).
+      description: Name of the vacation to create; must be unique on the thermostat (required).
       example: "Skiing"
     cool_temp:
-      description: The cooling temperature during the vacation (required).
+      description: Cooling temperature during the vacation (required).
       example: 23
     heat_temp:
-      description: The heating temperature during the vacation (required).
+      description: Hheating temperature during the vacation (required).
       example: 25
     start_date:
       description: >-
-        The date the vacation starts in the YYYY-MM-DD format (optional, immediately if not provided along with
+        Date the vacation starts in the YYYY-MM-DD format (optional, immediately if not provided along with
         start_time, end_date, and end_time).
       example: "2019-03-15"
     start_time:
-      description: The time the vacation starts, in the local time of the thermostat, in the 24-hour format "HH:MM:SS"
+      description: Time the vacation starts, in the local time of the thermostat, in the 24-hour format "HH:MM:SS"
       example: "20:00:00"
     end_date:
       description: >-
-        The date the vacation ends in the YYYY-MM-DD format (optional, 14 days from now if not provided along with
+        Date the vacation ends in the YYYY-MM-DD format (optional, 14 days from now if not provided along with
         start_date, start_time, and end_time).
       example: "2019-03-20"
     end_time:
-      description: The time the vacation ends, in the local time of the thermostat, in the 24-hour format "HH:MM:SS"
+      description: Time the vacation ends, in the local time of the thermostat, in the 24-hour format "HH:MM:SS"
       example: "20:00:00"
     fan_mode:
-      description: The fan mode of the thermostat during the vacation (auto or on) (optional, auto if not provided).
+      description: Fan mode of the thermostat during the vacation (auto or on) (optional, auto if not provided).
       example: "on"
     fan_min_on_time:
-      description: The minimum number of minutes to run the fan each hour (0 to 60) during the vacation (optional, 0 if not provided).
+      description: Minimum number of minutes to run the fan each hour (0 to 60) during the vacation (optional, 0 if not provided).
       example: 30
 
 delete_vacation:
@@ -44,10 +44,10 @@ delete_vacation:
     Delete a vacation on the selected thermostat.
   fields:
     entity_id:
-      description: Thermostat on which to delete the vacation (required).
+      description: ecobee thermostat on which to delete the vacation (required).
       example: "climate.kitchen"
     vacation_name:
-      description: The name of the vacation to delete (required).
+      description: Name of the vacation to delete (required).
       example: "Skiing"
 
 resume_program:

--- a/homeassistant/components/ecobee/services.yaml
+++ b/homeassistant/components/ecobee/services.yaml
@@ -14,7 +14,7 @@ create_vacation:
       description: Cooling temperature during the vacation (required).
       example: 23
     heat_temp:
-      description: Hheating temperature during the vacation (required).
+      description: Heating temperature during the vacation (required).
       example: 25
     start_date:
       description: >-

--- a/homeassistant/components/ecobee/services.yaml
+++ b/homeassistant/components/ecobee/services.yaml
@@ -1,3 +1,55 @@
+create_vacation:
+  description: >-
+    Create a vacation on the selected thermostat. Note: start/end date and time must all be specified
+    together for these parameters to have an effect. If start/end date and time are not specified, the
+    vacation will start immediately and last 14 days (unless deleted earlier).
+  fields:
+    entity_id:
+      description: Thermostat on which to create the vacation (required).
+      example: "climate.kitchen"
+    vacation_name:
+      description: The name of the vacation to create; must be unique on the thermostat (required).
+      example: "Skiing"
+    cool_temp:
+      description: The cooling temperature during the vacation (required).
+      example: 23
+    heat_temp:
+      description: The heating temperature during the vacation (required).
+      example: 25
+    start_date:
+      description: >-
+        The date the vacation starts in the YYYY-MM-DD format (optional, immediately if not provided along with
+        start_time, end_date, and end_time).
+      example: "2019-03-15"
+    start_time:
+      description: The time the vacation starts, in the local time of the thermostat, in the 24-hour format "HH:MM:SS"
+      example: "20:00:00"
+    end_date:
+      description: >-
+        The date the vacation ends in the YYYY-MM-DD format (optional, 14 days from now if not provided along with
+        start_date, start_time, and end_time).
+      example: "2019-03-20"
+    end_time:
+      description: The time the vacation ends, in the local time of the thermostat, in the 24-hour format "HH:MM:SS"
+      example: "20:00:00"
+    fan_mode:
+      description: The fan mode of the thermostat during the vacation (auto or on) (optional, auto if not provided).
+      example: "on"
+    fan_min_on_time:
+      description: The minimum number of minutes to run the fan each hour (0 to 60) during the vacation (optional, 0 if not provided).
+      example: 30
+
+delete_vacation:
+  description: >-
+    Delete a vacation on the selected thermostat.
+  fields:
+    entity_id:
+      description: Thermostat on which to delete the vacation (required).
+      example: "climate.kitchen"
+    vacation_name:
+      description: The name of the vacation to delete (required).
+      example: "Skiing"
+
 resume_program:
   description: Resume the programmed schedule.
   fields:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1483,7 +1483,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.2
+python-ecobee-api==0.1.3
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -356,7 +356,7 @@ pysonos==0.0.23
 pyspcwebgw==0.4.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.2
+python-ecobee-api==0.1.3
 
 # homeassistant.components.darksky
 python-forecastio==1.4.0


### PR DESCRIPTION
## Description:

Adds two new services to the ecobee integration: create_vacation and delete_vacation.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
https://github.com/home-assistant/home-assistant.io/pull/10457

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
