### PR TITLE
Add device registry support to ecobee integration

### DIFF
--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -69,9 +69,10 @@ class EcobeeBinarySensor(BinarySensorDevice):
                         model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
                     except KeyError:
                         _LOGGER.error(
-                            "Model name for ecobee thermostat %s not recognized. "
-                            "Please open an issue on GitHub and provide this information: "
-                            "Unrecognized model: %s",
+                            "Model number for ecobee thermostat %s not recognized. "
+                            "Please visit this link and provide the following information: "
+                            "https://github.com/home-assistant/home-assistant/issues/27172 "
+                            "Unrecognized model number: %s",
                             thermostat["name"],
                             thermostat["modelNumber"],
                         )

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -58,25 +58,28 @@ class EcobeeBinarySensor(BinarySensorDevice):
         identifier = None
         model = None
         for sensor in self.data.ecobee.get_remote_sensors(self.index):
-            if sensor["name"] == self.sensor_name:
-                if "code" in sensor:
-                    identifier = sensor["code"]
-                    model = "ecobee Room Sensor"
-                else:
-                    thermostat = self.data.ecobee.get_thermostat(self.index)
-                    identifier = thermostat["identifier"]
-                    try:
-                        model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
-                    except KeyError:
-                        _LOGGER.error(
-                            "Model number for ecobee thermostat %s not recognized. "
-                            "Please visit this link and provide the following information: "
-                            "https://github.com/home-assistant/home-assistant/issues/27172 "
-                            "Unrecognized model number: %s",
-                            thermostat["name"],
-                            thermostat["modelNumber"],
-                        )
-                break
+            if sensor["name"] != self.sensor_name:
+                continue
+            if "code" in sensor:
+                identifier = sensor["code"]
+                model = "ecobee Room Sensor"
+            else:
+                thermostat = self.data.ecobee.get_thermostat(self.index)
+                identifier = thermostat["identifier"]
+                try:
+                    model = (
+                        f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
+                    )
+                except KeyError:
+                    _LOGGER.error(
+                        "Model number for ecobee thermostat %s not recognized. "
+                        "Please visit this link and provide the following information: "
+                        "https://github.com/home-assistant/home-assistant/issues/27172 "
+                        "Unrecognized model number: %s",
+                        thermostat["name"],
+                        thermostat["modelNumber"],
+                    )
+            break
 
         if identifier is not None and model is not None:
             return {

--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -4,7 +4,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OCCUPANCY,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER, _LOGGER
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -51,6 +51,40 @@ class EcobeeBinarySensor(BinarySensorDevice):
                 if "code" in sensor:
                     return f"{sensor['code']}-{self.device_class}"
                 return f"{sensor['id']}-{self.device_class}"
+
+    @property
+    def device_info(self):
+        """Return device information for this sensor."""
+        identifier = None
+        model = None
+        for sensor in self.data.ecobee.get_remote_sensors(self.index):
+            if sensor["name"] == self.sensor_name:
+                if "code" in sensor:
+                    identifier = sensor["code"]
+                    model = "ecobee Room Sensor"
+                else:
+                    thermostat = self.data.ecobee.get_thermostat(self.index)
+                    identifier = thermostat["identifier"]
+                    try:
+                        model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
+                    except KeyError:
+                        _LOGGER.error(
+                            "Model name for ecobee thermostat %s not recognized. "
+                            "Please open an issue on GitHub and provide this information: "
+                            "Unrecognized model: %s",
+                            thermostat["name"],
+                            thermostat["modelNumber"],
+                        )
+                break
+
+        if identifier is not None and model is not None:
+            return {
+                "identifiers": {(DOMAIN, identifier)},
+                "name": self.sensor_name,
+                "manufacturer": MANUFACTURER,
+                "model": model,
+            }
+        return None
 
     @property
     def is_on(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
 from homeassistant.util.temperature import convert
 import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN, _LOGGER
+from .const import DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER, _LOGGER
 from .util import ecobee_date, ecobee_time
 
 ATTR_COOL_TEMP = "cool_temp"
@@ -309,6 +309,28 @@ class Thermostat(ClimateDevice):
     def unique_id(self):
         """Return a unique identifier for this ecobee thermostat."""
         return self.thermostat["identifier"]
+
+    @property
+    def device_info(self):
+        """Return device information for this ecobee thermostat."""
+        try:
+            model = f"{ECOBEE_MODEL_TO_NAME[self.thermostat['modelNumber']]} Thermostat"
+        except KeyError:
+            _LOGGER.error(
+                "Model name for ecobee thermostat %s not recognized. "
+                "Please open an issue on GitHub and provide this information: "
+                "Unrecognized model: %s",
+                self.name,
+                self.thermostat["modelNumber"],
+            )
+            return None
+
+        return {
+            "identifiers": {(DOMAIN, self.thermostat["identifier"])},
+            "name": self.name,
+            "manufacturer": MANUFACTURER,
+            "model": model,
+        }
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -317,9 +317,10 @@ class Thermostat(ClimateDevice):
             model = f"{ECOBEE_MODEL_TO_NAME[self.thermostat['modelNumber']]} Thermostat"
         except KeyError:
             _LOGGER.error(
-                "Model name for ecobee thermostat %s not recognized. "
-                "Please open an issue on GitHub and provide this information: "
-                "Unrecognized model: %s",
+                "Model number for ecobee thermostat %s not recognized. "
+                "Please visit this link and provide the following information: "
+                "https://github.com/home-assistant/home-assistant/issues/27172 "
+                "Unrecognized model number: %s",
                 self.name,
                 self.thermostat["modelNumber"],
             )

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -10,3 +10,5 @@ CONF_INDEX = "index"
 CONF_REFRESH_TOKEN = "refresh_token"
 
 ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]
+
+MANUFACTURER = "ecobee"

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -9,6 +9,18 @@ DATA_ECOBEE_CONFIG = "ecobee_config"
 CONF_INDEX = "index"
 CONF_REFRESH_TOKEN = "refresh_token"
 
+ECOBEE_MODEL_TO_NAME = {
+    "idtSmart": "ecobee Smart",
+    "idtEms": "ecobee Smart EMS",
+    "siSmart": "ecobee Si Smart",
+    "siEms": "ecobee Si EMS",
+    "athenaSmart": "ecobee3 Smart",
+    "athenaEms": "ecobee3 EMS",
+    "corSmart": "Carrier/Bryant Cor",
+    "nikeSmart": "ecobee3 lite Smart",
+    "nikeEms": "ecobee3 lite EMS",
+}
+
 ECOBEE_PLATFORMS = ["binary_sensor", "climate", "sensor", "weather"]
 
 MANUFACTURER = "ecobee"

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -69,25 +69,28 @@ class EcobeeSensor(Entity):
         identifier = None
         model = None
         for sensor in self.data.ecobee.get_remote_sensors(self.index):
-            if sensor["name"] == self.sensor_name:
-                if "code" in sensor:
-                    identifier = sensor["code"]
-                    model = "ecobee Room Sensor"
-                else:
-                    thermostat = self.data.ecobee.get_thermostat(self.index)
-                    identifier = thermostat["identifier"]
-                    try:
-                        model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
-                    except KeyError:
-                        _LOGGER.error(
-                            "Model number for ecobee thermostat %s not recognized. "
-                            "Please visit this link and provide the following information: "
-                            "https://github.com/home-assistant/home-assistant/issues/27172 "
-                            "Unrecognized model number: %s",
-                            thermostat["name"],
-                            thermostat["modelNumber"],
-                        )
-                break
+            if sensor["name"] != self.sensor_name:
+                continue
+            if "code" in sensor:
+                identifier = sensor["code"]
+                model = "ecobee Room Sensor"
+            else:
+                thermostat = self.data.ecobee.get_thermostat(self.index)
+                identifier = thermostat["identifier"]
+                try:
+                    model = (
+                        f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
+                    )
+                except KeyError:
+                    _LOGGER.error(
+                        "Model number for ecobee thermostat %s not recognized. "
+                        "Please visit this link and provide the following information: "
+                        "https://github.com/home-assistant/home-assistant/issues/27172 "
+                        "Unrecognized model number: %s",
+                        thermostat["name"],
+                        thermostat["modelNumber"],
+                    )
+            break
 
         if identifier is not None and model is not None:
             return {

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -80,9 +80,10 @@ class EcobeeSensor(Entity):
                         model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
                     except KeyError:
                         _LOGGER.error(
-                            "Model name for ecobee thermostat %s not recognized. "
-                            "Please open an issue on GitHub and provide this information: "
-                            "Unrecognized model: %s",
+                            "Model number for ecobee thermostat %s not recognized. "
+                            "Please visit this link and provide the following information: "
+                            "https://github.com/home-assistant/home-assistant/issues/27172 "
+                            "Unrecognized model number: %s",
                             thermostat["name"],
                             thermostat["modelNumber"],
                         )

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -13,7 +13,7 @@ from homeassistant.components.weather import (
 )
 from homeassistant.const import TEMP_FAHRENHEIT
 
-from .const import DOMAIN
+from .const import DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER, _LOGGER
 
 ATTR_FORECAST_TEMP_HIGH = "temphigh"
 ATTR_FORECAST_PRESSURE = "pressure"
@@ -65,6 +65,29 @@ class EcobeeWeather(WeatherEntity):
     def unique_id(self):
         """Return a unique identifier for the weather platform."""
         return self.data.ecobee.get_thermostat(self._index)["identifier"]
+
+    @property
+    def device_info(self):
+        """Return device information for the ecobee weather platform."""
+        thermostat = self.data.ecobee.get_thermostat(self._index)
+        try:
+            model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
+        except KeyError:
+            _LOGGER.error(
+                "Model name for ecobee thermostat %s not recognized. "
+                "Please open an issue on GitHub and provide this information: "
+                "Unrecognized model: %s",
+                thermostat["name"],
+                thermostat["modelNumber"],
+            )
+            return None
+
+        return {
+            "identifiers": {(DOMAIN, thermostat["identifier"])},
+            "name": self.name,
+            "manufacturer": MANUFACTURER,
+            "model": model,
+        }
 
     @property
     def condition(self):

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -74,9 +74,10 @@ class EcobeeWeather(WeatherEntity):
             model = f"{ECOBEE_MODEL_TO_NAME[thermostat['modelNumber']]} Thermostat"
         except KeyError:
             _LOGGER.error(
-                "Model name for ecobee thermostat %s not recognized. "
-                "Please open an issue on GitHub and provide this information: "
-                "Unrecognized model: %s",
+                "Model number for ecobee thermostat %s not recognized. "
+                "Please visit this link and provide the following information: "
+                "https://github.com/home-assistant/home-assistant/issues/27172 "
+                "Unrecognized model number: %s",
                 thermostat["name"],
                 thermostat["modelNumber"],
             )


### PR DESCRIPTION
## Description:

Adds device_info property to binary_sensor, climate, sensor, and weather platforms in the ecobee integration to add support for the device registry.

_Note to reviewers_: tests in the ecobee integration badly need updating to account for the changed code in this and previous PRs. Rather than update them piecemeal with each PR, I intend to rewrite and add tests (as needed) for the whole integration in a separate PR.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
