### PR TITLE
Add ability to select register type to Modbus Binary Sensor

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -220,6 +220,12 @@ class ModbusHub:
             kwargs = {"unit": unit} if unit else {}
             return self._client.read_coils(address, count, **kwargs)
 
+    def read_discrete_inputs(self, unit, address, count):
+        """Read discrete inputs."""
+        with self._lock:
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.read_discrete_inputs(address, count, **kwargs)
+
     def read_input_registers(self, unit, address, count):
         """Read input registers."""
         with self._lock:


### PR DESCRIPTION
## Breaking Change:

None.

## Description:

Modbus protocol defines 2 types of binary inputs:
* coil (modbus function code 1)
* discrete inputs (modbus function code 2)

This commit adds ability to read data from discrete inputs using Modbus Binary Sensor.
It adds `register_type` configuration parameter with possible values of `coil` and `discrete_input`.
Default is `coil` so compatibility with previous behavior is kept.

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#10689

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: modbus
    coils:
      - name: BinSensor1
        hub: hub1
        slave: 1
        coil: 100
        register_type: discrete_input
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
