### PR TITLE
Update KNX integration to xknx 0.11.2

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -3,7 +3,7 @@
   "name": "Knx",
   "documentation": "https://www.home-assistant.io/components/knx",
   "requirements": [
-    "xknx==0.11.1"
+    "xknx==0.11.2"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1973,7 +1973,7 @@ xboxapi==0.1.1
 xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
-xknx==0.11.1
+xknx==0.11.2
 
 # homeassistant.components.bluesound
 # homeassistant.components.startca


### PR DESCRIPTION
## Description:

Updates xknx requirement of knx integration. 
Some bugs are fixed and a new sensor type was added: DPT 9.006 as `pressure_2byte`.

For detailed information see https://github.com/XKNX/xknx/releases/tag/0.11.2

**Related issue (if applicable):** #25900 depends on this.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10578


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
