### PR TITLE
Bump adb-shell to 0.0.4; bump androidtv to 0.0.30

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,8 +3,8 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
-    "adb-shell==0.0.3",
-    "androidtv==0.0.29"
+    "adb-shell==0.0.4",
+    "androidtv==0.0.30"
   ],
   "dependencies": [],
   "codeowners": ["@JeffLIrion"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -112,7 +112,7 @@ adafruit-blinka==1.2.1
 adafruit-circuitpython-mcp230xx==1.1.2
 
 # homeassistant.components.androidtv
-adb-shell==0.0.3
+adb-shell==0.0.4
 
 # homeassistant.components.adguard
 adguardhome==0.2.1
@@ -203,7 +203,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.29
+androidtv==0.0.30
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -83,7 +83,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.29
+androidtv==0.0.30
 
 # homeassistant.components.apns
 apns2==0.3.0


### PR DESCRIPTION
## Description:

Improve support for newer devices using the [Python ADB implementation](https://www.home-assistant.io/components/androidtv/#2-python-adb-implementation) (as opposed to the [ADB server](https://www.home-assistant.io/components/androidtv/#1-adb-server) approach).  

**Related issue (if applicable):** This fixes a bug where the ADB connection attempt would fail but `adb-shell` would incorrectly report to `androidtv` that the connection was available, and when `androidtv` would send an ADB command it would cause an exception.  With this fix in place, if the ADB connection attempt fails then a `PlatformNotReady` exception will be raised, which is the desired behavior.  

This also applies to the case that a re-connect attempt fails, which could occur during a reboot of the device. 

### Any chance this bug fix could be included in 0.100?

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
