### PR TITLE
Add missing documentation for some Hassio services

### DIFF
--- a/homeassistant/components/hassio/services.yaml
+++ b/homeassistant/components/hassio/services.yaml
@@ -7,36 +7,42 @@ addon_install:
     version:
       description: Optional or it will be use the latest version.
       example: "0.2"
+
 addon_start:
   description: Start a HassIO docker addon.
   fields:
     addon:
       description: Name of addon.
       example: smb_config
+
 addon_restart:
   description: Restart a HassIO docker addon.
   fields:
     addon:
       description: Name of addon.
       example: smb_config
+
 addon_stdin:
   description: Write data to a HassIO docker addon stdin .
   fields:
     addon:
       description: Name of addon.
       example: smb_config
+
 addon_stop:
   description: Stop a HassIO docker addon.
   fields:
     addon:
       description: Name of addon.
       example: smb_config
+
 addon_uninstall:
   description: Uninstall a HassIO docker addon.
   fields:
     addon:
       description: Name of addon.
       example: smb_config
+
 addon_update:
   description: Update a HassIO docker addon.
   fields:
@@ -46,24 +52,30 @@ addon_update:
     version:
       description: Optional or it will be use the latest version.
       example: "0.2"
+
 homeassistant_update:
   description: Update HomeAssistant docker image.
   fields:
     version:
       description: Optional or it will be use the latest version.
       example: 0.40.1
+
 host_reboot:
   description: Reboot host computer.
+
 host_shutdown:
   description: Poweroff host computer.
+
 host_update:
   description: Update host computer.
   fields:
     version:
       description: Optional or it will be use the latest version.
       example: "0.3"
+
 supervisor_reload:
   description: Reload HassIO supervisor addons/updates/configs.
+
 supervisor_update:
   description: Update HassIO supervisor.
   fields:

--- a/homeassistant/components/hassio/services.yaml
+++ b/homeassistant/components/hassio/services.yaml
@@ -1,5 +1,5 @@
 addon_install:
-  description: Install a HassIO docker add-on.
+  description: Install a Hass.io docker add-on.
   fields:
     addon:
       description: The add-on slug.
@@ -9,42 +9,42 @@ addon_install:
       example: "0.2"
 
 addon_start:
-  description: Start a HassIO docker add-on.
+  description: Start a Hass.io docker add-on.
   fields:
     addon:
       description: The add-on slug.
       example: core_ssh
 
 addon_restart:
-  description: Restart a HassIO docker add-on.
+  description: Restart a Hass.io docker add-on.
   fields:
     addon:
       description: The add-on slug.
       example: core_ssh
 
 addon_stdin:
-  description: Write data to a HassIO docker add-on stdin .
+  description: Write data to a Hass.io docker add-on stdin .
   fields:
     addon:
       description: The add-on slug.
       example: core_ssh
 
 addon_stop:
-  description: Stop a HassIO docker add-on.
+  description: Stop a Hass.io docker add-on.
   fields:
     addon:
       description: The add-on slug.
       example: core_ssh
 
 addon_uninstall:
-  description: Uninstall a HassIO docker add-on.
+  description: Uninstall a Hass.io docker add-on.
   fields:
     addon:
       description: The add-on slug.
       example: core_ssh
 
 addon_update:
-  description: Update a HassIO docker add-on.
+  description: Update a Hass.io docker add-on.
   fields:
     addon:
       description: The add-on slug.
@@ -74,10 +74,10 @@ host_update:
       example: "0.3"
 
 supervisor_reload:
-  description: Reload the HassIO supervisor.
+  description: Reload the Hass.io supervisor.
 
 supervisor_update:
-  description: Update the HassIO supervisor.
+  description: Update the Hass.io supervisor.
   fields:
     version:
       description: Optional or it will be use the latest version.

--- a/homeassistant/components/hassio/services.yaml
+++ b/homeassistant/components/hassio/services.yaml
@@ -1,83 +1,83 @@
 addon_install:
-  description: Install a HassIO docker addon.
+  description: Install a HassIO docker add-on.
   fields:
     addon:
-      description: Name of addon.
-      example: smb_config
+      description: The add-on slug.
+      example: core_ssh
     version:
       description: Optional or it will be use the latest version.
       example: "0.2"
 
 addon_start:
