### PR TITLE
Generate ADB key for Android TV integration

### DIFF
--- a/homeassistant/components/androidtv/manifest.json
+++ b/homeassistant/components/androidtv/manifest.json
@@ -3,8 +3,8 @@
   "name": "Androidtv",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
   "requirements": [
-    "adb-shell==0.0.4",
-    "androidtv==0.0.30"
+    "adb-shell==0.0.7",
+    "androidtv==0.0.32"
   ],
   "dependencies": [],
   "codeowners": ["@JeffLIrion"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -112,7 +112,7 @@ adafruit-blinka==1.2.1
 adafruit-circuitpython-mcp230xx==1.1.2
 
 # homeassistant.components.androidtv
-adb-shell==0.0.4
+adb-shell==0.0.7
 
 # homeassistant.components.adguard
 adguardhome==0.2.1
@@ -203,7 +203,7 @@ ambiclimate==0.2.1
 amcrest==1.5.3
 
 # homeassistant.components.androidtv
-androidtv==0.0.30
+androidtv==0.0.32
 
 # homeassistant.components.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -49,7 +49,7 @@ YesssSMS==0.4.1
 abodepy==0.16.5
 
 # homeassistant.components.androidtv
-adb-shell==0.0.4
+adb-shell==0.0.7
 
 # homeassistant.components.adguard
 adguardhome==0.2.1
@@ -98,7 +98,7 @@ airly==0.0.2
 ambiclimate==0.2.1
 
 # homeassistant.components.androidtv
-androidtv==0.0.30
+androidtv==0.0.32
 
 # homeassistant.components.apns
 apns2==0.3.0

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -127,17 +127,10 @@ def patch_shell(response=None, error=False):
     }
 
 
-def do_nothing(*args, **kwargs):
-    """Do nothing."""
-
-
 PATCH_ADB_DEVICE = patch("androidtv.adb_manager.AdbDevice", AdbDeviceFake)
-PATCH_SIGNER = patch("androidtv.adb_manager.PythonRSASigner", do_nothing)
-PATCH_KEYGEN = patch(
-    "homeassistant.components.androidtv.media_player.keygen", do_nothing
-)
-
 PATCH_ANDROIDTV_OPEN = patch("androidtv.adb_manager.open", mock_open())
+PATCH_KEYGEN = patch("homeassistant.components.androidtv.media_player.keygen")
+PATCH_SIGNER = patch("androidtv.adb_manager.PythonRSASigner")
 
 
 def isfile(filepath):

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -1,7 +1,7 @@
 """Define patches used for androidtv tests."""
 
 from socket import error as socket_error
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 
 class AdbDeviceFake:
@@ -127,4 +127,23 @@ def patch_shell(response=None, error=False):
     }
 
 
+def do_nothing(*args, **kwargs):
+    """Do nothing."""
+
+
 PATCH_ADB_DEVICE = patch("androidtv.adb_manager.AdbDevice", AdbDeviceFake)
+PATCH_SIGNER = patch("androidtv.adb_manager.PythonRSASigner", do_nothing)
+PATCH_KEYGEN = patch(
+    "homeassistant.components.androidtv.media_player.keygen", do_nothing
+)
+
+PATCH_ANDROIDTV_OPEN = patch("androidtv.adb_manager.open", mock_open())
+
+
+def isfile(filepath):
+    """Mock `os.path.isfile`."""
+    return filepath.endswith("adbkey")
+
+
+PATCH_ISFILE = patch("os.path.isfile", isfile)
+PATCH_ACCESS = patch("os.access", return_value=True)

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -148,6 +148,8 @@ async def _test_reconnect(hass, caplog, config):
             in caplog.record_tuples[2]
         )
 
+    return True
+
 
 async def _test_adb_shell_returns_none(hass, config):
     """Test the case that the ADB shell command returns `None`.
@@ -174,6 +176,8 @@ async def _test_adb_shell_returns_none(hass, config):
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
+
+    return True
 
 
 async def test_reconnect_androidtv_python_adb(hass, caplog):

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -148,8 +148,6 @@ async def _test_reconnect(hass, caplog, config):
             in caplog.record_tuples[2]
         )
 
-    return True
-
 
 async def _test_adb_shell_returns_none(hass, config):
     """Test the case that the ADB shell command returns `None`.
@@ -176,8 +174,6 @@ async def _test_adb_shell_returns_none(hass, config):
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
-
-    return True
 
 
 async def test_reconnect_androidtv_python_adb(hass, caplog):
