### PR TITLE
Bump python-songpal to 0.11

### DIFF
--- a/homeassistant/components/songpal/manifest.json
+++ b/homeassistant/components/songpal/manifest.json
@@ -3,7 +3,7 @@
   "name": "Songpal",
   "documentation": "https://www.home-assistant.io/integrations/songpal",
   "requirements": [
-    "python-songpal==0.0.9.1"
+    "python-songpal==0.11"
   ],
   "dependencies": [],
   "codeowners": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1561,7 +1561,7 @@ python-ripple-api==0.0.3
 python-sochain-api==0.0.2
 
 # homeassistant.components.songpal
-python-songpal==0.0.9.1
+python-songpal==0.11
 
 # homeassistant.components.synologydsm
 python-synology==0.2.0


### PR DESCRIPTION
##  Description:
Bumps python-songpal to the most recent release, fixing too noisy warning messages and paving way to add control for multiple zones.

Fixes #24269 and fixes #26776 - potentially also #22116

Changelogs: 
* https://github.com/rytilahti/python-songpal/releases/tag/0.10
* https://github.com/rytilahti/python-songpal/releases/tag/0.11

**Related issue (if applicable):** fixes #24269 #26776

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
