### PR TITLE
Fix ecobee binary sensor and sensor unique ids

### DIFF
--- a/homeassistant/components/ecobee/binary_sensor.py
+++ b/homeassistant/components/ecobee/binary_sensor.py
@@ -50,7 +50,8 @@ class EcobeeBinarySensor(BinarySensorDevice):
             if sensor["name"] == self.sensor_name:
                 if "code" in sensor:
                     return f"{sensor['code']}-{self.device_class}"
-                return f"{sensor['id']}-{self.device_class}"
+                thermostat = self.data.ecobee.get_thermostat(self.index)
+                return f"{thermostat['identifier']}-{sensor['id']}-{self.device_class}"
 
     @property
     def device_info(self):

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -61,7 +61,8 @@ class EcobeeSensor(Entity):
             if sensor["name"] == self.sensor_name:
                 if "code" in sensor:
                     return f"{sensor['code']}-{self.device_class}"
-                return f"{sensor['id']}-{self.device_class}"
+                thermostat = self.data.ecobee.get_thermostat(self.index)
+                return f"{thermostat['identifier']}-{sensor['id']}-{self.device_class}"
 
     @property
     def device_info(self):


### PR DESCRIPTION
## Description:

As it turns out the ecobee API documentation has a different interpretation of the word "unique" than I do. What they mean to say is "unique to a particular thermostat". When a user has multiple thermostats (as @arsaboo does) the value I used for unique_id for the sensors built into the thermostat is no longer unique. I've added the thermostat serial number in this situation which will make the value truly unique across thermostats. @arsaboo is testing.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
