### PR TITLE
Add above and below to sensor device trigger extra_fields

### DIFF
--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -140,6 +140,10 @@ async def async_get_trigger_capabilities(hass, trigger):
     """List trigger capabilities."""
     return {
         "extra_fields": vol.Schema(
-            {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
+            {
+                vol.Optional(CONF_ABOVE): vol.Coerce(float),
+                vol.Optional(CONF_BELOW): vol.Coerce(float),
+                vol.Optional(CONF_FOR): cv.positive_time_period_dict,
+            }
         )
     }

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -86,7 +86,9 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
     entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
     expected_capabilities = {
         "extra_fields": [
-            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            {"name": "above", "optional": True, "type": "float"},
+            {"name": "below", "optional": True, "type": "float"},
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"},
         ]
     }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)


### PR DESCRIPTION
## Description:
Add `above` and `below` to sensor trigger `extra_fields`.
This is missing from PR #27133 which introduces device triggers for sensors.

Once frontend PR home-assistant/home-assistant-polymer#3721 is merged we will then get a UI like this:
![image](https://user-images.githubusercontent.com/14281572/66157706-a3090800-e624-11e9-88ca-12597622e1e0.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
