### PR TITLE
Add poll option for rpi_gpio binary sensor

### DIFF
--- a/homeassistant/components/rpi_gpio/__init__.py
+++ b/homeassistant/components/rpi_gpio/__init__.py
@@ -46,6 +46,14 @@ def read_input(port):
     return GPIO.input(port)
 
 
-def edge_detect(port, event_callback, bounce):
+def edge_detect(port, edge, event_callback, bounce):
     """Add detection for RISING and FALLING events."""
-    GPIO.add_event_detect(port, GPIO.BOTH, callback=event_callback, bouncetime=bounce)
+
+    if edge == "RISING":
+        edge = GPIO.RISING
+    elif edge == "FALLING":
+        edge = GPIO.FALLING
+    elif edge == "BOTH":
+        edge = GPIO.BOTH
+
+    GPIO.add_event_detect(port, edge, callback=event_callback, bouncetime=bounce)

--- a/homeassistant/components/rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/rpi_gpio/binary_sensor.py
@@ -1,5 +1,6 @@
 """Support for binary sensor using RPi GPIO."""
 import logging
+from enum import Enum
 
 import voluptuous as vol
 
@@ -14,10 +15,31 @@ CONF_BOUNCETIME = "bouncetime"
 CONF_INVERT_LOGIC = "invert_logic"
 CONF_PORTS = "ports"
 CONF_PULL_MODE = "pull_mode"
+CONF_DETECT = "detect"
 
 DEFAULT_BOUNCETIME = 50
 DEFAULT_INVERT_LOGIC = False
 DEFAULT_PULL_MODE = "UP"
+DEFAULT_DETECT = "input"
+
+
+class DetectConfig:
+    """RPi GPIO edge detection configuration."""
+
+    def __init__(self, poll: bool, edge: bool):
+        """Initialise configuration options."""
+
+        self.poll = poll
+        self.edge = edge
+
+
+class DetectEnum(Enum):
+    """Sensor detection modes for config validation."""
+
+    input = DetectConfig(poll=False, edge=False)
+    input_poll = DetectConfig(poll=True, edge=False)
+    edge = DetectConfig(poll=True, edge=True)
+
 
 _SENSORS_SCHEMA = vol.Schema({cv.positive_int: cv.string})
 
@@ -27,6 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_BOUNCETIME, default=DEFAULT_BOUNCETIME): cv.positive_int,
         vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean,
         vol.Optional(CONF_PULL_MODE, default=DEFAULT_PULL_MODE): cv.string,
+        vol.Optional(CONF_DETECT, default=DEFAULT_DETECT): cv.enum(DetectEnum),
     }
 )
 
@@ -36,13 +59,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     pull_mode = config.get(CONF_PULL_MODE)
     bouncetime = config.get(CONF_BOUNCETIME)
     invert_logic = config.get(CONF_INVERT_LOGIC)
+    detect = config.get(CONF_DETECT).value
 
     binary_sensors = []
     ports = config.get("ports")
     for port_num, port_name in ports.items():
         binary_sensors.append(
             RPiGPIOBinarySensor(
-                port_name, port_num, pull_mode, bouncetime, invert_logic
+                port_name, port_num, pull_mode, bouncetime, invert_logic, detect
             )
         )
     add_entities(binary_sensors, True)
@@ -51,28 +75,39 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class RPiGPIOBinarySensor(BinarySensorDevice):
     """Represent a binary sensor that uses Raspberry Pi GPIO."""
 
-    def __init__(self, name, port, pull_mode, bouncetime, invert_logic):
+    def __init__(self, name, port, pull_mode, bouncetime, invert_logic, detect):
         """Initialize the RPi binary sensor."""
         self._name = name or DEVICE_DEFAULT_NAME
         self._port = port
         self._pull_mode = pull_mode
         self._bouncetime = bouncetime
         self._invert_logic = invert_logic
+        self._detect = detect
         self._state = None
 
         rpi_gpio.setup_input(self._port, self._pull_mode)
 
         def read_gpio(port):
-            """Read state from GPIO."""
-            self._state = rpi_gpio.read_input(self._port)
+            """Edge detection callback."""
+            self._state = (
+                rpi_gpio.read_input(self._port) ^ self._invert_logic
+            ) or self._detect.edge
             self.schedule_update_ha_state()
 
-        rpi_gpio.edge_detect(self._port, read_gpio, self._bouncetime)
+        if self._detect.edge:
+            if self._invert_logic:
+                trigger_edge = "FALLING"
+            else:
+                trigger_edge = "RISING"
+        else:
+            trigger_edge = "BOTH"
+
+        rpi_gpio.edge_detect(self._port, trigger_edge, read_gpio, self._bouncetime)
 
     @property
     def should_poll(self):
-        """No polling needed."""
-        return False
+        """Poll GPIO status if configured."""
+        return self._detect.poll
 
     @property
     def name(self):
@@ -82,8 +117,8 @@ class RPiGPIOBinarySensor(BinarySensorDevice):
     @property
     def is_on(self):
         """Return the state of the entity."""
-        return self._state != self._invert_logic
+        return self._state
 
     def update(self):
         """Update the GPIO state."""
-        self._state = rpi_gpio.read_input(self._port)
+        self._state = rpi_gpio.read_input(self._port) ^ self._invert_logic


### PR DESCRIPTION
## Description:

This small change adds a `poll` option to the `rpi_gpio` binary sensor that enables polling. This fixes a stuck sensor due to a missed edge after at most `scan_interval` seconds.

I do not have a local development environment (this was implemented and tested as a custom component) but if there is interest and no one else is willing to help out, I will try and add the missing items below.

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
binary_sensor:
  - platform: rpi_gpio
    poll: true 
    scan_interval: 1
    ports:
      11: PIR Office
      12: PIR Bedroom
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
