### PR TITLE
Fix Plex external auth for single server

### DIFF
--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -57,7 +57,7 @@ class PlexServer:
                 raise ServerNotSpecified(available_servers)
 
             server_choice = (
-                self._server_name if self._server_name else available_servers[0]
+                self._server_name if self._server_name else available_servers[0][0]
             )
             connections = account.resource(server_choice).connections
             local_url = [x.httpuri for x in connections if x.local]


### PR DESCRIPTION
## Description:
The Plex external auth config flow fails when a single Plex server is connected to the account. I switched my testing environment to have multiple servers during development and added a feature that broke the single server use case.

This is a fix for beta functionality in 0.100 and needs to be merged before release.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html