### PR TITLE
Add doods contains flags on areas to allow specifying overlap

### DIFF
--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -12,6 +12,7 @@ from homeassistant.components.image_processing import (
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_SOURCE,
+    CONF_TIMEOUT,
     PLATFORM_SCHEMA,
     ImageProcessingEntity,
     draw_box,
@@ -60,6 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_URL): cv.string,
         vol.Required(CONF_DETECTOR): cv.string,
+        vol.Required(CONF_TIMEOUT, default=90): cv.positive_int,
         vol.Optional(CONF_AUTH_KEY, default=""): cv.string,
         vol.Optional(CONF_FILE_OUT, default=[]): vol.All(cv.ensure_list, [cv.template]),
         vol.Optional(CONF_CONFIDENCE, default=0.0): vol.Range(min=0, max=100),
@@ -76,8 +78,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     url = config[CONF_URL]
     auth_key = config[CONF_AUTH_KEY]
     detector_name = config[CONF_DETECTOR]
+    timeout = config[CONF_TIMEOUT]
 
-    doods = PyDOODS(url, auth_key)
+    doods = PyDOODS(url, auth_key, timeout)
     response = doods.get_detectors()
     if not isinstance(response, dict):
         _LOGGER.warning("Could not connect to doods server: %s", url)

--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -14,6 +14,7 @@ from homeassistant.components.image_processing import (
     CONF_SOURCE,
     PLATFORM_SCHEMA,
     ImageProcessingEntity,
+    draw_box,
 )
 from homeassistant.core import split_entity_id
 from homeassistant.helpers import template
@@ -68,24 +69,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_AREA): AREA_SCHEMA,
     }
 )
-
-
-def draw_box(draw, box, img_width, img_height, text="", color=(255, 255, 0)):
-    """Draw bounding box on image."""
-    ymin, xmin, ymax, xmax = box
-    (left, right, top, bottom) = (
-        xmin * img_width,
-        xmax * img_width,
-        ymin * img_height,
-        ymax * img_height,
-    )
-    draw.line(
-        [(left, top), (left, bottom), (right, bottom), (right, top), (left, top)],
-        width=5,
-        fill=color,
-    )
-    if text:
-        draw.text((left, abs(top - 15)), text, fill=color)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -32,7 +32,7 @@ CONF_AUTH_KEY = "auth_key"
 CONF_DETECTOR = "detector"
 CONF_LABELS = "labels"
 CONF_AREA = "area"
-CONF_CONTAINS = "contains"
+CONF_COVERS = "covers"
 CONF_TOP = "top"
 CONF_BOTTOM = "bottom"
 CONF_RIGHT = "right"
@@ -45,7 +45,7 @@ AREA_SCHEMA = vol.Schema(
         vol.Optional(CONF_LEFT, default=0): cv.small_float,
         vol.Optional(CONF_RIGHT, default=1): cv.small_float,
         vol.Optional(CONF_TOP, default=0): cv.small_float,
-        vol.Optional(CONF_CONTAINS, default=True): cv.boolean,
+        vol.Optional(CONF_COVERS, default=True): cv.boolean,
     }
 )
 
@@ -145,7 +145,7 @@ class Doods(ImageProcessingEntity):
         # handle labels and specific detection areas
         labels = config[CONF_LABELS]
         self._label_areas = {}
-        self._label_contains = {}
+        self._label_covers = {}
         for label in labels:
             if isinstance(label, dict):
                 label_name = label[CONF_NAME]
@@ -163,7 +163,7 @@ class Doods(ImageProcessingEntity):
                 # Label area
                 label_area = label.get(CONF_AREA)
                 self._label_areas[label_name] = [0, 0, 1, 1]
-                self._label_contains[label_name] = True
+                self._label_covers[label_name] = True
                 if label_area:
                     self._label_areas[label_name] = [
                         label_area[CONF_TOP],
@@ -171,7 +171,7 @@ class Doods(ImageProcessingEntity):
                         label_area[CONF_BOTTOM],
                         label_area[CONF_RIGHT],
                     ]
-                    self._label_contains[label_name] = label_area[CONF_CONTAINS]
+                    self._label_covers[label_name] = label_area[CONF_COVERS]
             else:
                 if label not in detector["labels"] and label != "*":
                     _LOGGER.warning("Detector does not support label %s", label)
@@ -185,7 +185,7 @@ class Doods(ImageProcessingEntity):
 
         # Handle global detection area
         self._area = [0, 0, 1, 1]
-        self._contains = True
+        self._covers = True
         area_config = config.get(CONF_AREA)
         if area_config:
             self._area = [
@@ -194,7 +194,7 @@ class Doods(ImageProcessingEntity):
                 area_config[CONF_BOTTOM],
                 area_config[CONF_RIGHT],
             ]
-            self._contains = area_config[CONF_CONTAINS]
+            self._covers = area_config[CONF_COVERS]
 
         template.attach(hass, self._file_out)
 
@@ -320,7 +320,7 @@ class Doods(ImageProcessingEntity):
                 continue
 
             # Exclude matches outside global area definition
-            if self._contains:
+            if self._covers:
                 if (
                     boxes[0] < self._area[0]
                     or boxes[1] < self._area[1]
@@ -339,7 +339,7 @@ class Doods(ImageProcessingEntity):
 
             # Exclude matches outside label specific area definition
             if self._label_areas.get(label):
-                if self._label_contains[label]:
+                if self._label_covers[label]:
                     if (
                         boxes[0] < self._label_areas[label][0]
                         or boxes[1] < self._label_areas[label][1]

--- a/homeassistant/components/doods/image_processing.py
+++ b/homeassistant/components/doods/image_processing.py
@@ -7,12 +7,12 @@ import voluptuous as vol
 from PIL import Image, ImageDraw
 from pydoods import PyDOODS
 
+from homeassistant.const import CONF_TIMEOUT
 from homeassistant.components.image_processing import (
     CONF_CONFIDENCE,
     CONF_ENTITY_ID,
     CONF_NAME,
     CONF_SOURCE,
-    CONF_TIMEOUT,
     PLATFORM_SCHEMA,
     ImageProcessingEntity,
     draw_box,


### PR DESCRIPTION
## Description:
This adds a contains flag to areas in the doods image processing component. People have asked for the capability to detect only part of an image vs completely containing detection in an area. This makes it much easier to define detection areas.


Documentation Pull Request: https://github.com/home-assistant/home-assistant.io/pull/10471

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example advanced configuration.yaml entry
# Example configuration.yaml entry
image_processing:
  - platform: doods
    scan_interval: 1000
    url: "http://<my doods server>:8080"
    timeout: 60
    detector: default
    source:
      - entity_id: camera.front_yard
    file_out:
      - "/tmp/{% raw %}{{ camera_entity.split('.')[1] }}{% endraw %}_latest.jpg"
      - "/tmp/{% raw %}{{ camera_entity.split('.')[1] }}_{{ now().strftime('%Y%m%d_%H%M%S') }}{% endraw %}.jpg"
    confidence: 50
    # This global detection area is required for all labels
    area:
      # Exclude top 10% of image
      top: 0.1
      # Exclude right 5% of image
      right: 0.95
      # The entire detection must be inside this box
      covers: true
    labels:
      - name: person
        confidence: 40
        area:
          # Exclude top 10% of image
          top: 0.1
          # Exclude right 15% of image
          right: 0.85
          # Any part of the detection inside this area will trigger
          covers: false
      - car
      - truck
```
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
