### PR TITLE
Make it possible to set options and system options on entry create

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -598,8 +598,8 @@ class ConfigEntries:
             domain=result["handler"],
             title=result["title"],
             data=result["data"],
-            options={},
-            system_options={},
+            options=result.get("options", {}),
+            system_options=result.get("system_options", {}),
             source=flow.context["source"],
             connection_class=flow.CONNECTION_CLASS,
         )

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -208,6 +208,7 @@ class FlowHandler:
         data: Dict,
         description: Optional[str] = None,
         description_placeholders: Optional[Dict] = None,
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """Finish config flow and create a config entry."""
         return {
@@ -219,6 +220,7 @@ class FlowHandler:
             "data": data,
             "description": description,
             "description_placeholders": description_placeholders,
+            **kwargs,
         }
 
     @callback


### PR DESCRIPTION
## Description:

Make it possible to create config entries with an initial set of options and system options. This is especially useful on config import, and for some integrations it would be desirable to disable new entities by default as discussed in #26675.

**Related issue (if applicable):** #26675, #27612 (alternative approach)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
