### PR TITLE
Standardize times in time sensors Jewish calendar

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -44,10 +44,12 @@ CONF_DIASPORA = "diaspora"
 CONF_LANGUAGE = "language"
 CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
 CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
+CONF_TIME_FORMAT = "time_format"
 
 CANDLE_LIGHT_DEFAULT = 18
 
 DEFAULT_NAME = "Jewish Calendar"
+DEFAULT_TIME_FORMAT = "%H:%M"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -65,6 +67,7 @@ CONFIG_SCHEMA = vol.Schema(
                 ): int,
                 # Default of 0 means use 8.5 degrees / 'three_stars' time.
                 vol.Optional(CONF_HAVDALAH_OFFSET_MINUTES, default=0): int,
+                vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_FORMAT): cv.string,
             }
         )
     },
@@ -83,6 +86,7 @@ async def async_setup(hass, config):
 
     candle_lighting_offset = config[DOMAIN][CONF_CANDLE_LIGHT_MINUTES]
     havdalah_offset = config[DOMAIN][CONF_HAVDALAH_OFFSET_MINUTES]
+    time_format = config[DOMAIN][CONF_TIME_FORMAT]
 
     location = hdate.Location(
         latitude=latitude,
@@ -98,6 +102,7 @@ async def async_setup(hass, config):
         "candle_lighting_offset": candle_lighting_offset,
         "havdalah_offset": havdalah_offset,
         "diaspora": diaspora,
+        "time_format": time_format,
     }
 
     hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, {}, config))

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -44,12 +44,10 @@ CONF_DIASPORA = "diaspora"
 CONF_LANGUAGE = "language"
 CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
 CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
-CONF_TIME_FORMAT = "time_format"
 
 CANDLE_LIGHT_DEFAULT = 18
 
 DEFAULT_NAME = "Jewish Calendar"
-DEFAULT_TIME_FORMAT = "%H:%M"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -67,7 +65,6 @@ CONFIG_SCHEMA = vol.Schema(
                 ): int,
                 # Default of 0 means use 8.5 degrees / 'three_stars' time.
                 vol.Optional(CONF_HAVDALAH_OFFSET_MINUTES, default=0): int,
-                vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_FORMAT): cv.string,
             }
         )
     },
@@ -86,7 +83,6 @@ async def async_setup(hass, config):
 
     candle_lighting_offset = config[DOMAIN][CONF_CANDLE_LIGHT_MINUTES]
     havdalah_offset = config[DOMAIN][CONF_HAVDALAH_OFFSET_MINUTES]
-    time_format = config[DOMAIN][CONF_TIME_FORMAT]
 
     location = hdate.Location(
         latitude=latitude,
@@ -102,7 +98,6 @@ async def async_setup(hass, config):
         "candle_lighting_offset": candle_lighting_offset,
         "havdalah_offset": havdalah_offset,
         "diaspora": diaspora,
-        "time_format": time_format,
     }
 
     hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, {}, config))

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -110,15 +110,17 @@ class JewishCalendarSensor(Entity):
         # refers to "current" or "upcoming" dates.
         if self._type == "date":
             return after_shkia_date.hebrew_date
-        elif self._type == "weekly_portion":
+        if self._type == "weekly_portion":
             # Compute the weekly portion based on the upcoming shabbat.
             return after_tzais_date.upcoming_shabbat.parasha
-        elif self._type == "holiday_name":
+        if self._type == "holiday_name":
             return after_shkia_date.holiday_description
-        elif self._type == "holiday_type":
+        if self._type == "holiday_type":
             return after_shkia_date.holiday_type
-        elif self._type == "omer_count":
+        if self._type == "omer_count":
             return after_shkia_date.omer_day
+
+        return None
 
 
 class JewishCalendarTimeSensor(JewishCalendarSensor):
@@ -163,19 +165,19 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
                 after_tzais_date.upcoming_shabbat.previous_day.gdate
             )
             return times.candle_lighting
