### PR TITLE
Support zone expanders in alarmdecoder

### DIFF
--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -174,7 +174,7 @@ def setup(hass, config):
         hass.helpers.dispatcher.dispatcher_send(SIGNAL_ZONE_RESTORE, zone)
 
     def handle_rel_message(sender, message):
-        """Handle relay message from AlarmDecoder."""
+        """Handle relay or zone expander message from AlarmDecoder."""
         hass.helpers.dispatcher.dispatcher_send(SIGNAL_REL_MESSAGE, message)
 
     controller = False
@@ -195,7 +195,7 @@ def setup(hass, config):
     controller.on_zone_fault += zone_fault_callback
     controller.on_zone_restore += zone_restore_callback
     controller.on_close += handle_closed_connection
-    controller.on_relay_changed += handle_rel_message
+    controller.on_expander_message += handle_rel_message
 
     hass.data[DATA_AD] = controller
 

--- a/homeassistant/components/alarmdecoder/binary_sensor.py
+++ b/homeassistant/components/alarmdecoder/binary_sensor.py
@@ -151,10 +151,15 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
             self.schedule_update_ha_state()
 
     def _rel_message_callback(self, message):
-        """Update relay state."""
+        """Update relay / expander state."""
+
         if self._relay_addr == message.address and self._relay_chan == message.channel:
             _LOGGER.debug(
-                "Relay %d:%d value:%d", message.address, message.channel, message.value
+                "%s %d:%d value:%d",
+                "Relay" if message.type == message.RELAY else "ZoneExpander",
+                message.address,
+                message.channel,
+                message.value,
             )
             self._state = message.value
             self.schedule_update_ha_state()


### PR DESCRIPTION
## Description:

This is a minor change to the alarmdecoder integration to support both zone expander and relay expander boards. By using the on_expander_message instead of _on_relay_changed callback, both relay expander and zone expander board messages are supported.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10594

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
