### PR TITLE
Add guards for missing information in call stack frames

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -600,7 +600,8 @@ def deprecated(
     if module is not None:
         module_name = module.__name__
     else:
-        # Unclear when it is None, but it happens, so let's guard.
+        # If Python is unable to access the sources files, the call stack frame
+        # will be missing information, so let's guard.
         # https://github.com/home-assistant/home-assistant/issues/24982
         module_name = __name__
 

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -54,7 +54,15 @@ def get_deprecated(
     and a warning is issued to the user.
     """
     if old_name in config:
-        module_name = inspect.getmodule(inspect.stack()[1][0]).__name__  # type: ignore
+        module = inspect.getmodule(inspect.stack()[1][0])
+        if module is not None:
+            module_name = module.__name__
+        else:
+            # If Python is unable to access the sources files, the call stack frame
+            # will be missing information, so let's guard.
+            # https://github.com/home-assistant/home-assistant/issues/24982
+            module_name = __name__
+
         logger = logging.getLogger(module_name)
         logger.warning(
             "'%s' is deprecated. Please rename '%s' to '%s' in your "

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -494,7 +494,10 @@ def test_deprecated_with_no_optionals(caplog, schema):
     test_data = {"mars": True}
     output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 1
-    assert caplog.records[0].name == __name__
+    assert caplog.records[0].name in [
+        __name__,
+        "homeassistant.helpers.config_validation",
+    ]
     assert (
         "The 'mars' option (with value 'True') is deprecated, "
         "please remove it from your configuration"

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -72,12 +72,8 @@ async def test_async_create_catching_coro(hass, caplog):
 
     async def job():
         raise Exception("This is a bad coroutine")
-        pass
 
     hass.async_create_task(logging_util.async_create_catching_coro(job()))
     await hass.async_block_till_done()
     assert "This is a bad coroutine" in caplog.text
-    assert (
-        "hass.async_create_task("
-        "logging_util.async_create_catching_coro(job()))" in caplog.text
-    )
+    assert "in test_async_create_catching_coro" in caplog.text


### PR DESCRIPTION
## Description:

I've run into an issue when I started mixing up running a local development setup & jumping into a VSCode dev container from the same git clone of the codebase. I was working on an improvement for our VSCode dev container, but in my newer setup, the tests failed in weird ways.

So what is happening?

When installing with `pip install -e .`, a symlink is created to install the `homeassistant` module.

Let's assume, for this example, the Home Assistant code is in `/home/frenck/homeassistant`.

- I've ran `pip install -e .` from the `/home/frenck/homeassistant` folder. The symlink is now expecting it to be in that folder, so it points to it.
- Start a Docker container, volume mount `/home/frenck/homeassistant` as `/workspace`.

Whenever Home Assistant now calls up the call trace, it will be missing information. Python will search for information in files located in `/home/frenck/homeassistant`, however, inside that container, it is not available. We only have `/workspace`.

This is why we get `NoneType` and other missing information, like the code of the line called, in our call trace.

This PR adjusts and guards all occurrences and adjust the tests to allow for this case.

As a result:

- In case Python cannot access the source files, the log messages will be outputted via an "incorrect" logger.
- `logging_util.async_create_catching_coro()` tests have been adjusted to not check for the source line in the trace, since well, it is simply not there in those cases. I've replaced it with a piece that is available in both cases.

**Related issue (if applicable):** #25077, fixes #24982

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
🚫  Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
🚫 [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
🚫  New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
🚫  Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been ~~added~~ adjusted to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
