### PR TITLE
Plex external config flow

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -44,7 +44,6 @@ from .const import (  # pylint: disable=unused-import
 from .errors import NoServersFound, ServerNotSpecified
 from .server import PlexServer
 
-DELAY_CONFIGURE = 5
 USER_SCHEMA = vol.Schema({vol.Optional("manual_setup"): bool})
 
 _LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -250,7 +250,9 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.plexauth = PlexAuth(payload, session)
         await self.plexauth.initiate_auth()
         forward_url = f"{self.hass.config.api.base_url}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
-        auth_url = self.plexauth.auth_url(forward_url)
+        auth_url = await self.hass.async_add_executor_job(
+            self.plexauth.auth_url, forward_url
+        )
         return self.async_external_step(step_id="obtain_token", url=auth_url)
 
     async def async_step_obtain_token(self, user_input=None):

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -249,9 +249,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.plexauth = PlexAuth(payload, session)
         await self.plexauth.initiate_auth()
         forward_url = f"{self.hass.config.api.base_url}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
-        auth_url = await self.hass.async_add_executor_job(
-            self.plexauth.auth_url, forward_url
-        )
+        auth_url = self.plexauth.auth_url(forward_url)
         return self.async_external_step(step_id="obtain_token", url=auth_url)
 
     async def async_step_obtain_token(self, user_input=None):

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -7,6 +7,7 @@ from plexauth import PlexAuth
 import requests.exceptions
 import voluptuous as vol
 
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant import config_entries
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.const import (
@@ -240,7 +241,8 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             "X-Plex-Platform": X_PLEX_PLATFORM,
             "X-Plex-Model": "Plex OAuth",
         }
-        self.plexauth = PlexAuth(payload)
+        session = async_get_clientsession(self.hass)
+        self.plexauth = PlexAuth(payload, session)
         await self.plexauth.initiate_auth()
         auth_url = self.plexauth.auth_url()
         self.hass.helpers.event.async_call_later(

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -257,7 +257,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_obtain_token(self, user_input=None):
         """Obtain token after external auth completed."""
-        token = await self.plexauth.token(120)
+        token = await self.plexauth.token(10)
 
         if not token:
             return self.async_external_step_done(next_step_id="timed_out")

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -39,6 +39,7 @@ from .const import (  # pylint: disable=unused-import
 from .errors import NoServersFound, ServerNotSpecified
 from .server import PlexServer
 
+DELAY_CONFIGURE = 5
 USER_SCHEMA = vol.Schema({vol.Optional("manual_setup"): bool})
 
 _LOGGER = logging.getLogger(__package__)
@@ -243,7 +244,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await self.plexauth.initiate_auth()
         auth_url = self.plexauth.auth_url()
         self.hass.helpers.event.async_call_later(
-            5, await self.hass.config_entries.flow.async_configure(self.flow_id)
+            DELAY_CONFIGURE, self.hass.config_entries.flow.async_configure(self.flow_id)
         )
         return self.async_external_step(step_id="obtain_token", url=auth_url)
 

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 
+from aiohttp import web_response
 import plexapi.exceptions
 from plexauth import PlexAuth
 import requests.exceptions
@@ -248,10 +249,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         session = async_get_clientsession(self.hass)
         self.plexauth = PlexAuth(payload, session)
         await self.plexauth.initiate_auth()
-        base_url = self.hass.config.api.base_url.rstrip("/")
-        forward_url = "{}{}?flow_id={}".format(
-            base_url, AUTH_CALLBACK_PATH, self.flow_id
-        )
+        forward_url = f"{self.hass.config.api.base_url}{AUTH_CALLBACK_PATH}?flow_id={self.flow_id}"
         auth_url = self.plexauth.auth_url(forward_url)
         return self.async_external_step(step_id="obtain_token", url=auth_url)
 
@@ -323,8 +321,6 @@ class PlexAuthorizationCallbackView(HomeAssistantView):
 
     async def get(self, request):
         """Receive authorization confirmation."""
-        from aiohttp import web_response
-
         hass = request.app["hass"]
         await hass.config_entries.flow.async_configure(
             flow_id=request.query["flow_id"], user_input=None

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -21,6 +21,9 @@ CONF_SERVER_IDENTIFIER = "server_id"
 CONF_USE_EPISODE_ART = "use_episode_art"
 CONF_SHOW_ALL_CONTROLS = "show_all_controls"
 
+AUTH_CALLBACK_PATH = "/auth/plex/callback"
+AUTH_CALLBACK_NAME = "auth:plex:callback"
+
 X_PLEX_DEVICE_NAME = "Home Assistant"
 X_PLEX_PLATFORM = "Home Assistant"
 X_PLEX_PRODUCT = "Home Assistant"

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -1,4 +1,6 @@
 """Constants for the Plex component."""
+from homeassistant.const import __version__
+
 DOMAIN = "plex"
 NAME_FORMAT = "Plex {}"
 
@@ -18,3 +20,8 @@ CONF_SERVER = "server"
 CONF_SERVER_IDENTIFIER = "server_id"
 CONF_USE_EPISODE_ART = "use_episode_art"
 CONF_SHOW_ALL_CONTROLS = "show_all_controls"
+
+X_PLEX_DEVICE_NAME = "Home Assistant"
+X_PLEX_PLATFORM = "Home Assistant"
+X_PLEX_PRODUCT = "Home Assistant"
+X_PLEX_VERSION = __version__

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -4,7 +4,8 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/plex",
   "requirements": [
-    "plexapi==3.0.6"
+    "plexapi==3.0.6",
+    "plexauth==0.0.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/components/plex",
   "requirements": [
     "plexapi==3.0.6",
-    "plexauth==0.0.2"
+    "plexauth==0.0.3"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/components/plex",
   "requirements": [
     "plexapi==3.0.6",
-    "plexauth==0.0.3"
+    "plexauth==0.0.4"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -11,8 +11,20 @@ from .const import (
     CONF_SHOW_ALL_CONTROLS,
     CONF_USE_EPISODE_ART,
     DEFAULT_VERIFY_SSL,
+    X_PLEX_DEVICE_NAME,
+    X_PLEX_PLATFORM,
+    X_PLEX_PRODUCT,
+    X_PLEX_VERSION,
 )
 from .errors import NoServersFound, ServerNotSpecified
+
+# Set default headers sent by plexapi
+plexapi.X_PLEX_DEVICE_NAME = X_PLEX_DEVICE_NAME
+plexapi.X_PLEX_PLATFORM = X_PLEX_PLATFORM
+plexapi.X_PLEX_PRODUCT = X_PLEX_PRODUCT
+plexapi.X_PLEX_VERSION = X_PLEX_VERSION
+plexapi.myplex.BASE_HEADERS = plexapi.reset_base_headers()
+plexapi.server.BASE_HEADERS = plexapi.reset_base_headers()
 
 
 class PlexServer:

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -21,9 +21,8 @@
             },
             "user": {
                 "title": "Connect Plex server",
-                "description": "Enter a Plex token for automatic setup or manually configure a server.",
+                "description": "Continue to authorize at plex.tv or manually configure a server.",
                 "data": {
-                    "token": "Plex token",
                     "manual_setup": "Manual setup"
                 }
             }
@@ -31,14 +30,14 @@
         "error": {
             "faulty_credentials": "Authorization failed",
             "no_servers": "No servers linked to account",
-            "not_found": "Plex server not found",
-            "no_token": "Provide a token or select manual setup"
+            "not_found": "Plex server not found"
         },
         "abort": {
             "all_configured": "All linked servers already configured",
             "already_configured": "This Plex server is already configured",
             "already_in_progress": "Plex is being configured",
             "invalid_import": "Imported configuration is invalid",
+            "token_request_timeout": "Timed out obtaining token",
             "unknown": "Failed for unknown reason"
         }
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -961,6 +961,9 @@ pizzapi==0.0.3
 # homeassistant.components.plex
 plexapi==3.0.6
 
+# homeassistant.components.plex
+plexauth==0.0.2
+
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -962,7 +962,7 @@ pizzapi==0.0.3
 plexapi==3.0.6
 
 # homeassistant.components.plex
-plexauth==0.0.3
+plexauth==0.0.4
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -962,7 +962,7 @@ pizzapi==0.0.3
 plexapi==3.0.6
 
 # homeassistant.components.plex
-plexauth==0.0.2
+plexauth==0.0.3
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -262,7 +262,7 @@ pillow==6.1.0
 plexapi==3.0.6
 
 # homeassistant.components.plex
-plexauth==0.0.3
+plexauth==0.0.4
 
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -262,7 +262,7 @@ pillow==6.1.0
 plexapi==3.0.6
 
 # homeassistant.components.plex
-plexauth==0.0.2
+plexauth==0.0.3
 
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -261,6 +261,9 @@ pillow==6.1.0
 # homeassistant.components.plex
 plexapi==3.0.6
 
+# homeassistant.components.plex
+plexauth==0.0.2
+
 # homeassistant.components.mhz19
 # homeassistant.components.serial_pm
 pmsensor==0.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -113,6 +113,7 @@ TEST_REQUIREMENTS = (
     "pilight",
     "pillow",
     "plexapi",
+    "plexauth",
     "pmsensor",
     "prometheus_client",
     "ptvsd",

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -1,9 +1,9 @@
 """Mock classes used in tests."""
 
 MOCK_HOST_1 = "1.2.3.4"
-MOCK_PORT_1 = "32400"
+MOCK_PORT_1 = 32400
 MOCK_HOST_2 = "4.3.2.1"
-MOCK_PORT_2 = "32400"
+MOCK_PORT_2 = 32400
 
 
 class MockAvailableServer:  # pylint: disable=too-few-public-methods

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -261,9 +261,7 @@ async def test_no_servers_found(hass):
         )
         assert result["type"] == "external"
 
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={"manual_setup": False}
-        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
         assert result["type"] == "external_done"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -640,9 +638,7 @@ async def test_external_timed_out(hass):
         )
         assert result["type"] == "external"
 
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={"manual_setup": False}
-        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
         assert result["type"] == "external_done"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"])

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -666,9 +666,7 @@ async def test_callback_view(hass, aiohttp_client):
         assert result["type"] == "external"
 
         client = await aiohttp_client(hass.http.app)
-        forward_url = "{}?flow_id={}".format(
-            config_flow.AUTH_CALLBACK_PATH, result["flow_id"]
-        )
+        forward_url = f'{config_flow.AUTH_CALLBACK_PATH}?flow_id={result["flow_id"]}'
 
         resp = await client.get(forward_url)
         assert resp.status == 200


### PR DESCRIPTION
## Description:
Instead of prompting a user to provide an existing token, will redirect them to the plex.tv website to complete authentication and will obtain a token on their behalf with an OAuth-like process. Relies on new library [plexauth](https://github.com/jjlawren/python-plexauth/).

This new auth method has the added benefit of showing a separate "Home Assistant" authorized device on the Plex account, instead of the legacy method of hijacking an existing authenticated device's token.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10462

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html