### PR TITLE
Add missing http dependency for Plex

### DIFF
--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -7,7 +7,9 @@
     "plexapi==3.0.6",
     "plexauth==0.0.4"
   ],
-  "dependencies": [],
+  "dependencies": [
+    "http"
+  ],
   "codeowners": [
     "@jjlawren"
   ]


### PR DESCRIPTION
## Description:
Add `http` dependency missing from https://github.com/home-assistant/home-assistant/pull/26936

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
