### PR TITLE
UniFi - Try to handle when UniFi erroneously marks offline client as wired

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -1,14 +1,13 @@
 """Support for devices connected to UniFi POE."""
 import voluptuous as vol
 
-from homeassistant.components.unifi.config_flow import (
-    get_controller_id_from_config_entry,
-)
 from homeassistant.const import CONF_HOST
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 import homeassistant.helpers.config_validation as cv
 
+from .config_flow import get_controller_id_from_config_entry
 from .const import (
     ATTR_MANUFACTURER,
     CONF_BLOCK_CLIENT,
@@ -20,8 +19,13 @@ from .const import (
     CONF_SSID_FILTER,
     DOMAIN,
     UNIFI_CONFIG,
+    UNIFI_WIRELESS_CLIENTS,
 )
 from .controller import UniFiController
+
+SAVE_DELAY = 10
+STORAGE_KEY = "unifi_data"
+STORAGE_VERSION = 1
 
 CONF_CONTROLLERS = "controllers"
 
@@ -61,6 +65,9 @@ async def async_setup(hass, config):
     if DOMAIN in config:
         hass.data[UNIFI_CONFIG] = config[DOMAIN][CONF_CONTROLLERS]
 
+    hass.data[UNIFI_WIRELESS_CLIENTS] = wireless_clients = unifi_wireless_clients(hass)
+    await wireless_clients.async_load()
+
     return True
 
 
@@ -70,9 +77,7 @@ async def async_setup_entry(hass, config_entry):
         hass.data[DOMAIN] = {}
 
     controller = UniFiController(hass, config_entry)
-
     controller_id = get_controller_id_from_config_entry(config_entry)
-
     hass.data[DOMAIN][controller_id] = controller
 
     if not await controller.async_setup():
@@ -99,3 +104,42 @@ async def async_unload_entry(hass, config_entry):
     controller_id = get_controller_id_from_config_entry(config_entry)
     controller = hass.data[DOMAIN].pop(controller_id)
     return await controller.async_reset()
+
+
+class unifi_wireless_clients:
+    """Class to store clients known to be wireless.
+
+    This is needed since wireless devices going offline might get marked as wired by UniFi.
+    """
+
+    def __init__(self, hass):
+        """Set up client storage."""
+        self.hass = hass
+        self.data = {}
+        self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+
+    async def async_load(self):
+        """Load data from file."""
+        data = await self._store.async_load()
+
+        if data is not None:
+            self.data = data
+
+    @callback
+    def get_data(self, config_entry):
+        """Get data related to a specific controller."""
+        controller_id = get_controller_id_from_config_entry(config_entry)
+        return set(self.data.get(controller_id, list()))
+
+    @callback
+    def update_data(self, data, config_entry):
+        """Update data and schedule to save to file."""
+        controller_id = get_controller_id_from_config_entry(config_entry)
+        self.data[controller_id] = list(data)
+
+        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
+
+    @callback
+    def _data_to_save(self):
+        """Return data of UniFi wireless clients to store in a file."""
+        return self.data

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -129,13 +129,14 @@ class unifi_wireless_clients:
     def get_data(self, config_entry):
         """Get data related to a specific controller."""
         controller_id = get_controller_id_from_config_entry(config_entry)
-        return set(self.data.get(controller_id, list()))
+        data = self.data.get(controller_id, {"wireless_devices": []})
+        return set(data["wireless_devices"])
 
     @callback
     def update_data(self, data, config_entry):
         """Update data and schedule to save to file."""
         controller_id = get_controller_id_from_config_entry(config_entry)
-        self.data[controller_id] = list(data)
+        self.data[controller_id] = {"wireless_devices": list(data)}
 
         self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -65,7 +65,7 @@ async def async_setup(hass, config):
     if DOMAIN in config:
         hass.data[UNIFI_CONFIG] = config[DOMAIN][CONF_CONTROLLERS]
 
-    hass.data[UNIFI_WIRELESS_CLIENTS] = wireless_clients = unifi_wireless_clients(hass)
+    hass.data[UNIFI_WIRELESS_CLIENTS] = wireless_clients = UnifiWirelessClients(hass)
     await wireless_clients.async_load()
 
     return True
@@ -106,7 +106,7 @@ async def async_unload_entry(hass, config_entry):
     return await controller.async_reset()
 
 
-class unifi_wireless_clients:
+class UnifiWirelessClients:
     """Class to store clients known to be wireless.
 
     This is needed since wireless devices going offline might get marked as wired by UniFi.

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -10,6 +10,7 @@ CONF_CONTROLLER = "controller"
 CONF_SITE_ID = "site"
 
 UNIFI_CONFIG = "unifi_config"
+UNIFI_WIRELESS_CLIENTS = "unifi_wireless_clients"
 
 CONF_BLOCK_CLIENT = "block_client"
 CONF_DETECTION_TIME = "detection_time"

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -132,17 +132,17 @@ class UniFiController:
 
     def update_wireless_clients(self):
         """Update set of known to be wireless clients."""
-        wireless_clients = set()
+        new_wireless_clients = set()
 
         for client_id in self.api.clients:
             if (
                 client_id not in self.wireless_clients
                 and not self.api.clients[client_id].is_wired
             ):
-                wireless_clients.add(client_id)
+                new_wireless_clients.add(client_id)
 
-        if wireless_clients:
-            self.wireless_clients |= wireless_clients
+        if new_wireless_clients:
+            self.wireless_clients |= new_wireless_clients
             unifi_wireless_clients = self.hass.data[UNIFI_WIRELESS_CLIENTS]
             unifi_wireless_clients.update_data(self.wireless_clients, self.config_entry)
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -36,6 +36,7 @@ from .const import (
     DOMAIN,
     LOGGER,
     UNIFI_CONFIG,
+    UNIFI_WIRELESS_CLIENTS,
 )
 from .errors import AuthenticationRequired, CannotConnect
 
@@ -50,6 +51,7 @@ class UniFiController:
         self.available = True
         self.api = None
         self.progress = None
+        self.wireless_clients = None
 
         self._site_name = None
         self._site_role = None
@@ -128,6 +130,22 @@ class UniFiController:
         """Event specific per UniFi entry to signal new options."""
         return f"unifi-options-{CONTROLLER_ID.format(host=self.host, site=self.site)}"
 
+    def update_wireless_clients(self):
+        """Update set of known to be wireless clients."""
+        wireless_clients = set()
+
+        for client_id in self.api.clients:
+            if (
+                client_id not in self.wireless_clients
+                and not self.api.clients[client_id].is_wired
+            ):
+                wireless_clients.add(client_id)
+
+        if wireless_clients:
+            self.wireless_clients |= wireless_clients
+            unifi_wireless_clients = self.hass.data[UNIFI_WIRELESS_CLIENTS]
+            unifi_wireless_clients.update_data(self.wireless_clients, self.config_entry)
+
     async def request_update(self):
         """Request an update."""
         if self.progress is not None:
@@ -170,6 +188,8 @@ class UniFiController:
             LOGGER.info("Reconnected to controller %s", self.host)
             self.available = True
 
+        self.update_wireless_clients()
+
         async_dispatcher_send(self.hass, self.signal_update)
 
     async def async_setup(self):
@@ -196,6 +216,10 @@ class UniFiController:
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.error("Unknown error connecting with UniFi controller: %s", err)
             return False
+
+        wireless_clients = hass.data[UNIFI_WIRELESS_CLIENTS]
+        self.wireless_clients = wireless_clients.get_data(self.config_entry)
+        self.update_wireless_clients()
 
         self.import_configuration()
 

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -88,7 +88,7 @@ def update_items(controller, async_add_entities, switches, switches_off):
         new_switches.append(switches[block_client_id])
         LOGGER.debug("New UniFi Block switch %s (%s)", client.hostname, client.mac)
 
-    # control poe
+    # control POE
     for client_id in controller.api.clients:
 
         poe_client_id = f"poe-{client_id}"
@@ -108,9 +108,10 @@ def update_items(controller, async_add_entities, switches, switches_off):
             pass
         # Network device with active POE
         elif (
-            not client.is_wired
+            client_id in controller.wireless_clients
             or client.sw_mac not in devices
             or not devices[client.sw_mac].ports[client.sw_port].port_poe
+            or not devices[client.sw_mac].ports[client.sw_port].poe_enable
             or controller.mac == client.mac
         ):
             continue

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -8,6 +8,7 @@ from homeassistant.components.unifi.const import (
     CONF_CONTROLLER,
     CONF_SITE_ID,
     UNIFI_CONFIG,
+    UNIFI_WIRELESS_CLIENTS,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -49,7 +50,8 @@ async def test_controller_setup():
                 controller.CONF_DETECTION_TIME: 30,
                 controller.CONF_SSID_FILTER: ["ssid"],
             }
-        ]
+        ],
+        UNIFI_WIRELESS_CLIENTS: Mock(),
     }
     entry = Mock()
     entry.data = ENTRY_CONFIG
@@ -57,6 +59,7 @@ async def test_controller_setup():
     api = Mock()
     api.initialize.return_value = mock_coro(True)
     api.sites.return_value = mock_coro(CONTROLLER_SITES)
+    api.clients = []
 
     unifi_controller = controller.UniFiController(hass, entry)
 
@@ -100,7 +103,8 @@ async def test_controller_site():
 async def test_controller_mac():
     """Test that it is possible to identify controller mac."""
     hass = Mock()
-    hass.data = {UNIFI_CONFIG: {}}
+    hass.data = {UNIFI_CONFIG: {}, UNIFI_WIRELESS_CLIENTS: Mock()}
+    hass.data[UNIFI_WIRELESS_CLIENTS].get_data.return_value = set()
     entry = Mock()
     entry.data = ENTRY_CONFIG
     entry.options = {}
@@ -123,7 +127,7 @@ async def test_controller_mac():
 async def test_controller_no_mac():
     """Test that it works to not find the controllers mac."""
     hass = Mock()
-    hass.data = {UNIFI_CONFIG: {}}
+    hass.data = {UNIFI_CONFIG: {}, UNIFI_WIRELESS_CLIENTS: Mock()}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     entry.options = {}
@@ -133,6 +137,7 @@ async def test_controller_no_mac():
     api.initialize.return_value = mock_coro(True)
     api.clients = {"client1": client}
     api.sites.return_value = mock_coro(CONTROLLER_SITES)
+    api.clients = {}
 
     unifi_controller = controller.UniFiController(hass, entry)
 
@@ -195,13 +200,14 @@ async def test_reset_if_entry_had_wrong_auth():
 async def test_reset_unloads_entry_if_setup():
     """Calling reset when the entry has been setup."""
     hass = Mock()
-    hass.data = {UNIFI_CONFIG: {}}
+    hass.data = {UNIFI_CONFIG: {}, UNIFI_WIRELESS_CLIENTS: Mock()}
     entry = Mock()
     entry.data = ENTRY_CONFIG
     entry.options = {}
     api = Mock()
     api.initialize.return_value = mock_coro(True)
     api.sites.return_value = mock_coro(CONTROLLER_SITES)
+    api.clients = []
 
     unifi_controller = controller.UniFiController(hass, entry)
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -21,6 +21,7 @@ from homeassistant.components.unifi.const import (
     CONF_TRACK_WIRED_CLIENTS,
     CONTROLLER_ID as CONF_CONTROLLER_ID,
     UNIFI_CONFIG,
+    UNIFI_WIRELESS_CLIENTS,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -110,7 +111,9 @@ CONTROLLER_ID = CONF_CONTROLLER_ID.format(host="mock-host", site="mock-site")
 def mock_controller(hass):
     """Mock a UniFi Controller."""
     hass.data[UNIFI_CONFIG] = {}
+    hass.data[UNIFI_WIRELESS_CLIENTS] = Mock()
     controller = unifi.UniFiController(hass, None)
+    controller.wireless_clients = set()
 
     controller.api = Mock()
     controller.mock_requests = []

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -1,8 +1,10 @@
 """The tests for the UniFi device tracker platform."""
 from collections import deque
 from copy import copy
-from unittest.mock import Mock
+
 from datetime import timedelta
+
+from asynctest import Mock
 
 import pytest
 
@@ -96,7 +98,7 @@ CONTROLLER_DATA = {
     CONF_PASSWORD: "mock-pswd",
     CONF_PORT: 1234,
     CONF_SITE_ID: "mock-site",
-    CONF_VERIFY_SSL: True,
+    CONF_VERIFY_SSL: False,
 }
 
 ENTRY_CONFIG = {CONF_CONTROLLER: CONTROLLER_DATA}
@@ -251,6 +253,45 @@ async def test_tracked_devices(hass, mock_controller):
     assert client_2 is None
     device_1 = hass.states.get("device_tracker.device_1")
     assert device_1 is None
+
+
+async def test_wireless_client_go_wired_issue(hass, mock_controller):
+    """Test the solution to catch wireless device go wired UniFi issue.
+
+    UniFi has a known issue that when a wireless device goes away it sometimes gets marked as wired.
+    """
+    client_1_client = copy(CLIENT_1)
+    client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
+    mock_controller.mock_client_responses.append([client_1_client])
+    mock_controller.mock_device_responses.append({})
+
+    await setup_controller(hass, mock_controller)
+    assert len(mock_controller.mock_requests) == 2
+    assert len(hass.states.async_all()) == 3
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1 is not None
+    assert client_1.state == "home"
+
+    client_1_client["is_wired"] = True
+    client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
+    mock_controller.mock_client_responses.append([client_1_client])
+    mock_controller.mock_device_responses.append({})
+    await mock_controller.async_update()
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1.state == "not_home"
+
+    client_1_client["is_wired"] = False
+    client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
+    mock_controller.mock_client_responses.append([client_1_client])
+    mock_controller.mock_device_responses.append({})
+    await mock_controller.async_update()
+    await hass.async_block_till_done()
+
+    client_1 = hass.states.get("device_tracker.client_1")
+    assert client_1.state == "home"
 
 
 async def test_restoring_client(hass, mock_controller):

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -17,6 +17,7 @@ from homeassistant.components.unifi.const import (
     CONF_SITE_ID,
     CONTROLLER_ID as CONF_CONTROLLER_ID,
     UNIFI_CONFIG,
+    UNIFI_WIRELESS_CLIENTS,
 )
 from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
@@ -221,7 +222,9 @@ CONTROLLER_ID = CONF_CONTROLLER_ID.format(host="mock-host", site="mock-site")
 def mock_controller(hass):
     """Mock a UniFi Controller."""
     hass.data[UNIFI_CONFIG] = {}
+    hass.data[UNIFI_WIRELESS_CLIENTS] = Mock()
     controller = unifi.UniFiController(hass, None)
+    controller.wireless_clients = set()
 
     controller._site_role = "admin"
 
@@ -326,7 +329,7 @@ async def test_switches(hass, mock_controller):
 
     await setup_controller(hass, mock_controller, options)
     assert len(mock_controller.mock_requests) == 3
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 4
 
     switch_1 = hass.states.get("switch.poe_client_1")
     assert switch_1 is not None


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
There is an issue with UniFi that when the client goes offline that it is marked as wired and with a different time stamp, this makes it hard to use the client tracker since it will look like the client is at home. This makes some improvements toto handle not creating faulty POE control switches.

**Related issue (if applicable):** fixes #25915 #25893

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
