### PR TITLE
Fix unavailable climate entities in Alexa StateReport

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -445,7 +445,7 @@ class AlexaTemperatureSensor(AlexaCapibility):
             unit = self.hass.config.units.temperature_unit
             temp = self.entity.attributes.get(climate.ATTR_CURRENT_TEMPERATURE)
 
-        if temp in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        if temp in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
             return None
 
         try:
@@ -572,6 +572,9 @@ class AlexaThermostatController(AlexaCapibility):
 
     def get_property(self, name):
         """Read and return a property."""
+        if self.entity.state == STATE_UNAVAILABLE:
+            return None
+
         if name == "thermostatMode":
             preset = self.entity.attributes.get(climate.ATTR_PRESET_MODE)
 


### PR DESCRIPTION
## Description:
Handles climate entities with `unavailable` state. Essentially ignores reporting `AlexaThermostatController` and `AlexaTemperatureSensor` properties and allows the `Alexa.EndpointHealth` to handle reporting the `unavailable` state. Preserves raising an error for unsupported states. 

Added additional tests for reporting `climate.state`/`thermostatMode` to Alexa. 

**Related issue (if applicable):** fixes #27027 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
