### PR TITLE
Add Xiaomi PM2.5 Air Quality Monitor S1 (cgllc.airmonitor.s1) support

### DIFF
--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -14,8 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = "Xiaomi Miio Sensor"
 DATA_KEY = "sensor.xiaomi_miio"
 
-MODEL_AIRQUALITYMONITOR_V1 = "zhimi.airmonitor.v1"
-MODEL_AIRQUALITYMONITOR_S1 = "cgllc.airmonitor.s1"
+MODEL_AIR_QUALITY_MONITOR_V1 = "zhimi.airmonitor.v1"
+MODEL_AIR_QUALITY_MONITOR_S1 = "cgllc.airmonitor.s1"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -104,7 +104,7 @@ class XiaomiAirQualityMonitor(Entity):
         self._model = model
         self._unique_id = unique_id
 
-        if self._model == MODEL_AIRQUALITYMONITOR_S1:
+        if self._model == MODEL_AIR_QUALITY_MONITOR_S1:
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRQUALITYMONITOR_S1
             self._unit_of_measurement = "µg/m3"
         else:
@@ -170,7 +170,7 @@ class XiaomiAirQualityMonitor(Entity):
 
             self._available = True
 
-            if self._model == MODEL_AIRQUALITYMONITOR_S1:
+            if self._model == MODEL_AIR_QUALITY_MONITOR_S1:
                 self._state = state.pm25
             else:
                 self._state = state.aqi

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -14,8 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = "Xiaomi Miio Sensor"
 DATA_KEY = "sensor.xiaomi_miio"
 
-MODEL_AIRQUALITYMONITOR_V1 = 'zhimi.airmonitor.v1'
-MODEL_AIRQUALITYMONITOR_S1 = 'cgllc.airmonitor.s1'
+MODEL_AIRQUALITYMONITOR_V1 = "zhimi.airmonitor.v1"
+MODEL_AIRQUALITYMONITOR_S1 = "cgllc.airmonitor.s1"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -1,5 +1,4 @@
 """Support for Xiaomi Mi Air Quality Monitor (PM2.5)."""
-from enum import Enum
 import logging
 
 import voluptuous as vol
@@ -121,14 +120,6 @@ class XiaomiAirQualityMonitor(Entity):
         self._available = None
         self._state = None
 
-    @staticmethod
-    def _extract_value_from_attribute(state, attribute):
-        value = getattr(state, attribute)
-        if isinstance(value, Enum):
-            return value.value
-
-        return value
-
     @property
     def should_poll(self):
         """Poll the miio device."""
@@ -186,7 +177,7 @@ class XiaomiAirQualityMonitor(Entity):
 
             self._state_attrs.update(
                 {
-                    key: self._extract_value_from_attribute(state, value)
+                    key: getattr(state, value)
                     for key, value in self._available_attributes.items()
                 }
             )

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -54,7 +54,7 @@ AVAILABLE_ATTRIBUTES_AIRQUALITYMONITOR_S1 = {
     ATTR_BATTERY_LEVEL: "battery",
     ATTR_CO2: "co2",
     ATTR_HUMIDITY: "humidity",
-    ATTR_TEMPERATURE"temperature",
+    ATTR_TEMPERATURE: "temperature",
     ATTR_TVOC: "tvoc",
 }
 

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -14,7 +14,6 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = "Xiaomi Miio Sensor"
 DATA_KEY = "sensor.xiaomi_miio"
 
-CONF_MODEL = "model"
 MODEL_AIRQUALITYMONITOR_V1 = 'zhimi.airmonitor.v1'
 MODEL_AIRQUALITYMONITOR_S1 = 'cgllc.airmonitor.s1'
 
@@ -23,12 +22,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=32, max=32)),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_MODEL): vol.In(
-            [
-                MODEL_AIRQUALITYMONITOR_V1,
-                MODEL_AIRQUALITYMONITOR_S1,
-            ]
-        ),
     }
 )
 

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -1,4 +1,5 @@
 """Support for Xiaomi Mi Air Quality Monitor (PM2.5)."""
+from enum import Enum
 import logging
 
 import voluptuous as vol


### PR DESCRIPTION
## Description:

Adds support for the Xiaomi PM2.5 Air Quality Monitor S1. The sensor shows the PM2.5 value and some attributes (temperature, humidity, co2, tvoc, battery_level). 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** TBD.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
