### PR TITLE
Allow device registry to get populated without unique_id

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -160,7 +160,8 @@ class EntityRegistry:
 
         if unique_id:
             entity_id = self.async_get_entity_id(domain, platform, unique_id)
-        else:
+
+        if entity_id is None:
             entity_id = self.async_generate_entity_id(
                 domain,
                 suggested_object_id or f"{platform}_{unique_id}",


### PR DESCRIPTION
## Description:
Let device registry get populated without unique_id on entities. This allow entities that can't set good unique id's to still create devices and make use of the new features related to device configuration.

This will let entities without unique_id into entity registry. This will let entities make use of new features such as disabled by default and rename of visible name (whole customize.yaml could theoretically now move into entity registry).

Entries are added to the entity registry by their suggested_name. A new entity_id is generated via the standard rules for non unique_id entities (first come, first served basis). Since this is a stable way of generating entity_ids, settings for the entity will be retained.

### Known issues that should be okey
 - The order of platform addition of conflictingly named entities will decided which entry in the registry will be mapped to them. So they may get wrong settings. But this same issue is currently present for customize.yaml and any service/function that relies on entity_id:s. 

### Known issues that must be solved:
 - Renaming entity_id via gui will fail (solvable with extension to storage format, or by disabling feature in gui)
 - Don't allow entities that have no linked config entry into entity registry since those will never get cleaned up.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
