### PR TITLE
Add device condition support to sensor entities

### DIFF
--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -102,7 +102,8 @@ async def async_get_conditions(hass: HomeAssistant, device_id: str) -> List[dict
         if not state or not unit_of_measurement:
             continue
 
-        device_class = state.attributes.get(ATTR_DEVICE_CLASS)
+        if ATTR_DEVICE_CLASS in state.attributes:
+            device_class = state.attributes[ATTR_DEVICE_CLASS]
 
         templates = ENTITY_CONDITIONS.get(
             device_class, ENTITY_CONDITIONS[DEVICE_CLASS_NONE]

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -1,0 +1,142 @@
+"""Provides device conditions for sensors."""
+from typing import List
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+import homeassistant.components.automation.numeric_state as numeric_state_automation
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_ABOVE,
+    CONF_BELOW,
+    CONF_ENTITY_ID,
+    CONF_FOR,
+    CONF_TYPE,
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_SIGNAL_STRENGTH,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_TIMESTAMP,
+)
+from homeassistant.helpers.entity_registry import (
+    async_entries_for_device,
+    async_get_registry,
+)
+from homeassistant.helpers import condition, config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+
+
+# mypy: allow-untyped-defs, no-check-untyped-defs
+
+DEVICE_CLASS_NONE = "none"
+
+CONF_IS_BATTERY_LEVEL = "is_battery_level"
+CONF_IS_HUMIDITY = "is_humidity"
+CONF_IS_ILLUMINANCE = "is_illuminance"
+CONF_IS_POWER = "is_power"
+CONF_IS_PRESSURE = "is_pressure"
+CONF_IS_SIGNAL_STRENGTH = "is_signal_strength"
+CONF_IS_TEMPERATURE = "is_temperature"
+CONF_IS_TIMESTAMP = "is_timestamp"
+CONF_IS_VALUE = "is_value"
+
+ENTITY_CONDITIONS = {
+    DEVICE_CLASS_BATTERY: [{CONF_TYPE: CONF_IS_BATTERY_LEVEL}],
+    DEVICE_CLASS_HUMIDITY: [{CONF_TYPE: CONF_IS_HUMIDITY}],
+    DEVICE_CLASS_ILLUMINANCE: [{CONF_TYPE: CONF_IS_ILLUMINANCE}],
+    DEVICE_CLASS_POWER: [{CONF_TYPE: CONF_IS_POWER}],
+    DEVICE_CLASS_PRESSURE: [{CONF_TYPE: CONF_IS_PRESSURE}],
+    DEVICE_CLASS_SIGNAL_STRENGTH: [{CONF_TYPE: CONF_IS_SIGNAL_STRENGTH}],
+    DEVICE_CLASS_TEMPERATURE: [{CONF_TYPE: CONF_IS_TEMPERATURE}],
+    DEVICE_CLASS_TIMESTAMP: [{CONF_TYPE: CONF_IS_TIMESTAMP}],
+    DEVICE_CLASS_NONE: [{CONF_TYPE: CONF_IS_VALUE}],
+}
+
+CONDITION_SCHEMA = vol.All(
+    cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_ENTITY_ID): cv.entity_id,
+            vol.Required(CONF_TYPE): vol.In(
+                [
+                    CONF_IS_BATTERY_LEVEL,
+                    CONF_IS_HUMIDITY,
+                    CONF_IS_ILLUMINANCE,
+                    CONF_IS_POWER,
+                    CONF_IS_PRESSURE,
+                    CONF_IS_SIGNAL_STRENGTH,
+                    CONF_IS_TEMPERATURE,
+                    CONF_IS_TIMESTAMP,
+                    CONF_IS_VALUE,
+                ]
+            ),
+            vol.Optional(CONF_BELOW): vol.Any(vol.Coerce(float)),
+            vol.Optional(CONF_ABOVE): vol.Any(vol.Coerce(float)),
+        }
+    ),
+    cv.has_at_least_one_key(CONF_BELOW, CONF_ABOVE),
+)
+
+
+async def async_get_conditions(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device conditions."""
+    conditions: List[dict] = []
+    entity_registry = await async_get_registry(hass)
+    entries = [
+        entry
+        for entry in async_entries_for_device(entity_registry, device_id)
+        if entry.domain == DOMAIN
+    ]
+
+    for entry in entries:
+        device_class = DEVICE_CLASS_NONE
+        state = hass.states.get(entry.entity_id)
+        unit_of_measurement = (
+            state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else None
+        )
+
+        if not state or not unit_of_measurement:
+            continue
+
+        device_class = state.attributes.get(ATTR_DEVICE_CLASS)
+
+        templates = ENTITY_CONDITIONS.get(
+            device_class, ENTITY_CONDITIONS[DEVICE_CLASS_NONE]
+        )
+
+        conditions.extend(
+            (
+                {
+                    **template,
+                    "condition": "device",
+                    "device_id": device_id,
+                    "entity_id": entry.entity_id,
+                    "domain": DOMAIN,
+                }
+                for template in templates
+            )
+        )
+
+    return conditions
+
+
+def async_condition_from_config(
+    config: ConfigType, config_validation: bool
+) -> condition.ConditionCheckerType:
+    """Evaluate state based on configuration."""
+    if config_validation:
+        config = CONDITION_SCHEMA(config)
+    numeric_state_config = {
+        numeric_state_automation.CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        numeric_state_automation.CONF_ABOVE: config.get(CONF_ABOVE),
+        numeric_state_automation.CONF_BELOW: config.get(CONF_BELOW),
+        numeric_state_automation.CONF_FOR: config.get(CONF_FOR),
+    }
+
+    return condition.async_numeric_state_from_config(
+        numeric_state_config, config_validation
+    )

--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -121,7 +121,8 @@ async def async_get_triggers(hass, device_id):
         if not state or not unit_of_measurement:
             continue
 
-        device_class = state.attributes.get(ATTR_DEVICE_CLASS)
+        if ATTR_DEVICE_CLASS in state.attributes:
+            device_class = state.attributes[ATTR_DEVICE_CLASS]
 
         templates = ENTITY_TRIGGERS.get(
             device_class, ENTITY_TRIGGERS[DEVICE_CLASS_NONE]

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -1,0 +1,289 @@
+"""The test for sensor device automation."""
+import pytest
+
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.components.sensor.device_condition import ENTITY_CONDITIONS
+from homeassistant.const import STATE_UNKNOWN, CONF_PLATFORM
+from homeassistant.setup import async_setup_component
+import homeassistant.components.automation as automation
+from homeassistant.helpers import device_registry
+
+from tests.common import (
+    MockConfigEntry,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+    async_get_device_automations,
+)
+from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
+
+
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock serivce."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_conditions(hass, device_reg, entity_reg):
+    """Test we get the expected conditions from a sensor."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init()
+
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    for device_class in DEVICE_CLASSES:
+        entity_reg.async_get_or_create(
+            DOMAIN,
+            "test",
+            platform.ENTITIES[device_class].unique_id,
+            device_id=device_entry.id,
+        )
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    expected_conditions = [
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": condition["type"],
+            "device_id": device_entry.id,
+            "entity_id": platform.ENTITIES[device_class].entity_id,
+        }
+        for device_class in DEVICE_CLASSES
+        for condition in ENTITY_CONDITIONS[device_class]
+        if device_class != "none"
+    ]
+    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    assert conditions == expected_conditions
+
+
+async def test_if_state_not_above_below(hass, calls, caplog):
+    """Test for bad value conditions."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    sensor1 = platform.ENTITIES["battery"]
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": sensor1.entity_id,
+                            "type": "is_battery_level",
+                        }
+                    ],
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    assert "must contain at least one of below, above" in caplog.text
+
+
+async def test_if_state_above(hass, calls):
+    """Test for value conditions."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    sensor1 = platform.ENTITIES["battery"]
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": sensor1.entity_id,
+                            "type": "is_battery_level",
+                            "above": 10,
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "{{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(("platform", "event.event_type"))
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(sensor1.entity_id).state == STATE_UNKNOWN
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(sensor1.entity_id, 9)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(sensor1.entity_id, 11)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "event - test_event1"
+
+
+async def test_if_state_below(hass, calls):
+    """Test for value conditions."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    sensor1 = platform.ENTITIES["battery"]
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": sensor1.entity_id,
+                            "type": "is_battery_level",
+                            "below": 10,
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "{{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(("platform", "event.event_type"))
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(sensor1.entity_id).state == STATE_UNKNOWN
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(sensor1.entity_id, 11)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(sensor1.entity_id, 9)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "event - test_event1"
+
+
+async def test_if_state_between(hass, calls):
+    """Test for value conditions."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    sensor1 = platform.ENTITIES["battery"]
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": sensor1.entity_id,
+                            "type": "is_battery_level",
+                            "above": 10,
+                            "below": 20,
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "{{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(("platform", "event.event_type"))
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(sensor1.entity_id).state == STATE_UNKNOWN
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(sensor1.entity_id, 9)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(sensor1.entity_id, 11)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "event - test_event1"
+
+    hass.states.async_set(sensor1.entity_id, 21)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_set(sensor1.entity_id, 19)
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "event - test_event1"


### PR DESCRIPTION
## Description:
Add device condition support to sensor entities with `unit_of_measurement`

This includes condition part from #26854

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
