### PR TITLE
Add io:SomfyBasicContactIOSystemSensor to TaHoma component

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -42,6 +42,7 @@ TAHOMA_TYPES = {
     "io:RollerShutterUnoIOComponent": "cover",
     "io:RollerShutterVeluxIOComponent": "cover",
     "io:RollerShutterWithLowSpeedManagementIOComponent": "cover",
+    "io:SomfyBasicContactIOSystemSensor": "sensor",
     "io:SomfyContactIOSystemSensor": "sensor",
     "io:VerticalExteriorAwningIOComponent": "cover",
     "io:WindowOpenerVeluxIOComponent": "cover",

--- a/homeassistant/components/tahoma/sensor.py
+++ b/homeassistant/components/tahoma/sensor.py
@@ -44,6 +44,8 @@ class TahomaSensor(TahomaDevice, Entity):
             return None
         if self.tahoma_device.type == "io:SomfyContactIOSystemSensor":
             return None
+        if self.tahoma_device.type == "io:SomfyBasicContactIOSystemSensor":
+            return None
         if self.tahoma_device.type == "io:LightIOSystemSensor":
             return "lx"
         if self.tahoma_device.type == "Humidity Sensor":
@@ -62,6 +64,11 @@ class TahomaSensor(TahomaDevice, Entity):
                 self.tahoma_device.active_states.get("core:StatusState") == "available"
             )
         if self.tahoma_device.type == "io:SomfyContactIOSystemSensor":
+            self.current_value = self.tahoma_device.active_states["core:ContactState"]
+            self._available = bool(
+                self.tahoma_device.active_states.get("core:StatusState") == "available"
+            )
+        if self.tahoma_device.type == "io:SomfyBasicContactIOSystemSensor":
             self.current_value = self.tahoma_device.active_states["core:ContactState"]
             self._available = bool(
                 self.tahoma_device.active_states.get("core:StatusState") == "available"


### PR DESCRIPTION
## Description:

Adds io:SomfyBasicContactIOSystemSensor to TaHoma component. As this sensor is working exactly like _io:SomfyContactIOSystemSensor_ this is a minor addition.

**Related issue (if applicable):**

None

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** 

None

## Example entry for `configuration.yaml` (if applicable):

None

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
