### PR TITLE
Improve speed websocket sends messages

### DIFF
--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -62,11 +62,13 @@ class WebSocketHandler:
                 if message is None:
                     break
                 self._logger.debug("Sending %s", message)
+
+                if isinstance(message, str):
+                    await self.wsock.send_str(message)
+                    return
+
                 try:
-                    if isinstance(message, str):
-                        await self.wsock.send_str(message)
-                    else:
-                        await self.wsock.send_json(message, dumps=JSON_DUMP)
+                    dumped = JSON_DUMP(message)
                 except (ValueError, TypeError) as err:
                     self._logger.error(
                         "Unable to serialize to JSON: %s\n%s", err, message
@@ -76,6 +78,9 @@ class WebSocketHandler:
                             message["id"], ERR_UNKNOWN_ERROR, "Invalid JSON in response"
                         )
                     )
+                    return
+
+                await self.wsock.send_str(dumped)
 
     @callback
     def _send_message(self, message):

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -61,11 +61,12 @@ class WebSocketHandler:
                 message = await self._to_write.get()
                 if message is None:
                     break
+
                 self._logger.debug("Sending %s", message)
 
                 if isinstance(message, str):
                     await self.wsock.send_str(message)
-                    return
+                    continue
 
                 try:
                     dumped = JSON_DUMP(message)
@@ -78,7 +79,7 @@ class WebSocketHandler:
                             message["id"], ERR_UNKNOWN_ERROR, "Invalid JSON in response"
                         )
                     )
-                    return
+                    continue
 
                 await self.wsock.send_str(dumped)
 


### PR DESCRIPTION
## Description:
Based on the implementation of [`websocket_client.send_json`](https://github.com/aio-libs/aiohttp/blob/c09c538e036619ae549280fb9051fd6084e8252c/aiohttp/client_ws.py#L165-L168) we can just use `send_str`, which saves us an await. This makes sending data slightly faster.

**Related issue (if applicable):** https://github.com/zachowj/node-red-contrib-home-assistant-websocket/issues/153

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
