### PR TITLE
Allow MQTT json light floating point transition

### DIFF
--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -463,10 +463,7 @@ class MqttLightJson(
                 message["flash"] = self._flash_times[CONF_FLASH_TIME_SHORT]
 
         if ATTR_TRANSITION in kwargs:
-            if kwargs[ATTR_TRANSITION].is_integer():
-                message["transition"] = int(kwargs[ATTR_TRANSITION])
-            else:
-                message["transition"] = kwargs[ATTR_TRANSITION]
+            message["transition"] = kwargs[ATTR_TRANSITION]
 
         if ATTR_BRIGHTNESS in kwargs and self._brightness is not None:
             message["brightness"] = int(
@@ -524,10 +521,7 @@ class MqttLightJson(
         message = {"state": "OFF"}
 
         if ATTR_TRANSITION in kwargs:
-            if kwargs[ATTR_TRANSITION].is_integer():
-                message["transition"] = int(kwargs[ATTR_TRANSITION])
-            else:
-                message["transition"] = kwargs[ATTR_TRANSITION]
+            message["transition"] = kwargs[ATTR_TRANSITION]
 
         mqtt.async_publish(
             self.hass,

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -463,7 +463,10 @@ class MqttLightJson(
                 message["flash"] = self._flash_times[CONF_FLASH_TIME_SHORT]
 
         if ATTR_TRANSITION in kwargs:
-            message["transition"] = int(kwargs[ATTR_TRANSITION])
+            if kwargs[ATTR_TRANSITION].is_integer():
+                message["transition"] = int(kwargs[ATTR_TRANSITION])
+            else:
+                message["transition"] = kwargs[ATTR_TRANSITION]
 
         if ATTR_BRIGHTNESS in kwargs and self._brightness is not None:
             message["brightness"] = int(
@@ -521,7 +524,10 @@ class MqttLightJson(
         message = {"state": "OFF"}
 
         if ATTR_TRANSITION in kwargs:
-            message["transition"] = int(kwargs[ATTR_TRANSITION])
+            if kwargs[ATTR_TRANSITION].is_integer():
+                message["transition"] = int(kwargs[ATTR_TRANSITION])
+            else:
+                message["transition"] = kwargs[ATTR_TRANSITION]
 
         mqtt.async_publish(
             self.hass,


### PR DESCRIPTION
## Breaking Change:
The MQTT light with JSON schema will now sent a float instead of an int with the `transition` key.
Lights that are based on the "ArduinoJson" module should not experience problems due to the change from int to float (the float value will be truncated to an int).

## Description:
Allow to use floating point values for the transition time of the MQTT json light.
In this way transitions shorter than 1s can be used (0.5 seconds for instance) if the MQTT light supports it.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10763


## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
