### PR TITLE
Switch on/off all lights, and wait for the result

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -316,7 +316,7 @@ async def async_setup(hass, config):
                 poll_lights.append(light)
 
         if change_tasks:
-            await asyncio.gather(*change_tasks)
+            await asyncio.wait(change_tasks)
 
         if poll_lights:
             await asyncio.wait(

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -292,7 +292,8 @@ async def async_setup(hass, config):
         preprocess_turn_on_alternatives(params)
         turn_lights_off, off_params = preprocess_turn_off(params)
 
-        update_tasks = []
+        poll_lights = []
+        change_tasks = []
         for light in target_lights:
             light.async_set_context(service.context)
 
@@ -305,17 +306,22 @@ async def async_setup(hass, config):
                 preprocess_turn_on_alternatives(pars)
                 turn_light_off, off_pars = preprocess_turn_off(pars)
             if turn_light_off:
-                await light.async_turn_off(**off_pars)
+                task = light.async_request_call(light.async_turn_off, **off_pars)
             else:
-                await light.async_turn_on(**pars)
+                task = light.async_request_call(light.async_turn_on, **pars)
 
-            if not light.should_poll:
-                continue
+            change_tasks.append(task)
 
-            update_tasks.append(light.async_update_ha_state(True))
+            if light.should_poll:
+                poll_lights.append(light)
 
-        if update_tasks:
-            await asyncio.wait(update_tasks)
+        if change_tasks:
+            await asyncio.gather(*change_tasks)
+
+        if poll_lights:
+            await asyncio.wait(
+                [light.async_update_ha_state(True) for light in poll_lights]
+            )
 
     # Listen for light on and light off service calls.
     hass.services.async_register(

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -306,9 +306,9 @@ async def async_setup(hass, config):
                 preprocess_turn_on_alternatives(pars)
                 turn_light_off, off_pars = preprocess_turn_off(pars)
             if turn_light_off:
-                task = light.async_request_call(light.async_turn_off, **off_pars)
+                task = light.async_request_call(light.async_turn_off(**off_pars))
             else:
-                task = light.async_request_call(light.async_turn_on, **pars)
+                task = light.async_request_call(light.async_turn_on(**pars))
 
             change_tasks.append(task)
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -551,6 +551,19 @@ class Entity:
         """Return the representation."""
         return "<Entity {}: {}>".format(self.name, self.state)
 
+    # call an requests
+    async def async_request_call(self, coro, *args, **kwargs):
+        """Process request batched."""
+
+        if self.parallel_updates:
+            await self.parallel_updates.acquire()
+
+        try:
+            await coro(*args, **kwargs)
+        finally:
+            if self.parallel_updates:
+                self.parallel_updates.release()
+
 
 class ToggleEntity(Entity):
     """An abstract class for entities that can be turned on and off."""

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -552,14 +552,14 @@ class Entity:
         return "<Entity {}: {}>".format(self.name, self.state)
 
     # call an requests
-    async def async_request_call(self, coro, *args, **kwargs):
+    async def async_request_call(self, coro):
         """Process request batched."""
 
         if self.parallel_updates:
             await self.parallel_updates.acquire()
 
         try:
-            await coro(*args, **kwargs)
+            await coro
         finally:
             if self.parallel_updates:
                 self.parallel_updates.release()

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -313,11 +313,10 @@ async def test_signal_repetitions_cancelling(hass, monkeypatch):
 
     await hass.async_block_till_done()
 
-    assert protocol.send_command_ack.call_args_list[0][0][1] == "on"
-    assert protocol.send_command_ack.call_args_list[1][0][1] == "off"
-    assert protocol.send_command_ack.call_args_list[2][0][1] == "off"
-    assert protocol.send_command_ack.call_args_list[3][0][1] == "off"
-
+    assert protocol.send_command_ack.call_args_list[0][0][1] == "off"
+    assert protocol.send_command_ack.call_args_list[1][0][1] == "on"
+    assert protocol.send_command_ack.call_args_list[2][0][1] == "on"
+    assert protocol.send_command_ack.call_args_list[3][0][1] == "on"
 
 async def test_type_toggle(hass, monkeypatch):
     """Test toggle type lights (on/on)."""

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -318,6 +318,7 @@ async def test_signal_repetitions_cancelling(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[2][0][1] == "on"
     assert protocol.send_command_ack.call_args_list[3][0][1] == "on"
 
+
 async def test_type_toggle(hass, monkeypatch):
     """Test toggle type lights (on/on)."""
     config = {

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -231,6 +231,96 @@ def test_async_schedule_update_ha_state(hass):
     assert update_call is True
 
 
+async def test_async_async_request_call_without_lock(hass):
+    """Test for async_requests_call works without a lock."""
+    updates = []
+
+    class AsyncEntity(entity.Entity):
+        def __init__(self, entity_id):
+            """Initialize Async test entity."""
+            self.entity_id = entity_id
+            self.hass = hass
+
+        def testhelper(self, count):
+            """Helper function."""
+            updates.append(count)
+
+    ent_1 = AsyncEntity("light.test_1")
+    ent_2 = AsyncEntity("light.test_2")
+
+    try:
+        job1 = ent_1.async_request_call(ent_1.testhelper, 1)
+        job2 = ent_2.async_request_call(ent_2.testhelper, 2)
+
+        assert len(updates) == 0
+        assert updates == []
+
+        hass.async_create_task(job1)
+        hass.async_create_task(job2)
+
+        while True:
+            if len(updates) >= 2:
+                break
+            await asyncio.sleep(0)
+    finally:
+        pass
+
+    assert len(updates) == 2
+    updates.sort()
+    assert updates == [1, 2]
+
+
+async def test_async_async_request_call_with_lock(hass):
+    """Test for async_requests_call works with a semaphore."""
+    updates = []
+
+    test_semaphore = asyncio.Semaphore(1)
+
+    class AsyncEntity(entity.Entity):
+        def __init__(self, entity_id, lock):
+            """Initialize Async test entity."""
+            self.entity_id = entity_id
+            self.hass = hass
+            self.parallel_updates = lock
+
+        def testhelper(self, count):
+            """Helper function."""
+            updates.append(count)
+
+    ent_1 = AsyncEntity("light.test_1", test_semaphore)
+    ent_2 = AsyncEntity("light.test_2", test_semaphore)
+
+    try:
+        assert test_semaphore.locked() is False
+        await test_semaphore.acquire()
+        assert test_semaphore.locked()
+
+        job1 = ent_1.async_request_call(ent_1.testhelper, 1)
+        job2 = ent_2.async_request_call(ent_2.testhelper, 2)
+
+        hass.async_create_task(job1)
+        hass.async_create_task(job2)
+
+        await asyncio.sleep(0)
+
+        assert len(updates) == 0
+        assert updates == []
+        assert test_semaphore._value == 0
+
+        test_semaphore.release()
+
+        while True:
+            if len(updates) >= 2:
+                break
+            await asyncio.sleep(0)
+    finally:
+        test_semaphore.release()
+
+    assert len(updates) == 2
+    updates.sort()
+    assert updates == [1, 2]
+
+
 async def test_async_parallel_updates_with_zero(hass):
     """Test parallel updates with 0 (disabled)."""
     updates = []

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -241,23 +241,17 @@ async def test_async_async_request_call_without_lock(hass):
             self.entity_id = entity_id
             self.hass = hass
 
-        def testhelper(self, count):
+        async def testhelper(self, count):
             """Helper function."""
             updates.append(count)
 
     ent_1 = AsyncEntity("light.test_1")
     ent_2 = AsyncEntity("light.test_2")
-
     try:
-        job1 = ent_1.async_request_call(ent_1.testhelper, 1)
-        job2 = ent_2.async_request_call(ent_2.testhelper, 2)
+        job1 = ent_1.async_request_call(ent_1.testhelper(1))
+        job2 = ent_2.async_request_call(ent_2.testhelper(2))
 
-        assert len(updates) == 0
-        assert updates == []
-
-        hass.async_create_task(job1)
-        hass.async_create_task(job2)
-
+        await asyncio.wait([job1, job2])
         while True:
             if len(updates) >= 2:
                 break
@@ -283,7 +277,7 @@ async def test_async_async_request_call_with_lock(hass):
             self.hass = hass
             self.parallel_updates = lock
 
-        def testhelper(self, count):
+        async def testhelper(self, count):
             """Helper function."""
             updates.append(count)
 
@@ -295,13 +289,11 @@ async def test_async_async_request_call_with_lock(hass):
         await test_semaphore.acquire()
         assert test_semaphore.locked()
 
-        job1 = ent_1.async_request_call(ent_1.testhelper, 1)
-        job2 = ent_2.async_request_call(ent_2.testhelper, 2)
+        job1 = ent_1.async_request_call(ent_1.testhelper(1))
+        job2 = ent_2.async_request_call(ent_2.testhelper(2))
 
         hass.async_create_task(job1)
         hass.async_create_task(job2)
-
-        await asyncio.sleep(0)
 
         assert len(updates) == 0
         assert updates == []


### PR DESCRIPTION
## Description:

This changes the order of the async tasks fired when switching lights on or of. This should make switching lights on a more parallel process

the current flow is( pseudo code)
```
foreach light in lights:
   fire change task
  wait change task
  fire state poll task
wait for all state poll tasks
```
the new flow will be:
```
foreach light in lights:
  fire change task
wait for allchange tasks

foreach light in lights:
  fire state poll task
wait for all state poll tasks
```

Pro's
when switching on a group of lights, there is no wait in firing the change task, which should make the time between lights switching on shorter

Con's
the state poll fire will wait for the last light in the group to finish the change task

**Related issue (if applicable):** fixes #17477.

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools: N/A
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

Only the order is changed, there should be no change in start/end scenarios, only the order in which the events are fired


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
