### PR TITLE
Add night arm support to Envisalink

### DIFF
--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
@@ -126,6 +127,8 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
 
         if self._info["status"]["alarm"]:
             state = STATE_ALARM_TRIGGERED
+        elif self._info["status"]["armed_zero_entry_delay"]:
+            state = STATE_ALARM_ARMED_NIGHT
         elif self._info["status"]["armed_away"]:
             state = STATE_ALARM_ARMED_AWAY
         elif self._info["status"]["armed_stay"]:
@@ -172,6 +175,12 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
     async def async_alarm_trigger(self, code=None):
         """Alarm trigger command. Will be used to trigger a panic alarm."""
         self.hass.data[DATA_EVL].panic_alarm(self._panic_type)
+
+    async def async_alarm_arm_night(self, code=None):
+        """Send arm night command."""
+        self.hass.data[DATA_EVL].arm_night_partition(
+            str(code) if code else str(self._code), self._partition_number
+        )
 
     @callback
     def async_alarm_keypress(self, keypress=None):

--- a/homeassistant/components/envisalink/manifest.json
+++ b/homeassistant/components/envisalink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Envisalink",
   "documentation": "https://www.home-assistant.io/components/envisalink",
   "requirements": [
-    "pyenvisalink==3.8"
+    "pyenvisalink==4.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1165,7 +1165,7 @@ pyeight==0.1.1
 pyemby==1.6
 
 # homeassistant.components.envisalink
-pyenvisalink==3.8
+pyenvisalink==4.0
 
 # homeassistant.components.ephember
 pyephember==0.2.0


### PR DESCRIPTION
## Description:
Add alarm control panel night arm support to Envisalink

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10510

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
