### PR TITLE
Add improved scene support to the light integration

### DIFF
--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -70,21 +70,9 @@ async def _async_reproduce_state(
         return
 
     # Return if we are already at the right state.
-    # pylint: disable=too-many-boolean-expressions
-    if (
-        cur_state.state == state.state
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_BRIGHTNESS)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_COLOR_NAME)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_COLOR_TEMP)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_EFFECT)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_FLASH)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_HS_COLOR)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_KELVIN)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_PROFILE)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_RGB_COLOR)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_TRANSITION)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_WHITE_VALUE)
-        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_XY_COLOR)
+    if cur_state.state == state.state and all(
+        check_attr_equal(cur_state.attributes, state.attributes, attr)
+        for attr in ATTR_GROUP + COLOR_GROUP
     ):
         return
 

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -1,6 +1,7 @@
 """Reproduce an Light state."""
 import asyncio
 import logging
+from types import MappingProxyType
 from typing import Iterable, Optional
 
 from homeassistant.const import (
@@ -114,6 +115,8 @@ async def async_reproduce_states(
     )
 
 
-def check_attr_equal(attr1, attr2, attr_str):
+def check_attr_equal(
+    attr1: MappingProxyType, attr2: MappingProxyType, attr_str: str
+) -> bool:
     """Return true if the given attributes are equal."""
     return attr1.get(attr_str) == attr2.get(attr_str)

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -33,6 +33,15 @@ from . import (
 _LOGGER = logging.getLogger(__name__)
 
 VALID_STATES = {STATE_ON, STATE_OFF}
+
+ATTR_GROUP = [
+    ATTR_BRIGHTNESS,
+    ATTR_EFFECT,
+    ATTR_FLASH,
+    ATTR_WHITE_VALUE,
+    ATTR_TRANSITION,
+]
+
 COLOR_GROUP = [
     ATTR_COLOR_NAME,
     ATTR_COLOR_TEMP,
@@ -83,18 +92,13 @@ async def _async_reproduce_state(
 
     if state.state == STATE_ON:
         service = SERVICE_TURN_ON
-        if ATTR_BRIGHTNESS in state.attributes:
-            service_data[ATTR_BRIGHTNESS] = state.attributes[ATTR_BRIGHTNESS]
-        if ATTR_EFFECT in state.attributes:
-            service_data[ATTR_EFFECT] = state.attributes[ATTR_EFFECT]
-        if ATTR_FLASH in state.attributes:
-            service_data[ATTR_FLASH] = state.attributes[ATTR_FLASH]
-        if ATTR_TRANSITION in state.attributes:
-            service_data[ATTR_TRANSITION] = state.attributes[ATTR_TRANSITION]
-        if ATTR_WHITE_VALUE in state.attributes:
-            service_data[ATTR_WHITE_VALUE] = state.attributes[ATTR_WHITE_VALUE]
+        for attr in ATTR_GROUP:
+            # All attributes that are not colors
+            if attr in state.attributes:
+                service_data[attr] = state.attributes[attr]
 
         for color_attr in COLOR_GROUP:
+            # Choose the first color that is specified
             if color_attr in state.attributes:
                 service_data[color_attr] = state.attributes[color_attr]
                 break

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -17,15 +17,10 @@ from homeassistant.helpers.typing import HomeAssistantType
 from . import (
     DOMAIN,
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_NAME,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
-    ATTR_FLASH,
     ATTR_HS_COLOR,
-    ATTR_KELVIN,
-    ATTR_PROFILE,
     ATTR_RGB_COLOR,
-    ATTR_TRANSITION,
     ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
 )
@@ -33,24 +28,8 @@ from . import (
 _LOGGER = logging.getLogger(__name__)
 
 VALID_STATES = {STATE_ON, STATE_OFF}
-
-ATTR_GROUP = [
-    ATTR_BRIGHTNESS,
-    ATTR_EFFECT,
-    ATTR_FLASH,
-    ATTR_WHITE_VALUE,
-    ATTR_TRANSITION,
-]
-
-COLOR_GROUP = [
-    ATTR_COLOR_NAME,
-    ATTR_COLOR_TEMP,
-    ATTR_HS_COLOR,
-    ATTR_KELVIN,
-    ATTR_PROFILE,
-    ATTR_RGB_COLOR,
-    ATTR_XY_COLOR,
-]
+ATTR_GROUP = [ATTR_BRIGHTNESS, ATTR_EFFECT, ATTR_WHITE_VALUE]
+COLOR_GROUP = [ATTR_COLOR_TEMP, ATTR_HS_COLOR, ATTR_RGB_COLOR, ATTR_XY_COLOR]
 
 
 async def _async_reproduce_state(

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -61,6 +61,7 @@ async def _async_reproduce_state(
         return
 
     # Return if we are already at the right state.
+    # pylint: disable=too-many-boolean-expressions
     if (
         cur_state.state == state.state
         and check_attr_equal(cur_state.attributes, state.attributes, ATTR_BRIGHTNESS)

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -1,0 +1,119 @@
+"""Reproduce an Light state."""
+import asyncio
+import logging
+from typing import Iterable, Optional
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_ON,
+    STATE_OFF,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.core import Context, State
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import (
+    DOMAIN,
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_NAME,
+    ATTR_COLOR_TEMP,
+    ATTR_EFFECT,
+    ATTR_FLASH,
+    ATTR_HS_COLOR,
+    ATTR_KELVIN,
+    ATTR_PROFILE,
+    ATTR_RGB_COLOR,
+    ATTR_TRANSITION,
+    ATTR_WHITE_VALUE,
+    ATTR_XY_COLOR,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_STATES = {STATE_ON, STATE_OFF}
+COLOR_GROUP = [
+    ATTR_COLOR_NAME,
+    ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
+    ATTR_KELVIN,
+    ATTR_PROFILE,
+    ATTR_RGB_COLOR,
+    ATTR_XY_COLOR,
+]
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistantType, state: State, context: Optional[Context] = None
+) -> None:
+    """Reproduce a single state."""
+    cur_state = hass.states.get(state.entity_id)
+
+    if cur_state is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if state.state not in VALID_STATES:
+        _LOGGER.warning(
+            "Invalid state specified for %s: %s", state.entity_id, state.state
+        )
+        return
+
+    # Return if we are already at the right state.
+    if (
+        cur_state.state == state.state
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_BRIGHTNESS)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_COLOR_NAME)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_COLOR_TEMP)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_EFFECT)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_FLASH)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_HS_COLOR)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_KELVIN)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_PROFILE)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_RGB_COLOR)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_TRANSITION)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_WHITE_VALUE)
+        and check_attr_equal(cur_state.attributes, state.attributes, ATTR_XY_COLOR)
+    ):
+        return
+
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    if state.state == STATE_ON:
+        service = SERVICE_TURN_ON
+        if ATTR_BRIGHTNESS in state.attributes:
+            service_data[ATTR_BRIGHTNESS] = state.attributes[ATTR_BRIGHTNESS]
+        if ATTR_EFFECT in state.attributes:
+            service_data[ATTR_EFFECT] = state.attributes[ATTR_EFFECT]
+        if ATTR_FLASH in state.attributes:
+            service_data[ATTR_FLASH] = state.attributes[ATTR_FLASH]
+        if ATTR_TRANSITION in state.attributes:
+            service_data[ATTR_TRANSITION] = state.attributes[ATTR_TRANSITION]
+        if ATTR_WHITE_VALUE in state.attributes:
+            service_data[ATTR_WHITE_VALUE] = state.attributes[ATTR_WHITE_VALUE]
+
+        for color_attr in COLOR_GROUP:
+            if color_attr in state.attributes:
+                service_data[color_attr] = state.attributes[color_attr]
+                break
+
+    elif state.state == STATE_OFF:
+        service = SERVICE_TURN_OFF
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
+) -> None:
+    """Reproduce Light states."""
+    await asyncio.gather(
+        *(_async_reproduce_state(hass, state, context) for state in states)
+    )
+
+
+def check_attr_equal(attr1, attr2, attr_str):
+    """Return true if the given attributes are equal."""
+    return attr1.get(attr_str) == attr2.get(attr_str)

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -7,7 +7,18 @@ from tests.common import async_mock_service
 async def test_reproducing_states(hass, caplog):
     """Test reproducing Light states."""
     hass.states.async_set("light.entity_off", "off", {})
