### PR TITLE
Bump pybotvac and use new exceptions

### DIFF
--- a/homeassistant/components/neato/.translations/en.json
+++ b/homeassistant/components/neato/.translations/en.json
@@ -13,7 +13,8 @@
             }
         },
         "error": {
-            "invalid_credentials": "Invalid credentials"
+            "invalid_credentials": "Invalid credentials",
+            "unexpected_error": "Unexpected error"
         },
         "create_entry": {
             "default": "See [Neato documentation]({docs_url})."

--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from requests.exceptions import HTTPError, ConnectionError as ConnError
+from pybotvac.exceptions import NeatoException, NeatoLoginException, NeatoRobotException
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
@@ -20,6 +20,7 @@ from .const import (
     NEATO_ROBOTS,
     NEATO_PERSISTENT_MAPS,
     NEATO_MAP_DATA,
+    SCAN_INTERVAL_MINUTES,
     VALID_VENDORS,
 )
 
@@ -103,7 +104,12 @@ async def async_setup_entry(hass, entry):
         _LOGGER.debug("Failed to login to Neato API")
         return False
 
-    await hass.async_add_executor_job(hub.update_robots)
+    try:
+        await hass.async_add_executor_job(hub.update_robots)
+    except NeatoRobotException:
+        _LOGGER.debug("Failed to connect to Neato API")
+        return False
+
     for component in ("camera", "vacuum", "switch"):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
@@ -144,8 +150,11 @@ class NeatoHub:
                 self.config[CONF_USERNAME], self.config[CONF_PASSWORD], self._vendor
             )
             self.logged_in = True
-        except (HTTPError, ConnError):
-            _LOGGER.error("Unable to connect to Neato API")
+        except NeatoException as ex:
+            if isinstance(ex, NeatoLoginException):
+                _LOGGER.error("Invalid credentials")
+            else:
+                _LOGGER.error("Unable to connect to Neato API")
             self.logged_in = False
             return
 
@@ -154,7 +163,7 @@ class NeatoHub:
         self._hass.data[NEATO_PERSISTENT_MAPS] = self.my_neato.persistent_maps
         self._hass.data[NEATO_MAP_DATA] = self.my_neato.maps
 
-    @Throttle(timedelta(seconds=300))
+    @Throttle(timedelta(minutes=SCAN_INTERVAL_MINUTES))
     def update_robots(self):
         """Update the robot states."""
         _LOGGER.debug("Running HUB.update_robots %s", self._hass.data[NEATO_ROBOTS])

--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -150,18 +150,17 @@ class NeatoHub:
                 self.config[CONF_USERNAME], self.config[CONF_PASSWORD], self._vendor
             )
             self.logged_in = True
+
+            _LOGGER.debug("Successfully connected to Neato API")
+            self._hass.data[NEATO_ROBOTS] = self.my_neato.robots
+            self._hass.data[NEATO_PERSISTENT_MAPS] = self.my_neato.persistent_maps
+            self._hass.data[NEATO_MAP_DATA] = self.my_neato.maps
         except NeatoException as ex:
             if isinstance(ex, NeatoLoginException):
                 _LOGGER.error("Invalid credentials")
             else:
                 _LOGGER.error("Unable to connect to Neato API")
             self.logged_in = False
-            return
-
-        _LOGGER.debug("Successfully connected to Neato API")
-        self._hass.data[NEATO_ROBOTS] = self.my_neato.robots
-        self._hass.data[NEATO_PERSISTENT_MAPS] = self.my_neato.persistent_maps
-        self._hass.data[NEATO_MAP_DATA] = self.my_neato.maps
 
     @Throttle(timedelta(minutes=SCAN_INTERVAL_MINUTES))
     def update_robots(self):

--- a/homeassistant/components/neato/camera.py
+++ b/homeassistant/components/neato/camera.py
@@ -43,6 +43,7 @@ class NeatoCleaningMap(Camera):
 
     def __init__(self, hass, robot):
         """Initialize Neato cleaning map."""
+        super().__init__()
         self.robot = robot
         self.neato = hass.data[NEATO_LOGIN] if NEATO_LOGIN in hass.data else None
         self._robot_name = f"{self.robot.name} Cleaning Map"
@@ -79,7 +80,7 @@ class NeatoCleaningMap(Camera):
             self._image_url = image_url
 
         except NeatoRobotException as ex:
-            _LOGGER.warning("Neato camera connection error: %s", ex)
+            _LOGGER.error("Neato camera connection error: %s", ex)
             self._image = None
             self._image_url = None
 

--- a/homeassistant/components/neato/camera.py
+++ b/homeassistant/components/neato/camera.py
@@ -43,7 +43,6 @@ class NeatoCleaningMap(Camera):
 
     def __init__(self, hass, robot):
         """Initialize Neato cleaning map."""
