### PR TITLE
Bump adb-shell to 0.0.3

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/components/androidtv",
   "requirements": [
-    "adb-shell==0.0.2",
+    "adb-shell==0.0.3",
     "androidtv==0.0.28"
   ],
   "dependencies": [],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -112,7 +112,7 @@ adafruit-blinka==1.2.1
 adafruit-circuitpython-mcp230xx==1.1.2
 
 # homeassistant.components.androidtv
-adb-shell==0.0.2
+adb-shell==0.0.3
 
 # homeassistant.components.adguard
 adguardhome==0.2.1


### PR DESCRIPTION
## Description:

This bumps the `adb-shell` package to version 0.0.3.  This *should* fix the issues using the Python ADB implementation for newer Android TV / Fire TV devices.  Here is 1 report that this fixed the issue: https://community.home-assistant.io/t/community-hass-io-add-on-adb-android-debug-bridge/96375/295

**Related issue (if applicable):** 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