-        elif self._type == "upcoming_candle_lighting":
+        if self._type == "upcoming_candle_lighting":
             times = self.make_zmanim(
                 after_tzais_date.upcoming_shabbat_or_yom_tov.first_day.previous_day.gdate
             )
             return times.candle_lighting
-        elif self._type == "upcoming_shabbat_havdalah":
+        if self._type == "upcoming_shabbat_havdalah":
             times = self.make_zmanim(after_tzais_date.upcoming_shabbat.gdate)
             return times.havdalah
-        elif self._type == "upcoming_havdalah":
+        if self._type == "upcoming_havdalah":
             times = self.make_zmanim(
                 after_tzais_date.upcoming_shabbat_or_yom_tov.last_day.gdate
             )
             return times.havdalah
-        else:
-            times = self.make_zmanim(dt_util.now()).zmanim
-            return times[self._type]
+
+        times = self.make_zmanim(dt_util.now()).zmanim
+        return times[self._type]

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -43,7 +43,6 @@ class JewishCalendarSensor(Entity):
         self._candle_lighting_offset = data["candle_lighting_offset"]
         self._havdalah_offset = data["havdalah_offset"]
         self._diaspora = data["diaspora"]
-        self._time_format = data["time_format"]
         self._state = None
 
     @property
@@ -129,11 +128,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return (
-            self._state.strftime(self._time_format)
-            if self._state is not None
-            else self._state
-        )
+        return self._state
 
     @property
     def device_class(self):

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -143,12 +143,6 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
         if self._state is None:
             return attrs
 
-        attrs["year"] = self._state.year
-        attrs["month"] = self._state.month
-        attrs["day"] = self._state.day
-        attrs["hour"] = self._state.hour
-        attrs["minute"] = self._state.minute
-        attrs["second"] = self._state.second
         attrs["timestamp"] = self._state.timestamp()
 
         return attrs

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -136,11 +136,6 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
         )
 
     @property
-    def device_class(self):
-        """Return the class of this sensor."""
-        return "timestamp"
-
-    @property
     def state_attributes(self):
         """Return the state attributes."""
         attrs = {}

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -136,6 +136,11 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
         )
 
     @property
+    def device_class(self):
+        """Return the class of this sensor."""
+        return "timestamp"
+
+    @property
     def state_attributes(self):
         """Return the state attributes."""
         attrs = {}

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -136,7 +136,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
         return "timestamp"
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
         attrs = {}
 

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -63,7 +63,7 @@ class JewishCalendarSensor(Entity):
     async def async_update(self):
         """Update the state of the sensor."""
         now = dt_util.now()
-        _LOGGER.debug("Now: %s Timezone = %s", now, now.tzinfo)
+        _LOGGER.debug("Now: %s Location: %r", now, self._location)
 
         today = now.date()
         sunset = dt_util.as_local(
@@ -91,7 +91,7 @@ class JewishCalendarSensor(Entity):
             after_tzais_date = date.next_day
 
         self._state = self.get_state(after_shkia_date, after_tzais_date)
-        _LOGGER.debug("New value: %s", self._state)
+        _LOGGER.debug("New value for %s: %s", self._type, self._state)
 
     def make_zmanim(self, date):
         """Create a Zmanim object."""
@@ -128,7 +128,7 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._state
+        return dt_util.as_utc(self._state) if self._state is not None else None
 
     @property
     def device_class(self):

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -174,6 +174,7 @@ async def test_jewish_calendar_sensor(
                     "name": "test",
                     "language": language,
                     "diaspora": diaspora,
+                    "time_format": "%c"
                 }
             },
         )
@@ -183,7 +184,7 @@ async def test_jewish_calendar_sensor(
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    result = result.strftime("%H:%M") if isinstance(result, dt) else result
+    result = result.strftime("%c") if isinstance(result, dt) else result
 
     assert hass.states.get(f"sensor.test_{sensor}").state == str(result)
 

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -174,7 +174,6 @@ async def test_jewish_calendar_sensor(
                     "name": "test",
                     "language": language,
                     "diaspora": diaspora,
-                    "time_format": "%c",
                 }
             },
         )
