### PR TITLE
Split homematic color and effect support

### DIFF
--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -54,9 +54,12 @@ class HMLight(HMDevice, Light):
     @property
     def supported_features(self):
         """Flag supported features."""
+        features = SUPPORT_BRIGHTNESS
         if "COLOR" in self._hmdevice.WRITENODE:
-            return SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_EFFECT
-        return SUPPORT_BRIGHTNESS
+            features |= SUPPORT_COLOR
+            if "PROGRAM" in self._hmdevice.WRITENODE:
+                features |= SUPPORT_EFFECT
+        return features
 
     @property
     def hs_color(self):
@@ -110,4 +113,6 @@ class HMLight(HMDevice, Light):
         self._data[self._state] = None
 
         if self.supported_features & SUPPORT_COLOR:
-            self._data.update({"COLOR": None, "PROGRAM": None})
+            self._data.update({"COLOR": None})
+        if self.supported_features & SUPPORT_EFFECT:
+            self._data.update({"PROGRAM": None})

--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -57,8 +57,8 @@ class HMLight(HMDevice, Light):
         features = SUPPORT_BRIGHTNESS
         if "COLOR" in self._hmdevice.WRITENODE:
             features |= SUPPORT_COLOR
-            if "PROGRAM" in self._hmdevice.WRITENODE:
-                features |= SUPPORT_EFFECT
+        if "PROGRAM" in self._hmdevice.WRITENODE:
+            features |= SUPPORT_EFFECT
         return features
 
     @property


### PR DESCRIPTION
There are homematic devices (like HmIP-BSL) that support color but
do not support effects.
Split the support, so that color can be supported even if effects are not.

## Description:
Small refactoring in preparation for adding color support to the HmIP-BSL device in pyhomematic.
The current implementation of color lights for homematic links support for color with support for effects, since the currently only supported device (HM-LC-RGBW-WM) supports both.
The HmIP-BSL device supports color, but does not support effects, so the linking needs to be removed.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
