### PR TITLE
Add turn_on method to ecobee climate platform

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -295,6 +295,12 @@ class Thermostat(ClimateDevice):
         else:
             await self.data.update()
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
+        self._last_active_hvac_mode = (
+            ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
+            if ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
+            is not HVAC_MODE_OFF
+            else HVAC_MODE_AUTO
+        )
 
     @property
     def available(self):
@@ -603,8 +609,6 @@ class Thermostat(ClimateDevice):
             _LOGGER.error("Invalid mode for set_hvac_mode: %s", hvac_mode)
             return
         self.data.ecobee.set_hvac_mode(self.thermostat_index, ecobee_value)
-        if ecobee_value is not HVAC_MODE_OFF:
-            self._last_active_hvac_mode = ecobee_value
         self.update_without_throttle = True
 
     def set_fan_min_on_time(self, fan_min_on_time):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -295,13 +295,8 @@ class Thermostat(ClimateDevice):
         else:
             await self.data.update()
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
-        if (
-            ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
-            is not HVAC_MODE_OFF
-        ):
-            self._last_active_hvac_mode = ECOBEE_HVAC_TO_HASS[
-                self.thermostat["settings"]["hvacMode"]
-            ]
+        if self.hvac_mode is not HVAC_MODE_OFF:
+            self._last_active_hvac_mode = self.hvac_mode
 
     @property
     def available(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -295,12 +295,13 @@ class Thermostat(ClimateDevice):
         else:
             await self.data.update()
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
-        self._last_active_hvac_mode = (
+        if (
             ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
-            if ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
             is not HVAC_MODE_OFF
-            else HVAC_MODE_AUTO
-        )
+        ):
+            self._last_active_hvac_mode = ECOBEE_HVAC_TO_HASS[
+                self.thermostat["settings"]["hvacMode"]
+            ]
 
     @property
     def available(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -264,12 +264,7 @@ class Thermostat(ClimateDevice):
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
         self._name = self.thermostat["name"]
         self.vacation = None
-        self._last_active_hvac_mode = (
-            ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
-            if ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
-            is not HVAC_MODE_OFF
-            else HVAC_MODE_AUTO
-        )
+        self._last_active_hvac_mode = HVAC_MODE_AUTO
 
         self._operation_list = []
         if self.thermostat["settings"]["heatStages"]:

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -689,6 +689,8 @@ class Thermostat(ClimateDevice):
     def turn_on(self):
         """Set the thermostat to the last active HVAC mode."""
         _LOGGER.debug(
-            f"Turning on ecobee thermostat {self.name} in {self._last_active_hvac_mode} mode"
+            "Turning on ecobee thermostat %s in %s mode",
+            self.name,
+            self._last_active_hvac_mode,
         )
         self.set_hvac_mode(self._last_active_hvac_mode)

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -264,7 +264,7 @@ class Thermostat(ClimateDevice):
         self.thermostat = self.data.ecobee.get_thermostat(self.thermostat_index)
         self._name = self.thermostat["name"]
         self.vacation = None
-        self._last_hvac_mode = (
+        self._last_active_hvac_mode = (
             ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
             if ECOBEE_HVAC_TO_HASS[self.thermostat["settings"]["hvacMode"]]
             is not HVAC_MODE_OFF
@@ -604,7 +604,7 @@ class Thermostat(ClimateDevice):
             return
         self.data.ecobee.set_hvac_mode(self.thermostat_index, ecobee_value)
         if ecobee_value is not HVAC_MODE_OFF:
-            self._last_hvac_mode = ecobee_value
+            self._last_active_hvac_mode = ecobee_value
         self.update_without_throttle = True
 
     def set_fan_min_on_time(self, fan_min_on_time):
@@ -689,6 +689,6 @@ class Thermostat(ClimateDevice):
     def turn_on(self):
         """Set the thermostat to the last active HVAC mode."""
         _LOGGER.debug(
-            f"Turning on ecobee thermostat {self.name} in {self._last_hvac_mode} mode"
+            f"Turning on ecobee thermostat {self.name} in {self._last_active_hvac_mode} mode"
         )
-        self.set_hvac_mode(self._last_hvac_mode)
+        self.set_hvac_mode(self._last_active_hvac_mode)


### PR DESCRIPTION
## Breaking Change:

Previously, calling `climate.turn_on` would cause the ecobee thermostat to turn on in `heat` mode, regardless of the mode when the thermostat was turned off. Now, the thermostat will turn on to the last "active" HVAC mode (i.e. "heat", "cool", or "auto") (or, if the thermostat was "off" when Home Assistant started, to "auto").
 
## Description:

With no turn_on method in the ecobee climate platform, `climate.turn_on` was causing the ecobee thermostat to always turn on in "heat" mode (as a result of using the "fake" turn on in `async_turn_on` from the climate entity class). This PR adds a variable (`self._last_active_hvac_mode`) to track the last "active" (i.e. non-off) HVAC mode, and updates it in `async_update` with the latest non-off state retrieved from the ecobee API. And, the `turn_on` method sets the HVAC mode to the value contained in `self._last_active_hvac_mode`, which should be more intuitive for users.

**Related issue (if applicable):** fixes #27091 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
