### PR TITLE
Fix the todoist integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -290,6 +290,7 @@ homeassistant/components/threshold/* @fabaff
 homeassistant/components/tibber/* @danielhiversen
 homeassistant/components/tile/* @bachya
 homeassistant/components/time_date/* @fabaff
+homeassistant/components/todoist/* @boralyl
 homeassistant/components/toon/* @frenck
 homeassistant/components/tplink/* @rytilahti
 homeassistant/components/traccar/* @ludeeus

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -1,6 +1,5 @@
 """Support for Todoist task management (https://todoist.com)."""
 from datetime import datetime, timedelta
-from typing import Union
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -1,5 +1,6 @@
 """Support for Todoist task management (https://todoist.com)."""
 from datetime import datetime, timedelta
+from typing import Union
 import logging
 
 import voluptuous as vol
@@ -11,6 +12,7 @@ from homeassistant.components.calendar import (
 )
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TOKEN
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util import Throttle, dt
 
@@ -36,6 +38,7 @@ CONTENT = "content"
 DESCRIPTION = "description"
 # Calendar Platform: Used in the '_get_date()' method
 DATETIME = "dateTime"
+DUE = "due"
 # Service Call: When is this task due (in natural language)?
 DUE_DATE_STRING = "due_date_string"
 # Service Call: The language of DUE_DATE_STRING
@@ -206,7 +209,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         project_id = project_id_lookup[project_name]
 
         # Create the task
-        item = api.items.add(call.data[CONTENT], project_id)
+        item = api.items.add(call.data[CONTENT], project_id=project_id)
 
         if LABELS in call.data:
             task_labels = call.data[LABELS]
@@ -216,11 +219,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if PRIORITY in call.data:
             item.update(priority=call.data[PRIORITY])
 
+        _due: dict = {}
         if DUE_DATE_STRING in call.data:
-            item.update(date_string=call.data[DUE_DATE_STRING])
+            _due["string"] = call.data[DUE_DATE_STRING]
 
         if DUE_DATE_LANG in call.data:
-            item.update(date_lang=call.data[DUE_DATE_LANG])
+            _due["lang"] = call.data[DUE_DATE_LANG]
 
         if DUE_DATE in call.data:
             due_date = dt.parse_datetime(call.data[DUE_DATE])
@@ -231,7 +235,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             due_date = dt.as_utc(due_date)
             date_format = "%Y-%m-%dT%H:%M"
             due_date = datetime.strftime(due_date, date_format)
-            item.update(due_date_utc=due_date)
+            _due["date"] = due_date
+
+        if _due:
+            item.update(due=_due)
+
         # Commit changes
         api.commit()
         _LOGGER.debug("Created Todoist task: %s", call.data[CONTENT])
@@ -381,6 +389,16 @@ class TodoistProjectData:
         else:
             self._project_id_whitelist = []
 
+    def _parse_due_date(self, data: dict) -> datetime:
+        """Parse the due date dict into a datetime object."""
+        # Add time information to date only strings.
+        if len(data["date"]) == 10:
+            data["date"] += "T00:00:00"
+        # If there is no timezone provided, use UTC.
+        if data["timezone"] is None:
+            data["date"] += "Z"
+        return dt_util.parse_datetime(data["date"])
+
     def create_todoist_task(self, data):
         """
         Create a dictionary based on a Task passed from the Todoist API.
@@ -412,16 +430,8 @@ class TodoistProjectData:
         # complete the task.
         # Generally speaking, that means right now.
         task[START] = dt.utcnow()
-        if data[DUE_DATE_UTC] is not None:
-            due_date = data[DUE_DATE_UTC]
-
-            # Due dates are represented in RFC3339 format, in UTC.
-            # Home Assistant exclusively uses UTC, so it'll
-            # handle the conversion.
-            time_format = "%a %d %b %Y %H:%M:%S %z"
-            # HASS' built-in parse time function doesn't like
-            # Todoist's time format; strptime has to be used.
-            task[END] = datetime.strptime(due_date, time_format)
+        if data[DUE] is not None:
+            task[END] = self._parse_due_date(data[DUE])
 
             if self._latest_due_date is not None and (
                 task[END] > self._latest_due_date
@@ -540,9 +550,8 @@ class TodoistProjectData:
             project_task_data = project_data[TASKS]
 
         events = []
-        time_format = "%a %d %b %Y %H:%M:%S %z"
         for task in project_task_data:
-            due_date = datetime.strptime(task["due_date_utc"], time_format)
+            due_date = self._parse_due_date(task["due"])
             if start_date < due_date < end_date:
                 event = {
                     "uid": task["id"],

--- a/homeassistant/components/todoist/manifest.json
+++ b/homeassistant/components/todoist/manifest.json
@@ -6,5 +6,5 @@
     "todoist-python==8.0.0"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@boralyl"]
 }

--- a/homeassistant/components/todoist/manifest.json
+++ b/homeassistant/components/todoist/manifest.json
@@ -3,7 +3,7 @@
   "name": "Todoist",
   "documentation": "https://www.home-assistant.io/integrations/todoist",
   "requirements": [
-    "todoist-python==7.0.17"
+    "todoist-python==8.0.0"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/todoist/services.yaml
+++ b/homeassistant/components/todoist/services.yaml
@@ -1,0 +1,25 @@
+new_task:
+  description: Create a new task and add it to a project.
+  fields:
+    content:
+      description: The name of the task.
+      example: Pick up the mail.
+    project:
+      description: The name of the project this task should belong to. Defaults to Inbox.
+      example: Errands
+    labels:
+      description: Any labels that you want to apply to this task, separated by a comma.
+      example: Chores,Delivieries
+    priority:
+      description: The priority of this task, from 1 (normal) to 4 (urgent).
+      example: 2
+    due_date_string:
+      description: The day this task is due, in natural language.
+      example: Tomorrow
+    due_date_lang:
+      description: The language of due_date_string.
+      example: en
+    due_date:
+      description: The day this task is due, in format YYYY-MM-DD.
+      example: 2019-10-22
+

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1891,7 +1891,7 @@ thingspeak==0.4.1
 tikteck==0.4
 
 # homeassistant.components.todoist
-todoist-python==7.0.17
+todoist-python==8.0.0
 
 # homeassistant.components.toon
 toonapilib==3.2.4


### PR DESCRIPTION
## Description:
This fixes the todoist integration as mentioned [in the forums](https://community.home-assistant.io/t/todoist-has-no-calendar/135810/4).  When `v8.0.0` of the python library was released, the api changes were backwards-incompatible.  This caused the current integration to fail to parse any data since the release.

  The main change is the `due` parameter is now an object rather than having separate `due_*` properties.  See the [changelog](https://github.com/Doist/todoist-python/blob/411a39a46ae9ceee44f3897b9a6b19890893530c/CHANGELOG.md).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