-  description: Start a HassIO docker addon.
+  description: Start a HassIO docker add-on.
   fields:
     addon:
-      description: Name of addon.
-      example: smb_config
+      description: The add-on slug.
+      example: core_ssh
 
 addon_restart:
-  description: Restart a HassIO docker addon.
+  description: Restart a HassIO docker add-on.
   fields:
     addon:
-      description: Name of addon.
-      example: smb_config
+      description: The add-on slug.
+      example: core_ssh
 
 addon_stdin:
-  description: Write data to a HassIO docker addon stdin .
+  description: Write data to a HassIO docker add-on stdin .
   fields:
     addon:
-      description: Name of addon.
-      example: smb_config
+      description: The add-on slug.
+      example: core_ssh
 
 addon_stop:
-  description: Stop a HassIO docker addon.
+  description: Stop a HassIO docker add-on.
   fields:
     addon:
-      description: Name of addon.
-      example: smb_config
+      description: The add-on slug.
+      example: core_ssh
 
 addon_uninstall:
-  description: Uninstall a HassIO docker addon.
+  description: Uninstall a HassIO docker add-on.
   fields:
     addon:
-      description: Name of addon.
-      example: smb_config
+      description: The add-on slug.
+      example: core_ssh
 
 addon_update:
-  description: Update a HassIO docker addon.
+  description: Update a HassIO docker add-on.
   fields:
     addon:
-      description: Name of addon.
-      example: smb_config
+      description: The add-on slug.
+      example: core_ssh
     version:
       description: Optional or it will be use the latest version.
       example: "0.2"
 
 homeassistant_update:
-  description: Update HomeAssistant docker image.
+  description: Update the Home Assistant docker image.
   fields:
     version:
       description: Optional or it will be use the latest version.
       example: 0.40.1
 
 host_reboot:
-  description: Reboot host computer.
+  description: Reboot the host system.
 
 host_shutdown:
-  description: Poweroff host computer.
+  description: Poweroff the host system.
 
 host_update:
-  description: Update host computer.
+  description: Update the host system.
   fields:
     version:
       description: Optional or it will be use the latest version.
       example: "0.3"
 
 supervisor_reload:
-  description: Reload HassIO supervisor addons/updates/configs.
+  description: Reload the HassIO supervisor.
 
 supervisor_update:
-  description: Update HassIO supervisor.
+  description: Update the HassIO supervisor.
   fields:
     version:
       description: Optional or it will be use the latest version.

--- a/homeassistant/components/hassio/services.yaml
+++ b/homeassistant/components/hassio/services.yaml
@@ -1,37 +1,66 @@
 addon_install:
   description: Install a HassIO docker addon.
   fields:
-    addon: {description: Name of addon., example: smb_config}
-    version: {description: Optional or it will be use the latest version., example: '0.2'}
+    addon: { description: Name of addon., example: smb_config }
+    version:
+      {
+        description: Optional or it will be use the latest version.,
+        example: "0.2",
+      }
 addon_start:
   description: Start a HassIO docker addon.
   fields:
-    addon: {description: Name of addon., example: smb_config}
+    addon: { description: Name of addon., example: smb_config }
+addon_restart:
+  description: Restart a HassIO docker addon.
+  fields:
+    addon: { description: Name of addon., example: smb_config }
+addon_stdin:
+  description: Write data to a HassIO docker addon stdin .
+  fields:
+    addon: { description: Name of addon., example: smb_config }
 addon_stop:
   description: Stop a HassIO docker addon.
   fields:
-    addon: {description: Name of addon., example: smb_config}
+    addon: { description: Name of addon., example: smb_config }
 addon_uninstall:
   description: Uninstall a HassIO docker addon.
   fields:
-    addon: {description: Name of addon., example: smb_config}
+    addon: { description: Name of addon., example: smb_config }
 addon_update:
   description: Update a HassIO docker addon.
   fields:
-    addon: {description: Name of addon., example: smb_config}
-    version: {description: Optional or it will be use the latest version., example: '0.2'}
+    addon: { description: Name of addon., example: smb_config }
+    version:
+      {
+        description: Optional or it will be use the latest version.,
+        example: "0.2",
+      }
 homeassistant_update:
   description: Update HomeAssistant docker image.
   fields:
