### PR TITLE
Add Pi-hole enable and disable services

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -5,7 +5,13 @@ import voluptuous as vol
 from hole import Hole
 from hole.exceptions import HoleError
 
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SSL, CONF_VERIFY_SSL
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_API_KEY,
+    CONF_SSL,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -21,6 +27,8 @@ from .const import (
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
     MIN_TIME_BETWEEN_UPDATES,
+    SERVICE_DISABLE,
+    SERVICE_DISABLE_ATTR_DURATION,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -31,6 +39,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(CONF_API_KEY, default=None): cv.string_or_none,
                 vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
                 vol.Optional(CONF_LOCATION, default=DEFAULT_LOCATION): cv.string,
                 vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
@@ -40,6 +49,10 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+SERVICE_DISABLE_SCHEMA = vol.Schema(
+    {vol.Required(SERVICE_DISABLE_ATTR_DURATION): cv.positive_int}
+)
+
 
 async def async_setup(hass, config):
     """Set up the pi_hole integration."""
@@ -47,6 +60,7 @@ async def async_setup(hass, config):
     conf = config[DOMAIN]
     name = conf[CONF_NAME]
     host = conf[CONF_HOST]
+    api_key = conf.get(CONF_API_KEY)
     use_tls = conf[CONF_SSL]
     verify_tls = conf[CONF_VERIFY_SSL]
     location = conf[CONF_LOCATION]
@@ -62,6 +76,7 @@ async def async_setup(hass, config):
             location=location,
             tls=use_tls,
             verify_tls=verify_tls,
+            api_token=api_key,
         ),
         name,
     )
@@ -69,6 +84,20 @@ async def async_setup(hass, config):
     await pi_hole.async_update()
 
     hass.data[DOMAIN] = pi_hole
+
+    async def handle_disable(call):
+        if api_key is None:
+            LOGGER.error("api_key is required in configuration to disable")
+            return
+
+        duration = call.data.get(SERVICE_DISABLE_ATTR_DURATION)
+
+        LOGGER.info("Disabling %s %s for %d seconds", DOMAIN, host, duration)
+        await pi_hole.api.disable(duration)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_DISABLE, handle_disable, schema=SERVICE_DISABLE_SCHEMA
+    )
 
     hass.async_create_task(async_load_platform(hass, SENSOR_DOMAIN, DOMAIN, {}, config))
 

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -40,7 +40,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                vol.Optional(CONF_API_KEY, default=None): cv.string_or_none,
+                vol.Optional(CONF_API_KEY, default=None): cv.optional_string,
                 vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
                 vol.Optional(CONF_LOCATION, default=DEFAULT_LOCATION): cv.string,
                 vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     MIN_TIME_BETWEEN_UPDATES,
     SERVICE_DISABLE,
     SERVICE_DISABLE_ATTR_DURATION,
+    SERVICE_ENABLE,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -95,9 +96,19 @@ async def async_setup(hass, config):
         LOGGER.info("Disabling %s %s for %d seconds", DOMAIN, host, duration)
         await pi_hole.api.disable(duration)
 
+    async def handle_enable(call):
+        if api_key is None:
+            LOGGER.error("api_key is required in configuration to enable")
+            return
+
+        LOGGER.info("Enabling %s %s", DOMAIN, host)
+        await pi_hole.api.enable()
+
     hass.services.async_register(
         DOMAIN, SERVICE_DISABLE, handle_disable, schema=SERVICE_DISABLE_SCHEMA
     )
+
+    hass.services.async_register(DOMAIN, SERVICE_ENABLE, handle_enable)
 
     hass.async_create_task(async_load_platform(hass, SENSOR_DOMAIN, DOMAIN, {}, config))
 

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -40,7 +40,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                vol.Optional(CONF_API_KEY, default=None): cv.optional_string,
+                vol.Optional(CONF_API_KEY): cv.string,
                 vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
                 vol.Optional(CONF_LOCATION, default=DEFAULT_LOCATION): cv.string,
                 vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
@@ -61,7 +61,7 @@ async def async_setup(hass, config):
     conf = config[DOMAIN]
     name = conf[CONF_NAME]
     host = conf[CONF_HOST]
-    api_key = conf.get(CONF_API_KEY)
+    api_key = conf[CONF_API_KEY] if CONF_API_KEY in conf else None
     use_tls = conf[CONF_SSL]
     verify_tls = conf[CONF_VERIFY_SSL]
     location = conf[CONF_LOCATION]
@@ -88,20 +88,20 @@ async def async_setup(hass, config):
 
     async def handle_disable(call):
         if api_key is None:
