### PR TITLE
Update libpyfoscam to 1.1. Released March 20, 2019

### DIFF
--- a/homeassistant/components/foscam/manifest.json
+++ b/homeassistant/components/foscam/manifest.json
@@ -1,10 +1,10 @@
 {
-  "domain": "foscam",
-  "name": "Foscam",
-  "documentation": "https://www.home-assistant.io/integrations/foscam",
-  "requirements": [
-    "libpyfoscam==1.0"
-  ],
-  "dependencies": [],
-  "codeowners": []
+    "domain": "foscam",
+    "name": "Foscam",
+    "documentation": "https://www.home-assistant.io/integrations/foscam",
+    "requirements": [
+        "libpyfoscam==1.1"
+    ],
+    "dependencies": [],
+    "codeowners": []
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -733,7 +733,7 @@ lakeside==0.12
 libpurecool==0.5.0
 
 # homeassistant.components.foscam
-libpyfoscam==1.0
+libpyfoscam==1.1
 
 # homeassistant.components.vivotek
 libpyvivotek==0.2.2


### PR DESCRIPTION
## Description:

Update libpyfoscam to most recent version 1.1 Released on March 20, 2019
https://pypi.org/project/libpyfoscam/#history

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
