### PR TITLE
Do not fail smtp notify service on connection error

### DIFF
--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -81,10 +81,8 @@ def get_service(hass, config, discovery_info=None):
         config.get(CONF_DEBUG),
     )
 
-    if mail_service.connection_is_valid():
-        return mail_service
-
-    return None
+    mail_service.connection_is_valid()
+    return mail_service
 
 
 class MailNotificationService(BaseNotificationService):
@@ -143,14 +141,12 @@ class MailNotificationService(BaseNotificationService):
                 self._server,
                 self._port,
             )
-            return False
 
         except (smtplib.SMTPAuthenticationError, ConnectionRefusedError):
             _LOGGER.exception(
                 "Login not possible. "
                 "Please check your setting and/or your credentials"
             )
-            return False
 
         finally:
             if server:


### PR DESCRIPTION
Currently the SMTP notify service gets disabled if it can't contact the mail server on startup. This is a bit strange, (to me for sure and obviously others).  I think it would make sense to error on startup if the server is unavailable but not disable the service. 

This PR is a possible solution.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/20026

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
