### PR TITLE
Move imports in geo_rss_events component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,6 +104,7 @@ homeassistant/components/fronius/* @nielstron
 homeassistant/components/frontend/* @home-assistant/frontend
 homeassistant/components/gearbest/* @HerrHofrat
 homeassistant/components/geniushub/* @zxdavb
+homeassistant/components/geo_rss_events/* @exxamalte
 homeassistant/components/geonetnz_quakes/* @exxamalte
 homeassistant/components/gitter/* @fabaff
 homeassistant/components/glances/* @fabaff

--- a/homeassistant/components/geo_rss_events/manifest.json
+++ b/homeassistant/components/geo_rss_events/manifest.json
@@ -1,10 +1,12 @@
 {
   "domain": "geo_rss_events",
-  "name": "Geo rss events",
+  "name": "Geo RSS events",
   "documentation": "https://www.home-assistant.io/integrations/geo_rss_events",
   "requirements": [
     "georss_generic_client==0.2"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": [
+    "@exxamalte"
+  ]
 }

--- a/homeassistant/components/geo_rss_events/sensor.py
+++ b/homeassistant/components/geo_rss_events/sensor.py
@@ -12,6 +12,8 @@ import logging
 from datetime import timedelta
 
 import voluptuous as vol
+from georss_client import UPDATE_OK, UPDATE_OK_NO_DATA
+from georss_client.generic_feed import GenericFeed
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -108,7 +110,6 @@ class GeoRssServiceSensor(Entity):
         self._state = None
         self._state_attributes = None
         self._unit_of_measurement = unit_of_measurement
-        from georss_client.generic_feed import GenericFeed
 
         self._feed = GenericFeed(
             coordinates,
@@ -146,10 +147,9 @@ class GeoRssServiceSensor(Entity):
 
     def update(self):
         """Update this sensor from the GeoRSS service."""
-        import georss_client
 
         status, feed_entries = self._feed.update()
-        if status == georss_client.UPDATE_OK:
+        if status == UPDATE_OK:
             _LOGGER.debug(
                 "Adding events to sensor %s: %s", self.entity_id, feed_entries
             )
@@ -159,7 +159,7 @@ class GeoRssServiceSensor(Entity):
             for entry in feed_entries:
                 matrix[entry.title] = f"{entry.distance_to_home:.0f}km"
             self._state_attributes = matrix
-        elif status == georss_client.UPDATE_OK_NO_DATA:
+        elif status == UPDATE_OK_NO_DATA:
             _LOGGER.debug("Update successful, but no data received from %s", self._feed)
             # Don't change the state or state attributes.
         else:

--- a/tests/components/geo_rss_events/test_sensor.py
+++ b/tests/components/geo_rss_events/test_sensor.py
@@ -59,7 +59,7 @@ class TestGeoRssServiceUpdater(unittest.TestCase):
         feed_entry.category = category
         return feed_entry
 
-    @mock.patch("georss_client.generic_feed.GenericFeed")
+    @mock.patch("homeassistant.components.geo_rss_events.sensor.GenericFeed")
     def test_setup(self, mock_feed):
         """Test the general setup of the platform."""
         # Set up some mock feed entries for this test.
@@ -122,7 +122,7 @@ class TestGeoRssServiceUpdater(unittest.TestCase):
                     ATTR_ICON: "mdi:alert",
                 }
 
-    @mock.patch("georss_client.generic_feed.GenericFeed")
+    @mock.patch("homeassistant.components.geo_rss_events.sensor.GenericFeed")
     def test_setup_with_categories(self, mock_feed):
         """Test the general setup of the platform."""
         # Set up some mock feed entries for this test.


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved imports from functions to top-level as requested in https://github.com/home-assistant/home-assistant/issues/27284

**Related issue (if applicable):** #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
