### PR TITLE
Revert Nest HVAC mode when disabling Eco mode

### DIFF
--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -192,7 +192,10 @@ class NestThermostat(ClimateDevice):
     def hvac_mode(self):
         """Return current operation ie. heat, cool, idle."""
         if self._mode == NEST_MODE_ECO:
-            # We assume the first operation in operation list is the main one
+            if self.device.previous_mode in MODE_NEST_TO_HASS:
+                return MODE_NEST_TO_HASS[self.device.previous_mode]
+
+            # previous_mode not supported so return the first compatible mode
             return self._operation_list[0]
 
         return MODE_NEST_TO_HASS[self._mode]
@@ -270,7 +273,7 @@ class NestThermostat(ClimateDevice):
         if self._mode == NEST_MODE_ECO:
             return PRESET_ECO
 
-        return None
+        return PRESET_NONE
 
     @property
     def preset_modes(self):
@@ -294,7 +297,7 @@ class NestThermostat(ClimateDevice):
             if need_eco:
                 self.device.mode = NEST_MODE_ECO
             else:
-                self.device.mode = MODE_HASS_TO_NEST[self._operation_list[0]]
+                self.device.mode = self.device.previous_mode
 
     @property
     def fan_mode(self):


### PR DESCRIPTION
## Description:

Also fixed a bug where preset_mode was returning None instead of PRESET_NONE

**Related issue (if applicable):** fixes #26851 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

