### PR TITLE
Add CO2 level reading for Kaiterra integration

### DIFF
--- a/homeassistant/components/kaiterra/air_quality.py
+++ b/homeassistant/components/kaiterra/air_quality.py
@@ -83,6 +83,11 @@ class KaiterraAirQuality(AirQualityEntity):
         return self._data("rpm10c")
 
     @property
+    def carbon_dioxide(self):
+        """Return the CO2 (carbon dioxide) level."""
+        return self._data("rco2")
+
+    @property
     def volatile_organic_compounds(self):
         """Return the VOC (Volatile Organic Compounds) level."""
         return self._data("rtvoc")

--- a/homeassistant/components/kaiterra/api_data.py
+++ b/homeassistant/components/kaiterra/api_data.py
@@ -23,7 +23,7 @@ from .const import (
 
 _LOGGER = getLogger(__name__)
 
-POLLUTANTS = {"rpm25c": "PM2.5", "rpm10c": "PM10", "rtvoc": "TVOC"}
+POLLUTANTS = {"rpm25c": "PM2.5", "rpm10c": "PM10", "rtvoc": "TVOC", "rco2": "CO2"}
 
 
 class KaiterraApiData:


### PR DESCRIPTION
## Description:
Adds missing CO2 level reading to Kaiterra integration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
