### PR TITLE
Adds fields to light.toggle service description

### DIFF
--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -5,22 +5,22 @@ turn_on:
   fields:
     entity_id:
       description: Name(s) of entities to turn on
-      example: 'light.kitchen'
+      example: "light.kitchen"
     transition:
       description: Duration in seconds it takes to get to next state
       example: 60
     rgb_color:
       description: Color for the light in RGB-format.
-      example: '[255, 100, 100]'
+      example: "[255, 100, 100]"
     color_name:
       description: A human readable color name.
-      example: 'red'
+      example: "red"
     hs_color:
       description: Color for the light in hue/sat format. Hue is 0-360 and Sat is 0-100.
-      example: '[300, 70]'
+      example: "[300, 70]"
     xy_color:
       description: Color for the light in XY-format.
-      example: '[0.52, 0.43]'
+      example: "[0.52, 0.43]"
     color_temp:
       description: Color temperature for the light in mireds.
       example: 250
@@ -29,7 +29,7 @@ turn_on:
       example: 4000
     white_value:
       description: Number between 0..255 indicating level of white.
-      example: '250'
+      example: "250"
     brightness:
       description: Number between 0..255 indicating brightness, where 0 turns the light off, 1 is the minimum brightness and 255 is the maximum brightness supported by the light.
       example: 120
@@ -55,7 +55,7 @@ turn_off:
   fields:
     entity_id:
       description: Name(s) of entities to turn off.
-      example: 'light.kitchen'
+      example: "light.kitchen"
     transition:
       description: Duration in seconds it takes to get to next state.
       example: 60
@@ -68,23 +68,67 @@ turn_off:
 toggle:
   description: Toggles a light.
   fields:
-    '...':
-      description: All turn_on parameters can be used.
+    entity_id:
+      description: Name(s) of entities to turn on
+      example: "light.kitchen"
+    transition:
+      description: Duration in seconds it takes to get to next state
+      example: 60
+    rgb_color:
+      description: Color for the light in RGB-format.
+      example: "[255, 100, 100]"
+    color_name:
+      description: A human readable color name.
+      example: "red"
+    hs_color:
+      description: Color for the light in hue/sat format. Hue is 0-360 and Sat is 0-100.
+      example: "[300, 70]"
+    xy_color:
+      description: Color for the light in XY-format.
+      example: "[0.52, 0.43]"
+    color_temp:
+      description: Color temperature for the light in mireds.
+      example: 250
+    kelvin:
+      description: Color temperature for the light in Kelvin.
+      example: 4000
+    white_value:
+      description: Number between 0..255 indicating level of white.
+      example: "250"
+    brightness:
+      description: Number between 0..255 indicating brightness, where 0 turns the light off, 1 is the minimum brightness and 255 is the maximum brightness supported by the light.
+      example: 120
+    brightness_pct:
+      description: Number between 0..100 indicating percentage of full brightness, where 0 turns the light off, 1 is the minimum brightness and 100 is the maximum brightness supported by the light.
+      example: 47
+    profile:
+      description: Name of a light profile to use.
+      example: relax
+    flash:
+      description: If the light should flash.
+      values:
+        - short
+        - long
+    effect:
+      description: Light effect.
+      values:
+        - colorloop
+        - random
 
 lifx_set_state:
   description: Set a color/brightness and possibliy turn the light on/off.
   fields:
     entity_id:
       description: Name(s) of entities to set a state on.
-      example: 'light.garage'
-    '...':
+      example: "light.garage"
+    "...":
       description: All turn_on parameters can be used to specify a color.
     infrared:
       description: Automatic infrared level (0..255) when light brightness is low.
       example: 255
     zones:
       description: List of zone numbers to affect (8 per LIFX Z, starts at 0).
-      example: '[0,5]'
+      example: "[0,5]"
     transition:
       description: Duration in seconds it takes to get to the final state.
       example: 10
@@ -97,19 +141,19 @@ lifx_effect_pulse:
   fields:
     entity_id:
       description: Name(s) of entities to run the effect on.
-      example: 'light.kitchen'
+      example: "light.kitchen"
     mode:
-      description: 'Decides how colors are changed. Possible values: blink, breathe, ping, strobe, solid.'
+      description: "Decides how colors are changed. Possible values: blink, breathe, ping, strobe, solid."
       example: strobe
     brightness:
       description: Number between 0..255 indicating brightness of the temporary color.
       example: 120
     color_name:
       description: A human readable color name.
-      example: 'red'
+      example: "red"
     rgb_color:
       description: The temporary color in RGB-format.
-      example: '[255, 100, 100]'
+      example: "[255, 100, 100]"
     period:
       description: Duration of the effect in seconds (default 1.0).
       example: 3
@@ -125,7 +169,7 @@ lifx_effect_colorloop:
   fields:
     entity_id:
       description: Name(s) of entities to run the effect on.
-      example: 'light.disco1, light.disco2, light.disco3'
+      example: "light.disco1, light.disco2, light.disco3"
     brightness:
       description: Number between 0 and 255 indicating brightness of the effect. Leave this out to maintain the current brightness of each participating light.
       example: 120
@@ -147,14 +191,14 @@ lifx_effect_stop:
   fields:
     entity_id:
       description: Name(s) of entities to stop effects on. Leave out to stop effects everywhere.
-      example: 'light.bedroom'
+      example: "light.bedroom"
 
 xiaomi_miio_set_scene:
   description: Set a fixed scene.
   fields:
     entity_id:
       description: Name of the light entity.
-      example: 'light.xiaomi_miio'
+      example: "light.xiaomi_miio"
     scene:
       description: Number of the fixed scene, between 1 and 4.
       example: 1
@@ -164,7 +208,7 @@ xiaomi_miio_set_delayed_turn_off:
   fields:
     entity_id:
       description: Name of the light entity.
-      example: 'light.xiaomi_miio'
+      example: "light.xiaomi_miio"
     time_period:
       description: Time period for the delayed turn off.
       example: "5, '0:05', {'minutes': 5}"


### PR DESCRIPTION
## Description:

Noticed this during playing with 0.100 with the new YAML in service calls feature.

`light.turn_on` ("FILL EXAMPLE DATA" button works):

![image](https://user-images.githubusercontent.com/195327/66154930-dfd20080-e61e-11e9-8bc6-8a29716f7b22.png)

`light.toggle`:

"FILL EXAMPLE DATA" button only enters `{}`, also the selection box for `entity_id` is now missing.

![image](https://user-images.githubusercontent.com/195327/66154899-ca5cd680-e61e-11e9-9f9c-c87fd452cb98.png)

This PR copies the fields from the `light.turn_on` service to the `light.toggle` service.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - 🚫  Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - 🚫 [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - 🚫 New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - 🚫 Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - 🚫 Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
