### PR TITLE
Only generate device trigger for sensor with unit

### DIFF
--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -5,6 +5,7 @@ import homeassistant.components.automation.numeric_state as numeric_state_automa
 from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_ABOVE,
     CONF_BELOW,
     CONF_ENTITY_ID,
@@ -113,8 +114,14 @@ async def async_get_triggers(hass, device_id):
     for entry in entries:
         device_class = DEVICE_CLASS_NONE
         state = hass.states.get(entry.entity_id)
-        if state:
-            device_class = state.attributes.get(ATTR_DEVICE_CLASS)
+        unit_of_measurement = (
+            state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else None
+        )
+
+        if not state or not unit_of_measurement:
+            continue
+
+        device_class = state.attributes.get(ATTR_DEVICE_CLASS)
 
         templates = ENTITY_TRIGGERS.get(
             device_class, ENTITY_TRIGGERS[DEVICE_CLASS_NONE]

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 import pytest
 
-from homeassistant.components.sensor import DOMAIN, DEVICE_CLASSES
+from homeassistant.components.sensor import DOMAIN
 from homeassistant.components.sensor.device_trigger import ENTITY_TRIGGERS
 from homeassistant.const import STATE_UNKNOWN, CONF_PLATFORM
 from homeassistant.setup import async_setup_component
@@ -19,6 +19,7 @@ from tests.common import (
     async_get_device_automations,
     async_get_device_automation_capabilities,
 )
+from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
 
 
 @pytest.fixture
@@ -70,6 +71,7 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         }
         for device_class in DEVICE_CLASSES
         for trigger in ENTITY_TRIGGERS[device_class]
+        if device_class != "none"
     ]
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
     assert triggers == expected_triggers

--- a/tests/testing_config/custom_components/test/sensor.py
+++ b/tests/testing_config/custom_components/test/sensor.py
@@ -3,9 +3,23 @@ Provide a mock sensor platform.
 
 Call init before using it in your tests to ensure clean test data.
 """
-from homeassistant.components.sensor import DEVICE_CLASSES
+import homeassistant.components.sensor as sensor
 from tests.common import MockEntity
 
+
+DEVICE_CLASSES = list(sensor.DEVICE_CLASSES)
+DEVICE_CLASSES.append("none")
+
+UNITS_OF_MEASUREMENT = {
+    sensor.DEVICE_CLASS_BATTERY: "%",  # % of battery that is left
+    sensor.DEVICE_CLASS_HUMIDITY: "%",  # % of humidity in the air
+    sensor.DEVICE_CLASS_ILLUMINANCE: "lm",  # current light level (lx/lm)
+    sensor.DEVICE_CLASS_SIGNAL_STRENGTH: "dB",  # signal strength (dB/dBm)
+    sensor.DEVICE_CLASS_TEMPERATURE: "C",  # temperature (C/F)
+    sensor.DEVICE_CLASS_TIMESTAMP: "hh:mm:ss",  # timestamp (ISO8601)
+    sensor.DEVICE_CLASS_PRESSURE: "hPa",  # pressure (hPa/mbar)
+    sensor.DEVICE_CLASS_POWER: "kW",  # power (W/kW)
+}
 
 ENTITIES = {}
 
@@ -22,6 +36,7 @@ def init(empty=False):
                 name=f"{device_class} sensor",
                 unique_id=f"unique_{device_class}",
                 device_class=device_class,
+                unit_of_measurement=UNITS_OF_MEASUREMENT.get(device_class),
             )
             for device_class in DEVICE_CLASSES
         }
@@ -42,3 +57,8 @@ class MockSensor(MockEntity):
     def device_class(self):
         """Return the class of this sensor."""
         return self._handle("device_class")
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit_of_measurement of this sensor."""
+        return self._handle("unit_of_measurement")


### PR DESCRIPTION
## Description:
Only generate device trigger for sensor with unit.
This check is missing from PR #27133 which introduces device triggers for sensors.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
