### PR TITLE
Add above and below to sensor condition extra_fields

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -153,7 +153,11 @@ async def _async_get_device_automation_capabilities(hass, automation_type, autom
         # The device automation has no capabilities
         return {}
 
-    capabilities = await getattr(platform, function_name)(hass, automation)
+    try:
+        capabilities = await getattr(platform, function_name)(hass, automation)
+    except InvalidDeviceAutomationConfig:
+        return {}
+
     capabilities = capabilities.copy()
 
     extra_fields = capabilities.get("extra_fields")

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
     CONF_BELOW,
     CONF_ENTITY_ID,
     CONF_TYPE,
-    CONF_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -153,12 +152,10 @@ async def async_get_condition_capabilities(hass, config):
         "extra_fields": vol.Schema(
             {
                 vol.Optional(
-                    CONF_ABOVE,
-                    description={CONF_UNIT_OF_MEASUREMENT: unit_of_measurement},
+                    CONF_ABOVE, description={"suffix": unit_of_measurement}
                 ): vol.Coerce(float),
                 vol.Optional(
-                    CONF_BELOW,
-                    description={CONF_UNIT_OF_MEASUREMENT: unit_of_measurement},
+                    CONF_BELOW, description={"suffix": unit_of_measurement}
                 ): vol.Coerce(float),
             }
         )

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -145,8 +145,11 @@ async def async_get_condition_capabilities(hass, config):
     """List condition capabilities."""
     state = hass.states.get(config[CONF_ENTITY_ID])
     unit_of_measurement = (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else ""
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else None
     )
+
+    if not state or not unit_of_measurement:
+        return {}
 
     return {
         "extra_fields": vol.Schema(

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -2,6 +2,9 @@
 from typing import List
 import voluptuous as vol
 
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -149,7 +152,7 @@ async def async_get_condition_capabilities(hass, config):
     )
 
     if not state or not unit_of_measurement:
-        return {}
+        raise InvalidDeviceAutomationConfig
 
     return {
         "extra_fields": vol.Schema(

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     CONF_BELOW,
     CONF_ENTITY_ID,
     CONF_TYPE,
+    CONF_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -139,3 +140,26 @@ def async_condition_from_config(
         numeric_state_config[condition.CONF_BELOW] = config[CONF_BELOW]
 
     return condition.async_numeric_state_from_config(numeric_state_config)
+
+
+async def async_get_condition_capabilities(hass, config):
+    """List condition capabilities."""
+    state = hass.states.get(config[CONF_ENTITY_ID])
+    unit_of_measurement = (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else ""
+    )
+
+    return {
+        "extra_fields": vol.Schema(
+            {
+                vol.Optional(
+                    CONF_ABOVE,
+                    description={CONF_UNIT_OF_MEASUREMENT: unit_of_measurement},
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_BELOW,
+                    description={CONF_UNIT_OF_MEASUREMENT: unit_of_measurement},
+                ): vol.Coerce(float),
+            }
+        )
+    }

--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -3,6 +3,9 @@ import voluptuous as vol
 
 import homeassistant.components.automation.numeric_state as numeric_state_automation
 from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -156,7 +159,7 @@ async def async_get_trigger_capabilities(hass, config):
     )
 
     if not state or not unit_of_measurement:
-        return {}
+        raise InvalidDeviceAutomationConfig
 
     return {
         "extra_fields": vol.Schema(

--- a/homeassistant/components/sensor/device_trigger.py
+++ b/homeassistant/components/sensor/device_trigger.py
@@ -152,8 +152,11 @@ async def async_get_trigger_capabilities(hass, config):
     """List trigger capabilities."""
     state = hass.states.get(config[CONF_ENTITY_ID])
     unit_of_measurement = (
-        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else ""
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if state else None
     )
+
+    if not state or not unit_of_measurement:
+        return {}
 
     return {
         "extra_fields": vol.Schema(

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -97,13 +97,13 @@ async def test_get_condition_capabilities(hass, device_reg, entity_reg):
     expected_capabilities = {
         "extra_fields": [
             {
-                "description": {"unit_of_measurement": "%"},
+                "description": {"suffix": "%"},
                 "name": "above",
                 "optional": True,
                 "type": "float",
             },
             {
-                "description": {"unit_of_measurement": "%"},
+                "description": {"suffix": "%"},
                 "name": "below",
                 "optional": True,
                 "type": "float",

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -119,6 +119,41 @@ async def test_get_condition_capabilities(hass, device_reg, entity_reg):
         assert capabilities == expected_capabilities
 
 
+async def test_get_condition_capabilities_none(hass, device_reg, entity_reg):
+    """Test we get the expected capabilities from a sensor condition."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init()
+
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    conditions = [
+        {
+            "condition": "device",
+            "device_id": "8770c43885354d5fa27604db6817f63f",
+            "domain": "sensor",
+            "entity_id": "sensor.beer",
+            "type": "is_battery_level",
+        },
+        {
+            "condition": "device",
+            "device_id": "8770c43885354d5fa27604db6817f63f",
+            "domain": "sensor",
+            "entity_id": platform.ENTITIES["none"].entity_id,
+            "type": "is_battery_level",
+        },
+    ]
+
+    expected_capabilities = {}
+    for condition in conditions:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, "condition", condition
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_state_not_above_below(hass, calls, caplog):
     """Test for bad value conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -14,6 +14,7 @@ from tests.common import (
     mock_device_registry,
     mock_registry,
     async_get_device_automations,
+    async_get_device_automation_capabilities,
 )
 from tests.testing_config.custom_components.test.sensor import DEVICE_CLASSES
 
@@ -71,6 +72,51 @@ async def test_get_conditions(hass, device_reg, entity_reg):
     ]
     conditions = await async_get_device_automations(hass, "condition", device_entry.id)
     assert conditions == expected_conditions
+
+
+async def test_get_condition_capabilities(hass, device_reg, entity_reg):
+    """Test we get the expected capabilities from a sensor condition."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init()
+
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(
+        DOMAIN,
+        "test",
+        platform.ENTITIES["battery"].unique_id,
+        device_id=device_entry.id,
+    )
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    expected_capabilities = {
+        "extra_fields": [
+            {
+                "description": {"unit_of_measurement": "%"},
+                "name": "above",
+                "optional": True,
+                "type": "float",
+            },
+            {
+                "description": {"unit_of_measurement": "%"},
+                "name": "below",
+                "optional": True,
+                "type": "float",
+            },
+        ]
+    }
+    conditions = await async_get_device_automations(hass, "condition", device_entry.id)
+    assert len(conditions) == 1
+    for condition in conditions:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, "condition", condition
+        )
+        assert capabilities == expected_capabilities
 
 
 async def test_if_state_not_above_below(hass, calls, caplog):

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -124,6 +124,41 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
         assert capabilities == expected_capabilities
 
 
+async def test_get_trigger_capabilities_none(hass, device_reg, entity_reg):
+    """Test we get the expected capabilities from a sensor trigger."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init()
+
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+
+    triggers = [
+        {
+            "platform": "device",
+            "device_id": "8770c43885354d5fa27604db6817f63f",
+            "domain": "sensor",
+            "entity_id": "sensor.beer",
+            "type": "is_battery_level",
+        },
+        {
+            "platform": "device",
+            "device_id": "8770c43885354d5fa27604db6817f63f",
+            "domain": "sensor",
+            "entity_id": platform.ENTITIES["none"].entity_id,
+            "type": "is_battery_level",
+        },
+    ]
+
+    expected_capabilities = {}
+    for trigger in triggers:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, "trigger", trigger
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_fires_not_on_above_below(hass, calls, caplog):
     """Test for value triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")


### PR DESCRIPTION
## Description:
Add `above` and `below` to sensor trigger `extra_fields`.
This is missing from PR #27163 which introduces device conditions for sensors.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