-    hass.states.async_set("light.entity_on", "on", {"color_name": "red"})
+    hass.states.async_set("light.entity_bright", "on", {"brightness": 180})
+    hass.states.async_set("light.entity_white", "on", {"white_value": 200})
+    hass.states.async_set("light.entity_flash", "on", {"flash": "short"})
+    hass.states.async_set("light.entity_effect", "on", {"effect": "random"})
+    hass.states.async_set("light.entity_trans", "on", {"transition": 15})
+    hass.states.async_set("light.entity_name", "on", {"color_name": "red"})
+    hass.states.async_set("light.entity_temp", "on", {"color_temp": 240})
+    hass.states.async_set("light.entity_hs", "on", {"hs_color": (345, 75)})
+    hass.states.async_set("light.entity_kelvin", "on", {"kelvin": 4000})
+    hass.states.async_set("light.entity_profile", "on", {"profile": "relax"})
+    hass.states.async_set("light.entity_rgb", "on", {"rgb_color": (255, 63, 111)})
+    hass.states.async_set("light.entity_xy", "on", {"xy_color": (0.59, 0.274)})
 
     turn_on_calls = async_mock_service(hass, "light", "turn_on")
     turn_off_calls = async_mock_service(hass, "light", "turn_off")
@@ -16,7 +27,18 @@ async def test_reproducing_states(hass, caplog):
     await hass.helpers.state.async_reproduce_state(
         [
             State("light.entity_off", "off"),
-            State("light.entity_on", "on", {"color_name": "red"}),
+            State("light.entity_bright", "on", {"brightness": 180}),
+            State("light.entity_white", "on", {"white_value": 200}),
+            State("light.entity_flash", "on", {"flash": "short"}),
+            State("light.entity_effect", "on", {"effect": "random"}),
+            State("light.entity_trans", "on", {"transition": 15}),
+            State("light.entity_name", "on", {"color_name": "red"}),
+            State("light.entity_temp", "on", {"color_temp": 240}),
+            State("light.entity_hs", "on", {"hs_color": (345, 75)}),
+            State("light.entity_kelvin", "on", {"kelvin": 4000}),
+            State("light.entity_profile", "on", {"profile": "relax"}),
+            State("light.entity_rgb", "on", {"rgb_color": (255, 63, 111)}),
+            State("light.entity_xy", "on", {"xy_color": (0.59, 0.274)}),
         ],
         blocking=True,
     )
