### PR TITLE
Fix pioneer volume when using onkyo component

### DIFF
--- a/homeassistant/components/onkyo/manifest.json
+++ b/homeassistant/components/onkyo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Onkyo",
   "documentation": "https://www.home-assistant.io/components/onkyo",
   "requirements": [
-    "onkyo-eiscp==1.2.4"
+    "onkyo-eiscp==1.2.5"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/onkyo/manifest.json
+++ b/homeassistant/components/onkyo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Onkyo",
   "documentation": "https://www.home-assistant.io/components/onkyo",
   "requirements": [
-    "onkyo-eiscp==1.2.5"
+    "onkyo-eiscp==1.2.7"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -76,11 +76,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_RECEIVER_MAX_VOLUME, default=DEFAULT_RECEIVER_MAX_VOLUME): vol.All(
-            vol.Coerce(int)
-        ),
         vol.Optional(CONF_MAX_VOLUME, default=SUPPORTED_MAX_VOLUME): vol.All(
             vol.Coerce(int), vol.Range(min=1, max=100)
+        ),
+        vol.Optional(CONF_RECEIVER_MAX_VOLUME, default=DEFAULT_RECEIVER_MAX_VOLUME): vol.All(
+            vol.Coerce(int), vol.Range(min=0)
         ),
         vol.Optional(CONF_SOURCES, default=DEFAULT_SOURCES): {cv.string: cv.string},
     }
@@ -335,13 +335,12 @@ class OnkyoDevice(MediaPlayerDevice):
 
     def set_volume_level(self, volume):
         """
-        Set volume level, input is range 0..1. however full volume on the amp
-        is usually far too loud so allow the user to specify the upper range with CONF_MAX_VOLUME
+        Set volume level, input is range 0..1.
 
-        First we change as per max_volume set by user. This means that if max volume is 80 then full
+        However full volume on the amp is usually far too loud so allow the user to specify the upper range
+        with CONF_MAX_VOLUME.  we change as per max_volume set by user. This means that if max volume is 80 then full
         volume in HA will give 80% volume on the receiver. Then we convert
-        that to the correct scale for the receiver."""
-
+        that to the correct scale for the receiver.
         """
 #        HA_VOL * (MAX VOL / 100) * MAX_RECEIVER_VOL
         self.command(f"volume {int(volume * (self._max_volume / 100) * self._receiver_max_volume)}")
@@ -452,12 +451,12 @@ class OnkyoDeviceZone(OnkyoDevice):
 
     def set_volume_level(self, volume):
         """
-        Set volume level, input is range 0..1. however full volume on the amp
-        is usually far too loud so allow the user to specify the upper range with CONF_MAX_VOLUME
+        Set volume level, input is range 0..1.
 
-        First we change as per max_volume set by user. This means that if max volume is 80 then full
+        However full volume on the amp is usually far too loud so allow the user to specify the upper range
+        with CONF_MAX_VOLUME.  we change as per max_volume set by user. This means that if max volume is 80 then full
         volume in HA will give 80% volume on the receiver. Then we convert
-        that to the correct scale for the receiver."""
+        that to the correct scale for the receiver.
         """
         # HA_VOL * (MAX VOL / 100) * MAX_RECEIVER_VOL
         self.command(f"zone{self._zone}.volume={int(volume * (self._max_volume / 100) * self._receiver_max_volume)}")

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -215,7 +215,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class OnkyoDevice(MediaPlayerDevice):
     """Representation of an Onkyo device."""
 
-    def __init__(self, receiver, sources, name, max_volume, receiver_max_volume):
+    def __init__(self, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME, receiver_max_volume=DEFAULT_RECEIVER_MAX_VOLUME):
         """Initialize the Onkyo Receiver."""
         self._receiver = receiver
         self._muted = False
@@ -388,7 +388,7 @@ class OnkyoDevice(MediaPlayerDevice):
 class OnkyoDeviceZone(OnkyoDevice):
     """Representation of an Onkyo device's extra zone."""
 
-    def __init__(self, zone, receiver, sources, name, max_volume, receiver_max_volume):
+    def __init__(self, zone, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME, receiver_max_volume=DEFAULT_RECEIVER_MAX_VOLUME):
         """Initialize the Zone with the zone identifier."""
         self._zone = zone
         self._supports_volume = True

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -209,7 +209,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class OnkyoDevice(MediaPlayerDevice):
     """Representation of an Onkyo device."""
 
-    def __init__(self, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME):
+    def __init__(self, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME, receiver_max_volume=RECEIVER_MAX_VOLUME):
         """Initialize the Onkyo Receiver."""
         self._receiver = receiver
         self._muted = False
@@ -219,6 +219,7 @@ class OnkyoDevice(MediaPlayerDevice):
             name or f"{receiver.info['model_name']}_{receiver.info['identifier']}"
         )
         self._max_volume = max_volume
+        self._receiver_max_volume = receiver_max_volume
         self._current_source = None
         self._source_list = list(sources.values())
         self._source_mapping = sources
@@ -276,7 +277,7 @@ class OnkyoDevice(MediaPlayerDevice):
 
         self._muted = bool(mute_raw[1] == "on")
 #       AMP_VOL/MAX_RECEIVER_VOL*(MAX_VOL/100)
