### PR TITLE
Add exclude_scenes option for vera

### DIFF
--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -28,6 +28,8 @@ VERA_CONTROLLER = "vera_controller"
 
 CONF_CONTROLLER = "vera_controller_url"
 
+CONF_EXCLUDE_SCENES = "exclude_scenes"
+
 VERA_ID_FORMAT = "{}_{}"
 
 ATTR_CURRENT_POWER_W = "current_power_w"
@@ -44,6 +46,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_CONTROLLER): cv.url,
                 vol.Optional(CONF_EXCLUDE, default=[]): VERA_ID_LIST_SCHEMA,
+                vol.Optional(CONF_EXCLUDE_SCENES, default=[]): VERA_ID_LIST_SCHEMA,
                 vol.Optional(CONF_LIGHTS, default=[]): VERA_ID_LIST_SCHEMA,
             }
         )
@@ -78,6 +81,7 @@ def setup(hass, base_config):
     base_url = config.get(CONF_CONTROLLER)
     light_ids = config.get(CONF_LIGHTS)
     exclude_ids = config.get(CONF_EXCLUDE)
+    exclude_scene_ids = config.get(CONF_EXCLUDE_SCENES)
 
     # Initialize the Vera controller.
     controller, _ = veraApi.init_controller(base_url)
@@ -105,8 +109,11 @@ def setup(hass, base_config):
         vera_devices[device_type].append(device)
     hass.data[VERA_DEVICES] = vera_devices
 
+    # Exclude scenes unwanted by user.
+    scenes = [scene for scene in all_scenes if scene.scene_id not in exclude_scene_ids]
+
     vera_scenes = []
-    for scene in all_scenes:
+    for scene in scenes:
         vera_scenes.append(scene)
     hass.data[VERA_SCENES] = vera_scenes
 


### PR DESCRIPTION
## Description:

This adds the exclude_scenes option to the vera integration.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10606

## Example entry for `configuration.yaml` (if applicable):
```yaml
vera:
  vera_controller_url: http://192.168.1.161:3480/
  exclude: [ 13, 14, 16, 20, 23, 72, 73, 74, 75, 76, 77, 78, 88, 89, 99]
  exclude_scenes: [5, 6]
  lights: [15, 17, 19, 21, 22, 24, 26, 43, 64, 70, 87]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
