### PR TITLE
Split vacuum services documentation

### DIFF
--- a/homeassistant/components/neato/services.yaml
+++ b/homeassistant/components/neato/services.yaml
@@ -1,0 +1,18 @@
+neato_custom_cleaning:
+  description: Zone Cleaning service call specific to Neato Botvacs.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity. [Required]
+      example: "vacuum.neato"
+    mode:
+      description: "Set the cleaning mode: 1 for eco and 2 for turbo. Defaults to turbo if not set."
+      example: 2
+    navigation:
+      description: "Set the navigation mode: 1 for normal, 2 for extra care, 3 for deep. Defaults to normal if not set."
+      example: 1
+    category:
+      description: "Whether to use a persistent map or not for cleaning (i.e. No go lines): 2 for no map, 4 for map. Default to using map if not set (and fallback to no map if no map is found)."
+      example: 2
+    zone:
+      description: Only supported on the Botvac D7. Name of the zone to clean. Defaults to no zone i.e. complete house cleanup.
+      example: "Kitchen"

--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -5,73 +5,80 @@ turn_on:
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 turn_off:
   description: Stop the current cleaning task and return to home.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
+
+toggle:
+  descritption: WIP
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 stop:
   description: Stop the current cleaning task.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 locate:
   description: Locate the vacuum cleaner robot.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 start_pause:
   description: Start, pause, or resume the cleaning task.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 start:
   description: Start or resume the cleaning task.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 pause:
   description: Pause the cleaning task.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 return_to_base:
   description: Tell the vacuum cleaner to return to its dock.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 clean_spot:
   description: Tell the vacuum cleaner to do a spot clean-up.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
 
 send_command:
   description: Send a raw command to the vacuum cleaner.
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
     command:
       description: Command to execute.
-      example: 'set_dnd_timer'
+      example: "set_dnd_timer"
     params:
       description: Parameters for the command.
       example: '{ "key": "value" }'
@@ -81,85 +88,7 @@ set_fan_speed:
   fields:
     entity_id:
       description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
+      example: "vacuum.xiaomi_vacuum_cleaner"
     fan_speed:
       description: Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium' or by percentage, between 0 and 100.
-      example: 'low'
-
-xiaomi_remote_control_start:
-  description: Start remote control of the vacuum cleaner. You can then move it with `remote_control_move`, when done call `remote_control_stop`.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
-
-xiaomi_remote_control_stop:
-  description: Stop remote control mode of the vacuum cleaner.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
-
-xiaomi_remote_control_move:
-  description: Remote control the vacuum cleaner, make sure you first set it in remote control mode with `remote_control_start`.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
-    velocity:
-      description: Speed, between -0.29 and 0.29.
-      example: '0.2'
-    rotation:
-      description: Rotation, between -179 degrees and 179 degrees.
-      example: '90'
-    duration:
-      description: Duration of the movement.
-      example: '1500'
-
-xiaomi_remote_control_move_step:
-  description: Remote control the vacuum cleaner, only makes one move and then stops.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
-    velocity:
-      description: Speed, between -0.29 and 0.29.
-      example: '0.2'
-    rotation:
-      description: Rotation, between -179 degrees and 179 degrees.
-      example: '90'
-    duration:
-      description: Duration of the movement.
-      example: '1500'
-
-xiaomi_clean_zone:
-  description: Start the cleaning operation in the selected areas for the number of repeats indicated.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: 'vacuum.xiaomi_vacuum_cleaner'
-    zone:
-      description: Array of zones. Each zone is an array of 4 integer values.
-      example: '[[23510,25311,25110,26362]]'
-    repeats:
-      description: Number of cleaning repeats for each zone between 1 and 3.
-      example: '1'
-
-neato_custom_cleaning:
-  description: Zone Cleaning service call specific to Neato Botvacs.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity. [Required]
-      example: 'vacuum.neato'
-    mode:
-      description: "Set the cleaning mode: 1 for eco and 2 for turbo. Defaults to turbo if not set."
-      example: 2
-    navigation:
-      description: "Set the navigation mode: 1 for normal, 2 for extra care, 3 for deep. Defaults to normal if not set."
-      example: 1
-    category:
-      description: "Whether to use a persistent map or not for cleaning (i.e. No go lines): 2 for no map, 4 for map. Default to using map if not set (and fallback to no map if no map is found)."
-      example: 2
-    zone:
-      description: Only supported on the Botvac D7. Name of the zone to clean. Defaults to no zone i.e. complete house cleanup.
-      example: "Kitchen"
+      example: "low"

--- a/homeassistant/components/xiaomi_miio/services.yaml
+++ b/homeassistant/components/xiaomi_miio/services.yaml
@@ -1,0 +1,58 @@
+xiaomi_remote_control_start:
+  description: Start remote control of the vacuum cleaner. You can then move it with `remote_control_move`, when done call `remote_control_stop`.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+
+xiaomi_remote_control_stop:
+  description: Stop remote control mode of the vacuum cleaner.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+
+xiaomi_remote_control_move:
+  description: Remote control the vacuum cleaner, make sure you first set it in remote control mode with `remote_control_start`.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+    velocity:
+      description: Speed, between -0.29 and 0.29.
+      example: "0.2"
+    rotation:
+      description: Rotation, between -179 degrees and 179 degrees.
+      example: "90"
+    duration:
+      description: Duration of the movement.
+      example: "1500"
+
+xiaomi_remote_control_move_step:
+  description: Remote control the vacuum cleaner, only makes one move and then stops.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+    velocity:
+      description: Speed, between -0.29 and 0.29.
+      example: "0.2"
+    rotation:
+      description: Rotation, between -179 degrees and 179 degrees.
+      example: "90"
+    duration:
+      description: Duration of the movement.
+      example: "1500"
+
+xiaomi_clean_zone:
+  description: Start the cleaning operation in the selected areas for the number of repeats indicated.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: "vacuum.xiaomi_vacuum_cleaner"
+    zone:
+      description: Array of zones. Each zone is an array of 4 integer values.
+      example: "[[23510,25311,25110,26362]]"
+    repeats:
+      description: Number of cleaning repeats for each zone between 1 and 3.
+      example: "1"


### PR DESCRIPTION
## Description:
`xiaomi_miio` and `neato` have empty `services.yaml` files. After investigation, all the services documentation were in the `vacuum` integration. This PR split the documentation where they should be.

**Related issue (if applicable):** fixes partially #27289 

**Open point to be discuss before merge**: in the `vacuum` integration there is a service with no implementation called `toggle`. It seems never used here and in other vacuum platforms and no clue of the function role in the doc.
Is there someone who can explain clearly what was the idea? Do we want to keep it?

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html