### PR TITLE
Add create, remove of devices without a restart for HomematicIP_Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -6,6 +6,8 @@ from homematicip.aio.device import AsyncDevice
 from homematicip.aio.home import AsyncHome
 
 from homeassistant.components import homematicip_cloud
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,6 +53,8 @@ class HomematicipGenericDevice(Entity):
         self._home = home
         self._device = device
         self.post = post
+        # Marker showing that the HmIP device hase been removed.
+        self.hmip_device_removed = False
         _LOGGER.info("Setting up %s (%s)", self.name, self._device.modelType)
 
     @property
@@ -74,7 +78,9 @@ class HomematicipGenericDevice(Entity):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._device.on_update(self._async_device_changed)
+        self._device.on_remove(self._async_device_removed)
 
+    @callback
     def _async_device_changed(self, *args, **kwargs):
         """Handle device state changes."""
         # Don't update disabled entities
@@ -87,6 +93,47 @@ class HomematicipGenericDevice(Entity):
                 self.name,
                 self._device.modelType,
             )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+
+        # Only go further if the device/entity should be removed from registries
+        # due to a removal of the HmIP device.
+        if self.hmip_device_removed:
+            await self.async_remove_from_registries()
+
+    async def async_remove_from_registries(self) -> None:
+        """Remove entity/device from registry."""
+
+        # Remove callback from device.
+        self._device.remove_callback(self._async_device_changed)
+        self._device.remove_callback(self._async_device_removed)
+
+        if not self.registry_entry:
+            return
+
+        device_id = self.registry_entry.device_id
+        if device_id:
+            # Remove from device registry.
+            device_registry = await dr.async_get_registry(self.hass)
+            if device_id in device_registry.devices:
+                # This will also remove associated entities from entity registry.
+                device_registry.async_remove_device(device_id)
+        else:
+            # Remove from entity registry.
+            # Only relevant for entities that do not belong to a device.
+            entity_id = self.registry_entry.entity_id
+            if entity_id:
+                entity_registry = await er.async_get_registry(self.hass)
+                if entity_id in entity_registry.entities:
+                    entity_registry.async_remove(entity_id)
+
+    @callback
+    def _async_device_removed(self, *args, **kwargs):
+        """Handle hmip device removal."""
+        # Set marker showing that the HmIP device hase been removed.
+        self.hmip_device_removed = True
+        self.hass.async_create_task(self.async_remove())
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/homematicip_cloud",
   "requirements": [
-    "homematicip==0.10.11"
+    "homematicip==0.10.12"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -646,7 +646,7 @@ homeassistant-pyozw==0.1.4
 homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.11
+homematicip==0.10.12
 
 # homeassistant.components.horizon
 horimote==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -188,7 +188,7 @@ home-assistant-frontend==20190919.1
 homekit[IP]==0.15.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.11
+homematicip==0.10.12
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk


### PR DESCRIPTION
## Description:
This PR adds adds the ability to create and remove of HomematicIP devices and groups without restarting Homeassistant.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10470

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
