### PR TITLE
move ATTR_MODE to homeassistant.const

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -5,7 +5,7 @@ import random
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
+from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL, ATTR_MODE
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
@@ -30,7 +30,6 @@ CONF_CUSTOM_EFFECT = "custom_effect"
 CONF_COLORS = "colors"
 CONF_SPEED_PCT = "speed_pct"
 CONF_TRANSITION = "transition"
-ATTR_MODE = "mode"
 
 DOMAIN = "flux_led"
 

--- a/homeassistant/components/gpsd/sensor.py
+++ b/homeassistant/components/gpsd/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    ATTR_MODE,
     CONF_HOST,
     CONF_PORT,
     CONF_NAME,
@@ -19,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_CLIMB = "climb"
 ATTR_ELEVATION = "elevation"
 ATTR_GPS_TIME = "gps_time"
-ATTR_MODE = "mode"
 ATTR_SPEED = "speed"
 
 DEFAULT_HOST = "localhost"

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    ATTR_MODE,
     CONF_MODE,
     CONF_NAME,
     CONF_UNIT_SYSTEM,
@@ -77,7 +78,6 @@ ATTR_ROUTE = "route"
 ATTR_ORIGIN = "origin"
 ATTR_DESTINATION = "destination"
 
-ATTR_MODE = "mode"
 ATTR_UNIT_SYSTEM = CONF_UNIT_SYSTEM
 ATTR_TRAFFIC_MODE = CONF_TRAFFIC_MODE
 

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_MODE,
     ATTR_NAME,
     CONF_HOST,
     CONF_HOSTS,
@@ -47,7 +48,6 @@ ATTR_VALUE_TYPE = "value_type"
 ATTR_INTERFACE = "interface"
 ATTR_ERRORCODE = "error"
 ATTR_MESSAGE = "message"
-ATTR_MODE = "mode"
 ATTR_TIME = "time"
 ATTR_UNIQUE_ID = "unique_id"
 ATTR_PARAMSET_KEY = "paramset_key"

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -7,6 +7,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
+    ATTR_MODE,
     CONF_ICON,
     CONF_NAME,
     CONF_MODE,
@@ -32,7 +33,6 @@ ATTR_VALUE = "value"
 ATTR_MIN = "min"
 ATTR_MAX = "max"
 ATTR_STEP = "step"
-ATTR_MODE = "mode"
 
 SERVICE_SET_VALUE = "set_value"
 SERVICE_INCREMENT = "increment"

--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -7,6 +7,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import ENTITY_SERVICE_SCHEMA
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
+    ATTR_MODE,
     CONF_ICON,
     CONF_NAME,
     CONF_MODE,
@@ -30,7 +31,6 @@ ATTR_VALUE = "value"
 ATTR_MIN = "min"
 ATTR_MAX = "max"
 ATTR_PATTERN = "pattern"
-ATTR_MODE = "mode"
 
 SERVICE_SET_VALUE = "set_value"
 

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -33,7 +33,7 @@ from homeassistant.components.light import (
     Light,
     preprocess_turn_on_alternatives,
 )
-from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
@@ -77,7 +77,6 @@ SERVICE_EFFECT_COLORLOOP = "lifx_effect_colorloop"
 SERVICE_EFFECT_STOP = "lifx_effect_stop"
 
 ATTR_POWER_ON = "power_on"
-ATTR_MODE = "mode"
 ATTR_PERIOD = "period"
 ATTR_CYCLES = "cycles"
 ATTR_SPREAD = "spread"

