### PR TITLE
Update documentation link URL for integrations

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,9 +23,9 @@
 Please provide details about your environment.
 -->
 
-**Component/platform:**
+**Integration:**
 <!--
-Please add the link to the documentation at https://www.home-assistant.io/components/ of the component/platform in question.
+Please add the link to the documentation at https://www.home-assistant.io/integrations/ of the integration in question.
 -->
 
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -29,9 +29,9 @@ about: Create a report to help us improve
 Please provide details about your environment.
 -->
 
-**Component/platform:**
+**Integration:**
 <!--
-Please add the link to the documentation at https://www.home-assistant.io/components/ of the component/platform in question.
+Please add the link to the documentation at https://www.home-assistant.io/integrations/ of the integration in question.
 -->
 
 

--- a/README.rst
+++ b/README.rst
@@ -32,4 +32,4 @@ of a component, check the `Home Assistant help section <https://home-assistant.i
 .. |screenshot-states| image:: https://raw.github.com/home-assistant/home-assistant/master/docs/screenshots.png
    :target: https://home-assistant.io/demo/
 .. |screenshot-components| image:: https://raw.github.com/home-assistant/home-assistant/dev/docs/screenshot-components.png
-   :target: https://home-assistant.io/components/
+   :target: https://home-assistant.io/integrations/

--- a/homeassistant/components/ambiclimate/.translations/en.json
+++ b/homeassistant/components/ambiclimate/.translations/en.json
@@ -3,7 +3,7 @@
         "abort": {
             "access_token": "Unknown error generating an access token.",
             "already_setup": "The Ambiclimate account is configured.",
-            "no_config": "You need to configure Ambiclimate before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/ambiclimate/)."
+            "no_config": "You need to configure Ambiclimate before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/integrations/ambiclimate/)."
         },
         "create_entry": {
             "default": "Successfully authenticated with Ambiclimate"

--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -1,5 +1,5 @@
 configure:
-  description: Set attribute of device in deCONZ. See https://home-assistant.io/components/deconz/#device-services for details.
+  description: Set attribute of device in deCONZ. See https://home-assistant.io/integrations/deconz/#device-services for details.
   fields:
     entity:
       description: Entity id representing a specific device in deCONZ.

--- a/homeassistant/components/dialogflow/config_flow.py
+++ b/homeassistant/components/dialogflow/config_flow.py
@@ -8,6 +8,6 @@ config_entry_flow.register_webhook_flow(
     "Dialogflow Webhook",
     {
         "dialogflow_url": "https://dialogflow.com/docs/fulfillment#webhook",
-        "docs_url": "https://www.home-assistant.io/components/dialogflow/",
+        "docs_url": "https://www.home-assistant.io/integrations/dialogflow/",
     },
 )

--- a/homeassistant/components/geofency/config_flow.py
+++ b/homeassistant/components/geofency/config_flow.py
@@ -6,5 +6,5 @@ from .const import DOMAIN
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     "Geofency Webhook",
-    {"docs_url": "https://www.home-assistant.io/components/geofency/"},
+    {"docs_url": "https://www.home-assistant.io/integrations/geofency/"},
 )

--- a/homeassistant/components/gpslogger/config_flow.py
+++ b/homeassistant/components/gpslogger/config_flow.py
@@ -6,5 +6,5 @@ from .const import DOMAIN
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     "GPSLogger Webhook",
-    {"docs_url": "https://www.home-assistant.io/components/gpslogger/"},
+    {"docs_url": "https://www.home-assistant.io/integrations/gpslogger/"},
 )

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -141,7 +141,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     _LOGGER.warning(
         "The honeywell component has been deprecated for EU (i.e. non-US) "
         "systems. For EU-based systems, use the evohome component, "
-        "see: https://home-assistant.io/components/evohome"
+        "see: https://home-assistant.io/integrations/evohome"
     )
 
 

--- a/homeassistant/components/ifttt/config_flow.py
+++ b/homeassistant/components/ifttt/config_flow.py
@@ -8,6 +8,6 @@ config_entry_flow.register_webhook_flow(
     "IFTTT Webhook",
     {
         "applet_url": "https://ifttt.com/maker_webhooks",
-        "docs_url": "https://www.home-assistant.io/components/ifttt/",
+        "docs_url": "https://www.home-assistant.io/integrations/ifttt/",
     },
 )

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -2,7 +2,7 @@
 Platform for the iZone AC.
 
 For more details about this component, please refer to the documentation
-https://home-assistant.io/components/izone/
+https://home-assistant.io/integrations/izone/
 """
 import logging
 

--- a/homeassistant/components/life360/config_flow.py
+++ b/homeassistant/components/life360/config_flow.py
@@ -13,7 +13,7 @@ from .helpers import get_api
 
 _LOGGER = logging.getLogger(__name__)
 
-DOCS_URL = "https://www.home-assistant.io/components/life360"
+DOCS_URL = "https://www.home-assistant.io/integrations/life360"
 
 
 @config_entries.HANDLERS.register(DOMAIN)

--- a/homeassistant/components/locative/config_flow.py
+++ b/homeassistant/components/locative/config_flow.py
@@ -6,5 +6,5 @@ from .const import DOMAIN
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     "Locative Webhook",
-    {"docs_url": "https://www.home-assistant.io/components/locative/"},
+    {"docs_url": "https://www.home-assistant.io/integrations/locative/"},
 )

--- a/homeassistant/components/logi_circle/.translations/en.json
+++ b/homeassistant/components/logi_circle/.translations/en.json
@@ -4,7 +4,7 @@
             "already_setup": "You can only configure a single Logi Circle account.",
             "external_error": "Exception occurred from another flow.",
             "external_setup": "Logi Circle successfully configured from another flow.",
-            "no_flows": "You need to configure Logi Circle before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/logi_circle/)."
+            "no_flows": "You need to configure Logi Circle before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/integrations/logi_circle/)."
         },
         "create_entry": {
             "default": "Successfully authenticated with Logi Circle."

--- a/homeassistant/components/mailgun/config_flow.py
+++ b/homeassistant/components/mailgun/config_flow.py
@@ -8,6 +8,6 @@ config_entry_flow.register_webhook_flow(
     "Mailgun Webhook",
     {
         "mailgun_url": "https://documentation.mailgun.com/en/latest/user_manual.html#webhooks",  # noqa: E501 pylint: disable=line-too-long
-        "docs_url": "https://www.home-assistant.io/components/mailgun/",
+        "docs_url": "https://www.home-assistant.io/integrations/mailgun/",
     },
 )

--- a/homeassistant/components/nest/.translations/en.json
+++ b/homeassistant/components/nest/.translations/en.json
@@ -4,7 +4,7 @@
             "already_setup": "You can only configure a single Nest account.",
             "authorize_url_fail": "Unknown error generating an authorize url.",
             "authorize_url_timeout": "Timeout generating authorize url.",
-            "no_flows": "You need to configure Nest before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/nest/)."
+            "no_flows": "You need to configure Nest before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/integrations/nest/)."
         },
         "error": {
             "internal_error": "Internal error validating code",

--- a/homeassistant/components/opentherm_gw/services.yaml
+++ b/homeassistant/components/opentherm_gw/services.yaml
@@ -64,7 +64,7 @@ set_gpio_mode:
     mode:
       description: >
         Mode to set on the GPIO pin. Values 0 through 6 are accepted for both GPIOs, 7 is only accepted for GPIO "B".
-        See https://www.home-assistant.io/components/opentherm_gw/#gpio-modes for an explanation of the values.
+        See https://www.home-assistant.io/integrations/opentherm_gw/#gpio-modes for an explanation of the values.
       example: '5'
 
 set_led_mode:
@@ -79,7 +79,7 @@ set_led_mode:
     mode:
       description: >
         The function to assign to the LED. One of "R", "X", "T", "B", "O", "F", "H", "W", "C", "E", "M" or "P".
-        See https://www.home-assistant.io/components/opentherm_gw/#led-modes for an explanation of the values.
+        See https://www.home-assistant.io/integrations/opentherm_gw/#led-modes for an explanation of the values.
       example: 'F'
 
 set_max_modulation:

--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -58,7 +58,7 @@ class OwnTracksFlow(config_entries.ConfigFlow):
                 "android_url": "https://play.google.com/store/apps/details?"
                 "id=org.owntracks.android",
                 "ios_url": "https://itunes.apple.com/us/app/owntracks/id692424691?mt=8",
-                "docs_url": "https://www.home-assistant.io/components/owntracks/",
+                "docs_url": "https://www.home-assistant.io/integrations/owntracks/",
             },
         )
 

--- a/homeassistant/components/plaato/config_flow.py
+++ b/homeassistant/components/plaato/config_flow.py
@@ -3,5 +3,7 @@ from homeassistant.helpers import config_entry_flow
 from .const import DOMAIN
 
 config_entry_flow.register_webhook_flow(
-    DOMAIN, "Webhook", {"docs_url": "https://www.home-assistant.io/components/plaato/"}
+    DOMAIN,
+    "Webhook",
+    {"docs_url": "https://www.home-assistant.io/integrations/plaato/"},
 )

--- a/homeassistant/components/point/.translations/en.json
+++ b/homeassistant/components/point/.translations/en.json
@@ -5,7 +5,7 @@
             "authorize_url_fail": "Unknown error generating an authorize url.",
             "authorize_url_timeout": "Timeout generating authorize url.",
             "external_setup": "Point successfully configured from another flow.",
-            "no_flows": "You need to configure Point before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/point/)."
+            "no_flows": "You need to configure Point before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/integrations/point/)."
         },
         "create_entry": {
             "default": "Successfully authenticated with Minut for your Point device(s)"

--- a/homeassistant/components/ps4/.translations/en.json
+++ b/homeassistant/components/ps4/.translations/en.json
@@ -4,8 +4,8 @@
             "credential_error": "Error fetching credentials.",
             "devices_configured": "All devices found are already configured.",
             "no_devices_found": "No PlayStation 4 devices found on the network.",
-            "port_987_bind_error": "Could not bind to port 987. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
-            "port_997_bind_error": "Could not bind to port 997. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info."
+            "port_987_bind_error": "Could not bind to port 987. Refer to the [documentation](https://www.home-assistant.io/integrations/ps4/) for additional info.",
+            "port_997_bind_error": "Could not bind to port 997. Refer to the [documentation](https://www.home-assistant.io/integrations/ps4/) for additional info."
         },
         "error": {
             "credential_timeout": "Credential service timed out. Press submit to restart.",
@@ -25,7 +25,7 @@
                     "name": "Name",
                     "region": "Region"
                 },
-                "description": "Enter your PlayStation 4 information. For 'PIN', navigate to 'Settings' on your PlayStation 4 console. Then navigate to 'Mobile App Connection Settings' and select 'Add Device'. Enter the PIN that is displayed. Refer to the [documentation](https://www.home-assistant.io/components/ps4/) for additional info.",
+                "description": "Enter your PlayStation 4 information. For 'PIN', navigate to 'Settings' on your PlayStation 4 console. Then navigate to 'Mobile App Connection Settings' and select 'Add Device'. Enter the PIN that is displayed. Refer to the [documentation](https://www.home-assistant.io/integrations/ps4/) for additional info.",
                 "title": "PlayStation 4"
             },
             "mode": {

--- a/homeassistant/components/smarthab/__init__.py
+++ b/homeassistant/components/smarthab/__init__.py
@@ -2,7 +2,7 @@
 Support for SmartHab device integration.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/smarthab/
+https://home-assistant.io/integrations/smarthab/
 """
 import logging
 

--- a/homeassistant/components/smarthab/cover.py
+++ b/homeassistant/components/smarthab/cover.py
@@ -2,7 +2,7 @@
 Support for SmartHab device integration.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/smarthab/
+https://home-assistant.io/integrations/smarthab/
 """
 import logging
 from datetime import timedelta

--- a/homeassistant/components/smarthab/light.py
+++ b/homeassistant/components/smarthab/light.py
@@ -2,7 +2,7 @@
 Support for SmartHab device integration.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/smarthab/
+https://home-assistant.io/integrations/smarthab/
 """
 import logging
 from datetime import timedelta

--- a/homeassistant/components/smartthings/config_flow.py
+++ b/homeassistant/components/smartthings/config_flow.py
@@ -176,7 +176,7 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow):
             errors=errors,
             description_placeholders={
                 "token_url": "https://account.smartthings.com/tokens",
-                "component_url": "https://www.home-assistant.io/components/smartthings/",
+                "component_url": "https://www.home-assistant.io/integrations/smartthings/",
             },
         )
 

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -2,7 +2,7 @@
 Support for Somfy hubs.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/somfy/
+https://home-assistant.io/integrations/somfy/
 """
 import logging
 from datetime import timedelta

--- a/homeassistant/components/toon/.translations/en.json
+++ b/homeassistant/components/toon/.translations/en.json
@@ -4,7 +4,7 @@
             "client_id": "The client ID from the configuration is invalid.",
             "client_secret": "The client secret from the configuration is invalid.",
             "no_agreements": "This account has no Toon displays.",
-            "no_app": "You need to configure Toon before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/components/toon/).",
+            "no_app": "You need to configure Toon before being able to authenticate with it. [Please read the instructions](https://www.home-assistant.io/integrations/toon/).",
             "unknown_auth_fail": "Unexpected error occured, while authenticating."
         },
         "error": {

--- a/homeassistant/components/traccar/config_flow.py
+++ b/homeassistant/components/traccar/config_flow.py
@@ -6,5 +6,5 @@ from .const import DOMAIN
 config_entry_flow.register_webhook_flow(
     DOMAIN,
     "Traccar Webhook",
-    {"docs_url": "https://www.home-assistant.io/components/traccar/"},
+    {"docs_url": "https://www.home-assistant.io/integrations/traccar/"},
 )

--- a/homeassistant/components/twilio/config_flow.py
+++ b/homeassistant/components/twilio/config_flow.py
@@ -9,6 +9,6 @@ config_entry_flow.register_webhook_flow(
     "Twilio Webhook",
     {
         "twilio_url": "https://www.twilio.com/docs/glossary/what-is-a-webhook",
-        "docs_url": "https://www.home-assistant.io/components/twilio/",
+        "docs_url": "https://www.home-assistant.io/integrations/twilio/",
     },
 )

--- a/homeassistant/components/zha/core/__init__.py
+++ b/homeassistant/components/zha/core/__init__.py
@@ -2,7 +2,7 @@
 Core module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 
 # flake8: noqa

--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -2,7 +2,7 @@
 Channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import asyncio
 from concurrent.futures import TimeoutError as Timeout

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -2,7 +2,7 @@
 Closures channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -2,7 +2,7 @@
 General channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -2,7 +2,7 @@
 Home automation channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -2,7 +2,7 @@
 HVAC channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -2,7 +2,7 @@
 Lighting channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/lightlink.py
+++ b/homeassistant/components/zha/core/channels/lightlink.py
@@ -2,7 +2,7 @@
 Lightlink channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -2,7 +2,7 @@
 Manufacturer specific channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/measurement.py
+++ b/homeassistant/components/zha/core/channels/measurement.py
@@ -2,7 +2,7 @@
 Measurement channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/protocol.py
+++ b/homeassistant/components/zha/core/channels/protocol.py
@@ -2,7 +2,7 @@
 Protocol channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -2,7 +2,7 @@
 Security channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -2,7 +2,7 @@
 Smart energy channels module for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import logging
 

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -2,7 +2,7 @@
 Device for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import asyncio
 from datetime import timedelta

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -2,7 +2,7 @@
 Device discovery functions for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 
 import logging

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -2,7 +2,7 @@
 Virtual gateway for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 
 import asyncio

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -2,7 +2,7 @@
 Helpers for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import asyncio
 import collections

--- a/homeassistant/components/zha/core/patches.py
+++ b/homeassistant/components/zha/core/patches.py
@@ -2,7 +2,7 @@
 Patch functions for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 
 

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -2,7 +2,7 @@
 Mapping registries for Zigbee Home Automation.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/zha/
+https://home-assistant.io/integrations/zha/
 """
 import collections
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -60,7 +60,7 @@ _LOGGER = logging.getLogger(__name__)
 DATA_PERSISTENT_ERRORS = "bootstrap_persistent_errors"
 RE_YAML_ERROR = re.compile(r"homeassistant\.util\.yaml")
 RE_ASCII = re.compile(r"\033\[[^m]*m")
-HA_COMPONENT_URL = "[{}](https://home-assistant.io/components/{}/)"
+HA_COMPONENT_URL = "[{}](https://home-assistant.io/integrations/{}/)"
 YAML_CONFIG_FILE = "configuration.yaml"
 VERSION_FILE = ".HA_VERSION"
 CONFIG_DIR_NAME = ".homeassistant"
@@ -462,7 +462,7 @@ def _format_config_error(ex: Exception, domain: str, config: Dict) -> str:
     if domain != CONF_CORE:
         message += (
             "Please check the docs at "
-            "https://home-assistant.io/components/{}/".format(domain)
+            "https://home-assistant.io/integrations/{}/".format(domain)
         )
 
     return message

--- a/script/scaffold/templates/integration/integration/manifest.json
+++ b/script/scaffold/templates/integration/integration/manifest.json
@@ -2,7 +2,7 @@
   "domain": "NEW_DOMAIN",
   "name": "NEW_NAME",
   "config_flow": false,
-  "documentation": "https://www.home-assistant.io/components/NEW_DOMAIN",
+  "documentation": "https://www.home-assistant.io/integrations/NEW_DOMAIN",
   "requirements": [],
   "ssdp": {},
   "homekit": {},


### PR DESCRIPTION
## Description:

This PR updates documentation URL's across the codebase to have the new URL structure for integrations. This is a followup of PR #27114

Adjusts:
- GitHub repository issue/pr templates
- Translations with links (only `en` source)
- Config flow messages
- Code & code comment references

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
