### PR TITLE
[homematic]Pass channel to light color functions

### DIFF
--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -63,7 +63,7 @@ class HMLight(HMDevice, Light):
         """Return the hue and saturation color value [float, float]."""
         if not self.supported_features & SUPPORT_COLOR:
             return None
-        hue, sat = self._hmdevice.get_hs_color()
+        hue, sat = self._hmdevice.get_hs_color(self._channel)
         return hue * 360.0, sat * 100.0
 
     @property
@@ -95,6 +95,7 @@ class HMLight(HMDevice, Light):
             self._hmdevice.set_hs_color(
                 hue=kwargs[ATTR_HS_COLOR][0] / 360.0,
                 saturation=kwargs[ATTR_HS_COLOR][1] / 100.0,
+                channel=self._channel
             )
         if ATTR_EFFECT in kwargs:
             self._hmdevice.set_effect(kwargs[ATTR_EFFECT])


### PR DESCRIPTION
## Description:
The Homematic (IP) BSL device has two independent color LEDs that can be controlled via different channels. In order to do that, the pyhomematic implementation needs the information which channel is currently referenced by the home assistant entity.

**Related issue (if applicable):** fixes [pyhomematic issue 255](https://github.com/danielperna84/pyhomematic/issues/255)

***This PR requires a related [PR](https://github.com/danielperna84/pyhomematic/pull/261) in pyhomematic to be merged first.***

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
