### PR TITLE
Add service description to lock.open

### DIFF
--- a/homeassistant/components/lock/services.yaml
+++ b/homeassistant/components/lock/services.yaml
@@ -47,6 +47,16 @@ lock:
       description: An optional code to lock the lock with.
       example: 1234
 
+open:
+  description: Open all or specified locks.
+  fields:
+    entity_id:
+      description: Name of lock to open.
+      example: 'lock.front_door'
+    code:
+      description: An optional code to open the lock with.
+      example: 1234
+
 set_usercode:
   description: Set a usercode to lock.
   fields:


### PR DESCRIPTION
## Description:
Add service description to lock.open
![image](https://user-images.githubusercontent.com/15657682/66226950-55e86d00-e6dc-11e9-8d76-4edebeee3c96.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
