### PR TITLE
Unload cert_expiry config entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,7 +49,7 @@ homeassistant/components/broadlink/* @danielhiversen
 homeassistant/components/brunt/* @eavanvalkenburg
 homeassistant/components/bt_smarthub/* @jxwolstenholme
 homeassistant/components/buienradar/* @mjj4791 @ties
-homeassistant/components/cert_expiry/* @cereal2nd
+homeassistant/components/cert_expiry/* @Cereal2nd @jjlawren
 homeassistant/components/cisco_ios/* @fbradyirl
 homeassistant/components/cisco_mobility_express/* @fbradyirl
 homeassistant/components/cisco_webex_teams/* @fbradyirl

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -15,3 +15,11 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
         hass.config_entries.async_forward_entry_setup(entry, "sensor")
     )
     return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    )
+    return True

--- a/homeassistant/components/cert_expiry/manifest.json
+++ b/homeassistant/components/cert_expiry/manifest.json
@@ -5,5 +5,8 @@
     "requirements": [],
     "config_flow": true,
     "dependencies": [],
-    "codeowners": ["@cereal2nd"]
+    "codeowners": [
+        "@Cereal2nd",
+        "@jjlawren"
+    ]
 }


### PR DESCRIPTION
## Description:
Unload config entries cleanly for cert_expiry component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
