### PR TITLE
Envisalink startup reconnect

### DIFF
--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -141,7 +141,9 @@ async def async_setup(hass, config):
     @callback
     def connection_fail_callback(data):
         """Network failure callback."""
-        _LOGGER.error("Could not establish a connection with the Envisalink- retrying...")
+        _LOGGER.error(
+            "Could not establish a connection with the Envisalink- retrying..."
+        )
 
     @callback
     def connection_success_callback(data):

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -146,7 +146,7 @@ async def async_setup(hass, config):
     @callback
     def connection_success_callback(data):
         """Handle a successful connection."""
-        _LOGGER.info("Established a connection with the Envisalink123")
+        _LOGGER.info("Established a connection with the Envisalink")
         if not sync_connect.done():
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
             sync_connect.set_result(True)

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -141,14 +141,12 @@ async def async_setup(hass, config):
     @callback
     def connection_fail_callback(data):
         """Network failure callback."""
-        _LOGGER.error("Could not establish a connection with the Envisalink")
-        if not sync_connect.done():
-            sync_connect.set_result(False)
+        _LOGGER.error("Could not establish a connection with the Envisalink- retrying...")
 
     @callback
     def connection_success_callback(data):
         """Handle a successful connection."""
-        _LOGGER.info("Established a connection with the Envisalink")
+        _LOGGER.info("Established a connection with the Envisalink123")
         if not sync_connect.done():
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
             sync_connect.set_result(True)

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -144,6 +144,9 @@ async def async_setup(hass, config):
         _LOGGER.error(
             "Could not establish a connection with the Envisalink- retrying..."
         )
+        if not sync_connect.done():
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
+            sync_connect.set_result(True)
 
     @callback
     def connection_success_callback(data):

--- a/homeassistant/components/envisalink/manifest.json
+++ b/homeassistant/components/envisalink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Envisalink",
   "documentation": "https://www.home-assistant.io/components/envisalink",
   "requirements": [
-    "pyenvisalink==3.8"
+    "pyenvisalink==4.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1165,7 +1165,7 @@ pyeight==0.1.1
 pyemby==1.6
 
 # homeassistant.components.envisalink
-pyenvisalink==3.8
+pyenvisalink==4.0
 
 # homeassistant.components.ephember
 pyephember==0.2.0


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Enable retries/reconnection to the device if we fail during initialization- so we won't give up if we fail to connect, but will keep the initialization routine going.  Since we're doing this asynchronously it won't interfere with other component initializations.

**Related issue (if applicable):** fixes #26438

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