-    version: {description: Optional or it will be use the latest version., example: 0.40.1}
-host_reboot: {description: Reboot host computer.}
-host_shutdown: {description: Poweroff host computer.}
+    version:
+      {
+        description: Optional or it will be use the latest version.,
+        example: 0.40.1,
+      }
+host_reboot: { description: Reboot host computer. }
+host_shutdown: { description: Poweroff host computer. }
 host_update:
   description: Update host computer.
   fields:
-    version: {description: Optional or it will be use the latest version., example: '0.3'}
-supervisor_reload: {description: Reload HassIO supervisor addons/updates/configs.}
+    version:
+      {
+        description: Optional or it will be use the latest version.,
+        example: "0.3",
+      }
+supervisor_reload:
+  { description: Reload HassIO supervisor addons/updates/configs. }
 supervisor_update:
   description: Update HassIO supervisor.
   fields:
-    version: {description: Optional or it will be use the latest version., example: '0.3'}
+    version:
+      {
+        description: Optional or it will be use the latest version.,
+        example: "0.3",
+      }

--- a/homeassistant/components/hassio/services.yaml
+++ b/homeassistant/components/hassio/services.yaml
@@ -1,66 +1,72 @@
 addon_install:
   description: Install a HassIO docker addon.
   fields:
-    addon: { description: Name of addon., example: smb_config }
+    addon:
+      description: Name of addon.
+      example: smb_config
     version:
-      {
-        description: Optional or it will be use the latest version.,
-        example: "0.2",
-      }
+      description: Optional or it will be use the latest version.
+      example: "0.2"
 addon_start:
   description: Start a HassIO docker addon.
   fields:
-    addon: { description: Name of addon., example: smb_config }
+    addon:
+      description: Name of addon.
+      example: smb_config
 addon_restart:
   description: Restart a HassIO docker addon.
   fields:
-    addon: { description: Name of addon., example: smb_config }
+    addon:
+      description: Name of addon.
+      example: smb_config
 addon_stdin:
   description: Write data to a HassIO docker addon stdin .
   fields:
-    addon: { description: Name of addon., example: smb_config }
+    addon:
+      description: Name of addon.
+      example: smb_config
 addon_stop:
   description: Stop a HassIO docker addon.
   fields:
-    addon: { description: Name of addon., example: smb_config }
+    addon:
+      description: Name of addon.
+      example: smb_config
 addon_uninstall:
   description: Uninstall a HassIO docker addon.
   fields:
-    addon: { description: Name of addon., example: smb_config }
+    addon:
+      description: Name of addon.
+      example: smb_config
 addon_update:
   description: Update a HassIO docker addon.
   fields:
-    addon: { description: Name of addon., example: smb_config }
+    addon:
+      description: Name of addon.
+      example: smb_config
     version:
-      {
-        description: Optional or it will be use the latest version.,
-        example: "0.2",
-      }
+      description: Optional or it will be use the latest version.
+      example: "0.2"
 homeassistant_update:
   description: Update HomeAssistant docker image.
   fields:
     version:
-      {
-        description: Optional or it will be use the latest version.,
-        example: 0.40.1,
-      }
-host_reboot: { description: Reboot host computer. }
-host_shutdown: { description: Poweroff host computer. }
+      description: Optional or it will be use the latest version.
+      example: 0.40.1
+host_reboot:
+  description: Reboot host computer.
+host_shutdown:
+  description: Poweroff host computer.
 host_update:
   description: Update host computer.
   fields:
     version:
-      {
-        description: Optional or it will be use the latest version.,
-        example: "0.3",
-      }
+      description: Optional or it will be use the latest version.
+      example: "0.3"
 supervisor_reload:
-  { description: Reload HassIO supervisor addons/updates/configs. }
+  description: Reload HassIO supervisor addons/updates/configs.
 supervisor_update:
   description: Update HassIO supervisor.
   fields:
     version:
-      {
-        description: Optional or it will be use the latest version.,
-        example: "0.3",
-      }
+      description: Optional or it will be use the latest version.
+      example: "0.3"


### PR DESCRIPTION
## Description:
Add missing documentation for `addon_restart` and `addon_stdin` for hassio integration in `services.yaml` file.
I Took the opportunity to reformat all the file in full YAML

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html