### PR TITLE
Add heating_type for ViCare integration

### DIFF
--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -153,31 +153,7 @@ class ViCareClimate(ClimateDevice):
 
             self._attributes["burner_modulation"] = self._api.getBurnerModulation()
             self._attributes["boiler_temperature"] = self._api.getBoilerTemperature()
-            self._attributes["current_power"] = self._api.getCurrentPower()
-            self._attributes[
-                "gas_consumption_heating_days"
-            ] = self._api.getGasConsumptionHeatingDays()
-            self._attributes[
-                "gas_consumption_heating_today"
-            ] = self._api.getGasConsumptionHeatingToday()
-            self._attributes[
-                "gas_consumption_heating_weeks"
-            ] = self._api.getGasConsumptionHeatingWeeks()
-            self._attributes[
-                "gas_consumption_heating_this_week"
-            ] = self._api.getGasConsumptionHeatingThisWeek()
-            self._attributes[
-                "gas_consumption_heating_months"
-            ] = self._api.getGasConsumptionHeatingMonths()
-            self._attributes[
-                "gas_consumption_heating_this_month"
-            ] = self._api.getGasConsumptionHeatingThisMonth()
-            self._attributes[
-                "gas_consumption_heating_years"
-            ] = self._api.getGasConsumptionHeatingYears()
-            self._attributes[
-                "gas_consumption_heating_this_year"
-            ] = self._api.getGasConsumptionHeatingThisYear()
+
         elif self._heating_type == HeatingType.heatpump:
             self._current_action = self._api.getCompressorActive()
 

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -150,6 +150,30 @@ class ViCareClimate(ClimateDevice):
             self._attributes["burner_modulation"] = self._api.getBurnerModulation()
             self._attributes["boiler_temperature"] = self._api.getBoilerTemperature()
             self._attributes["current_power"] = self._api.getCurrentPower()
+            self._attributes[
+                "gas_consumption_heating_days"
+            ] = self._api.getGasConsumptionHeatingDays()
+            self._attributes[
+                "gas_consumption_heating_today"
+            ] = self._api.getGasConsumptionHeatingToday()
+            self._attributes[
+                "gas_consumption_heating_weeks"
+            ] = self._api.getGasConsumptionHeatingWeeks()
+            self._attributes[
+                "gas_consumption_heating_this_week"
+            ] = self._api.getGasConsumptionHeatingThisWeek()
+            self._attributes[
+                "gas_consumption_heating_months"
+            ] = self._api.getGasConsumptionHeatingMonths()
+            self._attributes[
+                "gas_consumption_heating_this_month"
+            ] = self._api.getGasConsumptionHeatingThisMonth()
+            self._attributes[
+                "gas_consumption_heating_years"
+            ] = self._api.getGasConsumptionHeatingYears()
+            self._attributes[
+                "gas_consumption_heating_this_year"
+            ] = self._api.getGasConsumptionHeatingThisYear()
         elif self._heating_type == HeatingType.heatpump:
             self._attributes["compressor_active"] = self._api.getCompressorActive()
             self._attributes["return_temperature"] = self._api.getReturnTemperature()

--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "dependencies": [],
   "codeowners": ["@oischinger"],
-  "requirements": ["PyViCare==0.1.1"]
+  "requirements": ["PyViCare==0.1.2"]
 }
 

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -140,8 +140,3 @@ class ViCareWater(WaterHeaterDevice):
     def operation_list(self):
         """Return the list of available operation modes."""
         return list(HA_TO_VICARE_HVAC_DHW)
-
-    @property
-    def device_state_attributes(self):
-        """Show Device Attributes."""
-        return self._attributes

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -11,7 +11,6 @@ from . import DOMAIN as VICARE_DOMAIN
 from . import VICARE_API
 from . import VICARE_NAME
 from . import VICARE_HEATING_TYPE
-from . import HeatingType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,34 +84,6 @@ class ViCareWater(WaterHeaterDevice):
         self._target_temperature = self._api.getDomesticHotWaterConfiguredTemperature()
 
         self._current_mode = self._api.getActiveMode()
-
-        # Update the generic device attributes
-        self._attributes = {}
-        if self._heating_type == HeatingType.gas:
-            self._attributes[
-                "gas_consumption_dhw_days"
-            ] = self._api.getGasConsumptionDomesticHotWaterDays()
-            self._attributes[
-                "gas_consumption_dhw_today"
-            ] = self._api.getGasConsumptionDomesticHotWaterToday()
-            self._attributes[
-                "gas_consumption_dhw_weeks"
-            ] = self._api.getGasConsumptionDomesticHotWaterWeeks()
-            self._attributes[
-                "gas_consumption_dhw_this_week"
-            ] = self._api.getGasConsumptionDomesticHotWaterThisWeek()
-            self._attributes[
-                "gas_consumption_dhw_months"
-            ] = self._api.getGasConsumptionDomesticHotWaterMonths()
-            self._attributes[
-                "gas_consumption_dhw_this_month"
-            ] = self._api.getGasConsumptionDomesticHotWaterThisMonth()
-            self._attributes[
-                "gas_consumption_dhw_years"
-            ] = self._api.getGasConsumptionDomesticHotWaterYears()
-            self._attributes[
-                "gas_consumption_dhw_this_year"
-            ] = self._api.getGasConsumptionDomesticHotWaterThisYear()
 
     @property
     def supported_features(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -75,7 +75,7 @@ PyRMVtransport==0.1.3
 PyTransportNSW==0.1.1
 
 # homeassistant.components.vicare
-PyViCare==0.1.1
+PyViCare==0.1.2
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.12.4


### PR DESCRIPTION
## Description:
Add a `heating_type` configuration option to provide additional values as attributes from the ViCare API.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10656

## Example entry for `configuration.yaml` (if applicable):
```yaml
vicare:
  username: 'email'
  password: 'password'
  heating_type: 'heatpump'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
