### PR TITLE
Move imports in transport_nsw component

### DIFF
--- a/homeassistant/components/transport_nsw/sensor.py
+++ b/homeassistant/components/transport_nsw/sensor.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import logging
 
 import voluptuous as vol
+from TransportNSW import TransportNSW
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -120,8 +121,6 @@ class PublicTransportData:
 
     def __init__(self, stop_id, route, destination, api_key):
         """Initialize the data object."""
-        import TransportNSW
-
         self._stop_id = stop_id
         self._route = route
         self._destination = destination
@@ -134,7 +133,7 @@ class PublicTransportData:
             ATTR_DESTINATION: "n/a",
             ATTR_MODE: None,
         }
-        self.tnsw = TransportNSW.TransportNSW()
+        self.tnsw = TransportNSW()
 
     def update(self):
         """Get the next leave time."""


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved import from function to top-level as requested in #27284

**Related issue (if applicable):** #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
