### PR TITLE
Fix Logi Circle cameras not responding to turn on/off commands

### DIFF
--- a/homeassistant/components/logi_circle/camera.py
+++ b/homeassistant/components/logi_circle/camera.py
@@ -148,11 +148,11 @@ class LogiCam(Camera):
 
     async def async_turn_off(self):
         """Disable streaming mode for this camera."""
-        await self._camera.set_streaming_mode(False)
+        await self._camera.set_config("streaming", False)
 
     async def async_turn_on(self):
         """Enable streaming mode for this camera."""
-        await self._camera.set_streaming_mode(True)
+        await self._camera.set_config("streaming", True)
 
     @property
     def should_poll(self):


### PR DESCRIPTION
## Description:

Fixes an issue where Logi Circle cameras stopped responding to `camera.turn_on` and `camera.turn_off` requests after the API wrapper version was last bumped.

**Related issue (if applicable):** N/A

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
