### PR TITLE
Add xiaomi_aqara protocol version config for Xiaomi Gateway 2.0/3.0

### DIFF
--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -33,6 +33,7 @@ CONF_GATEWAYS = "gateways"
 CONF_INTERFACE = "interface"
 CONF_KEY = "key"
 CONF_DISABLE = "disable"
+CONF_PROTO = "proto"
 
 DOMAIN = "xiaomi_aqara"
 
@@ -71,6 +72,7 @@ GATEWAY_CONFIG = vol.Schema(
         vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=9898): cv.port,
         vol.Optional(CONF_DISABLE, default=False): cv.boolean,
+        vol.Optional(CONF_PROTO, default=None): cv.string,
     }
 )
 


### PR DESCRIPTION
## Description:
xiaomi_aqara module currently (without this change) does not support proto other than 1.0 for gateways even though the underlying PyXiaomiGateway supports them. 
The simple reason turned out to be the inability to mention the protocol version in the config. 
This change let's one mention protocol version in the config optionally.

**Related issue (if applicable):** fixes #27041 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10478

## Example entry for `configuration.yaml` (if applicable):
```yaml
xiaomi_aqara:
  gateways:
    - mac: xyza1234mnop
      key: abcd4321pqrs9876
      host: 192.168.1.10
      proto: 3.0
```

## Checklist:
  - [ y] The code change is tested and works locally.
  - [ y] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ y] There is no commented out code in this PR.
  - [ n] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ y] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ -] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ -] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ -] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ n] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
