### PR TITLE
Fix Lutron Pico

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -68,7 +68,6 @@ def setup(hass, base_config):
                 hass.data[LUTRON_DEVICES]["switch"].append((area.name, output))
         for keypad in area.keypads:
             for button in keypad.buttons:
-<<<<<<< HEAD
                 # This is the best way to determine if a button does anything
                 # useful until pylutron is updated to provide information on
                 # which buttons actually control scenes.
@@ -83,23 +82,6 @@ def setup(hass, base_config):
                         )
                 # All keypads have LEDs except Pico keypads
                 if not keypad.leds:
-=======
-                # All keypads have LEDs except Pico keypads
-                if keypad.leds:
-                    # This is the best way to determine if a button does anything
-                    # useful until pylutron is updated to provide information on
-                    # which buttons actually control scenes.
-                    for led in keypad.leds:
-                        if (
-                            led.number == button.number
-                            and button.name != "Unknown Button"
-                            and button.button_type in ("SingleAction", "Toggle")
-                        ):
-                            hass.data[LUTRON_DEVICES]["scene"].append(
-                                (area.name, keypad.name, button, led)
-                            )
-                else:
->>>>>>> 5ec92e592... Lutron Pico fix
                     hass.data[LUTRON_DEVICES]["scene"].append(
                         (area.name, keypad.name, button, None)
                     )

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -68,22 +68,18 @@ def setup(hass, base_config):
                 hass.data[LUTRON_DEVICES]["switch"].append((area.name, output))
         for keypad in area.keypads:
             for button in keypad.buttons:
-                # This is the best way to determine if a button does anything
-                # useful until pylutron is updated to provide information on
-                # which buttons actually control scenes.
-                for led in keypad.leds:
-                    if (
-                        led.number == button.number
-                        and button.name != "Unknown Button"
-                        and button.button_type in ("SingleAction", "Toggle")
-                    ):
-                        hass.data[LUTRON_DEVICES]["scene"].append(
-                            (area.name, keypad.name, button, led)
-                        )
-                # All keypads have LEDs except Pico keypads
-                if not keypad.leds:
+                # If the button has a function assigned to it, add it as a scene
+                if button.name != "Unknown Button" and button.button_type in (
+                    "SingleAction",
+                    "Toggle",
+                ):
+                    # Associate an LED with a button if there is one
+                    led = next(
+                        (led for led in keypad.leds if led.number == button.number),
+                        None,
+                    )
                     hass.data[LUTRON_DEVICES]["scene"].append(
-                        (area.name, keypad.name, button, None)
+                        (area.name, keypad.name, button, led)
                     )
 
                 hass.data[LUTRON_BUTTONS].append(LutronButton(hass, keypad, button))

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -55,7 +55,7 @@ def setup(hass, base_config):
 
     hass.data[LUTRON_CONTROLLER].load_xml_db()
     hass.data[LUTRON_CONTROLLER].connect()
-    _LOGGER.info("Connected to main repeater at %s", config[CONF_HOST])
+    _LOGGER.info(f"Connected to main repeater at {config[CONF_HOST]}")
 
     # Sort our devices into types
     for area in hass.data[LUTRON_CONTROLLER].areas:
@@ -68,6 +68,7 @@ def setup(hass, base_config):
                 hass.data[LUTRON_DEVICES]["switch"].append((area.name, output))
         for keypad in area.keypads:
             for button in keypad.buttons:
+<<<<<<< HEAD
                 # This is the best way to determine if a button does anything
                 # useful until pylutron is updated to provide information on
                 # which buttons actually control scenes.
@@ -82,6 +83,23 @@ def setup(hass, base_config):
                         )
                 # All keypads have LEDs except Pico keypads
                 if not keypad.leds:
+=======
+                # All keypads have LEDs except Pico keypads
+                if keypad.leds:
+                    # This is the best way to determine if a button does anything
+                    # useful until pylutron is updated to provide information on
+                    # which buttons actually control scenes.
+                    for led in keypad.leds:
+                        if (
+                            led.number == button.number
+                            and button.name != "Unknown Button"
+                            and button.button_type in ("SingleAction", "Toggle")
+                        ):
+                            hass.data[LUTRON_DEVICES]["scene"].append(
+                                (area.name, keypad.name, button, led)
+                            )
+                else:
+>>>>>>> 5ec92e592... Lutron Pico fix
                     hass.data[LUTRON_DEVICES]["scene"].append(
                         (area.name, keypad.name, button, None)
                     )

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -80,6 +80,11 @@ def setup(hass, base_config):
                         hass.data[LUTRON_DEVICES]["scene"].append(
                             (area.name, keypad.name, button, led)
                         )
+                # All keypads have LEDs except Pico keypads
+                if not keypad.leds:
+                    hass.data[LUTRON_DEVICES]["scene"].append(
+                        (area.name, keypad.name, button, None)
+                    )
 
                 hass.data[LUTRON_BUTTONS].append(LutronButton(hass, keypad, button))
         if area.occupancy_group is not None:

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -55,7 +55,7 @@ def setup(hass, base_config):
 
     hass.data[LUTRON_CONTROLLER].load_xml_db()
     hass.data[LUTRON_CONTROLLER].connect()
-    _LOGGER.info(f"Connected to main repeater at {config[CONF_HOST]}")
+    _LOGGER.info("Connected to main repeater at %s", config[CONF_HOST])
 
     # Sort our devices into types
     for area in hass.data[LUTRON_CONTROLLER].areas:


### PR DESCRIPTION
## Description:
Lutron Pico keypads do not work. The problem is because they don't have LEDs assigned to them within the configuration, so they get skipped over when keypads are being added to HASS. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10490

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
