### PR TITLE
Move imports in google_travel_time component

### DIFF
--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -1,25 +1,25 @@
 """Support for Google travel time sensors."""
+from datetime import datetime, timedelta
 import logging
-from datetime import datetime
-from datetime import timedelta
 
+import googlemaps
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_NAME,
-    EVENT_HOMEASSISTANT_START,
+    ATTR_ATTRIBUTION,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_ATTRIBUTION,
+    CONF_API_KEY,
     CONF_MODE,
+    CONF_NAME,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.helpers import location
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -202,8 +202,6 @@ class GoogleTravelTimeSensor(Entity):
             self._destination_entity_id = destination
         else:
             self._destination = destination
-
-        import googlemaps
 
         self._client = googlemaps.Client(api_key, timeout=10)
         try:


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
None

## Description:

Moved import from function to top-level as requested in #27284

**Related issue (if applicable):** #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
N/A
## Example entry for `configuration.yaml` (if applicable):
N/A
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