@@ -36,21 +58,71 @@ async def test_reproducing_states(hass, caplog):
     # Make sure correct services are called
     await hass.helpers.state.async_reproduce_state(
         [
-            State("light.entity_on", "off"),
-            State("light.entity_off", "on", {"color_name": "red"}),
-            # Should not raise
-            State("light.non_existing", "on"),
+            State("light.entity_xy", "off"),
+            State("light.entity_off", "on", {"brightness": 180}),
+            State("light.entity_bright", "on", {"white_value": 200}),
+            State("light.entity_white", "on", {"flash": "short"}),
+            State("light.entity_flash", "on", {"effect": "random"}),
+            State("light.entity_effect", "on", {"transition": 15}),
+            State("light.entity_trans", "on", {"color_name": "red"}),
+            State("light.entity_name", "on", {"color_temp": 240}),
+            State("light.entity_temp", "on", {"hs_color": (345, 75)}),
+            State("light.entity_hs", "on", {"kelvin": 4000}),
+            State("light.entity_kelvin", "on", {"profile": "relax"}),
+            State("light.entity_profile", "on", {"rgb_color": (255, 63, 111)}),
+            State("light.entity_rgb", "on", {"xy_color": (0.59, 0.274)}),
         ],
         blocking=True,
     )
 
-    assert len(turn_on_calls) == 1
-    assert turn_on_calls[0].domain == "light"
-    assert turn_on_calls[0].data == {
-        "entity_id": "light.entity_off",
+    assert len(turn_on_calls) == 12
+
+    for i in range(0, 12):
+        assert turn_on_calls[i].domain == "light"
+
+    assert turn_on_calls[0].data == {"entity_id": "light.entity_off", "brightness": 180}
+    assert turn_on_calls[1].data == {
+        "entity_id": "light.entity_bright",
+        "white_value": 200,
+    }
+    assert turn_on_calls[2].data == {
+        "entity_id": "light.entity_white",
+        "flash": "short",
+    }
+    assert turn_on_calls[3].data == {
+        "entity_id": "light.entity_flash",
+        "effect": "random",
+    }
+    assert turn_on_calls[4].data == {
+        "entity_id": "light.entity_effect",
+        "transition": 15,
+    }
+    assert turn_on_calls[5].data == {
+        "entity_id": "light.entity_trans",
         "color_name": "red",
+    }
+    assert turn_on_calls[6].data == {
+        "entity_id": "light.entity_name",
+        "color_temp": 240,
+    }
+    assert turn_on_calls[7].data == {
+        "entity_id": "light.entity_temp",
+        "hs_color": (345, 75),
+    }
+    assert turn_on_calls[8].data == {"entity_id": "light.entity_hs", "kelvin": 4000}
+    assert turn_on_calls[9].data == {
+        "entity_id": "light.entity_kelvin",
+        "profile": "relax",
+    }
+    assert turn_on_calls[10].data == {
+        "entity_id": "light.entity_profile",
+        "rgb_color": (255, 63, 111),
+    }
+    assert turn_on_calls[11].data == {
+        "entity_id": "light.entity_rgb",
+        "xy_color": (0.59, 0.274),
     }
 
     assert len(turn_off_calls) == 1
     assert turn_off_calls[0].domain == "light"
-    assert turn_off_calls[0].data == {"entity_id": "light.entity_on"}
+    assert turn_off_calls[0].data == {"entity_id": "light.entity_xy"}

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -5,14 +5,9 @@ from tests.common import async_mock_service
 
 VALID_BRIGHTNESS = {"brightness": 180}
 VALID_WHITE_VALUE = {"white_value": 200}
-VALID_FLASH = {"flash": "short"}
 VALID_EFFECT = {"effect": "random"}
-VALID_TRANSITION = {"transition": 15}
-VALID_COLOR_NAME = {"color_name": "red"}
 VALID_COLOR_TEMP = {"color_temp": 240}
 VALID_HS_COLOR = {"hs_color": (345, 75)}
-VALID_KELVIN = {"kelvin": 4000}
-VALID_PROFILE = {"profile": "relax"}
 VALID_RGB_COLOR = {"rgb_color": (255, 63, 111)}
 VALID_XY_COLOR = {"xy_color": (0.59, 0.274)}
 
@@ -22,14 +17,9 @@ async def test_reproducing_states(hass, caplog):
     hass.states.async_set("light.entity_off", "off", {})
     hass.states.async_set("light.entity_bright", "on", VALID_BRIGHTNESS)
     hass.states.async_set("light.entity_white", "on", VALID_WHITE_VALUE)
-    hass.states.async_set("light.entity_flash", "on", VALID_FLASH)
     hass.states.async_set("light.entity_effect", "on", VALID_EFFECT)
-    hass.states.async_set("light.entity_trans", "on", VALID_TRANSITION)
-    hass.states.async_set("light.entity_name", "on", VALID_COLOR_NAME)
     hass.states.async_set("light.entity_temp", "on", VALID_COLOR_TEMP)
     hass.states.async_set("light.entity_hs", "on", VALID_HS_COLOR)
-    hass.states.async_set("light.entity_kelvin", "on", VALID_KELVIN)
-    hass.states.async_set("light.entity_profile", "on", VALID_PROFILE)
     hass.states.async_set("light.entity_rgb", "on", VALID_RGB_COLOR)
     hass.states.async_set("light.entity_xy", "on", VALID_XY_COLOR)
 
@@ -42,14 +32,9 @@ async def test_reproducing_states(hass, caplog):
             State("light.entity_off", "off"),
             State("light.entity_bright", "on", VALID_BRIGHTNESS),
             State("light.entity_white", "on", VALID_WHITE_VALUE),
-            State("light.entity_flash", "on", VALID_FLASH),
             State("light.entity_effect", "on", VALID_EFFECT),
-            State("light.entity_trans", "on", VALID_TRANSITION),
-            State("light.entity_name", "on", VALID_COLOR_NAME),
             State("light.entity_temp", "on", VALID_COLOR_TEMP),
             State("light.entity_hs", "on", VALID_HS_COLOR),
-            State("light.entity_kelvin", "on", VALID_KELVIN),
-            State("light.entity_profile", "on", VALID_PROFILE),
             State("light.entity_rgb", "on", VALID_RGB_COLOR),
             State("light.entity_xy", "on", VALID_XY_COLOR),
         ],
