### PR TITLE
Add unique_id to cert_expiry

### DIFF
--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -70,7 +70,7 @@ class SSLCertificate(Entity):
     @property
     def unique_id(self):
         """Return a unique id for the sensor."""
-        return f"cert_expiry-{self.server_name}-{self.server_port}"
+        return f"{self.server_name}:{self.server_port}"
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/cert_expiry/sensor.py
+++ b/homeassistant/components/cert_expiry/sensor.py
@@ -68,6 +68,11 @@ class SSLCertificate(Entity):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return a unique id for the sensor."""
+        return f"cert_expiry-{self.server_name}-{self.server_port}"
+
+    @property
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return "days"


### PR DESCRIPTION
## Description:
Adds a unique_id property to cert_expiry sensors.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
