### PR TITLE
Add "zero is turn off" feature to homekit component

### DIFF
--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -129,15 +129,19 @@ class Fan(HomeAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_SPEED: speed}
         self.call_service(DOMAIN, SERVICE_SET_SPEED, params, speed)
 
+    def _set_hk_state(self, state):
+        """Set state in HomeKit."""
+        self._state = state
+        if not self._flag[CHAR_ACTIVE] and self.char_active.value != self._state:
+            self.char_active.set_value(self._state)
+        self._flag[CHAR_ACTIVE] = False
+
     def update_state(self, new_state):
         """Update fan after state change."""
         # Handle State
         state = new_state.state
         if state in (STATE_ON, STATE_OFF):
-            self._state = 1 if state == STATE_ON else 0
-            if not self._flag[CHAR_ACTIVE] and self.char_active.value != self._state:
-                self.char_active.set_value(self._state)
-            self._flag[CHAR_ACTIVE] = False
+            self._set_hk_state(1 if state == STATE_ON else 0)
 
         # Handle Direction
         if self.char_direction is not None:
@@ -156,7 +160,10 @@ class Fan(HomeAccessory):
             speed = new_state.attributes.get(ATTR_SPEED)
             hk_speed_value = self.speed_mapping.speed_to_homekit(speed)
             if hk_speed_value is not None and self.char_speed.value != hk_speed_value:
-                self.char_speed.set_value(hk_speed_value)
+                if hk_speed_value == 0:
+                    self._set_hk_state(0)
+                else:
+                    self.char_speed.set_value(hk_speed_value)
 
         # Handle Oscillating
         if self.char_swing is not None:

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -223,3 +223,51 @@ async def test_fan_speed(hass, hk_driver, cls, events):
     assert call_set_speed[0].data[ATTR_SPEED] == "ludicrous"
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] == "ludicrous"
+
+
+async def test_fan_speed_zero_is_turn_off(hass, hk_driver, cls, events):
+    """Test fan with speed."""
+    entity_id = "fan.demo"
+    speed_list = [SPEED_OFF, SPEED_LOW, SPEED_HIGH]
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED,
+            ATTR_SPEED: SPEED_LOW,
+            ATTR_SPEED_LIST: speed_list,
+        },
+    )
+    await hass.async_block_till_done()
+    acc = cls.fan(hass, hk_driver, "Fan", entity_id, 2, None)
+    assert acc.char_speed.value == 0
+
+    await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
+
+    assert acc.char_speed.value == 50
+
+    hass.states.async_set(
+        entity_id,
+        STATE_OFF,
+        {
+            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED,
+            ATTR_SPEED: SPEED_OFF,
+            ATTR_SPEED_LIST: speed_list,
+        },
+    )
+    await hass.async_block_till_done()
+    assert acc.char_speed.value == 50
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_FEATURES: SUPPORT_SET_SPEED,
+            ATTR_SPEED: SPEED_LOW,
+            ATTR_SPEED_LIST: speed_list,
+        },
+    )
+    await hass.async_block_till_done()
+    assert acc.char_speed.value == 50

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -203,3 +203,41 @@ async def test_light_rgb_color(hass, hk_driver, cls, events):
     assert call_turn_on[0].data[ATTR_HS_COLOR] == (145, 75)
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] == "set color at (145, 75)"
+
+
+async def test_light_brightness_zero_is_turn_off(hass, hk_driver, cls, events):
+    """Test light with brightness."""
+    entity_id = "light.demo"
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 102},
+    )
+    await hass.async_block_till_done()
+    acc = cls.light(hass, hk_driver, "Light", entity_id, 2, None)
+
+    assert acc.char_brightness.value == 0
+
+    await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
+
+    assert acc.char_brightness.value == 40
+
+    hass.states.async_set(
+        entity_id,
+        STATE_OFF,
+        {ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 0},
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_brightness.value == 40
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS: 102},
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_brightness.value == 40


### PR DESCRIPTION
## Breaking Change:

Previously, some lights and fan entities will send 0% brightness and speed attribute and update homekit characteristic to 0% when the entities are turned off. This causes some issues. When the device is turn on again, homekit will send update to 100% brightness and speed because homekit actually requires brightness and speed characteristic to still be accessible when turned off and they do not want the experience where the user turns on a light but the brightness is 0% which might confuse users.

So, this patch prevents sending 0% brightness and speed update to homekit characteristic. Instead, the homekit device "on" characteristic is updated to "off" when receive 0% brightness and speed update from the entity.

~~The user can still opt for the old behavior by using a `zero_is_turn_off` config that is default to on.~~

## Description:

This patch prevents sending 0% brightness and speed update to homekit characteristic. Instead, the homekit device "on" characteristic is updated to "off" when receive 0% brightness and speed update from the entity.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
