### PR TITLE
Add neural support to amazon polly

### DIFF
--- a/homeassistant/components/amazon_polly/manifest.json
+++ b/homeassistant/components/amazon_polly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Amazon polly",
   "documentation": "https://www.home-assistant.io/components/amazon_polly",
   "requirements": [
-    "boto3==1.9.16"
+    "boto3==1.9.233"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/amazon_polly/tts.py
+++ b/homeassistant/components/amazon_polly/tts.py
@@ -33,6 +33,7 @@ SUPPORTED_REGIONS = [
     "sa-east-1",
 ]
 
+CONF_ENGINE = "engine"
 CONF_VOICE = "voice"
 CONF_OUTPUT_FORMAT = "output_format"
 CONF_SAMPLE_RATE = "sample_rate"
@@ -101,10 +102,12 @@ SUPPORTED_VOICES = [
 
 SUPPORTED_OUTPUT_FORMATS = ["mp3", "ogg_vorbis", "pcm"]
 
-SUPPORTED_SAMPLE_RATES = ["8000", "16000", "22050"]
+SUPPORTED_ENGINES = ["neural", "standard"]
+
+SUPPORTED_SAMPLE_RATES = ["8000", "16000", "22050", "24000"]
 
 SUPPORTED_SAMPLE_RATES_MAP = {
-    "mp3": ["8000", "16000", "22050"],
+    "mp3": ["8000", "16000", "22050", "24000"],
     "ogg_vorbis": ["8000", "16000", "22050"],
     "pcm": ["8000", "16000"],
 }
@@ -113,6 +116,7 @@ SUPPORTED_TEXT_TYPES = ["text", "ssml"]
 
 CONTENT_TYPE_EXTENSIONS = {"audio/mpeg": "mp3", "audio/ogg": "ogg", "audio/pcm": "pcm"}
 
+DEFAULT_ENGINE = "standard"
 DEFAULT_VOICE = "Joanna"
 DEFAULT_OUTPUT_FORMAT = "mp3"
 DEFAULT_TEXT_TYPE = "text"
@@ -126,6 +130,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Inclusive(CONF_SECRET_ACCESS_KEY, ATTR_CREDENTIALS): cv.string,
         vol.Exclusive(CONF_PROFILE_NAME, ATTR_CREDENTIALS): cv.string,
         vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(SUPPORTED_VOICES),
+        vol.Optional(CONF_ENGINE, default=DEFAULT_ENGINE): vol.In(SUPPORTED_ENGINES),
         vol.Optional(CONF_OUTPUT_FORMAT, default=DEFAULT_OUTPUT_FORMAT): vol.In(
             SUPPORTED_OUTPUT_FORMATS
         ),
@@ -225,6 +230,7 @@ class AmazonPollyProvider(Provider):
             return None, None
 
         resp = self.client.synthesize_speech(
+            Engine=self.config[CONF_ENGINE],
             OutputFormat=self.config[CONF_OUTPUT_FORMAT],
             SampleRate=self.config[CONF_SAMPLE_RATE],
             Text=message,

--- a/homeassistant/components/route53/manifest.json
+++ b/homeassistant/components/route53/manifest.json
@@ -3,7 +3,7 @@
   "name": "Route53",
   "documentation": "https://www.home-assistant.io/components/route53",
   "requirements": [
-    "boto3==1.9.16",
+    "boto3==1.9.233",
     "ipify==1.0.0"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -300,10 +300,8 @@ blockchain==1.4.4
 # homeassistant.components.bom
 bomradarloop==0.1.3
 
-# homeassistant.components.route53
-boto3==1.9.16
-
 # homeassistant.components.amazon_polly
+# homeassistant.components.route53
 boto3==1.9.233
 
 # homeassistant.components.braviatv

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -300,9 +300,11 @@ blockchain==1.4.4
 # homeassistant.components.bom
 bomradarloop==0.1.3
 
-# homeassistant.components.amazon_polly
 # homeassistant.components.route53
 boto3==1.9.16
+
+# homeassistant.components.amazon_polly
+boto3==1.9.233
 
 # homeassistant.components.braviatv
 braviarc-homeassistant==0.3.7.dev0


### PR DESCRIPTION
This is my second attempt at this. I first created a dev environment and a branch within my fork and pushed the changes to it. Then I created a PR from the branch. Hopefully I did it right.

Please delete the old PR. I couldn't figure out how to fix the git issues with it: https://github.com/home-assistant/home-assistant/pull/26836

## Breaking Change: None

## Description:
Adds neural support.  Neural only work with the proper combinations of features such as voice and region. See the official docs. I'll probably put a note about this in the hass docs PR I submit.

https://docs.aws.amazon.com/en_pv/polly/latest/dg/NTTS-main.html
https://aws.amazon.com/blogs/aws/amazon-polly-introduces-neural-text-to-speech-and-newscaster-style/


**Related issue (if applicable):**  none

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
https://github.com/home-assistant/home-assistant.io/pull/10548

Can someone confirm this is correct before I spend a bunch of time trying to update the docs? I previously screwed that up too because of "rebasing".

## Example entry for `configuration.yaml` (if applicable):
```yaml

tts:
  - platform: amazon_polly
    aws_access_key_id: x
    aws_secret_access_key: x
    voice: Joanna
    sample_rate: 24000 
    engine: neural
```


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
