### PR TITLE
UniFi - Remove last of device tracker configuration

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -1,9 +1,8 @@
 """Track devices using UniFi controllers."""
 import logging
-import voluptuous as vol
 
 from homeassistant.components.unifi.config_flow import get_controller_from_config_entry
-from homeassistant.components.device_tracker import DOMAIN, PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.core import callback
@@ -39,13 +38,6 @@ DEVICE_ATTRIBUTES = [
     "vlan",
 ]
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
-
-
-async def async_setup_scanner(hass, config, sync_see, discovery_info):
-    """Set up the Unifi integration."""
-    return True
-
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up device tracker for UniFi component."""
@@ -59,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         if (
             entity.config_entry_id == config_entry.entry_id
-            and entity.domain == DOMAIN
+            and entity.domain == DEVICE_TRACKER_DOMAIN
             and "-" in entity.unique_id
         ):
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -163,12 +163,12 @@ async def setup_controller(hass, mock_controller, options={}):
 
 
 async def test_platform_manually_configured(hass):
-    """Test that we do not discover anything or try to set up a bridge."""
+    """Test that nothing happens when configuring unifi through device tracker platform."""
     assert (
         await async_setup_component(
             hass, device_tracker.DOMAIN, {device_tracker.DOMAIN: {"platform": "unifi"}}
         )
-        is True
+        is False
     )
     assert unifi.DOMAIN not in hass.data
 


### PR DESCRIPTION
## Breaking Change:

As previously communicated with Home Assistant release 0.99 `unifi` `device_tracker` platform configuration section will be removed with Home Assistant release 0.100.

- In 0.100, UniFi integration will fail on config validation and not allow the `unifi` `device_tracker`  section to exist in configuration.yaml. 

TL;DR This will no longer work:
```yaml
device_tracker:
  - platform: unifi
```
Extra configuration through config entry options from the GUI (see [release notes 0.98](https://www.home-assistant.io/blog/2019/08/28/release-98/#config-entry-options) for example) and through [unifi configuration](https://www.home-assistant.io/components/unifi/#extra-configuration-for-device-tracker) in configuration.yaml will continue to work.

## Description:
Removes the last pieces of device tracker configuration as previously communicated

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
