### PR TITLE
Install requirements for all deps with tests

### DIFF
--- a/homeassistant/components/epsonworkforce/sensor.py
+++ b/homeassistant/components/epsonworkforce/sensor.py
@@ -10,8 +10,6 @@ from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ["epsonprinter==0.0.9"]
-
 _LOGGER = logging.getLogger(__name__)
 MONITORED_CONDITIONS = {
     "black": ["Ink level Black", "%", "mdi:water"],

--- a/homeassistant/components/ign_sismologia/geo_location.py
+++ b/homeassistant/components/ign_sismologia/geo_location.py
@@ -19,8 +19,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
 from homeassistant.helpers.event import track_time_interval
 
-REQUIREMENTS = ["georss_ign_sismologia_client==0.2"]
-
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_EXTERNAL_ID = "external_id"

--- a/homeassistant/components/supla/__init__.py
+++ b/homeassistant/components/supla/__init__.py
@@ -9,8 +9,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ["pysupla==0.0.3"]
-
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "supla"
 

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -3,6 +3,7 @@ import asyncio
 from ipaddress import IPv4Address
 
 import aiohttp
+from async_upnp_client.profiles.igd import IgdDevice
 
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import HomeAssistantType
@@ -28,9 +29,6 @@ class Device:
             local_ip = hass.data[DOMAIN]["config"].get(CONF_LOCAL_IP)
         if local_ip:
             local_ip = IPv4Address(local_ip)
-
-        # discover devices
-        from async_upnp_client.profiles.igd import IgdDevice
 
         discovery_infos = await IgdDevice.async_search(source_ip=local_ip, timeout=10)
 

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -59,9 +59,6 @@ class Device:
         factory = UpnpFactory(requester, disable_state_variable_validation=True)
         upnp_device = await factory.async_create_device(ssdp_description)
 
-        # wrap with async_upnp_client.IgdDevice
-        from async_upnp_client.profiles.igd import IgdDevice
-
         igd_device = IgdDevice(upnp_device, None)
 
         return cls(igd_device)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -33,6 +33,3 @@ enum34==1000000000.0.0
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
-
-# Contains code to modify Home Assistant to work around our rules
-python-systemair-savecair==1000000000.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,9 +131,6 @@ caldav==0.6.1
 # homeassistant.components.coinmarketcap
 coinmarketcap==5.0.3
 
-# homeassistant.components.upc_connect
-connect-box==0.2.5
-
 # homeassistant.components.eddystone_temperature
 # homeassistant.components.eq3btsmart
 # homeassistant.components.xiaomi_miio
@@ -161,9 +158,6 @@ eebrightbox==0.0.4
 
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.8
-
-# homeassistant.components.entur_public_transport
-enturclient==0.2.0
 
 # homeassistant.components.season
 ephem==3.7.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -30,6 +30,9 @@ HAP-python==2.6.0
 # homeassistant.components.owntracks
 PyNaCl==1.3.0
 
+# homeassistant.auth.mfa_modules.totp
+PyQRCode==1.2.1
+
 # homeassistant.components.rmvtransport
 PyRMVtransport==0.1.3
 
@@ -131,10 +134,16 @@ caldav==0.6.1
 # homeassistant.components.coinmarketcap
 coinmarketcap==5.0.3
 
+# homeassistant.scripts.check_config
+colorlog==4.0.2
+
 # homeassistant.components.eddystone_temperature
 # homeassistant.components.eq3btsmart
 # homeassistant.components.xiaomi_miio
 construct==2.9.45
+
+# homeassistant.scripts.credstash
+# credstash==1.15.0
 
 # homeassistant.components.datadog
 datadog==0.15.0
@@ -250,6 +259,12 @@ influxdb==5.2.3
 
 # homeassistant.components.verisure
 jsonpath==0.75
+
+# homeassistant.scripts.keyring
+keyring==17.1.1
+
+# homeassistant.scripts.keyring
+keyrings.alt==3.1.1
 
 # homeassistant.components.dyson
 libpurecool==0.5.0
@@ -451,6 +466,11 @@ pyopenuv==1.0.9
 
 # homeassistant.components.opentherm_gw
 pyotgw==0.5b0
+
+# homeassistant.auth.mfa_modules.notify
+# homeassistant.auth.mfa_modules.totp
+# homeassistant.components.otp
+pyotp==2.3.0
 
 # homeassistant.components.point
 pypoint==1.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,8 +36,14 @@ PyRMVtransport==0.1.3
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1
 
+# homeassistant.components.remember_the_milk
+RtmAPI==0.7.0
+
 # homeassistant.components.yessssms
 YesssSMS==0.4.1
+
+# homeassistant.components.androidtv
+adb-shell==0.0.4
 
 # homeassistant.components.adguard
 adguardhome==0.2.1
@@ -47,6 +53,9 @@ aio_geojson_geonetnz_quakes==0.10
 
 # homeassistant.components.ambient_station
 aioambient==0.3.2
+
+# homeassistant.components.asuswrt
+aioasuswrt==1.1.21
 
 # homeassistant.components.automatic
 aioautomatic==0.6.5
@@ -91,6 +100,13 @@ apns2==0.3.0
 # homeassistant.components.aprs
 aprslib==0.6.46
 
+# homeassistant.components.arcam_fmj
+arcam-fmj==0.4.3
+
+# homeassistant.components.dlna_dmr
+# homeassistant.components.upnp
+async-upnp-client==0.14.11
+
 # homeassistant.components.stream
 av==6.1.2
 
@@ -100,16 +116,42 @@ axis==25
 # homeassistant.components.zha
 bellows-homeassistant==0.10.0
 
+# homeassistant.components.bom
+bomradarloop==0.1.3
+
+# homeassistant.components.broadlink
+broadlink==0.12.0
+
+# homeassistant.components.buienradar
+buienradar==1.0.1
+
 # homeassistant.components.caldav
 caldav==0.6.1
 
 # homeassistant.components.coinmarketcap
 coinmarketcap==5.0.3
 
+# homeassistant.components.upc_connect
+connect-box==0.2.5
+
+# homeassistant.components.eddystone_temperature
+# homeassistant.components.eq3btsmart
+# homeassistant.components.xiaomi_miio
+construct==2.9.45
+
+# homeassistant.components.datadog
+datadog==0.15.0
+
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns
 # homeassistant.components.ohmconnect
 defusedxml==0.6.0
+
+# homeassistant.components.directv
+directpy==0.5
+
+# homeassistant.components.updater
+distro==1.4.0
 
 # homeassistant.components.dsmr
 dsmr_parser==0.12
@@ -120,8 +162,8 @@ eebrightbox==0.0.4
 # homeassistant.components.emulated_roku
 emulated_roku==0.1.8
 
-# homeassistant.components.enocean
-enocean==0.50
+# homeassistant.components.entur_public_transport
+enturclient==0.2.0
 
 # homeassistant.components.season
 ephem==3.7.6.0
@@ -160,6 +202,9 @@ getmac==0.8.1
 # homeassistant.components.google
 google-api-python-client==1.6.4
 
+# homeassistant.components.google_pubsub
+google-cloud-pubsub==0.39.1
+
 # homeassistant.components.ffmpeg
 ha-ffmpeg==2.0
 
@@ -186,6 +231,9 @@ holidays==0.9.11
 
 # homeassistant.components.frontend
 home-assistant-frontend==20191002.1
+
+# homeassistant.components.zwave
+homeassistant-pyozw==0.1.4
 
 # homeassistant.components.homekit_controller
 homekit[IP]==0.15.0
@@ -215,6 +263,9 @@ libpurecool==0.5.0
 # homeassistant.components.soundtouch
 libsoundtouch==0.7.2
 
+# homeassistant.components.logi_circle
+logi_circle==0.2.2
+
 # homeassistant.components.luftdaten
 luftdaten==0.6.3
 
@@ -227,9 +278,21 @@ mficlient==0.3.0
 # homeassistant.components.minio
 minio==4.0.9
 
+# homeassistant.components.tts
+mutagen==1.42.0
+
+# homeassistant.components.ness_alarm
+nessclient==0.9.15
+
 # homeassistant.components.discovery
 # homeassistant.components.ssdp
 netdisco==2.6.0
+
+# homeassistant.components.nsw_fuel_station
+nsw-fuel-api-client==1.0.10
+
+# homeassistant.components.nuheat
+nuheat==0.3.0
 
 # homeassistant.components.iqvia
 # homeassistant.components.opencv
@@ -268,6 +331,12 @@ plexauth==0.0.4
 # homeassistant.components.serial_pm
 pmsensor==0.4
 
+# homeassistant.components.reddit
+praw==6.3.1
+
+# homeassistant.components.islamic_prayer_times
+prayer_times_calculator==0.0.3
+
 # homeassistant.components.prometheus
 prometheus_client==0.7.1
 
@@ -280,6 +349,9 @@ pushbullet.py==0.11.0
 # homeassistant.components.canary
 py-canary==0.5.0
 
+# homeassistant.components.melissa
+py-melissa-climate==2.0.0
+
 # homeassistant.components.seventeentrack
 py17track==2.2.2
 
@@ -290,6 +362,15 @@ pyHS100==0.3.5
 # homeassistant.components.norway_air
 pyMetno==0.4.6
 
+# homeassistant.components.rfxtrx
+pyRFXtrx==0.23
+
+# homeassistant.components.nextbus
+py_nextbusnext==0.1.4
+
+# homeassistant.components.arlo
+pyarlo==0.2.3
+
 # homeassistant.components.blackbird
 pyblackbird==0.5
 
@@ -299,11 +380,29 @@ pybotvac==0.0.16
 # homeassistant.components.cast
 pychromecast==4.0.1
 
+# homeassistant.components.daikin
+pydaikin==1.6.1
+
 # homeassistant.components.deconz
 pydeconz==63
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5
+
+# homeassistant.components.everlights
+pyeverlights==0.1.0
+
+# homeassistant.components.fido
+pyfido==2.1.1
+
+# homeassistant.components.fritzbox
+pyfritzhome==0.4.0
+
+# homeassistant.components.ifttt
+pyfttt==0.3
+
+# homeassistant.components.version
+pyhaversion==3.1.0
 
 # homeassistant.components.heos
 pyheos==0.6.0
@@ -311,8 +410,20 @@ pyheos==0.6.0
 # homeassistant.components.homematic
 pyhomematic==0.1.60
 
+# homeassistant.components.hydroquebec
+pyhydroquebec==2.2.2
+
+# homeassistant.components.ipma
+pyipma==1.2.1
+
 # homeassistant.components.iqvia
 pyiqvia==0.2.1
+
+# homeassistant.components.kira
+pykira==0.1.1
+
+# homeassistant.components.webostv
+pylgtv==0.1.9
 
 # homeassistant.components.linky
 pylinky==0.4.0
@@ -320,8 +431,17 @@ pylinky==0.4.0
 # homeassistant.components.litejet
 pylitejet==0.1
 
+# homeassistant.components.mailgun
+pymailgunner==1.4
+
 # homeassistant.components.somfy
 pymfy==0.5.2
+
+# homeassistant.components.mochad
+pymochad==0.2.0
+
+# homeassistant.components.modbus
+pymodbus==1.5.2
 
 # homeassistant.components.monoprice
 pymonoprice==0.3
@@ -338,10 +458,8 @@ pyopenuv==1.0.9
 # homeassistant.components.opentherm_gw
 pyotgw==0.5b0
 
-# homeassistant.auth.mfa_modules.notify
-# homeassistant.auth.mfa_modules.totp
-# homeassistant.components.otp
-pyotp==2.3.0
+# homeassistant.components.point
+pypoint==1.1.1
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.0.1
@@ -376,6 +494,9 @@ python-forecastio==1.4.0
 # homeassistant.components.izone
 python-izone==1.1.1
 
+# homeassistant.components.xiaomi_miio
+python-miio==0.4.6
+
 # homeassistant.components.nest
 python-nest==4.1.0
 
@@ -384,6 +505,9 @@ python-velbus==2.0.27
 
 # homeassistant.components.awair
 python_awair==0.0.4
+
+# homeassistant.components.traccar
+pytraccar==0.9.0
 
 # homeassistant.components.tradfri
 pytradfri[async]==6.3.1
@@ -409,6 +533,9 @@ ring_doorbell==0.2.3
 # homeassistant.components.yamaha
 rxv==0.6.0
 
+# homeassistant.components.samsungtv
+samsungctl[websocket]==0.7.1
+
 # homeassistant.components.simplisafe
 simplisafe-python==5.0.1
 
@@ -431,14 +558,28 @@ sqlalchemy==1.3.9
 # homeassistant.components.statsd
 statsd==3.2.1
 
+# homeassistant.components.solaredge
+# homeassistant.components.thermoworks_smoke
+# homeassistant.components.traccar
+stringcase==1.2.0
+
+# homeassistant.components.tellduslive
+tellduslive==0.10.10
+
 # homeassistant.components.toon
 toonapilib==3.2.4
+
+# homeassistant.components.tplink
+tplink==0.2.1
 
 # homeassistant.components.transmission
 transmissionrpc==0.11
 
 # homeassistant.components.twentemilieu
 twentemilieu==0.1.0
+
+# homeassistant.components.twilio
+twilio==6.19.1
 
 # homeassistant.components.uvc
 uvcclient==0.11.0
@@ -454,11 +595,42 @@ vultr==0.1.2
 # homeassistant.components.wake_on_lan
 wakeonlan==1.1.6
 
+# homeassistant.components.folder_watcher
+watchdog==0.8.3
+
+# homeassistant.components.webostv
+websockets==6.0
+
 # homeassistant.components.withings
 withings-api==2.0.0b7
+
+# homeassistant.components.bluesound
+# homeassistant.components.startca
+# homeassistant.components.ted5000
+# homeassistant.components.yr
+# homeassistant.components.zestimate
+xmltodict==0.12.0
+
+# homeassistant.components.yandex_transport
+ya_ma==0.3.7
+
+# homeassistant.components.yweather
+yahooweather==0.10
 
 # homeassistant.components.zeroconf
 zeroconf==0.23.0
 
 # homeassistant.components.zha
+zha-quirks==0.0.26
+
+# homeassistant.components.zha
+zigpy-deconz==0.5.0
+
+# homeassistant.components.zha
 zigpy-homeassistant==0.9.0
+
+# homeassistant.components.zha
+zigpy-xbee-homeassistant==0.5.0
+
+# homeassistant.components.zha
+zigpy-zigate==0.4.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -233,7 +233,13 @@ def requirements_test_output(reqs):
     filtered = {
         requirement: modules
         for requirement, modules in reqs.items()
-        if any(has_tests(mdl) for mdl in modules)
+        if any(
+            # Always install requirements that are not part of integrations
+            not mdl.startswith("homeassistant.components.") or
+            # Install tests for integrations that have tests
+            has_tests(mdl)
+            for mdl in modules
+        )
     }
     output.append(generate_requirements_list(filtered))
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -70,8 +70,20 @@ def has_tests(module: str):
     Module format: homeassistant.components.hue
     Test if exists: tests/components/hue
     """
+    path = Path(module.replace(".", "/").replace("homeassistant", "tests"))
+    if not path.exists():
+        return False
 
-    return Path(module.replace(".", "/").replace("homeassistant", "tests")).exists()
+    if not path.is_dir():
+        return True
+
+    # Dev environments might have stale directories around
+    # from removed tests. Check for that.
+    content = [f.name for f in path.glob("*")]
+
+    # Directories need to contain more than `__pycache__`
+    # to exist in Git and so be seen by CI.
+    return content != ["__pycache__"]
 
 
 def explore_module(package, explore_children):

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -289,7 +289,7 @@ def main(validate):
             print()
             print("\n\n".join(errors))
             print()
-            print("Please run script/gen_requirements_all.py")
+            print("Please run python3 -m script.gen_requirements_all")
             return 1
 
         return 0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -41,158 +41,7 @@ COMMENT_REQUIREMENTS = (
     "VL53L1X2",
 )
 
-TEST_REQUIREMENTS = (
-    "adguardhome",
-    "aio_geojson_geonetnz_quakes",
-    "aioambient",
-    "aioautomatic",
-    "aiobotocore",
-    "aioesphomeapi",
-    "aiohttp_cors",
-    "aiohue",
-    "aionotion",
-    "aioswitcher",
-    "aiounifi",
-    "aiowwlln",
-    "airly",
-    "ambiclimate",
-    "androidtv",
-    "apns2",
-    "aprslib",
-    "av",
-    "axis",
-    "bellows-homeassistant",
-    "caldav",
-    "coinmarketcap",
-    "defusedxml",
-    "dsmr_parser",
-    "eebrightbox",
-    "emulated_roku",
-    "enocean",
-    "ephem",
-    "evohomeclient",
-    "feedparser-homeassistant",
-    "foobot_async",
-    "geojson_client",
-    "geopy",
-    "georss_generic_client",
-    "georss_ign_sismologia_client",
-    "georss_qld_bushfire_alert_client",
-    "getmac",
-    "google-api-python-client",
-    "gTTS-token",
-    "ha-ffmpeg",
-    "hangups",
-    "HAP-python",
-    "hass-nabucasa",
-    "haversine",
-    "hbmqtt",
-    "hdate",
-    "herepy",
-    "hole",
-    "holidays",
-    "home-assistant-frontend",
-    "homekit[IP]",
-    "homematicip",
-    "httplib2",
-    "huawei-lte-api",
-    "iaqualink",
-    "influxdb",
-    "jsonpath",
-    "libpurecool",
-    "libsoundtouch",
-    "luftdaten",
-    "mbddns",
-    "mficlient",
-    "minio",
-    "netdisco",
-    "numpy",
-    "oauth2client",
-    "paho-mqtt",
-    "pexpect",
-    "pilight",
-    "pillow",
-    "plexapi",
-    "plexauth",
-    "pmsensor",
-    "prometheus_client",
-    "ptvsd",
-    "pushbullet.py",
-    "py-canary",
-    "py17track",
-    "pyblackbird",
-    "pybotvac",
-    "pychromecast",
-    "pydeconz",
-    "pydispatcher",
-    "pyheos",
-    "pyhomematic",
-    "pyHS100",
-    "pyiqvia",
-    "pylinky",
-    "pylitejet",
-    "pyMetno",
-    "pymfy",
-    "pymonoprice",
-    "PyNaCl",
-    "pynws",
-    "pynx584",
-    "pyopenuv",
-    "pyotgw",
-    "pyotp",
-    "pyps4-2ndscreen",
-    "pyqwikswitch",
-    "PyRMVtransport",
-    "pysma",
-    "pysmartapp",
-    "pysmartthings",
-    "pysoma",
-    "pysonos",
-    "pyspcwebgw",
-    "python_awair",
-    "python-ecobee-api",
-    "python-forecastio",
-    "python-izone",
-    "python-nest",
-    "python-velbus",
-    "pythonwhois",
-    "pytradfri[async]",
-    "PyTransportNSW",
-    "pyunifi",
-    "pyupnp-async",
-    "pyvesync",
-    "pywebpush",
-    "regenmaschine",
-    "restrictedpython",
-    "rflink",
-    "ring_doorbell",
-    "ruamel.yaml",
-    "rxv",
-    "simplisafe-python",
-    "sleepyq",
-    "smhi-pkg",
-    "solaredge",
-    "somecomfort",
-    "sqlalchemy",
-    "srpenergy",
-    "statsd",
-    "toonapilib",
-    "transmissionrpc",
-    "twentemilieu",
-    "uvcclient",
-    "vsure",
-    "vultr",
-    "wakeonlan",
-    "warrant",
-    "withings-api",
-    "YesssSMS",
-    "zeroconf",
-    "zigpy-homeassistant",
-)
-
 IGNORE_PIN = ("colorlog>2.1,<3", "keyring>=9.3,<10.0", "urllib3")
-
-IGNORE_REQ = ("colorama<=1",)  # Windows only requirement in check_config
 
 URL_PIN = (
     "https://developers.home-assistant.io/docs/"
@@ -211,10 +60,19 @@ enum34==1000000000.0.0
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
-
-# Contains code to modify Home Assistant to work around our rules
-python-systemair-savecair==1000000000.0.0
 """
+
+
+def has_tests(module: str):
+    """Test if a module has tests.
+
+    Module format: homeassistant.components.hue
+    Test if exists: tests/components/hue
+    """
+
+    return pathlib.Path(
+        module.replace(".", "/").replace("homeassistant", "tests")
+    ).exists()
 
 
 def explore_module(package, explore_children):
@@ -319,8 +177,6 @@ def gather_requirements_from_modules(errors, reqs):
 def process_requirements(errors, module_requirements, package, reqs):
     """Process all of the requirements."""
     for req in module_requirements:
-        if req in IGNORE_REQ:
-            continue
         if "://" in req:
             errors.append(f"{package}[Only pypi dependencies are allowed: {req}]")
         if req.partition("==")[1] == "" and req not in IGNORE_PIN:
@@ -362,13 +218,11 @@ def requirements_test_output(reqs):
     with open("requirements_test.txt") as test_file:
         output.append(test_file.read())
     output.append("\n")
+
     filtered = {
-        key: value
-        for key, value in reqs.items()
-        if any(
-            re.search(r"(^|#){}($|[=><])".format(re.escape(ign)), key) is not None
-            for ign in TEST_REQUIREMENTS
-        )
+        requirement: modules
+        for requirement, modules in reqs.items()
+        if any(has_tests(mdl) for mdl in modules)
     }
     output.append(generate_requirements_list(filtered))
 

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -59,17 +59,20 @@ async def test_async_setup_entry_default(hass):
     }
     with MockDependency("netdisco.discovery"), patch(
         "homeassistant.components.upnp.get_local_ip", return_value="192.168.1.10"
-    ):
+    ), patch.object(Device, "async_create_device") as create_device, patch.object(
+        Device, "async_create_device"
+    ) as create_device, patch.object(
+        Device, "async_discover", return_value=mock_coro([])
+    ) as async_discover:
         await async_setup_component(hass, "http", config)
         await async_setup_component(hass, "upnp", config)
         await hass.async_block_till_done()
 
