### PR TITLE
Delete here_travel_time dead code COORDINATE_SCHEMA

### DIFF
--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -93,13 +93,6 @@ TRACKABLE_DOMAINS = ["device_tracker", "sensor", "zone", "person"]
 
 NO_ROUTE_ERROR_MESSAGE = "HERE could not find a route based on the input"
 
-COORDINATE_SCHEMA = vol.Schema(
-    {
-        vol.Inclusive(CONF_DESTINATION_LATITUDE, "coordinates"): cv.latitude,
-        vol.Inclusive(CONF_DESTINATION_LONGITUDE, "coordinates"): cv.longitude,
-    }
-)
-
 PLATFORM_SCHEMA = vol.All(
     cv.has_at_least_one_key(CONF_DESTINATION_LATITUDE, CONF_DESTINATION_ENTITY_ID),
     cv.has_at_least_one_key(CONF_ORIGIN_LATITUDE, CONF_ORIGIN_ENTITY_ID),


### PR DESCRIPTION
## Breaking Change:

No

## Description:

Delete a redundant schema in here_travel_time. This is a remnant of the early development cycle of this integration.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