@@ -74,21 +59,16 @@ async def test_reproducing_states(hass, caplog):
             State("light.entity_xy", "off"),
             State("light.entity_off", "on", VALID_BRIGHTNESS),
             State("light.entity_bright", "on", VALID_WHITE_VALUE),
-            State("light.entity_white", "on", VALID_FLASH),
-            State("light.entity_flash", "on", VALID_EFFECT),
-            State("light.entity_effect", "on", VALID_TRANSITION),
-            State("light.entity_trans", "on", VALID_COLOR_NAME),
-            State("light.entity_name", "on", VALID_COLOR_TEMP),
+            State("light.entity_white", "on", VALID_EFFECT),
+            State("light.entity_effect", "on", VALID_COLOR_TEMP),
             State("light.entity_temp", "on", VALID_HS_COLOR),
-            State("light.entity_hs", "on", VALID_KELVIN),
-            State("light.entity_kelvin", "on", VALID_PROFILE),
-            State("light.entity_profile", "on", VALID_RGB_COLOR),
+            State("light.entity_hs", "on", VALID_RGB_COLOR),
             State("light.entity_rgb", "on", VALID_XY_COLOR),
         ],
         blocking=True,
     )
 
-    assert len(turn_on_calls) == 12
+    assert len(turn_on_calls) == 7
 
     expected_calls = []
 
@@ -100,41 +80,21 @@ async def test_reproducing_states(hass, caplog):
     expected_bright["entity_id"] = "light.entity_bright"
     expected_calls.append(expected_bright)
 
-    expected_white = VALID_FLASH
+    expected_white = VALID_EFFECT
     expected_white["entity_id"] = "light.entity_white"
     expected_calls.append(expected_white)
 
-    expected_flash = VALID_EFFECT
-    expected_flash["entity_id"] = "light.entity_flash"
-    expected_calls.append(expected_flash)
-
-    expected_effect = VALID_TRANSITION
+    expected_effect = VALID_COLOR_TEMP
     expected_effect["entity_id"] = "light.entity_effect"
     expected_calls.append(expected_effect)