-    # mock homeassistant.components.upnp.device.Device
-    mock_device = MockDevice(udn)
-    discovery_infos = [{"udn": udn, "ssdp_description": "http://192.168.1.1/desc.xml"}]
-    with patch.object(Device, "async_create_device") as create_device, patch.object(
-        Device, "async_discover"
-    ) as async_discover:  # noqa:E125
+        # mock homeassistant.components.upnp.device.Device
+        mock_device = MockDevice(udn)
+        discovery_infos = [
+            {"udn": udn, "ssdp_description": "http://192.168.1.1/desc.xml"}
+        ]
 
         create_device.return_value = mock_coro(return_value=mock_device)
         async_discover.return_value = mock_coro(return_value=discovery_infos)
@@ -100,16 +103,17 @@ async def test_async_setup_entry_port_mapping(hass):
     }
     with MockDependency("netdisco.discovery"), patch(
         "homeassistant.components.upnp.get_local_ip", return_value="192.168.1.10"
-    ):
+    ), patch.object(Device, "async_create_device") as create_device, patch.object(
+        Device, "async_discover", return_value=mock_coro([])
+    ) as async_discover:
         await async_setup_component(hass, "http", config)
         await async_setup_component(hass, "upnp", config)
         await hass.async_block_till_done()
 
