### PR TITLE
Add functionality to webostv media_player

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -419,6 +419,8 @@ class LgWebOSDevice(MediaPlayerDevice):
 
             return
 
+        self._client.launch_app_with_content_id(media_type, media_id)
+
     def media_play(self):
         """Send play command."""
         self._playing = True

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -11,6 +11,7 @@ from homeassistant import util
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
+    MEDIA_TYPE_URL,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
@@ -42,8 +43,13 @@ _LOGGER = logging.getLogger(__name__)
 CONF_SOURCES = "sources"
 CONF_ON_ACTION = "turn_on_action"
 
+BROWSER_APP_ID = "com.webos.app.browser"
 DEFAULT_NAME = "LG webOS Smart TV"
 LIVETV_APP_ID = "com.webos.app.livetv"
+MEDIA_TYPE_YOUTUBE = "youtube"
+MEDIA_TYPE_NETFLIX = "netflix"
+NETFLIX_APP_ID = "netflix"
+YOUTUBE_APP_ID = "youtube.leanback.v4"
 
 WEBOSTV_CONFIG_FILE = "webostv.conf"
 
@@ -419,7 +425,14 @@ class LgWebOSDevice(MediaPlayerDevice):
 
             return
 
-        self._client.launch_app_with_content_id(media_type, media_id)
+        if media_type == MEDIA_TYPE_URL:
+            self._client.launch_app_with_content_id(BROWSER_APP_ID, media_id)
+
+        if media_type == MEDIA_TYPE_NETFLIX:
+            self._client.launch_app_with_content_id(NETFLIX_APP_ID, media_id)
+
+        if media_type == MEDIA_TYPE_YOUTUBE:
+            self._client.launch_app_with_content_id(YOUTUBE_APP_ID, media_id)
 
     def media_play(self):
         """Send play command."""


### PR DESCRIPTION
## Breaking Change:

Nil

## Description:

Added ability to launch apps with contentId set using play_media service. Adds a line so if media_play is called and media_type is not channel then attempt to launch an app with the contentid parameter set. Previously if media_type was not channel the function just ended.

Documentation has been updated and has some examples.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10650

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
