### PR TITLE
Fix rest_command when server is unreachable

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -98,10 +98,7 @@ async def async_setup(hass, config):
             try:
                 with async_timeout.timeout(timeout):
                     request = await getattr(websession, method)(
-                        request_url,
-                        data=payload,
-                        auth=auth,
-                        headers=headers,
+                        request_url, data=payload, auth=auth, headers=headers
                     )
 
                 if request.status < 400:

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -112,7 +112,7 @@ async def async_setup(hass, config):
                 _LOGGER.warning("Timeout call %s.", request.url)
 
             except aiohttp.ClientError:
-                _LOGGER.error("Client error %s.", request.url)
+                _LOGGER.error("Client error %s.", command_config[CONF_URL])
 
         # register services
         hass.services.async_register(DOMAIN, name, async_service_handler)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -112,7 +112,8 @@ async def async_setup(hass, config):
                 _LOGGER.warning("Timeout call %s.", request.url)
 
             except aiohttp.ClientError:
-                _LOGGER.error("Client error %s.", template_url.async_render(variables=service.data))
+                _LOGGER.error("Client error %s.",
+                    template_url.async_render(variables=service.data))
 
         # register services
         hass.services.async_register(DOMAIN, name, async_service_handler)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -112,8 +112,10 @@ async def async_setup(hass, config):
                 _LOGGER.warning("Timeout call %s.", request.url)
 
             except aiohttp.ClientError:
-                _LOGGER.error("Client error %s.",
-                    template_url.async_render(variables=service.data))
+                _LOGGER.error(
+                    "Client error %s.",
+                    template_url.async_render(variables=service.data),
+                )
 
         # register services
         hass.services.async_register(DOMAIN, name, async_service_handler)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -112,7 +112,7 @@ async def async_setup(hass, config):
                 _LOGGER.warning("Timeout call %s.", request.url)
 
             except aiohttp.ClientError:
-                _LOGGER.error("Client error %s.", command_config[CONF_URL])
+                _LOGGER.error("Client error %s.", template_url.async_render(variables=service.data))
 
         # register services
         hass.services.async_register(DOMAIN, name, async_service_handler)

--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -94,10 +94,11 @@ async def async_setup(hass, config):
                     template_payload.async_render(variables=service.data), "utf-8"
                 )
 
+            request_url = template_url.async_render(variables=service.data)
             try:
                 with async_timeout.timeout(timeout):
                     request = await getattr(websession, method)(
-                        template_url.async_render(variables=service.data),
+                        request_url,
                         data=payload,
                         auth=auth,
                         headers=headers,
@@ -112,10 +113,7 @@ async def async_setup(hass, config):
                 _LOGGER.warning("Timeout call %s.", request.url)
 
             except aiohttp.ClientError:
-                _LOGGER.error(
-                    "Client error %s.",
-                    template_url.async_render(variables=service.data),
-                )
+                _LOGGER.error("Client error %s.", request_url)
 
         # register services
         hass.services.async_register(DOMAIN, name, async_service_handler)


### PR DESCRIPTION
When a server doesn't exist, the connection fails immediately, rather
than waiting for a timeout. This means that the async handler is never
reached, and the request variable never filled, yet it's used in the
client error exception handler, so this one bugs out.

By using the command_config, we avoid using the potentially unassigned
request variable, avoiding this problem.

This patch makes scripts work that have a rest_command in them which
fails due to a server being offline.

## Description:

I'm using a rest_command to switch off one specific lamp in the middle of a "go to bed" script. When that lamp is offline, the rest_command fails and the remainder of my script never executes (some lights stay on).
The rest_command handler only takes timeouts into account, but not a server being entirely unreachable, apparently. In this case, the request variable that is used only to log the client url never gets assigned, leading to an execution error. The url is also available from the command_config, so if I just use that in the exception handler to print the client url, the remainder of hte scripts finishes fine (and all my lights turn off, and I can sleep peacefully). 


## Example entry for `configuration.yaml` (if applicable):
```yaml
rest_command:
  livinglamp_off:
    url: http://192.168.1.211/effect?effect=off
```
in scripts.yaml:
```yaml
ttest:
  alias: TTest
  sequence:
  - service: light.turn_on
    data:
      entity_id: light.living_room
  - data: {}
    service: rest_command.livinglamp_off
  - delay:
      seconds: 5
  - service: light.turn_off
    data:
      entity_id: light.living_room


```