-
-    expected_trans = VALID_COLOR_NAME
-    expected_trans["entity_id"] = "light.entity_trans"
-    expected_calls.append(expected_trans)
-
-    expected_name = VALID_COLOR_TEMP
-    expected_name["entity_id"] = "light.entity_name"
-    expected_calls.append(expected_name)
 
     expected_temp = VALID_HS_COLOR
     expected_temp["entity_id"] = "light.entity_temp"
     expected_calls.append(expected_temp)
 
-    expected_hs = VALID_KELVIN
+    expected_hs = VALID_RGB_COLOR
     expected_hs["entity_id"] = "light.entity_hs"
     expected_calls.append(expected_hs)
-
-    expected_kelvin = VALID_PROFILE
-    expected_kelvin["entity_id"] = "light.entity_kelvin"
-    expected_calls.append(expected_kelvin)
-
-    expected_profile = VALID_RGB_COLOR
-    expected_profile["entity_id"] = "light.entity_profile"
-    expected_calls.append(expected_profile)
 
     expected_rgb = VALID_XY_COLOR
     expected_rgb["entity_id"] = "light.entity_rgb"

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -3,22 +3,35 @@ from homeassistant.core import State
 
 from tests.common import async_mock_service
 
+VALID_BRIGHTNESS = {"brightness": 180}
+VALID_WHITE_VALUE = {"white_value": 200}
+VALID_FLASH = {"flash": "short"}
+VALID_EFFECT = {"effect": "random"}
+VALID_TRANSITION = {"transition": 15}
+VALID_COLOR_NAME = {"color_name": "red"}
+VALID_COLOR_TEMP = {"color_temp": 240}
+VALID_HS_COLOR = {"hs_color": (345, 75)}
+VALID_KELVIN = {"kelvin": 4000}
+VALID_PROFILE = {"profile": "relax"}
+VALID_RGB_COLOR = {"rgb_color": (255, 63, 111)}
+VALID_XY_COLOR = {"xy_color": (0.59, 0.274)}
+
 
 async def test_reproducing_states(hass, caplog):
     """Test reproducing Light states."""
     hass.states.async_set("light.entity_off", "off", {})
-    hass.states.async_set("light.entity_bright", "on", {"brightness": 180})
-    hass.states.async_set("light.entity_white", "on", {"white_value": 200})
-    hass.states.async_set("light.entity_flash", "on", {"flash": "short"})
-    hass.states.async_set("light.entity_effect", "on", {"effect": "random"})
-    hass.states.async_set("light.entity_trans", "on", {"transition": 15})
-    hass.states.async_set("light.entity_name", "on", {"color_name": "red"})
-    hass.states.async_set("light.entity_temp", "on", {"color_temp": 240})
-    hass.states.async_set("light.entity_hs", "on", {"hs_color": (345, 75)})
-    hass.states.async_set("light.entity_kelvin", "on", {"kelvin": 4000})
-    hass.states.async_set("light.entity_profile", "on", {"profile": "relax"})
-    hass.states.async_set("light.entity_rgb", "on", {"rgb_color": (255, 63, 111)})
-    hass.states.async_set("light.entity_xy", "on", {"xy_color": (0.59, 0.274)})
+    hass.states.async_set("light.entity_bright", "on", VALID_BRIGHTNESS)
+    hass.states.async_set("light.entity_white", "on", VALID_WHITE_VALUE)
+    hass.states.async_set("light.entity_flash", "on", VALID_FLASH)
+    hass.states.async_set("light.entity_effect", "on", VALID_EFFECT)
+    hass.states.async_set("light.entity_trans", "on", VALID_TRANSITION)
+    hass.states.async_set("light.entity_name", "on", VALID_COLOR_NAME)
+    hass.states.async_set("light.entity_temp", "on", VALID_COLOR_TEMP)
+    hass.states.async_set("light.entity_hs", "on", VALID_HS_COLOR)
+    hass.states.async_set("light.entity_kelvin", "on", VALID_KELVIN)
+    hass.states.async_set("light.entity_profile", "on", VALID_PROFILE)
+    hass.states.async_set("light.entity_rgb", "on", VALID_RGB_COLOR)
+    hass.states.async_set("light.entity_xy", "on", VALID_XY_COLOR)
 
     turn_on_calls = async_mock_service(hass, "light", "turn_on")
     turn_off_calls = async_mock_service(hass, "light", "turn_off")
