### PR TITLE
Fix error on failed Plex setup

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -121,7 +121,7 @@ async def async_setup_entry(hass, entry):
     ) as error:
         _LOGGER.error(
             "Login to %s failed, verify token and SSL settings: [%s]",
-            server_config[CONF_SERVER],
+            entry.data[CONF_SERVER],
             error,
         )
         return False


### PR DESCRIPTION
## Description:
Parameter in log entry refers to incorrect location in config entry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