@@ -276,5 +272,3 @@ async def test_setup_with_adbkey(hass):
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_OFF
-
-    return True

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -5,6 +5,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.components.androidtv.media_player import (
     ANDROIDTV_DOMAIN,
     CONF_ADB_SERVER_IP,
+    CONF_ADBKEY,
 )
 from homeassistant.components.media_player.const import DOMAIN
 from homeassistant.const import (
@@ -61,14 +62,8 @@ CONFIG_FIRETV_ADB_SERVER = {
 }
 
 
-async def _test_reconnect(hass, caplog, config):
-    """Test that the error and reconnection attempts are logged correctly.
-
-    "Handles device/service unavailable. Log a warning once when
-    unavailable, log once when reconnected."
-
-    https://developers.home-assistant.io/docs/en/integration_quality_scale_index.html
-    """
+def _setup(hass, config):
+    """Perform common setup tasks for the tests."""
     if CONF_ADB_SERVER_IP not in config[DOMAIN]:
         patch_key = "python"
     else:
@@ -79,10 +74,26 @@ async def _test_reconnect(hass, caplog, config):
     else:
         entity_id = "media_player.fire_tv"
 
+    return patch_key, entity_id
+
+
+async def _test_reconnect(hass, caplog, config):
+    """Test that the error and reconnection attempts are logged correctly.
+
+    "Handles device/service unavailable. Log a warning once when
+    unavailable, log once when reconnected."
+
+    https://developers.home-assistant.io/docs/en/integration_quality_scale_index.html
+    """
+    patch_key, entity_id = _setup(hass, config)
+
     with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
         patch_key
-    ], patchers.patch_shell("")[patch_key]:
+    ], patchers.patch_shell("")[
+        patch_key
+    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         assert await async_setup_component(hass, DOMAIN, config)
+
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -93,7 +104,7 @@ async def _test_reconnect(hass, caplog, config):
 
     with patchers.patch_connect(False)[patch_key], patchers.patch_shell(error=True)[
         patch_key
-    ]:
+    ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         for _ in range(5):
             await hass.helpers.entity_component.async_update_entity(entity_id)
             state = hass.states.get(entity_id)
@@ -105,7 +116,9 @@ async def _test_reconnect(hass, caplog, config):
     assert caplog.record_tuples[1][1] == logging.WARNING
 
     caplog.set_level(logging.DEBUG)
-    with patchers.patch_connect(True)[patch_key], patchers.patch_shell("1")[patch_key]:
+    with patchers.patch_connect(True)[patch_key], patchers.patch_shell("1")[
+        patch_key
+    ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         # Update 1 will reconnect
         await hass.helpers.entity_component.async_update_entity(entity_id)
 
@@ -143,19 +156,13 @@ async def _test_adb_shell_returns_none(hass, config):
 
     The state should be `None` and the device should be unavailable.
     """
-    if CONF_ADB_SERVER_IP not in config[DOMAIN]:
-        patch_key = "python"
-    else:
-        patch_key = "server"
-
-    if config[DOMAIN].get(CONF_DEVICE_CLASS) != "firetv":
-        entity_id = "media_player.android_tv"
-    else:
-        entity_id = "media_player.fire_tv"
+    patch_key, entity_id = _setup(hass, config)
 
     with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
         patch_key
-    ], patchers.patch_shell("")[patch_key]:
+    ], patchers.patch_shell("")[
+        patch_key
+    ], patchers.PATCH_KEYGEN, patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
@@ -164,7 +171,7 @@ async def _test_adb_shell_returns_none(hass, config):
 
     with patchers.patch_shell(None)[patch_key], patchers.patch_shell(error=True)[
         patch_key
-    ]:
+    ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER:
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
@@ -251,3 +258,23 @@ async def test_adb_shell_returns_none_firetv_adb_server(hass):
 
     """
     assert await _test_adb_shell_returns_none(hass, CONFIG_FIRETV_ADB_SERVER)
+
+
+async def test_setup_with_adbkey(hass):
+    """Test that setup succeeds when using an ADB key."""
+    config = CONFIG_ANDROIDTV_PYTHON_ADB.copy()
+    config[DOMAIN][CONF_ADBKEY] = hass.config.path("user_provided_adbkey")
+    patch_key, entity_id = _setup(hass, config)
+
+    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
+        patch_key
+    ], patchers.patch_shell("")[
+        patch_key
+    ], patchers.PATCH_ANDROIDTV_OPEN, patchers.PATCH_SIGNER, patchers.PATCH_ISFILE, patchers.PATCH_ACCESS:
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.helpers.entity_component.async_update_entity(entity_id)
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_OFF
+
+    return True


### PR DESCRIPTION
## Description:

This greatly simplifies the setup of the `androidtv` integration in 2 ways:

1. Fixes in the backend `adb-shell` package make it so that users do not need to setup an ADB server.
2. If a user is setting up the `androidtv` integration and they do not provide a key, then generate a key for them and use it to authenticate.
    * When authenticating for the first time, the user will have 10 seconds to approve the connection. If they miss this window, it's not a big deal -- as long as they click "OK" on their TV, then HA will connect on its next attempt to setup the integration. 

User feedback: https://community.home-assistant.io/t/testers-needed-android-tv-fire-tv-key-generation/141498

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/10743

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
