### PR TITLE
SNMP Switch payloads are not guaranteed to be integers

### DIFF
--- a/homeassistant/components/snmp/switch.py
+++ b/homeassistant/components/snmp/switch.py
@@ -186,20 +186,15 @@ class SnmpSwitch(SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
-        from pyasn1.type.univ import Integer
-
-        await self._set(Integer(self._command_payload_on))
+        await self._set(self._command_payload_on)
 
     async def async_turn_off(self, **kwargs):
         """Turn off the switch."""
-        from pyasn1.type.univ import Integer
-
-        await self._set(Integer(self._command_payload_off))
+        await self._set(self._command_payload_off)
 
     async def async_update(self):
         """Update the state."""
         from pysnmp.hlapi.asyncio import getCmd, ObjectType, ObjectIdentity
-        from pyasn1.type.univ import Integer
 
         errindication, errstatus, errindex, restable = await getCmd(
             *self._request_args, ObjectType(ObjectIdentity(self._baseoid))
@@ -215,9 +210,9 @@ class SnmpSwitch(SwitchDevice):
             )
         else:
             for resrow in restable:
-                if resrow[-1] == Integer(self._payload_on):
+                if resrow[-1] == self._payload_on:
                     self._state = True
-                elif resrow[-1] == Integer(self._payload_off):
+                elif resrow[-1] == self._payload_off:
                     self._state = False
                 else:
                     self._state = None


### PR DESCRIPTION
Description:
SNMP can handle various payloads, including strings and other non-integers. This patch allows other types of payload.

**Related issue (if applicable):** fixes #27171

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A, no configuration changes

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
No changes to documented behaviour.

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.
No changes to communication with devices

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