-        self._volume = volume_raw[1] / RECEIVER_MAX_VOLUME * (self._max_volume / 100)
+        self._volume = volume_raw[1] / self._receiver_max_volume * (self._max_volume / 100)
 #       self._volume = volume_raw[1] / self._max_volume
 
         if not hdmi_out_raw:
@@ -336,7 +337,7 @@ class OnkyoDevice(MediaPlayerDevice):
         """
 #        self.command(f"volume {int(volume * self._max_volume)}")
 #        HA_VOL * (MAX VOL / 100) * MAX_RECEIVER_VOL
-        self.command(f"volume {int(volume * (self._max_volume / 100) * RECEIVER_MAX_VOLUME)}")
+        self.command(f"volume {int(volume * (self._max_volume / 100) * self._receiver_max_volume)}")
 
     def volume_up(self):
         """Increase volume by 1 step."""
@@ -377,11 +378,11 @@ class OnkyoDevice(MediaPlayerDevice):
 class OnkyoDeviceZone(OnkyoDevice):
     """Representation of an Onkyo device's extra zone."""
 
-    def __init__(self, zone, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME):
+    def __init__(self, zone, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME, receiver_max_volume=RECEIVER_MAX_VOLUME):
         """Initialize the Zone with the zone identifier."""
         self._zone = zone
         self._supports_volume = True
-        super().__init__(receiver, sources, name, max_volume)
+        super().__init__(receiver, sources, name, max_volume, receiver_max_volumr)
 
     def update(self):
         """Get the latest state from the device."""
@@ -430,7 +431,7 @@ class OnkyoDeviceZone(OnkyoDevice):
         if self._supports_volume:
             # self._volume = volume_raw[1] / 80.0
             # AMP_VOL/MAX_RECEIVER_VOL*(MAX_VOL/100)
-            self._volume = volume_raw[1] / RECEIVER_MAX_VOLUME * (self._max_volume / 100)
+            self._volume = volume_raw[1] / self._receiver_max_volume * (self._max_volume / 100)
 
     @property
     def supported_features(self):
@@ -447,7 +448,7 @@ class OnkyoDeviceZone(OnkyoDevice):
         """Set volume level, input is range 0..1. Onkyo ranges from 1-80."""
         # self.command(f"zone{self._zone}.volume={int(volume * 80)}")
         # HA_VOL * (MAX VOL / 100) * MAX_RECEIVER_VOL
-        self.command(f"zone{self._zone}.volume={int(volume * (self._max_volume / 100) * RECEIVER_MAX_VOLUME)}")
+        self.command(f"zone{self._zone}.volume={int(volume * (self._max_volume / 100) * self._receiver_max_volume)}")
 
     def volume_up(self):
         """Increase volume by 1 step."""

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -215,7 +215,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class OnkyoDevice(MediaPlayerDevice):
     """Representation of an Onkyo device."""
 
-    def __init__(self, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME, receiver_max_volume=DEFAULT_RECEIVER_MAX_VOLUME):
+    def __init__(
+        self,
+        receiver,
+        sources,
+        name=None,
+        max_volume=SUPPORTED_MAX_VOLUME,
+        receiver_max_volume=DEFAULT_RECEIVER_MAX_VOLUME,
+    ):
         """Initialize the Onkyo Receiver."""
         self._receiver = receiver
         self._muted = False
@@ -388,7 +395,15 @@ class OnkyoDevice(MediaPlayerDevice):
 class OnkyoDeviceZone(OnkyoDevice):
     """Representation of an Onkyo device's extra zone."""
 
-    def __init__(self, zone, receiver, sources, name=None, max_volume=SUPPORTED_MAX_VOLUME, receiver_max_volume=DEFAULT_RECEIVER_MAX_VOLUME):
+    def __init__(
+        self,
+        zone,
+        receiver,
+        sources,
+        name=None,
+        max_volume=SUPPORTED_MAX_VOLUME,
+        receiver_max_volume=DEFAULT_RECEIVER_MAX_VOLUME,
+    ):
         """Initialize the Zone with the zone identifier."""
         self._zone = zone
         self._supports_volume = True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -890,7 +890,7 @@ oauth2client==4.0.0
 oemthermostat==1.1
 
 # homeassistant.components.onkyo
-onkyo-eiscp==1.2.4
+onkyo-eiscp==1.2.7
 
 # homeassistant.components.onvif
 onvif-zeep-async==0.2.0


### PR DESCRIPTION
## Breaking Change:

Added max_receiver_volume which sets the maximum volume of the receiver - this will default to 80 which worked with older Onkyo models. See documentation for details on how to find your receivers max volume.

The max_volume is now a percentage instead of a number from 0 to 80. If you have a max_volume setting of 80 you will need to change this to 100, if you have it as 40 you will need to change this to 50. To work out the new max volume setting use this formula: 

(<current setting> / 80) * 100

## Description:


**Related issue (if applicable):**
fixes #10712
closes #26341

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):**
https://github.com/home-assistant/home-assistant.io/pull/10627

## Example entry for `configuration.yaml` (if applicable):
```yaml
    - platform: onkyo
      host: 192.168.0.80
      name: Amplifier
      # A HA volume of 100 will convert to 80% of the receivers max volume
      max_volume: 80 
      # The max volume number the receiver expects
      receiver_max_volume: 164
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
