### PR TITLE
Google allow unavailable entities

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -185,7 +185,7 @@ class GoogleEntity:
     @callback
     def is_supported(self) -> bool:
         """Return if the entity is supported by Google."""
-        return self.state.state != STATE_UNAVAILABLE and bool(self.traits())
+        return bool(self.traits())
 
     @callback
     def might_2fa(self) -> bool:

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -466,8 +466,8 @@ async def test_serialize_input_boolean(hass):
     }
 
 
-async def test_unavailable_state_doesnt_sync(hass):
-    """Test that an unavailable entity does not sync over."""
+async def test_unavailable_state_syncs(hass):
+    """Test that an unavailable entity syncs over."""
     light = DemoLight(None, "Demo Light", state=False)
     light.hass = hass
     light.entity_id = "light.demo_light"
@@ -483,7 +483,29 @@ async def test_unavailable_state_doesnt_sync(hass):
 
     assert result == {
         "requestId": REQ_ID,
-        "payload": {"agentUserId": "test-agent", "devices": []},
+        "payload": {
+            "agentUserId": "test-agent",
+            "devices": [
+                {
+                    "attributes": {
+                        "colorModel": "hsv",
+                        "colorTemperatureRange": {
+                            "temperatureMaxK": 6535,
+                            "temperatureMinK": 2000,
+                        },
+                    },
+                    "id": "light.demo_light",
+                    "name": {"name": "Demo Light"},
+                    "traits": [
+                        "action.devices.traits.Brightness",
+                        "action.devices.traits.OnOff",
+                        "action.devices.traits.ColorSetting",
+                    ],
+                    "type": "action.devices.types.LIGHT",
+                    "willReportState": False,
+                }
+            ],
+        },
     }
 
 


### PR DESCRIPTION
## Description:
Allow unavailable entities to be synced to Google.

**Blocked by https://github.com/home-assistant/architecture/issues/297**

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
