### PR TITLE
Fix tests running in hass.io image

### DIFF
--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -17,6 +17,13 @@ from homeassistant.requirements import (
 from tests.common import get_test_home_assistant, MockModule, mock_integration
 
 
+def env_without_wheel_links():
+    """Return env without wheel links."""
+    env = dict(os.environ)
+    env.pop("WHEEL_LINKS", None)
+    return env
+
+
 class TestRequirements:
     """Test the requirements module."""
 
@@ -36,7 +43,7 @@ class TestRequirements:
     @patch("homeassistant.util.package.is_virtual_env", return_value=True)
     @patch("homeassistant.util.package.is_docker_env", return_value=False)
     @patch("homeassistant.util.package.install_package", return_value=True)
-    @patch.dict(os.environ, {}, clear=True)
+    @patch.dict(os.environ, env_without_wheel_links(), clear=True)
     def test_requirement_installed_in_venv(
         self, mock_install, mock_denv, mock_venv, mock_dirname
     ):
@@ -56,7 +63,7 @@ class TestRequirements:
     @patch("homeassistant.util.package.is_virtual_env", return_value=False)
     @patch("homeassistant.util.package.is_docker_env", return_value=False)
     @patch("homeassistant.util.package.install_package", return_value=True)
-    @patch.dict(os.environ, {}, clear=True)
+    @patch.dict(os.environ, env_without_wheel_links(), clear=True)
     def test_requirement_installed_in_deps(
         self, mock_install, mock_denv, mock_venv, mock_dirname
     ):
@@ -157,7 +164,7 @@ async def test_install_on_docker(hass):
     ), patch("homeassistant.util.package.install_package") as mock_inst, patch(
         "os.path.dirname"
     ) as mock_dir, patch.dict(
-        os.environ, {}, clear=True
+        os.environ, env_without_wheel_links(), clear=True
     ):
         mock_dir.return_value = "ha_package_path"
         assert await setup.async_setup_component(hass, "comp", {})

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,7 +1,7 @@
 """Test requirements module."""
 import os
 from pathlib import Path
-from unittest.mock import patch, call
+from unittest.mock import patch, call, ANY
 from pytest import raises
 
 from homeassistant import setup
@@ -49,6 +49,8 @@ class TestRequirements:
             "package==0.0.1",
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
             no_cache_dir=False,
+            # To allow running tests in hass.io images
+            find_links=ANY,
         )
 
     @patch("os.path.dirname")
@@ -69,6 +71,8 @@ class TestRequirements:
             target=self.hass.config.path("deps"),
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
             no_cache_dir=False,
+            # To allow running tests in hass.io images
+            find_links=ANY,
         )
 
 
@@ -163,6 +167,8 @@ async def test_install_on_docker(hass):
             "hello==1.0.0",
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
             no_cache_dir=True,
+            # To allow running tests in hass.io images
+            find_links=ANY,
         )
 
 


### PR DESCRIPTION
## Description:
Fix running the requirements test running in Hass.io image.

Happened because Hass.io image runs with `WHEEL_LINKS=https://…` which causes an extra call arg.

Found by @frenck 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
