### PR TITLE
PS4 bump to renamed dependency

### DIFF
--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -172,12 +172,8 @@ def load_games(hass: HomeAssistantType) -> dict:
         _LOGGER.error("Games file was not parsed correctly")
         games = {}
 
-    # If file does not exist, create empty file.
-    if not os.path.isfile(g_file):
-        _LOGGER.info("Creating PS4 Games File")
-        games = {}
-        save_games(hass, games)
-    else:
+    # If file exists
+    if os.path.isfile(g_file):
         games = _reformat_data(hass, games)
     return games
 

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -3,8 +3,8 @@ import logging
 import os
 
 import voluptuous as vol
-from pyps4_homeassistant.ddp import async_create_ddp_endpoint
-from pyps4_homeassistant.media_art import COUNTRIES
+from pyps4_2ndscreen.ddp import async_create_ddp_endpoint
+from pyps4_2ndscreen.media_art import COUNTRIES
 
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_TYPE,

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -2,6 +2,9 @@
 from collections import OrderedDict
 import logging
 
+from pyps4_2ndscreen.errors import CredentialTimeout
+from pyps4_2ndscreen.helpers import Helper
+from pyps4_2ndscreen.media_art import COUNTRIES
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -37,8 +40,6 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
     def __init__(self):
         """Initialize the config flow."""
-        from pyps4_homeassistant import Helper
-
         self.helper = Helper()
         self.creds = None
         self.name = None
@@ -61,8 +62,6 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_creds(self, user_input=None):
         """Return PS4 credentials from 2nd Screen App."""
-        from pyps4_homeassistant.errors import CredentialTimeout
-
         errors = {}
         if user_input is not None:
             try:
@@ -103,8 +102,6 @@ class PlayStation4FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_link(self, user_input=None):
         """Prompt user input. Create or edit entry."""
