### PR TITLE
Add examples to lights service

### DIFF
--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -40,12 +40,14 @@ turn_on:
       description: Name of a light profile to use.
       example: relax
     flash:
-      description: If the light should flash.
+      description: If the light should flash. Valid values are short and long.
+      example: short
       values:
         - short
         - long
     effect:
       description: Light effect.
+      example: random
       values:
         - colorloop
         - random
@@ -60,7 +62,8 @@ turn_off:
       description: Duration in seconds it takes to get to next state.
       example: 60
     flash:
-      description: If the light should flash.
+      description: If the light should flash. Valid values are short and long.
+      example: short
       values:
         - short
         - long
@@ -105,12 +108,14 @@ toggle:
       description: Name of a light profile to use.
       example: relax
     flash:
-      description: If the light should flash.
+      description: If the light should flash. Valid values are short and long.
+      example: short
       values:
         - short
         - long
     effect:
       description: Light effect.
+      example: random
       values:
         - colorloop
         - random


### PR DESCRIPTION
## Description:
Add missing example fields for _flash_ and _effect_

Before:
![grafik](https://user-images.githubusercontent.com/15657682/66207831-11e17200-e6b4-11e9-94e5-ee391fa57186.png)

After:
![grafik](https://user-images.githubusercontent.com/15657682/66208178-c8455700-e6b4-11e9-918f-06f4753d558c.png)


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
