### PR TITLE
Remove Plex manual config flow step

### DIFF
--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -2,16 +2,6 @@
     "config": {
         "title": "Plex",
         "step": {
-            "manual_setup": {
-                "title": "Plex server",
-                "data": {
-                    "host": "Host",
-                    "port": "Port",
-                    "ssl": "Use SSL",
-                    "verify_ssl": "Verify SSL certificate",
-                    "token": "Token (if required)"
-                }
-            },
             "select_server": {
                 "title": "Select Plex server",
                 "description": "Multiple servers available, select one:",
@@ -19,12 +9,9 @@
                     "server": "Server"
                 }
             },
-            "user": {
+            "start_website_auth": {
                 "title": "Connect Plex server",
-                "description": "Continue to authorize at plex.tv or manually configure a server.",
-                "data": {
-                    "manual_setup": "Manual setup"
-                }
+                "description": "Continue to authorize at plex.tv."
             }
         },
         "error": {
@@ -36,6 +23,7 @@
             "all_configured": "All linked servers already configured",
             "already_configured": "This Plex server is already configured",
             "already_in_progress": "Plex is being configured",
+            "discovery_no_file": "No legacy config file found",
             "invalid_import": "Imported configuration is invalid",
             "token_request_timeout": "Timed out obtaining token",
             "unknown": "Failed for unknown reason"


### PR DESCRIPTION
## Description:
Remove manual configuration flow step. Manual configuration will only be available via YAML configuration.

Not breaking as this feature was never officially released.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10655

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html