### PR TITLE
Fix update on cert_expiry startup

### DIFF
--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -36,11 +36,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up certificate expiry sensor."""
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config)
+
+    @callback
+    def do_import(_):
+        """Process YAML import after HA is fully started."""
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config)
+            )
         )
-    )
+
+    # Delay to avoid validation during setup in case we're checking our own cert.
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_import)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -47,6 +47,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(
         [SSLCertificate(entry.title, entry.data[CONF_HOST], entry.data[CONF_PORT])],
         False,
+        # Don't update in case we're checking our own cert.
     )
     return True
 
@@ -84,7 +85,7 @@ class SSLCertificate(Entity):
 
     @property
     def available(self):
-        """Icon to use in the frontend, if any."""
+        """Return the availability of the sensor."""
         return self._available
 
     async def async_added_to_hass(self):
@@ -94,7 +95,11 @@ class SSLCertificate(Entity):
             """Run the update method when the start event was fired."""
             self.update()
 
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_update)
+        if self.hass.is_running:
+            await self.update()
+        else:
+            # Delay until HA is fully started in case we're checking our own cert.
+            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_update)
 
     def update(self):
         """Fetch the certificate information."""
@@ -120,3 +125,4 @@ class SSLCertificate(Entity):
         expiry = timestamp - datetime.today()
         self._available = True
         self._state = expiry.days
+        self.schedule_update_ha_state()

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_PORT,
     EVENT_HOMEASSISTANT_START,
 )
+from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT
@@ -91,13 +92,13 @@ class SSLCertificate(Entity):
     async def async_added_to_hass(self):
         """Once the entity is added we should update to get the initial data loaded."""
 
+        @callback
         def do_update(_):
             """Run the update method when the start event was fired."""
-            self.update()
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state(True)
 
         if self.hass.is_running:
-            await self.update()
+            self.async_schedule_update_ha_state(True)
         else:
             # Delay until HA is fully started in case we're checking our own cert.
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_update)

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -9,7 +9,12 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_HOST,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_START,
+)
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT
@@ -41,7 +46,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Add cert-expiry entry."""
     async_add_entities(
         [SSLCertificate(entry.title, entry.data[CONF_HOST], entry.data[CONF_PORT])],
-        True,
+        False,
     )
     return True
 
@@ -81,6 +86,15 @@ class SSLCertificate(Entity):
     def available(self):
         """Icon to use in the frontend, if any."""
         return self._available
+
+    async def async_added_to_hass(self):
+        """Once the entity is added we should update to get the initial data loaded."""
+
+        def do_update(_):
+            """Run the update method when the start event was fired."""
+            self.update()
+
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_update)
 
     def update(self):
         """Fetch the certificate information."""

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -9,12 +9,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_START,
-)
+from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, DEFAULT_NAME, DEFAULT_PORT
@@ -86,15 +81,6 @@ class SSLCertificate(Entity):
     def available(self):
         """Icon to use in the frontend, if any."""
         return self._available
-
-    async def async_added_to_hass(self):
-        """Once the entity is added we should update to get the initial data loaded."""
-
-        def do_update(_):
-            """Run the update method when the start event was fired."""
-            self.update()
-
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, do_update)
 
     def update(self):
         """Fetch the certificate information."""

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -94,6 +94,7 @@ class SSLCertificate(Entity):
         def do_update(_):
             """Run the update method when the start event was fired."""
             self.update()
+            self.schedule_update_ha_state()
 
         if self.hass.is_running:
             await self.update()
@@ -125,4 +126,3 @@ class SSLCertificate(Entity):
         expiry = timestamp - datetime.today()
         self._available = True
         self._state = expiry.days
-        self.schedule_update_ha_state()


### PR DESCRIPTION
## Description:
Cert Expiry sensors are now updated when the entities are created if home assistant is running or at home assistant start if home assistant is not running yet.

Import of config yaml is delayed and done at home assistant start, to avoid issues with checking certificate served by home assistant.

**Related issue (if applicable):** may fix #26740 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
