### PR TITLE
Improve z-wave thermostat support

### DIFF
--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -87,6 +87,15 @@ MODE_SETPOINT_MAPPINGS = {
     "cool econ": ("setpoint_eco_cooling",),
     "away": ("setpoint_away_heating", "setpoint_away_cooling"),
     "full power": ("setpoint_full_power",),
+    # aliases found in xml configs
+    "comfort": ("setpoint_heating",),
+    "heat mode": ("setpoint_heating",),
+    "heat (default)": ("setpoint_heating",),
+    "dry floor": ("setpoint_dry_air",),
+    "heat eco": ("setpoint_eco_heating",),
+    "energy saving": ("setpoint_eco_heating",),
+    "energy heat": ("setpoint_eco_heating",),
+    "vacation": ("setpoint_away_heating", "setpoint_away_cooling"),
     # for tests
     "heat_cool": ("setpoint_heating", "setpoint_cooling"),
 }

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -481,7 +481,6 @@ class ZWaveClimate(ZWaveDeviceEntity, ClimateDevice):
             (setpoint_low, setpoint_high) = current_setpoints
             target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
             target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-            print("SETTING: ", target_temp_low, target_temp_high)
             if setpoint_low is not None and target_temp_low is not None:
                 _LOGGER.debug("Set low temperature to %s", target_temp_low)
                 setpoint_low.data = target_temp_low

--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -69,6 +69,51 @@ DISCOVERY_SCHEMAS = [
                     const.DISC_INDEX: [2],
                     const.DISC_OPTIONAL: True,
                 },
+                "setpoint_furnace": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [7],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_dry_air": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [8],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_moist_air": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [9],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_auto_changeover": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [10],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_eco_heating": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [11],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_eco_cooling": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [12],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_away_heating": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [13],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_away_cooling": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [14],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_full_power": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [15],
+                    const.DISC_OPTIONAL: True,
+                },
                 "temperature": {
                     const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SENSOR_MULTILEVEL],
                     const.DISC_INDEX: [const.INDEX_SENSOR_MULTILEVEL_TEMPERATURE],

--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -57,15 +57,21 @@ DISCOVERY_SCHEMAS = [
             DEFAULT_VALUES_SCHEMA,
             **{
                 const.DISC_PRIMARY: {
-                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT]
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_MODE]
+                },
+                "setpoint_heating": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [1],
+                    const.DISC_OPTIONAL: True,
+                },
+                "setpoint_cooling": {
+                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_SETPOINT],
+                    const.DISC_INDEX: [2],
+                    const.DISC_OPTIONAL: True,
                 },
                 "temperature": {
                     const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_SENSOR_MULTILEVEL],
                     const.DISC_INDEX: [const.INDEX_SENSOR_MULTILEVEL_TEMPERATURE],
