### PR TITLE
Reduce scan interval XBox Live

### DIFF
--- a/homeassistant/components/xbox_live/sensor.py
+++ b/homeassistant/components/xbox_live/sensor.py
@@ -1,4 +1,5 @@
 """Sensor for Xbox Live account status."""
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -9,6 +10,8 @@ from homeassistant.const import CONF_API_KEY, STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=60)
 
 CONF_XUID = "xuid"
 


### PR DESCRIPTION
## Description:

This PR reduces the scan interval for the XBox Live integration. Currently, it has not defined a sane scan interval, causing users on the free tier to hit the API rate limits.

**Related issue (if applicable):** fixes #16105 (closed stale)
Came up in the following docs PR provided by a user: home-assistant/home-assistant.io#10436

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: xbox_live
    api_key: YOUR_API_KEY
    xuid:
      - account1
      - account2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