@@ -184,7 +183,7 @@ async def test_jewish_calendar_sensor(
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    result = result.strftime("%c") if isinstance(result, dt) else result
+    result = time_zone.localize(result) if isinstance(result, dt) else result
 
     assert hass.states.get(f"sensor.test_{sensor}").state == str(result)
 
@@ -527,14 +526,8 @@ async def test_shabbat_times_sensor(
 
         sensor_type = sensor_type.replace(f"{language}_", "")
 
-        result_value = (
-            result_value.strftime("%H:%M")
-            if isinstance(result_value, dt)
-            else result_value
-        )
-
-        assert (
-            hass.states.get(f"sensor.test_{sensor_type}").state == result_value
+        assert hass.states.get(f"sensor.test_{sensor_type}").state == str(
+            result_value
         ), f"Value for {sensor_type}"
 
 

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -1,5 +1,5 @@
 """The tests for the Jewish calendar sensors."""
-from datetime import time, timedelta
+from datetime import timedelta
 from datetime import datetime as dt
 
 import pytest
@@ -81,7 +81,7 @@ TEST_PARAMS = [
         "hebrew",
         "t_set_hakochavim",
         True,
-        time(19, 48),
+        dt(2018, 9, 8, 19, 48),
     ),
     (
         dt(2018, 9, 8),
@@ -91,7 +91,7 @@ TEST_PARAMS = [
         "hebrew",
         "t_set_hakochavim",
         False,
-        time(19, 21),
+        dt(2018, 9, 8, 19, 21),
     ),
     (
         dt(2018, 10, 14),
@@ -182,6 +182,8 @@ async def test_jewish_calendar_sensor(
         future = dt_util.utcnow() + timedelta(seconds=30)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
+
+    result = result.strftime("%H:%M") if isinstance(result, dt) else result
 
     assert hass.states.get(f"sensor.test_{sensor}").state == str(result)
 
@@ -524,8 +526,14 @@ async def test_shabbat_times_sensor(
 
         sensor_type = sensor_type.replace(f"{language}_", "")
 
-        assert hass.states.get(f"sensor.test_{sensor_type}").state == str(
-            result_value
+        result_value = (
+            result_value.strftime("%H:%M")
+            if isinstance(result_value, dt)
+            else result_value
+        )
+
+        assert (
+            hass.states.get(f"sensor.test_{sensor_type}").state == result_value
         ), f"Value for {sensor_type}"
 
 

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -174,7 +174,7 @@ async def test_jewish_calendar_sensor(
                     "name": "test",
                     "language": language,
                     "diaspora": diaspora,
-                    "time_format": "%c"
+                    "time_format": "%c",
                 }
             },
         )

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -183,7 +183,9 @@ async def test_jewish_calendar_sensor(
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-    result = time_zone.localize(result) if isinstance(result, dt) else result
+    result = (
+        dt_util.as_utc(time_zone.localize(result)) if isinstance(result, dt) else result
+    )
 
     assert hass.states.get(f"sensor.test_{sensor}").state == str(result)
 
@@ -525,6 +527,12 @@ async def test_shabbat_times_sensor(
             continue
 
         sensor_type = sensor_type.replace(f"{language}_", "")
+
+        result_value = (
+            dt_util.as_utc(result_value)
+            if isinstance(result_value, dt)
+            else result_value
+        )
 
         assert hass.states.get(f"sensor.test_{sensor_type}").state == str(
             result_value


### PR DESCRIPTION
## Breaking Change:

The output of the timestamp sensors have been streamlined so they're easier to use in automations. All the timestamp sensors will return UTC time in ISO 8601 format.
Attributes have been added to get a UNIX timestamp.

**Please note if you have any automations relying on the timestamp, you'll need to update them to compare to the UTC timestamp.**

## Description:
This standardizes the times in the timestamp sensors for the Jewish calendar, times like candle lighting, havdalah etc. are all defined as timestamp sensors. As such, their state will show ISO8601 UTC timestamps.
Also, timestamp attributes have been added to the sensor. This should allow easier automation triggers and conditions when comparing timestamps.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10463

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