--- a/homeassistant/components/logi_circle/__init__.py
+++ b/homeassistant/components/logi_circle/__init__.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.camera import ATTR_FILENAME, CAMERA_SERVICE_SCHEMA
 from homeassistant.const import (
+    ATTR_MODE,
     CONF_MONITORED_CONDITIONS,
     CONF_SENSORS,
     EVENT_HOMEASSISTANT_STOP,
@@ -42,7 +43,6 @@ SERVICE_SET_CONFIG = "set_config"
 SERVICE_LIVESTREAM_SNAPSHOT = "livestream_snapshot"
 SERVICE_LIVESTREAM_RECORD = "livestream_record"
 
-ATTR_MODE = "mode"
 ATTR_VALUE = "value"
 ATTR_DURATION = "duration"
 

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -27,7 +27,7 @@ from homeassistant.components.vacuum import (
     SUPPORT_STOP,
     StateVacuumDevice,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import extract_entity_ids
 
@@ -66,7 +66,6 @@ ATTR_CLEAN_BATTERY_END = "battery_level_at_clean_end"
 ATTR_CLEAN_SUSP_COUNT = "clean_suspension_count"
 ATTR_CLEAN_SUSP_TIME = "clean_suspension_time"
 
-ATTR_MODE = "mode"
 ATTR_NAVIGATION = "navigation"
 ATTR_CATEGORY = "category"
 ATTR_ZONE = "zone"

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import DOMAIN as COMP_SENSOR
 from homeassistant.const import (
     ATTR_DATE,
     ATTR_ID,
+    ATTR_MODE,
     ATTR_TEMPERATURE,
     ATTR_TIME,
     CONF_DEVICE,
@@ -28,7 +29,6 @@ import homeassistant.helpers.config_validation as cv
 
 from .const import (
     ATTR_GW_ID,
-    ATTR_MODE,
     ATTR_LEVEL,
     ATTR_DHW_OVRD,
     CONF_CLIMATE,

--- a/homeassistant/components/opentherm_gw/const.py
+++ b/homeassistant/components/opentherm_gw/const.py
@@ -4,7 +4,6 @@ import pyotgw.vars as gw_vars
 from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS
 
 ATTR_GW_ID = "gateway_id"
-ATTR_MODE = "mode"
 ATTR_LEVEL = "level"
 ATTR_DHW_OVRD = "dhw_override"
 

--- a/homeassistant/components/transport_nsw/sensor.py
+++ b/homeassistant/components/transport_nsw/sensor.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_API_KEY, ATTR_ATTRIBUTION
+from homeassistant.const import ATTR_MODE, CONF_NAME, CONF_API_KEY, ATTR_ATTRIBUTION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,7 +17,6 @@ ATTR_DUE_IN = "due"
 ATTR_DELAY = "delay"
 ATTR_REAL_TIME = "real_time"
 ATTR_DESTINATION = "destination"
-ATTR_MODE = "mode"
 
 ATTRIBUTION = "Data provided by Transport NSW"
 

--- a/homeassistant/components/wink/lock.py
+++ b/homeassistant/components/wink/lock.py
@@ -4,7 +4,13 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import ATTR_CODE, ATTR_ENTITY_ID, ATTR_NAME, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_CODE,
+    ATTR_ENTITY_ID,
+    ATTR_MODE,
+    ATTR_NAME,
+    STATE_UNKNOWN,
+)
 import homeassistant.helpers.config_validation as cv
 
 from . import DOMAIN, WinkDevice
@@ -20,7 +26,6 @@ SERVICE_ADD_KEY = "wink_add_new_lock_key_code"
 
 ATTR_ENABLED = "enabled"
 ATTR_SENSITIVITY = "sensitivity"
-ATTR_MODE = "mode"
 
 ALARM_SENSITIVITY_MAP = {
     "low": 0.2,

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -12,7 +12,13 @@ from homeassistant.components.fan import (
     SUPPORT_SET_SPEED,
     DOMAIN,
 )
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_TOKEN, ATTR_ENTITY_ID
+from homeassistant.const import (
+    ATTR_MODE,
+    CONF_NAME,
+    CONF_HOST,
+    CONF_TOKEN,
+    ATTR_ENTITY_ID,
+)
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
@@ -75,7 +81,6 @@ ATTR_MODEL = "model"
 ATTR_TEMPERATURE = "temperature"
 ATTR_HUMIDITY = "humidity"
 ATTR_AIR_QUALITY_INDEX = "aqi"
-ATTR_MODE = "mode"
 ATTR_FILTER_HOURS_USED = "filter_hours_used"
 ATTR_FILTER_LIFE = "filter_life_remaining"
 ATTR_FAVORITE_LEVEL = "favorite_level"

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -6,7 +6,13 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import DOMAIN, PLATFORM_SCHEMA, SwitchDevice
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_MODE,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_TOKEN,
+)
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
@@ -44,7 +50,6 @@ ATTR_POWER = "power"
 ATTR_TEMPERATURE = "temperature"
 ATTR_LOAD_POWER = "load_power"
 ATTR_MODEL = "model"
-ATTR_MODE = "mode"
 ATTR_POWER_MODE = "power_mode"
 ATTR_WIFI_LED = "wifi_led"
 ATTR_POWER_PRICE = "power_price"

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -11,7 +11,7 @@ from homeassistant.util.color import (
     color_temperature_mired_to_kelvin as mired_to_kelvin,
     color_temperature_kelvin_to_mired as kelvin_to_mired,
 )
-from homeassistant.const import CONF_HOST, ATTR_ENTITY_ID, CONF_NAME
+from homeassistant.const import CONF_HOST, ATTR_ENTITY_ID, ATTR_MODE, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -64,7 +64,6 @@ SUPPORT_YEELIGHT_WHITE_TEMP = SUPPORT_YEELIGHT | SUPPORT_COLOR_TEMP
 
 SUPPORT_YEELIGHT_RGB = SUPPORT_YEELIGHT_WHITE_TEMP | SUPPORT_COLOR
 
-ATTR_MODE = "mode"
 ATTR_MINUTES = "minutes"
 
 SERVICE_SET_MODE = "set_mode"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -271,6 +271,8 @@ ATTR_DISCOVERED = "discovered"
 # Location of the device/sensor
 ATTR_LOCATION = "location"
 
+ATTR_MODE = "mode"
+
 ATTR_BATTERY_CHARGING = "battery_charging"
 ATTR_BATTERY_LEVEL = "battery_level"
 ATTR_WAKEUP = "wake_up_interval"


### PR DESCRIPTION
## Description:
Create a central definition of `ATTR_MODE` in `homeassistant.const` instead of defining it several times for each integration using it.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
