### PR TITLE
Disable flaky/slow ecobee test

### DIFF
--- a/tests/components/ecobee/test_config_flow.py
+++ b/tests/components/ecobee/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the ecobee config flow."""
+import pytest
 from unittest.mock import patch
 
 from pyecobee import ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
@@ -116,6 +117,7 @@ async def test_token_request_fails(hass):
         assert result["description_placeholders"] == {"pin": "test-pin"}
 
 
+@pytest.mark.skip(reason="Flaky/slow")
 async def test_import_flow_triggered_but_no_ecobee_conf(hass):
     """Test expected result if import flow triggers but ecobee.conf doesn't exist."""
     flow = config_flow.EcobeeFlowHandler()


### PR DESCRIPTION
Test `test_import_flow_triggered_but_no_ecobee_conf` is slow and flaky:
https://dev.azure.com/home-assistant/Home%20Assistant/_build/results?buildId=10880&view=logs&j=641e29f4-92ec-5dde-69c3-b45a7bd26967&t=a889306f-ddd6-5fc9-6488-5f3f5770f1cb&l=273
https://dev.azure.com/home-assistant/Home%20Assistant/_build/results?buildId=10867&view=logs&j=641e29f4-92ec-5dde-69c3-b45a7bd26967&t=a889306f-ddd6-5fc9-6488-5f3f5770f1cb&l=273

Disable the test for now, ping @marthoc 