@@ -27,18 +40,18 @@ async def test_reproducing_states(hass, caplog):
     await hass.helpers.state.async_reproduce_state(
         [
             State("light.entity_off", "off"),
-            State("light.entity_bright", "on", {"brightness": 180}),
-            State("light.entity_white", "on", {"white_value": 200}),
-            State("light.entity_flash", "on", {"flash": "short"}),
-            State("light.entity_effect", "on", {"effect": "random"}),
-            State("light.entity_trans", "on", {"transition": 15}),
-            State("light.entity_name", "on", {"color_name": "red"}),
-            State("light.entity_temp", "on", {"color_temp": 240}),
-            State("light.entity_hs", "on", {"hs_color": (345, 75)}),
-            State("light.entity_kelvin", "on", {"kelvin": 4000}),
-            State("light.entity_profile", "on", {"profile": "relax"}),
-            State("light.entity_rgb", "on", {"rgb_color": (255, 63, 111)}),
-            State("light.entity_xy", "on", {"xy_color": (0.59, 0.274)}),
+            State("light.entity_bright", "on", VALID_BRIGHTNESS),
+            State("light.entity_white", "on", VALID_WHITE_VALUE),
+            State("light.entity_flash", "on", VALID_FLASH),
+            State("light.entity_effect", "on", VALID_EFFECT),
+            State("light.entity_trans", "on", VALID_TRANSITION),
+            State("light.entity_name", "on", VALID_COLOR_NAME),
+            State("light.entity_temp", "on", VALID_COLOR_TEMP),
+            State("light.entity_hs", "on", VALID_HS_COLOR),
+            State("light.entity_kelvin", "on", VALID_KELVIN),
+            State("light.entity_profile", "on", VALID_PROFILE),
+            State("light.entity_rgb", "on", VALID_RGB_COLOR),
+            State("light.entity_xy", "on", VALID_XY_COLOR),
         ],
         blocking=True,
     )
@@ -59,18 +72,18 @@ async def test_reproducing_states(hass, caplog):
     await hass.helpers.state.async_reproduce_state(
         [
             State("light.entity_xy", "off"),
-            State("light.entity_off", "on", {"brightness": 180}),
-            State("light.entity_bright", "on", {"white_value": 200}),
-            State("light.entity_white", "on", {"flash": "short"}),
-            State("light.entity_flash", "on", {"effect": "random"}),
-            State("light.entity_effect", "on", {"transition": 15}),
-            State("light.entity_trans", "on", {"color_name": "red"}),
-            State("light.entity_name", "on", {"color_temp": 240}),
-            State("light.entity_temp", "on", {"hs_color": (345, 75)}),
-            State("light.entity_hs", "on", {"kelvin": 4000}),
-            State("light.entity_kelvin", "on", {"profile": "relax"}),
-            State("light.entity_profile", "on", {"rgb_color": (255, 63, 111)}),
-            State("light.entity_rgb", "on", {"xy_color": (0.59, 0.274)}),
+            State("light.entity_off", "on", VALID_BRIGHTNESS),
+            State("light.entity_bright", "on", VALID_WHITE_VALUE),
+            State("light.entity_white", "on", VALID_FLASH),
+            State("light.entity_flash", "on", VALID_EFFECT),
+            State("light.entity_effect", "on", VALID_TRANSITION),
+            State("light.entity_trans", "on", VALID_COLOR_NAME),
+            State("light.entity_name", "on", VALID_COLOR_TEMP),
+            State("light.entity_temp", "on", VALID_HS_COLOR),
+            State("light.entity_hs", "on", VALID_KELVIN),
+            State("light.entity_kelvin", "on", VALID_PROFILE),
+            State("light.entity_profile", "on", VALID_RGB_COLOR),
+            State("light.entity_rgb", "on", VALID_XY_COLOR),
         ],
         blocking=True,
     )
@@ -80,48 +93,53 @@ async def test_reproducing_states(hass, caplog):
     for i in range(0, 12):
         assert turn_on_calls[i].domain == "light"
 
