### PR TITLE
Refactor IKEA Tradfri, part 2

### DIFF
--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -61,13 +61,14 @@ class TradfriBaseDevice(Entity):
 
         return {
             "identifiers": {(TRADFRI_DOMAIN, self._device.id)},
-            "name": self._name,
-            "serial": info.serial,
             "manufacturer": info.manufacturer,
             "model": info.model_number,
-            "sw_version": info.firmware_version,
-            "via_device": (TRADFRI_DOMAIN, self._gateway_id),
+            "name": self._name,
             "power_source": info.power_source_str,
+            "serial": info.serial,
+            "sw_version": info.firmware_version,
+            "battery_level": info.battery_level,
+            "via_device": (TRADFRI_DOMAIN, self._gateway_id),
         }
 
     @property

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -62,10 +62,12 @@ class TradfriBaseDevice(Entity):
         return {
             "identifiers": {(TRADFRI_DOMAIN, self._device.id)},
             "name": self._name,
+            "serial": info.serial,
             "manufacturer": info.manufacturer,
             "model": info.model_number,
             "sw_version": info.firmware_version,
             "via_device": (TRADFRI_DOMAIN, self._gateway_id),
+            "power_source": info.power_source_str,
         }
 
     @property

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -64,10 +64,7 @@ class TradfriBaseDevice(Entity):
             "manufacturer": info.manufacturer,
             "model": info.model_number,
             "name": self._name,
-            "power_source": info.power_source_str,
-            "serial": info.serial,
             "sw_version": info.firmware_version,
-            "battery_level": info.battery_level,
             "via_device": (TRADFRI_DOMAIN, self._gateway_id),
         }
 

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -2,6 +2,7 @@
 import logging
 
 from homeassistant.components.tradfri.base_class import TradfriBaseDevice
+from homeassistant.const import ATTR_BATTERY_LEVEL
 from . import KEY_API, KEY_GATEWAY
 from .const import CONF_GATEWAY_ID
 
@@ -38,7 +39,7 @@ class TradfriSensor(TradfriBaseDevice):
     @property
     def device_state_attributes(self):
         """Return the devices' state attributes."""
-        return self.device_info
+        return {ATTR_BATTERY_LEVEL: self._device.device_info.battery_level}
 
     @property
     def state(self):

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -2,7 +2,7 @@
 import logging
 
 from homeassistant.components.tradfri.base_class import TradfriBaseDevice
-from homeassistant.const import ATTR_BATTERY_LEVEL
+from homeassistant.const import DEVICE_CLASS_BATTERY
 from . import KEY_API, KEY_GATEWAY
 from .const import CONF_GATEWAY_ID
 
@@ -37,9 +37,9 @@ class TradfriSensor(TradfriBaseDevice):
         self._unique_id = f"{gateway_id}-{device.id}"
 
     @property
-    def device_state_attributes(self):
+    def device_class(self):
         """Return the devices' state attributes."""
-        return {ATTR_BATTERY_LEVEL: self._device.device_info.battery_level}
+        return DEVICE_CLASS_BATTERY
 
     @property
     def state(self):

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -19,7 +19,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     devices = (
         dev
         for dev in all_devices
-        if not dev.has_light_control and not dev.has_socket_control
+        if not dev.has_light_control
+        and not dev.has_socket_control
+        and not dev.has_blind_control
     )
     if devices:
         async_add_entities(TradfriSensor(device, api, gateway_id) for device in devices)

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -1,20 +1,16 @@
 """Support for IKEA Tradfri sensors."""
 import logging
-from datetime import timedelta
 
-from pytradfri.error import PytradfriError
-
-from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity
+from homeassistant.components.tradfri.base_class import TradfriBaseDevice
 from . import KEY_API, KEY_GATEWAY
+from .const import CONF_GATEWAY_ID
 
 _LOGGER = logging.getLogger(__name__)
-
-SCAN_INTERVAL = timedelta(minutes=5)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Tradfri config entry."""
+    gateway_id = config_entry.data[CONF_GATEWAY_ID]
     api = hass.data[KEY_API][config_entry.entry_id]
     gateway = hass.data[KEY_GATEWAY][config_entry.entry_id]
 
@@ -25,82 +21,29 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for dev in all_devices
         if not dev.has_light_control and not dev.has_socket_control
     )
-    async_add_entities(TradfriDevice(device, api) for device in devices)
+    if devices:
+        async_add_entities(TradfriSensor(device, api, gateway_id) for device in devices)
 
 
-class TradfriDevice(Entity):
+class TradfriSensor(TradfriBaseDevice):
     """The platform class required by Home Assistant."""
 
-    def __init__(self, device, api):
+    def __init__(self, device, api, gateway_id):
         """Initialize the device."""
-        self._api = api
-        self._device = None
-        self._name = None
-
-        self._refresh(device)
-
-    async def async_added_to_hass(self):
-        """Start thread when added to hass."""
-        self._async_start_observe()
-
-    @property
-    def should_poll(self):
-        """No polling needed for tradfri."""
-        return False
-
-    @property
-    def name(self):
-        """Return the display name of this device."""
-        return self._name
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit_of_measurement of the device."""
-        return "%"
+        super().__init__(device, api, gateway_id)
+        self._unique_id = f"{gateway_id}-{device.id}"
 
     @property
     def device_state_attributes(self):
         """Return the devices' state attributes."""
-        info = self._device.device_info
-        attrs = {
-            "manufacturer": info.manufacturer,
-            "model_number": info.model_number,
-            "serial": info.serial,
-            "firmware_version": info.firmware_version,
-            "power_source": info.power_source_str,
-            "battery_level": info.battery_level,
-        }
-        return attrs
+        return self.device_info
 
     @property
     def state(self):
         """Return the current state of the device."""
         return self._device.device_info.battery_level
 
-    @callback
-    def _async_start_observe(self, exc=None):
-        """Start observation of light."""
-        if exc:
-            _LOGGER.warning("Observation failed for %s", self._name, exc_info=exc)
-
-        try:
-            cmd = self._device.observe(
-                callback=self._observe_update,
-                err_callback=self._async_start_observe,
-                duration=0,
-            )
-            self.hass.async_create_task(self._api(cmd))
-        except PytradfriError as err:
-            _LOGGER.warning("Observation failed, trying again", exc_info=err)
-            self._async_start_observe()
-
-    def _refresh(self, device):
-        """Refresh the device data."""
-        self._device = device
-        self._name = device.name
-
-    def _observe_update(self, tradfri_device):
-        """Receive new state data for this device."""
-        self._refresh(tradfri_device)
-
-        self.hass.async_create_task(self.async_update_ha_state())
+    @property
+    def unit_of_measurement(self):
+        """Return the unit_of_measurement of the device."""
+        return "%"


### PR DESCRIPTION
## Breaking Change:
The Tradfri sensors (eg: button remotes and motion detectors) are now being represented as battery entities and will no longer have remaining battery power represented as an attribute. Use the sensors state instead to monitor remaining battery power.


<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
This continues the work of #26864, where the intent is to clean up the code of the Tradfri-integration to make it easier to maintain.

**Related issue (if applicable):** relates to #26863

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
