### PR TITLE
Add more Octoprint job info

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -73,6 +73,9 @@ SENSOR_TYPES = {
     "Job Percentage": ["job", "progress", None, "completion", "%", "mdi:file-percent"],
     "Time Remaining": ["job", "progress", None, "printTimeLeft", "seconds", "mdi:clock-end"],
     "Time Elapsed": ["job", "progress", None, "printTime", "seconds", "mdi:clock-start"],
+    "Job Filename": ["job", "job", "file", "name", "", "mdi:file-document"],
+    "Job Origin": ["job", "job", "file", "origin", "", "mdi:source-branch"],
+    "Job User": ["job", "job", None, "user", "", "mdi:account"],
 }
 
 SENSOR_SCHEMA = vol.Schema(
@@ -254,7 +257,7 @@ class OctoPrintAPI:
         """Return the value for sensor_type from the provided endpoint."""
         response = self.get(end_point)
         if response is not None:
-            return get_value_from_json(response, sensor_type, group, tool)
+            return get_value_from_json(response, sensor_type, group, secondary_group, tool)
         return response
 
 
@@ -266,9 +269,10 @@ def get_value_from_json(json_dict, sensor_type, group, secondary_group, tool):
     if sensor_type in json_dict[group]:
         if sensor_type == "target" and json_dict[sensor_type] is None:
             return 0
-        if secondary_group is not None:
-            return json_dict[group][secondary_group][sensor_type]
         return json_dict[group][sensor_type]
+
+    if secondary_group is not None and sensor_type in json_dict[group][secondary_group]:
+        return json_dict[group][secondary_group][sensor_type]
 
     if tool is not None:
         if sensor_type in json_dict[group][tool]:

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -71,8 +71,22 @@ SENSOR_TYPES = {
     "Temperatures": ["printer", "temperature", "*", TEMP_CELSIUS],
     "Current State": ["printer", "state", None, "text", None, "mdi:printer-3d"],
     "Job Percentage": ["job", "progress", None, "completion", "%", "mdi:file-percent"],
-    "Time Remaining": ["job", "progress", None, "printTimeLeft", "seconds", "mdi:clock-end"],
-    "Time Elapsed": ["job", "progress", None, "printTime", "seconds", "mdi:clock-start"],
+    "Time Remaining": [
+        "job",
+        "progress",
+        None,
+        "printTimeLeft",
+        "seconds",
+        "mdi:clock-end",
+    ],
+    "Time Elapsed": [
+        "job",
+        "progress",
+        None,
+        "printTime",
+        "seconds",
+        "mdi:clock-start",
+    ],
     "Job Filename": ["job", "job", "file", "name", "", "mdi:file-document"],
     "Job Origin": ["job", "job", "file", "origin", "", "mdi:source-branch"],
     "Job User": ["job", "job", None, "user", "", "mdi:account"],
@@ -257,7 +271,9 @@ class OctoPrintAPI:
         """Return the value for sensor_type from the provided endpoint."""
         response = self.get(end_point)
         if response is not None:
-            return get_value_from_json(response, sensor_type, group, secondary_group, tool)
+            return get_value_from_json(
+                response, sensor_type, group, secondary_group, tool
+            )
         return response
 
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -69,10 +69,10 @@ BINARY_SENSOR_SCHEMA = vol.Schema(
 SENSOR_TYPES = {
     # API Endpoint, Group, Key, unit, icon
     "Temperatures": ["printer", "temperature", "*", TEMP_CELSIUS],
-    "Current State": ["printer", "state", "text", None, "mdi:printer-3d"],
-    "Job Percentage": ["job", "progress", "completion", "%", "mdi:file-percent"],
-    "Time Remaining": ["job", "progress", "printTimeLeft", "seconds", "mdi:clock-end"],
-    "Time Elapsed": ["job", "progress", "printTime", "seconds", "mdi:clock-start"],
+    "Current State": ["printer", "state", None, "text", None, "mdi:printer-3d"],
+    "Job Percentage": ["job", "progress", None, "completion", "%", "mdi:file-percent"],
+    "Time Remaining": ["job", "progress", None, "printTimeLeft", "seconds", "mdi:clock-end"],
+    "Time Elapsed": ["job", "progress", None, "printTime", "seconds", "mdi:clock-start"],
 }
 
 SENSOR_SCHEMA = vol.Schema(
@@ -250,7 +250,7 @@ class OctoPrintAPI:
             self.available = False
             return None
 
-    def update(self, sensor_type, end_point, group, tool=None):
+    def update(self, sensor_type, end_point, group, secondary_group=None, tool=None):
         """Return the value for sensor_type from the provided endpoint."""
         response = self.get(end_point)
         if response is not None:
@@ -258,7 +258,7 @@ class OctoPrintAPI:
         return response
 
 
-def get_value_from_json(json_dict, sensor_type, group, tool):
+def get_value_from_json(json_dict, sensor_type, group, secondary_group, tool):
     """Return the value for sensor_type from the JSON."""
     if group not in json_dict:
         return None
@@ -266,6 +266,8 @@ def get_value_from_json(json_dict, sensor_type, group, tool):
     if sensor_type in json_dict[group]:
         if sensor_type == "target" and json_dict[sensor_type] is None:
             return 0
+        if secondary_group is not None:
+            return json_dict[group][secondary_group][sensor_type]
         return json_dict[group][sensor_type]
 
     if tool is not None:

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -101,6 +101,7 @@ class OctoPrintSensor(Entity):
         self._unit_of_measurement = unit
         self.api_endpoint = endpoint
         self.api_group = group
+        self.api_secondary_group = secondary_group
         self.api_tool = tool
         self._icon = icon
         _LOGGER.debug("Created OctoPrint sensor %r", self)
@@ -130,7 +131,7 @@ class OctoPrintSensor(Entity):
         """Update state of sensor."""
         try:
             self._state = self.api.update(
-                self.sensor_type, self.api_endpoint, self.api_group, self.api.secondary_group, self.api_tool
+                self.sensor_type, self.api_endpoint, self.api_group, self.api_secondary_group, self.api_tool
             )
         except requests.exceptions.ConnectionError:
             # Error calling the api, already logged in api.update()

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -52,6 +52,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                         SENSOR_TYPES[octo_type][3],
                         SENSOR_TYPES[octo_type][0],
                         SENSOR_TYPES[octo_type][1],
+                        None,
                         tool,
                     )
                     devices.append(new_sensor)
@@ -59,13 +60,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             new_sensor = OctoPrintSensor(
                 octoprint_api,
                 octo_type,
-                SENSOR_TYPES[octo_type][2],
-                name,
                 SENSOR_TYPES[octo_type][3],
+                name,
+                SENSOR_TYPES[octo_type][4],
                 SENSOR_TYPES[octo_type][0],
                 SENSOR_TYPES[octo_type][1],
+                SENSOR_TYPES[octo_type][2],
                 None,
-                SENSOR_TYPES[octo_type][4],
+                SENSOR_TYPES[octo_type][5],
             )
             devices.append(new_sensor)
     add_entities(devices, True)
@@ -83,6 +85,7 @@ class OctoPrintSensor(Entity):
         unit,
         endpoint,
         group,
+        secondary_group=None,
         tool=None,
         icon=None,
     ):
@@ -127,7 +130,7 @@ class OctoPrintSensor(Entity):
         """Update state of sensor."""
         try:
             self._state = self.api.update(
-                self.sensor_type, self.api_endpoint, self.api_group, self.api_tool
+                self.sensor_type, self.api_endpoint, self.api_group, self.api.secondary_group, self.api_tool
             )
         except requests.exceptions.ConnectionError:
             # Error calling the api, already logged in api.update()

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -131,7 +131,11 @@ class OctoPrintSensor(Entity):
         """Update state of sensor."""
         try:
             self._state = self.api.update(
-                self.sensor_type, self.api_endpoint, self.api_group, self.api_secondary_group, self.api_tool
+                self.sensor_type,
+                self.api_endpoint,
+                self.api_group,
+                self.api_secondary_group,
+                self.api_tool,
             )
         except requests.exceptions.ConnectionError:
             # Error calling the api, already logged in api.update()


### PR DESCRIPTION
## Description:

Added some more information for the octoprint component.

New sensors:
* Current job's filename
* Current job's origin (`local` or `sdcard`)
* Current job's user (who started it)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10530

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
