### PR TITLE
Add opentherm_gw options flow

### DIFF
--- a/homeassistant/components/opentherm_gw/.translations/en.json
+++ b/homeassistant/components/opentherm_gw/.translations/en.json
@@ -19,5 +19,16 @@
             }
         },
         "title": "OpenTherm Gateway"
+    },
+    "options": {
+        "step": {
+            "init": {
+                "description": "Options for the OpenTherm Gateway",
+                "data": {
+                      "floor_temperature": "Floor Temperature",
+                      "precision": "Precision"
+                }
+            }
+        }
     }
 }

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -7,9 +7,7 @@
         "data": {
           "name": "Name",
           "device": "Path or URL",
-          "id": "ID",
-          "precision": "Climate temperature precision",
-          "floor_temperature": "Floor climate temperature"
+          "id": "ID"
         }
       }
     },
@@ -19,5 +17,16 @@
       "serial_error": "Error connecting to device",
       "timeout": "Connection attempt timed out"
 	}
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Options for the OpenTherm Gateway",
+        "data": {
+          "floor_temperature": "Floor Temperature",
+          "precision": "Precision"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description:
Add an options flow to `opentherm_gw` to allow configuration of the climate entity.
Reintroduces options that were removed in #27148 

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10661

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
N/A

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
