### PR TITLE
Add missing homeassistant.set_location service documentation

### DIFF
--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -7,6 +7,16 @@ reload_core_config:
 restart:
   description: Restart the Home Assistant service.
 
+set_location:
+  description: Update the Home Assistant location.
+  fields:
+    latitude:
+      description: Latitude of your location
+      example: 32.87336
+    longitude:
+      description: Longitude of your location
+      example: 117.22743
+
 stop:
   description: Stop the Home Assistant service.
 


### PR DESCRIPTION
## Description:
Add the documentation for `homeassistant.set_location` service in `services.yaml` file.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
