### PR TITLE
WAQI add unique ID and availability

### DIFF
--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -73,7 +73,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             stations = await client.search(location_name)
             _LOGGER.debug("The following stations were returned: %s", stations)
             for station in stations:
-                waqi_sensor = WaqiSensor(client, station, location_name)
+                waqi_sensor = WaqiSensor(client, station)
                 if not station_filter or {
                     waqi_sensor.uid,
                     waqi_sensor.url,
@@ -89,7 +89,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class WaqiSensor(Entity):
     """Implementation of a WAQI sensor."""
 
-    def __init__(self, client, station, location_name):
+    def __init__(self, client, station):
         """Initialize the sensor."""
         self._client = client
         try:
@@ -108,7 +108,6 @@ class WaqiSensor(Entity):
             self.station_name = None
 
         self._data = None
-        self._unique_id = f"{location_name}-{self.uid}"
 
     @property
     def name(self):
@@ -137,7 +136,7 @@ class WaqiSensor(Entity):
     @property
     def unique_id(self):
         """Return unique ID."""
-        return self._unique_id
+        return self.uid
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -108,7 +108,7 @@ class WaqiSensor(Entity):
             self.station_name = None
 
         self._data = None
-        self._unique_id = token
+        self._unique_id = f"{token}-{self.uid}"
 
     @property
     def name(self):
@@ -132,9 +132,7 @@ class WaqiSensor(Entity):
     @property
     def available(self):
         """Return sensor availability."""
-        if self._data is not None:
-            return True
-        return False
+        return self._data is not None
 
     @property
     def unique_id(self):

--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -73,7 +73,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             stations = await client.search(location_name)
             _LOGGER.debug("The following stations were returned: %s", stations)
             for station in stations:
-                waqi_sensor = WaqiSensor(client, station)
+                waqi_sensor = WaqiSensor(client, station, token)
                 if not station_filter or {
                     waqi_sensor.uid,
                     waqi_sensor.url,
@@ -89,7 +89,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class WaqiSensor(Entity):
     """Implementation of a WAQI sensor."""
 
-    def __init__(self, client, station):
+    def __init__(self, client, station, token):
         """Initialize the sensor."""
         self._client = client
         try:
@@ -108,6 +108,7 @@ class WaqiSensor(Entity):
             self.station_name = None
 
         self._data = None
+        self._unique_id = token
 
     @property
     def name(self):
@@ -127,6 +128,18 @@ class WaqiSensor(Entity):
         if self._data is not None:
             return self._data.get("aqi")
         return None
+
+    @property
+    def available(self):
+        """Return sensor availability."""
+        if self._data is not None:
+            return True
+        return False
+
+    @property
+    def unique_id(self):
+        """Return unique ID."""
+        return self._unique_id
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -73,7 +73,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             stations = await client.search(location_name)
             _LOGGER.debug("The following stations were returned: %s", stations)
             for station in stations:
-                waqi_sensor = WaqiSensor(client, station, token)
+                waqi_sensor = WaqiSensor(client, station, location_name)
                 if not station_filter or {
                     waqi_sensor.uid,
                     waqi_sensor.url,
@@ -89,7 +89,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class WaqiSensor(Entity):
     """Implementation of a WAQI sensor."""
 
-    def __init__(self, client, station, token):
+    def __init__(self, client, station, location_name):
         """Initialize the sensor."""
         self._client = client
         try:
@@ -108,7 +108,7 @@ class WaqiSensor(Entity):
             self.station_name = None
 
         self._data = None
-        self._unique_id = f"{token}-{self.uid}"
+        self._unique_id = f"{location_name}-{self.uid}"
 
     @property
     def name(self):


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:

Add unique ID for entity registry and availability

**Related issue (if applicable):** fixes #N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: waqi
    token: token
    locations:
      - location
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
