### PR TITLE
Fix statistics sensor honouring max_age

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -20,8 +20,8 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
-    async_track_state_change,
     async_track_point_in_utc_time,
+    async_track_state_change,
 )
 from homeassistant.util import dt as dt_util
 
@@ -278,7 +278,6 @@ class StatisticsSensor(Entity):
                 self.min_age = self.max_age = dt_util.utcnow()
                 self.change = self.average_change = STATE_UNKNOWN
                 self.change_rate = STATE_UNKNOWN
-        self.async_schedule_update_ha_state()
 
         # If max_age is set, ensure to update again after the defined interval.
         next_to_purge_timestamp = self._next_to_purge_timestamp()
@@ -293,7 +292,7 @@ class StatisticsSensor(Entity):
             async def _scheduled_update(now):
                 """Timer callback for sensor update."""
                 _LOGGER.debug("%s: executing scheduled update", self.entity_id)
-                await self.async_update()
+                self.async_schedule_update_ha_state(True)
 
             self._update_listener = async_track_point_in_utc_time(
                 self.hass, _scheduled_update, next_to_purge_timestamp

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -283,7 +283,7 @@ class StatisticsSensor(Entity):
         next_to_purge_timestamp = self._next_to_purge_timestamp()
         if next_to_purge_timestamp:
             _LOGGER.debug(
-                "%s: scheduling update at %s.", self.entity_id, next_to_purge_timestamp
+                "%s: scheduling update at %s", self.entity_id, next_to_purge_timestamp
             )
             if self._update_listener:
                 self._update_listener()

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -289,7 +289,8 @@ class StatisticsSensor(Entity):
                 self._update_listener()
                 self._update_listener = None
 
-            async def _scheduled_update(now):
+            @callback
+            def _scheduled_update(now):
                 """Timer callback for sensor update."""
                 _LOGGER.debug("%s: executing scheduled update", self.entity_id)
                 self.async_schedule_update_ha_state(True)

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -279,7 +279,6 @@ class StatisticsSensor(Entity):
                 self._update_listener()
                 self._update_listener = None
 
-            # @callback
             async def _scheduled_update(now):
                 """Timer callback for sensor update."""
                 _LOGGER.debug("%s: executing scheduled update", self.entity_id)

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1,6 +1,5 @@
 """The test for the statistics sensor platform."""
 from datetime import datetime, timedelta
-import logging
 import statistics
 import unittest
 from unittest.mock import patch
@@ -18,8 +17,6 @@ from tests.common import (
     get_test_home_assistant,
     init_recorder_component,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class TestStatisticsSensor(unittest.TestCase):
@@ -261,7 +258,6 @@ class TestStatisticsSensor(unittest.TestCase):
 
             # wait for 3 minutes (max_age).
             mock_data["return_time"] += timedelta(minutes=3)
-            _LOGGER.error("fire_time_changed %s", mock_data["return_time"])
             fire_time_changed(self.hass, mock_data["return_time"])
             self.hass.block_till_done()
 

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -249,21 +249,14 @@ class TestStatisticsSensor(unittest.TestCase):
                 self.hass.block_till_done()
                 # insert the next value 30 seconds later
                 mock_data["return_time"] += timedelta(seconds=30)
-                # fire_time_changed(self.hass, mock_data["return_time"])
-                # self.hass.block_till_done()
 
             state = self.hass.states.get("sensor.test")
 
             assert 3.8 == state.attributes.get("min_value")
             assert 15.2 == state.attributes.get("max_value")
 
-            # wait for 2 * 2 minutes (longer than max_age).
-            mock_data["return_time"] += timedelta(minutes=2)
-            _LOGGER.error("fire_time_changed %s", mock_data["return_time"])
-            fire_time_changed(self.hass, mock_data["return_time"])
-            self.hass.block_till_done()
-
-            mock_data["return_time"] += timedelta(minutes=2)
+            # wait for 3 minutes (max_age).
+            mock_data["return_time"] += timedelta(minutes=3)
             _LOGGER.error("fire_time_changed %s", mock_data["return_time"])
             fire_time_changed(self.hass, mock_data["return_time"])
             self.hass.block_till_done()

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1,18 +1,21 @@
 """The test for the statistics sensor platform."""
-from datetime import datetime, timedelta
-import statistics
+import logging
 import unittest
+import statistics
 from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import recorder
 from homeassistant.components.statistics.sensor import StatisticsSensor
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS
 from homeassistant.setup import setup_component
 from homeassistant.util import dt as dt_util
+from tests.common import get_test_home_assistant, fire_time_changed
+from datetime import datetime, timedelta
+from tests.common import init_recorder_component
+from homeassistant.components import recorder
 
-from tests.common import get_test_home_assistant, init_recorder_component
+_LOGGER = logging.getLogger(__name__)
 
 
 class TestStatisticsSensor(unittest.TestCase):
@@ -210,6 +213,66 @@ class TestStatisticsSensor(unittest.TestCase):
 
         assert 6 == state.attributes.get("min_value")
         assert 14 == state.attributes.get("max_value")
+
+    def test_max_age_without_sensor_change(self):
+        """Test value deprecation."""
+        mock_data = {"return_time": datetime(2017, 8, 2, 12, 23, tzinfo=dt_util.UTC)}
+
+        def mock_now():
+            return mock_data["return_time"]
+
+        with patch(
+            "homeassistant.components.statistics.sensor.dt_util.utcnow", new=mock_now
+        ):
+            assert setup_component(
+                self.hass,
+                "sensor",
+                {
+                    "sensor": {
+                        "platform": "statistics",
+                        "name": "test",
+                        "entity_id": "sensor.test_monitored",
+                        "max_age": {"minutes": 3},
+                    }
+                },
+            )
+
+            self.hass.start()
+            self.hass.block_till_done()
+
+            for value in self.values:
+                self.hass.states.set(
+                    "sensor.test_monitored",
+                    value,
+                    {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS},
+                )
+                self.hass.block_till_done()
+                # insert the next value 30 seconds later
+                mock_data["return_time"] += timedelta(seconds=30)
+                # fire_time_changed(self.hass, mock_data["return_time"])
+                # self.hass.block_till_done()
+
+            state = self.hass.states.get("sensor.test")
+
+            assert 3.8 == state.attributes.get("min_value")
+            assert 15.2 == state.attributes.get("max_value")
+
+            # wait for 2 * 2 minutes (longer than max_age).
+            mock_data["return_time"] += timedelta(minutes=2)
+            _LOGGER.error("fire_time_changed %s", mock_data["return_time"])
+            fire_time_changed(self.hass, mock_data["return_time"])
+            self.hass.block_till_done()
+
+            mock_data["return_time"] += timedelta(minutes=2)
+            _LOGGER.error("fire_time_changed %s", mock_data["return_time"])
+            fire_time_changed(self.hass, mock_data["return_time"])
+            self.hass.block_till_done()
+
+            state = self.hass.states.get("sensor.test")
+
+            assert state.attributes.get("min_value") == STATE_UNKNOWN
+            assert state.attributes.get("max_value") == STATE_UNKNOWN
+            assert state.attributes.get("count") == 0
 
     def test_change_rate(self):
         """Test min_age/max_age and change_rate."""

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1,19 +1,23 @@
 """The test for the statistics sensor platform."""
+from datetime import datetime, timedelta
 import logging
-import unittest
 import statistics
+import unittest
 from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components import recorder
 from homeassistant.components.statistics.sensor import StatisticsSensor
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS
 from homeassistant.setup import setup_component
 from homeassistant.util import dt as dt_util
-from tests.common import get_test_home_assistant, fire_time_changed
-from datetime import datetime, timedelta
-from tests.common import init_recorder_component
-from homeassistant.components import recorder
+
+from tests.common import (
+    fire_time_changed,
+    get_test_home_assistant,
+    init_recorder_component,
+)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
If `max_age` is configured, this change will keep updating the statistics even when none of the observed entities change their state. That means that after some time all recorded states are purged and the statistics sensor itself changes to state `unknown` instead of just keeping its old state indefinitely. Also, some attributes (`total`, `min_age`, `change`, `change_rate`, `mean`, `stdev`) will change to `unknown`.
You should ensure that any automations that interrogate the statistics sensor's state and attributes can handle `unknown`.

This change is necessary to fix the behavior for use-cases where the observed entities are not regularly changing their state (for example counters), but the statistics sensor should change its state as time passes.

## Description:
The statistics sensor currently only updates its own state if any of the observed entities change their state. If `max_age` is configured then all outdated entity states will be purged before updating its own state.
However, if none of the observed entities actually change their state, then no outdated entity states will be purged, and the calculated statistics are going out of date.

This change will introduce an additional update of the sensor at the time when the next stored state would need to be purged, hence always keeping the statistics up to date.

**Related issue (if applicable):** fixes #19800

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: statistics
    entity_id: sensor.pulse_counter
    max_age:
      minutes: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
