### PR TITLE
Add documentation for logger.set_level service

### DIFF
--- a/homeassistant/components/logger/services.yaml
+++ b/homeassistant/components/logger/services.yaml
@@ -2,31 +2,24 @@ set_default_level:
   description: Set the default log level for components.
   fields:
     level:
-      description: "Default severity level. Possible values are notset, debug,
-        info, warn, warning, error, fatal, critical"
+      description: "Default severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
       example: debug
 
 set_level:
   description: Set log level for components.
   fields:
     homeassistant.core:
-      description: "Home Assistant name space severity level. Possible values are notset, debug,
-        info, warn, warning, error, fatal, critical"
+      description: "Home Assistant name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
       example: debug
     homeassistant.components.mqtt:
-      description: "Integration name space severity level. Possible values are notset, debug,
-        info, warn, warning, error, fatal, critical"
+      description: "Integration name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
       example: warning
     homeassistant.components.smartthings.light:
-      description: "Component platform name space severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical"
+      description: "Component platform name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
       example: info
     custom_components.my_integration:
-      description: "Custom component name space severity level. Possible values are notset, debug,
-        info, warn, warning, error, fatal, critical"
+      description: "Custom component name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
       example: debug
     aiohttp:
-      description: "Python module name space severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical"
+      description: "Python module name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
       example: error
-

--- a/homeassistant/components/logger/services.yaml
+++ b/homeassistant/components/logger/services.yaml
@@ -1,6 +1,44 @@
 set_default_level:
   description: Set the default log level for components.
   fields:
-    level: {description: 'Default severity level. Possible values are notset, debug,
-        info, warn, warning, error, fatal, critical', example: debug}
-set_level: {description: Set log level for components.}
+    level:
+      { description: "Default severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical", example: debug }
+set_level:
+  description: Set log level for components.
+  fields:
+    homeassistant.core:
+      {
+        description:
+          "Home Assistant name space severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical",
+        example: debug,
+      }
+    homeassistant.components.mqtt:
+      {
+        description:
+          "Integration name space severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical",
+        example: warning,
+      }
+    homeassistant.components.smartthings.light:
+      {
+        description:
+          "Component platform name space severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical",
+        example: info,
+      }
+    custom_components.my_integration:
+      {
+        description:
+          "Custom component name space severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical",
+        example: debug,
+      }
+    aiohttp:
+      {
+        description:
+          "Python module name space severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical",
+        example: error,
+      }

--- a/homeassistant/components/logger/services.yaml
+++ b/homeassistant/components/logger/services.yaml
@@ -2,43 +2,31 @@ set_default_level:
   description: Set the default log level for components.
   fields:
     level:
-      { description: "Default severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical", example: debug }
+      description: "Default severity level. Possible values are notset, debug,
+        info, warn, warning, error, fatal, critical"
+      example: debug
+
 set_level:
   description: Set log level for components.
   fields:
     homeassistant.core:
-      {
-        description:
-          "Home Assistant name space severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical",
-        example: debug,
-      }
+      description: "Home Assistant name space severity level. Possible values are notset, debug,
+        info, warn, warning, error, fatal, critical"
+      example: debug
     homeassistant.components.mqtt:
-      {
-        description:
-          "Integration name space severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical",
-        example: warning,
-      }
+      description: "Integration name space severity level. Possible values are notset, debug,
+        info, warn, warning, error, fatal, critical"
+      example: warning
     homeassistant.components.smartthings.light:
-      {
-        description:
-          "Component platform name space severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical",
-        example: info,
-      }
+      description: "Component platform name space severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical"
+      example: info
     custom_components.my_integration:
-      {
-        description:
-          "Custom component name space severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical",
-        example: debug,
-      }
+      description: "Custom component name space severity level. Possible values are notset, debug,
+        info, warn, warning, error, fatal, critical"
+      example: debug
     aiohttp:
-      {
-        description:
-          "Python module name space severity level. Possible values are notset, debug,
-          info, warn, warning, error, fatal, critical",
-        example: error,
-      }
+      description: "Python module name space severity level. Possible values are notset, debug,
+          info, warn, warning, error, fatal, critical"
+      example: error
+

--- a/homeassistant/components/logger/services.yaml
+++ b/homeassistant/components/logger/services.yaml
@@ -2,24 +2,21 @@ set_default_level:
   description: Set the default log level for components.
   fields:
     level:
-      description: "Default severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
+      description: "Default severity level. Possible values are debug, info, warn, warning, error, fatal, critical"
       example: debug
 
 set_level:
   description: Set log level for components.
   fields:
     homeassistant.core:
-      description: "Home Assistant name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
+      description: "Example on how to change the logging level for a Home Assistant core components. Possible values are debug, info, warn, warning, error, fatal, critical"
       example: debug
     homeassistant.components.mqtt:
-      description: "Integration name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
+      description: "Example on how to change the logging level for an Integration. Possible values are debug, info, warn, warning, error, fatal, critical"
       example: warning
-    homeassistant.components.smartthings.light:
-      description: "Component platform name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
-      example: info
     custom_components.my_integration:
-      description: "Custom component name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
+      description: "Example on how to change the logging level for a Custom Integration. Possible values are debug, info, warn, warning, error, fatal, critical"
       example: debug
     aiohttp:
-      description: "Python module name space severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical"
+      description: "Example on how to change the logging level for a Python module. Possible values are debug, info, warn, warning, error, fatal, critical"
       example: error


### PR DESCRIPTION
## Description:

Add missing description for `logger.set_level` service in `services.yaml`


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html