### PR TITLE
Squeezebox LMS reconnect

### DIFF
--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -127,9 +127,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Get IP of host, to prevent duplication of same host (different DNS names)
     try:
         ipaddr = socket.gethostbyname(host)
-    except (OSError) as error:
+    except OSError as error:
         _LOGGER.error("Could not communicate with %s:%d: %s", host, port, error)
-        raise PlatformNotReady
+        raise PlatformNotReady from error
 
     if ipaddr in known_servers:
         return

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -40,6 +40,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util.dt import utcnow
 
 _LOGGER = logging.getLogger(__name__)
@@ -128,16 +129,19 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         ipaddr = socket.gethostbyname(host)
     except (OSError) as error:
         _LOGGER.error("Could not communicate with %s:%d: %s", host, port, error)
-        return False
+        raise PlatformNotReady
 
     if ipaddr in known_servers:
         return
 
-    known_servers.add(ipaddr)
     _LOGGER.debug("Creating LMS object for %s", ipaddr)
     lms = LogitechMediaServer(hass, host, port, username, password)
 
     players = await lms.create_players()
+    if players is None:
+        raise PlatformNotReady
+
+    known_servers.add(ipaddr)
 
     hass.data[DATA_SQUEEZEBOX].extend(players)
     async_add_entities(players)
@@ -194,7 +198,7 @@ class LogitechMediaServer:
         result = []
         data = await self.async_query("players", "status")
         if data is False:
-            return result
+            return None
         for players in data.get("players_loop", []):
             player = SqueezeBoxDevice(self, players["playerid"], players["name"])
             await player.async_update()


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:
Raise PlatformNotReady if there is error connection with LMS.

**Related issue (if applicable):** fixes #26429 #26838

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
