### PR TITLE
Centralize helper method get_location_from_attributes for travel_time integrations

### DIFF
--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -9,8 +9,6 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
     ATTR_MODE,
     CONF_MODE,
     CONF_NAME,
@@ -18,10 +16,11 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM_IMPERIAL,
     CONF_UNIT_SYSTEM_METRIC,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import location
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.travel_time import get_location_from_attributes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -299,7 +298,7 @@ class HERETravelTimeSensor(Entity):
 
         # Check if the entity has location attributes
         if location.has_location(entity):
-            return self._get_location_from_attributes(entity)
+            return get_location_from_attributes(entity)
 
         # Check if device is in a zone
         zone_entity = self.hass.states.get("zone.{}".format(entity.state))
@@ -307,17 +306,11 @@ class HERETravelTimeSensor(Entity):
             _LOGGER.debug(
                 "%s is in %s, getting zone location", entity_id, zone_entity.entity_id
             )
-            return self._get_location_from_attributes(zone_entity)
+            return get_location_from_attributes(zone_entity)
 
         # If zone was not found in state then use the state as the location
         if entity_id.startswith("sensor."):
             return entity.state
-
-    @staticmethod
-    def _get_location_from_attributes(entity: State) -> str:
-        """Get the lat/long string from an entities attributes."""
-        attr = entity.attributes
-        return "{},{}".format(attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))
 
 
 class HERETravelTimeData:

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -10,15 +10,14 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     CONF_NAME,
     CONF_REGION,
-    EVENT_HOMEASSISTANT_START,
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
-    CONF_UNIT_SYSTEM_METRIC,
     CONF_UNIT_SYSTEM_IMPERIAL,
+    CONF_UNIT_SYSTEM_METRIC,
+    EVENT_HOMEASSISTANT_START,
 )
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.travel_time import get_location_from_attributes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,12 +89,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, lambda _: sensor.update())
-
-
-def _get_location_from_attributes(state):
-    """Get the lat/long string from an states attributes."""
-    attr = state.attributes
-    return "{},{}".format(attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))
 
 
 class WazeTravelTime(Entity):
@@ -172,7 +165,7 @@ class WazeTravelTime(Entity):
         # Check if the entity has location attributes.
         if location.has_location(state):
             _LOGGER.debug("Getting %s location", entity_id)
-            return _get_location_from_attributes(state)
+            return get_location_from_attributes(state)
 
         # Check if device is inside a zone.
         zone_state = self.hass.states.get(f"zone.{state.state}")
@@ -180,7 +173,7 @@ class WazeTravelTime(Entity):
             _LOGGER.debug(
                 "%s is in %s, getting zone location", entity_id, zone_state.entity_id
             )
-            return _get_location_from_attributes(zone_state)
+            return get_location_from_attributes(zone_state)
 
         # If zone was not found in state then use the state as the location.
         if entity_id.startswith("sensor."):
@@ -194,7 +187,7 @@ class WazeTravelTime(Entity):
         states = self.hass.states.all()
         for state in states:
             if state.domain == "zone" and state.name == friendly_name:
-                return _get_location_from_attributes(state)
+                return get_location_from_attributes(state)
 
         return friendly_name
 

--- a/homeassistant/helpers/travel_time.py
+++ b/homeassistant/helpers/travel_time.py
@@ -1,0 +1,9 @@
+"""Helper methods for travel_time integrations."""
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.core import State
+
+
+def get_location_from_attributes(entity: State) -> str:
+    """Get the lat/long string from an entities attributes."""
+    attr = entity.attributes
+    return "{},{}".format(attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))


### PR DESCRIPTION
## Description:

The start of https://github.com/home-assistant/architecture/issues/166.
Remove duplicate code and use central helper methods.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
