### PR TITLE
Add support to disable characteristics in homekit component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -123,6 +123,7 @@ homeassistant/components/history/* @home-assistant/core
 homeassistant/components/history_graph/* @andrey-git
 homeassistant/components/hive/* @Rendili @KJonline
 homeassistant/components/homeassistant/* @home-assistant/core
+homeassistant/components/homekit/* @fuzzie360
 homeassistant/components/homekit_controller/* @Jc2k
 homeassistant/components/homematic/* @pvizeli @danielperna84
 homeassistant/components/homematicip_cloud/* @SukramJ

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -11,6 +11,7 @@ ATTR_VALUE = "value"
 
 # #### Config ####
 CONF_AUTO_START = "auto_start"
+CONF_DISABLE_CHARACTERISTICS = "disable_characteristics"
 CONF_ENTITY_CONFIG = "entity_config"
 CONF_FEATURE = "feature"
 CONF_FEATURE_LIST = "feature_list"
@@ -18,6 +19,7 @@ CONF_FILTER = "filter"
 CONF_LINKED_BATTERY_SENSOR = "linked_battery_sensor"
 CONF_LOW_BATTERY_THRESHOLD = "low_battery_threshold"
 CONF_SAFE_MODE = "safe_mode"
+CONF_TURN_ON_DATA = "turn_on_data"
 
 # #### Config Defaults ####
 DEFAULT_AUTO_START = True

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -6,5 +6,7 @@
     "HAP-python==2.6.0"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@fuzzie360"
+  ]
 }

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -5,6 +5,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import fan, media_player, sensor
+from homeassistant.components.fan import FAN_TURN_ON_SCHEMA
+from homeassistant.components.light import LIGHT_TURN_ON_SCHEMA
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_SUPPORTED_FEATURES,
@@ -17,10 +19,19 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.util.temperature as temp_util
 
 from .const import (
+    CHAR_BRIGHTNESS,
+    CHAR_COLOR_TEMPERATURE,
+    CHAR_HUE,
+    CHAR_ROTATION_DIRECTION,
+    CHAR_ROTATION_SPEED,
+    CHAR_SATURATION,
+    CHAR_SWING_MODE,
+    CONF_DISABLE_CHARACTERISTICS,
     CONF_FEATURE,
     CONF_FEATURE_LIST,
     CONF_LINKED_BATTERY_SENSOR,
     CONF_LOW_BATTERY_THRESHOLD,
+    CONF_TURN_ON_DATA,
     DEFAULT_LOW_BATTERY_THRESHOLD,
     FEATURE_ON_OFF,
     FEATURE_PLAY_PAUSE,
@@ -90,6 +101,45 @@ SWITCH_TYPE_SCHEMA = BASIC_INFO_SCHEMA.extend(
     }
 )
 
+LIGHT_TYPE_SCHEMA = BASIC_INFO_SCHEMA.extend(
+    {
+        vol.Optional(CONF_TURN_ON_DATA): LIGHT_TURN_ON_SCHEMA,
+        vol.Optional(CONF_DISABLE_CHARACTERISTICS): vol.All(
+            cv.ensure_list,
+            [
+                vol.All(
+                    cv.string,
+                    vol.In(
+                        (
+                            CHAR_BRIGHTNESS,
+                            CHAR_COLOR_TEMPERATURE,
+                            CHAR_HUE,
+                            CHAR_SATURATION,
+                        )
+                    ),
+                )
+            ],
+        ),
+    }
+)
+
+FAN_TYPE_SCHEMA = BASIC_INFO_SCHEMA.extend(
+    {
+        vol.Optional(CONF_TURN_ON_DATA): FAN_TURN_ON_SCHEMA,
+        vol.Optional(CONF_DISABLE_CHARACTERISTICS): vol.All(
+            cv.ensure_list,
+            [
+                vol.All(
+                    cv.string,
+                    vol.In(
+                        (CHAR_ROTATION_DIRECTION, CHAR_ROTATION_SPEED, CHAR_SWING_MODE)
+                    ),
+                )
+            ],
+        ),
+    }
+)
+
 
 def validate_entity_config(values):
     """Validate config entry for CONF_ENTITY."""
@@ -122,6 +172,12 @@ def validate_entity_config(values):
 
         elif domain == "switch":
             config = SWITCH_TYPE_SCHEMA(config)
+
+        elif domain == "light":
+            config = LIGHT_TYPE_SCHEMA(config)
+
+        elif domain == "fan":
+            config = FAN_TYPE_SCHEMA(config)
 
         else:
             config = BASIC_INFO_SCHEMA(config)

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -2,11 +2,16 @@
 import pytest
 import voluptuous as vol
 
+
 from homeassistant.components.homekit.const import (
+    CHAR_BRIGHTNESS,
+    CHAR_ROTATION_SPEED,
+    CONF_DISABLE_CHARACTERISTICS,
     CONF_FEATURE,
     CONF_FEATURE_LIST,
     CONF_LINKED_BATTERY_SENSOR,
     CONF_LOW_BATTERY_THRESHOLD,
+    CONF_TURN_ON_DATA,
     FEATURE_ON_OFF,
     FEATURE_PLAY_PAUSE,
     HOMEKIT_NOTIFY_ID,
@@ -17,6 +22,8 @@ from homeassistant.components.homekit.const import (
     TYPE_SWITCH,
     TYPE_VALVE,
 )
+from homeassistant.components.fan import ATTR_SPEED
+from homeassistant.components.light import ATTR_BRIGHTNESS_PCT
 from homeassistant.components.homekit.util import (
     HomeKitSpeedMapping,
     SpeedRange,
@@ -75,6 +82,10 @@ def test_validate_entity_config():
             }
         },
         {"switch.test": {CONF_TYPE: "invalid_type"}},
+        {"light.test": {CONF_TURN_ON_DATA: {ATTR_SPEED: "low"}}},
+        {"light.test": {CONF_DISABLE_CHARACTERISTICS: [CHAR_ROTATION_SPEED]}},
+        {"fan.test": {CONF_TURN_ON_DATA: {ATTR_BRIGHTNESS_PCT: 1}}},
+        {"fan.test": {CONF_DISABLE_CHARACTERISTICS: [CHAR_BRIGHTNESS]}},
     ]
 
     for conf in configs:
@@ -145,6 +156,30 @@ def test_validate_entity_config():
     }
     assert vec({"switch.demo": {CONF_TYPE: TYPE_VALVE}}) == {
         "switch.demo": {CONF_TYPE: TYPE_VALVE, CONF_LOW_BATTERY_THRESHOLD: 20}
+    }
+    assert vec({"light.test": {CONF_TURN_ON_DATA: {ATTR_BRIGHTNESS_PCT: 1}}}) == {
+        "light.test": {
+            CONF_TURN_ON_DATA: {ATTR_BRIGHTNESS_PCT: 1},
+            CONF_LOW_BATTERY_THRESHOLD: 20,
+        }
+    }
+    assert vec({"light.test": {CONF_DISABLE_CHARACTERISTICS: [CHAR_BRIGHTNESS]}}) == {
+        "light.test": {
+            CONF_DISABLE_CHARACTERISTICS: [CHAR_BRIGHTNESS],
+            CONF_LOW_BATTERY_THRESHOLD: 20,
+        }
+    }
+    assert vec({"fan.test": {CONF_TURN_ON_DATA: {ATTR_SPEED: "low"}}}) == {
+        "fan.test": {
+            CONF_TURN_ON_DATA: {ATTR_SPEED: "low"},
+            CONF_LOW_BATTERY_THRESHOLD: 20,
+        }
+    }
+    assert vec({"fan.test": {CONF_DISABLE_CHARACTERISTICS: [CHAR_ROTATION_SPEED]}}) == {
+        "fan.test": {
+            CONF_DISABLE_CHARACTERISTICS: [CHAR_ROTATION_SPEED],
+            CONF_LOW_BATTERY_THRESHOLD: 20,
+        }
     }
 
 


### PR DESCRIPTION
## Description:

Some home assistant entities do not behave correctly with the homekit component. For example,

- The xiaomi air purfier component has a fan speed list of Auto, Silent, Favorite. This is not a linear speed list and should not be linearly mapped and exposed as a rotation speed characterstic (not to mention that Auto is not off, which homekit component incorrectly assumes)
- The yeelight bulb does not correctly return brightness levels 1-255, but 0-255 but 0 is off in the eyes of homekit. 

Yes, maybe some of this issues could be fixed on the component side, but I can still find some valid use cases where the user may not want to expose these characteristics to the homekit UI for customization reasons.

This patch adds the ability to disable characteristics of a homekit accessory. The home assistant entity itself will still have the features related to the characteristics, just that you can no longer do updates to the home assistant entity via homekit UI.

Also, to further help with usability with characteristics disabled, there is a turn_on_data section in the config that allows the user to set the default turn on options when controlling the entity through homekit.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10560

## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
  entity_config:
    fan.kitchen_fan:
      disable_characteristics:
        "RotationSpeed"
    light.living_room_light:
      disable_characteristics:
        "Brightness"
      turn_on_data:
        brightness_pct: 50
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
