### PR TITLE
Add support for homematic HmIP-BSL LEDs

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -82,6 +82,7 @@ HM_DEVICE_TYPES = {
         "IPKeySwitchPowermeter",
         "IPGarage",
         "IPKeySwitch",
+        "IPKeySwitchLevel",
         "IPMultiIO",
     ],
     DISCOVER_LIGHTS: [
@@ -90,6 +91,7 @@ HM_DEVICE_TYPES = {
         "IPKeyDimmer",
         "IPDimmer",
         "ColorEffectLight",
+        "IPKeySwitchLevel",
     ],
     DISCOVER_SENSORS: [
         "SwitchPowermeter",
@@ -671,6 +673,11 @@ def _get_devices(hass, discovery_type, keys, interface):
                 and class_name not in HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS.get(param, [])
             ):
                 continue
+            if discovery_type == DISCOVER_SWITCHES and class_name == "IPKeySwitchLevel":
+                channels.remove(8)
+                channels.remove(12)
+            if discovery_type == DISCOVER_LIGHTS and class_name == "IPKeySwitchLevel":
+                channels.remove(4)
 
             # Add devices
             _LOGGER.debug(


### PR DESCRIPTION
## Description:
Add support for the LEDs in the HmIP-BSL device

With this commit, 3 entities are created for the HmIP-BSL device:
2 lights for the two independent LEDs and 1 switch for the relais

Requires changes in pyhomematic as well.



**Related issue (if applicable):** fixes issue [255](https://github.com/danielperna84/pyhomematic/issues/255) in pyhomematic

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
