### PR TITLE
Migrate Neato to use top-level imports

### DIFF
--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -3,8 +3,9 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from pybotvac.exceptions import NeatoException, NeatoLoginException, NeatoRobotException
 import voluptuous as vol
+from pybotvac import Account, Neato, Vorwerk
+from pybotvac.exceptions import NeatoException, NeatoLoginException, NeatoRobotException
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -17,9 +18,9 @@ from .const import (
     NEATO_CONFIG,
     NEATO_DOMAIN,
     NEATO_LOGIN,
-    NEATO_ROBOTS,
-    NEATO_PERSISTENT_MAPS,
     NEATO_MAP_DATA,
+    NEATO_PERSISTENT_MAPS,
+    NEATO_ROBOTS,
     SCAN_INTERVAL_MINUTES,
     VALID_VENDORS,
 )
@@ -91,8 +92,6 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up config entry."""
-    from pybotvac import Account, Neato, Vorwerk
-
     if entry.data[CONF_VENDOR] == "neato":
         hass.data[NEATO_LOGIN] = NeatoHub(hass, entry.data, Account, Neato)
     elif entry.data[CONF_VENDOR] == "vorwerk":

--- a/homeassistant/components/neato/camera.py
+++ b/homeassistant/components/neato/camera.py
@@ -8,9 +8,9 @@ from homeassistant.components.camera import Camera
 
 from .const import (
     NEATO_DOMAIN,
+    NEATO_LOGIN,
     NEATO_MAP_DATA,
     NEATO_ROBOTS,
-    NEATO_LOGIN,
     SCAN_INTERVAL_MINUTES,
 )
 

--- a/homeassistant/components/neato/config_flow.py
+++ b/homeassistant/components/neato/config_flow.py
@@ -2,7 +2,8 @@
 
 import logging
 
-import pybotvac
+from pybotvac import Account, Neato, Vorwerk
+from pybotvac.exceptions import NeatoLoginException, NeatoRobotException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -97,15 +98,15 @@ class NeatoConfigFlow(config_entries.ConfigFlow, domain=NEATO_DOMAIN):
         """Try logging in to device and return any errors."""
         this_vendor = None
         if vendor == "vorwerk":
-            this_vendor = pybotvac.Vorwerk()
+            this_vendor = Vorwerk()
         else:  # Neato
-            this_vendor = pybotvac.Neato()
+            this_vendor = Neato()
 
         try:
-            pybotvac.Account(username, password, this_vendor)
-        except pybotvac.exceptions.NeatoLoginException:
+            Account(username, password, this_vendor)
+        except NeatoLoginException:
             return "invalid_credentials"
-        except pybotvac.exceptions.NeatoRobotException:
+        except NeatoRobotException:
             return "unexpected_error"
 
         return None

--- a/homeassistant/components/neato/config_flow.py
+++ b/homeassistant/components/neato/config_flow.py
@@ -2,15 +2,14 @@
 
 import logging
 
+import pybotvac
 import voluptuous as vol
-from pybotvac.exceptions import NeatoLoginException, NeatoRobotException
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 # pylint: disable=unused-import
 from .const import CONF_VENDOR, NEATO_DOMAIN, VALID_VENDORS
-
 
 DOCS_URL = "https://www.home-assistant.io/components/neato"
 DEFAULT_VENDOR = "neato"
@@ -96,19 +95,17 @@ class NeatoConfigFlow(config_entries.ConfigFlow, domain=NEATO_DOMAIN):
     @staticmethod
     def try_login(username, password, vendor):
         """Try logging in to device and return any errors."""
-        from pybotvac import Account, Neato, Vorwerk
-
         this_vendor = None
         if vendor == "vorwerk":
-            this_vendor = Vorwerk()
+            this_vendor = pybotvac.Vorwerk()
         else:  # Neato
-            this_vendor = Neato()
+            this_vendor = pybotvac.Neato()
 
         try:
-            Account(username, password, this_vendor)
-        except NeatoLoginException:
+            pybotvac.Account(username, password, this_vendor)
+        except pybotvac.exceptions.NeatoLoginException:
             return "invalid_credentials"
-        except NeatoRobotException:
+        except pybotvac.exceptions.NeatoRobotException:
             return "unexpected_error"
 
         return None

--- a/homeassistant/components/neato/const.py
+++ b/homeassistant/components/neato/const.py
@@ -3,11 +3,11 @@
 NEATO_DOMAIN = "neato"
 
 CONF_VENDOR = "vendor"
-NEATO_ROBOTS = "neato_robots"
-NEATO_LOGIN = "neato_login"
 NEATO_CONFIG = "neato_config"
+NEATO_LOGIN = "neato_login"
 NEATO_MAP_DATA = "neato_map_data"
 NEATO_PERSISTENT_MAPS = "neato_persistent_maps"
+NEATO_ROBOTS = "neato_robots"
 
 SCAN_INTERVAL_MINUTES = 5
 

--- a/homeassistant/components/neato/sensor.py
+++ b/homeassistant/components/neato/sensor.py
@@ -1,13 +1,13 @@
 """Support for Neato sensors."""
+from datetime import timedelta
 import logging
 
-from datetime import timedelta
 from pybotvac.exceptions import NeatoRobotException
 
 from homeassistant.components.sensor import DEVICE_CLASS_BATTERY
 from homeassistant.helpers.entity import Entity
 
-from .const import NEATO_ROBOTS, NEATO_LOGIN, NEATO_DOMAIN, SCAN_INTERVAL_MINUTES
+from .const import NEATO_DOMAIN, NEATO_LOGIN, NEATO_ROBOTS, SCAN_INTERVAL_MINUTES
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 import logging
 
 from pybotvac.exceptions import NeatoRobotException
-
 import voluptuous as vol
 
 from homeassistant.components.vacuum import (
@@ -35,8 +34,8 @@ from .const import (
     ALERTS,
     ERRORS,
     MODE,
-    NEATO_LOGIN,
     NEATO_DOMAIN,
+    NEATO_LOGIN,
     NEATO_MAP_DATA,
     NEATO_PERSISTENT_MAPS,
     NEATO_ROBOTS,

--- a/tests/components/neato/test_config_flow.py
+++ b/tests/components/neato/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.neato import config_flow
 from homeassistant.components.neato.const import CONF_VENDOR, NEATO_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
 from tests.common import MockConfigEntry
 
 USERNAME = "myUsername"
@@ -20,7 +21,7 @@ VENDOR_INVALID = "invalid"
 @pytest.fixture(name="account")
 def mock_controller_login():
     """Mock a successful login."""
-    with patch("pybotvac.Account", return_value=True):
+    with patch("homeassistant.components.neato.config_flow.Account", return_value=True):
         yield
 
 
@@ -106,7 +107,10 @@ async def test_abort_on_invalid_credentials(hass):
     """Test when we have invalid credentials."""
     flow = init_config_flow(hass)
 
-    with patch("pybotvac.Account", side_effect=NeatoLoginException()):
+    with patch(
+        "homeassistant.components.neato.config_flow.Account",
+        side_effect=NeatoLoginException(),
+    ):
         result = await flow.async_step_user(
             {
                 CONF_USERNAME: USERNAME,
@@ -132,7 +136,10 @@ async def test_abort_on_unexpected_error(hass):
     """Test when we have an unexpected error."""
     flow = init_config_flow(hass)
 
-    with patch("pybotvac.Account", side_effect=NeatoRobotException()):
+    with patch(
+        "homeassistant.components.neato.config_flow.Account",
+        side_effect=NeatoRobotException(),
+    ):
         result = await flow.async_step_user(
             {
                 CONF_USERNAME: USERNAME,

--- a/tests/components/neato/test_config_flow.py
+++ b/tests/components/neato/test_config_flow.py
@@ -2,11 +2,12 @@
 import pytest
 from unittest.mock import patch
 
+from pybotvac.exceptions import NeatoLoginException, NeatoRobotException
+
 from homeassistant import data_entry_flow
 from homeassistant.components.neato import config_flow
-from homeassistant.components.neato.const import NEATO_DOMAIN, CONF_VENDOR
+from homeassistant.components.neato.const import CONF_VENDOR, NEATO_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-
 from tests.common import MockConfigEntry
 
 USERNAME = "myUsername"
@@ -103,8 +104,6 @@ async def test_abort_if_already_setup(hass, account):
 
 async def test_abort_on_invalid_credentials(hass):
     """Test when we have invalid credentials."""
-    from pybotvac.exceptions import NeatoLoginException
-
     flow = init_config_flow(hass)
 
     with patch("pybotvac.Account", side_effect=NeatoLoginException()):
@@ -131,8 +130,6 @@ async def test_abort_on_invalid_credentials(hass):
 
 async def test_abort_on_unexpected_error(hass):
     """Test when we have an unexpected error."""
-    from pybotvac.exceptions import NeatoRobotException
-
     flow = init_config_flow(hass)
 
     with patch("pybotvac.Account", side_effect=NeatoRobotException()):

--- a/tests/components/neato/test_init.py
+++ b/tests/components/neato/test_init.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import patch
 
-from homeassistant.components.neato.const import NEATO_DOMAIN, CONF_VENDOR
+from homeassistant.components.neato.const import CONF_VENDOR, NEATO_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.setup import async_setup_component
 
@@ -30,7 +30,7 @@ INVALID_CONFIG = {
 @pytest.fixture(name="account")
 def mock_controller_login():
     """Mock a successful login."""
-    with patch("pybotvac.Account", return_value=True):
+    with patch("homeassistant.components.neato.config_flow.Account", return_value=True):
         yield
 
 


### PR DESCRIPTION
## Breaking Change:

Nothing breaks

## Description:
Migrate integrations to use top-level imports

**Related issue (if applicable):** partially fixes #27284 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
