### PR TITLE
Move imports in onkyo component

### DIFF
--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -3,6 +3,8 @@ import logging
 from typing import List
 
 import voluptuous as vol
+import eiscp
+from eiscp import eISCP
 
 from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
@@ -133,9 +135,6 @@ def determine_zones(receiver):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Onkyo platform."""
-    import eiscp
-    from eiscp import eISCP
-
     host = config.get(CONF_HOST)
     hosts = []
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Moved import from function to top-level as requested in #27284

I tested this component manually with an Onkyo TX-L50 because there are unfortunately no unit tests.

**Related issue (if applicable):** #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
