### PR TITLE
Fix bug in ecobee integration by bumping python-ecobee-api to 0.1.4

### DIFF
--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -4,6 +4,6 @@
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/components/ecobee",
     "dependencies": [],
-    "requirements": ["python-ecobee-api==0.1.3"],
+    "requirements": ["python-ecobee-api==0.1.4"],
     "codeowners": ["@marthoc"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1486,7 +1486,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.3
+python-ecobee-api==0.1.4
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -356,7 +356,7 @@ pysonos==0.0.23
 pyspcwebgw==0.4.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.1.3
+python-ecobee-api==0.1.4
 
 # homeassistant.components.darksky
 python-forecastio==1.4.0


### PR DESCRIPTION
## Description:

A bug in python-ecobee-api was causing tokens to never refresh, which meant that an hour after Home Assistant startup, the access token would expire and ecobee entities would stop updating. The bug has been caught in python-ecobee-api and the new version includes the fix.

**Related issue (if applicable):** fixes #27025 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
