### PR TITLE
Add improved scene support to the lock integration

### DIFF
--- a/homeassistant/components/lock/reproduce_state.py
+++ b/homeassistant/components/lock/reproduce_state.py
@@ -1,0 +1,61 @@
+"""Reproduce an Lock state."""
+import asyncio
+import logging
+from typing import Iterable, Optional
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+    SERVICE_LOCK,
+    SERVICE_UNLOCK,
+)
+from homeassistant.core import Context, State
+from homeassistant.helpers.typing import HomeAssistantType
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_STATES = {STATE_LOCKED, STATE_UNLOCKED}
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistantType, state: State, context: Optional[Context] = None
+) -> None:
+    """Reproduce a single state."""
+    cur_state = hass.states.get(state.entity_id)
+
+    if cur_state is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if state.state not in VALID_STATES:
+        _LOGGER.warning(
+            "Invalid state specified for %s: %s", state.entity_id, state.state
+        )
+        return
+
+    # Return if we are already at the right state.
+    if cur_state.state == state.state:
+        return
+
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    if state.state == STATE_LOCKED:
+        service = SERVICE_LOCK
+    elif state.state == STATE_UNLOCKED:
+        service = SERVICE_UNLOCK
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistantType, states: Iterable[State], context: Optional[Context] = None
+) -> None:
+    """Reproduce Lock states."""
+    await asyncio.gather(
+        *(_async_reproduce_state(hass, state, context) for state in states)
+    )

--- a/tests/components/lock/test_reproduce_state.py
+++ b/tests/components/lock/test_reproduce_state.py
@@ -1,0 +1,53 @@
+"""Test reproduce state for Lock."""
+from homeassistant.core import State
+
+from tests.common import async_mock_service
+
+
+async def test_reproducing_states(hass, caplog):
+    """Test reproducing Lock states."""
+    hass.states.async_set("lock.entity_locked", "locked", {})
+    hass.states.async_set("lock.entity_unlocked", "unlocked", {})
+
+    lock_calls = async_mock_service(hass, "lock", "lock")
+    unlock_calls = async_mock_service(hass, "lock", "unlock")
+
+    # These calls should do nothing as entities already in desired state
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("lock.entity_locked", "locked"),
+            State("lock.entity_unlocked", "unlocked", {}),
+        ],
+        blocking=True,
+    )
+
+    assert len(lock_calls) == 0
+    assert len(unlock_calls) == 0
+
+    # Test invalid state is handled
+    await hass.helpers.state.async_reproduce_state(
+        [State("lock.entity_locked", "not_supported")], blocking=True
+    )
+
+    assert "not_supported" in caplog.text
+    assert len(lock_calls) == 0
+    assert len(unlock_calls) == 0
+
+    # Make sure correct services are called
+    await hass.helpers.state.async_reproduce_state(
+        [
+            State("lock.entity_locked", "unlocked"),
+            State("lock.entity_unlocked", "locked"),
+            # Should not raise
+            State("lock.non_existing", "on"),
+        ],
+        blocking=True,
+    )
+
+    assert len(lock_calls) == 1
+    assert lock_calls[0].domain == "lock"
+    assert lock_calls[0].data == {"entity_id": "lock.entity_unlocked"}
+
+    assert len(unlock_calls) == 1
+    assert unlock_calls[0].domain == "lock"
+    assert unlock_calls[0].data == {"entity_id": "lock.entity_locked"}


### PR DESCRIPTION
## Description:
Add improved scene support to the lock integration

**Related issue (if applicable):** fixes #26973

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