-            LOGGER.error("api_key is required in configuration to disable")
+            LOGGER.error("Pi-hole `api_key` is required in configuration to disable")
             return
 
-        duration = call.data.get(SERVICE_DISABLE_ATTR_DURATION)
+        duration = call.data[SERVICE_DISABLE_ATTR_DURATION]
 
-        LOGGER.info("Disabling %s %s for %d seconds", DOMAIN, host, duration)
+        LOGGER.debug("Disabling %s %s for %d seconds", DOMAIN, host, duration)
         await pi_hole.api.disable(duration)
 
     async def handle_enable(call):
         if api_key is None:
-            LOGGER.error("api_key is required in configuration to enable")
+            LOGGER.error("Pi-hole `api_key` is required in configuration to enable")
             return
 
-        LOGGER.info("Enabling %s %s", DOMAIN, host)
+        LOGGER.debug("Enabling %s %s", DOMAIN, host)
         await pi_hole.api.enable()
 
     hass.services.async_register(

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -65,10 +65,10 @@ async def async_setup(hass, config):
     conf = config[DOMAIN]
     name = conf[CONF_NAME]
     host = conf[CONF_HOST]
-    api_key = conf[CONF_API_KEY] if CONF_API_KEY in conf else None
     use_tls = conf[CONF_SSL]
     verify_tls = conf[CONF_VERIFY_SSL]
     location = conf[CONF_LOCATION]
+    api_key = conf.get(CONF_API_KEY)
 
     LOGGER.debug("Setting up %s integration with host %s", DOMAIN, host)
 

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -13,6 +13,7 @@ DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
 SERVICE_DISABLE = "disable"
+SERVICE_ENABLE = "enable"
 SERVICE_DISABLE_ATTR_DURATION = "duration"
 
 ATTR_BLOCKED_DOMAINS = "domains_blocked"

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -12,6 +12,9 @@ DEFAULT_NAME = "Pi-Hole"
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
+SERVICE_DISABLE = "disable"
+SERVICE_DISABLE_ATTR_DURATION = "duration"
+
 ATTR_BLOCKED_DOMAINS = "domains_blocked"
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)

--- a/homeassistant/components/pi_hole/services.yaml
+++ b/homeassistant/components/pi_hole/services.yaml
@@ -1,8 +1,8 @@
 disable:
-  description: Disable pi-hole for an amount of time
+  description: Disable Pi-hole for an amount of time
   fields:
     duration:
-      description: Length of time to disable the pi-hole, in seconds
-      example: 600
+      description: Time that the Pi-hole should be disabled for
+      example: "00:00:15"
 enable:
-  description: Enable pi-hole
+  description: Enable Pi-hole

--- a/homeassistant/components/pi_hole/services.yaml
+++ b/homeassistant/components/pi_hole/services.yaml
@@ -4,3 +4,5 @@ disable:
     duration:
       description: Length of time to disable the pi-hole, in seconds
       example: 600
+enable:
+  description: Enable pi-hole

--- a/homeassistant/components/pi_hole/services.yaml
+++ b/homeassistant/components/pi_hole/services.yaml
@@ -1,0 +1,6 @@
+disable:
+  description: Disable pi-hole for an amount of time
+  fields:
+    duration:
+      description: Length of time to disable the pi-hole, in seconds
+      example: 600

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -439,6 +439,16 @@ def string(value: Any) -> str:
     return str(value)
 
 
+def string_or_none(value: Any) -> str:
+    """Coerce value to string, except if None."""
+    if value is None:
+        return None
+    if isinstance(value, (list, dict)):
+        raise vol.Invalid("value should be a string")
+
+    return str(value)
+
+
 def temperature_unit(value: Any) -> str:
     """Validate and transform temperature unit."""
     value = str(value).upper()

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -439,16 +439,6 @@ def string(value: Any) -> str:
     return str(value)
 
 
-def optional_string(value: Any) -> Optional[str]:
-    """Coerce value to string, except if None."""
-    if value is None:
-        return None
-    if isinstance(value, (list, dict)):
-        raise vol.Invalid("value should be a string")
-
-    return str(value)
-
-
 def temperature_unit(value: Any) -> str:
     """Validate and transform temperature unit."""
     value = str(value).upper()

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -439,7 +439,7 @@ def string(value: Any) -> str:
     return str(value)
 
 
-def string_or_none(value: Any) -> str:
+def optional_string(value: Any) -> Optional[str]:
     """Coerce value to string, except if None."""
     if value is None:
         return None


### PR DESCRIPTION
## Description:
 Introduces `pi_hole.disable` service to disable a Pi-hole for a specified amount of time, and `pi_hole.enable` service to enable a disabled Pi-hole

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10485

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
