### PR TITLE
Fix remote_rpi_gpio switch output value always inverted regardless invert_logic option

### DIFF
--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -25,7 +25,9 @@ def setup_output(address, port, invert_logic):
     from gpiozero.pins.pigpio import PiGPIOFactory
 
     try:
-        return LED(port, active_high=invert_logic, pin_factory=PiGPIOFactory(address))
+        return LED(
+            port, active_high=not invert_logic, pin_factory=PiGPIOFactory(address)
+        )
     except (ValueError, IndexError, KeyError):
         return None
 

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -76,12 +76,12 @@ class RemoteRPiGPIOSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        remote_rpi_gpio.write_output(self._switch, 0 if self._invert_logic else 1)
+        remote_rpi_gpio.write_output(self._switch, 1)
         self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        remote_rpi_gpio.write_output(self._switch, 1 if self._invert_logic else 0)
+        remote_rpi_gpio.write_output(self._switch, 0)
         self._state = False
         self.schedule_update_ha_state()


### PR DESCRIPTION
## Description:
Switch output value always inverted regardless invert_logic option. This PR fix this issue.
 
**Related issue (if applicable):** fixes #24571


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
