### PR TITLE
Fix SSL connections to Pi-hole

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -72,16 +72,10 @@ async def async_setup(hass, config):
 
     LOGGER.debug("Setting up %s integration with host %s", DOMAIN, host)
 
-    session = async_get_clientsession(hass, True)
+    session = async_get_clientsession(hass, verify_tls)
     pi_hole = PiHoleData(
         Hole(
-            host,
-            hass.loop,
-            session,
-            location=location,
-            tls=use_tls,
-            verify_tls=verify_tls,
-            api_token=api_key,
+            host, hass.loop, session, location=location, tls=use_tls, api_token=api_key
         ),
         name,
     )


### PR DESCRIPTION
## Description:

Fixes SSL connections to Pi-hole. `verify_tls` setting was not being honored by the component.

**Related issue (if applicable):** fixes #26792, fixes #26747. Props @a-nicholls for the troubleshooting help.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

~~If user exposed functionality or configuration variables are added/changed:~~
  - ~~[ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~~

~~If the code communicates with devices, web services, or third-party tools:~~
  - ~~[ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.~~
~~  - ~~[ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.~~
  - ~~[ ] Untested files have been added to `.coveragerc`.~~

~~If the code does not interact with devices:~~
  - ~~[ ] Tests have been added to verify that the new code works.~~

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
