### PR TITLE
Return esphome cover position as Integer

### DIFF
--- a/homeassistant/components/esphome/cover.py
+++ b/homeassistant/components/esphome/cover.py
@@ -91,11 +91,11 @@ class EsphomeCover(EsphomeEntity, CoverDevice):
         return self._state.current_operation == CoverOperation.IS_CLOSING
 
     @esphome_state_property
-    def current_cover_position(self) -> Optional[float]:
+    def current_cover_position(self) -> Optional[int]:
         """Return current position of cover. 0 is closed, 100 is open."""
         if not self._static_info.supports_position:
             return None
-        return self._state.position * 100.0
+        return round(self._state.position * 100.0)
 
     @esphome_state_property
     def current_cover_tilt_position(self) -> Optional[float]:


### PR DESCRIPTION
## Description: 
Cover position is [specified as Integer 0-100](https://www.home-assistant.io/components/cover/), we should not return float here.

**Related issue (if applicable):** fixes #25738

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