-    assert turn_on_calls[0].data == {"entity_id": "light.entity_off", "brightness": 180}
-    assert turn_on_calls[1].data == {
-        "entity_id": "light.entity_bright",
-        "white_value": 200,
-    }
-    assert turn_on_calls[2].data == {
-        "entity_id": "light.entity_white",
-        "flash": "short",
-    }
-    assert turn_on_calls[3].data == {
-        "entity_id": "light.entity_flash",
-        "effect": "random",
-    }
-    assert turn_on_calls[4].data == {
-        "entity_id": "light.entity_effect",
-        "transition": 15,
-    }
-    assert turn_on_calls[5].data == {
-        "entity_id": "light.entity_trans",
-        "color_name": "red",
-    }
-    assert turn_on_calls[6].data == {
-        "entity_id": "light.entity_name",
-        "color_temp": 240,
-    }
-    assert turn_on_calls[7].data == {
-        "entity_id": "light.entity_temp",
-        "hs_color": (345, 75),
-    }
-    assert turn_on_calls[8].data == {"entity_id": "light.entity_hs", "kelvin": 4000}
-    assert turn_on_calls[9].data == {
-        "entity_id": "light.entity_kelvin",
-        "profile": "relax",
-    }
-    assert turn_on_calls[10].data == {
-        "entity_id": "light.entity_profile",
-        "rgb_color": (255, 63, 111),
-    }
-    assert turn_on_calls[11].data == {
-        "entity_id": "light.entity_rgb",
-        "xy_color": (0.59, 0.274),
-    }
+    expected_off = VALID_BRIGHTNESS
+    expected_off["entity_id"] = "light.entity_off"
+    assert turn_on_calls[0].data == expected_off
+
+    expected_bright = VALID_WHITE_VALUE
+    expected_bright["entity_id"] = "light.entity_bright"
+    assert turn_on_calls[1].data == expected_bright
+
+    expected_white = VALID_FLASH
+    expected_white["entity_id"] = "light.entity_white"
+    assert turn_on_calls[2].data == expected_white
+
+    expected_flash = VALID_EFFECT
+    expected_flash["entity_id"] = "light.entity_flash"
+    assert turn_on_calls[3].data == expected_flash
+
+    expected_effect = VALID_TRANSITION
+    expected_effect["entity_id"] = "light.entity_effect"
+    assert turn_on_calls[4].data == expected_effect
+
+    expected_trans = VALID_COLOR_NAME
+    expected_trans["entity_id"] = "light.entity_trans"
+    assert turn_on_calls[5].data == expected_trans
+
+    expected_name = VALID_COLOR_TEMP
+    expected_name["entity_id"] = "light.entity_name"
+    assert turn_on_calls[6].data == expected_name
+
+    expected_temp = VALID_HS_COLOR
+    expected_temp["entity_id"] = "light.entity_temp"
+    assert turn_on_calls[7].data == expected_temp
+
+    expected_hs = VALID_KELVIN
+    expected_hs["entity_id"] = "light.entity_hs"
+    assert turn_on_calls[8].data == expected_hs
+
+    expected_kelvin = VALID_PROFILE
+    expected_kelvin["entity_id"] = "light.entity_kelvin"
+    assert turn_on_calls[9].data == expected_kelvin
+
+    expected_profile = VALID_RGB_COLOR
+    expected_profile["entity_id"] = "light.entity_profile"
+    assert turn_on_calls[10].data == expected_profile
+
+    expected_rgb = VALID_XY_COLOR
+    expected_rgb["entity_id"] = "light.entity_rgb"
+    assert turn_on_calls[11].data == expected_rgb
 
     assert len(turn_off_calls) == 1
     assert turn_off_calls[0].domain == "light"

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -1,0 +1,56 @@
+"""Test reproduce state for Light."""
+from homeassistant.core import State
+
+from tests.common import async_mock_service
+
+
+async def test_reproducing_states(hass, caplog):
+    """Test reproducing Light states."""
+    hass.states.async_set("light.entity_off", "off", {})
+    hass.states.async_set("light.entity_on", "on", {"color_name": "red"})
+
+    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+    turn_off_calls = async_mock_service(hass, "light", "turn_off")
+
+    # These calls should do nothing as entities already in desired state
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("light.entity_off", "off"),
+            State("light.entity_on", "on", {"color_name": "red"}),
+        ],
+        blocking=True,
+    )
+
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+
+    # Test invalid state is handled
+    await hass.helpers.state.async_reproduce_state(
+        [State("light.entity_off", "not_supported")], blocking=True
+    )
+
+    assert "not_supported" in caplog.text
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+
+    # Make sure correct services are called
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("light.entity_on", "off"),
+            State("light.entity_off", "on", {"color_name": "red"}),
+            # Should not raise
+            State("light.non_existing", "on"),
+        ],
+        blocking=True,
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "light"
+    assert turn_on_calls[0].data == {
+        "entity_id": "light.entity_off",
+        "color_name": "red",
+    }
+
+    assert len(turn_off_calls) == 1
+    assert turn_off_calls[0].domain == "light"
+    assert turn_off_calls[0].data == {"entity_id": "light.entity_on"}

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -90,56 +90,67 @@ async def test_reproducing_states(hass, caplog):
 
     assert len(turn_on_calls) == 12
 
-    for i in range(0, 12):
-        assert turn_on_calls[i].domain == "light"
+    expected_calls = []
 
     expected_off = VALID_BRIGHTNESS
     expected_off["entity_id"] = "light.entity_off"
-    assert turn_on_calls[0].data == expected_off
+    expected_calls.append(expected_off)
 
     expected_bright = VALID_WHITE_VALUE
     expected_bright["entity_id"] = "light.entity_bright"
-    assert turn_on_calls[1].data == expected_bright
+    expected_calls.append(expected_bright)
 
     expected_white = VALID_FLASH
     expected_white["entity_id"] = "light.entity_white"
