### PR TITLE
Add transmission info about torrents that is accessible with templating

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -305,7 +305,7 @@ homeassistant/components/tplink/* @rytilahti
 homeassistant/components/traccar/* @ludeeus
 homeassistant/components/tradfri/* @ggravlingen
 homeassistant/components/trafikverket_train/* @endor-force
-homeassistant/components/transmission/* @engrbm87
+homeassistant/components/transmission/* @engrbm87 @JPHutchins
 homeassistant/components/tts/* @robbiet480
 homeassistant/components/twentemilieu/* @frenck
 homeassistant/components/twilio_call/* @robbiet480

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -312,8 +312,8 @@ class TransmissionData:
         for torrent in all_torrents:
             if torrent.status == _TRPC["downloading"]:
                 info = self.started_torrent_dict[torrent.name] = {
-                    "addedDate": torrent.addedDate,
-                    "percentDone": "%.2f" % (torrent.percentDone * 100),
+                    "added_date": torrent.addedDate,
+                    "percent_done": f"{torrent.percentDone * 100:.2f}",
                 }
                 try:
                     info["eta"] = str(torrent.eta)
@@ -324,7 +324,7 @@ class TransmissionData:
 
             elif torrent.status == _TRPC["download pending"]:
                 self.started_torrent_dict[torrent.name] = {
-                    "addedDate": torrent.addedDate
+                    "added_date": torrent.addedDate
                 }
                 current_down[torrent.name] = True
 
@@ -342,10 +342,6 @@ class TransmissionData:
     def get_completed_torrent_count(self):
         """Get the number of completed torrents."""
         return len(self.completed_torrents)
-
-    def get_started_torrent_dict(self):
-        """Get the started torrent dict."""
-        return self.started_torrent_dict
 
     def get_started_torrent_info(self):
         """Return True if there is info in state attribute."""

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -336,10 +336,6 @@ class TransmissionData:
         """Get the number of completed torrents."""
         return len(self.completed_torrents)
 
-    def get_started_torrent_info(self):
-        """Return True if there is info in state attribute."""
-        return bool(self.started_torrent_dict)
-
     def start_torrents(self):
         """Start all torrents."""
         self._api.start_all()

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -28,7 +28,6 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     SERVICE_ADD_TORRENT,
-    _TRPC,
 )
 from .errors import AuthenticationError, CannotConnect, UnknownError
 
@@ -310,7 +309,7 @@ class TransmissionData:
         current_down = {}
 
         for torrent in all_torrents:
-            if torrent.status == _TRPC["downloading"]:
+            if torrent.status == "downloading":
                 info = self.started_torrent_dict[torrent.name] = {
                     "added_date": torrent.addedDate,
                     "percent_done": f"{torrent.percentDone * 100:.2f}",
@@ -320,12 +319,6 @@ class TransmissionData:
                 except ValueError:
                     info["eta"] = "unknown"
 
-                current_down[torrent.name] = True
-
-            elif torrent.status == _TRPC["download pending"]:
-                self.started_torrent_dict[torrent.name] = {
-                    "added_date": torrent.addedDate
-                }
                 current_down[torrent.name] = True
 
             elif torrent.name in self.started_torrent_dict:

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -2,14 +2,14 @@
 DOMAIN = "transmission"
 
 SENSOR_TYPES = {
-    "active_torrents": ["Active Torrents", None, None],
-    "current_status": ["Status", None, None],
-    "download_speed": ["Down Speed", "MB/s", None],
-    "paused_torrents": ["Paused Torrents", None, None],
-    "total_torrents": ["Total Torrents", None, None],
-    "upload_speed": ["Up Speed", "MB/s", None],
-    "completed_torrents": ["Completed Torrents", None, None],
-    "started_torrents": ["Started Torrents", None, None],
+    "active_torrents": ["Active Torrents", None],
+    "current_status": ["Status", None],
+    "download_speed": ["Down Speed", "MB/s"],
+    "paused_torrents": ["Paused Torrents", None],
+    "total_torrents": ["Total Torrents", None],
+    "upload_speed": ["Up Speed", "MB/s"],
+    "completed_torrents": ["Completed Torrents", None],
+    "started_torrents": ["Started Torrents", None],
 }
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 
@@ -22,13 +22,3 @@ ATTR_TORRENT = "torrent"
 SERVICE_ADD_TORRENT = "add_torrent"
 
 DATA_UPDATED = "transmission_data_updated"
-
-_TRPC = {
-    "check pending": "check pending",
-    "checking": "checking",
-    "downloading": "downloading",
-    "seeding": "seeding",
-    "stopped": "stopped",
-    "download pending": "download pending",
-    "seed pending": "seed pending",
-}

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -22,7 +22,6 @@ ATTR_TORRENT = "torrent"
 SERVICE_ADD_TORRENT = "add_torrent"
 
 DATA_UPDATED = "transmission_data_updated"
-DATA_TRANSMISSION = "data_transmission"
 
 _TRPC = {
     "check pending": "check pending",

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -10,7 +10,6 @@ SENSOR_TYPES = {
     "upload_speed": ["Up Speed", "MB/s", None],
     "completed_torrents": ["Completed Torrents", None, None],
     "started_torrents": ["Started Torrents", None, None],
-    "started_torrent_info": ["Torrent Info", None, None],
 }
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -2,14 +2,16 @@
 DOMAIN = "transmission"
 
 SENSOR_TYPES = {
-    "active_torrents": ["Active Torrents", None],
-    "current_status": ["Status", None],
-    "download_speed": ["Down Speed", "MB/s"],
-    "paused_torrents": ["Paused Torrents", None],
-    "total_torrents": ["Total Torrents", None],
-    "upload_speed": ["Up Speed", "MB/s"],
-    "completed_torrents": ["Completed Torrents", None],
-    "started_torrents": ["Started Torrents", None],
+    "active_torrents": ["Active Torrents", None, None],
+    "current_status": ["Status", None, None],
+    "download_speed": ["Down Speed", "MB/s", None],
+    "paused_torrents": ["Paused Torrents", None, None],
+    "total_torrents": ["Total Torrents", None, None],
+    "upload_speed": ["Up Speed", "MB/s", None],
+    "completed_torrents": ["Completed Torrents", None, None],
+    "started_torrents": ["Started Torrents", None, None],
+    "torrent_down_list": ["Downloading", None, None],
+    "started_torrent_dict": ["Torrent Info", None, None],
 }
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 
@@ -17,7 +19,21 @@ DEFAULT_NAME = "Transmission"
 DEFAULT_PORT = 9091
 DEFAULT_SCAN_INTERVAL = 120
 
-ATTR_TORRENT = "torrent"
+STATE_ATTR_TORRENT_INFO = "torrent_info"
 SERVICE_ADD_TORRENT = "add_torrent"
 
 DATA_UPDATED = "transmission_data_updated"
+<<<<<<< HEAD
+=======
+DATA_TRANSMISSION = "data_transmission"
+
+_TRPC = {
+    "check pending": "check pending",
+    "checking": "checking",
+    "downloading": "downloading",
+    "seeding": "seeding",
+    "stopped": "stopped",
+    "download pending": "download pending",
+    "seed pending": "seed pending",
+}
+>>>>>>> Add information about current downloads.

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -10,8 +10,7 @@ SENSOR_TYPES = {
     "upload_speed": ["Up Speed", "MB/s", None],
     "completed_torrents": ["Completed Torrents", None, None],
     "started_torrents": ["Started Torrents", None, None],
-    "torrent_down_list": ["Downloading", None, None],
-    "started_torrent_dict": ["Torrent Info", None, None],
+    "started_torrent_info": ["Torrent Info", None, None],
 }
 SWITCH_TYPES = {"on_off": "Switch", "turtle_mode": "Turtle Mode"}
 
@@ -20,6 +19,7 @@ DEFAULT_PORT = 9091
 DEFAULT_SCAN_INTERVAL = 120
 
 STATE_ATTR_TORRENT_INFO = "torrent_info"
+ATTR_TORRENT = "torrent"
 SERVICE_ADD_TORRENT = "add_torrent"
 
 DATA_UPDATED = "transmission_data_updated"

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -22,8 +22,6 @@ ATTR_TORRENT = "torrent"
 SERVICE_ADD_TORRENT = "add_torrent"
 
 DATA_UPDATED = "transmission_data_updated"
-<<<<<<< HEAD
-=======
 DATA_TRANSMISSION = "data_transmission"
 
 _TRPC = {
@@ -35,4 +33,3 @@ _TRPC = {
     "download pending": "download pending",
     "seed pending": "seed pending",
 }
->>>>>>> Add information about current downloads.

--- a/homeassistant/components/transmission/manifest.json
+++ b/homeassistant/components/transmission/manifest.json
@@ -9,6 +9,6 @@
   "dependencies": [],
   "codeowners": [
     "@engrbm87",
-    "JPHutchins"
+    "@JPHutchins"
   ]
 }

--- a/homeassistant/components/transmission/manifest.json
+++ b/homeassistant/components/transmission/manifest.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": [],
   "codeowners": [
-    "@engrbm87"
+    "@engrbm87",
     "JPHutchins"
   ]
 }

--- a/homeassistant/components/transmission/manifest.json
+++ b/homeassistant/components/transmission/manifest.json
@@ -9,5 +9,6 @@
   "dependencies": [],
   "codeowners": [
     "@engrbm87"
+    "JPHutchins"
   ]
 }

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -6,11 +6,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from .const import (
-    DOMAIN,
-    SENSOR_TYPES,
-    STATE_ATTR_TORRENT_INFO,
-)
+from .const import DOMAIN, SENSOR_TYPES, STATE_ATTR_TORRENT_INFO
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,7 +32,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 name,
                 SENSOR_TYPES[sensor_type][0],
                 SENSOR_TYPES[sensor_type][1],
-                SENSOR_TYPES[sensor_type][2],
             )
         )
 
@@ -47,14 +42,7 @@ class TransmissionSensor(Entity):
     """Representation of a Transmission sensor."""
 
     def __init__(
-        self,
-        sensor_type,
-        tm_client,
-        transmission_api,
-        client_name,
-        sensor_name,
-        unit_of_measurement,
-        torrent_info,
+        self, sensor_type, tm_client, client_name, sensor_name, unit_of_measurement
     ):
         """Initialize the sensor."""
         self._name = sensor_name
@@ -64,7 +52,6 @@ class TransmissionSensor(Entity):
         self._data = None
         self.client_name = client_name
         self.type = sensor_type
-        self._torrent_info = torrent_info
 
     @property
     def name(self):
@@ -99,8 +86,8 @@ class TransmissionSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes, if any."""
-        if self._torrent_info:
-            return {STATE_ATTR_TORRENT_INFO: self._torrent_info}
+        if self._tm_client.api.started_torrent_dict and self.type == "started_torrents":
+            return {STATE_ATTR_TORRENT_INFO: self._tm_client.api.started_torrent_dict}
         return None
 
     async def async_added_to_hass(self):
@@ -122,8 +109,7 @@ class TransmissionSensor(Entity):
         if self.type == "completed_torrents":
             self._state = self._tm_client.api.get_completed_torrent_count()
         elif self.type == "started_torrents":
-            self._state = self._transmission_api.get_started_torrent_count()
-            self._torrent_info = self._transmission_api.started_torrent_dict
+            self._state = self._tm_client.api.get_started_torrent_count()
 
         if self.type == "current_status":
             if self._data:

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -109,6 +109,8 @@ class TransmissionSensor(Entity):
         """Return the state attributes, if any."""
         if self._torrent_info:
             return {STATE_ATTR_TORRENT_INFO: self._torrent_info}
+        else:
+            return None
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -163,4 +163,4 @@ class TransmissionSensor(Entity):
                 self._state = self._data.torrentCount
             elif self.type == "started_torrent_info":
                 self._state = self._transmission_api.get_started_torrent_info()
-                self._torrent_info = self._transmission_api.get_started_torrent_dict()
+                self._torrent_info = self._transmission_api.started_torrent_dict

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -109,8 +109,7 @@ class TransmissionSensor(Entity):
         """Return the state attributes, if any."""
         if self._torrent_info:
             return {STATE_ATTR_TORRENT_INFO: self._torrent_info}
-        else:
-            return None
+        return None
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -7,8 +7,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
 from .const import (
-    DATA_TRANSMISSION,
-    DATA_UPDATED,
     DOMAIN,
     SENSOR_TYPES,
     STATE_ATTR_TORRENT_INFO,
@@ -51,6 +49,7 @@ class TransmissionSensor(Entity):
     def __init__(
         self,
         sensor_type,
+        tm_client,
         transmission_api,
         client_name,
         sensor_name,

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -49,9 +49,6 @@ class TransmissionSensor(Entity):
     """Representation of a Transmission sensor."""
 
     def __init__(
-<<<<<<< HEAD
-        self, sensor_type, tm_client, client_name, sensor_name, unit_of_measurement
-=======
         self,
         sensor_type,
         transmission_api,
@@ -59,7 +56,6 @@ class TransmissionSensor(Entity):
         sensor_name,
         unit_of_measurement,
         torrent_info,
->>>>>>> Add information about current downloads.
     ):
         """Initialize the sensor."""
         self._name = sensor_name
@@ -127,12 +123,8 @@ class TransmissionSensor(Entity):
         if self.type == "completed_torrents":
             self._state = self._tm_client.api.get_completed_torrent_count()
         elif self.type == "started_torrents":
-<<<<<<< HEAD
-            self._state = self._tm_client.api.get_started_torrent_count()
-=======
             self._state = self._transmission_api.get_started_torrent_count()
             self._torrent_info = self._transmission_api.started_torrent_dict
->>>>>>> Remove transmission_downloading, give started_torrents the info.
 
         if self.type == "current_status":
             if self._data:

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -105,7 +105,7 @@ class TransmissionSensor(Entity):
         return self._tm_client.api.available
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes, if any."""
         if self._torrent_info:
             return {STATE_ATTR_TORRENT_INFO: self._torrent_info}

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -107,7 +107,8 @@ class TransmissionSensor(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes, if any."""
-        return {STATE_ATTR_TORRENT_INFO: self._torrent_info}
+        if self._torrent_info:
+            return {STATE_ATTR_TORRENT_INFO: self._torrent_info}
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -160,9 +161,6 @@ class TransmissionSensor(Entity):
                 self._state = self._data.pausedTorrentCount
             elif self.type == "total_torrents":
                 self._state = self._data.torrentCount
-
-        if self.type == "torrent_down_list":
-            self._state = self._transmission_api.get_started_torrent_list()
-            self._torrent_info = self._transmission_api.get_started_torrent_dict()
-        if self.type == "started_torrent_dict":
-            self._state = self._transmission_api.get_started_torrent_dict()
+            elif self.type == "started_torrent_info":
+                self._state = self._transmission_api.get_started_torrent_info()
+                self._torrent_info = self._transmission_api.get_started_torrent_dict()

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -130,7 +130,12 @@ class TransmissionSensor(Entity):
         if self.type == "completed_torrents":
             self._state = self._tm_client.api.get_completed_torrent_count()
         elif self.type == "started_torrents":
+<<<<<<< HEAD
             self._state = self._tm_client.api.get_started_torrent_count()
+=======
+            self._state = self._transmission_api.get_started_torrent_count()
+            self._torrent_info = self._transmission_api.started_torrent_dict
+>>>>>>> Remove transmission_downloading, give started_torrents the info.
 
         if self.type == "current_status":
             if self._data:
@@ -162,6 +167,3 @@ class TransmissionSensor(Entity):
                 self._state = self._data.pausedTorrentCount
             elif self.type == "total_torrents":
                 self._state = self._data.torrentCount
-            elif self.type == "started_torrent_info":
-                self._state = self._transmission_api.get_started_torrent_info()
-                self._torrent_info = self._transmission_api.started_torrent_dict

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -6,9 +6,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-<<<<<<< HEAD
-from .const import DOMAIN, SENSOR_TYPES
-=======
 from .const import (
     DATA_TRANSMISSION,
     DATA_UPDATED,
@@ -16,7 +13,7 @@ from .const import (
     SENSOR_TYPES,
     STATE_ATTR_TORRENT_INFO,
 )
->>>>>>> Add information about current downloads.
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -6,7 +6,17 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
+<<<<<<< HEAD
 from .const import DOMAIN, SENSOR_TYPES
+=======
+from .const import (
+    DATA_TRANSMISSION,
+    DATA_UPDATED,
+    DOMAIN,
+    SENSOR_TYPES,
+    STATE_ATTR_TORRENT_INFO,
+)
+>>>>>>> Add information about current downloads.
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +41,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 name,
                 SENSOR_TYPES[sensor_type][0],
                 SENSOR_TYPES[sensor_type][1],
+                SENSOR_TYPES[sensor_type][2],
             )
         )
 
@@ -41,7 +52,17 @@ class TransmissionSensor(Entity):
     """Representation of a Transmission sensor."""
 
     def __init__(
+<<<<<<< HEAD
         self, sensor_type, tm_client, client_name, sensor_name, unit_of_measurement
+=======
+        self,
+        sensor_type,
+        transmission_api,
+        client_name,
+        sensor_name,
+        unit_of_measurement,
+        torrent_info,
+>>>>>>> Add information about current downloads.
     ):
         """Initialize the sensor."""
         self._name = sensor_name
@@ -51,6 +72,7 @@ class TransmissionSensor(Entity):
         self._data = None
         self.client_name = client_name
         self.type = sensor_type
+        self._torrent_info = torrent_info
 
     @property
     def name(self):
@@ -81,6 +103,11 @@ class TransmissionSensor(Entity):
     def available(self):
         """Could the device be accessed during the last update call."""
         return self._tm_client.api.available
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes, if any."""
+        return {STATE_ATTR_TORRENT_INFO: self._torrent_info}
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -133,3 +160,9 @@ class TransmissionSensor(Entity):
                 self._state = self._data.pausedTorrentCount
             elif self.type == "total_torrents":
                 self._state = self._data.torrentCount
+
+        if self.type == "torrent_down_list":
+            self._state = self._transmission_api.get_started_torrent_list()
+            self._torrent_info = self._transmission_api.get_started_torrent_dict()
+        if self.type == "started_torrent_dict":
+            self._state = self._transmission_api.get_started_torrent_dict()


### PR DESCRIPTION
## Description:
<strike> Added is a new sensor that contains a dictionary of "started torrents" in its state attribute.</strike>  The inspiration comes from the add_torrent service implemented with an input_text entity.  Ultimately I believe Home Assistant can act as a simple interface for adding, sorting, and observing torrent progress, very useful to friends and family that have a hard time managing their Linux ISOs in the regular interface.

This example is just to see if there is interest.  I am trying to learn HA architecture while improving my programming ability.  To this end I would like to know if a better implementation would be for torrents to be registered as entities (like how discovery or device tracker does)?
## Example state attribute:
Here is what you can expect in Developer Tools->States->sensor.transmission_started_torrents->Attributes.
```json
torrent_info: {
  "torrent_file_1_as_added_to_transmission": {
    "added_date": 1569812023,
    "percent_done": "5.83",
    "eta": "02:04:30"
  },
  "torrent_file_2_as_added_to_transmission": {
    "added_date": 1569812048,
    "percent_done": "68.03",
    "eta": "00:05:14"
  }
}
```
![example torrent list](https://user-images.githubusercontent.com/34154542/66366944-f2ae4300-e946-11e9-9a73-5900439b5262.PNG)
## Example templating:
Add a Markdown card like this one.  This took me forever Jinja and I do not understand one another.
```jinja2
content: >
  {% set payload = state_attr('sensor.transmission_started_torrents', 'torrent_info') %}

  {% for torrent in payload.items() %} {% set name = torrent[0] %} {% set data = torrent[1] %}
  
  {{ name|truncate(20) }} is {{ data.percent_done }}% complete, {{ data.eta }} remaining {% endfor %}
type: markdown
```
![templating](https://user-images.githubusercontent.com/34154542/66366958-fc37ab00-e946-11e9-9082-21cd68f7f784.PNG)

Clicking on the started_torrents sensor for "more info" yields inadequate results - can this be templated?
![more info](https://user-images.githubusercontent.com/34154542/66366981-1b363d00-e947-11e9-906e-92130ae0c0f2.PNG)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
Documentation added: https://github.com/home-assistant/home-assistant.io/pull/10574

Cheers,
J.P.