### PR TITLE
Fix colorTemperatureInKelvin in Alexa report when light is off

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -326,7 +326,7 @@ class AlexaColorTemperatureController(AlexaCapibility):
             return color_util.color_temperature_mired_to_kelvin(
                 self.entity.attributes["color_temp"]
             )
-        return 0
+        return None
 
 
 class AlexaPercentageController(AlexaCapibility):

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -293,8 +293,8 @@ async def test_report_colored_temp_light_state(hass):
     )
 
     properties = await reported_properties(hass, "light.test_off")
-    properties.assert_equal(
-        "Alexa.ColorTemperatureController", "colorTemperatureInKelvin", 0
+    properties.assert_not_has_property(
+        "Alexa.ColorTemperatureController", "colorTemperatureInKelvin"
     )
 
 


### PR DESCRIPTION
## Description: 
`color_temp` attribute is not available when light state is off. Therefore `colorTemperatureInKelvin` does not need to be reported to Alexa API in state change. Returning None prevents the property from being included when the light state is off. 


**Related issue (if applicable):** fixes #26405


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
