### PR TITLE
Include unit_of_measurement in sensor device trigger capabilities

### DIFF
--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -147,7 +147,6 @@ async def async_get_triggers(hass, device_id):
 
 async def async_get_trigger_capabilities(hass, config):
     """List trigger capabilities."""
-    config = TRIGGER_SCHEMA(config)
     state = hass.states.get(config[CONF_ENTITY_ID])
     unit_of_measurement = (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else ""

--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_FOR,
     CONF_TYPE,
+    CONF_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -146,11 +147,23 @@ async def async_get_triggers(hass, device_id):
 
 async def async_get_trigger_capabilities(hass, config):
     """List trigger capabilities."""
+    config = TRIGGER_SCHEMA(config)
+    state = hass.states.get(config[CONF_ENTITY_ID])
+    unit_of_measurement = (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else ""
+    )
+
     return {
         "extra_fields": vol.Schema(
             {
-                vol.Optional(CONF_ABOVE): vol.Coerce(float),
-                vol.Optional(CONF_BELOW): vol.Coerce(float),
+                vol.Optional(
+                    CONF_ABOVE,
+                    description={CONF_UNIT_OF_MEASUREMENT: unit_of_measurement},
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_BELOW,
+                    description={CONF_UNIT_OF_MEASUREMENT: unit_of_measurement},
+                ): vol.Coerce(float),
                 vol.Optional(CONF_FOR): cv.positive_time_period_dict,
             }
         )

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -74,26 +74,49 @@ async def test_get_triggers(hass, device_reg, entity_reg):
         if device_class != "none"
     ]
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert len(triggers) == 8
     assert triggers == expected_triggers
 
 
 async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
-    """Test we get the expected capabilities from a binary_sensor trigger."""
+    """Test we get the expected capabilities from a sensor trigger."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init()
+
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
     device_entry = device_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        platform.ENTITIES["battery"].unique_id,
+        device_id=device_entry.id,
+    )
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
     expected_capabilities = {
         "extra_fields": [
-            {"name": "above", "optional": True, "type": "float"},
-            {"name": "below", "optional": True, "type": "float"},
+            {
+                "description": {"unit_of_measurement": "%"},
+                "name": "above",
+                "optional": True,
+                "type": "float",
+            },
+            {
+                "description": {"unit_of_measurement": "%"},
+                "name": "below",
+                "optional": True,
+                "type": "float",
+            },
             {"name": "for", "optional": True, "type": "positive_time_period_dict"},
         ]
     }
     triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert len(triggers) == 1
     for trigger in triggers:
         capabilities = await async_get_device_automation_capabilities(
             hass, "trigger", trigger


### PR DESCRIPTION
## Description:

Include unit_of_measurement in sensor device trigger capabilities
TODO: Update tests

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
