### PR TITLE
Bump sqlalchemy to 1.3.10

### DIFF
--- a/homeassistant/components/recorder/manifest.json
+++ b/homeassistant/components/recorder/manifest.json
@@ -3,7 +3,7 @@
   "name": "Recorder",
   "documentation": "https://www.home-assistant.io/integrations/recorder",
   "requirements": [
-    "sqlalchemy==1.3.9"
+    "sqlalchemy==1.3.10"
   ],
   "dependencies": [],
   "codeowners": []

--- a/homeassistant/components/sql/manifest.json
+++ b/homeassistant/components/sql/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sql",
   "documentation": "https://www.home-assistant.io/integrations/sql",
   "requirements": [
-    "sqlalchemy==1.3.9"
+    "sqlalchemy==1.3.10"
   ],
   "dependencies": [],
   "codeowners": [

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -21,7 +21,7 @@ pytz>=2019.03
 pyyaml==5.1.2
 requests==2.22.0
 ruamel.yaml==0.15.100
-sqlalchemy==1.3.9
+sqlalchemy==1.3.10
 voluptuous-serialize==2.3.0
 voluptuous==0.11.7
 zeroconf==0.23.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1820,7 +1820,7 @@ spotipy-homeassistant==2.4.4.dev1
 
 # homeassistant.components.recorder
 # homeassistant.components.sql
-sqlalchemy==1.3.9
+sqlalchemy==1.3.10
 
 # homeassistant.components.starlingbank
 starlingbank==3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -570,7 +570,7 @@ somecomfort==0.5.2
 
 # homeassistant.components.recorder
 # homeassistant.components.sql
-sqlalchemy==1.3.9
+sqlalchemy==1.3.10
 
 # homeassistant.components.statsd
 statsd==3.2.1


### PR DESCRIPTION
# Description:

Bump sqlalchemy to 1.3.10
- https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_3_10
- https://docs.sqlalchemy.org/en/13/changelog/changelog_13.html#change-1.3.10

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
recoder:

sensor:
  - platform: sql
    queries:
      - name: Sun state
        query: "SELECT * FROM states WHERE entity_id = 'sun.sun' ORDER BY state_id DESC LIMIT 1;"
        column: 'state'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