-    assert turn_on_calls[2].data == expected_white
+    expected_calls.append(expected_white)
 
     expected_flash = VALID_EFFECT
     expected_flash["entity_id"] = "light.entity_flash"
-    assert turn_on_calls[3].data == expected_flash
+    expected_calls.append(expected_flash)
 
     expected_effect = VALID_TRANSITION
     expected_effect["entity_id"] = "light.entity_effect"
-    assert turn_on_calls[4].data == expected_effect
+    expected_calls.append(expected_effect)
 
     expected_trans = VALID_COLOR_NAME
     expected_trans["entity_id"] = "light.entity_trans"
-    assert turn_on_calls[5].data == expected_trans
+    expected_calls.append(expected_trans)
 
     expected_name = VALID_COLOR_TEMP
     expected_name["entity_id"] = "light.entity_name"
-    assert turn_on_calls[6].data == expected_name
+    expected_calls.append(expected_name)
 
     expected_temp = VALID_HS_COLOR
     expected_temp["entity_id"] = "light.entity_temp"
-    assert turn_on_calls[7].data == expected_temp
+    expected_calls.append(expected_temp)
 
     expected_hs = VALID_KELVIN
     expected_hs["entity_id"] = "light.entity_hs"
-    assert turn_on_calls[8].data == expected_hs
+    expected_calls.append(expected_hs)
 
     expected_kelvin = VALID_PROFILE
     expected_kelvin["entity_id"] = "light.entity_kelvin"
-    assert turn_on_calls[9].data == expected_kelvin
+    expected_calls.append(expected_kelvin)
 
     expected_profile = VALID_RGB_COLOR
     expected_profile["entity_id"] = "light.entity_profile"
-    assert turn_on_calls[10].data == expected_profile
+    expected_calls.append(expected_profile)
 
     expected_rgb = VALID_XY_COLOR
     expected_rgb["entity_id"] = "light.entity_rgb"
-    assert turn_on_calls[11].data == expected_rgb
+    expected_calls.append(expected_rgb)
+
+    for call in turn_on_calls:
+        assert call.domain == "light"
+        found = False
+        for expected in expected_calls:
+            if call.data["entity_id"] == expected["entity_id"]:
+                # We found the matching entry
+                assert call.data == expected
+                found = True
+                break
+        # No entry found
+        assert found
 
     assert len(turn_off_calls) == 1
     assert turn_off_calls[0].domain == "light"

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -129,7 +129,7 @@ async def test_reproduce_turn_on(hass):
     last_call = calls[-1]
     assert last_call.domain == "light"
     assert SERVICE_TURN_ON == last_call.service
-    assert ["light.test"] == last_call.data.get("entity_id")
+    assert "light.test" == last_call.data.get("entity_id")
 
 
 async def test_reproduce_turn_off(hass):
@@ -146,7 +146,7 @@ async def test_reproduce_turn_off(hass):
     last_call = calls[-1]
     assert last_call.domain == "light"
     assert SERVICE_TURN_OFF == last_call.service
-    assert ["light.test"] == last_call.data.get("entity_id")
+    assert "light.test" == last_call.data.get("entity_id")
 
 
 async def test_reproduce_complex_data(hass):
@@ -155,10 +155,10 @@ async def test_reproduce_complex_data(hass):
 
     hass.states.async_set("light.test", "off")
 
-    complex_data = ["hello", {"11": "22"}]
+    complex_data = [255, 100, 100]
 
     await state.async_reproduce_state(
-        hass, ha.State("light.test", "on", {"complex": complex_data})
+        hass, ha.State("light.test", "on", {"rgb_color": complex_data})
     )
 
     await hass.async_block_till_done()
@@ -167,7 +167,7 @@ async def test_reproduce_complex_data(hass):
     last_call = calls[-1]
     assert last_call.domain == "light"
     assert SERVICE_TURN_ON == last_call.service
-    assert complex_data == last_call.data.get("complex")
+    assert complex_data == last_call.data.get("rgb_color")
 
 
 async def test_reproduce_bad_state(hass):


### PR DESCRIPTION
## Description:
Add improved scene support to the light integration.

**Related issue (if applicable):** fixes #26962

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html

## Additional Information
Some attributes are no longer available. You can use all attributes, that are show under _developer-tools -> states_.
Some common cases and their solutions are listed below:
- brightness has to be specified as `brightness` (value between 0 and 255). `brightness_pct` is no longer available.
- Colors have to be specified by either `hs_color`, `rgb_color` or `xy_color`. See the [docs](https://www.home-assistant.io/integrations/light/) to learn how to use these attributes.
- `profile` can not be used anymore. You have to specify the profile within the scene itself.
- Instead of `transition` you can use a script: Thanks to @exxamalte https://github.com/home-assistant/home-assistant/issues/28412#issuecomment-548704325 
