### PR TITLE
Improve evohome debug logging

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -454,6 +454,8 @@ class EvoChild(EvoDevice):
             self._evo_device.schedule(), refresh=False
         )
 
+        _LOGGER.warn("Schedule['%s'] = %s", self._unique_id, self._schedule)
+
     async def async_update(self) -> None:
         """Get the latest state data."""
         next_sp_from = self._setpoints.get("next_sp_from", "2000-01-01T00:00:00+00:00")

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -454,7 +454,7 @@ class EvoChild(EvoDevice):
             self._evo_device.schedule(), refresh=False
         )
 
-        _LOGGER.warn("Schedule['%s'] = %s", self._unique_id, self._schedule)
+        _LOGGER.warn("Schedule['%s'] = %s", self.name, self._schedule)
 
     async def async_update(self) -> None:
         """Get the latest state data."""

--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -454,7 +454,7 @@ class EvoChild(EvoDevice):
             self._evo_device.schedule(), refresh=False
         )
 
-        _LOGGER.warn("Schedule['%s'] = %s", self.name, self._schedule)
+        _LOGGER.debug("Schedule['%s'] = %s", self.name, self._schedule)
 
     async def async_update(self) -> None:
         """Get the latest state data."""


### PR DESCRIPTION
## Breaking Change:

None known.

## Description:
The **evohome** integration is now schedule-aware, and recently had taken on another new hardware platform, **RoundWireless**, with #27168.

I have been unable to test scheduling for **evohome** Thermostats (as opposed to HeatingZones) thus far - all users I know of use HA for scheduling!  In addition, this portion of the code is new (in 0.99), is not stable and so it is possible that there will be issues in the area in future (Winter is here now)...

This PR adds debug logging for Schedules in anticipation of a need.

Given this is a single line PR and (I feel) uncontroversial, I am happy to merge this PR without review.

**Related issue (if applicable):** fixes N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): 
```yaml
logger:
  logs:
    homeassistant.components.climate.evohome: debug
    homeassistant.components.water_heater.evohome: debug
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
