### PR TITLE
Guard against network errors for Dark Sky

### DIFF
--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -127,7 +127,9 @@ class DarkSkyWeather(WeatherEntity):
     @property
     def humidity(self):
         """Return the humidity."""
-        return round(self._ds_currently.get("humidity") * 100.0, 2)
+        if "humidity" in self._ds_currently:
+            return round(self._ds_currently.get("humidity") * 100.0, 2)
+        return None
 
     @property
     def wind_speed(self):
@@ -176,7 +178,7 @@ class DarkSkyWeather(WeatherEntity):
 
         data = None
 
-        if self._mode == "daily":
+        if self._mode == "daily" and self._ds_daily:
             data = [
                 {
                     ATTR_FORECAST_TIME: utc_from_timestamp(
@@ -193,7 +195,7 @@ class DarkSkyWeather(WeatherEntity):
                 }
                 for entry in self._ds_daily.data
             ]
-        else:
+        elif self._ds_hourly:
             data = [
                 {
                     ATTR_FORECAST_TIME: utc_from_timestamp(
@@ -215,7 +217,8 @@ class DarkSkyWeather(WeatherEntity):
         self._dark_sky.update()
 
         self._ds_data = self._dark_sky.data
-        self._ds_currently = self._dark_sky.currently.d
+        currently = self._dark_sky.currently
+        self._ds_currently = currently.d if currently else {}
         self._ds_hourly = self._dark_sky.hourly
         self._ds_daily = self._dark_sky.daily
 
@@ -255,5 +258,5 @@ class DarkSkyData:
     def units(self):
         """Get the unit system of returned data."""
         if self.data is None:
-            return None
+            return {}
         return self.data.json.get("flags").get("units")

--- a/homeassistant/components/darksky/weather.py
+++ b/homeassistant/components/darksky/weather.py
@@ -103,6 +103,11 @@ class DarkSkyWeather(WeatherEntity):
         self._ds_daily = None
 
     @property
+    def available(self):
+        """Return if weather data is available from Dark Sky."""
+        return self._ds_data is not None
+
+    @property
     def attribution(self):
         """Return the attribution."""
         return ATTRIBUTION
@@ -127,9 +132,7 @@ class DarkSkyWeather(WeatherEntity):
     @property
     def humidity(self):
         """Return the humidity."""
-        if "humidity" in self._ds_currently:
-            return round(self._ds_currently.get("humidity") * 100.0, 2)
-        return None
+        return round(self._ds_currently.get("humidity") * 100.0, 2)
 
     @property
     def wind_speed(self):
@@ -178,7 +181,7 @@ class DarkSkyWeather(WeatherEntity):
 
         data = None
 
-        if self._mode == "daily" and self._ds_daily:
+        if self._mode == "daily":
             data = [
                 {
                     ATTR_FORECAST_TIME: utc_from_timestamp(
@@ -195,7 +198,7 @@ class DarkSkyWeather(WeatherEntity):
                 }
                 for entry in self._ds_daily.data
             ]
-        elif self._ds_hourly:
+        else:
             data = [
                 {
                     ATTR_FORECAST_TIME: utc_from_timestamp(
@@ -258,5 +261,5 @@ class DarkSkyData:
     def units(self):
         """Get the unit system of returned data."""
         if self.data is None:
-            return {}
+            return None
         return self.data.json.get("flags").get("units")

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -62,4 +62,4 @@ class TestDarkSky(unittest.TestCase):
         )
 
         state = self.hass.states.get("weather.test")
-        assert state.state == "unknown"
+        assert state.state == "unavailable"

--- a/tests/components/darksky/test_weather.py
+++ b/tests/components/darksky/test_weather.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import forecastio
 import requests_mock
 
+from requests.exceptions import ConnectionError
+
 from homeassistant.components import weather
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.setup import setup_component
@@ -48,3 +50,16 @@ class TestDarkSky(unittest.TestCase):
 
         state = self.hass.states.get("weather.test")
         assert state.state == "sunny"
+
+    @patch("forecastio.load_forecast", side_effect=ConnectionError())
+    def test_failed_setup(self, mock_load_forecast):
+        """Test to ensure that a network error does not break component state."""
+
+        assert setup_component(
+            self.hass,
+            weather.DOMAIN,
+            {"weather": {"name": "test", "platform": "darksky", "api_key": "foo"}},
+        )
+
+        state = self.hass.states.get("weather.test")
+        assert state.state == "unknown"


### PR DESCRIPTION
## Description:

Sometimes when I'm starting up home-assistant, the docker container doesn't seem to get network connectivity in time, which causes a cascade of error logs. Along with those logs, though, I noticed that the Dark Sky component was failing to initialize because its network request failed (which caused an error in the UI).

It's a small change, but I've removed the assumption of a successful network request from the Dark Sky component's initialization, so that retries shouldn't encounter an uninitialized component.

Please correct me if I have the control flow wrong here or if this is completely unnecessary; I'm just starting to dig into the architecture, but I figured this kind of separation couldn't hurt anything, and it would help limit the error logs in situations like mine to the actual problem.


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
_A couple of the tests time out on my Macbook Pro with the default `tox` config, but they're unrelated to this change. Any further pointers on getting this working are welcome._
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
