### PR TITLE
Fix ecobee integration

### DIFF
--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -33,7 +33,11 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="one_instance_only")
 
         errors = {}
-        stored_api_key = self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
+        stored_api_key = (
+            self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
+            if DATA_ECOBEE_CONFIG in self.hass.data
+            else None
+        )
 
         if user_input is not None:
             # Use the user-supplied API key to attempt to obtain a PIN from ecobee.

--- a/homeassistant/components/ecobee/config_flow.py
+++ b/homeassistant/components/ecobee/config_flow.py
@@ -36,7 +36,7 @@ class EcobeeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         stored_api_key = (
             self.hass.data[DATA_ECOBEE_CONFIG].get(CONF_API_KEY)
             if DATA_ECOBEE_CONFIG in self.hass.data
-            else None
+            else ""
         )
 
         if user_input is not None:


### PR DESCRIPTION
## Description:

Fixes the ecobee config flow crashing when there is no entry in configuration.yaml. Without an entry in configuration.yaml, async_step_user raises a KeyError as DATA_ECOBEE_CONFIG does not exist in hass.data (as async_setup is never called), so a check is needed in async_step_user.

**Related issue (if applicable):** fixes #26950 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
