### PR TITLE
Fix connection issues with withings API by switching to a maintained codebase

### DIFF
--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -4,7 +4,7 @@ import logging
 import re
 import time
 
-import nokia
+import withings_api as withings
 from oauthlib.oauth2.rfc6749.errors import MissingTokenError
 from requests_oauthlib import TokenUpdated
 
@@ -68,7 +68,9 @@ class WithingsDataManager:
 
     service_available = None
 
-    def __init__(self, hass: HomeAssistantType, profile: str, api: nokia.NokiaApi):
+    def __init__(
+        self, hass: HomeAssistantType, profile: str, api: withings.WithingsApi
+    ):
         """Constructor."""
         self._hass = hass
         self._api = api
@@ -253,7 +255,7 @@ def create_withings_data_manager(
     """Set up the sensor config entry."""
     entry_creds = entry.data.get(const.CREDENTIALS) or {}
     profile = entry.data[const.PROFILE]
-    credentials = nokia.NokiaCredentials(
+    credentials = withings.WithingsCredentials(
         entry_creds.get("access_token"),
         entry_creds.get("token_expiry"),
         entry_creds.get("token_type"),
@@ -266,7 +268,7 @@ def create_withings_data_manager(
     def credentials_saver(credentials_param):
         _LOGGER.debug("Saving updated credentials of type %s", type(credentials_param))
 
-        # Sanitizing the data as sometimes a NokiaCredentials object
+        # Sanitizing the data as sometimes a WithingsCredentials object
         # is passed through from the API.
         cred_data = credentials_param
         if not isinstance(credentials_param, dict):
@@ -275,8 +277,8 @@ def create_withings_data_manager(
         entry.data[const.CREDENTIALS] = cred_data
         hass.config_entries.async_update_entry(entry, data={**entry.data})
 
-    _LOGGER.debug("Creating nokia api instance")
-    api = nokia.NokiaApi(
+    _LOGGER.debug("Creating withings api instance")
+    api = withings.WithingsApi(
         credentials, refresh_cb=(lambda token: credentials_saver(api.credentials))
     )
 

--- a/homeassistant/components/withings/config_flow.py
+++ b/homeassistant/components/withings/config_flow.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional
 
 import aiohttp
-import nokia
+import withings_api as withings
 import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
@@ -75,7 +75,7 @@ class WithingsFlowHandler(config_entries.ConfigFlow):
             profile,
         )
 
-        return nokia.NokiaAuth(
+        return withings.WithingsAuth(
             client_id,
             client_secret,
             callback_uri,

--- a/homeassistant/components/withings/manifest.json
+++ b/homeassistant/components/withings/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/components/withings",
   "requirements": [
-    "nokia==1.2.0"
+    "withings-api==2.0.0b7"
   ],
   "dependencies": [
     "api",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -864,9 +864,6 @@ niko-home-control==0.2.1
 # homeassistant.components.nilu
 niluclient==0.1.2
 
-# homeassistant.components.withings
-nokia==1.2.0
-
 # homeassistant.components.nederlandse_spoorwegen
 nsapi==2.7.4
 
@@ -1965,6 +1962,9 @@ websockets==6.0
 
 # homeassistant.components.wirelesstag
 wirelesstagpy==0.4.0
+
+# homeassistant.components.withings
+withings-api==2.0.0b7
 
 # homeassistant.components.wunderlist
 wunderpy2==0.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -224,9 +224,6 @@ minio==4.0.9
 # homeassistant.components.ssdp
 netdisco==2.6.0
 
-# homeassistant.components.withings
-nokia==1.2.0
-
 # homeassistant.components.iqvia
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow
@@ -423,6 +420,9 @@ vultr==0.1.2
 # homeassistant.components.samsungtv
 # homeassistant.components.wake_on_lan
 wakeonlan==1.1.6
+
+# homeassistant.components.withings
+withings-api==2.0.0b7
 
 # homeassistant.components.zeroconf
 zeroconf==0.23.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -173,6 +173,7 @@ TEST_REQUIREMENTS = (
     "vultr",
     "wakeonlan",
     "warrant",
+    "withings-api",
     "YesssSMS",
     "zeroconf",
     "zigpy-homeassistant",

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -104,7 +104,6 @@ TEST_REQUIREMENTS = (
     "mficlient",
     "minio",
     "netdisco",
-    "nokia",
     "numpy",
     "oauth2client",
     "paho-mqtt",

--- a/tests/components/withings/common.py
+++ b/tests/components/withings/common.py
@@ -1,7 +1,7 @@
 """Common data for for the withings component tests."""
 import time
 
-import nokia
+import withings_api as withings
 
 import homeassistant.components.withings.const as const
 
@@ -92,7 +92,7 @@ def new_measure(type_str, value, unit):
     }
 
 
-def nokia_sleep_response(states):
+def withings_sleep_response(states):
     """Create a sleep response based on states."""
     data = []
     for state in states:
@@ -104,10 +104,10 @@ def nokia_sleep_response(states):
             )
         )
 
-    return nokia.NokiaSleep(new_sleep_data("aa", data))
+    return withings.WithingsSleep(new_sleep_data("aa", data))
 
 
-NOKIA_MEASURES_RESPONSE = nokia.NokiaMeasures(
+WITHINGS_MEASURES_RESPONSE = withings.WithingsMeasures(
     {
         "updatetime": "",
         "timezone": "",
@@ -174,7 +174,7 @@ NOKIA_MEASURES_RESPONSE = nokia.NokiaMeasures(
 )
 
 
-NOKIA_SLEEP_RESPONSE = nokia_sleep_response(
+WITHINGS_SLEEP_RESPONSE = withings_sleep_response(
     [
         const.MEASURE_TYPE_SLEEP_STATE_AWAKE,
         const.MEASURE_TYPE_SLEEP_STATE_LIGHT,
@@ -183,7 +183,7 @@ NOKIA_SLEEP_RESPONSE = nokia_sleep_response(
     ]
 )
 
-NOKIA_SLEEP_SUMMARY_RESPONSE = nokia.NokiaSleepSummary(
+WITHINGS_SLEEP_SUMMARY_RESPONSE = withings.WithingsSleepSummary(
     {
         "series": [
             new_sleep_summary(

--- a/tests/components/withings/conftest.py
+++ b/tests/components/withings/conftest.py
@@ -3,7 +3,7 @@ import time
 from typing import Awaitable, Callable, List
 
 import asynctest
-import nokia
+import withings_api as withings
 import pytest
 
 import homeassistant.components.api as api
@@ -15,9 +15,9 @@ from homeassistant.const import CONF_UNIT_SYSTEM, CONF_UNIT_SYSTEM_METRIC
 from homeassistant.setup import async_setup_component
 
 from .common import (
-    NOKIA_MEASURES_RESPONSE,
-    NOKIA_SLEEP_RESPONSE,
-    NOKIA_SLEEP_SUMMARY_RESPONSE,
+    WITHINGS_MEASURES_RESPONSE,
+    WITHINGS_SLEEP_RESPONSE,
+    WITHINGS_SLEEP_SUMMARY_RESPONSE,
 )
 
 
@@ -34,17 +34,17 @@ class WithingsFactoryConfig:
         measures: List[str] = None,
         unit_system: str = None,
         throttle_interval: int = const.THROTTLE_INTERVAL,
-        nokia_request_response="DATA",
-        nokia_measures_response: nokia.NokiaMeasures = NOKIA_MEASURES_RESPONSE,
-        nokia_sleep_response: nokia.NokiaSleep = NOKIA_SLEEP_RESPONSE,
-        nokia_sleep_summary_response: nokia.NokiaSleepSummary = NOKIA_SLEEP_SUMMARY_RESPONSE,
+        withings_request_response="DATA",
+        withings_measures_response: withings.WithingsMeasures = WITHINGS_MEASURES_RESPONSE,
+        withings_sleep_response: withings.WithingsSleep = WITHINGS_SLEEP_RESPONSE,
+        withings_sleep_summary_response: withings.WithingsSleepSummary = WITHINGS_SLEEP_SUMMARY_RESPONSE,
     ) -> None:
         """Constructor."""
         self._throttle_interval = throttle_interval
-        self._nokia_request_response = nokia_request_response
-        self._nokia_measures_response = nokia_measures_response
-        self._nokia_sleep_response = nokia_sleep_response
-        self._nokia_sleep_summary_response = nokia_sleep_summary_response
+        self._withings_request_response = withings_request_response
+        self._withings_measures_response = withings_measures_response
+        self._withings_sleep_response = withings_sleep_response
+        self._withings_sleep_summary_response = withings_sleep_summary_response
         self._withings_config = {
             const.CLIENT_ID: "my_client_id",
             const.CLIENT_SECRET: "my_client_secret",
@@ -103,24 +103,24 @@ class WithingsFactoryConfig:
         return self._throttle_interval
 
     @property
-    def nokia_request_response(self):
+    def withings_request_response(self):
         """Request response."""
-        return self._nokia_request_response
+        return self._withings_request_response
 
     @property
-    def nokia_measures_response(self) -> nokia.NokiaMeasures:
+    def withings_measures_response(self) -> withings.WithingsMeasures:
         """Measures response."""
-        return self._nokia_measures_response
+        return self._withings_measures_response
 
     @property
-    def nokia_sleep_response(self) -> nokia.NokiaSleep:
+    def withings_sleep_response(self) -> withings.WithingsSleep:
         """Sleep response."""
-        return self._nokia_sleep_response
+        return self._withings_sleep_response
 
     @property
-    def nokia_sleep_summary_response(self) -> nokia.NokiaSleepSummary:
+    def withings_sleep_summary_response(self) -> withings.WithingsSleepSummary:
         """Sleep summary response."""
-        return self._nokia_sleep_summary_response
+        return self._withings_sleep_summary_response
 
 
 class WithingsFactoryData:
@@ -130,21 +130,21 @@ class WithingsFactoryData:
         self,
         hass,
         flow_id,
-        nokia_auth_get_credentials_mock,
-        nokia_api_request_mock,
-        nokia_api_get_measures_mock,
-        nokia_api_get_sleep_mock,
-        nokia_api_get_sleep_summary_mock,
+        withings_auth_get_credentials_mock,
+        withings_api_request_mock,
+        withings_api_get_measures_mock,
+        withings_api_get_sleep_mock,
+        withings_api_get_sleep_summary_mock,
         data_manager_get_throttle_interval_mock,
     ):
         """Constructor."""
         self._hass = hass
         self._flow_id = flow_id
-        self._nokia_auth_get_credentials_mock = nokia_auth_get_credentials_mock
-        self._nokia_api_request_mock = nokia_api_request_mock
-        self._nokia_api_get_measures_mock = nokia_api_get_measures_mock
-        self._nokia_api_get_sleep_mock = nokia_api_get_sleep_mock
-        self._nokia_api_get_sleep_summary_mock = nokia_api_get_sleep_summary_mock
+        self._withings_auth_get_credentials_mock = withings_auth_get_credentials_mock
+        self._withings_api_request_mock = withings_api_request_mock
+        self._withings_api_get_measures_mock = withings_api_get_measures_mock
+        self._withings_api_get_sleep_mock = withings_api_get_sleep_mock
+        self._withings_api_get_sleep_summary_mock = withings_api_get_sleep_summary_mock
         self._data_manager_get_throttle_interval_mock = (
             data_manager_get_throttle_interval_mock
         )
@@ -160,29 +160,29 @@ class WithingsFactoryData:
         return self._flow_id
 
     @property
-    def nokia_auth_get_credentials_mock(self):
+    def withings_auth_get_credentials_mock(self):
         """Get auth credentials mock."""
-        return self._nokia_auth_get_credentials_mock
+        return self._withings_auth_get_credentials_mock
 
     @property
-    def nokia_api_request_mock(self):
+    def withings_api_request_mock(self):
         """Get request mock."""
-        return self._nokia_api_request_mock
+        return self._withings_api_request_mock
 
     @property
-    def nokia_api_get_measures_mock(self):
+    def withings_api_get_measures_mock(self):
         """Get measures mock."""
-        return self._nokia_api_get_measures_mock
+        return self._withings_api_get_measures_mock
 
     @property
-    def nokia_api_get_sleep_mock(self):
+    def withings_api_get_sleep_mock(self):
         """Get sleep mock."""
-        return self._nokia_api_get_sleep_mock
+        return self._withings_api_get_sleep_mock
 
     @property
-    def nokia_api_get_sleep_summary_mock(self):
+    def withings_api_get_sleep_summary_mock(self):
         """Get sleep summary mock."""
-        return self._nokia_api_get_sleep_summary_mock
+        return self._withings_api_get_sleep_summary_mock
 
     @property
     def data_manager_get_throttle_interval_mock(self):
@@ -243,9 +243,9 @@ def withings_factory_fixture(request, hass) -> WithingsFactory:
         assert await async_setup_component(hass, http.DOMAIN, config.hass_config)
         assert await async_setup_component(hass, api.DOMAIN, config.hass_config)
 
-        nokia_auth_get_credentials_patch = asynctest.patch(
-            "nokia.NokiaAuth.get_credentials",
-            return_value=nokia.NokiaCredentials(
+        withings_auth_get_credentials_patch = asynctest.patch(
+            "withings_api.WithingsAuth.get_credentials",
+            return_value=withings.WithingsCredentials(
                 access_token="my_access_token",
                 token_expiry=time.time() + 600,
                 token_type="my_token_type",
@@ -255,28 +255,33 @@ def withings_factory_fixture(request, hass) -> WithingsFactory:
                 consumer_secret=config.withings_config.get(const.CLIENT_SECRET),
             ),
         )
-        nokia_auth_get_credentials_mock = nokia_auth_get_credentials_patch.start()
+        withings_auth_get_credentials_mock = withings_auth_get_credentials_patch.start()
 
-        nokia_api_request_patch = asynctest.patch(
-            "nokia.NokiaApi.request", return_value=config.nokia_request_response
+        withings_api_request_patch = asynctest.patch(
+            "withings_api.WithingsApi.request",
+            return_value=config.withings_request_response,
         )
-        nokia_api_request_mock = nokia_api_request_patch.start()
+        withings_api_request_mock = withings_api_request_patch.start()
 
-        nokia_api_get_measures_patch = asynctest.patch(
-            "nokia.NokiaApi.get_measures", return_value=config.nokia_measures_response
+        withings_api_get_measures_patch = asynctest.patch(
+            "withings_api.WithingsApi.get_measures",
+            return_value=config.withings_measures_response,
         )
-        nokia_api_get_measures_mock = nokia_api_get_measures_patch.start()
+        withings_api_get_measures_mock = withings_api_get_measures_patch.start()
 
-        nokia_api_get_sleep_patch = asynctest.patch(
-            "nokia.NokiaApi.get_sleep", return_value=config.nokia_sleep_response
+        withings_api_get_sleep_patch = asynctest.patch(
+            "withings_api.WithingsApi.get_sleep",
+            return_value=config.withings_sleep_response,
         )
-        nokia_api_get_sleep_mock = nokia_api_get_sleep_patch.start()
+        withings_api_get_sleep_mock = withings_api_get_sleep_patch.start()
 
-        nokia_api_get_sleep_summary_patch = asynctest.patch(
-            "nokia.NokiaApi.get_sleep_summary",
-            return_value=config.nokia_sleep_summary_response,
+        withings_api_get_sleep_summary_patch = asynctest.patch(
+            "withings_api.WithingsApi.get_sleep_summary",
+            return_value=config.withings_sleep_summary_response,
         )
-        nokia_api_get_sleep_summary_mock = nokia_api_get_sleep_summary_patch.start()
+        withings_api_get_sleep_summary_mock = (
+            withings_api_get_sleep_summary_patch.start()
+        )
 
         data_manager_get_throttle_interval_patch = asynctest.patch(
             "homeassistant.components.withings.common.WithingsDataManager"
@@ -295,11 +300,11 @@ def withings_factory_fixture(request, hass) -> WithingsFactory:
 
         patches.extend(
             [
-                nokia_auth_get_credentials_patch,
-                nokia_api_request_patch,
-                nokia_api_get_measures_patch,
-                nokia_api_get_sleep_patch,
-                nokia_api_get_sleep_summary_patch,
+                withings_auth_get_credentials_patch,
+                withings_api_request_patch,
+                withings_api_get_measures_patch,
+                withings_api_get_sleep_patch,
+                withings_api_get_sleep_summary_patch,
                 data_manager_get_throttle_interval_patch,
                 get_measures_patch,
             ]
@@ -328,11 +333,11 @@ def withings_factory_fixture(request, hass) -> WithingsFactory:
         return WithingsFactoryData(
             hass,
             flow_id,
-            nokia_auth_get_credentials_mock,
-            nokia_api_request_mock,
-            nokia_api_get_measures_mock,
-            nokia_api_get_sleep_mock,
-            nokia_api_get_sleep_summary_mock,
+            withings_auth_get_credentials_mock,
+            withings_api_request_mock,
+            withings_api_get_measures_mock,
+            withings_api_get_sleep_mock,
+            withings_api_get_sleep_summary_mock,
             data_manager_get_throttle_interval_mock,
         )
 

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -1,6 +1,6 @@
 """Tests for the Withings component."""
 from asynctest import MagicMock
-import nokia
+import withings_api as withings
 from oauthlib.oauth2.rfc6749.errors import MissingTokenError
 import pytest
 from requests_oauthlib import TokenUpdated
@@ -13,19 +13,19 @@ from homeassistant.components.withings.common import (
 from homeassistant.exceptions import PlatformNotReady
 
 
-@pytest.fixture(name="nokia_api")
-def nokia_api_fixture():
-    """Provide nokia api."""
-    nokia_api = nokia.NokiaApi.__new__(nokia.NokiaApi)
-    nokia_api.get_measures = MagicMock()
-    nokia_api.get_sleep = MagicMock()
-    return nokia_api
+@pytest.fixture(name="withings_api")
+def withings_api_fixture():
+    """Provide withings api."""
+    withings_api = withings.WithingsApi.__new__(withings.WithingsApi)
+    withings_api.get_measures = MagicMock()
+    withings_api.get_sleep = MagicMock()
+    return withings_api
 
 
 @pytest.fixture(name="data_manager")
-def data_manager_fixture(hass, nokia_api: nokia.NokiaApi):
+def data_manager_fixture(hass, withings_api: withings.WithingsApi):
     """Provide data manager."""
-    return WithingsDataManager(hass, "My Profile", nokia_api)
+    return WithingsDataManager(hass, "My Profile", withings_api)
 
 
 def test_print_service():


### PR DESCRIPTION

## Breaking Change:
No breaking changes.

## Description:
Shortly after inclusion into home assistant, the withings API started requiring extra data when authorizing. The client code the withings component uses was maintained. So we have switched over to a maintained api client.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
fixes #26716 


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
