### PR TITLE
Move imports in rmvtransport component

### DIFF
--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -3,6 +3,8 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from RMVtransport import RMVtransport
+from RMVtransport.rmvtransport import RMVtransportApiConnectionError
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -208,8 +210,6 @@ class RMVDepartureData:
         timeout,
     ):
         """Initialize the sensor."""
-        from RMVtransport import RMVtransport
-
         self.station = None
         self._station_id = station_id
         self._destinations = destinations
@@ -224,8 +224,6 @@ class RMVDepartureData:
     @Throttle(SCAN_INTERVAL)
     async def async_update(self):
         """Update the connection data."""
-        from RMVtransport.rmvtransport import RMVtransportApiConnectionError
-
         try:
             _data = await self.rmv.get_departures(
                 self._station_id,


### PR DESCRIPTION
## Description:

Move import to top-level as requested in #27284

**Related issue (if applicable):** #27284

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
