### PR TITLE
Bump up ZHA dependencies.

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -6,7 +6,7 @@
   "requirements": [
     "bellows-homeassistant==0.10.0",
     "zha-quirks==0.0.26",
-    "zigpy-deconz==0.4.0",
+    "zigpy-deconz==0.5.0",
     "zigpy-homeassistant==0.9.0",
     "zigpy-xbee-homeassistant==0.5.0",
     "zigpy-zigate==0.4.0"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2032,7 +2032,7 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.4.0
+zigpy-deconz==0.5.0
 
 # homeassistant.components.zha
 zigpy-homeassistant==0.9.0


### PR DESCRIPTION
## Description:
Bump up ZHA [zigpy-deconz](https://github.com/zigpy/zigpy-deconz/releases/tag/0.5.0) dependency.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