-        super().__init__()
         self.robot = robot
         self.neato = hass.data[NEATO_LOGIN] if NEATO_LOGIN in hass.data else None
         self._robot_name = f"{self.robot.name} Cleaning Map"

--- a/homeassistant/components/neato/camera.py
+++ b/homeassistant/components/neato/camera.py
@@ -2,13 +2,21 @@
 from datetime import timedelta
 import logging
 
+from pybotvac.exceptions import NeatoRobotException
+
 from homeassistant.components.camera import Camera
 
-from .const import NEATO_DOMAIN, NEATO_MAP_DATA, NEATO_ROBOTS, NEATO_LOGIN
+from .const import (
+    NEATO_DOMAIN,
+    NEATO_MAP_DATA,
+    NEATO_ROBOTS,
+    NEATO_LOGIN,
+    SCAN_INTERVAL_MINUTES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(minutes=10)
+SCAN_INTERVAL = timedelta(minutes=SCAN_INTERVAL_MINUTES)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -37,9 +45,9 @@ class NeatoCleaningMap(Camera):
         """Initialize Neato cleaning map."""
         super().__init__()
         self.robot = robot
-        self._robot_name = "{} {}".format(self.robot.name, "Cleaning Map")
+        self.neato = hass.data[NEATO_LOGIN] if NEATO_LOGIN in hass.data else None
+        self._robot_name = f"{self.robot.name} Cleaning Map"
         self._robot_serial = self.robot.serial
-        self.neato = hass.data[NEATO_LOGIN]
         self._image_url = None
         self._image = None
 
@@ -50,16 +58,31 @@ class NeatoCleaningMap(Camera):
 
     def update(self):
         """Check the contents of the map list."""
-        self.neato.update_robots()
-        image_url = None
-        map_data = self.hass.data[NEATO_MAP_DATA]
-        image_url = map_data[self._robot_serial]["maps"][0]["url"]
-        if image_url == self._image_url:
-            _LOGGER.debug("The map image_url is the same as old")
+        if self.neato is None:
+            _LOGGER.error("Error while updating camera")
+            self._image = None
+            self._image_url = None
             return
-        image = self.neato.download_map(image_url)
-        self._image = image.read()
-        self._image_url = image_url
+
+        _LOGGER.debug("Running camera update")
+        try:
+            self.neato.update_robots()
+
+            image_url = None
+            map_data = self.hass.data[NEATO_MAP_DATA][self._robot_serial]["maps"][0]
+            image_url = map_data["url"]
+            if image_url == self._image_url:
+                _LOGGER.debug("The map image_url is the same as old")
+                return
+
+            image = self.neato.download_map(image_url)
+            self._image = image.read()
+            self._image_url = image_url
+
+        except NeatoRobotException as ex:
+            _LOGGER.warning("Neato camera connection error: %s", ex)
+            self._image = None
+            self._image_url = None
 
     @property
     def name(self):

--- a/homeassistant/components/neato/config_flow.py
+++ b/homeassistant/components/neato/config_flow.py
@@ -3,7 +3,7 @@
 import logging
 
 import voluptuous as vol
-from requests.exceptions import HTTPError, ConnectionError as ConnError
+from pybotvac.exceptions import NeatoLoginException, NeatoRobotException
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -106,7 +106,9 @@ class NeatoConfigFlow(config_entries.ConfigFlow, domain=NEATO_DOMAIN):
 
         try:
             Account(username, password, this_vendor)
-        except (HTTPError, ConnError):
+        except NeatoLoginException:
             return "invalid_credentials"
+        except NeatoRobotException:
+            return "unexpected_error"
 
         return None

--- a/homeassistant/components/neato/const.py
+++ b/homeassistant/components/neato/const.py
@@ -9,6 +9,8 @@ NEATO_CONFIG = "neato_config"
 NEATO_MAP_DATA = "neato_map_data"
 NEATO_PERSISTENT_MAPS = "neato_persistent_maps"
 
+SCAN_INTERVAL_MINUTES = 5
+
 VALID_VENDORS = ["neato", "vorwerk"]
 
 MODE = {1: "Eco", 2: "Turbo"}

--- a/homeassistant/components/neato/manifest.json
+++ b/homeassistant/components/neato/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/neato",
   "requirements": [
-    "pybotvac==0.0.15"
+    "pybotvac==0.0.16"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/components/neato/strings.json
+++ b/homeassistant/components/neato/strings.json
@@ -13,7 +13,8 @@
             }
         },
         "error": {
-            "invalid_credentials": "Invalid credentials"
+            "invalid_credentials": "Invalid credentials",
+            "unexpected_error": "Unexpected error"
         },
         "create_entry": {
             "default": "See [Neato documentation]({docs_url})."

--- a/homeassistant/components/neato/switch.py
+++ b/homeassistant/components/neato/switch.py
@@ -42,7 +42,6 @@ class NeatoConnectedSwitch(ToggleEntity):
 
     def __init__(self, hass, robot, switch_type):
         """Initialize the Neato Connected switches."""
-        super().__init__()
         self.type = switch_type
         self.robot = robot
         self.neato = hass.data[NEATO_LOGIN] if NEATO_LOGIN in hass.data else None

--- a/homeassistant/components/neato/switch.py
+++ b/homeassistant/components/neato/switch.py
@@ -63,7 +63,7 @@ class NeatoConnectedSwitch(ToggleEntity):
             self.neato.update_robots()
             self._state = self.robot.state
         except NeatoRobotException as ex:
-            _LOGGER.warning("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato switch connection error: %s", ex)
             self._state = None
             return
 
@@ -107,9 +107,15 @@ class NeatoConnectedSwitch(ToggleEntity):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         if self.type == SWITCH_TYPE_SCHEDULE:
-            self.robot.enable_schedule()
+            try:
+                self.robot.enable_schedule()
+            except NeatoRobotException as ex:
+                _LOGGER.error("Neato switch connection error: %s", ex)
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         if self.type == SWITCH_TYPE_SCHEDULE:
-            self.robot.disable_schedule()
+            try:
+                self.robot.disable_schedule()
+            except NeatoRobotException as ex:
+                _LOGGER.error("Neato switch connection error: %s", ex)

--- a/homeassistant/components/neato/switch.py
+++ b/homeassistant/components/neato/switch.py
@@ -2,16 +2,16 @@
 from datetime import timedelta
 import logging
 
-import requests
+from pybotvac.exceptions import NeatoRobotException
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity import ToggleEntity
 
-from .const import NEATO_DOMAIN, NEATO_LOGIN, NEATO_ROBOTS
+from .const import NEATO_DOMAIN, NEATO_LOGIN, NEATO_ROBOTS, SCAN_INTERVAL_MINUTES
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(minutes=10)
+SCAN_INTERVAL = timedelta(minutes=SCAN_INTERVAL_MINUTES)
 
 SWITCH_TYPE_SCHEDULE = "schedule"
 
@@ -42,10 +42,11 @@ class NeatoConnectedSwitch(ToggleEntity):
 
     def __init__(self, hass, robot, switch_type):
         """Initialize the Neato Connected switches."""
+        super().__init__()
         self.type = switch_type
         self.robot = robot
-        self.neato = hass.data[NEATO_LOGIN]
-        self._robot_name = "{} {}".format(self.robot.name, SWITCH_TYPES[self.type][0])
+        self.neato = hass.data[NEATO_LOGIN] if NEATO_LOGIN in hass.data else None
+        self._robot_name = f"{self.robot.name} {SWITCH_TYPES[self.type][0]}"
         self._state = None
         self._schedule_state = None
         self._clean_state = None
@@ -53,17 +54,20 @@ class NeatoConnectedSwitch(ToggleEntity):
 
     def update(self):
         """Update the states of Neato switches."""
-        _LOGGER.debug("Running switch update")
-        self.neato.update_robots()
-        try:
-            self._state = self.robot.state
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.HTTPError,
-        ) as ex:
-            _LOGGER.warning("Neato connection error: %s", ex)
+        if self.neato is None:
+            _LOGGER.error("Error while updating switches")
             self._state = None
             return
