### PR TITLE
Add entity registry support to ecobee integration

### DIFF
--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -44,6 +44,16 @@ class EcobeeBinarySensor(BinarySensorDevice):
         return self._name.rstrip()
 
     @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        for sensor in self.data.ecobee.get_remote_sensors(self.index):
+            if sensor["name"] == self.sensor_name:
+                if "code" in sensor:
+                    return f"{sensor['code']}-{self.device_class}"
+                else:
+                    return f"{sensor['id']}-{self.device_class}"
+
+    @property
     def is_on(self):
         """Return the status of the sensor."""
         return self._state == "true"

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -50,8 +50,7 @@ class EcobeeBinarySensor(BinarySensorDevice):
             if sensor["name"] == self.sensor_name:
                 if "code" in sensor:
                     return f"{sensor['code']}-{self.device_class}"
-                else:
-                    return f"{sensor['id']}-{self.device_class}"
+                return f"{sensor['id']}-{self.device_class}"
 
     @property
     def is_on(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -306,6 +306,11 @@ class Thermostat(ClimateDevice):
         return self.thermostat["name"]
 
     @property
+    def unique_id(self):
+        """Return a unique identifier for this ecobee thermostat."""
+        return self.thermostat["identifier"]
+
+    @property
     def temperature_unit(self):
         """Return the unit of measurement."""
         return TEMP_FAHRENHEIT

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -55,6 +55,16 @@ class EcobeeSensor(Entity):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        for sensor in self.data.ecobee.get_remote_sensors(self.index):
+            if sensor["name"] == self.sensor_name:
+                if "code" in sensor:
+                    return f"{sensor['code']}-{self.device_class}"
+                else:
+                    return f"{sensor['id']}-{self.device_class}"
+
+    @property
     def device_class(self):
         """Return the device class of the sensor."""
         if self.type in (DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE):

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -61,8 +61,7 @@ class EcobeeSensor(Entity):
             if sensor["name"] == self.sensor_name:
                 if "code" in sensor:
                     return f"{sensor['code']}-{self.device_class}"
-                else:
-                    return f"{sensor['id']}-{self.device_class}"
+                return f"{sensor['id']}-{self.device_class}"
 
     @property
     def device_class(self):

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -64,8 +64,7 @@ class EcobeeWeather(WeatherEntity):
     @property
     def unique_id(self):
         """Return a unique identifier for the weather platform."""
-        thermostat = self.data.ecobee.get_thermostat(self._index)
-        return f"{thermostat['identifier']}-weather"
+        return self.data.ecobee.get_thermostat(self._index)["identifier"]
 
     @property
     def condition(self):

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -62,6 +62,12 @@ class EcobeeWeather(WeatherEntity):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return a unique identifier for the weather platform."""
+        thermostat = self.data.ecobee.get_thermostat(self._index)
+        return f"{thermostat['identifier']}-weather"
+
+    @property
     def condition(self):
         """Return the current condition."""
         try:


### PR DESCRIPTION
## Description:

Add the unique_id property to binary sensor, climate, sensor and weather platforms to add support for the entity registry.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): 
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
