### PR TITLE
Fix template fan turn_on action

### DIFF
--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -270,7 +270,8 @@ class TemplateFan(FanEntity):
     # pylint: disable=arguments-differ
     async def async_turn_on(self, speed: str = None) -> None:
         """Turn on the fan."""
-        await self._on_script.async_run(context=self._context)
+        await self._on_script.async_run(
+            {ATTR_SPEED: speed}, context=self._context)
         self._state = STATE_ON
 
         if speed is not None:


### PR DESCRIPTION
The turn_on action of a template fan should
receive the 'speed' attribute in order to give
the user the possibility of define the behaviour
of this action as he desires

Fixes #27176 

## Description:

I have an esphome fan defined by 3 relays (one relay for speed). I have integrated it in Home Assistant using a template fan. When I call the service fan.turn_on with the following data: {"entity_id": "xxx", "speed": "3" } the fan always started at the speed 1 and after millisecods change to speed "3". The definition of the template fan turn_on is the following:

    turn_on:
      service: switch.turn_on
      data_template:
        entity_id: >
          {% if speed == '3' %}
            switch.ventilador_velocidad_3
          {% elif speed  == '2' %}
            switch.ventilador_velocidad_2
          {% else %}
            switch.ventilador_velocidad_1
          {% endif %}

The problem is that the 'speed' attribute does not contain anything.

This problem also happens in the frontend, when i set a speed in the checkbox, it calls the fan.turn_on {entity_id, speed} action, so the fan first turn_on at speed "1" and after that it changes the speed to "3".

**Related issue (if applicable):** fixes #27176

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