+
+        _LOGGER.debug("Running switch update")
+        try:
+            self.neato.update_robots()
+            self._state = self.robot.state
+        except NeatoRobotException as ex:
+            _LOGGER.warning("Neato switch connection error: %s", ex)
+            self._state = None
+            return
+
         _LOGGER.debug("self._state=%s", self._state)
         if self.type == SWITCH_TYPE_SCHEDULE:
             _LOGGER.debug("State: %s", self._state)

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -325,14 +325,14 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             elif self._state["state"] == 3:
                 self.robot.resume_cleaning()
         except NeatoRobotException as ex:
-            _LOGGER.error("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato vacuum connection error: %s", ex)
 
     def pause(self):
         """Pause the vacuum."""
         try:
             self.robot.pause_cleaning()
         except NeatoRobotException as ex:
-            _LOGGER.error("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato vacuum connection error: %s", ex)
 
     def return_to_base(self, **kwargs):
         """Set the vacuum cleaner to return to the dock."""
@@ -342,28 +342,28 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._clean_state = STATE_RETURNING
             self.robot.send_to_base()
         except NeatoRobotException as ex:
-            _LOGGER.error("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato vacuum connection error: %s", ex)
 
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
         try:
             self.robot.stop_cleaning()
         except NeatoRobotException as ex:
-            _LOGGER.error("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato vacuum connection error: %s", ex)
 
     def locate(self, **kwargs):
         """Locate the robot by making it emit a sound."""
         try:
             self.robot.locate()
         except NeatoRobotException as ex:
