### PR TITLE
Remove notification by changing withings config flow init source

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation at
 """
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import ConfigEntry, SOURCE_USER
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.helpers import config_validation as cv
 
@@ -58,7 +58,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data={}
+            DOMAIN, context={"source": SOURCE_USER}, data={}
         )
     )
 


### PR DESCRIPTION
## Description:
Unnecessary notification for withings was constantly appearing. Changed the config flow context source to one that does not create a notification.

**Related issue (if applicable):** fixes #27187

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [X] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [X] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
