### PR TITLE
Bump aiohttp to 3.6.2

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==1.7.1
 PyNaCl==1.3.0
-aiohttp==3.6.1
+aiohttp==3.6.2
 aiohttp_cors==0.7.0
 astral==1.10.1
 async_timeout==3.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-aiohttp==3.6.1
+aiohttp==3.6.2
 astral==1.10.1
 async_timeout==3.0.1
 attrs==19.2.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ PROJECT_URLS = {
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 
 REQUIRES = [
-    "aiohttp==3.6.1",
+    "aiohttp==3.6.2",
     "astral==1.10.1",
     "async_timeout==3.0.1",
     "attrs==19.2.0",


### PR DESCRIPTION
# Description:

Changelog: https://github.com/aio-libs/aiohttp/releases/tag/v3.6.2

**Related issue (if applicable):** n/a

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