-            _LOGGER.error("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato vacuum connection error: %s", ex)
 
     def clean_spot(self, **kwargs):
         """Run a spot cleaning starting from the base."""
         try:
             self.robot.start_spot_cleaning()
         except NeatoRobotException as ex:
-            _LOGGER.error("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato vacuum connection error: %s", ex)
 
     def neato_custom_cleaning(self, mode, navigation, category, zone=None, **kwargs):
         """Zone cleaning service call."""
@@ -382,4 +382,4 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         try:
             self.robot.start_cleaning(mode, navigation, category, boundary_id)
         except NeatoRobotException as ex:
-            _LOGGER.error("Neato switch connection error: %s", ex)
+            _LOGGER.error("Neato vacuum connection error: %s", ex)

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -132,7 +132,6 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
     def __init__(self, hass, robot):
         """Initialize the Neato Connected Vacuum."""
-        super().__init__()
         self.robot = robot
         self.neato = hass.data[NEATO_LOGIN]
         self._name = f"{self.robot.name}"

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -171,7 +171,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._available = True
         except NeatoRobotException as ex:
             if self._available:  # print only once when available
-                _LOGGER.warning("Neato vacuum connection error: %s", ex)
+                _LOGGER.error("Neato vacuum connection error: %s", ex)
             self._state = None
             self._available = False
             return
@@ -319,33 +319,51 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
     def start(self):
         """Start cleaning or resume cleaning."""
-        if self._state["state"] == 1:
-            self.robot.start_cleaning()
-        elif self._state["state"] == 3:
-            self.robot.resume_cleaning()
+        try:
+            if self._state["state"] == 1:
+                self.robot.start_cleaning()
+            elif self._state["state"] == 3:
+                self.robot.resume_cleaning()
+        except NeatoRobotException as ex:
+            _LOGGER.error("Neato switch connection error: %s", ex)
 
     def pause(self):
         """Pause the vacuum."""
-        self.robot.pause_cleaning()
+        try:
+            self.robot.pause_cleaning()
+        except NeatoRobotException as ex:
+            _LOGGER.error("Neato switch connection error: %s", ex)
 
     def return_to_base(self, **kwargs):
         """Set the vacuum cleaner to return to the dock."""
-        if self._clean_state == STATE_CLEANING:
-            self.robot.pause_cleaning()
-        self._clean_state = STATE_RETURNING
-        self.robot.send_to_base()
+        try:
+            if self._clean_state == STATE_CLEANING:
+                self.robot.pause_cleaning()
+            self._clean_state = STATE_RETURNING
+            self.robot.send_to_base()
+        except NeatoRobotException as ex:
+            _LOGGER.error("Neato switch connection error: %s", ex)
 
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
-        self.robot.stop_cleaning()
+        try:
+            self.robot.stop_cleaning()
+        except NeatoRobotException as ex:
+            _LOGGER.error("Neato switch connection error: %s", ex)
 
     def locate(self, **kwargs):
         """Locate the robot by making it emit a sound."""
-        self.robot.locate()
+        try:
+            self.robot.locate()
+        except NeatoRobotException as ex:
+            _LOGGER.error("Neato switch connection error: %s", ex)
 
     def clean_spot(self, **kwargs):
         """Run a spot cleaning starting from the base."""
-        self.robot.start_spot_cleaning()
+        try:
+            self.robot.start_spot_cleaning()
+        except NeatoRobotException as ex:
+            _LOGGER.error("Neato switch connection error: %s", ex)
 
     def neato_custom_cleaning(self, mode, navigation, category, zone=None, **kwargs):
         """Zone cleaning service call."""
@@ -361,4 +379,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                 return
 
         self._clean_state = STATE_CLEANING
-        self.robot.start_cleaning(mode, navigation, category, boundary_id)
+        try:
+            self.robot.start_cleaning(mode, navigation, category, boundary_id)
+        except NeatoRobotException as ex:
+            _LOGGER.error("Neato switch connection error: %s", ex)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1102,7 +1102,7 @@ pyblackbird==0.5
 # pybluez==0.22
 
 # homeassistant.components.neato
-pybotvac==0.0.15
+pybotvac==0.0.16
 
 # homeassistant.components.nissan_leaf
 pycarwings2==2.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -297,7 +297,7 @@ pyMetno==0.4.6
 pyblackbird==0.5
 
 # homeassistant.components.neato
-pybotvac==0.0.15
+pybotvac==0.0.16
 
 # homeassistant.components.cast
 pychromecast==4.0.1


### PR DESCRIPTION
## Breaking Change:

Nothing breaks

## Description:
Within the latest release pybotvac introduces new exceptions. This PR bumps pybotvac and adapt the interface to the new exceptions.

Closes: #24119

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