-    mock_device = MockDevice(udn)
-    discovery_infos = [{"udn": udn, "ssdp_description": "http://192.168.1.1/desc.xml"}]
-    with patch.object(Device, "async_create_device") as create_device, patch.object(
-        Device, "async_discover"
-    ) as async_discover:  # noqa:E125
+        mock_device = MockDevice(udn)
+        discovery_infos = [
+            {"udn": udn, "ssdp_description": "http://192.168.1.1/desc.xml"}
+        ]
 
         create_device.return_value = mock_coro(return_value=mock_device)
         async_discover.return_value = mock_coro(return_value=discovery_infos)

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -41,7 +41,7 @@ async def test_get_actions(hass, config_entry, zha_gateway):
         zha_gateway,
     )
 
-    await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
+    await hass.config_entries.async_forward_entry_setup(config_entry, "binary_sensor")
     await hass.async_block_till_done()
     hass.config_entries._entries.append(config_entry)
 


### PR DESCRIPTION
## Description:
This improves `script/gen_requirements_all.py` to automatically detect the requirements that need to be installed in a test environment. It does so by checking if there are tests for the integration that uses it. 

Will need to see what impact this has on test installation time. I envision that it will be fast as we can cache a bunch.

So if `tests/components/hue` exists, we will list the requirements from `homeassistant/components/hue/manifest.json`.

**Related issue (if applicable):** inspired by #27357, will make #27284 easier.