-        from pyps4_homeassistant.media_art import COUNTRIES
-
         regions = sorted(COUNTRIES.keys())
         default_region = None
         errors = {}

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ps4",
   "requirements": [
-    "pyps4-homeassistant==0.8.7"
+    "pyps4-2ndscreen==0.9.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ps4",
   "requirements": [
-    "pyps4-2ndscreen==1.0.0"
+    "pyps4-2ndscreen==1.0.1"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/manifest.json
+++ b/homeassistant/components/ps4/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ps4",
   "requirements": [
-    "pyps4-2ndscreen==0.9.0"
+    "pyps4-2ndscreen==1.0.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -2,8 +2,8 @@
 import logging
 import asyncio
 
-import pyps4_homeassistant.ps4 as pyps4
-from pyps4_homeassistant.errors import NotReady
+import pyps4_2ndscreen.ps4 as pyps4
+from pyps4_2ndscreen.errors import NotReady
 
 from homeassistant.core import callback
 from homeassistant.components.media_player import ENTITY_IMAGE_URL, MediaPlayerDevice
@@ -254,7 +254,7 @@ class PS4Device(MediaPlayerDevice):
 
     async def async_get_title_data(self, title_id, name):
         """Get PS Store Data."""
-        from pyps4_homeassistant.errors import PSDataIncomplete
+        from pyps4_2ndscreen.errors import PSDataIncomplete
 
         app_name = None
         art = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.0.0
+pyps4-2ndscreen==1.0.1
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==0.9.0
+pyps4-2ndscreen==1.0.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ pypjlink2==1.2.0
 pypoint==1.1.1
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.7
+pyps4-2ndscreen==0.9.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -338,7 +338,7 @@ pyopenuv==1.0.9
 pyotp==2.3.0
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==1.0.0
+pyps4-2ndscreen==1.0.1
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -338,7 +338,7 @@ pyopenuv==1.0.9
 pyotp==2.3.0
 
 # homeassistant.components.ps4
-pyps4-2ndscreen==0.9.0
+pyps4-2ndscreen==1.0.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -337,9 +337,6 @@ pyopenuv==1.0.9
 # homeassistant.components.otp
 pyotp==2.3.0
 
-# homeassistant.components.ps4
-pyps4-2ndscreen==1.0.0
-
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -338,7 +338,7 @@ pyopenuv==1.0.9
 pyotp==2.3.0
 
 # homeassistant.components.ps4
-pyps4-homeassistant==0.8.7
+pyps4-2ndscreen==0.9.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -337,6 +337,9 @@ pyopenuv==1.0.9
 # homeassistant.components.otp
 pyotp==2.3.0
 
+# homeassistant.components.ps4
+pyps4-2ndscreen==1.0.0
+
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.93
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -138,7 +138,7 @@ TEST_REQUIREMENTS = (
     "pynx584",
     "pyopenuv",
     "pyotp",
-    "pyps4-homeassistant",
+    "pyps4-2ndscreen",
     "pyqwikswitch",
     "PyRMVtransport",
     "pysma",

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -1,7 +1,7 @@
 """Tests for the PS4 media player platform."""
 from unittest.mock import MagicMock, patch
 
-from pyps4_homeassistant.credential import get_ddp_message
+from pyps4_2ndscreen.credential import get_ddp_message
 
 from homeassistant.components import ps4
 from homeassistant.components.media_player.const import (
@@ -295,9 +295,7 @@ async def test_media_attributes_are_loaded(hass):
 async def test_device_info_is_set_from_status_correctly(hass):
     """Test that device info is set correctly from status update."""
     mock_d_registry = mock_device_registry(hass)
-    with patch(
-        "pyps4_homeassistant.ps4.get_status", return_value=MOCK_STATUS_OFF
-    ), patch(MOCK_SAVE, side_effect=MagicMock()):
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_OFF):
         mock_entity_id = await setup_mock_component(hass)
 
     await hass.async_block_till_done()
@@ -447,9 +445,9 @@ async def test_media_stop(hass):
 async def test_select_source(hass):
     """Test that select source service calls function with title."""
     mock_data = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
-    with patch(
-        "pyps4_homeassistant.ps4.get_status", return_value=MOCK_STATUS_IDLE
-    ), patch(MOCK_LOAD, return_value=mock_data):
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE), patch(
+        MOCK_LOAD, return_value=mock_data
+    ):
         mock_entity_id = await setup_mock_component(hass)
 
     mock_func = "{}{}".format(
@@ -473,9 +471,9 @@ async def test_select_source(hass):
 async def test_select_source_caps(hass):
     """Test that select source service calls function with upper case title."""
     mock_data = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
-    with patch(
-        "pyps4_homeassistant.ps4.get_status", return_value=MOCK_STATUS_IDLE
-    ), patch(MOCK_LOAD, return_value=mock_data):
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE), patch(
+        MOCK_LOAD, return_value=mock_data
+    ):
         mock_entity_id = await setup_mock_component(hass)
 
     mock_func = "{}{}".format(
@@ -502,9 +500,9 @@ async def test_select_source_caps(hass):
 async def test_select_source_id(hass):
     """Test that select source service calls function with Title ID."""
     mock_data = {MOCK_TITLE_ID: MOCK_GAMES_DATA}
-    with patch(
-        "pyps4_homeassistant.ps4.get_status", return_value=MOCK_STATUS_IDLE
-    ), patch(MOCK_LOAD, return_value=mock_data):
+    with patch("pyps4_2ndscreen.ps4.get_status", return_value=MOCK_STATUS_IDLE), patch(
+        MOCK_LOAD, return_value=mock_data
+    ):
         mock_entity_id = await setup_mock_component(hass)
 
     mock_func = "{}{}".format(


### PR DESCRIPTION
## Description:

- Use renamed pypi dependency to 'pyps4-2ndscreen' from 'pyps4-homeassistant'
- Fixes issue where cannot turn on PS4 consistently.
- Try to fix flaky tests leaving files behind

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