-                    const.DISC_OPTIONAL: True,
-                },
-                "mode": {
-                    const.DISC_COMMAND_CLASS: [const.COMMAND_CLASS_THERMOSTAT_MODE],
                     const.DISC_OPTIONAL: True,
                 },
                 "fan_mode": {

--- a/tests/components/zwave/test_climate.py
+++ b/tests/components/zwave/test_climate.py
@@ -16,6 +16,9 @@ from homeassistant.components.climate.const import (
     SUPPORT_PRESET_MODE,
     SUPPORT_SWING_MODE,
     SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_TARGET_TEMPERATURE_RANGE,
+    ATTR_TARGET_TEMP_LOW,
+    ATTR_TARGET_TEMP_HIGH,
 )
 from homeassistant.components.zwave import climate
 from homeassistant.components.zwave.climate import DEFAULT_HVAC_MODES
@@ -29,9 +32,7 @@ def device(hass, mock_openzwave):
     """Fixture to provide a precreated climate device."""
     node = MockNode()
     values = MockEntityValues(
-        primary=MockValue(data=1, node=node),
-        temperature=MockValue(data=5, node=node, units=None),
-        mode=MockValue(
+        primary=MockValue(
             data=HVAC_MODE_HEAT,
             data_items=[
                 HVAC_MODE_OFF,
@@ -41,6 +42,9 @@ def device(hass, mock_openzwave):
             ],
             node=node,
         ),
+        setpoint_heating=MockValue(data=1, node=node),
+        setpoint_cooling=MockValue(data=10, node=node),
+        temperature=MockValue(data=5, node=node, units=None),
         fan_mode=MockValue(data="test2", data_items=[3, 4, 5], node=node),
         operating_state=MockValue(data=CURRENT_HVAC_HEAT, node=node),
         fan_action=MockValue(data=7, node=node),
@@ -56,9 +60,7 @@ def device_zxt_120(hass, mock_openzwave):
     node = MockNode(manufacturer_id="5254", product_id="8377")
 
     values = MockEntityValues(
-        primary=MockValue(data=1, node=node),
-        temperature=MockValue(data=5, node=node, units=None),
-        mode=MockValue(
+        primary=MockValue(
             data=HVAC_MODE_HEAT,
             data_items=[
                 HVAC_MODE_OFF,
@@ -68,6 +70,9 @@ def device_zxt_120(hass, mock_openzwave):
             ],
             node=node,
         ),
+        setpoint_heating=MockValue(data=1, node=node),
+        setpoint_cooling=MockValue(data=10, node=node),
+        temperature=MockValue(data=5, node=node, units=None),
         fan_mode=MockValue(data="test2", data_items=[3, 4, 5], node=node),
         operating_state=MockValue(data=CURRENT_HVAC_HEAT, node=node),
         fan_action=MockValue(data=7, node=node),
@@ -83,13 +88,14 @@ def device_mapping(hass, mock_openzwave):
     """Fixture to provide a precreated climate device. Test state mapping."""
     node = MockNode()
     values = MockEntityValues(
-        primary=MockValue(data=1, node=node),
-        temperature=MockValue(data=5, node=node, units=None),
-        mode=MockValue(
+        primary=MockValue(
             data="Heat",
             data_items=["Off", "Cool", "Heat", "Full Power", "heat_cool"],
             node=node,
         ),
+        setpoint_heating=MockValue(data=1, node=node),
+        setpoint_cooling=MockValue(data=10, node=node),
+        temperature=MockValue(data=5, node=node, units=None),
         fan_mode=MockValue(data="test2", data_items=[3, 4, 5], node=node),
         operating_state=MockValue(data="heating", node=node),
         fan_action=MockValue(data=7, node=node),
@@ -104,13 +110,14 @@ def device_unknown(hass, mock_openzwave):
     """Fixture to provide a precreated climate device. Test state unknown."""
     node = MockNode()
     values = MockEntityValues(
-        primary=MockValue(data=1, node=node),
-        temperature=MockValue(data=5, node=node, units=None),
-        mode=MockValue(
+        primary=MockValue(
             data="Heat",
             data_items=["Off", "Cool", "Heat", "heat_cool", "Abcdefg"],
             node=node,
         ),
+        setpoint_heating=MockValue(data=1, node=node),
+        setpoint_cooling=MockValue(data=10, node=node),
+        temperature=MockValue(data=5, node=node, units=None),
         fan_mode=MockValue(data="test2", data_items=[3, 4, 5], node=node),
         operating_state=MockValue(data="test4", node=node),
         fan_action=MockValue(data=7, node=node),
@@ -125,9 +132,7 @@ def device_heat_cool(hass, mock_openzwave):
     """Fixture to provide a precreated climate device. Test state heat only."""
     node = MockNode()
     values = MockEntityValues(
-        primary=MockValue(data=1, node=node),
-        temperature=MockValue(data=5, node=node, units=None),
-        mode=MockValue(
+        primary=MockValue(
             data=HVAC_MODE_HEAT,
             data_items=[
                 HVAC_MODE_OFF,
@@ -138,6 +143,36 @@ def device_heat_cool(hass, mock_openzwave):
             ],
             node=node,
         ),
+        setpoint_heating=MockValue(data=1, node=node),
+        setpoint_cooling=MockValue(data=10, node=node),
+        temperature=MockValue(data=5, node=node, units=None),
+        fan_mode=MockValue(data="test2", data_items=[3, 4, 5], node=node),
+        operating_state=MockValue(data="test4", node=node),
+        fan_action=MockValue(data=7, node=node),
+    )
+    device = climate.get_device(hass, node=node, values=values, node_config={})
+
+    yield device
+
+
+@pytest.fixture
+def device_heat_cool_range(hass, mock_openzwave):
+    """Fixture to provide a precreated climate device. Target range mode."""
+    node = MockNode()
+    values = MockEntityValues(
+        primary=MockValue(
+            data=HVAC_MODE_HEAT_COOL,
+            data_items=[
+                HVAC_MODE_OFF,
+                HVAC_MODE_HEAT,
+                HVAC_MODE_COOL,
+                HVAC_MODE_HEAT_COOL,
+            ],
+            node=node,
+        ),
+        setpoint_heating=MockValue(data=1, node=node),
+        setpoint_cooling=MockValue(data=10, node=node),
+        temperature=MockValue(data=5, node=node, units=None),
         fan_mode=MockValue(data="test2", data_items=[3, 4, 5], node=node),
         operating_state=MockValue(data="test4", node=node),
         fan_action=MockValue(data=7, node=node),
@@ -156,6 +191,14 @@ def test_default_hvac_modes():
 def test_supported_features(device):
     """Test supported features flags."""
     assert device.supported_features == SUPPORT_FAN_MODE + SUPPORT_TARGET_TEMPERATURE
+
+
+def test_supported_features_temp_range(device_heat_cool_range):
+    """Test supported features flags with target temp range."""
+    device = device_heat_cool_range
+    assert (
+        device.supported_features == SUPPORT_FAN_MODE + SUPPORT_TARGET_TEMPERATURE_RANGE
+    )
 
 
 def test_supported_features_preset_mode(device_mapping):
@@ -207,14 +250,6 @@ def test_temperature_unit(device):
     assert device.temperature_unit == TEMP_CELSIUS
 
 
-def test_default_target_temperature(device):
-    """Test default setting of target temperature."""
-    assert device.target_temperature == 1
-    device.values.primary.data = 0
-    value_changed(device.values.primary)
-    assert device.target_temperature == 5  # Current Temperature
-
-
 def test_data_lists(device):
     """Test data lists from zwave value items."""
     assert device.fan_modes == [3, 4, 5]
@@ -225,7 +260,7 @@ def test_data_lists(device):
         HVAC_MODE_HEAT_COOL,
     ]
     assert device.preset_modes == []
-    device.values.mode = None
+    device.values.primary = None
     assert device.preset_modes == []
 
 
@@ -234,71 +269,100 @@ def test_data_lists_mapping(device_mapping):
     device = device_mapping
     assert device.hvac_modes == ["off", "cool", "heat", "heat_cool"]
     assert device.preset_modes == ["boost", "none"]
-    device.values.mode = None
+    device.values.primary = None
     assert device.preset_modes == []
 
 
 def test_target_value_set(device):
     """Test values changed for climate device."""
-    assert device.values.primary.data == 1
+    assert device.values.setpoint_heating.data == 1
+    assert device.values.setpoint_cooling.data == 10
     device.set_temperature()
-    assert device.values.primary.data == 1
+    assert device.values.setpoint_heating.data == 1
+    assert device.values.setpoint_cooling.data == 10
     device.set_temperature(**{ATTR_TEMPERATURE: 2})
-    assert device.values.primary.data == 2
+    assert device.values.setpoint_heating.data == 2
+    assert device.values.setpoint_cooling.data == 10
+    device.set_hvac_mode(HVAC_MODE_COOL)
+    value_changed(device.values.primary)
+    assert device.values.setpoint_heating.data == 2
+    assert device.values.setpoint_cooling.data == 10
+    device.set_temperature(**{ATTR_TEMPERATURE: 9})
+    assert device.values.setpoint_heating.data == 2
+    assert device.values.setpoint_cooling.data == 9
+
+
+def test_target_value_set_range(device_heat_cool_range):
+    """Test values changed for climate device."""
+    device = device_heat_cool_range
+    assert device.values.setpoint_heating.data == 1
+    assert device.values.setpoint_cooling.data == 10
+    device.set_temperature()
+    assert device.values.setpoint_heating.data == 1
+    assert device.values.setpoint_cooling.data == 10
+    device.set_temperature(**{ATTR_TARGET_TEMP_LOW: 2})
+    assert device.values.setpoint_heating.data == 2
+    assert device.values.setpoint_cooling.data == 10
+    device.set_temperature(**{ATTR_TARGET_TEMP_HIGH: 9})
+    assert device.values.setpoint_heating.data == 2
+    assert device.values.setpoint_cooling.data == 9
+    device.set_temperature(**{ATTR_TARGET_TEMP_LOW: 3, ATTR_TARGET_TEMP_HIGH: 8})
+    assert device.values.setpoint_heating.data == 3
+    assert device.values.setpoint_cooling.data == 8
 
 
 def test_operation_value_set(device):
     """Test values changed for climate device."""
-    assert device.values.mode.data == HVAC_MODE_HEAT
+    assert device.values.primary.data == HVAC_MODE_HEAT
     device.set_hvac_mode(HVAC_MODE_COOL)
-    assert device.values.mode.data == HVAC_MODE_COOL
+    assert device.values.primary.data == HVAC_MODE_COOL
     device.set_preset_mode(PRESET_ECO)
-    assert device.values.mode.data == PRESET_ECO
+    assert device.values.primary.data == PRESET_ECO
     device.set_preset_mode(PRESET_NONE)
-    assert device.values.mode.data == HVAC_MODE_HEAT_COOL
-    device.values.mode = None
+    assert device.values.primary.data == HVAC_MODE_HEAT_COOL
+    device.values.primary = None
     device.set_hvac_mode("test_set_failes")
-    assert device.values.mode is None
+    assert device.values.primary is None
     device.set_preset_mode("test_set_failes")
-    assert device.values.mode is None
+    assert device.values.primary is None
 
 
 def test_operation_value_set_mapping(device_mapping):
     """Test values changed for climate device. Mapping."""
     device = device_mapping
-    assert device.values.mode.data == "Heat"
+    assert device.values.primary.data == "Heat"
     device.set_hvac_mode(HVAC_MODE_COOL)
-    assert device.values.mode.data == "Cool"
+    assert device.values.primary.data == "Cool"
     device.set_hvac_mode(HVAC_MODE_OFF)
-    assert device.values.mode.data == "Off"
+    assert device.values.primary.data == "Off"
     device.set_preset_mode(PRESET_BOOST)
-    assert device.values.mode.data == "Full Power"
+    assert device.values.primary.data == "Full Power"
     device.set_preset_mode(PRESET_ECO)
-    assert device.values.mode.data == "eco"
+    assert device.values.primary.data == "eco"
 
 
 def test_operation_value_set_unknown(device_unknown):
     """Test values changed for climate device. Unknown."""
     device = device_unknown
-    assert device.values.mode.data == "Heat"
+    assert device.values.primary.data == "Heat"
     device.set_preset_mode("Abcdefg")
-    assert device.values.mode.data == "Abcdefg"
+    assert device.values.primary.data == "Abcdefg"
     device.set_preset_mode(PRESET_NONE)
-    assert device.values.mode.data == HVAC_MODE_HEAT_COOL
+    assert device.values.primary.data == HVAC_MODE_HEAT_COOL
 
 
 def test_operation_value_set_heat_cool(device_heat_cool):
     """Test values changed for climate device. Heat/Cool only."""
     device = device_heat_cool
-    assert device.values.mode.data == HVAC_MODE_HEAT
+    assert device.values.primary.data == HVAC_MODE_HEAT
     device.set_preset_mode("Heat Eco")
-    assert device.values.mode.data == "Heat Eco"
+    assert device.values.primary.data == "Heat Eco"
     device.set_preset_mode(PRESET_NONE)
-    assert device.values.mode.data == HVAC_MODE_HEAT
+    assert device.values.primary.data == HVAC_MODE_HEAT
     device.set_preset_mode("Cool Eco")
-    assert device.values.mode.data == "Cool Eco"
+    assert device.values.primary.data == "Cool Eco"
     device.set_preset_mode(PRESET_NONE)
-    assert device.values.mode.data == HVAC_MODE_COOL
+    assert device.values.primary.data == HVAC_MODE_COOL
 
 
 def test_fan_mode_value_set(device):
@@ -314,9 +378,43 @@ def test_fan_mode_value_set(device):
 def test_target_value_changed(device):
     """Test values changed for climate device."""
     assert device.target_temperature == 1
-    device.values.primary.data = 2
-    value_changed(device.values.primary)
+    device.values.setpoint_heating.data = 2
+    value_changed(device.values.setpoint_heating)
     assert device.target_temperature == 2
+    device.values.primary.data = HVAC_MODE_COOL
+    value_changed(device.values.primary)
+    assert device.target_temperature == 10
+    device.values.setpoint_cooling.data = 9
+    value_changed(device.values.setpoint_cooling)
+    assert device.target_temperature == 9
+
+
+def test_target_range_changed(device_heat_cool_range):
+    """Test values changed for climate device."""
+    device = device_heat_cool_range
+    assert device.target_temperature_low == 1
+    assert device.target_temperature_high == 10
+    device.values.setpoint_heating.data = 2
+    value_changed(device.values.setpoint_heating)
+    assert device.target_temperature_low == 2
+    assert device.target_temperature_high == 10
+    device.values.setpoint_cooling.data = 9
+    value_changed(device.values.setpoint_cooling)
+    assert device.target_temperature_low == 2
+    assert device.target_temperature_high == 9
+
+
+def test_target_changed_with_mode(device):
+    """Test values changed for climate device."""
+    assert device.hvac_mode == HVAC_MODE_HEAT
+    assert device.target_temperature == 1
+    device.values.primary.data = HVAC_MODE_COOL
+    value_changed(device.values.primary)
+    assert device.target_temperature == 10
+    device.values.primary.data = HVAC_MODE_HEAT_COOL
+    value_changed(device.values.primary)
+    assert device.target_temperature_low == 1
+    assert device.target_temperature_high == 10
 
 
 def test_temperature_value_changed(device):
@@ -331,15 +429,15 @@ def test_operation_value_changed(device):
     """Test values changed for climate device."""
     assert device.hvac_mode == HVAC_MODE_HEAT
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = HVAC_MODE_COOL
-    value_changed(device.values.mode)
+    device.values.primary.data = HVAC_MODE_COOL
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_COOL
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = HVAC_MODE_OFF
-    value_changed(device.values.mode)
+    device.values.primary.data = HVAC_MODE_OFF
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_OFF
     assert device.preset_mode == PRESET_NONE
-    device.values.mode = None
+    device.values.primary = None
     assert device.hvac_mode == HVAC_MODE_HEAT_COOL
     assert device.preset_mode == PRESET_NONE
 
@@ -349,8 +447,8 @@ def test_operation_value_changed_preset(device_mapping):
     device = device_mapping
     assert device.hvac_mode == HVAC_MODE_HEAT
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = PRESET_ECO
-    value_changed(device.values.mode)
+    device.values.primary.data = PRESET_ECO
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_HEAT_COOL
     assert device.preset_mode == PRESET_ECO
 
@@ -360,12 +458,12 @@ def test_operation_value_changed_mapping(device_mapping):
     device = device_mapping
     assert device.hvac_mode == HVAC_MODE_HEAT
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = "Off"
-    value_changed(device.values.mode)
+    device.values.primary.data = "Off"
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_OFF
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = "Cool"
-    value_changed(device.values.mode)
+    device.values.primary.data = "Cool"
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_COOL
     assert device.preset_mode == PRESET_NONE
 
@@ -375,11 +473,11 @@ def test_operation_value_changed_mapping_preset(device_mapping):
     device = device_mapping
     assert device.hvac_mode == HVAC_MODE_HEAT
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = "Full Power"
-    value_changed(device.values.mode)
+    device.values.primary.data = "Full Power"
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_HEAT_COOL
     assert device.preset_mode == PRESET_BOOST
-    device.values.mode = None
+    device.values.primary = None
     assert device.hvac_mode == HVAC_MODE_HEAT_COOL
     assert device.preset_mode == PRESET_NONE
 
@@ -389,8 +487,8 @@ def test_operation_value_changed_unknown(device_unknown):
     device = device_unknown
     assert device.hvac_mode == HVAC_MODE_HEAT
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = "Abcdefg"
-    value_changed(device.values.mode)
+    device.values.primary.data = "Abcdefg"
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_HEAT_COOL
     assert device.preset_mode == "Abcdefg"
 
@@ -400,12 +498,12 @@ def test_operation_value_changed_heat_cool(device_heat_cool):
     device = device_heat_cool
     assert device.hvac_mode == HVAC_MODE_HEAT
     assert device.preset_mode == PRESET_NONE
-    device.values.mode.data = "Cool Eco"
-    value_changed(device.values.mode)
+    device.values.primary.data = "Cool Eco"
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_COOL
     assert device.preset_mode == "Cool Eco"
-    device.values.mode.data = "Heat Eco"
-    value_changed(device.values.mode)
+    device.values.primary.data = "Heat Eco"
+    value_changed(device.values.primary)
     assert device.hvac_mode == HVAC_MODE_HEAT
     assert device.preset_mode == "Heat Eco"
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -574,17 +574,32 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
     assert len(mock_receivers) == 1
 
     node = MockNode(node_id=11, generic=const.GENERIC_TYPE_THERMOSTAT)
-    setpoint = MockValue(
+    thermostat_mode = MockValue(
+        data="Heat",
+        data_items=["Off", "Heat"],
+        node=node,
+        command_class=const.COMMAND_CLASS_THERMOSTAT_MODE,
+        genre=const.GENRE_USER,
+    )
+    setpoint_heating = MockValue(
         data=22.0,
         node=node,
-        index=12,
-        instance=13,
         command_class=const.COMMAND_CLASS_THERMOSTAT_SETPOINT,
+        index=1,
         genre=const.GENRE_USER,
-        units="C",
     )
-    hass.async_add_job(mock_receivers[0], node, setpoint)
+
+    hass.async_add_job(mock_receivers[0], node, thermostat_mode)
     await hass.async_block_till_done()
+
+    def mock_update(self):
+        self.hass.add_job(self.async_update_ha_state)
+
+    with patch.object(
+        zwave.node_entity.ZWaveBaseEntity, "maybe_schedule_update", new=mock_update
+    ):
+        hass.async_add_job(mock_receivers[0], node, setpoint_heating)
+        await hass.async_block_till_done()
 
     assert (
         hass.states.get("climate.mock_node_mock_value").attributes["temperature"]
@@ -597,9 +612,6 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
         is None
     )
 
-    def mock_update(self):
-        self.hass.add_job(self.async_update_ha_state)
-
     with patch.object(
         zwave.node_entity.ZWaveBaseEntity, "maybe_schedule_update", new=mock_update
     ):
@@ -607,7 +619,6 @@ async def test_value_discovery_existing_entity(hass, mock_openzwave):
             data=23.5,
             node=node,
             index=1,
-            instance=13,
             command_class=const.COMMAND_CLASS_SENSOR_MULTILEVEL,
             genre=const.GENRE_USER,
             units="C",


### PR DESCRIPTION
Discover thermostats using `COMMAND_CLASS_THERMOSTAT_MODE` so that it is a single entity when there are multiple setpoints. 
z-wave docs mention this command class is required to be present.
Add support for single/dual target temperature depending
on the current thermostat mode.
I also verified thermostat is correctly exposed through Amazon Alexa/Google Assistant and single/dual setpoints are dynamically updating based on the current mode.

## Breaking Change:
This changes the  primary command class for z-wave thermostats in discovery schemas from `COMMAND_CLASS_THERMOSTAT_SETPOINT` to `COMMAND_CLASS_THERMOSTAT_MODE`.
This will cause a typical dual setpoint thermostat to be correctly represented as a single entity.

## Description:
Previously z-wave thermostats were discovered using `COMMAND_CLASS_THERMOSTAT_SETPOINT` as a primary value.
That caused a single thermostat to be exposed multiple times - once for each setpoint. 
Also this PR adds dynamic single/dual setpoint support based on the current thermostat mode.
e.g. if current mode is `HVAC_MODE_HEAT` or `HVAC_MODE_COOL`  - expose single target temp `ATTR_TEMPERATURE`, if current mode is `HVAC_MODE_HEAT_COOL` - expose target range attributes `ATTR_TARGET_TEMP_LOW` and `ATTR_TARGET_TEMP_HIGH`

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
I will create PR for docs once I get feedback on this PR

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
