### PR TITLE
Fix Plex media_player.play_media service

### DIFF
--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -685,7 +685,7 @@ class PlexClient(MediaPlayerDevice):
         media = None
 
         if media_type == "MUSIC":
-            media = self._get_music_choice(library, src)
+            media = self._get_music_media(library, src)
         elif media_type == "EPISODE":
             media = self._get_tv_media(library, src)
         elif media_type == "PLAYLIST":
@@ -708,7 +708,8 @@ class PlexClient(MediaPlayerDevice):
 
         self.update_devices()
 
-    def _get_music_choice(self, library_name, src):
+    def _get_music_media(self, library_name, src):
+        """Find music media and return a Plex media object."""
         artist_name = src["artist_name"]
         album_name = src.get("album_name")
         track_name = src.get("track_name")

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -109,3 +109,20 @@ class PlexServer:
     def show_all_controls(self):
         """Return show_all_controls option."""
         return self.options[MP_DOMAIN][CONF_SHOW_ALL_CONTROLS]
+
+    @property
+    def library(self):
+        """Return library attribute from server object."""
+        return self._plex_server.library
+
+    def playlist(self, title):
+        """Return playlist from server object."""
+        return self._plex_server.playlist(title)
+
+    def create_playlist(
+        self, title, items=None, section=None, limit=None, smart=None, **kwargs
+    ):
+        """Create playlist using server object."""
+        return self._plex_server.createPlaylist(
+            title, items=items, section=section, limit=limit, smart=smart, **kwargs
+        )

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -1,5 +1,6 @@
 """Shared class to maintain Plex server instances."""
 import plexapi.myplex
+import plexapi.playqueue
 import plexapi.server
 from requests import Session
 
@@ -119,10 +120,6 @@ class PlexServer:
         """Return playlist from server object."""
         return self._plex_server.playlist(title)
 
-    def create_playlist(
-        self, title, items=None, section=None, limit=None, smart=None, **kwargs
-    ):
-        """Create playlist using server object."""
-        return self._plex_server.createPlaylist(
-            title, items=items, section=section, limit=limit, smart=smart, **kwargs
-        )
+    def create_playqueue(self, media, **kwargs):
+        """Create playqueue on Plex server."""
+        return plexapi.playqueue.PlayQueue.create(self._plex_server, media, **kwargs)


### PR DESCRIPTION
## Description:
Fix the `media_player.play_media` service. Some JSON parameters in `media_content_id` are now optional, which will be documented.

**Related issue (if applicable):** fixes #19623 

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#TODO

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
