### PR TITLE
Fix possible OpenUV exception due to missing data

### DIFF
--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -102,6 +102,11 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorDevice):
         if not data:
             return
 
+        for key in ("from_time", "to_time", "from_uv", "to_uv"):
+            if not data.get(key):
+                _LOGGER.info("Skipping update due to missing data: %s", key)
+                return
+
         if self._sensor_type == TYPE_PROTECTION_WINDOW:
             self._state = (
                 parse_datetime(data["from_time"])


### PR DESCRIPTION
## Description:

Very rarely, OpenUV can fail to return fields when requesting data, which can cause an unhandled device update exception. This PR addresses that possibility.

**Related issue (if applicable):** fixes #https://github.com/home-assistant/home-assistant/issues/26946

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
