### PR TITLE
Only auth on enter_learning in response to errors for broadlink

### DIFF
--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -50,6 +50,7 @@ def async_setup_service(hass, host, device):
             for retry in range(DEFAULT_RETRY):
                 try:
                     await hass.async_add_executor_job(device.enter_learning)
+                    break
                 except (socket.timeout, ValueError):
                     try:
                         await hass.async_add_executor_job(device.auth)

--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -88,6 +88,7 @@ def async_setup_service(hass, host, device):
                 except socket.timeout:
                     if retry == DEFAULT_RETRY - 1:
                         _LOGGER.error("Failed to enter learning mode")
+                        return
 
         _LOGGER.info("Press the key you want Home Assistant to learn")
         start_time = utcnow()

--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -57,7 +57,6 @@ def async_setup_service(hass, host, device):
                         if retry == DEFAULT_RETRY - 1:
                             _LOGGER.error("Failed to enter learning mode")
 
-
             _LOGGER.info("Press the key you want Home Assistant to learn")
             start_time = utcnow()
             while (utcnow() - start_time) < timedelta(seconds=20):

--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -47,16 +47,16 @@ def async_setup_service(hass, host, device):
             """Learn a packet from remote."""
             device = hass.data[DOMAIN][call.data[CONF_HOST]]
 
-            try:
-                auth = await hass.async_add_executor_job(device.auth)
-            except socket.timeout:
-                _LOGGER.error("Failed to connect to device, timeout")
-                return
-            if not auth:
-                _LOGGER.error("Failed to connect to device")
-                return
+            for retry in range(DEFAULT_RETRY):
+                try:
+                    await hass.async_add_executor_job(device.enter_learning)
+                except (socket.timeout, ValueError):
+                    try:
+                        await hass.async_add_executor_job(device.auth)
+                    except socket.timeout:
+                        if retry == DEFAULT_RETRY - 1:
+                            _LOGGER.error("Failed to enter learning mode")
 
-            await hass.async_add_executor_job(device.enter_learning)
 
             _LOGGER.info("Press the key you want Home Assistant to learn")
             start_time = utcnow()


### PR DESCRIPTION
## Breaking Change:

For a while now, multiple issues (#25943, #27213) have mentioned that learning new IR commands fails on the broadlink integration. I tracked this down to the fact that the auth() method seems to return False for all executions except the very first one (which happens during the switch component setup).

## Description:


**Related issue (if applicable):** fixes #27213

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
