### PR TITLE
Handle all single zone thermostats

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -73,21 +73,20 @@ async def async_setup_platform(
     loc_idx = broker.params[CONF_LOCATION_IDX]
 
     _LOGGER.debug(
-        "Found Location/Controller, id=%s [%s], name=%s (location_idx=%s)",
-        broker.tcs.systemId,
+        "Found the Location/Controller (%s), id=%s, name=%s (location_idx=%s)",
         broker.tcs.modelType,
+        broker.tcs.systemId,
         broker.tcs.location.name,
         loc_idx,
     )
 
-    # special case of RoundThermostat (is single zone)
-    if broker.config["zones"][0]["modelType"] == "RoundModulation":
+    # special case of RoundModulation/RoundWireless (is a single zone system)
+    if broker.config["zones"][0]["zoneType"] == "Thermostat":
         zone = list(broker.tcs.zones.values())[0]
         _LOGGER.debug(
-            "Found %s, id=%s [%s], name=%s",
-            zone.zoneType,
-            zone.zoneId,
+            "Found the Thermostat (%s), id=%s, name=%s",
             zone.modelType,
+            zone.zoneId,
             zone.name,
         )
 
@@ -99,10 +98,10 @@ async def async_setup_platform(
     zones = []
     for zone in broker.tcs.zones.values():
         _LOGGER.debug(
-            "Found %s, id=%s [%s], name=%s",
+            "Found a %s (%s), id=%s, name=%s",
             zone.zoneType,
-            zone.zoneId,
             zone.modelType,
+            zone.zoneId,
             zone.name,
         )
         zones.append(EvoZone(broker, zone))

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -30,7 +30,9 @@ async def async_setup_platform(
     broker = hass.data[DOMAIN]["broker"]
 
     _LOGGER.debug(
-        "Found %s, id: %s", broker.tcs.hotwater.zone_type, broker.tcs.hotwater.zoneId
+        "Found the DHW Controller (%s), id: %s",
+        broker.tcs.hotwater.zone_type,
+        broker.tcs.hotwater.zoneId,
     )
 
     evo_dhw = EvoDHW(broker, broker.tcs.hotwater)


### PR DESCRIPTION
## Breaking Change:

None known.

## Description:
Bugfix, to include all single zone systems, **RoundWireless** in addition to **RoundModulation**.

Tweaks debug text slightly to aid debugging.

**Related issue (if applicable):** fixes #27161

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

** Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
