### PR TITLE
Add PowerLevelController for fan to alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -614,3 +614,38 @@ class AlexaThermostatController(AlexaCapibility):
             return None
 
         return {"value": temp, "scale": API_TEMP_UNITS[unit]}
+
+
+class AlexaPowerLevelController(AlexaCapibility):
+    """Implements Alexa.PowerLevelController.
+
+    https://developer.amazon.com/docs/device-apis/alexa-powerlevelcontroller.html
+    """
+
+    def name(self):
+        """Return the Alexa API name of this interface."""
+        return "Alexa.PowerLevelController"
+
+    def properties_supported(self):
+        """Return what properties this entity supports."""
+        return [{"name": "powerLevel"}]
+
+    def properties_proactively_reported(self):
+        """Return True if properties asynchronously reported."""
+        return True
+
+    def properties_retrievable(self):
+        """Return True if properties can be retrieved."""
+        return True
+
+    def get_property(self, name):
+        """Read and return a property."""
+        if name != "powerLevel":
+            raise UnsupportedProperty(name)
+
+        if self.entity.domain == fan.DOMAIN:
+            speed = self.entity.attributes.get(fan.ATTR_SPEED)
+
+            return PERCENTAGE_FAN_MAP.get(speed, None)
+
+        return None

--- a/homeassistant/components/alexa/const.py
+++ b/homeassistant/components/alexa/const.py
@@ -62,7 +62,12 @@ API_THERMOSTAT_MODES = OrderedDict(
 )
 API_THERMOSTAT_PRESETS = {climate.PRESET_ECO: "ECO"}
 
-PERCENTAGE_FAN_MAP = {fan.SPEED_LOW: 33, fan.SPEED_MEDIUM: 66, fan.SPEED_HIGH: 100}
+PERCENTAGE_FAN_MAP = {
+    fan.SPEED_OFF: 0,
+    fan.SPEED_LOW: 33,
+    fan.SPEED_MEDIUM: 66,
+    fan.SPEED_HIGH: 100,
+}
 
 
 class Cause:

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -43,6 +43,7 @@ from .capabilities import (
     AlexaPercentageController,
     AlexaPlaybackController,
     AlexaPowerController,
+    AlexaPowerLevelController,
     AlexaSceneController,
     AlexaSpeaker,
     AlexaStepSpeaker,
@@ -344,6 +345,7 @@ class FanCapabilities(AlexaEntity):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & fan.SUPPORT_SET_SPEED:
             yield AlexaPercentageController(self.entity)
+            yield AlexaPowerLevelController(self.entity)
         yield AlexaEndpointHealth(self.hass, self.entity)
 
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -340,6 +340,7 @@ async def test_variable_fan(hass):
         appliance,
         "Alexa.PercentageController",
         "Alexa.PowerController",
+        "Alexa.PowerLevelController",
         "Alexa.EndpointHealth",
     )
 
@@ -360,6 +361,27 @@ async def test_variable_fan(hass):
         "AdjustPercentage",
         "fan#test_2",
         "percentageDelta",
+        "fan.set_speed",
+        "speed",
+    )
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.PowerLevelController",
+        "SetPowerLevel",
+        "fan#test_2",
+        "fan.set_speed",
+        hass,
+        payload={"powerLevel": "50"},
+    )
+    assert call.data["speed"] == "medium"
+
+    await assert_percentage_changes(
+        hass,
+        [("high", "-5"), ("high", "5"), ("low", "-80")],
+        "Alexa.PowerLevelController",
+        "AdjustPowerLevel",
+        "fan#test_2",
+        "powerLevelDelta",
         "fan.set_speed",
         "speed",
     )


### PR DESCRIPTION
## (Maybe) Breaking Change:
Not currently a breaking change, but could be. 

It is possible to expose both the `Alexa.PercentageController` and `Alexa.PowerLevelController` for variable fan entities. Existing entities will use the `Alexa.PercentageController` and newly discovered fan entities will expose both. During testing entities that expose both would receive `SetPowerLevel` directives vs. `SetPercentage` indicating Alexa prefers `powerLevel` and `powerLevelDelta` directives when both are exposed. 

Existing `Alexa.PercentageController` handlers for fan entities were left in to maintain backwards compatibility. 

However, If you want to remove the bloat. Just remove any references to fan entities from the `Alexa.PercentageController`s. But will likely break existing fan entities already connected to Alexa, and they will need to be removed and re-discovered. 

## Description:

Implements PowerLevelController for variable fan entities. While attempting to maintain PercentageContoller for existing entities already discovered by Alexa. 

This also provides a "bandaid" to speed percentage mapping when integrations override the default `ATTR_SPEED_LIST`. e.g. `lutron_caseta_pro` maps `SPEED_MEDIUM_HIGH` to 75, and would be 
 reported as 0 in change reports. 


**Related issue (if applicable):** checks off #24579

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Tests have been added to verify that the new code works.