### PR TITLE
add script shortcut for activating scenes

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -885,6 +885,8 @@ DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
 
 DEVICE_ACTION_SCHEMA = DEVICE_ACTION_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
 
+_SCRIPT_SCENE_SCHEMA = vol.Schema({vol.Required("scene"): string})
+
 SCRIPT_SCHEMA = vol.All(
     ensure_list,
     [
@@ -895,6 +897,7 @@ SCRIPT_SCHEMA = vol.All(
             EVENT_SCHEMA,
             CONDITION_SCHEMA,
             DEVICE_ACTION_SCHEMA,
+            _SCRIPT_SCENE_SCHEMA,
         )
     ],
 )

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -885,7 +885,7 @@ DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
 
 DEVICE_ACTION_SCHEMA = DEVICE_ACTION_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
 
-_SCRIPT_SCENE_SCHEMA = vol.Schema({vol.Required("scene"): string})
+_SCRIPT_SCENE_SCHEMA = vol.Schema({vol.Required("scene"): entity_domain("scene")})
 
 SCRIPT_SCHEMA = vol.All(
     ensure_list,


### PR DESCRIPTION
## Description:

Use `- scene: scene.<scene name>` in a script to activate a scene instead of writing

```yaml
- service: scene.turn_on
  data:
    entity_id: scene.<scene name>
```

Should it be just `-scene: <scene name>`? Writing `-scene: scene.` seems redundant.

**Related issue (if applicable):** fixes #27026

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io):** home-assistant/home-assistant.io#10616
**Pull request for [frontend](https://github.com/home-assistant/home-assistant-polymer):** home-assistant/home-assistant-polymer#<home-assistant-polymer PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
script:
  message_temperature:
    sequence:
      - scene: scene.morning_living_room
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
